### PR TITLE
feat(connector): cotal_persona + cotal_despawn

### DIFF
--- a/extensions/connector-core/src/agent.ts
+++ b/extensions/connector-core/src/agent.ts
@@ -343,6 +343,35 @@ export class MeshAgent extends EventEmitter {
     return this.ep.requestControl("manager", { op: "start", args: { name, role } });
   }
 
+  /** Ask the manager to tear a teammate down (its `stop` op). Graceful by default —
+   *  the session is told to exit cleanly (so it leaves the mesh) before the
+   *  process/tab is closed; `graceful:false` is a hard, immediate kill. */
+  async despawn(name: string, opts?: { graceful?: boolean }): Promise<ControlReply> {
+    this.assertConnected();
+    return this.ep.requestControl("manager", {
+      op: "stop",
+      args: { name, graceful: opts?.graceful ?? true },
+    });
+  }
+
+  /** Define a persona and persist it as config (the manager's `definePersona` op writes
+   *  .cotal/agents/<name>.md). On success, announce it on the channel — the "send it out"
+   *  half — so peers see the new persona; `spawn(name)` then launches an agent wearing it. */
+  async definePersona(def: {
+    name: string;
+    prompt: string;
+    role?: string;
+    model?: string;
+  }): Promise<ControlReply> {
+    this.assertConnected();
+    const reply = await this.ep.requestControl("manager", {
+      op: "definePersona",
+      args: { name: def.name, role: def.role, model: def.model, persona: def.prompt },
+    });
+    if (reply.ok) await this.send(`persona \`${def.name}\` is now available — spawn it to bring it online`);
+    return reply;
+  }
+
   // ---- presence ------------------------------------------------------------
 
   /** The full roster, including ourselves. */

--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -422,5 +422,56 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
         }
       },
     },
+    {
+      name: "cotal_despawn",
+      title: "Cotal: stop a teammate",
+      description:
+        "Ask the manager to tear a teammate down — it leaves the mesh and its process/tab is closed. Graceful by default (the session exits cleanly first); pass graceful:false for a hard, immediate kill. The inverse of cotal_spawn.",
+      schema: {
+        name: z.string().describe("Name of the peer to stop."),
+        graceful: z
+          .boolean()
+          .optional()
+          .describe("Default true: let the session exit cleanly. false = hard kill."),
+      },
+      async run(agent, _config, { name, graceful }: { name: string; graceful?: boolean }) {
+        try {
+          const reply = await agent.despawn(name, { graceful });
+          if (!reply.ok) return err(`Couldn't despawn ${name}: ${reply.error ?? "manager refused"}`);
+          return ok(`Stopping ${name}${graceful === false ? " (hard)" : ""} — it will leave the roster shortly.`);
+        } catch (e) {
+          return err(
+            `Couldn't despawn ${name}: no manager reachable (${(e as Error).message}). Is the manager running?`,
+          );
+        }
+      },
+    },
+    {
+      name: "cotal_persona",
+      title: "Cotal: define a persona",
+      description:
+        "Define a new persona and save it as config (the manager writes .cotal/agents/<name>.md), then announce it on the mesh. Afterwards cotal_spawn(name) launches a real agent wearing this persona/model. Use to grow the team with a custom role you describe on the fly.",
+      schema: {
+        name: z.string().describe("Unique name for the persona (also the spawn name)."),
+        prompt: z.string().describe("The persona — an appended system prompt describing who this agent is."),
+        role: z.string().optional().describe("Optional role label (e.g. reviewer, scout)."),
+        model: z.string().optional().describe("Optional model override (e.g. opus, sonnet)."),
+      },
+      async run(
+        agent,
+        _config,
+        { name, prompt, role, model }: { name: string; prompt: string; role?: string; model?: string },
+      ) {
+        try {
+          const reply = await agent.definePersona({ name, prompt, role, model });
+          if (!reply.ok) return err(`Couldn't define ${name}: ${reply.error ?? "manager refused"}`);
+          return ok(`Persona \`${name}\` saved — spawn it with cotal_spawn(name="${name}") to bring it online.`);
+        } catch (e) {
+          return err(
+            `Couldn't define ${name}: no manager reachable (${(e as Error).message}). Is the manager running?`,
+          );
+        }
+      },
+    },
   ];
 }

--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -452,10 +452,13 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
       description:
         "Define a new persona and save it as config (the manager writes .cotal/agents/<name>.md), then announce it on the mesh. Afterwards cotal_spawn(name) launches a real agent wearing this persona/model. Use to grow the team with a custom role you describe on the fly.",
       schema: {
-        name: z.string().describe("Unique name for the persona (also the spawn name)."),
-        prompt: z.string().describe("The persona — an appended system prompt describing who this agent is."),
-        role: z.string().optional().describe("Optional role label (e.g. reviewer, scout)."),
-        model: z.string().optional().describe("Optional model override (e.g. opus, sonnet)."),
+        name: z
+          .string()
+          .regex(/^[A-Za-z0-9_-]+$/, "letters, digits, _ or - only")
+          .describe("Unique name for the persona (also the spawn name): letters, digits, _ or -."),
+        prompt: z.string().max(10_000).describe("The persona — an appended system prompt describing who this agent is."),
+        role: z.string().max(120).optional().describe("Optional role label (e.g. reviewer, scout)."),
+        model: z.string().max(120).optional().describe("Optional model override (e.g. opus, sonnet)."),
       },
       async run(
         agent,

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -150,9 +150,19 @@ export class Manager {
     }
   }
 
+  /** Agent names become `.cotal/agents/<name>.md` paths and mesh identities, so they must be bare
+   *  tokens, never a path — blocks traversal / arbitrary writes from a model-supplied name. */
+  private nameError(name: string): string | undefined {
+    return /^[A-Za-z0-9_-]+$/.test(name)
+      ? undefined
+      : `unsafe name ${JSON.stringify(name)} (allowed: letters, digits, _ -)`;
+  }
+
   private async opStart(args: Record<string, unknown>): Promise<ControlReply> {
     const name = String(args.name ?? "").trim();
     if (!name) return { ok: false, error: "name required" };
+    const nameErr = this.nameError(name);
+    if (nameErr) return { ok: false, error: nameErr };
     if (this.agents.has(name)) return { ok: false, error: `agent "${name}" already running` };
     const agent = args.agent ? String(args.agent) : "cotal";
 
@@ -232,6 +242,8 @@ export class Manager {
   private opDefinePersona(args: Record<string, unknown>): ControlReply {
     const name = String(args.name ?? "").trim();
     if (!name) return { ok: false, error: "name required" };
+    const nameErr = this.nameError(name);
+    if (nameErr) return { ok: false, error: nameErr };
     const persona = String(args.persona ?? "").trim();
     if (!persona) return { ok: false, error: "persona required" };
     const def: AgentDef = {

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -10,8 +10,9 @@ import {
   newIdentity,
   provisionAgent,
   registry,
+  saveAgentFile,
 } from "@cotal-ai/core";
-import type { Connector, ControlReply, ControlRequest, SpaceAuth } from "@cotal-ai/core";
+import type { AgentDef, Connector, ControlReply, ControlRequest, SpaceAuth } from "@cotal-ai/core";
 import {
   createRuntime,
   findWorkspaceRoot,
@@ -133,6 +134,8 @@ export class Manager {
         return this.opStart(args);
       case "stop":
         return this.opStop(args);
+      case "definePersona":
+        return this.opDefinePersona(args);
       case "attach":
         return this.opAttach(args);
       case "ps":
@@ -218,9 +221,32 @@ export class Manager {
     const name = String(args.name ?? "").trim();
     const a = this.agents.get(name);
     if (!a) return { ok: false, error: `no agent "${name}"` };
-    a.handle.stop();
+    const graceful = args.graceful !== false;
+    a.handle.stop({ graceful });
     this.agents.delete(name);
-    return { ok: true, data: { name, stopped: true } };
+    return { ok: true, data: { name, stopped: true, graceful } };
+  }
+
+  /** Persist a peer-defined persona as config. After this, `start name` auto-discovers
+   *  .cotal/agents/<name>.md and the connector applies its persona/model at spawn. */
+  private opDefinePersona(args: Record<string, unknown>): ControlReply {
+    const name = String(args.name ?? "").trim();
+    if (!name) return { ok: false, error: "name required" };
+    const persona = String(args.persona ?? "").trim();
+    if (!persona) return { ok: false, error: "persona required" };
+    const def: AgentDef = {
+      name,
+      role: args.role ? String(args.role) : undefined,
+      model: args.model ? String(args.model) : undefined,
+      persona,
+    };
+    const path = agentFilePath(this.workspaceRoot, name);
+    try {
+      saveAgentFile(path, def);
+    } catch (e) {
+      return { ok: false, error: (e as Error).message };
+    }
+    return { ok: true, data: { name, path } };
   }
 
   private opAttach(args: Record<string, unknown>): ControlReply {


### PR DESCRIPTION
**Stack 4/6** — stacks on stack 3. Base: `feat/cmux-runtime-onboarding`.

- `cotal_persona` — define a persona; the manager persists `.cotal/agents/<name>.md` and announces it; `cotal_spawn` then brings it online.
- `cotal_despawn` — tear a teammate down (graceful by default, hard on request).
- `MeshAgent.definePersona`/`despawn`; manager `opDefinePersona` + graceful stop.

**Rebased onto the post-#12 tool set** — the two new specs are appended on top of `cotal_feedback` + the `source` param, so the feedback sender is untouched (its smoke still passes).

`pnpm typecheck` + `pnpm smoke:feedback` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)