### PR TITLE
feat(core): spaces helpers, runtime contract, agent-file save/face

### DIFF
--- a/packages/core/src/agent-file.ts
+++ b/packages/core/src/agent-file.ts
@@ -10,7 +10,8 @@
  *   channels: [general]    # channels this agent subscribes to (read)
  *   publish: [general]     # channels this agent may post to (write); omit = same as channels
  *   model: opus            # optional CLI/model override
- *   face: sven             # optional avatar id for face-capable viewers
+ *   face: sven             # any unmodelled key is kept verbatim in AgentDef.meta — e.g. the
+ *                          #   OpenCode connector reads meta.face for its avatar viewer
  *   ---
  *   <the Markdown body is the persona — an appended system prompt>
  *
@@ -36,8 +37,9 @@ export interface AgentDef {
   publish?: string[];
   /** Model override handed to the agent CLI (e.g. `claude --model`). */
   model?: string;
-  /** Avatar id for face-capable viewers (e.g. the face-term animated terminal view). */
-  face?: string;
+  /** Frontmatter keys not modelled above, kept verbatim so a connector can read its own launcher
+   *  hints without core knowing about each one (e.g. the OpenCode face viewer's `face:` avatar id). */
+  meta?: Record<string, string>;
   /** Markdown body — the agent's persona / appended system prompt. */
   persona?: string;
 }
@@ -100,6 +102,12 @@ export function loadAgentFile(path: string): AgentDef {
   if (kind && kind !== "agent" && kind !== "endpoint")
     throw new Error(`agent file ${path}: "kind" must be "agent" or "endpoint"`);
 
+  // Sweep every scalar frontmatter key we don't model into meta, verbatim — connector hints
+  // (face, etc.) ride here so core stays ignorant of surface-specific keys.
+  const known = new Set(["name", "role", "kind", "description", "tags", "channels", "publish", "model"]);
+  const meta: Record<string, string> = {};
+  for (const [k, v] of Object.entries(fm)) if (!known.has(k) && typeof v === "string") meta[k] = v;
+
   return {
     name,
     role: str("role"),
@@ -109,7 +117,7 @@ export function loadAgentFile(path: string): AgentDef {
     channels: list("channels"),
     publish: list("publish"),
     model: str("model"),
-    face: str("face"),
+    meta: Object.keys(meta).length ? meta : undefined,
     persona: persona || undefined,
   };
 }
@@ -128,7 +136,7 @@ export function saveAgentFile(path: string, def: AgentDef): void {
   if (def.channels?.length) lines.push(`channels: [${def.channels.map(fmItem).join(", ")}]`);
   if (def.publish?.length) lines.push(`publish: [${def.publish.map(fmItem).join(", ")}]`);
   if (def.model) lines.push(`model: ${fmScalar(def.model)}`);
-  if (def.face) lines.push(`face: ${fmScalar(def.face)}`);
+  if (def.meta) for (const [k, v] of Object.entries(def.meta)) lines.push(`${k}: ${fmScalar(v)}`);
   lines.push("---");
   const body = def.persona ? `${def.persona.trim()}\n` : "";
   mkdirSync(dirname(path), { recursive: true });

--- a/packages/core/src/agent-file.ts
+++ b/packages/core/src/agent-file.ts
@@ -10,6 +10,7 @@
  *   channels: [general]    # channels this agent subscribes to (read)
  *   publish: [general]     # channels this agent may post to (write); omit = same as channels
  *   model: opus            # optional CLI/model override
+ *   face: sven             # optional avatar id for face-capable viewers
  *   ---
  *   <the Markdown body is the persona — an appended system prompt>
  *
@@ -18,8 +19,8 @@
  * session reads its own card from it. Part of the wire contract's onboarding
  * half, alongside the join link.
  */
-import { readFileSync } from "node:fs";
-import { isAbsolute, join, resolve } from "node:path";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import type { EndpointKind } from "./types.js";
 
 export interface AgentDef {
@@ -35,6 +36,8 @@ export interface AgentDef {
   publish?: string[];
   /** Model override handed to the agent CLI (e.g. `claude --model`). */
   model?: string;
+  /** Avatar id for face-capable viewers (e.g. the face-term animated terminal view). */
+  face?: string;
   /** Markdown body — the agent's persona / appended system prompt. */
   persona?: string;
 }
@@ -106,8 +109,30 @@ export function loadAgentFile(path: string): AgentDef {
     channels: list("channels"),
     publish: list("publish"),
     model: str("model"),
+    face: str("face"),
     persona: persona || undefined,
   };
+}
+
+/** Write an agent definition back to disk in the form {@link loadAgentFile} reads:
+ *  the set frontmatter fields followed by the persona body. Round-trips through the
+ *  parser; creates parent dirs. The runtime persona-definition path uses this to
+ *  persist a peer-defined agent as config. */
+export function saveAgentFile(path: string, def: AgentDef): void {
+  if (!def.name) throw new Error('saveAgentFile: "name" is required');
+  const lines = ["---", `name: ${def.name}`];
+  if (def.role) lines.push(`role: ${def.role}`);
+  if (def.kind) lines.push(`kind: ${def.kind}`);
+  if (def.description) lines.push(`description: ${def.description}`);
+  if (def.tags?.length) lines.push(`tags: [${def.tags.join(", ")}]`);
+  if (def.channels?.length) lines.push(`channels: [${def.channels.join(", ")}]`);
+  if (def.publish?.length) lines.push(`publish: [${def.publish.join(", ")}]`);
+  if (def.model) lines.push(`model: ${def.model}`);
+  if (def.face) lines.push(`face: ${def.face}`);
+  lines.push("---");
+  const body = def.persona ? `${def.persona.trim()}\n` : "";
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${lines.join("\n")}\n\n${body}`);
 }
 
 /** Resolve a name-or-path to an agent file. A path (absolute, contains a slash,

--- a/packages/core/src/agent-file.ts
+++ b/packages/core/src/agent-file.ts
@@ -120,19 +120,36 @@ export function loadAgentFile(path: string): AgentDef {
  *  persist a peer-defined agent as config. */
 export function saveAgentFile(path: string, def: AgentDef): void {
   if (!def.name) throw new Error('saveAgentFile: "name" is required');
-  const lines = ["---", `name: ${def.name}`];
-  if (def.role) lines.push(`role: ${def.role}`);
-  if (def.kind) lines.push(`kind: ${def.kind}`);
-  if (def.description) lines.push(`description: ${def.description}`);
-  if (def.tags?.length) lines.push(`tags: [${def.tags.join(", ")}]`);
-  if (def.channels?.length) lines.push(`channels: [${def.channels.join(", ")}]`);
-  if (def.publish?.length) lines.push(`publish: [${def.publish.join(", ")}]`);
-  if (def.model) lines.push(`model: ${def.model}`);
-  if (def.face) lines.push(`face: ${def.face}`);
+  const lines = ["---", `name: ${fmScalar(def.name)}`];
+  if (def.role) lines.push(`role: ${fmScalar(def.role)}`);
+  if (def.kind) lines.push(`kind: ${fmScalar(def.kind)}`);
+  if (def.description) lines.push(`description: ${fmScalar(def.description)}`);
+  if (def.tags?.length) lines.push(`tags: [${def.tags.map(fmItem).join(", ")}]`);
+  if (def.channels?.length) lines.push(`channels: [${def.channels.map(fmItem).join(", ")}]`);
+  if (def.publish?.length) lines.push(`publish: [${def.publish.map(fmItem).join(", ")}]`);
+  if (def.model) lines.push(`model: ${fmScalar(def.model)}`);
+  if (def.face) lines.push(`face: ${fmScalar(def.face)}`);
   lines.push("---");
   const body = def.persona ? `${def.persona.trim()}\n` : "";
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, `${lines.join("\n")}\n\n${body}`);
+}
+
+/** Render a frontmatter scalar so {@link loadAgentFile} reads it back unchanged. Quotes values
+ *  the parser would otherwise misread (a leading `[`, a `,`/`:`/`#`, edge whitespace, or empty);
+ *  throws on values the line-based format can't represent (a newline, or both quote styles). */
+function fmScalar(value: string): string {
+  if (/[\r\n]/.test(value)) throw new Error(`saveAgentFile: value cannot contain a newline: ${JSON.stringify(value)}`);
+  if (value !== "" && value === value.trim() && !/^[[]/.test(value) && !/[,:#"']/.test(value)) return value;
+  if (!value.includes('"')) return `"${value}"`;
+  if (!value.includes("'")) return `'${value}'`;
+  throw new Error(`saveAgentFile: value cannot contain both quote styles: ${JSON.stringify(value)}`);
+}
+
+/** A list item additionally cannot hold a comma — the parser splits on `,` before unquoting. */
+function fmItem(value: string): string {
+  if (value.includes(",")) throw new Error(`saveAgentFile: list item cannot contain a comma: ${JSON.stringify(value)}`);
+  return fmScalar(value);
 }
 
 /** Resolve a name-or-path to an agent file. A path (absolute, contains a slash,

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -71,6 +71,9 @@ import {
 
 export const DEFAULT_SERVER = "nats://127.0.0.1:4222";
 
+/** Space joined when none is given on the CLI (the `cotal-<space>` cmux tab, etc.). */
+export const DEFAULT_SPACE = "main";
+
 export interface EndpointOptions {
   /** The collaboration to join. */
   space: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,8 @@ export * from "./streams.js";
 export * from "./channels.js";
 export * from "./agent-file.js";
 export * from "./endpoint.js";
+export * from "./spaces.js";
 export * from "./connector.js";
 export * from "./command.js";
+export * from "./runtime.js";
 export * from "./registry.js";

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -28,6 +28,9 @@ export interface AttachSession {
 export interface AgentHandle {
   readonly name: string;
   readonly kind: RuntimeKind;
+  /** OS pid of the spawned child, when the backend owns a real process (pty/host); absent for
+   *  backends that don't (tmux/cmux attach to an externally-owned process). */
+  readonly pid?: number;
   status(): "running" | "exited";
   /** Tear the agent down. `graceful` (default) signals a clean exit (so the session
    *  leaves the mesh on its own) before ensuring the process/tab is gone; otherwise

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1,0 +1,63 @@
+import type { Extension } from "./registry.js";
+import type { LaunchSpec } from "./connector.js";
+
+/** Which backend a manager spawns through. Open-ended: `pty`/`tmux` ship with the
+ *  manager, others (e.g. `cmux`) are contributed by a {@link RuntimeProvider}. */
+export type RuntimeKind = string;
+
+/** A live attach onto a running agent's terminal — the stream `cotal attach`
+ *  (and, later, the browser console) consumes. PTY frames flow here directly,
+ *  never over the mesh. */
+export interface AttachSession {
+  readonly cols: number;
+  readonly rows: number;
+  /** Scrollback so a late attach sees output that already scrolled past. */
+  backlog(): Buffer;
+  /** Subscribe to live output; returns an unsubscribe fn. */
+  onData(fn: (chunk: Buffer) => void): () => void;
+  /** Fires when the underlying process exits; returns an unsubscribe fn. */
+  onExit(fn: () => void): () => void;
+  /** Forward keystrokes to the process. */
+  write(data: string): void;
+  /** Resize the pseudo-terminal. */
+  resize(cols: number, rows: number): void;
+}
+
+/** An OS handle on one spawned agent — the manager owns this to *control* the
+ *  process (the mesh observes its presence separately). */
+export interface AgentHandle {
+  readonly name: string;
+  readonly kind: RuntimeKind;
+  status(): "running" | "exited";
+  /** Tear the agent down. `graceful` (default) signals a clean exit (so the session
+   *  leaves the mesh on its own) before ensuring the process/tab is gone; otherwise
+   *  it's a hard, immediate kill. */
+  stop(opts?: { graceful?: boolean }): void;
+  interrupt(): void;
+  /** Open a live attach. Throws on backends that can't stream (e.g. tmux/cmux, which
+   *  you attach to natively). */
+  attach(): AttachSession;
+}
+
+/** A pluggable agent backend — `pty` (default) owns a real pseudo-terminal; `tmux`
+ *  drives a multiplexer pane; `cmux` (an integration) opens a tab. */
+export interface Runtime {
+  readonly kind: RuntimeKind;
+  spawn(name: string, spec: LaunchSpec, cwd: string): AgentHandle;
+}
+
+/**
+ * A bridge that contributes one runtime backend — an {@link Extension} of kind
+ * `"runtime"`. `name` is the backend it provides (e.g. `"cmux"`), the key the
+ * manager resolves by. Providers self-register on import (like {@link Connector}),
+ * so the manager core stays ignorant of which runtimes exist beyond its built-ins.
+ */
+export interface RuntimeProvider extends Extension {
+  readonly kind: "runtime";
+  readonly name: RuntimeKind;
+  /** Whether this backend is reachable right now (e.g. the cmux app is running). */
+  available(): boolean;
+  /** Build a runtime instance. `session` names a per-space multiplexer session
+   *  when the backend uses one (tmux); others may ignore it. */
+  create(opts: { session: string }): Runtime;
+}

--- a/packages/core/src/spaces.ts
+++ b/packages/core/src/spaces.ts
@@ -1,0 +1,105 @@
+// listSpaces — discover the spaces present on a NATS server, with light per-space stats.
+// A space materializes as JetStream streams (CHAT_/DM_/TASK_<space>) plus a presence KV bucket
+// (cotal_presence_<space>); we read those names back to enumerate spaces. This works on an
+// open/dev mesh — one server, every space's streams visible to a bare connection. Under auth a
+// server hosts a single account/space, so this is really an open-mode admin capability.
+
+import { connect, credsAuthenticator } from "@nats-io/transport-node";
+import { jetstreamManager } from "@nats-io/jetstream";
+import { Kvm } from "@nats-io/kv";
+import { DEFAULT_SERVER } from "./endpoint.js";
+import { parseSubject, chatStream, dmStream, taskStream, presenceBucket } from "./subjects.js";
+
+/** One row of the space overview. */
+export interface SpaceInfo {
+  space: string;
+  agents: number; // presence KV entries (≈ agents currently present)
+  channels: number; // distinct chat channels with backlog
+  messages: number; // total chat messages
+}
+
+export interface ListSpacesOptions {
+  servers?: string;
+  creds?: string;
+  timeoutMs?: number;
+}
+
+/** Enumerate spaces by reading back the per-space chat streams + presence buckets. Opens a
+ *  short-lived connection (bare, or with `creds`) and closes it. Per-space stats are best-effort:
+ *  a stream/bucket that can't be inspected just leaves its counts at 0. */
+export async function listSpaces(opts: ListSpacesOptions = {}): Promise<SpaceInfo[]> {
+  const nc = await connect({
+    servers: opts.servers ?? DEFAULT_SERVER,
+    timeout: opts.timeoutMs ?? 2000,
+    reconnect: false,
+    maxReconnectAttempts: 0,
+    ...(opts.creds ? { authenticator: credsAuthenticator(new TextEncoder().encode(opts.creds)) } : {}),
+  });
+  try {
+    const jsm = await jetstreamManager(nc);
+    const bySpace = new Map<string, SpaceInfo>();
+    const get = (space: string): SpaceInfo => {
+      let s = bySpace.get(space);
+      if (!s) bySpace.set(space, (s = { space, agents: 0, channels: 0, messages: 0 }));
+      return s;
+    };
+
+    // Chat stream per space → message total + channel count (same subject-breakdown parse as
+    // endpoint.listChannels()).
+    for await (const name of jsm.streams.names()) {
+      const m = /^CHAT_(.+)$/.exec(name);
+      if (!m) continue;
+      const s = get(m[1]);
+      try {
+        const info = await jsm.streams.info(name, { subjects_filter: ">" });
+        s.messages = info.state.messages;
+        const chans = new Set<string>();
+        for (const subject of Object.keys(info.state.subjects ?? {})) {
+          const p = parseSubject(subject);
+          if (p?.kind === "chat") chans.add(p.rest);
+        }
+        s.channels = chans.size;
+      } catch {
+        /* leave stats at 0 if the stream can't be inspected */
+      }
+    }
+
+    // Presence KV per space → agents present.
+    try {
+      for await (const st of new Kvm(nc).list()) {
+        const m = /^cotal_presence_(.+)$/.exec(st.bucket);
+        if (m) get(m[1]).agents = st.values;
+      }
+    } catch {
+      /* no KV access (restricted creds) — leave agent counts at 0 */
+    }
+
+    return [...bySpace.values()].sort((a, b) => a.space.localeCompare(b.space));
+  } finally {
+    await nc.close();
+  }
+}
+
+/** Tear down a space — delete its chat/DM/task streams and presence KV bucket. Irreversible; all
+ *  history + presence for the space is gone. Open mode, or a cred allowing STREAM.DELETE. Mirrors
+ *  the smoke-test cleanup. Not-found streams are ignored (idempotent). */
+export async function deleteSpace(opts: { servers?: string; creds?: string; space: string }): Promise<void> {
+  const nc = await connect({
+    servers: opts.servers ?? DEFAULT_SERVER,
+    reconnect: false,
+    maxReconnectAttempts: 0,
+    ...(opts.creds ? { authenticator: credsAuthenticator(new TextEncoder().encode(opts.creds)) } : {}),
+  });
+  try {
+    const jsm = await jetstreamManager(nc);
+    const streams = [
+      chatStream(opts.space),
+      dmStream(opts.space),
+      taskStream(opts.space),
+      `KV_${presenceBucket(opts.space)}`,
+    ];
+    for (const s of streams) await jsm.streams.delete(s).catch(() => {});
+  } finally {
+    await nc.close();
+  }
+}

--- a/packages/core/src/spaces.ts
+++ b/packages/core/src/spaces.ts
@@ -8,7 +8,7 @@ import { connect, credsAuthenticator } from "@nats-io/transport-node";
 import { jetstreamManager } from "@nats-io/jetstream";
 import { Kvm } from "@nats-io/kv";
 import { DEFAULT_SERVER } from "./endpoint.js";
-import { parseSubject, chatStream, dmStream, taskStream, presenceBucket } from "./subjects.js";
+import { parseSubject, chatStream, dmStream, taskStream, presenceBucket, channelBucket } from "./subjects.js";
 
 /** One row of the space overview. */
 export interface SpaceInfo {
@@ -80,9 +80,9 @@ export async function listSpaces(opts: ListSpacesOptions = {}): Promise<SpaceInf
   }
 }
 
-/** Tear down a space — delete its chat/DM/task streams and presence KV bucket. Irreversible; all
- *  history + presence for the space is gone. Open mode, or a cred allowing STREAM.DELETE. Mirrors
- *  the smoke-test cleanup. Not-found streams are ignored (idempotent). */
+/** Tear down a space — delete its chat/DM/task streams plus the presence and channel-registry KV
+ *  buckets. Irreversible; all history, presence, and channel config for the space is gone. Open
+ *  mode, or a cred allowing STREAM.DELETE. Not-found streams are ignored (idempotent). */
 export async function deleteSpace(opts: { servers?: string; creds?: string; space: string }): Promise<void> {
   const nc = await connect({
     servers: opts.servers ?? DEFAULT_SERVER,
@@ -97,6 +97,7 @@ export async function deleteSpace(opts: { servers?: string; creds?: string; spac
       dmStream(opts.space),
       taskStream(opts.space),
       `KV_${presenceBucket(opts.space)}`,
+      `KV_${channelBucket(opts.space)}`,
     ];
     for (const s of streams) await jsm.streams.delete(s).catch(() => {});
   } finally {


### PR DESCRIPTION
**Stack 1/6** — splits the old #8 (`docs/spaces`) into reviewable, independently-green PRs. Base: `main`.

Pure protocol additions, no UI:
- `spaces.ts` — `listSpaces` / `deleteSpace`
- `runtime.ts` — `Runtime` / `RuntimeProvider` extension contract (moved out of the manager; consumed by PR 3)
- `agent-file.ts` — `saveAgentFile` + optional `face:` frontmatter key
- `endpoint.ts` — `DEFAULT_SPACE = "main"`
- core `index.ts` exports

`pnpm typecheck` + `pnpm smoke` green on its own. No dependency on the rest of the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)