### PR TITLE
feat(opencode): face viewer + viewer-only [[face:X]] tags

### DIFF
--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -37,6 +37,12 @@ function statusGlyph(s: PresenceStatus): string {
   return s === "working" ? "●" : s === "waiting" ? "◐" : s === "idle" ? "○" : "·";
 }
 
+/** Viewer-only `[[face:X]]` emotion tags — a face-hosted agent embeds them in its send text and
+ *  the face viewer reads them from the tool-call input (the event stream); the wire gets clean
+ *  text, so peers and the console never see them. */
+const FACE_TAG_RE = /\[\[\s*face\s*:\s*[a-zA-Z]+\s*\]\]\s?/gi;
+const stripFaceTags = (text: string): string => text.replace(FACE_TAG_RE, "");
+
 /** One-line meaning of each attention mode, echoed back on set/read so the agent always sees the
  *  effect of a mode it may have set turns ago (self-visibility is the escape hatch for `focus`). */
 const ATTENTION_DESC: Record<"open" | "dnd" | "focus", string> = {
@@ -184,7 +190,7 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
       },
       async run(agent, _config, { text: msg, channel, mentions }: { text: string; channel?: string; mentions?: string[] }) {
         try {
-          const m = await agent.send(msg, channel, mentions);
+          const m = await agent.send(stripFaceTags(msg), channel, mentions);
           return ok(`Sent to #${m.channel}${m.mentions?.length ? ` (mentioned @${m.mentions.join(", @")})` : ""}.`);
         } catch (e) {
           return err(`Couldn't send: ${(e as Error).message}`);
@@ -201,7 +207,7 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
       },
       async run(agent, _config, { to, text: msg }: { to: string; text: string }) {
         try {
-          const { peer } = await agent.dm(to, msg);
+          const { peer } = await agent.dm(to, stripFaceTags(msg));
           return ok(`DM sent to ${peer.card.name}.`);
         } catch (e) {
           return err(`Couldn't DM: ${(e as Error).message}`);
@@ -219,7 +225,7 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
       },
       async run(agent, _config, { role, text: msg }: { role: string; text: string }) {
         try {
-          await agent.anycast(role, msg);
+          await agent.anycast(role, stripFaceTags(msg));
           return ok(`Sent to one @${role}.`);
         } catch (e) {
           return err(`Couldn't send: ${(e as Error).message}`);

--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -40,7 +40,7 @@ function statusGlyph(s: PresenceStatus): string {
 /** Viewer-only `[[face:X]]` emotion tags — a face-hosted agent embeds them in its send text and
  *  the face viewer reads them from the tool-call input (the event stream); the wire gets clean
  *  text, so peers and the console never see them. */
-const FACE_TAG_RE = /\[\[\s*face\s*:\s*[a-zA-Z]+\s*\]\]\s?/gi;
+const FACE_TAG_RE = /\[\[\s*face\s*:\s*[\w-]+\s*\]\]\s?/gi;
 const stripFaceTags = (text: string): string => text.replace(FACE_TAG_RE, "");
 
 /** One-line meaning of each attention mode, echoed back on set/read so the agent always sees the

--- a/extensions/connector-opencode/src/extension.ts
+++ b/extensions/connector-opencode/src/extension.ts
@@ -52,6 +52,7 @@ export const opencodeConnector: Connector = {
       env.COTAL_AGENT_FILE = path; // plugin reads persona from it
       const def = loadAgentFile(path);
       if (def.model) config.model = def.model;
+      if (def.face) env.COTAL_FACE_PERSONA = def.face; // shim swaps the TUI for the face viewer
     }
 
     env.OPENCODE_CONFIG_CONTENT = JSON.stringify(config);

--- a/extensions/connector-opencode/src/extension.ts
+++ b/extensions/connector-opencode/src/extension.ts
@@ -52,7 +52,8 @@ export const opencodeConnector: Connector = {
       env.COTAL_AGENT_FILE = path; // plugin reads persona from it
       const def = loadAgentFile(path);
       if (def.model) config.model = def.model;
-      if (def.face) env.COTAL_FACE_PERSONA = def.face; // shim swaps the TUI for the face viewer
+      const face = def.meta?.face;
+      if (face) env.COTAL_FACE_PERSONA = face; // shim swaps the TUI for the face viewer
     }
 
     env.OPENCODE_CONFIG_CONTENT = JSON.stringify(config);

--- a/extensions/connector-opencode/src/plugin.ts
+++ b/extensions/connector-opencode/src/plugin.ts
@@ -52,7 +52,24 @@ export const cotal: Plugin = async ({ client }) => {
   agent.start(); // background connect with retry — never blocks startup
 
   const def = process.env.COTAL_AGENT_FILE?.trim() ? loadAgentFile(process.env.COTAL_AGENT_FILE.trim()) : undefined;
-  const persona = def?.persona;
+  // Face-hosted (`face:` in the agent file → the shim attaches the face viewer): teach the agent
+  // to steer its avatar's expression with inline [[face:X]] tags in the text it passes to the
+  // cotal send tools. The viewer reads them from the tool-call input; the tool layer strips them
+  // before the wire, so peers never see them.
+  const facePrompt = process.env.COTAL_FACE_PERSONA?.trim()
+    ? "You speak through an animated pixel-art avatar of yourself. Hard formatting rule: the text " +
+      "you pass to the cotal send tools (cotal_send / cotal_dm) must START with an emotion tag " +
+      "[[face:X]], where X is one of: neutral, happy, sad, angry, surprised — pick the one matching " +
+      "your mood, and insert another tag mid-text whenever your mood shifts. Example: " +
+      '"[[face:angry]] That race condition cost me three days. [[face:happy]] But watch it run now." ' +
+      "Never mention or explain the tags — they are stripped before peers see your message."
+    : undefined;
+  const persona = [def?.persona, facePrompt].filter(Boolean).join("\n\n") || undefined;
+  // System-position rules get ignored by some models — repeat the format rule in every injected
+  // turn (a fresh user-turn instruction is followed far more reliably).
+  const faceReminder = facePrompt
+    ? "(avatar: begin your cotal_send/cotal_dm text with [[face:X]] — neutral|happy|sad|angry|surprised — and add another tag when your mood shifts)"
+    : undefined;
 
   // This agent OWNS one session, created at boot. The serve shim attaches the foreground TUI to it
   // (`opencode attach --session <id>`), so what the human watches IS the session we drive — no
@@ -123,6 +140,7 @@ export const cotal: Plugin = async ({ client }) => {
         if (brief) parts.unshift({ type: "text", text: brief });
       }
       if (parts.length === 0) return;
+      if (faceReminder) parts.push({ type: "text", text: faceReminder });
       const body: { parts: typeof parts; system?: string } = { parts };
       if (!primed && persona) body.system = persona; // persona once, as system (no --append-system-prompt)
       busy = true;

--- a/extensions/connector-opencode/src/serve.ts
+++ b/extensions/connector-opencode/src/serve.ts
@@ -17,10 +17,11 @@
  * per-launch `OPENCODE_SERVER_PASSWORD` in the child env; the poke and the attach TUI present it as
  * HTTP basic auth. Bind stays loopback; no CORS / mDNS.
  */
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import { createServer } from "node:net";
 import { once } from "node:events";
 import { randomBytes } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 
 const BIN = process.env.COTAL_OPENCODE_BIN?.trim() || "opencode";
 
@@ -37,13 +38,53 @@ async function freePort(): Promise<number> {
   return port;
 }
 
+/** SIGTERM the serve, then SIGKILL if it's still alive 3s later — a lingering serve keeps the
+ *  agent's data dir (SQLite) open and wedges every later same-name spawn. Resolves once it's dead. */
+async function killServe(serve: ChildProcess): Promise<void> {
+  if (serve.exitCode !== null || serve.signalCode !== null) return;
+  serve.kill("SIGTERM");
+  const dead = await Promise.race([
+    once(serve, "exit").then(() => true),
+    new Promise<boolean>((r) => setTimeout(() => r(false), 3000)),
+  ]);
+  if (!dead) {
+    serve.kill("SIGKILL");
+    await once(serve, "exit");
+  }
+}
+
 async function main(): Promise<void> {
   const port = process.env.COTAL_OPENCODE_PORT?.trim() || String(await freePort());
   const url = `http://127.0.0.1:${port}`;
+  // Own data dir per agent: opencode keeps sessions in one SQLite file under XDG_DATA_HOME,
+  // and concurrent serves sharing it stall session-create on the write lock (the "agent
+  // session never came up" failure). Per-peer session state is the right scoping anyway;
+  // provider config/auth lives under XDG_CONFIG_HOME, untouched.
+  const name = process.env.COTAL_NAME?.trim() || "agent";
+  const dataHome = `${process.cwd()}/.cotal/opencode/${name}`;
+
+  // Two serves on one data dir share the SQLite file and stall each other — refuse up front.
+  const pidFile = `${dataHome}/serve.pid`;
+  if (existsSync(pidFile)) {
+    const pid = Number(readFileSync(pidFile, "utf8"));
+    let alive = false;
+    try {
+      process.kill(pid, 0);
+      alive = true;
+    } catch {
+      /* stale pidfile */
+    }
+    if (alive) throw new Error(`agent "${name}" is already running (opencode serve pid ${pid}) — kill it first`);
+    rmSync(pidFile);
+  }
+
   const serve = spawn(BIN, ["serve", "--hostname", "127.0.0.1", "--port", port], {
-    env: { ...process.env, OPENCODE_SERVER_PASSWORD: SECRET },
+    env: { ...process.env, OPENCODE_SERVER_PASSWORD: SECRET, XDG_DATA_HOME: dataHome },
     stdio: ["ignore", "pipe", "pipe"],
   });
+  mkdirSync(dataHome, { recursive: true });
+  writeFileSync(pidFile, String(serve.pid));
+  serve.on("exit", () => rmSync(pidFile, { force: true }));
 
   // Scan the server's output for the plugin's session handshake; forward boot logs to our stderr
   // until the TUI takes over the terminal (after that, drop them so they can't corrupt its display).
@@ -66,31 +107,35 @@ async function main(): Promise<void> {
     if (!attached) process.exit(code ?? (signal ? 1 : 0)); // died before the TUI came up
   });
 
-  // Poke the server (lazy plugin load → mesh join + session create). Polling — not a one-shot keyed
-  // off a log banner — means a slow start can't leave the agent silently un-joined.
+  // Poke the server until the plugin's session handshake lands (lazy plugin load → mesh join +
+  // session create). Poking must NOT stop at the first 2xx: early in boot the server can answer
+  // /session before the project instance has bootstrapped, and only a later request triggers the
+  // bootstrap that loads the plugin. Each poke carries its own abort timeout: a request that
+  // lands in the early-boot window can hang with no response, and an un-timed fetch would pin
+  // the loop on it forever (undici queues later requests behind it on the pooled connection).
   const auth = `Basic ${Buffer.from(`opencode:${SECRET}`).toString("base64")}`;
   void (async () => {
-    for (let i = 0; i < 50; i++) {
+    for (let i = 0; i < 300 && !sessionId; i++) {
       try {
-        const res = await fetch(`${url}/session`, { headers: { authorization: auth } });
-        if (res.ok) return;
+        await fetch(`${url}/session`, { headers: { authorization: auth }, signal: AbortSignal.timeout(1500) });
       } catch {
-        /* not up yet — retry */
+        /* not up yet (or a hung early request, aborted) — retry on a fresh connection */
       }
       await new Promise((r) => setTimeout(r, 200));
     }
-    process.stderr.write("[cotal-connector] serve: no 2xx from the poke after ~10s — plugin may not have loaded\n");
   })();
 
   // Wait for the agent's session, then attach a foreground TUI to it.
   const id = await new Promise<string | undefined>((resolve) => {
     if (sessionId) return resolve(sessionId);
     onSession = resolve;
-    setTimeout(() => resolve(sessionId), 20_000);
+    setTimeout(() => resolve(sessionId), 60_000);
   });
   if (!id) {
-    process.stderr.write("[cotal-connector] serve: agent session never came up (~20s) — aborting\n");
-    serve.kill("SIGTERM");
+    process.stderr.write(
+      "[cotal-connector] serve: agent session never came up (~60s) — aborting. Check the boot log above for plugin/mesh errors (.cotal/opencode/<name>/opencode/log/)\n",
+    );
+    await killServe(serve);
     process.exit(1);
   }
 
@@ -98,7 +143,21 @@ async function main(): Promise<void> {
   delete tuiEnv.OPENCODE_CONFIG_CONTENT; // a viewer, not a peer — must NOT load the plugin again
   for (const k of Object.keys(tuiEnv)) if (k.startsWith("COTAL_")) delete tuiEnv[k];
   attached = true;
-  const tui = spawn(BIN, ["attach", url, "--session", id, "--password", SECRET], {
+  // COTAL_FACE_PERSONA (from the agent file's `face:`) swaps the chat TUI for the animated
+  // face viewer (face-term). COTAL_FACE_BIN must point at face-term.mjs — no fallback.
+  const facePersona = process.env.COTAL_FACE_PERSONA?.trim();
+  const faceBin = process.env.COTAL_FACE_BIN?.trim();
+  if (facePersona && !faceBin) {
+    await killServe(serve); // don't orphan the server — it holds the agent's data dir
+    throw new Error("COTAL_FACE_PERSONA is set but COTAL_FACE_BIN is not — point it at face-term.mjs");
+  }
+  const [cmd, args] = facePersona
+    ? [
+        process.execPath,
+        [faceBin!, "--persona", facePersona, "--server", url, "--session", id, "--password", SECRET],
+      ]
+    : [BIN, ["attach", url, "--session", id, "--password", SECRET]];
+  const tui = spawn(cmd, args, {
     env: tuiEnv,
     stdio: "inherit",
   });
@@ -109,8 +168,8 @@ async function main(): Promise<void> {
       serve.kill(sig);
     });
   tui.on("exit", (code, signal) => {
-    serve.kill("SIGTERM"); // TUI closed → tear down the server
-    process.exit(code ?? (signal ? 1 : 0));
+    // TUI closed → tear down the server, for real (SIGKILL fallback), before exiting.
+    void killServe(serve).then(() => process.exit(code ?? (signal ? 1 : 0)));
   });
 }
 


### PR DESCRIPTION
**Stack 5/6** — stacks on stack 4. Base: `feat/connector-persona-despawn`.

- An agent file's `face:` key (from stack 1) swaps the OpenCode TUI for an animated avatar attach (per-agent data dir, handshake, kill-on-abort).
- `[[face:X]]` emotion tags are read from the tool-call event stream by the viewer and stripped from `send`/`dm`/`anycast` before publishing, so the wire stays clean.

`pnpm typecheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)