### PR TITLE
feat(feedback): cotal_feedback tool + CLI sender

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,6 +6,9 @@
   "linked": [],
   "access": "public",
   "baseBranch": "main",
+  "snapshot": {
+    "useCalculatedVersion": true
+  },
   "updateInternalDependencies": "patch",
   "ignore": [
     "@cotal-ai/example-01-lateral-coordination",

--- a/.changeset/feedback-sender.md
+++ b/.changeset/feedback-sender.md
@@ -1,0 +1,9 @@
+---
+"@cotal-ai/connector-core": minor
+"@cotal-ai/cli": minor
+"@cotal-ai/connector-claude-code": patch
+"@cotal-ai/connector-codex": patch
+"@cotal-ai/connector-opencode": patch
+---
+
+Add the `cotal_feedback` sender: a connector tool (always exposed) and a `cotal feedback "<summary>"` CLI mode. With a `COTAL_FEEDBACK_KEY` feedback routes to the keyed broker intake as before; without one it goes to the public intake at `https://cotal.ai/v1/feedback`, which requires a contact email (`COTAL_FEEDBACK_EMAIL` → git config → ask). `COTAL_FEEDBACK_URL` overrides either URL for self-hosted intakes.

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -5,11 +5,17 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      snapshot:
+        description: "Snapshot release: publish <version>-<tag>-<datetime> under this npm dist-tag (e.g. next). Leave empty for the normal release flow."
+        type: string
+        default: ""
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   version:
+    if: github.event_name == 'push' || inputs.snapshot == ''
     timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:
@@ -55,3 +61,35 @@ jobs:
         run: |
           pnpm changeset tag
           git push origin --tags
+
+  # Snapshot release from any ref — publishes <version>-<tag>-<datetime> under the given npm
+  # dist-tag so a branch can be tried out without merging. No commits, no git tags.
+  snapshot:
+    if: github.event_name == 'workflow_dispatch' && inputs.snapshot != ''
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6.0.8
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Version snapshot
+        run: pnpm changeset version --snapshot ${{ inputs.snapshot }}
+
+      - name: Build and publish
+        run: |
+          pnpm build
+          pnpm publish -r --provenance --access=public --no-git-checks --tag ${{ inputs.snapshot }}

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -119,15 +119,21 @@ and the agent authenticates as its own JWT identity. See [architecture.md](archi
 
 ## Beta feedback
 
-Set this in a beta tester's agent environment to expose `cotal_feedback`:
+`cotal_feedback` works out of the box: without a key it posts to the public intake at
+`https://cotal.ai/v1/feedback`, which requires a contact email (sourced from
+`COTAL_FEEDBACK_EMAIL`, then `git config user.email`, otherwise the agent asks the user).
+The CLI can send too: `cotal feedback "<summary>" [--type bug] [--email you@example.com]`.
+
+Set this in a beta tester's agent environment to route to the keyed intake instead:
 
 ```
 COTAL_FEEDBACK_KEY=fbk_<per-tester-key>
 ```
 
-The tool posts to the hardcoded intake URL `https://broker.cotal.ai/v1/feedback` with
+With a key the tool posts to `https://broker.cotal.ai/v1/feedback` with
 `Authorization: Bearer ...`; the server derives tester identity from the key, not from the
-model-supplied body. Each submission has `origin: "human" | "agent"`: human means the tester asked
+model-supplied body — no email needed. `COTAL_FEEDBACK_URL` overrides either URL (self-hosted
+intakes). Each submission has `origin: "human" | "agent"`: human means the tester asked
 the agent to send feedback; agent means the agent independently hit a major Cotal issue and
 auto-reported it.
 

--- a/extensions/connector-claude-code/src/mcp.ts
+++ b/extensions/connector-claude-code/src/mcp.ts
@@ -148,7 +148,7 @@ async function main(): Promise<void> {
     },
   );
 
-  registerCotalTools(server, agent, config);
+  registerCotalTools(server, agent, config, "claude-code");
 
   // One wake-nudge path, shared by incoming messages and the Stop→idle flush. It stays a stable
   // function gated on a *mutable* `channelActive` flag (flipped true only after the MCP

--- a/extensions/connector-codex/src/mcp.ts
+++ b/extensions/connector-codex/src/mcp.ts
@@ -40,7 +40,7 @@ async function main(): Promise<void> {
     },
   );
 
-  registerCotalTools(server, agent, config);
+  registerCotalTools(server, agent, config, "codex");
 
   const shutdown = async () => {
     try {

--- a/extensions/connector-core/feedback.smoke.ts
+++ b/extensions/connector-core/feedback.smoke.ts
@@ -1,0 +1,105 @@
+/**
+ * cotal_feedback sender test (no test runner) — spins up a tiny recording HTTP server, points
+ * the config's feedbackUrl at it, and drives the spec's run() directly to verify the routing:
+ *   - keyed: Authorization: Bearer <key>, no email required;
+ *   - keyless: contact email in the body, NO auth header;
+ *   - keyless without any email source: err() before any request leaves;
+ *   - a 400 reply surfaces the server's `error` field as an error result.
+ * Run: pnpm smoke:feedback
+ */
+import { strict as assert } from "node:assert";
+import { createServer, type IncomingMessage } from "node:http";
+import { cotalToolSpecs } from "./src/tool-specs.js";
+import type { AgentConfig } from "./src/config.js";
+
+let pass = 0;
+const check = (name: string, cond: boolean, extra?: unknown) => {
+  assert.ok(cond, `${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
+  pass++;
+  console.log(`  ✓ ${name}`);
+};
+
+interface Hit {
+  auth?: string;
+  body: Record<string, unknown>;
+}
+const hits: Hit[] = [];
+let nextStatus = 200;
+let nextReply: unknown = { ok: true, id: "fb_1" };
+
+const readBody = async (req: IncomingMessage) => {
+  const chunks: Buffer[] = [];
+  for await (const c of req) chunks.push(Buffer.isBuffer(c) ? c : Buffer.from(c));
+  return JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
+};
+const http = createServer(async (req, res) => {
+  hits.push({ auth: req.headers.authorization, body: await readBody(req) });
+  res.writeHead(nextStatus, { "content-type": "application/json" });
+  res.end(JSON.stringify(nextReply));
+});
+await new Promise<void>((r) => http.listen(0, "127.0.0.1", r));
+const url = `http://127.0.0.1:${(http.address() as { port: number }).port}/v1/feedback`;
+
+const baseCfg: AgentConfig = {
+  space: "fbsmoke",
+  name: "Otto",
+  servers: "nats://127.0.0.1:4222",
+  channels: ["general"],
+  publish: ["general"],
+  kind: "agent",
+  tls: false,
+  feedbackUrl: url,
+};
+const spec = (cfg: AgentConfig) => {
+  const s = cotalToolSpecs(cfg, "smoke").find((t) => t.name === "cotal_feedback");
+  assert.ok(s, "cotal_feedback spec exists");
+  return s;
+};
+const args = { origin: "agent", type: "bug", summary: "it broke" };
+delete process.env.COTAL_FEEDBACK_EMAIL;
+
+try {
+  // ---- keyed: Bearer header, no email needed ----
+  const keyed = await spec({ ...baseCfg, feedbackKey: "fbk_test" }).run(null as never, baseCfg, args);
+  check("keyed send succeeds", !keyed.isError, keyed.text);
+  check("keyed result carries the id", keyed.text.includes("fb_1"), keyed.text);
+  check("keyed request has Bearer header", hits[0]?.auth === "Bearer fbk_test", hits[0]?.auth);
+  check("keyed request stamps source", hits[0]?.body.source === "smoke", hits[0]?.body);
+
+  // ---- keyless: email in body, no auth header ----
+  const keyless = await spec(baseCfg).run(null as never, baseCfg, { ...args, email: "dev@example.com" });
+  check("keyless send succeeds", !keyless.isError, keyless.text);
+  check("keyless request has no auth header", hits[1]?.auth === undefined, hits[1]?.auth);
+  check("keyless request carries the email", hits[1]?.body.email === "dev@example.com", hits[1]?.body);
+
+  // ---- keyless without any email source: refused before any request ----
+  const before = hits.length;
+  const gitless = { ...process.env, GIT_DIR: "/nonexistent", GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null", GIT_CONFIG_NOSYSTEM: "1" };
+  const noEmail = await withEnv(gitless, () => spec(baseCfg).run(null as never, baseCfg, args));
+  check("keyless without email is an error", noEmail.isError === true, noEmail.text);
+  check("error asks for a contact email", /email/i.test(noEmail.text), noEmail.text);
+  check("no request left without an email", hits.length === before);
+
+  // ---- 400: server error surfaces ----
+  nextStatus = 400;
+  nextReply = { ok: false, error: "summary is required" };
+  const rejected = await spec({ ...baseCfg, feedbackKey: "fbk_test" }).run(null as never, baseCfg, args);
+  check("400 is an error result", rejected.isError === true, rejected.text);
+  check("400 surfaces the server's error", rejected.text.includes("summary is required"), rejected.text);
+
+  console.log(`\nfeedback smoke: ${pass} checks passed`);
+  process.exit(0);
+} finally {
+  http.close();
+}
+
+/** Run fn with process.env temporarily replaced (git lookup must not see a real user.email). */
+async function withEnv<T>(env: NodeJS.ProcessEnv, fn: () => T | Promise<T>): Promise<T> {
+  const prev = process.env;
+  process.env = env;
+  try {
+    return await fn();
+  } finally {
+    process.env = prev;
+  }
+}

--- a/extensions/connector-core/src/config.ts
+++ b/extensions/connector-core/src/config.ts
@@ -2,7 +2,10 @@ import { userInfo } from "node:os";
 import { readFileSync } from "node:fs";
 import { DEFAULT_SERVER, loadAgentFile, parseJoinLink, type AgentDef, type EndpointKind } from "@cotal-ai/core";
 
+/** Keyed beta intake — used when a `COTAL_FEEDBACK_KEY` is configured. */
 export const FEEDBACK_URL = "https://broker.cotal.ai/v1/feedback";
+/** Public hosted intake — used without a key; requires a contact email. */
+export const PUBLIC_FEEDBACK_URL = "https://cotal.ai/v1/feedback";
 
 /**
  * How a connector instance presents itself on the mesh. Everything is read from
@@ -32,8 +35,11 @@ export interface AgentConfig {
   user?: string;
   pass?: string;
   tls: boolean;
-  /** Optional beta-feedback key. The intake URL is fixed at {@link FEEDBACK_URL}. */
+  /** Optional beta-feedback key — routes feedback to the keyed intake at {@link FEEDBACK_URL};
+   *  without it, feedback goes to the public {@link PUBLIC_FEEDBACK_URL}. */
   feedbackKey?: string;
+  /** Optional intake URL override (`COTAL_FEEDBACK_URL`) for self-hosted intakes. */
+  feedbackUrl?: string;
 }
 
 function splitList(v: string | undefined): string[] {
@@ -87,6 +93,7 @@ export function configFromEnv(env: NodeJS.ProcessEnv = process.env): AgentConfig
     pass: link?.pass,
     tls: env.COTAL_TLS?.trim() === "1" || link?.tls || false,
     feedbackKey: env.COTAL_FEEDBACK_KEY?.trim() || undefined,
+    feedbackUrl: env.COTAL_FEEDBACK_URL?.trim() || undefined,
   };
 }
 
@@ -104,14 +111,18 @@ export function laneLine(config: AgentConfig): string {
     : `You read ${fmt(subs)}; you may post only to ${fmt(pubs)} (posts to other channels are rejected). `;
 }
 
-/** Optional beta-feedback guidance folded into connector instructions. */
+/** Beta-feedback guidance folded into connector instructions. */
 export function feedbackLine(config: AgentConfig): string {
-  if (!config.feedbackKey) return "";
+  const dest = config.feedbackKey
+    ? ""
+    : `Without a feedback key it goes to the public cotal.ai intake and needs a contact email — ` +
+      `the tool will tell you to ask the user for one if it can't find it. `;
   return (
-    `Beta feedback is enabled: use cotal_feedback with origin="human" when the user asks you to ` +
+    `Use cotal_feedback with origin="human" when the user asks you to ` +
     `send feedback or gives you feedback to pass along. If you independently hit a major Cotal ` +
     `issue — for example repeated Cotal tool failures, inability to connect, lost/incorrect mesh ` +
     `messages, or a workflow-blocking bug — send cotal_feedback yourself with origin="agent". ` +
-    `Do not send minor noise or secrets; include diagnostics only when they help debug the Cotal issue. `
+    `Do not send minor noise or secrets; include diagnostics only when they help debug the Cotal issue. ` +
+    dest
   );
 }

--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -7,10 +7,11 @@
  * Codex); the OpenCode connector renders the same specs as native plugin tools. One
  * source of truth, so the cotal_* surface can't drift across adapters.
  */
+import { execFileSync } from "node:child_process";
 import { z } from "zod";
 import { isConcreteChannel, type PresenceStatus } from "@cotal-ai/core";
 import type { MeshAgent, InboxItem } from "./agent.js";
-import type { AgentConfig } from "./config.js";
+import { FEEDBACK_URL, PUBLIC_FEEDBACK_URL, type AgentConfig } from "./config.js";
 
 /** What a Cotal tool returns: text to show the model, flagged on failure. MCP wraps it in
  *  `content`; the OpenCode plugin returns the string. */
@@ -79,6 +80,18 @@ function renderChannelInfo(
   return lines.join("\n");
 }
 
+/** Contact email for keyless feedback: explicit arg → COTAL_FEEDBACK_EMAIL → git config. */
+function resolveFeedbackEmail(explicit?: string): string | undefined {
+  if (explicit?.trim()) return explicit.trim();
+  if (process.env.COTAL_FEEDBACK_EMAIL?.trim()) return process.env.COTAL_FEEDBACK_EMAIL.trim();
+  try {
+    const email = execFileSync("git", ["config", "user.email"], { encoding: "utf8" }).trim();
+    return email || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Routing context for a `<channel …>` tag. Keys must be [A-Za-z0-9_] (others are dropped). */
 export function channelMeta(i: InboxItem): Record<string, string> {
   const m: Record<string, string> = { kind: i.kind, from: i.fromName, from_id: i.fromId };
@@ -90,8 +103,9 @@ export function channelMeta(i: InboxItem): Record<string, string> {
   return m;
 }
 
-/** The full Cotal tool set for a given config. Renderers iterate this. */
-export function cotalToolSpecs(config: AgentConfig): CotalToolSpec[] {
+/** The full Cotal tool set for a given config. Renderers iterate this; `source` names the
+ *  hosting connector and is stamped onto outgoing feedback. */
+export function cotalToolSpecs(config: AgentConfig, source = "connector"): CotalToolSpec[] {
   return [
     {
       name: "cotal_roster",
@@ -344,6 +358,54 @@ export function cotalToolSpecs(config: AgentConfig): CotalToolSpec[] {
           return err(
             `Couldn't spawn ${name}: no manager reachable (${(e as Error).message}). Is the manager running?`,
           );
+        }
+      },
+    },
+    {
+      name: "cotal_feedback",
+      title: "Cotal: send beta feedback",
+      description:
+        "Send feedback about Cotal to its developers. With a configured feedback key it goes to the keyed beta intake; without one it goes to the public cotal.ai intake, which requires a contact email.",
+      schema: {
+        origin: z
+          .enum(["human", "agent"])
+          .describe('"human" when relaying the user\'s feedback, "agent" when reporting an issue you hit yourself.'),
+        type: z.enum(["bug", "idea", "friction", "praise", "other"]).describe("What kind of feedback this is."),
+        summary: z.string().max(2000).describe("One-line summary of the feedback."),
+        details: z.string().max(10_000).optional().describe("Longer free-form details."),
+        severity: z.enum(["low", "medium", "high"]).optional().describe("How badly this hurts (bugs/friction)."),
+        area: z.string().optional().describe("The part of Cotal this concerns (e.g. presence, channels, CLI)."),
+        repro: z.string().optional().describe("Steps to reproduce."),
+        expected: z.string().optional().describe("What you expected to happen."),
+        actual: z.string().optional().describe("What actually happened."),
+        email: z
+          .string()
+          .optional()
+          .describe("Contact email — required on the keyless public path when none is configured in the environment."),
+      },
+      async run(_agent, _config, args: Record<string, unknown>) {
+        const { email, ...payload } = args;
+        const url = config.feedbackUrl ?? (config.feedbackKey ? FEEDBACK_URL : PUBLIC_FEEDBACK_URL);
+        const headers: Record<string, string> = { "content-type": "application/json" };
+        const body: Record<string, unknown> = { ...payload, source };
+        if (config.feedbackKey) {
+          headers.authorization = `Bearer ${config.feedbackKey}`;
+        } else {
+          const contact = resolveFeedbackEmail(email as string | undefined);
+          if (!contact)
+            return err(
+              "Keyless feedback goes to the public cotal.ai intake, which requires a traceable contact email — ask the user for one and retry with the email argument (or set COTAL_FEEDBACK_EMAIL).",
+            );
+          body.email = contact;
+        }
+        try {
+          const res = await fetch(url, { method: "POST", headers, body: JSON.stringify(body) });
+          const reply = (await res.json().catch(() => ({}))) as { id?: string; error?: string };
+          if (!res.ok)
+            return err(`Feedback rejected (${res.status}${reply.error ? `: ${reply.error}` : ""}).`);
+          return ok(`Feedback sent${reply.id ? ` (id ${reply.id})` : ""}. Thanks!`);
+        } catch (e) {
+          return err(`Couldn't reach the feedback intake at ${url}: ${(e as Error).message}`);
         }
       },
     },

--- a/extensions/connector-core/src/tools.ts
+++ b/extensions/connector-core/src/tools.ts
@@ -18,9 +18,10 @@ function toContent(r: ToolResult) {
 }
 
 /** Register the Cotal tool surface (roster, inbox, send, dm, anycast, status, channels,
- *  channel_info, join, leave, spawn) on an MCP server. */
-export function registerCotalTools(server: McpServer, agent: MeshAgent, config: AgentConfig): void {
-  for (const spec of cotalToolSpecs(config)) {
+ *  channel_info, join, leave, spawn, feedback) on an MCP server. `source` names the
+ *  hosting connector for outgoing feedback. */
+export function registerCotalTools(server: McpServer, agent: MeshAgent, config: AgentConfig, source?: string): void {
+  for (const spec of cotalToolSpecs(config, source)) {
     if (spec.schema) {
       server.registerTool(
         spec.name,

--- a/extensions/connector-opencode/src/tools.ts
+++ b/extensions/connector-opencode/src/tools.ts
@@ -14,7 +14,7 @@ import { cotalToolSpecs, type MeshAgent, type AgentConfig } from "@cotal-ai/conn
 /** Build the cotal_* tool map wired to one mesh agent, rendered from the shared specs. */
 export function buildCotalTools(agent: MeshAgent, config: AgentConfig): Record<string, ToolDefinition> {
   const tools: Record<string, ToolDefinition> = {};
-  for (const spec of cotalToolSpecs(config)) {
+  for (const spec of cotalToolSpecs(config, "opencode")) {
     if (spec.name === "cotal_inbox") {
       // Read-only: this connector delivers + acks each turn, so the tool must never drain. Force
       // peek (still surfaces focus-mode recall), and reframe push-primary / pull-secondary. (norman)

--- a/implementations/cli/src/commands/feedback.ts
+++ b/implementations/cli/src/commands/feedback.ts
@@ -1,4 +1,5 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { execFileSync } from "node:child_process";
 import { randomUUID, timingSafeEqual } from "node:crypto";
 import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
@@ -49,7 +50,104 @@ class HttpError extends Error {
   }
 }
 
+/** Keyed beta intake (with a feedback key) / public hosted intake (without). Mirrors
+ *  connector-core's constants — the CLI can't import extensions (tier rule). */
+const FEEDBACK_URL = "https://broker.cotal.ai/v1/feedback";
+const PUBLIC_FEEDBACK_URL = "https://cotal.ai/v1/feedback";
+
+/** Dual-mode: `--keys` runs the self-hosted intake server; otherwise sends feedback. */
 export async function feedback(argv: string[]): Promise<void> {
+  if (argv.includes("--keys")) return serve(argv);
+  return send(argv);
+}
+
+async function send(argv: string[]): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args: argv,
+    allowPositionals: true,
+    options: {
+      type: { type: "string" },
+      details: { type: "string" },
+      severity: { type: "string" },
+      area: { type: "string" },
+      email: { type: "string" },
+      name: { type: "string" },
+      url: { type: "string" },
+      key: { type: "string" },
+    },
+  });
+
+  const summary = positionals[0];
+  if (!summary) {
+    console.error(
+      c.red(
+        'usage: cotal feedback "<summary>" [--type bug|idea|friction|praise|other] [--details …] [--severity low|medium|high] [--area …] [--email …] [--name …] [--url …] [--key …]',
+      ),
+    );
+    process.exit(1);
+  }
+  const type = (values.type ?? "other") as FeedbackType;
+  if (!TYPES.has(type)) {
+    console.error(c.red(`--type must be one of ${[...TYPES].join(", ")}`));
+    process.exit(1);
+  }
+  if (values.severity && !SEVERITIES.has(values.severity as FeedbackSeverity)) {
+    console.error(c.red(`--severity must be one of ${[...SEVERITIES].join(", ")}`));
+    process.exit(1);
+  }
+
+  const key = values.key ?? process.env.COTAL_FEEDBACK_KEY?.trim() ?? undefined;
+  const url = values.url ?? process.env.COTAL_FEEDBACK_URL?.trim() ?? (key ? FEEDBACK_URL : PUBLIC_FEEDBACK_URL);
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  const body: Record<string, unknown> = {
+    origin: "human",
+    type,
+    summary,
+    details: values.details,
+    severity: values.severity,
+    area: values.area,
+    name: values.name,
+    source: "cli",
+  };
+  if (key) {
+    headers.authorization = `Bearer ${key}`;
+  } else {
+    const email = values.email ?? process.env.COTAL_FEEDBACK_EMAIL?.trim() ?? gitEmail();
+    if (!email) {
+      console.error(
+        c.red(
+          "The public feedback intake needs a traceable contact email — pass --email or set COTAL_FEEDBACK_EMAIL.",
+        ),
+      );
+      process.exit(1);
+    }
+    body.email = email;
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(url, { method: "POST", headers, body: JSON.stringify(body) });
+  } catch (e) {
+    console.error(c.red(`Couldn't reach the feedback intake at ${url}: ${(e as Error).message}`));
+    process.exit(1);
+  }
+  const reply = (await res.json().catch(() => ({}))) as { id?: string; error?: string };
+  if (!res.ok) {
+    console.error(c.red(`Feedback rejected (${res.status}${reply.error ? `: ${reply.error}` : ""}).`));
+    process.exit(1);
+  }
+  console.log(`Feedback sent${reply.id ? ` — id ${c.cyan(reply.id)}` : ""}. Thanks!`);
+}
+
+function gitEmail(): string | undefined {
+  try {
+    return execFileSync("git", ["config", "user.email"], { encoding: "utf8" }).trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function serve(argv: string[]): Promise<void> {
   const { values } = parseArgs({
     args: argv,
     allowPositionals: true,

--- a/implementations/cli/src/index.ts
+++ b/implementations/cli/src/index.ts
@@ -77,7 +77,7 @@ const baseCommands: Command[] = [
     name: "feedback",
     group: "Mesh",
     summary:
-      "run authenticated beta feedback intake — feedback --keys <keys.json> --creds <creds> [--port <n>]",
+      'send feedback — feedback "<summary>" [--type <t>] [--email <e>] — or run the intake server: feedback --keys <keys.json> --creds <creds> [--port <n>]',
     run: feedback,
   },
 ];

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "smoke:membership:auth": "tsx packages/core/membership-auth.smoke.ts",
     "smoke:channels": "tsx packages/core/channels.smoke.ts",
     "smoke:channels:auth": "tsx packages/core/channels-auth.smoke.ts",
-    "smoke:attention": "tsx extensions/connector-core/attention.smoke.ts"
+    "smoke:attention": "tsx extensions/connector-core/attention.smoke.ts",
+    "smoke:feedback": "tsx extensions/connector-core/feedback.smoke.ts"
   },
   "dependencies": {
     "@cotal-ai/cli": "workspace:*",


### PR DESCRIPTION
Adds the missing sender side of the beta feedback system.

- **`cotal_feedback` tool** in connector-core, always exposed. With a `COTAL_FEEDBACK_KEY` it posts to the keyed broker intake (Bearer auth, unchanged contract); without one it posts to the public intake at `https://cotal.ai/v1/feedback`, which requires a contact email (`email` arg → `COTAL_FEEDBACK_EMAIL` → `git config user.email` → ask the user). `COTAL_FEEDBACK_URL` overrides either URL for self-hosted intakes.
- **`cotal feedback` sender mode**: `cotal feedback "<summary>" [--type …] [--email …]` with the same routing; the existing `--keys` intake-server mode is untouched.
- `source` is stamped automatically per connector (claude-code / codex / opencode / cli).
- Docs updated, changeset added.

Tested with `pnpm typecheck` (green) and a new `pnpm smoke:feedback` (12 checks: Bearer on keyed, email + no auth on keyless, refusal without email, 400 error surfacing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)