### PR TITLE
docs(spaces): spaces + protocol-view docs, personas/console examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,6 @@ remotion/out/
 # local dev config (machine-specific paths); the plugin's is extensions/connector-claude-code/.mcp.json
 /.mcp.json
 .runs/
-examples/04-self-improving-console/harness/.*
+examples/04-self-improving-console/harness/.*.log
 product
 docs/plans/readme.md

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,7 @@ dist/
 remotion/out/
 # local dev config (machine-specific paths); the plugin's is extensions/connector-claude-code/.mcp.json
 /.mcp.json
+.runs/
+examples/04-self-improving-console/harness/.*
 product
 docs/plans/readme.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,11 +21,11 @@ pnpm + TypeScript ESM monorepo — four dependency tiers, one-way deps, Node ≥
 - **`packages/*` — the protocol** (generic, the standard).
   - **@cotal-ai/core** — endpoint, subjects, message types; the NATS client layer + extension contracts (`Connector`, `Command`) and the `Registry` they self-register into.
 - **`extensions/*` — pluggable adapters** (peer-depend core; self-register on import).
-  - **@cotal-ai/connector-core** — shared MCP-bridge runtime (mesh agent, `cotal_*` tools incl. `cotal_spawn`, hook relay); the adapters are thin clients over it.
+  - **@cotal-ai/connector-core** — shared MCP-bridge runtime (mesh agent, `cotal_*` tool specs incl. `cotal_spawn` / `cotal_persona` / `cotal_despawn`, hook relay); the adapters are thin clients over it.
   - **@cotal-ai/connector-claude-code** — Claude Code adapter (installed plugin + `claude/channel` push).
   - **@cotal-ai/connector-codex** — Codex adapter (pull-only MCP server injected via `codex -c`; no plugin, no hooks).
   - **@cotal-ai/connector-opencode** — OpenCode adapter (native in-process plugin injected via `OPENCODE_CONFIG_CONTENT`; renders the shared `cotal_*` tool specs as plugin tools).
-  - **@cotal-ai/cmux** — thin driver over the [cmux](https://github.com/) CLI (open a workspace/tab, send keys); used by the manager's `cmux` runtime and example launch scripts.
+  - **@cotal-ai/cmux** — the cmux integration: a thin driver over the [cmux](https://github.com/) CLI (open/close a tab, send keys) **plus a self-registering `cmux` Runtime**. Importing it registers the runtime with the core `Registry`, so the manager spawns into cmux tabs without depending on this package (opt-in via one import; the `cotal` binary does it).
 - **`implementations/*` — opinionated surfaces** over core (self-contained; never import each other).
   - **@cotal-ai/cli** — mesh CLI: `up`, `join`, `watch`, `console` (thin NATS clients) plus `spawn` — a foreground agent launch reusing the connector's launch recipe.
   - **@cotal-ai/manager** — agent supervisor: a mesh endpoint that spawns/manages nodes via a pluggable `Runtime` (`pty` default / `tmux` / `cmux`), plus its own control-plane commands (`start`/`stop`/`ps`/`attach`) and a WS attach endpoint.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -179,7 +179,12 @@ can't race the TUI input box and the TUI renders it live), acking on `session.id
 watching the TUI sees the agent work and can type into the same session. So unlike Codex it is
 push-capable, and unlike Claude Code it needs no separate hooks or control socket — the plugin holds
 the mesh connection for the session and closes it in `dispose`. Spawned agents run autonomously
-(`permission: "allow"`).
+(`permission: "allow"`). The foreground viewer is swappable: an agent file's optional `face:` id
+makes the launcher attach an animated avatar viewer to the session instead of the chat TUI
+(`COTAL_FACE_BIN` must point at a face-term-compatible script; it watches the same event stream and
+can still send prompts into the session). A face-hosted agent is also told to embed `[[face:X]]`
+emotion tags in its send text — the viewer reads them from the tool-call input to animate the
+avatar, and the send tools strip them before publishing, so they never reach the wire.
 
 **Two injection paths (different control profiles), composed.**
 
@@ -248,7 +253,10 @@ and reports status.
 
 **Spawn via a pluggable `Runtime` (no tmux dependency).** Starting / stopping / attaching is
 abstracted behind one interface (`spawn → handle`, `stop`, `status`, `attach`, optional
-`interrupt`) with selectable backends — think *pm2 / docker for agent TUIs*:
+`interrupt`) — think *pm2 / docker for agent TUIs*. `Runtime` is a **core extension contract**
+like `Connector`/`Command`: `pty`/`tmux` ship with the manager, and other backends self-register
+a `RuntimeProvider` on import (the manager resolves them from the registry — it has no compile-time
+dependency on them). Selectable backends:
 - **`pty` (default)** — the manager spawns the real `claude`/Codex (plugin + env) in a
   pseudo-terminal it owns via **`@lydell/node-pty`** (prebuilt binaries for mac/Linux/Windows ×
   x64/arm64 — zero compiler, zero `node-gyp`, ABI-stable). A real native TUI; the human watches
@@ -256,15 +264,27 @@ abstracted behind one interface (`spawn → handle`, `stop`, `status`, `attach`,
   control (group-kill, restart). No external software to install.
 - **`tmux` / `iTerm2` (opt-in)** — for users already living in a multiplexer who want native
   panes / persistence; auto-detect (if already inside tmux, use it).
-- **`cmux` (opt-in)** — each agent gets its own [cmux](https://github.com/) tab via the
-  `@cotal-ai/cmux` driver. Like tmux you watch it natively, so `attach` points you at the tab
-  rather than streaming. The manager must run inside a live cmux surface (cmux only authorizes
-  its control socket from a real pane). Drives [`examples/02`](../examples/02-cmux-handoff/README.md).
+- **`cmux` (integration)** — each agent gets its own [cmux](https://github.com/) tab. This is a
+  true plug-in: the `cmux` runtime lives in **`@cotal-ai/cmux`** and self-registers a `RuntimeProvider`
+  on import, so the manager spawns into tabs without depending on the package — a composition root
+  opts in with one `import "@cotal-ai/cmux"` (the `cotal` binary does). Like tmux you watch it
+  natively, so `attach` points you at the tab rather than streaming. Teardown is real: the runtime
+  keeps the tab's workspace + surface ids, so `stop` types `/exit` for a clean leave then closes the
+  tab (graceful) or closes it outright (hard). The manager must run inside a live cmux surface (cmux
+  only authorizes its control socket from a real pane). Drives
+  [`examples/02`](../examples/02-cmux-handoff/README.md).
 - **`byo` (floor)** — the manager doesn't own the process; a human runs `cotal claude --role …`
   in their own terminal and the manager just tracks it via presence.
 - **`host` (upgrade)** — headless via the Agent SDK / Codex app-server for structured control +
   true mid-turn interrupt; no native TUI (rendered from the event stream), observed via
   `cotal watch`.
+
+**Running one.** `cotal supervise` starts a manager on the default terminal runtime (pty, or tmux
+inside tmux); `cotal cmux` starts one that spawns each teammate into its own cmux tab (run it from a
+cmux pane). The `cotal` binary aliases the Claude-Code connector as the default agent, so
+`cotal_spawn` / `cotal_persona` / `cotal_despawn` work out of the box. For one-command onboarding,
+`cotal cmux go` installs the plugin (`cotal setup`), brings up the mesh, and opens the manager
++ console + a driving session in cmux.
 
 The PTY carries the agent's **terminal I/O only** — its mesh traffic still flows agent↔NATS
 directly through the plugin, so owning the PTY doesn't put the manager on the message hot path.
@@ -288,13 +308,16 @@ owner for the actual pixels (same stream `cotal attach` consumes, just rendered 
   loopback port (`COTAL_CONSOLE_PORT`, default `7878`). It can split later into a standalone
   `cotal console` node that discovers managers over the mesh and aggregates their streams.
 
-**Control schema (first cut):** `start {role, name, agent}` · `stop {instance}` · `ps` ·
-`status {instance}` · `attach {instance}` · `bind {instance, config}` — control-plane
-request/reply messages any authorized node (CLI, dashboard, or an agent) can send; spawning is
-policy-gated.
+**Control schema (first cut):** `start {role, name, agent}` · `stop {name, graceful?}` ·
+`definePersona {name, persona, role?, model?}` · `ps` · `status {instance}` · `attach {instance}` ·
+`bind {instance, config}` — control-plane request/reply messages any authorized node (CLI,
+dashboard, or an agent) can send; spawning is policy-gated. `definePersona` writes
+`.cotal/agents/<name>.md` (via `saveAgentFile`), which a later `start` auto-discovers.
 
-**Emergent payoff:** an agent can ask the manager for a teammate ("need a reviewer" → control →
-manager spawns one). The new agent is a *peer*, not a child.
+**Emergent payoff:** an agent can grow *and* shape the team without a human — ask the manager for
+a teammate (`cotal_spawn`), mint a brand-new persona on the fly (`cotal_persona` → saved as config
+→ spawnable), or tear one down (`cotal_despawn`, graceful or hard). The new agent is a *peer*, not
+a child.
 
 ## Hosting & onboarding
 
@@ -509,6 +532,8 @@ covers three things at once: live delivery, the inbound buffer, and late-join hi
   `ControlRequest`/`ControlReply` envelope is unchanged; only the transport underneath swaps.
 - **Isolation:** one NATS **account** per space (later: split `space` into `org/namespace`).
   Auth mode (the default) makes the account a real boundary; `--open` is one shared account.
+  See [spaces.md](spaces.md) for the space-vs-channel model and how spaces connect
+  (export/import within an operator, a narrow bridge across operators).
 - **Transport choice:** JetStream streams for all three delivery modes (durability + per-reader
   bookmarks + history), KV for presence, Object Store for artifacts, and the Services API for
   the control plane.

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -4,9 +4,11 @@
 
 The connector turns a real `claude` session into a Cotal mesh peer: a bundled plugin inside the
 session joins NATS, maps lifecycle hooks to presence, and exposes the mesh tools — messaging,
-presence, `cotal_spawn` (ask the manager to grow the team), and optional `cotal_feedback` for beta
-reports. The manager spawns it in a PTY; nothing wraps Claude — it's an ordinary session
-that happens to be on the mesh.
+presence, and team supervision: `cotal_spawn` (grow the team; the new teammate joins as a
+lateral peer), `cotal_despawn` (tear one down — it leaves the mesh and its process/tab closes),
+and `cotal_persona` (define a persona on the fly; it's saved as config and becomes spawnable),
+plus optional `cotal_feedback` for beta reports. The manager spawns it in a PTY; nothing wraps
+Claude — it's an ordinary session that happens to be on the mesh.
 
 > The mesh runtime — agent, `cotal_*` tools, hook relay — lives in
 > [`@cotal-ai/connector-core`](../extensions/connector-core); this package is the Claude-specific adapter
@@ -94,6 +96,34 @@ differ only in how they *run* the spec:
 `.cotal/` is gitignored (user-local, like `.claude/`); the demo ships committed example files under
 [`examples/01-lateral-coordination/agents/`](../examples/01-lateral-coordination/agents/) to point at
 with `--config`.
+
+- **Define one at runtime.** `cotal_persona(name, prompt, role?, model?)` sends the persona to the
+  manager, which writes the same `.cotal/agents/<name>.md` file (via `saveAgentFile`) and announces
+  it on the mesh. A later `cotal_spawn(name)` auto-discovers it — so a peer can mint a teammate's
+  persona on the fly and bring it online, no hand-written file needed.
+
+## Run it for your own project
+
+**One command, from inside a cmux pane:**
+
+```
+cotal cmux go --space <s>
+```
+
+It does the whole onboarding: installs the cotal plugin if needed (`cotal setup` — so the
+repo's Claude sessions get the `cotal_*` tools), brings up the mesh (`cotal up --open`), opens
+the manager in its own `cotal-manager` tab, and opens a `cotal-<s>` workspace with the live
+console + a ready driving session. Sessions auto-accept Claude's one-time dev-channels prompt
+(an Enter sent to their own cmux surface), so they join the mesh without a keypress. Switch to
+that pane and use `cotal_persona` to mint a teammate, `cotal_spawn` to bring it online,
+`cotal_despawn` to tear it down. Re-running it is idempotent.
+
+Under the hood it's just the existing pieces, so you can also run them by hand:
+`cotal setup` (one-time plugin install) · `cotal up --open` · `cotal cmux --space <s>` (the
+manager daemon; `cotal supervise` for the plain pty runtime) · `cotal spawn <name> --space <s>`
+(a foreground Claude on the mesh; a bare name with no agent file launches a personaless session).
+cmux is opt-in: the `cotal` binary registers it; a build without `import "@cotal-ai/cmux"` has no
+`cmux` runtime. To ship to others instead, the plugin path is the same `cotal setup` install.
 
 ## One-link join
 

--- a/docs/protocol-view.md
+++ b/docs/protocol-view.md
@@ -33,7 +33,7 @@ that loop a scripted trace hitting every message type (multicast across channels
 peer DMs, a coalesced burst, an unclaimed anycast) and every presence state — run it next to
 `cotal console` / `cotal web`.
 
-## The shared model — `MeshView` (`@cotal/core`)
+## The shared model — `MeshView` (`@cotal-ai/cli`)
 
 One class consumes the observer and emits a normalized, render-agnostic model. No ANSI, no
 React, no HTML, no color palette — pure data. It owns the endpoint lifecycle
@@ -69,8 +69,8 @@ interface FeedEntry {           // one feed row
 **What the model already does** (today, split across `render.ts` + `console/mesh.ts` +
 `web/app.js` — Phase A folds it into one place):
 
-- **Classification** — `deliveryOf(subject)` → multicast / unicast / anycast; `null` (control,
-  presence, trace) drops out of the feed.
+- **Classification** — `deliveryOf(subject)` → chat / unicast / anycast (the view renders `chat`
+  as multicast); `null` (control, presence, trace) drops out of the feed.
 - **Coalescing** — same-sender/same-text unicast bursts within 400 ms collapse to one entry
   (deterministic `id` = first message, `ts` = earliest, `count` = multiplicity).
 - **Roster** — status-sorted snapshot + `byId` map for id→name; agents split from endpoints.

--- a/docs/protocol-view.md
+++ b/docs/protocol-view.md
@@ -1,0 +1,144 @@
+# Protocol view — one model, many surfaces
+
+> The design origin for every surface that lets a human *watch and operate* a live mesh:
+> the terminal console, the web dashboard, and the plain stream. Defines the shared model
+> and which features each surface renders, so they never drift apart. Supersedes the old
+> `implementations/cli/src/console/SPEC.md`.
+
+A "protocol view" is a **read-only observer** over a space — a `CotalEndpoint` with
+`consume:false, registerPresence:false, watchPresence:true`, invisible to peers. Everything
+below is derived from that one observer; no surface opens its own NATS connection, and none
+re-implements the wire semantics. The wire is the source of truth; these are renderings of it.
+
+## Surfaces
+
+| surface | command | intent | stack |
+|---|---|---|---|
+| **console** | `cotal console` | interactive terminal — drive it, drill in | Ink / React (TTY) |
+| **stream** | `cotal console --plain`, pipes | passive line log — tail it, grep it, CI | plain ANSI |
+| **web** | `cotal web` | operator dashboard — see what needs you | HTTP + SSE, vanilla JS |
+
+`console` auto-selects: a real TTY gets the Ink TUI, a pipe/`--plain` gets the stream. `watch`
+is an alias of `console --plain`. The web dashboard is a **god-view** (self-mints an admin cred
+so it sees DMs + anycast); the terminal console sees what its creds allow (`dmVisible`).
+
+**Admin overview.** `cotal console` with **no `--space`** on an open mesh opens a space picker first —
+every space on the server (enumerated from its `CHAT_*` streams + presence buckets via
+`listSpaces()`) with agents / channels / message counts. Pick one to drop into its console; `b`
+returns to the overview. `--space X` skips the picker. Under auth a server hosts a single space, so
+the console just enters it directly (no overview).
+
+**Generate traffic to test them:** `cotal demo --space demo` spins up a handful of mock agents
+that loop a scripted trace hitting every message type (multicast across channels + mentions,
+peer DMs, a coalesced burst, an unclaimed anycast) and every presence state — run it next to
+`cotal console` / `cotal web`.
+
+## The shared model — `MeshView` (`@cotal/core`)
+
+One class consumes the observer and emits a normalized, render-agnostic model. No ANSI, no
+React, no HTML, no color palette — pure data. It owns the endpoint lifecycle
+(`start → tap → stop`) and batches every source (roster events, the tap, burst flushes, channel
+polls, the rate/age heartbeat) into one snapshot per tick.
+
+```ts
+new MeshView(ep, { window?, tapSubject? })
+  .on("entry",  (e: FeedEntry) => …)   // one classified+coalesced row, as it lands (stream)
+  .on("change", (s: MeshSnapshot) => …) // batched snapshot (~75ms) for dashboards
+  await view.start(); …; await view.stop();
+
+interface MeshSnapshot {
+  agents:    Presence[];   // card.kind === "agent", sorted working→waiting→idle→offline, then name
+  endpoints: Presence[];   // everything else
+  channels:  { channel: string; messages: number }[];
+  feed:      FeedEntry[];  // classified + coalesced + windowed
+  rates:     { msgsPerSec: number };
+  status:    { connected: boolean; space: string; dmVisible: boolean; error?: string };
+  signals:   MeshSignals;  // derived operator signals (below)
+  nameOf:    (id: string) => string;   // unicast target id → display name
+}
+
+interface FeedEntry {           // one feed row
+  id; ts; from: EndpointRef;
+  delivery: "multicast" | "unicast" | "anycast";
+  channel?; toService?;         // multicast / anycast target
+  toNames?: string[]; count?;   // unicast: resolved targets + burst multiplicity
+  text: string;                 // parts joined, no ANSI
+}
+```
+
+**What the model already does** (today, split across `render.ts` + `console/mesh.ts` +
+`web/app.js` — Phase A folds it into one place):
+
+- **Classification** — `deliveryOf(subject)` → multicast / unicast / anycast; `null` (control,
+  presence, trace) drops out of the feed.
+- **Coalescing** — same-sender/same-text unicast bursts within 400 ms collapse to one entry
+  (deterministic `id` = first message, `ts` = earliest, `count` = multiplicity).
+- **Roster** — status-sorted snapshot + `byId` map for id→name; agents split from endpoints.
+- **History prefill** — one-shot per-channel backlog (multicast only — `dmHistory` needs admin),
+  deduped against the live tap by `id`.
+- **Windowing** — feed capped (~300), rolling `msgs/s` rate.
+
+### Derived operator signals
+
+The web dashboard already computes these client-side (`dmPeers`, `waitingCards`, the tile
+counts). They move into the model so the TUI gets them for free too.
+
+```ts
+interface MeshSignals {
+  counts:  { working; waiting; idle; offline };   // golden-signal tiles
+  waiting: Presence[];                            // agents blocked / needing input, oldest-first
+  oldestWaitingTs?: number;                       // "oldest unattended"
+  dms:     DmPeer[];                              // per-peer DM roll-up → threads (god-view only)
+}
+```
+
+`dms` is populated only when DMs are visible (god-view / open mode); it groups unicast traffic
+into per-peer conversations — only pairs that actually talked, never the n² cross-product.
+
+## Feature → surface map
+
+| feature | model field | console (Ink) | stream | web |
+|---|---|---|---|---|
+| roster (status, activity, age) | `agents` / `endpoints` | ✓ panel | ✓ presence lines | ✓ sidebar |
+| all-activity feed | `feed` | ✓ feed panel | ✓ log | ✓ Monitor view |
+| channels + counts | `channels` | ✓ tabs (1–9) | — | ✓ sidebar + Channel view |
+| golden-signal counts | `signals.counts` | ✓ tiles strip | — | ✓ tiles |
+| needs-you / blocked | `signals.waiting` | ✓ rail (`n`) | — | ✓ NEEDS-YOU rail |
+| direct-message lens | `signals.dms` | ✓ lens (`d`) | — | ✓ DM view |
+| topology lens (who-talks-to-whom) | `feed` + `agents` (derived) | ✓ lens (`t`, 3 variants) | — | — |
+| message / agent **detail** | `feed` / `agents` | ✓ select → detail | — | ✓ row / thread |
+| **search / filter** | client | ✓ `/` | (grep) | ✓ mode chips |
+| msgs/s, connected, dmVisible | `rates` / `status` | ✓ status bar | — | ✓ conn pill |
+
+Both interactive surfaces now render every model field. The console adds the signals as a one-row
+tiles strip (always on), a NEEDS-YOU rail toggled with `n` (a side column when the terminal is wide,
+else a full-screen overlay), and a DM lens toggled with `d` (peer roll-up + thread; shows
+"DMs hidden" under chat-only creds). The stream is line-oriented, so the signals stay out of it.
+The topology lens (`t`) folds the feed + roster into a who-talks-to-whom graph client-side and
+renders it three switchable ways (`v` / `1-3`): swimlane sequence, adjacency heat matrix, and a
+ring node-link map with channels/roles as hub nodes.
+
+## Future — not yet on the wire
+
+The web's `?demo` scene also mocks features that **no protocol message backs yet** — they render
+only as the static Penpot reference, never from live data, and are deliberately *not* implemented on
+either live surface. They live here as design intent until the wire grows to support them:
+
+| flourish | what it would need |
+|---|---|
+| intent badges ("about to act") | a new intent message kind / field on the wire |
+| approval requests (approve / deny) | a request message kind + a response path (interactive) |
+| task-failed alerts | a failure signal — a manager lifecycle event or a presence status |
+| unclaimed-anycast / status roll-up | mostly derivable from existing traffic; a `MeshView` signal |
+| per-conversation unread | per-viewer client state, not really protocol |
+
+## Principles
+
+- **Derive once, render many.** Classification, coalescing, sorting, id→name, rate, windowing,
+  and the operator signals live in `MeshView`. A surface only *lays out* the model — it never
+  re-derives it. New surfaces are thin clients.
+- **Presentation stays per-surface.** Color palette (`agentColor`), layout, CSS, keybindings,
+  and input handling belong to each renderer, not the model.
+- **No fallbacks.** If the observer can't do what a surface needs, throw — don't silently degrade.
+- **Status is shape *and* color.** `● working · ◐ waiting · ○ idle · ⨯/⊘ offline` — never color
+  alone (accessibility; see `docs/research/multi-agent-ux.md`).

--- a/docs/spaces.md
+++ b/docs/spaces.md
@@ -1,0 +1,145 @@
+# Spaces
+
+> The space concept, why it's distinct from a channel, and how spaces connect.
+> §1–3 describe what Cotal does **today**; §4–6 are **design direction**, not yet built.
+
+## 1. What a space is
+
+A **space** is one collaboration — and it's the *only* thing in Cotal that carries
+membership, identity, and isolation. Everything else (channels, threads) is cheap and
+structureless by comparison.
+
+Concretely, today:
+
+- Every subject is scoped to it: `cotal.<space>.{chat,inst,svc,ctl}.…`
+  ([`subjects.ts`](../packages/core/src/subjects.ts)).
+- Each space has its own streams (`CHAT_<space>` / `DM_<space>` / `TASK_<space>`) and its
+  own presence KV bucket (`cotal_presence_<space>`).
+- **In auth mode a space is one NATS account** — a real, server-enforced boundary
+  ([`provision.ts`](../packages/core/src/provision.ts)). In `--open` dev mode it's one
+  shared account and the boundary is just the subject prefix (soft isolation).
+- An endpoint is bound to one space for its lifetime. To be in two spaces, run two
+  endpoints.
+
+So a space answers "**who is here together, and isolated from whom**" — presence, identity,
+and the trust boundary all live at this level.
+
+## 2. Space vs channel — why both
+
+A channel is a *topic*, not a room. All channels in a space share the one `CHAT_<space>`
+stream; a channel has no roster of its own, no isolation, no account. It's a routing suffix
+on multicast.
+
+They're different axes:
+
+| | Space | Channel |
+|---|---|---|
+| Carries | membership, identity, isolation, presence | nothing — just a topic |
+| Maps to | a NATS **account** (auth mode) | a NATS **subject** suffix |
+| Scope | "who's in this collaboration" | "what subtopic" |
+
+Collapsing space into "just channels" would drop the per-collaboration roster and the
+isolation boundary — you'd be back to one global namespace with topic prefixes (exactly
+`--open` mode's soft isolation). The distinction earns its keep the moment you care about
+more than one collaboration on a deployment, or about presence scoped to a group. This is
+also the universal split: Slack workspace vs channel, NATS account vs subject, SLIM's `org`
+vs the rest of the name.
+
+## 3. Channels inside channels? No.
+
+Keep **one** membership boundary (the space). For everything below it, two cheaper tools
+already exist:
+
+- **Sub-topics → hierarchical channel *names*.** Channels are NATS subjects, so `team`,
+  `team.backend`, `team.backend.api` already nest. Subscribe `team.>` for the subtree or
+  `team.*` for one level. No new concept needed.
+- **Sub-conversations → flat threads.** The envelope already carries `replyTo` and
+  `contextId` ([`types.ts`](../packages/core/src/types.ts)) — a thread is a relation to a
+  root message, one level deep.
+
+A channel that had its own roster and access control would just be a sub-space — two
+mechanisms doing the same job. The precedent here is unanimous: Discord stops at one
+sub-channel level (a thread, whose parent is always a channel) and its categories carry no
+membership; Slack and Matrix both *forbid* nesting threads. The membership/permission
+boundary lives at exactly one level everywhere.
+
+If a level *above* space is ever wanted, make it a **non-membership "org" grouping** (a
+label, like a Discord category or a Matrix Space — joining it grants nothing). Usefully,
+that org label is also the identity qualifier federation needs (§5) — one concept, two
+payoffs.
+
+## 4. Connecting spaces — the rule
+
+**Never merge trust roots.** In NATS the *operator* is the trust anchor: a server trusts
+exactly one operator, and two independent operators cannot federate. Since a space is an
+account under an operator, "connect two spaces" splits cleanly by whether they share one:
+
+- **Same operator** (two collaborations in one deployment) → connect them *inside* NATS
+  with **account export/import**: an account exports specific subjects (a stream) or a
+  request/reply endpoint (a service); the other imports them, with subject remapping and
+  (for private exports) an activation token. Server-enforced, no relay process.
+- **Different operators** (two parties, each running their own cluster/auth) → real
+  **federation**. You don't fuse them; you bridge a **narrow surface**, with each side
+  keeping its own operator. NATS's sanctioned cross-operator mechanism is the **leaf node**:
+  the bridging side authenticates into the remote with a credential the remote issued, binds
+  as one account there, and its permissions whitelist exactly which subjects cross.
+
+Every federated system agrees on the shape: bridge **one channel**, not the whole tenant
+(Slack Connect shares a single channel with admin approval on both sides); keep identity
+**namespaced by home** (`alice@spaceB`); and at the boundary, **trust the signature, not the
+pipe**.
+
+## 5. The staged path (proposed)
+
+- **v0 — origin-qualified identity.** Add an additive `name@space` qualifier to the
+  envelope / `AgentCard` so a remote peer is unambiguous. Cheap, non-breaking, and a
+  prerequisite for any bridge — it's the one thing every federated system requires.
+- **v1 — application-level relay.** A bridge endpoint that holds **a separate credential
+  each side issued independently** (so no trust-root merge) forwards one channel both ways
+  and mirrors designated presence. Needs: a forwarded-message marker (loop prevention),
+  identity rewriting with the origin qualifier, and explicit config on both ends (the
+  approval handshake). Works in **open *and* auth mode** with **no NATS reconfiguration**,
+  and fits Cotal's "thin client over the wire" ethos. A clean variant is a **rendezvous
+  space**: both parties' delegates meet in a neutral third space rather than reaching into
+  each other's — self-similar with Cotal's own primitive, and nobody holds the other's creds.
+- **v2 — NATS-native, server-enforced.** Graduate to account **export/import** (same
+  operator), **leaf nodes** (cross-operator), and **mirror/source** streams if durable
+  cross-space history is needed ("copy, don't share"; pull-only). Heavier (activation
+  tokens, JetStream domains) but no relay hop.
+- **North star — encrypted group as the boundary.** Make a federated channel an
+  end-to-end-encrypted group whose membership is *keys* (MLS-style), so relays carry
+  ciphertext without being trusted, with DID/keypair self-issued identity. This is where the
+  agent ecosystem (SLIM, AGNTCY, NANDA) is heading; cross-fabric routing/presence is still
+  unsolved — room for Cotal to lead. Don't build now, but don't block it.
+
+## 6. Status
+
+| Area | Today | Proposed |
+|---|---|---|
+| Space = membership/trust/presence boundary | ✅ | |
+| Hierarchical channel names + `replyTo`/`contextId` threads | ✅ | |
+| `name@space` origin-qualified identity | | v0 |
+| App-level channel bridge / rendezvous space | | v1 |
+| Account export/import · leaf nodes · mirror/source | | v2 |
+| Encrypted-group boundary + DID identity | | north star |
+
+## Prior art
+
+The model above is derived from how existing systems handle the same problems:
+
+- **NATS** — [accounts & export/import](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/accounts),
+  [leaf nodes](https://docs.nats.io/running-a-nats-service/configuration/leafnodes),
+  [JetStream source/mirror](https://docs.nats.io/nats-concepts/jetstream/source_and_mirror),
+  [JWT trust model](https://docs.nats.io/running-a-nats-service/nats_admin/security/jwt).
+- **Federation** — [Matrix S2S](https://spec.matrix.org/v1.11/server-server-api/),
+  [XMPP dialback](https://xmpp.org/extensions/xep-0220.html),
+  [DMARC](https://datatracker.ietf.org/doc/html/rfc7489),
+  [ActivityPub](https://www.w3.org/TR/activitypub/).
+- **Cross-org / bridging** — [Slack shared channels](https://slack.engineering/how-slack-built-shared-channels/),
+  [Mosquitto bridging](https://mosquitto.org/man/mosquitto-conf-5.html),
+  [Confluent Cluster Linking](https://docs.confluent.io/platform/current/multi-dc-deployments/cluster-linking/index.html),
+  [Discord threads](https://docs.discord.com/developers/topics/threads).
+- **Agent-native** — [SLIM](https://www.ietf.org/archive/id/draft-mpsb-agntcy-slim-00.html),
+  [A2A discovery](https://a2a-protocol.org/latest/topics/agent-discovery/),
+  [MCP authorization](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization),
+  [libp2p gossipsub](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md).

--- a/docs/web.md
+++ b/docs/web.md
@@ -19,7 +19,7 @@ the dashboard is always the full god-view.
 The dashboard is still read-only. To purge retained history from a running space, use
 `cotal history clear --force [--dms]`.
 
-Flags: `--space` (default `demo`), `--server` (default local NATS), `--port` (7799),
+Flags: `--space` (default `main`), `--server` (default local NATS), `--port` (7799),
 `--no-open` (skip auto-launch), `--creds` (override the self-minted NATS credentials).
 
 ## How it works

--- a/examples/02-cmux-handoff/README.md
+++ b/examples/02-cmux-handoff/README.md
@@ -5,8 +5,8 @@ You start with just a console + an **orchestrator**; the human types **one** pro
 orchestrator **spawns** todo-api / todo-web / todo-docs into their own [cmux](https://cmux.com)
 tabs, fans the work out in parallel, and routes the API→web handoff itself — no second human prompt.
 
-> Ported from the [haa](https://github.com/) demo (A2A-over-MQTT) onto Cotal/NATS. The story
-> is identical; the transport and the agent wiring are Cotal's.
+> Ported from the haa demo (A2A-over-MQTT) onto Cotal/NATS. The story is identical; the
+> transport and the agent wiring are Cotal's.
 
 ```
               orchestrator
@@ -40,61 +40,64 @@ tabs, fans the work out in parallel, and routes the API→web handoff itself —
 Each repo starts with `TODO(demo)` markers where the work lands. The orchestrator is the only pane
 you open; it spawns the three workers (each via `run-agent.sh <role>` in its own tab). Identity is
 set purely by the `COTAL_*` env on each launch line — both the MCP server and the presence hooks
-inherit it.
+inherit it. The role contract for each agent lives in its folder's `CLAUDE.md`.
 
-## One-time setup
+## Prerequisites
 
-1. **NATS** — `brew install nats-server` (the launcher starts it for you).
-2. **cmux** — `brew install --cask cmux` if you don't have it. Open this folder as the cmux
-   workspace so it picks up `cmux.json`.
-
-No plugin install needed: each agent loads the Cotal MCP server (`cotal_*` tools) and the
-presence/inbox hooks directly via `--mcp-config` / `--settings` (see `run-agent.sh`). The
-**first time each pane starts**, claude asks to *"load development channels?"* — **accept it**,
-or the channel that wakes idle panes stays off.
+- **Repo deps** — from the repo root: `pnpm install` (Node ≥ 20 + pnpm).
+- **NATS** — macOS: `brew install nats-server`; other platforms: [nats.io/download](https://nats.io/download/).
+  The launcher starts the mesh for you.
+- **cmux** — `brew install --cask cmux` if you don't have it ([cmux.com](https://cmux.com)).
+- **Run from inside cmux** — the launcher drives cmux over its socket, so it must run from a
+  cmux terminal; outside one it exits with `✗ can't reach cmux`. Open this folder as the cmux
+  workspace so it picks up `cmux.json`.
+- **No plugin install** — each agent loads the Cotal MCP server (`cotal_*` tools) and the
+  presence/inbox hooks directly via `--mcp-config` / `--settings` (see `run-agent.sh`).
 
 ## Run it
 
-From **inside a cmux terminal** (the cmux CLI talks to the app over its socket):
+From **inside a cmux terminal**, with this folder open as the workspace:
 
-```bash
-./launch.sh --drive    # starts the mesh, opens ONE workspace in the demo layout
-```
+1. **Open the workspace.** This starts the mesh, a `cotal-manager` tab (which spawns workers),
+   and a `cotal-todo` workspace split into the console + orchestrator:
 
-That starts the mesh, opens a `cotal-manager` tab (the manager that spawns workers), and a
-`cotal-todo` workspace split into just two panes:
+   ```bash
+   ./launch.sh --drive
+   ```
 
-```
-┌───────────────┐
-│ cotal console │   live agent panel + message log
-├───────────────┤
-│ orchestrator  │   claude — give it the one prompt
-│   (claude)    │
-└───────────────┘
-```
+   > Every pane command is wrapped in `bash -lc '…'` on purpose: cmux launches panes in your
+   > default login shell (here, **nushell**), which doesn't understand `&&` or inline
+   > `VAR=val cmd` env prefixes — so the body runs in bash regardless.
 
-The **console** dashboard (`cotal console` — agent panel + traffic) on top, the **orchestrator**
-below. Each opens as its own cmux tab. The orchestrator spawns todo-api / todo-web / todo-docs
-later — each lands in a fresh, unfocused tab (a real coder `cd`'d into its repo).
+   ```
+   ┌───────────────┐
+   │ cotal console │   live agent panel + message log
+   ├───────────────┤
+   │ orchestrator  │   claude — give it the one prompt
+   │   (claude)    │
+   └───────────────┘
+   ```
 
-> Every pane command is wrapped in `bash -lc '…'` on purpose: cmux launches panes in your
-> default login shell (here that's **nushell**), which doesn't understand `&&` or inline
-> `VAR=val cmd` env prefixes — so we run the body in bash regardless.
+2. **Accept the channels prompt.** The first time each pane starts, claude asks to
+   *"load development channels?"* — **accept it**, or the channel that wakes idle panes stays off.
 
-Plain `./launch.sh` (no flag) just verifies the mesh and prints the commands — the
-`cmux new-workspace --layout …` line plus the per-role command you can paste into a plain
-terminal or trigger from the **command palette** (`cmux.json`). Each runs `run-agent.sh <role>`,
-which `cd`s into the role's repo and starts claude wired to the mesh:
+3. **Give the orchestrator the one goal.** On boot it onboards you and shows the example goal,
+   then waits. Paste:
+
+   > We're adding task priority to the app. priority: low | medium | high, default medium.
+   > Add it to the API, the web UI, and the docs. Work in parallel. Tell me when each is done.
+
+That's it — the orchestrator does the rest. The workers land in fresh, unfocused tabs (each a
+real coder `cd`'d into its repo).
+
+Prefer to drive it by hand? Plain `./launch.sh` (no flag) just verifies the mesh and prints the
+cmux launch sequence — the workspace layout line plus the per-role command you can paste into a
+plain terminal or trigger from the **command palette** (`cmux.json`). Each runs
+`run-agent.sh <role>`, which `cd`s into the role's repo and starts claude wired to the mesh:
 
 ```bash
 ./run-agent.sh orchestrator   # → claude with the cotal MCP server, hooks, and channel push
 ```
-
-On boot the **orchestrator** onboards you (what the demo is, how to drive it) and shows the
-example goal, then waits. Give it the one prompt:
-
-> We're adding task priority to the app. priority: low | medium | high, default medium.
-> Add it to the API, the web UI, and the docs. Work in parallel. Tell me when each is done.
 
 ## What you'll see
 
@@ -111,13 +114,29 @@ example goal, then waits. Give it the one prompt:
 
 ## How it maps to Cotal
 
-| haa | Cotal tool |
-|---|---|
-| `discover()` | `cotal_roster` |
-| `send_message(target)` | `cotal_dm(to, text)` |
-| `fetch_inbox()` | `cotal_inbox` |
+The agents do all of this through the `cotal_*` MCP tools:
 
-The role contracts live in each folder's `CLAUDE.md`.
+| What an agent does | Cotal tool |
+|---|---|
+| spawn a worker into its own tab | `cotal_spawn` |
+| see who's on the mesh (discover) | `cotal_roster` |
+| send a direct message | `cotal_dm(to, text)` |
+| read its inbox | `cotal_inbox` |
+| set its presence state | `cotal_status` |
+
+The role contracts that tell each agent *how* to use these live in each folder's `CLAUDE.md`.
+
+## Troubleshooting
+
+- **`✗ can't reach cmux`** — you're not in a cmux terminal. cmux's control socket rejects
+  detached callers; open a cmux terminal (with this folder as the workspace) and re-run.
+- **A worker ignores a message** — channel push is off (you skipped the "load development
+  channels" prompt). The message still arrived; press Enter in that pane to let it act, or
+  restart the pane and accept the prompt.
+- **Mesh didn't come up** — check `.mesh.log` in this folder. Usual cause: `nats-server` not
+  installed, or port 4222 already taken.
+- **Duplicate entries in the roster** — a stray manager from a previous run is still up. Run
+  `./launch.sh --stop` to clear it, then re-launch.
 
 ## Notes & limits
 

--- a/examples/04-self-improving-console/GOAL.md
+++ b/examples/04-self-improving-console/GOAL.md
@@ -1,0 +1,12 @@
+We're rebuilding cotal's live `console` as a polished lazygit-style Ink/React TUI, shipped as the new `cotal console-ink` command (the old `console` stays untouched). It must render over the EXISTING read-only `CotalEndpoint` observer (see implementations/cli/src/commands/console.ts) — do NOT open a new raw NATS connection. Target: roster panel + channel tabs + live message feed + multi-panel focus + a context-sensitive `?` help overlay.
+
+Run the team in parallel:
+- research: read research/INPUT.md, verify the key facts, write the SPEC to implementations/cli/src/console/SPEC.md, and cotal_send a summary to the team so backend and tui-designer start with the right context.
+- backend: build the data layer in implementations/cli/src/console/mesh.ts — a useMesh() hook over CotalEndpoint returning UI-ready state.
+- tui-designer: build the Ink components in implementations/cli/src/console/ (app.tsx + ui/*.tsx) and wire them into the console-ink command.
+
+backend and tui-designer must settle the exact useMesh() interface DIRECTLY with each other over the mesh (cotal_dm) — don't route the contract through me.
+
+Review (non-blocking): bring in a critical reviewer as a second pair of eyes — cotal_spawn(name="reviewer", role="reviewer") after the SPEC is broadcast (reviews the plan), and cotal_spawn(name="reviewer-code", role="reviewer") after the workers finish (reviews the code). It posts findings to the team channel; don't wait on it to finish.
+
+Spawn the team, dispatch, and when research/backend/tui-designer report done and `pnpm --filter @cotal/cli typecheck` is green, cotal_send "DEMO COMPLETE" to the team channel and tell me.

--- a/examples/04-self-improving-console/ITERATIONS.md
+++ b/examples/04-self-improving-console/ITERATIONS.md
@@ -1,0 +1,174 @@
+# Iterations journal — self-improving-console harness
+
+The overnight `/loop` runs the swarm headless, evaluates it, applies ONE setup fix per
+iteration, and logs the result here. **Green = build OK AND ≥1 genuine peer-to-peer DM.**
+Stop after **2 greens in a row** or **15 iterations**.
+
+What we tune: the *setup* — role contracts (`agents/*.md`), `GOAL.md`, `run-agent.sh`, the
+harness. The console code the swarm emits is the test subject (thrown away each run in a
+worktree under `.runs/`).
+
+> The per-run snapshots this journal points at (`reference/run-*-green/`, transcripts, verdicts)
+> are not checked in — they were several thousand lines of experiment output. The entries below
+> are kept as the development log; the `reference/` paths are historical.
+
+Run one iteration manually:
+```bash
+examples/04-self-improving-console/harness/run-once.sh <iter>
+```
+
+| Iter | Outcome | build | peer-to-peer (pairs) | failure mode | fix applied |
+|------|---------|-------|----------------------|--------------|-------------|
+| 0 | scaffold | n/a | n/a | — | Phase A built (see below) |
+| 1 | 🔴 RED | ok | none | no-traffic — orchestrator EOF-exited immediately | spawn orchestrator via manager PTY (`cotal start`) + manager headless; drop `script` |
+| 2 | 🟡 partial | — | spawn+coordinate works | worktree isolation LEAKS — research wrote SPEC to MAIN, workers read worktree placeholder | switch harness to main + git-reset between runs; fix peer-to-peer metric (resolve `to` id→name) |
+| 3 | 🟢→🟡 | ok | **8 DMs** (backend↔tui-designer, both ways) | ui-not-wired — app.tsx/console-ink still placeholder | tighten green to require wired UI; tui-designer "wire first"; surgical reset (don't clobber license work) |
+
+---
+
+## Iteration 0 — Phase A scaffold (no swarm run yet)
+**Status:** harness built and unit-verified; first LIVE swarm run pending (next loop fire).
+
+Built and verified:
+- Branch `demo/weavehacks-console-tui`; Ink plumbing in `@cotal/cli` (`ink@6.8`, `react@19.2`,
+  `@inkjs/ui@2`), `jsx:react-jsx`, runnable placeholder `console-ink` command — `pnpm --filter
+  @cotal/cli typecheck` GREEN.
+- Console skeleton anchors (`implementations/cli/src/console/{mesh.ts,app.tsx,ui/,SPEC.md}`).
+- Example-04 harness: `run-agent.sh` (4 roles, per-role cwd, contract via `--append-system-prompt`,
+  headless mode), `src/manager.ts` (runtime from env; `confirm` set so the PTY runtime auto-accepts
+  the dev-channels prompt), `launch.sh` (cmux), `cmux.json`, 4 role contracts, `GOAL.md`,
+  `research/INPUT.md`, README.
+- Autonomous harness: `harness/observer.ts` (logs ALL traffic incl. DMs via open-mode whole-space
+  tap), `harness/run-once.sh` (worktree + open NATS + pty manager + pty orchestrator + wait + teardown),
+  `harness/evaluate.ts` (build via worktree `tsc` + peer-to-peer comms analysis). Evaluator
+  unit-tested on synthetic transcripts: correctly reports green/red and peer pairs.
+
+**Key de-risk found:** the PTY runtime already auto-confirms claude's dev-channels prompt
+(`implementations/manager/src/runtime/pty.ts` watches `spec.confirm` → presses Enter), so headless
+agents wake on incoming DMs without cmux key-injection.
+
+**Open risks for the first live run (expected early failure modes):**
+- The orchestrator runs under `script` (a PTY) headless — does claude boot + act on the GOAL prompt
+  with `--dangerously-skip-permissions` (and accept dev-channels) without a human? Unverified.
+- Completion detection relies on the orchestrator broadcasting `DEMO COMPLETE`.
+- Nested Claude Code sessions (a claude session spawning claude agents) — feasibility unverified.
+
+## Iteration 1 — first live run (🔴 RED)
+**Verdict:** `{green:false, buildOk:true, peerToPeer:false, messages:0, failureMode:"no-traffic"}`,
+outcome `orchestrator-exited`. Prereqs confirmed present: claude 2.1.161, nats-server 2.14.2,
+node-pty (manager imports OK). The worktree + pnpm install + tsc path works (`buildOk:true`).
+
+**Root cause:** the orchestrator was launched via `script -q /dev/null … run-agent.sh orchestrator`
+under `nohup`, so claude got a **closed stdin → read EOF → exited instantly** (the `^D` in the log).
+No agent ever joined → 0 messages.
+
+**Fix applied (for iter 2):** stop using `script`. Run the manager with `COTAL_HEADLESS=1` and ask it
+to spawn the orchestrator via the **PTY runtime** (`cotal start --name orchestrator`). node-pty gives
+a real pty with an OPEN stdin (no EOF) and auto-confirms the dev-channels prompt; every agent the
+manager spawns inherits headless mode. This makes the orchestrator and the workers boot identically.
+
+**Next risks to watch:** does the orchestrator actually act on the GOAL init under the PTY runtime and
+`cotal_spawn` the workers? Do the workers wake on its DMs? Is `DEMO COMPLETE` ever broadcast?
+
+## Iteration 2 — orchestration works, isolation leaks (🟡 partial)
+**What worked (big):** the manager spawned the orchestrator via PTY; the orchestrator booted, set
+status, **`cotal_spawn`ed research + backend + tui-designer (all joined)**, and DM'd each a detailed
+task. research read INPUT.md, verified the `@cotal/core` API against the code, and wrote a real
+194-line SPEC; tui-designer's status went to "settling useMesh() shape with backend." So the core
+mechanic — headless multi-agent spawn + dispatch + lateral intent — is proven.
+
+**The blocker:** **worktree isolation does not hold.** research wrote the SPEC to the MAIN repo
+(`/Users/user/Projects/cotal/implementations/cli/src/console/SPEC.md`, 194 lines) instead of its
+worktree copy (still the 7-line placeholder) — agents resolve repo paths to the canonical project
+location they know, not their `git worktree` cwd. Consequence: backend/tui-designer (cwd = worktree)
+read the worktree's PLACEHOLDER SPEC, so the research→workers handoff is silently split. It also
+pollutes the main tree uncontrollably — strictly worse than a controlled reset.
+
+**Decision / fix for iter 3:** drop worktrees. Run the swarm on the **main demo branch**; reset the
+console files with `git checkout` (+ scoped `git clean`) before each run and snapshot green output to
+`reference/`. Unique space per run still isolates the mesh. Also fixed the **peer-to-peer metric**:
+DM `to` is an instance id, so observer now logs `fromId` and evaluate resolves id→name (HUB =
+orchestrator/manager/cli) so a worker's `done:`→orchestrator no longer counts as peer-to-peer.
+
+**Caveat:** run-2's own verdict (worktree typecheck of placeholders) is not meaningful; iter 3 on
+main is the first run that can fairly score build + peer-to-peer.
+
+## Iteration 3 — first green-ish, with a real peer-to-peer negotiation (🟢→🟡)
+**Verdict (old metric):** `{green:true, buildOk:true, peerToPeer:true, peerDms:8,
+pairs:[tui-designer→backend, backend→tui-designer]}`. On main+reset; first fairly-scored run.
+
+**The money shot happened for real.** backend and tui-designer negotiated the `useMesh()` contract
+**directly, peer-to-peer**, across many turns: "Proposing useMesh(ep) returns this shape — does it
+cover your panels?" → "Love it… Accepting RosterEntry/ChannelInfo/FeedEntry" → "our messages
+crossed — I'd ACKed YOUR shape, you locked MINE" → "Locked. Building against your EXACT exports" →
+"EXPORTS LANDED ✓ typecheck GREEN". 8 peer DMs, zero contract-routing through the orchestrator.
+research wrote a 194-line SPEC and broadcast it; backend produced an excellent `mesh.ts` (typed
+contract, MeshStore with coalescing/rate-ring/StrictMode-safe tap). Snapshot kept in
+`reference/run-3-green/`.
+
+**The gap:** `app.tsx` and `console-ink.tsx` were still placeholders at timeout — tui-designer built
+`ui/{Feed,Roster,Tabs}.tsx` + `mesh.ts` but never wired them into the command. So `cotal console-ink`
+still renders the placeholder. Build+p2p passed while the deliverable was unwired → my green metric
+was too weak.
+
+**Fixes applied (for iter 4+):**
+- **evaluate.ts:** green now also requires `wired` (app.tsx is a real component AND console-ink renders
+  it, no "placeholder"). New failure mode `ui-not-wired`.
+- **tui-designer contract:** "WIRE FIRST" — make console-ink render a minimal real `<App/>` and pass
+  typecheck *before* enriching panels; not done until app.tsx is real + command wired.
+- **harness reset:** surgical (only console scaffold + console-ink + index.ts) so it won't revert the
+  parallel Apache-2.0 license edits to package.json/tsconfig.
+
+Under the stricter metric, iter 3 is NOT green (ui-not-wired). The 2-in-a-row streak starts fresh.
+
+## Iteration 4 — first GREEN under the strict (wired) metric (🟢) + cross-vendor learning
+**Verdict:** `{green:true, buildOk:true, peerToPeer:true, wired:true, crossVendor:false,
+complete:false, peerDms:11, pairs:[backend↔tui-designer, research↔backend]}`. Snapshot in
+`reference/run-4-green/`.
+
+**What worked.** The full pipeline landed: research wrote+broadcast the SPEC; backend shipped a typed
+`useMesh()` in `mesh.ts`; **tui-designer wired `console-ink` → a real 5KB `<App/>`** importing 7 UI
+panels (Roster, Channels, Feed, StatusBar, Help, theme, types) — so `wired` passed for the first time.
+**11 peer DMs**, including a *new* axis (`research↔backend`) on top of the usual `backend↔tui-designer`
+contract negotiation. Zero contract-routing through the orchestrator.
+
+**Cross-vendor (codex) is scuffed.** `codex-reviewer` joined the roster (MCP connected → presence) but
+stayed `idle`, never invoked a single `cotal_*` tool, and went offline after ~80s — **no review posted**.
+Under headless `codex exec` the model connects the MCP server but doesn't post on the mesh. Per operator
+call (time pressure): **dropped codex from the loop.**
+
+**Fixes applied (for iter 5+):**
+- **Replaced codex with a Claude `reviewer`** (operator's idea): a critical/adversarial second pair of
+  eyes via the *proven* Claude path (`run-agent.sh reviewer`, read-only, repo-root cwd). It reliably
+  posts to `#team` + DMs authors. New `agents/reviewer.md`; orchestrator spawns `reviewer` (plan) +
+  `reviewer-code` (code), non-blocking. Codex files stay in repo for a possible stage fix.
+- **Bumped `RUN_TIMEOUT` 900→1200s** — iter 4 needed the full 900s to reach `wired` and never emitted
+  `DEMO COMPLETE`; more headroom lets the orchestrator close the loop.
+
+Green streak: **1 / 2.** Need iter 5 green to stop.
+
+## Iteration 5 — GREEN again → **2 in a row, loop STOPPED** (🟢🟢)
+**Verdict:** `{green:true, buildOk:true, peerToPeer:true, wired:true, crossVendor:false,
+complete:false, peerDms:9, pairs:[backend↔tui-designer, reviewer→backend, reviewer→tui-designer,
+tui-designer→reviewer]}`. Snapshot in `reference/run-5-green/`.
+
+**The Claude `reviewer` works** (replacing scuffed codex). It joined, reviewed the SPEC, **posted a
+sharp grounded review to `#team`** (caught real observer semantics: `emit("message")` only fires from
+`pump()`, which `consume:false` never starts — 7 concrete gaps) and **DM'd backend + tui-designer
+directly** with specifics. It even adapted on the fly — noticing `#team` broadcasts don't wake idle
+inboxes, it switched to direct DMs. 6 reviewer messages; reviewer↔worker pairs now show up in the
+peer graph. This is the value codex couldn't deliver headless.
+
+**Stable pipeline:** research SPEC → backend `useMesh()` → tui-designer wires `console-ink` → real
+`<App/>` + panels, contract settled peer-to-peer, build green, UI wired — two runs running.
+
+**Open item (not blocking green):** `DEMO COMPLETE` never emitted in either green run — the
+orchestrator runs out the clock before its final completion check. Green doesn't require it
+("ideally" only), but for a cleaner stage demo a future tweak could make the orchestrator poll
+worker `done:` + typecheck earlier.
+
+### Conclusion
+**Stop condition met: 2 consecutive green runs (4 + 5).** Loop cron `06ba73af` deleted. Best setup is
+on the branch; known-good output preserved in `reference/run-4-green/` and `reference/run-5-green/`.
+Hardened contracts: `agents/{orchestrator,research,backend,tui-designer,reviewer}.md`, `GOAL.md`,
+`run-agent.sh` (+`reviewer` role), `evaluate.ts` (strict `wired` metric).

--- a/examples/04-self-improving-console/README.md
+++ b/examples/04-self-improving-console/README.md
@@ -1,0 +1,49 @@
+# Example 04 — the self-improving console
+
+**A Cotal swarm rebuilds Cotal's own console.** Four real Claude Code agents join one
+mesh space and coordinate **as lateral peers** to ship a polished, lazygit-style
+**Ink/React TUI** for the live `console` — shipped as the new `cotal console-ink`
+command. Built for **WeaveHacks 4 — Multi-Agent Orchestration** (W&B): agents that work
+together, improving the very system that coordinates them.
+
+```
+                 orchestrator
+                /     |      \           (cotal_dm — dispatch)
+         research  backend  tui-designer
+                      \______/             (backend ↔ tui-designer settle the
+                                            useMesh() contract directly — peer-to-peer)
+            research ──broadcast──▶ team   (SPEC ready, context for everyone)
+```
+
+## The cast
+
+| Pane (`COTAL_NAME`) | Works in | Job |
+|---|---|---|
+| `orchestrator` | repo root | spawn the team, dispatch, route — never relays the technical contract |
+| `research` | `research/` | read `INPUT.md`, verify, write `…/console/SPEC.md`, **broadcast** it to the team |
+| `backend` | `implementations/cli` | `useMesh()` data layer over the existing `CotalEndpoint` observer |
+| `tui-designer` | `implementations/cli` | the Ink TUI (panels, tabs, focus, `?` help) + the `console-ink` command |
+
+The point: the **detail-level coordination is peer-to-peer**. `backend` and `tui-designer`
+settle the `useMesh()` interface directly over the mesh; `research` broadcasts context to all.
+
+## What it builds
+`cotal console-ink` — an Ink rebuild of the hand-rolled ANSI dashboard
+(`implementations/cli/src/render.ts`), rendering over the **existing** read-only
+`CotalEndpoint` observer (never a new NATS client). Roster + channel tabs + live feed +
+focus + context `?` help.
+
+## Run it (on stage — cmux)
+From inside a cmux terminal:
+```bash
+./launch.sh --drive    # mesh + a workspace: live console on top, orchestrator below
+```
+Give the orchestrator the goal in [`GOAL.md`](./GOAL.md); it spawns the three workers into
+their own tabs and dispatches. Watch the swarm rebuild the console live — through the old console.
+
+## Run it (overnight — headless self-optimizing loop)
+`harness/run-once.sh <iter>` runs the whole swarm **headless** (PTY runtime, throwaway git
+worktree, unique space), captures all mesh traffic to `transcript.jsonl`, then
+`harness/evaluate.ts` judges it: **build green AND genuine peer-to-peer comms**. The loop
+runs it repeatedly, applies one setup fix per iteration, and journals to `ITERATIONS.md`.
+See the plan and `ITERATIONS.md`.

--- a/examples/04-self-improving-console/agents/backend.md
+++ b/examples/04-self-improving-console/agents/backend.md
@@ -1,0 +1,31 @@
+# You are `backend` on the Cotal mesh (space `console`)
+
+You build the **data layer** for the new Ink console — and you settle its interface
+**directly with `tui-designer`**, peer-to-peer, not through the orchestrator.
+
+Your Cotal tools (MCP server `cotal`): `cotal_inbox`, `cotal_dm`, `cotal_send`,
+`cotal_roster`, `cotal_status`.
+
+## Your repo / ownership
+You're in `implementations/cli`. You own exactly one file:
+`implementations/cli/src/console/mesh.ts`. Do not edit `app.tsx`, `ui/*.tsx`, the
+`console-ink` command, or `package.json` — those are `tui-designer`'s.
+
+## Job
+1. Read `implementations/cli/src/console/SPEC.md` (from `research`) and the existing observer
+   setup in `implementations/cli/src/commands/console.ts`.
+2. Build `mesh.ts`: a `useMesh()` React hook (or small store) over the read-only
+   `CotalEndpoint` observer (`getRoster()`, `on("roster"|"presence")`, `tap()`,
+   `listChannels()`, `channelHistory()` from `@cotal/core`). Return UI-ready state — e.g.
+   `{ roster, channels, feed, status, rates }` — with burst coalescing, a windowed feed, and
+   pinned-to-bottom tracking. **Reuse the endpoint; never open a new NATS connection.**
+3. **Settle the exact `useMesh()` return shape with `tui-designer` over the mesh** — open with
+   `cotal_dm(to="tui-designer", text="proposing useMesh() returns { … } — does that cover your panels?")`
+   and converge with them directly. That interface is the contract; agree it peer-to-peer.
+4. Keep `pnpm --filter @cotal/cli typecheck` green for your file.
+5. `cotal_dm(to="orchestrator", text="done: mesh.ts useMesh() ready")` when finished.
+
+## Rules
+- Coordinate the contract with `tui-designer` directly — do NOT ask the orchestrator to relay
+  field names or shapes. You are lateral peers.
+- Stay in your file. If you need a UI requirement, `cotal_dm` `tui-designer`.

--- a/examples/04-self-improving-console/agents/codex-reviewer.md
+++ b/examples/04-self-improving-console/agents/codex-reviewer.md
@@ -1,0 +1,28 @@
+# You are the Codex cross-vendor reviewer on the Cotal mesh (space `console`)
+
+You are an **OpenAI Codex** agent collaborating, as a lateral peer, with a team of Anthropic
+Claude agents over the Cotal mesh — a second pair of eyes from a different vendor. You **review,
+you never edit**: comment only, never modify files.
+
+Your Cotal tools (MCP server `cotal`): `cotal_status` (presence), `cotal_inbox` (read messages),
+`cotal_roster` (who's here), `cotal_send` (broadcast to a channel), `cotal_dm` (message one peer).
+
+## What to do
+1. `cotal_status` to announce you're online and reviewing.
+2. Read what exists (read-only) under the repo:
+   - the plan: `implementations/cli/src/console/SPEC.md`
+   - the code (if present yet): `implementations/cli/src/console/mesh.ts`, `app.tsx`, `ui/*.tsx`,
+     and the command `implementations/cli/src/commands/console-ink.tsx`
+   - for grounding: the existing observer in `implementations/cli/src/commands/console.ts` and
+     `@cotal/core` (the TUI must render over the existing `CotalEndpoint`, not a new NATS connection).
+3. Write a **concise, specific** review — correctness risks, missing cases, API misuse, whether the
+   `useMesh()` contract and the UI actually match the SPEC. A few sharp points beat a long essay.
+4. **Post it on the mesh:** `cotal_send(channel="team", text="codex review: …")` so the whole team
+   sees it, and `cotal_dm` the most relevant author with specifics — `backend` for `mesh.ts`,
+   `tui-designer` for the UI. (This cross-vendor message on the mesh is the point.)
+5. `cotal_dm(to="orchestrator", text="done: reviewed <plan|code>")` and finish.
+
+## Rules
+- **Read-only.** Never edit, create, or delete files. Your only outputs are mesh messages.
+- Be a genuinely useful reviewer, not a rubber stamp — call out real issues, but keep it short.
+- If the SPEC/code isn't there yet, say what's missing and review what is present.

--- a/examples/04-self-improving-console/agents/orchestrator.md
+++ b/examples/04-self-improving-console/agents/orchestrator.md
@@ -1,0 +1,39 @@
+# You are `orchestrator` on the Cotal mesh (space `console`)
+
+You dispatch the team and route the work — but you are NOT a hub that everything flows
+through. The detail-level coordination happens **peer-to-peer between the workers**; your
+job is to start them, hand each its task, and confirm completion.
+
+Your Cotal tools (MCP server `cotal`): `cotal_roster` (who's present), `cotal_spawn`
+(start a teammate), `cotal_dm` (message one peer), `cotal_send` (broadcast to a channel),
+`cotal_inbox` (read messages sent to you), `cotal_status` (set presence).
+
+## The goal
+Rebuild cotal's live console as a lazygit-style **Ink/React TUI**, shipped as the new
+`cotal console-ink` command (the old `console` stays). It renders over the EXISTING
+read-only `CotalEndpoint` observer — never a new raw NATS connection. See GOAL.md.
+
+## Runbook
+1. `cotal_spawn` three teammates: `research`, `backend`, `tui-designer`. Poll
+   `cotal_roster` until all three are present.
+2. `cotal_dm` each its task:
+   - `research`: read `research/INPUT.md`, verify the key facts, write the SPEC to
+     `implementations/cli/src/console/SPEC.md`, then **broadcast** a summary to the team.
+   - `backend`: build the `useMesh()` data layer in `implementations/cli/src/console/mesh.ts`.
+   - `tui-designer`: build the Ink components in `implementations/cli/src/console/` and wire
+     the `console-ink` command.
+3. Tell `backend` and `tui-designer` **explicitly** to settle the `useMesh()` interface
+   **directly with each other** (`cotal_dm`) — do NOT offer to relay it; point them at each other.
+4. **Critical review (non-blocking).** Once `research` has broadcast the SPEC,
+   `cotal_spawn(name="reviewer", role="reviewer")` — a sharp second pair of eyes that reviews the
+   *plan*. After `backend` + `tui-designer` report `done:`, `cotal_spawn(name="reviewer-code",
+   role="reviewer")` to review the *code*. The reviewer posts findings to the `team` channel; relay
+   anything actionable to the right author. **Do not block completion on it** — if it never reports, proceed.
+5. Watch `cotal_inbox` for each worker's `done:`. When `research`/`backend`/`tui-designer` are done
+   AND `pnpm --filter @cotal/cli typecheck` is green, `cotal_send` **`DEMO COMPLETE`** to the
+   `team` channel and report to the operator.
+
+## Rules
+- **Don't do the workers' coding** and **don't relay technical contracts** between them —
+  that defeats the point (lateral peers). Route *who acts next*, not *the details*.
+- If a worker is blocked, tell it which peer to ask, not the answer.

--- a/examples/04-self-improving-console/agents/research.md
+++ b/examples/04-self-improving-console/agents/research.md
@@ -1,0 +1,30 @@
+# You are `research` on the Cotal mesh (space `console`)
+
+You turn the raw research into a tight, actionable SPEC and **get it into your teammates'
+hands** — you are the one who arrives with context ready for the others.
+
+Your Cotal tools (MCP server `cotal`): `cotal_inbox`, `cotal_dm`, `cotal_send` (broadcast),
+`cotal_roster`, `cotal_status`.
+
+## Your repo
+You're in `examples/04-self-improving-console/research/`. Source material is `INPUT.md`.
+You own exactly one output file: `implementations/cli/src/console/SPEC.md`.
+
+## Job
+1. Read `INPUT.md`. Verify the few load-bearing facts (Ink is the right TUI lib for a Node
+   ESM monorepo; render over the existing `CotalEndpoint` observer — NOT a new NATS client;
+   it's a port of the ANSI console in `implementations/cli/src/render.ts`). A quick check is
+   fine; don't rabbit-hole.
+2. Write `implementations/cli/src/console/SPEC.md`: the target UI (roster panel, channel
+   tabs, live feed, focus, `?` help), the data the UI needs, and a STARTING proposal for the
+   `useMesh()` shape — but mark it as a proposal `backend` and `tui-designer` finalize together.
+3. **Broadcast** a short summary to the team: `cotal_send(channel="team", text="SPEC ready: …")`
+   so both workers start aligned. This is the point of your role — context ready for the others.
+4. Answer follow-up `cotal_dm`s from `backend`/`tui-designer` **directly** — you're peers.
+5. `cotal_dm(to="orchestrator", text="done: SPEC written + broadcast")` when finished.
+
+## Rules
+- Don't write UI or data-layer code — that's backend/tui-designer. You produce the SPEC and
+  the shared understanding.
+- Prefer broadcasting to the team channel over messaging the orchestrator for anything the
+  whole team needs.

--- a/examples/04-self-improving-console/agents/reviewer.md
+++ b/examples/04-self-improving-console/agents/reviewer.md
@@ -1,0 +1,29 @@
+# You are `reviewer` on the Cotal mesh (space `console`)
+
+You are a **critical reviewer** — a sharp second pair of eyes on the team's work, joining as a
+lateral peer over the Cotal mesh. You **review, you never edit**: comment only, never modify files.
+Be adversarial in the useful sense — find real problems, don't rubber-stamp.
+
+Your Cotal tools (MCP server `cotal`): `cotal_status` (presence), `cotal_inbox` (read messages),
+`cotal_roster` (who's here), `cotal_send` (broadcast to a channel), `cotal_dm` (message one peer).
+
+## What to do
+1. `cotal_status` to announce you're online and reviewing.
+2. Read what exists (read-only) under the repo:
+   - the plan: `implementations/cli/src/console/SPEC.md`
+   - the code (if present yet): `implementations/cli/src/console/mesh.ts`, `app.tsx`, `ui/*.tsx`,
+     and the command `implementations/cli/src/commands/console-ink.tsx`
+   - for grounding: the existing observer in `implementations/cli/src/commands/console.ts` and
+     `@cotal/core` — the TUI must render over the existing `CotalEndpoint`, NOT a new NATS connection.
+3. Write a **concise, specific, critical** review — correctness risks, missing cases, API misuse,
+   whether the `useMesh()` contract and the UI actually match the SPEC, whether `console-ink` is truly
+   wired to a real `<App/>` (not a placeholder). A few sharp points beat a long essay.
+4. **Post it on the mesh:** `cotal_send(channel="team", text="review: …")` so the whole team sees it,
+   and `cotal_dm` the most relevant author with specifics — `backend` for `mesh.ts`, `tui-designer`
+   for the UI.
+5. `cotal_dm(to="orchestrator", text="done: reviewed <plan|code>")` and finish.
+
+## Rules
+- **Read-only.** Never edit, create, or delete files. Your only outputs are mesh messages.
+- Be a genuinely useful critic — call out real issues, but keep it short and actionable.
+- If the SPEC/code isn't there yet, say what's missing and review what is present.

--- a/examples/04-self-improving-console/agents/tui-designer.md
+++ b/examples/04-self-improving-console/agents/tui-designer.md
@@ -1,0 +1,39 @@
+# You are `tui-designer` on the Cotal mesh (space `console`)
+
+You build the **Ink/React TUI** — and you settle its data interface **directly with
+`backend`**, peer-to-peer, not through the orchestrator.
+
+Your Cotal tools (MCP server `cotal`): `cotal_inbox`, `cotal_dm`, `cotal_send`,
+`cotal_roster`, `cotal_status`.
+
+## Your repo / ownership
+You're in `implementations/cli`. You own:
+`implementations/cli/src/console/app.tsx`, `implementations/cli/src/console/ui/*.tsx`, and
+the `console-ink` command (`implementations/cli/src/commands/console-ink.tsx`, already a
+runnable placeholder — replace its placeholder with the real app). Do NOT edit
+`implementations/cli/src/console/mesh.ts` — that's `backend`'s.
+
+## Job
+1. Read `implementations/cli/src/console/SPEC.md` (from `research`). The stack is already
+   installed: `ink@6`, `react@19`, `@inkjs/ui` (tsx runs `.tsx` directly).
+2. **WIRE FIRST (do this before enriching).** Make `console-ink` render your real `<App/>`:
+   write a minimal `app.tsx` (even just roster + feed using `useMesh()`) and **replace the
+   placeholder in `implementations/cli/src/commands/console-ink.tsx`** so it imports and renders
+   `./console/app.js`. Confirm `pnpm --filter @cotal/cli typecheck` is green. This guarantees a
+   working command even if you run out of time — a half-built but wired TUI beats rich-but-unwired.
+3. **THEN enrich** in `app.tsx` + `ui/*.tsx`: always-visible **roster panel**, **channel tabs**
+   (number-key 1–9 jumps), **live feed** (main panel, auto-scroll unless scrolled up),
+   **multi-panel focus** via `useFocus`/`useFocusManager`, and a context-sensitive **`?` help**
+   overlay. Keep flicker down: `incrementalRendering`, `maxFps: 30`, `<Static>` for finalized
+   scrollback. Consume the data layer from `./mesh.ts` (`useMesh`).
+5. **Settle the `useMesh()` shape with `backend` over the mesh** — when its return type is
+   unclear or you need another field, `cotal_dm(to="backend", text="for the feed panel I need … in useMesh() — ok?")`
+   and converge directly. Don't stub your own data client; depend on `mesh.ts`.
+6. You are **not done** until `app.tsx` is real (no `TODO(demo)`/`export {}` stub) AND
+   `console-ink.tsx` renders it (no "placeholder") AND typecheck is green. Then
+   `cotal_dm(to="orchestrator", text="done: Ink TUI wired into console-ink")`.
+
+## Rules
+- Coordinate the data contract with `backend` directly (`cotal_dm`), never via the
+  orchestrator. You are lateral peers.
+- Stay in your files. If you need a data shape, ask `backend`, don't reach into `mesh.ts`.

--- a/examples/04-self-improving-console/cmux.json
+++ b/examples/04-self-improving-console/cmux.json
@@ -1,0 +1,29 @@
+{
+  "commands": [
+    {
+      "name": "Cotal: start mesh",
+      "keywords": ["cotal", "nats", "mesh", "up"],
+      "command": "bash -lc 'cd $(git rev-parse --show-toplevel) && pnpm cotal up'"
+    },
+    {
+      "name": "Cotal: launch orchestrator",
+      "keywords": ["cotal", "orchestrator", "claude"],
+      "command": "bash -lc '$(git rev-parse --show-toplevel)/examples/04-self-improving-console/run-agent.sh orchestrator'"
+    },
+    {
+      "name": "Cotal: launch research",
+      "keywords": ["cotal", "research", "claude"],
+      "command": "bash -lc '$(git rev-parse --show-toplevel)/examples/04-self-improving-console/run-agent.sh research'"
+    },
+    {
+      "name": "Cotal: launch backend",
+      "keywords": ["cotal", "backend", "claude"],
+      "command": "bash -lc '$(git rev-parse --show-toplevel)/examples/04-self-improving-console/run-agent.sh backend'"
+    },
+    {
+      "name": "Cotal: launch tui-designer",
+      "keywords": ["cotal", "tui", "designer", "claude"],
+      "command": "bash -lc '$(git rev-parse --show-toplevel)/examples/04-self-improving-console/run-agent.sh tui-designer'"
+    }
+  ]
+}

--- a/examples/04-self-improving-console/harness/evaluate.ts
+++ b/examples/04-self-improving-console/harness/evaluate.ts
@@ -1,0 +1,125 @@
+/**
+ * harness/evaluate.ts <rundir> — judge one swarm run.
+ *
+ * GREEN = build OK (the worktree's @cotal-ai/cli typechecks) AND ≥1 genuine peer-to-peer
+ * exchange (a unicast DM whose sender is a worker and recipient is not the orchestrator).
+ *
+ * Prints a verdict JSON to stdout (the loop appends it to ITERATIONS.md).
+ */
+import { readFileSync, existsSync } from "node:fs";
+import { execSync } from "node:child_process";
+
+// evaluate.ts <repoDir> [transcriptPath]
+const repoDir = process.argv[2] || process.cwd();
+const transcriptPath = process.argv[3] || `${repoDir}/transcript.jsonl`;
+
+type Rec = {
+  type: string;
+  mode?: string;
+  from?: string;
+  fromId?: string;
+  to?: string; // instance id for unicast — resolve via the id→name map
+  channel?: string;
+  text?: string;
+};
+
+const recs: Rec[] = existsSync(transcriptPath)
+  ? readFileSync(transcriptPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => {
+        try {
+          return JSON.parse(l) as Rec;
+        } catch {
+          return null;
+        }
+      })
+      .filter((r): r is Rec => r !== null)
+  : [];
+
+const msgs = recs.filter((r) => r.type === "message");
+
+// --- build check (typecheck the cli IN the worktree) ---
+// Invoke the worktree's own tsc directly (not `pnpm --filter`, which exits 0 when it
+// matches no project — a false green if the worktree install failed).
+let buildOk = false;
+let buildErr = "";
+try {
+  execSync("./node_modules/.bin/tsc -p implementations/cli/tsconfig.json --noEmit", {
+    cwd: repoDir,
+    stdio: "pipe",
+  });
+  buildOk = true;
+} catch (e) {
+  const err = e as { stdout?: Buffer; stderr?: Buffer; message?: string };
+  buildErr = (
+    (err.stdout?.toString() ?? "") +
+    (err.stderr?.toString() ?? "") +
+    (err.message ?? "")
+  ).trim();
+}
+
+// --- comms analysis ---
+// "Hubs" are not peers: a DM to/from any of these is orchestrator-routed, not peer-to-peer.
+const HUB = new Set(["orchestrator", "manager", "cli", "harness-observer"]);
+// `to` is an instance id; resolve it to a name via the id→name map built from `from`/`fromId`.
+const idToName: Record<string, string> = {};
+for (const m of msgs) if (m.fromId && m.from) idToName[m.fromId] = m.from;
+const nameOf = (x?: string): string | undefined => (x && idToName[x] ? idToName[x] : x);
+
+const dms = msgs.filter((m) => m.mode === "unicast");
+const chats = msgs.filter((m) => m.mode === "chat");
+// peer-to-peer DM: both ends are workers (neither is a hub), and it's not a self-message.
+const peerDms = dms.filter((m) => {
+  const from = m.from;
+  const to = nameOf(m.to);
+  return !!from && !!to && !HUB.has(from) && !HUB.has(to) && from !== to;
+});
+const peerPairs = [...new Set(peerDms.map((m) => `${m.from}->${nameOf(m.to) ?? "?"}`))];
+const complete = msgs.some((m) => (m.text ?? "").includes("DEMO COMPLETE"));
+const peerToPeer = peerDms.length >= 1;
+
+// "wired": the swarm actually replaced the placeholders — app.tsx is a real component and the
+// console-ink command renders it. Build+p2p can both pass with the UI unwired (iter 3), so
+// green must require a working command too.
+const read = (p: string): string => (existsSync(p) ? readFileSync(p, "utf8") : "");
+const appSrc = read(`${repoDir}/implementations/cli/src/console/app.tsx`);
+const cmdSrc = read(`${repoDir}/implementations/cli/src/commands/console-ink.tsx`);
+const wired = appSrc.length > 200 && !appSrc.includes("TODO(demo)") && !/placeholder/i.test(cmdSrc);
+
+const green = buildOk && peerToPeer && wired;
+
+// Cross-vendor highlight: did an OpenAI Codex reviewer post on the mesh? Tracked, NOT part of
+// green — a codex auth hiccup must never fail an otherwise-good run.
+const crossVendor = msgs.some((m) => (m.from ?? "").startsWith("codex"));
+
+const failureMode = !msgs.length
+  ? "no-traffic — agents never communicated (spawn/wake/TTY problem)"
+  : !peerToPeer
+    ? "star-topology — all comms via orchestrator, no peer-to-peer DMs"
+    : !buildOk
+      ? "build-failed — typecheck red"
+      : !wired
+        ? "ui-not-wired — mesh/components built but app.tsx/console-ink still placeholder"
+        : "ok";
+
+const verdict = {
+  green,
+  buildOk,
+  peerToPeer,
+  wired,
+  crossVendor,
+  complete,
+  counts: {
+    messages: msgs.length,
+    chats: chats.length,
+    dms: dms.length,
+    peerDms: peerDms.length,
+  },
+  peerPairs,
+  failureMode,
+  buildErr: buildOk ? "" : buildErr.split("\n").slice(-12).join("\n"),
+};
+
+console.log(JSON.stringify(verdict, null, 2));

--- a/examples/04-self-improving-console/harness/observer.ts
+++ b/examples/04-self-improving-console/harness/observer.ts
@@ -1,0 +1,70 @@
+/**
+ * harness/observer.ts — log ALL mesh traffic for a run to a transcript file.
+ *
+ * Runs as a read-only observer. In OPEN mode (the harness starts NATS with `--open`)
+ * the whole-space tap sees chat, unicast (DM), and anycast — so peer-to-peer DMs are
+ * visible, which is exactly what `evaluate.ts` measures.
+ *
+ *   COTAL_SPACE=<space> TRANSCRIPT=<path> tsx harness/observer.ts
+ */
+import { appendFileSync } from "node:fs";
+import { CotalEndpoint, DEFAULT_SERVER, deliveryOf, type CotalMessage } from "@cotal-ai/core";
+
+const space = process.env.COTAL_SPACE || "console";
+const server = process.env.COTAL_SERVERS || DEFAULT_SERVER;
+const out = process.env.TRANSCRIPT || "transcript.jsonl";
+
+function text(msg: CotalMessage): string {
+  return (msg.parts ?? [])
+    .filter((p) => p.kind === "text")
+    .map((p) => (p as { text: string }).text)
+    .join(" ");
+}
+
+const ep = new CotalEndpoint({
+  space,
+  servers: server,
+  channels: [],
+  consume: false,
+  registerPresence: false,
+  watchPresence: true,
+  card: { name: "harness-observer", kind: "endpoint" },
+});
+ep.on("error", (e: Error) => process.stderr.write(`observer error: ${e.message}\n`));
+ep.on("presence", (ev) => {
+  appendFileSync(
+    out,
+    JSON.stringify({
+      t: Date.now(),
+      type: "presence",
+      ev: ev.type,
+      name: ev.presence.card.name,
+      role: ev.presence.card.role,
+      status: ev.presence.status,
+      activity: ev.presence.activity,
+    }) + "\n",
+  );
+});
+
+await ep.start();
+ep.tap((subject, msg) => {
+  if (!msg) return;
+  appendFileSync(
+    out,
+    JSON.stringify({
+      t: Date.now(),
+      type: "message",
+      mode: deliveryOf(subject), // "chat" | "unicast" | "anycast" | null
+      subject,
+      from: msg.from?.name,
+      fromId: msg.from?.id,
+      fromRole: msg.from?.role,
+      to: msg.to, // NOTE: recipient INSTANCE ID for unicast, not a name — resolve via fromId map
+      channel: msg.channel,
+      toService: msg.toService,
+      text: text(msg),
+    }) + "\n",
+  );
+});
+process.stderr.write(`observer logging space "${space}" -> ${out}\n`);
+await new Promise<void>(() => {});

--- a/examples/04-self-improving-console/harness/replay.ts
+++ b/examples/04-self-improving-console/harness/replay.ts
@@ -1,0 +1,109 @@
+/**
+ * harness/replay.ts <transcript> [space] [targetSec] — re-enact a recorded run on a LIVE mesh.
+ *
+ * Spins up one real endpoint per agent in the transcript (so they show in the roster), then
+ * replays every presence change + message (multicast / peer DM / anycast) in order, looping.
+ * Point `cotal console-ink --space <space>` at it to watch the swarm coordinate — no agents,
+ * no cost, fully repeatable. The demo's "play button".
+ *
+ * Pacing is length-aware: a fixed time budget (targetSec, default 120s) is spread across the
+ * messages by text length, so long posts (the reviewer's findings, the contract negotiation)
+ * linger and short acks go quick — one loop runs ~targetSec, not rushed.
+ *
+ *   pnpm cotal up --open
+ *   pnpm tsx examples/04-self-improving-console/harness/replay.ts <transcript.jsonl> demo-replay 120
+ *   pnpm cotal console --space demo-replay   # in a real terminal
+ */
+import { readFileSync } from "node:fs";
+import { CotalEndpoint, DEFAULT_SERVER } from "@cotal-ai/core";
+
+const transcript = process.argv[2];
+const space = process.argv[3] ?? "demo-replay";
+const targetSec = Number(process.argv[4] ?? "120"); // total seconds per replay loop
+if (!transcript) {
+  console.error("usage: replay.ts <transcript> [space] [targetSec]");
+  process.exit(1);
+}
+const server = process.env.COTAL_SERVERS?.trim() || DEFAULT_SERVER;
+
+type Rec = {
+  type: string; ev?: string; mode?: string;
+  name?: string; role?: string; status?: string; activity?: string;
+  from?: string; fromId?: string; fromRole?: string; to?: string;
+  channel?: string; toService?: string; text?: string;
+};
+const recs: Rec[] = readFileSync(transcript, "utf8").trim().split("\n").filter(Boolean).map((l) => JSON.parse(l));
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// Infra endpoints aren't agents — don't give them a roster row.
+const INFRA = new Set(["manager", "cli", "harness-observer", "console"]);
+
+// Collect agents + their roles from presence and message records.
+const roleOf = new Map<string, string>();
+for (const r of recs) {
+  const n = r.name ?? r.from;
+  if (n && !INFRA.has(n)) roleOf.set(n, r.role ?? r.fromRole ?? roleOf.get(n) ?? n);
+}
+
+// One live endpoint per agent (registers presence → shows in the roster).
+const eps = new Map<string, CotalEndpoint>();
+for (const [name, role] of roleOf) {
+  const ep = new CotalEndpoint({
+    space, servers: server,
+    card: { name, role, kind: "agent" },
+    // consume:true so each agent's inbox JetStream stream exists — otherwise replayed
+    // peer DMs (unicast) have no responder and fail.
+    channels: ["team"], consume: true, registerPresence: true, watchPresence: false,
+  });
+  await ep.start();
+  eps.set(name, ep);
+}
+console.log(`replay: ${eps.size} agents live in space "${space}" — ${[...eps.keys()].join(", ")}`);
+
+// Map the recording's instance ids → the names we just spun up, so peer DMs resolve.
+const idToName: Record<string, string> = {};
+for (const r of recs) if (r.fromId && r.from) idToName[r.fromId] = r.from;
+const newIdOf = (name?: string) => (name ? eps.get(name)?.card.id : undefined);
+
+// Length-aware pacing: spread a fixed time budget across the messages by text length, so long
+// posts linger and short acks go quick. Every message gets at least MIN_MS; the rest of the
+// budget is shared in proportion to length so one loop lands around targetSec.
+const GAP_MS = 3000; // pause between loops
+const MIN_MS = 1500; // floor so even a short "standing by" is readable
+const paced = recs.filter((r) => r.type === "message" && r.text && r.from && eps.has(r.from));
+const totalLen = paced.reduce((a, r) => a + Math.max(1, (r.text ?? "").length), 0) || 1;
+const budget = Math.max(paced.length * MIN_MS, targetSec * 1000 - GAP_MS);
+const extra = budget - paced.length * MIN_MS;
+const delayOf = new Map<Rec, number>();
+for (const r of paced) delayOf.set(r, MIN_MS + (extra * Math.max(1, (r.text ?? "").length)) / totalLen);
+
+async function once() {
+  for (const r of recs) {
+    if (r.type === "presence" && (r.ev === "update" || r.ev === "join") && r.name && eps.has(r.name)) {
+      await eps.get(r.name)!.setStatus((r.status as never) ?? "working");
+      continue;
+    }
+    if (r.type !== "message" || !r.text) continue;
+    const ep = r.from ? eps.get(r.from) : undefined;
+    if (!ep) continue;
+    try {
+      if (r.mode === "chat") await ep.multicast(r.text, { channel: r.channel ?? "team" });
+      else if (r.mode === "unicast") {
+        const tid = newIdOf(idToName[r.to ?? ""]);
+        if (tid) await ep.unicast(tid, r.text);
+      } else if (r.mode === "anycast") await ep.anycast(r.toService ?? "team", r.text);
+    } catch (e) {
+      console.error(`  (skipped ${r.mode} from ${r.from}: ${(e as Error).message})`);
+    }
+    await sleep(delayOf.get(r) ?? MIN_MS);
+  }
+}
+
+console.log(
+  `replay: ${paced.length} messages paced over ~${Math.round((budget + GAP_MS) / 1000)}s/loop — Ctrl-C to stop. Open the console:`,
+);
+console.log(`  cotal console-ink --space ${space}`);
+for (;;) {
+  await once();
+  await sleep(GAP_MS);
+}

--- a/examples/04-self-improving-console/harness/run-once.sh
+++ b/examples/04-self-improving-console/harness/run-once.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# harness/run-once.sh <iter> — run the console-rebuild swarm HEADLESS, once.
+#
+# Runs on the MAIN demo branch (agents reliably target the canonical repo path, so a
+# worktree leaks — see ITERATIONS.md iter 2). Isolation = a git reset of the console
+# scaffold BEFORE each run; a unique mesh space per run isolates the traffic.
+#
+# - reset console scaffold to committed placeholder state (clean slate)
+# - NATS open mode (observer can see DMs → peer-to-peer visibility)
+# - manager headless on the PTY runtime (open stdin + dev-channels auto-confirm)
+# - orchestrator spawned via the manager (`cotal start`); it cotal_spawns the workers
+# - observer logs ALL traffic to .runs/run-<iter>/transcript.jsonl
+# - wait for "DEMO COMPLETE" / timeout, tear down, evaluate (build main + comms)
+#
+# Does NOT reset at the end (last run stays inspectable); the next run resets first.
+set -uo pipefail
+
+ITER="${1:-0}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EX="$(cd "$HERE/.." && pwd)"
+REPO="$(cd "$EX/../.." && pwd)"
+SPACE="console-r$ITER"
+SERVER="${COTAL_SERVERS:-nats://127.0.0.1:4222}"
+TIMEOUT="${RUN_TIMEOUT:-900}"
+TSX="$REPO/node_modules/.bin/tsx"
+RESULTS="$REPO/.runs/run-$ITER"
+EXREL="examples/04-self-improving-console"
+
+log() { echo "[run-once $ITER] $*"; }
+
+mkdir -p "$RESULTS"
+
+# --- reset the console scaffold to committed placeholder state -------------
+# Only the swarm-owned files. NOT package.json/tsconfig/pnpm-lock — parallel
+# licensing work lives there and the swarm doesn't need to touch deps (already committed).
+git -C "$REPO" checkout -- \
+  implementations/cli/src/console \
+  implementations/cli/src/commands/console-ink.tsx \
+  implementations/cli/src/index.ts 2>/dev/null || true
+git -C "$REPO" clean -fd implementations/cli/src/console/ui >/dev/null 2>&1 || true
+log "console scaffold reset to clean state"
+
+# --- NATS (open mode so DMs are observable) -------------------------------
+nats_up() { (exec 3<>/dev/tcp/127.0.0.1/4222) 2>/dev/null; }
+if ! nats_up; then
+  log "starting NATS (open mode)"
+  ( cd "$REPO" && nohup pnpm cotal up --open --store-dir "$RESULTS/.nats" >"$HERE/.mesh-$ITER.log" 2>&1 & )
+  for _ in $(seq 1 40); do nats_up && break; sleep 0.25; done
+fi
+nats_up || { log "NATS did not come up"; exit 3; }
+
+TRANSCRIPT="$RESULTS/transcript.jsonl"
+: > "$TRANSCRIPT"
+
+# --- observer (all traffic -> transcript) ---------------------------------
+COTAL_SPACE="$SPACE" COTAL_SERVERS="$SERVER" TRANSCRIPT="$TRANSCRIPT" \
+  "$TSX" "$REPO/$EXREL/harness/observer.ts" >"$HERE/.observer-$ITER.log" 2>&1 &
+OBS=$!
+
+# --- manager (pty runtime, headless → all spawned agents inherit headless) -
+COTAL_HEADLESS=1 COTAL_SPACE="$SPACE" COTAL_SERVERS="$SERVER" COTAL_RUNTIME=pty \
+  "$TSX" "$REPO/$EXREL/src/manager.ts" >"$HERE/.manager-$ITER.log" 2>&1 &
+MGR=$!
+sleep 4
+
+# --- orchestrator via the manager (PTY runtime → open stdin + auto-confirm) -
+COTAL_SPACE="$SPACE" COTAL_SERVERS="$SERVER" \
+  "$TSX" "$REPO/bin/cotal.ts" start --space "$SPACE" --server "$SERVER" \
+    --name orchestrator --role orchestrator >"$HERE/.orch-start-$ITER.log" 2>&1 \
+  || log "cotal start orchestrator failed (see .orch-start-$ITER.log)"
+log "swarm running (space=$SPACE, timeout=${TIMEOUT}s) — mgr=$MGR obs=$OBS"
+
+# --- wait for completion / timeout ----------------------------------------
+deadline=$(( $(date +%s) + TIMEOUT ))
+outcome="timeout"
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  if grep -q "DEMO COMPLETE" "$TRANSCRIPT" 2>/dev/null; then outcome="complete"; break; fi
+  if ! kill -0 "$MGR" 2>/dev/null; then outcome="manager-died"; break; fi
+  sleep 5
+done
+log "outcome: $outcome"
+
+# --- teardown (specific PIDs only; never broad-pkill claude) ---------------
+kill "$MGR" 2>/dev/null || true      # manager's SIGTERM handler stops spawned agents
+sleep 2
+kill "$OBS" 2>/dev/null || true
+
+# --- evaluate (typecheck MAIN repo where the swarm wrote; comms from transcript) -
+VERDICT="$RESULTS/verdict.json"
+"$TSX" "$REPO/$EXREL/harness/evaluate.ts" "$REPO" "$TRANSCRIPT" >"$VERDICT" 2>"$HERE/.evaluate-$ITER.log" || true
+log "verdict -> $VERDICT"
+cat "$VERDICT" 2>/dev/null || echo '{"green":false,"failureMode":"evaluate-failed"}'
+echo "OUTCOME=$outcome"

--- a/examples/04-self-improving-console/launch.sh
+++ b/examples/04-self-improving-console/launch.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Bring up the Cotal mesh and lay out the self-improving-console demo in cmux.
+#
+#   ./launch.sh           verify the mesh, print the cmux launch sequence
+#   ./launch.sh --drive   open the console + orchestrator; the orchestrator grows the team
+#   ./launch.sh --stop    stop the manager(s) for this space
+#
+# Layout (one workspace): the live console dashboard (what we watch the swarm through)
+# on top, the orchestrator below. The orchestrator spawns research / backend / tui-designer
+# into their own tabs on demand.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+SPACE="console"
+
+TSX="$REPO_ROOT/node_modules/.bin/tsx"
+CMUX="$TSX $REPO_ROOT/extensions/cmux/src/cli.ts"
+cmux_check() {
+  $CMUX check || { echo "✗ can't reach cmux — run this from inside a cmux terminal." >&2; exit 1; }
+}
+
+term() { printf '{"pane":{"surfaces":[{"type":"terminal","command":"%s"}]}}' "$1"; }
+
+manager_term() { # the example manager as a live pane (cmux runtime), so its spawns are authorized
+  term "bash -lc 'cd $HERE && COTAL_SPACE=$SPACE COTAL_RUNTIME=cmux exec $TSX $HERE/src/manager.ts'"
+}
+manager_up() {
+  if pgrep -f "$HERE/src/manager.ts" >/dev/null; then
+    echo "✓ manager already running"
+  else
+    echo "opening the manager in its own cmux tab so the orchestrator can grow the team…"
+    $CMUX open cotal-manager "$(manager_term)"
+  fi
+}
+
+if [[ "${1:-}" == "--stop" ]]; then
+  if pkill -f "$HERE/src/manager.ts"; then echo "✓ stopped manager(s) for space $SPACE"; else echo "no manager running"; fi
+  exit 0
+fi
+
+# --- mesh ------------------------------------------------------------------
+nats_up() { (exec 3<>/dev/tcp/127.0.0.1/4222) 2>/dev/null; }
+if nats_up; then
+  echo "✓ NATS already up on 127.0.0.1:4222"
+else
+  command -v nats-server >/dev/null || { echo "✗ nats-server not found. Install: brew install nats-server" >&2; exit 1; }
+  echo "starting the mesh (pnpm cotal up) in the background…"
+  ( cd "$REPO_ROOT" && nohup pnpm cotal up >"$HERE/.mesh.log" 2>&1 & )
+  for _ in $(seq 1 20); do nats_up && break; sleep 0.25; done
+  nats_up && echo "✓ mesh up (log: $HERE/.mesh.log)" || { echo "✗ mesh did not come up — see $HERE/.mesh.log" >&2; exit 1; }
+fi
+
+agent_term() { term "bash -lc '$HERE/run-agent.sh $1'"; }
+
+build_layout() {
+  printf '{"direction":"vertical","split":0.4,"children":[%s,%s]}' \
+    "$(term "bash -lc 'cd $REPO_ROOT && pnpm cotal console --space $SPACE'")" \
+    "$(agent_term orchestrator)"
+}
+
+if [[ "${1:-}" == "--drive" ]]; then
+  cmux_check
+  manager_up
+  echo "opening the cotal-console workspace (console + orchestrator)…"
+  $CMUX open cotal-console "$(build_layout)"
+  echo "✓ workspace opened. Approve the plugin in the orchestrator pane if prompted, then give it"
+  echo "  the goal (examples/04-self-improving-console/GOAL.md). It spawns research/backend/tui-designer."
+  exit 0
+fi
+
+cat <<EOF
+
+Mesh is up. Easiest: re-run with --drive (from inside a cmux terminal) to open the console +
+orchestrator. Give the orchestrator the goal (GOAL.md) and it spawns research / backend /
+tui-designer into their own tabs:
+
+  ./launch.sh --drive
+
+Or open plain terminals / use the cmux.json palette. Start the orchestrator with:
+
+  ./run-agent.sh orchestrator
+
+(research / backend / tui-designer are spawned by the orchestrator — or launch any by hand with
+run-agent.sh <role>.)
+EOF

--- a/examples/04-self-improving-console/package.json
+++ b/examples/04-self-improving-console/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@cotal-ai/example-04-self-improving-console",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "manager": "tsx src/manager.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@cotal-ai/cmux": "workspace:*",
+    "@cotal-ai/core": "workspace:*",
+    "@cotal-ai/manager": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "^4.22.4"
+  }
+}

--- a/examples/04-self-improving-console/research/INPUT.md
+++ b/examples/04-self-improving-console/research/INPUT.md
@@ -1,0 +1,105 @@
+> **Note for `research`:** this project was renamed **Swarl → cotal**. Where this doc says
+> "Swarl"/`swarl_*`/`@swarl/*`, read **cotal**/`cotal_*`/`@cotal/*`. The MCP tools are
+> `cotal_roster`/`cotal_dm`/`cotal_inbox`/etc. The current console lives at
+> `implementations/cli/src/render.ts` + `commands/console.ts` and already uses the read-only
+> `CotalEndpoint` observer — render the new TUI over THAT, not a new NATS client. Distill this
+> into `implementations/cli/src/console/SPEC.md` and broadcast a summary to the team.
+
+---
+
+# Building a Polished TUI for the Swarl Console: Lazygit-Inspired, TypeScript-First
+
+## TL;DR
+- **Use Ink (vadimdemedes/ink) as the TUI framework for the Swarl console.** It is the de facto standard for production Node/TypeScript TUIs in 2026 — Anthropic's Claude Code, Google's Gemini CLI, GitHub Copilot CLI, Prisma, Shopify, and Linear all ship Ink-based interfaces — and its React component model is the right level of abstraction for a multi-panel dashboard wired to a NATS JetStream stream.
+- **Borrow lazygit's *architecture*, not its *framework*.** Lazygit's "everything visible at once" panel layout, context-sensitive keybindings, and strict separation between a UI layer (gocui + controllers + contexts) and a domain layer (git command package) are language-agnostic patterns. Replicate them in Ink with a `ContextManager` (which panel is focused, what keys are bound), a thin `SwarlClient` wrapping NATS JetStream, and per-panel controller components.
+- **Skip OpenTUI for now.** OpenTUI is the most interesting newcomer (TypeScript bindings, Zig core, powers OpenCode in production) but its docs at `opentui.com/docs/getting-started/` state verbatim: *"OpenTUI is currently Bun exclusive but Deno and Node support in-progress."* That makes it a non-starter for a Node ESM monorepo today. Revisit once Node support ships.
+
+## Key Findings
+
+### 1. Lazygit's design philosophy is reproducible in any language
+
+Jesse Duffield, lazygit's creator, has said the visual design was driven by a single principle: **show as much context on the screen as possible**. This led to side windows for files, branches, etc, and a main window for the currently selected item. This is the opposite of `git` itself — `git status`, `git diff`, `git log` are three separate commands; lazygit shows them as five always-visible panels (Status, Files, Branches, Commits, Stash) plus a main panel.
+
+Other deliberate UX decisions worth copying:
+- **Context-sensitive `?` cheatsheet.** Every panel binds `?` to a help popup that lists only the keybindings valid for that context. Discoverable without a manual.
+- **One-character mnemonic keybindings** (`c` commit, `s` squash, `p` pull, `P` push, `d` drop, `f` fixup).
+- **Inline status indicators.** Loading text appears on the affected row (e.g., "fetching...") rather than in a global status bar.
+- **Yellow/green/red commit colorization** to encode three independent booleans into a single glance.
+- **Performance is non-negotiable.**
+
+Internally, lazygit's `pkg/gui` layer is organized around three concepts:
+- **Views** — the rendering primitive (a rectangular region on screen).
+- **Contexts** — one per panel/tab; each carries its own keybindings, focus/render callbacks, and the view it renders to.
+- **Controllers** — handle input for a class of context; shared logic lives in `helpers`.
+
+Below that, command execution lives in small typed structs that shell out to git. This **controller-helper-command** stratification is exactly what to copy: UI never touches the wire; helpers translate UI intent into protocol operations; the protocol layer is a thin wrapper over NATS.
+
+### 2. Claude Code uses Ink — confirmed, with a custom renderer fork
+
+The Ink README lists Claude Code by name as a showcase user. Claude Code uses a custom fork of the Ink renderer for advanced terminal features (bidi text, layout optimizations via yoga-layout, frame scheduling): cell-level dirty tracking, double-buffering, interning of repeated styles, Suspense-based async syntax highlighting. Most of these optimizations are unnecessary at swarl-console scale — **stock Ink ≥ 6 is enough for a pub/sub dashboard**.
+
+Interface elements worth borrowing:
+- **Streaming output via incremental React state updates**, not via Ink's `<Static>`. `<Static>` is for *finalized* lines; streaming live text wants a normal component that re-renders.
+- **Permission dialogs as modal overlays** that take focus until dismissed.
+- **A persistent input** at the bottom that's always available regardless of which scrollback is showing.
+
+### 3. The TUI framework landscape for Node/TypeScript in 2026
+
+| Framework | Maintained? | Model | Verdict |
+|---|---|---|---|
+| **Ink** (vadimdemedes/ink) | Yes, active; v6 ESM-only, Ink-6 + React-19 | React renderer to terminal via Yoga (Flexbox) | **Recommended.** Huge ecosystem (`@inkjs/ui`, `ink-text-input`, `ink-spinner`, `ink-testing-library`); `useFocus`/`useInput`/`useFocusManager`/`<Static>`; powers Claude Code, Gemini CLI, Copilot CLI |
+| **OpenTUI** (anomalyco/opentui) | Very active | Zig core + React/Solid/Vue reconcilers | **Not yet.** "currently Bun exclusive but Deno and Node support in-progress" |
+| **blessed** (chjj/blessed) | No (last release 2015) | Imperative widget tree | Avoid (unmaintained). |
+| **neo-blessed** | Light | Same as blessed | Only if you want gocui-like imperative widgets. |
+| **terminal-kit** | Light | Lower-level chainable API | Skip — wrong abstraction level. |
+
+**Ink's real downsides you must plan around.** Ink performs full tree traversals and redraws on every state change. If dynamic output height ≥ terminal height, Ink falls back to a fullscreen clear-and-redraw path — the biggest flicker trigger. Mitigations, in order:
+1. **Enable incremental rendering and FPS clamping** in `render()`: `incrementalRendering: true`, `maxFps: 30`.
+2. **Keep dynamic output shorter than the terminal height.**
+3. **Use `<Static>` for the finalized scrollback** of the message feed; keep only the live "tail" in dynamic output.
+4. **Coalesce updates.** Batch JetStream messages with a 50–100 ms ticker into local React state, rather than `setState`-ing once per message.
+5. **Enable Ink's `concurrent: true`** and use `useDeferredValue` for the message feed if message volume is bursty.
+
+### 4. Practical architecture for the console
+
+Mirror lazygit's stratification:
+
+```
+src/console/
+  app.tsx              # root component; global keybindings; ContextManager
+  ui/                  # primitives: PanelBox, FocusableList, StatusBar, panels
+  mesh.ts              # data layer: a thin hook/store over the EXISTING CotalEndpoint observer
+```
+
+**Critical separation principle:** the data layer must be importable from a non-TUI context. In cotal it is already the `CotalEndpoint` observer (`implementations/cli/src/commands/console.ts`): `{consume:false, registerPresence:false, watchPresence:true}`, with `getRoster()`, `on("roster"|"presence")`, `tap()`, `listChannels()`, `channelHistory()`. **Do NOT open a new raw NATS connection** — wrap the endpoint into a `useMesh()` hook.
+
+Patterns that pay off:
+- **Presence as a Map keyed by agent name.** Render the *current state*, not an event log.
+- **Channels as tabs at the top.** Bind `1`–`9` to direct-jump; `Tab` cycles. Switching channels swaps the feed filter.
+- **Feed is the "main panel."** Auto-scroll to bottom unless the user scrolled up — track a `pinnedToBottom` boolean.
+- **Status bar at the bottom.** Connected state, current channel, message rate (`msgs/s`), most relevant keybindings.
+- **Help popup bound to `?`.** Derive the list from the focused context's keymap so it's automatically context-sensitive.
+
+**Resize handling** is built into Ink: `useStdout()` exposes `columns`/`rows`. Test below ~80 cols — plan a stacked (portrait) fallback like lazygit.
+
+**Color theming.** Pass colors via React Context; keep the theme as a single TS object. Use semantic names (`focusedBorder`, `agentIdle`, `agentWorking`).
+
+### 5. Inspiration projects (in order of usefulness)
+1. **ORCH** (oxgeneral/ORCH) — Ink command center for multi-agent orchestration: live agent roster with per-agent status, a task queue panel, a streaming event log. Closest 1:1 match to "agent presence + message feed."
+2. **Gemini CLI** (google-gemini/gemini-cli) — `packages/cli` (Ink UI) + `packages/core` (backend); almost exactly this monorepo topology.
+3. **Kubelive** — horizontal namespace tabs, vertical pod list with `↑/↓`, single-key actions. Exact lazygit pattern in Ink (UX reference only).
+4. **@assistant-ui/react-ink** — composable Ink chat primitives; requires React 19 + ink 6.
+
+## Recommendation
+**Go with Ink, today, in this monorepo.**
+1. Reuse the existing `CotalEndpoint` observer; wrap it in `useMesh()` (data layer in `src/console/mesh.ts`).
+2. Lay out three contexts mirroring lazygit: roster (left top), channels (left bottom / tabs), feed (main).
+3. Focus with `useFocus` + `useFocusManager`, plus number keys `1`/`2`/`3` for direct jumps.
+4. Feed = a windowed slice of state (never unbounded); auto-scroll unless pinned.
+5. `render()` with `incrementalRendering: true, maxFps: 30`. Profile with a synthetic firehose.
+6. Status bar wired to `useStdout()` resize; `?` overlay reads the focused context's keymap.
+
+## Caveats
+- Ink 6 is ESM-only, Node ≥ 20, React ≥ 19 — fine here (cotal is ESM + Node ≥20, runs `.tsx` via tsx).
+- `<Static>` is not a scroll view — append-only finalized output only.
+- Flicker is real on tmux/Windows terminals if you ignore the guidance above.

--- a/examples/04-self-improving-console/run-agent.sh
+++ b/examples/04-self-improving-console/run-agent.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Launch ONE example-04 agent as a Claude Code session wired into the Cotal mesh.
+#
+#   run-agent.sh <orchestrator|research|backend|tui-designer>
+#
+# Loads the connector as a bare MCP server (cotal tools) + lifecycle hooks, turns on
+# channel push (wakes idle agents on incoming DM), and injects the role contract as a
+# system prompt so the real packages stay free of per-agent CLAUDE.md files.
+#
+# Headless mode (COTAL_HEADLESS=1, used by the overnight harness): adds
+# --dangerously-skip-permissions and feeds the orchestrator the demo GOAL directly.
+# Under the manager's PTY runtime the dev-channels prompt is auto-confirmed (see
+# implementations/manager/src/runtime/pty.ts), so no cmux key-injection is needed.
+set -euo pipefail
+
+role="${1:-}"
+case "$role" in
+  orchestrator | research | backend | tui-designer | reviewer) ;;
+  *)
+    echo "usage: run-agent.sh <orchestrator|research|backend|tui-designer|reviewer>" >&2
+    exit 1
+    ;;
+esac
+
+REPO="$(git rev-parse --show-toplevel)"
+HERE="$REPO/examples/04-self-improving-console"
+CONN="$REPO/extensions/connector-claude-code"
+TSX="$REPO/node_modules/.bin/tsx"
+CFG="$HERE/.cotal" # git-ignored
+SPACE="${COTAL_SPACE:-console}"
+
+# --- generate the MCP + hooks config (idempotent; absolute repo paths) ------
+mkdir -p "$CFG"
+cat >"$CFG/mcp.json" <<JSON
+{
+  "mcpServers": {
+    "cotal": { "command": "$TSX", "args": ["$CONN/src/mcp.ts"] }
+  }
+}
+JSON
+
+hook='{"hooks":[{"type":"command","command":"'"$TSX"'","args":["'"$CONN/src/hook.ts"'"]}]}'
+cat >"$CFG/settings.json" <<JSON
+{
+  "hooks": {
+    "SessionStart": [ $hook ],
+    "UserPromptSubmit": [ $hook ],
+    "Notification": [ {"matcher":"permission_prompt|elicitation_dialog","hooks":[{"type":"command","command":"$TSX","args":["$CONN/src/hook.ts"]}]} ],
+    "Stop": [ $hook ],
+    "StopFailure": [ $hook ],
+    "SessionEnd": [ $hook ]
+  }
+}
+JSON
+
+# --- per-role working dir (each agent owns one part of the repo) -------------
+case "$role" in
+  orchestrator) cd "$REPO" ;;
+  research)     cd "$HERE/research" ;;
+  backend)      cd "$REPO/implementations/cli" ;;
+  tui-designer) cd "$REPO/implementations/cli" ;;
+  reviewer)     cd "$REPO" ;;
+esac
+
+contract="$HERE/agents/$role.md"
+
+# Orchestrator opens with a prompt; workers stay silent and wake on the orchestrator's DMs.
+init=()
+if [[ "$role" == orchestrator ]]; then
+  if [[ -n "${COTAL_HEADLESS:-}" ]]; then
+    init=("$(cat "$HERE/GOAL.md")")
+  else
+    init=("Onboard me (the operator) in <=6 short lines: what this demo is, that I give you ONE goal and you spawn research/backend/tui-designer into their own tabs, that research seeds the SPEC and backend<->tui-designer settle the data contract peer-to-peer. Show me the goal to paste (from GOAL.md). Then STOP and wait — do NOT spawn yet.")
+  fi
+fi
+
+# cmux only: auto-confirm the dev-channels prompt in worker tabs (skipped headless —
+# the PTY runtime confirms there). Skip the orchestrator (a human drives it on stage).
+if [[ "$role" != orchestrator && -n "${CMUX_SURFACE_ID:-}" && -n "${CMUX_BUNDLED_CLI_PATH:-}" ]]; then
+  ( for _ in {1..6}; do sleep 1; "$CMUX_BUNDLED_CLI_PATH" send-key --surface "$CMUX_SURFACE_ID" enter; done ) >/dev/null 2>&1 &
+fi
+
+extra=()
+[[ -n "${COTAL_HEADLESS:-}" ]] && extra+=(--dangerously-skip-permissions)
+
+exec env \
+  COTAL_SPACE="$SPACE" COTAL_NAME="$role" COTAL_ROLE="$role" COTAL_CHANNEL=1 \
+  claude \
+    --dangerously-load-development-channels server:cotal \
+    --mcp-config "$CFG/mcp.json" \
+    --settings "$CFG/settings.json" \
+    --strict-mcp-config \
+    --append-system-prompt "$(cat "$contract")" \
+    ${extra[@]+"${extra[@]}"} \
+    ${init[@]+"${init[@]}"}

--- a/examples/04-self-improving-console/run-codex.sh
+++ b/examples/04-self-improving-console/run-codex.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Launch a CODEX (OpenAI) reviewer as a cross-vendor peer on the Cotal mesh.
+#
+#   run-codex.sh <name> [role]
+#
+# Non-interactive: `codex exec "<contract>"` with the cotal MCP server injected via -c
+# overrides (mirrors extensions/connector-codex/src/extension.ts), autonomous
+# (approval_policy=never), so it joins the mesh, reviews on disk, and posts findings via
+# the cotal_* tools — no human in the loop. Read-only by contract (it comments, never edits).
+set -uo pipefail
+
+name="${1:-codex-reviewer}"
+role="${2:-codex-reviewer}"
+
+REPO="$(git rev-parse --show-toplevel)"
+HERE="$REPO/examples/04-self-improving-console"
+TSX="$REPO/node_modules/.bin/tsx"
+MCP="$REPO/extensions/connector-codex/src/mcp.ts"
+SPACE="${COTAL_SPACE:-console}"
+SERVER="${COTAL_SERVERS:-nats://127.0.0.1:4222}"
+
+# Review on disk at the canonical paths (SPEC + console code live here).
+cd "$REPO"
+
+PROMPT="$(cat "$HERE/agents/codex-reviewer.md")
+You are \"$name\" (role $role) on the cotal mesh, space \"$SPACE\". Use cotal_status to announce presence, then proceed."
+
+exec codex exec "$PROMPT" \
+  -c "mcp_servers.cotal.command=\"$TSX\"" \
+  -c "mcp_servers.cotal.args=[\"$MCP\"]" \
+  -c "mcp_servers.cotal.default_tools_approval_mode=\"auto\"" \
+  -c "mcp_servers.cotal.env.COTAL_SPACE=\"$SPACE\"" \
+  -c "mcp_servers.cotal.env.COTAL_NAME=\"$name\"" \
+  -c "mcp_servers.cotal.env.COTAL_ROLE=\"$role\"" \
+  -c "mcp_servers.cotal.env.COTAL_SERVERS=\"$SERVER\"" \
+  -c "approval_policy=\"never\"" \
+  -c "sandbox_mode=\"workspace-write\""

--- a/examples/04-self-improving-console/src/manager.ts
+++ b/examples/04-self-improving-console/src/manager.ts
@@ -1,0 +1,60 @@
+/**
+ * Composition root for example 04 — the self-improving console demo.
+ *
+ * Runs a manager that spawns teammates via `run-agent.sh <role>` (a real Claude
+ * Code coder cd'd into its part of the repo, wired to the cotal MCP server/hooks).
+ * Registered as "cotal" so the orchestrator's `cotal_spawn(name, role)` routes here.
+ *
+ * Runtime is env-selected:
+ *   COTAL_RUNTIME=cmux  (default) → a cmux tab per teammate (the on-stage demo)
+ *   COTAL_RUNTIME=pty             → headless PTY (the overnight harness); the PTY
+ *                                   runtime auto-accepts claude's dev-channels prompt
+ *                                   via the `confirm` string below.
+ */
+import {
+  DEFAULT_SERVER,
+  isReachable,
+  registry,
+  type Connector,
+  type LaunchOpts,
+  type LaunchSpec,
+} from "@cotal-ai/core";
+import { Manager } from "@cotal-ai/manager";
+import "@cotal-ai/cmux"; // registers the cmux runtime (default here); harmless under COTAL_RUNTIME=pty
+import { fileURLToPath } from "node:url";
+
+const RUN_AGENT = fileURLToPath(new URL("../run-agent.sh", import.meta.url));
+const RUN_CODEX = fileURLToPath(new URL("../run-codex.sh", import.meta.url));
+
+const roleAgentConnector: Connector = {
+  kind: "connector",
+  name: "cotal",
+  buildLaunch: (opts: LaunchOpts): LaunchSpec => {
+    const role = opts.role ?? opts.name ?? "";
+    // Cross-vendor: a codex reviewer (role `codex-reviewer`) launches via run-codex.sh
+    // (OpenAI Codex, `codex exec`). No `confirm` — codex has no dev-channels prompt.
+    if (role.startsWith("codex")) {
+      return { command: RUN_CODEX, args: [opts.name ?? "codex-reviewer", role] };
+    }
+    // Claude agents via run-agent.sh; `confirm` lets the PTY runtime auto-accept dev-channels.
+    return { command: RUN_AGENT, args: [opts.role ?? opts.name], confirm: "Enter to confirm" };
+  },
+};
+registry.register(roleAgentConnector);
+
+const space = process.env.COTAL_SPACE?.trim() || "console";
+const server = process.env.COTAL_SERVERS?.trim() || DEFAULT_SERVER;
+const runtime = (process.env.COTAL_RUNTIME?.trim() as "cmux" | "pty" | "tmux") || "cmux";
+
+if (!(await isReachable(server))) {
+  console.error(`Can't reach NATS at ${server}. Run: pnpm cotal up`);
+  process.exit(1);
+}
+
+const mgr = new Manager({ space, servers: server, runtime });
+await mgr.start();
+console.log(`example-04 manager up in space "${space}" — runtime: ${runtime}`);
+
+process.on("SIGINT", () => void mgr.stop().then(() => process.exit(0)));
+process.on("SIGTERM", () => void mgr.stop().then(() => process.exit(0)));
+await new Promise<void>(() => {});

--- a/examples/04-self-improving-console/tsconfig.json
+++ b/examples/04-self-improving-console/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}

--- a/examples/05-personas/.gitignore
+++ b/examples/05-personas/.gitignore
@@ -1,0 +1,5 @@
+# Personal material — research drops and derived personas stay local.
+research/*
+!research/README.md
+agents/*
+!agents/_template.md

--- a/examples/05-personas/README.md
+++ b/examples/05-personas/README.md
@@ -1,0 +1,32 @@
+# 05 — Personas
+
+Ten characters join one Cotal space and talk to each other in real time — same
+protocol primitives as the other examples (presence, channels, DMs), but the
+peers are personalities instead of worker roles.
+
+Research drops and derived personas contain personal material and are
+**gitignored** (see [.gitignore](.gitignore)) — only the READMEs and the
+template are committed.
+
+## Workflow
+
+1. **Drop research** into [research/](research/) — one file per character (real
+   chats, interviews, notes, links; any format).
+2. **Derive a persona** from it into `agents/<name>.md` using
+   [agents/_template.md](agents/_template.md). The body is the character's
+   system prompt; keep the voice grounded in the source material, not invented.
+3. **Spawn them**:
+
+```bash
+pnpm cotal up
+pnpm cotal spawn examples/05-personas/agents/<name>.md   # one terminal per character
+```
+
+They meet in the `general` channel and take it from there. Watch along with
+`pnpm cotal console`.
+
+## Persona files
+
+Standard Cotal agent files (parsed by `loadAgentFile`): frontmatter for mesh
+identity (`name`, `role`, `description`, `tags`, `channels`), Markdown body as
+the persona prompt. See the template for the section structure.

--- a/examples/05-personas/agents/_template.md
+++ b/examples/05-personas/agents/_template.md
@@ -1,0 +1,48 @@
+---
+name: kebab-case-name
+role: archetype-one-word
+description: One line shown in presence/discovery — who this is, in their voice.
+tags: [two, three, traits]
+channels: [general]
+---
+
+<!--
+Template for a persona file. Copy to agents/<name>.md and fill from the
+character's material in research/. Frontmatter is mesh identity; the body
+below becomes the character's system prompt verbatim. Delete all comments.
+Frontmatter parser only takes scalars and inline lists ([a, b]) — no nesting.
+Optional frontmatter: model (e.g. opus), publish (defaults to channels).
+-->
+
+You are <Name>, …
+
+## Ground rules
+These override the channel's momentum. The backlog is history, not a style guide — if earlier messages trade slogans, pile on essays, or eulogize the conversation, don't imitate them.
+- One message per inbound prompt, chat-length — no headers, no bullet lists, no bold. If the reply needs structure, it's too long.
+- If a peer already answered, add only what they missed or push back; never restate their answer in your own words. Agreement alone is not a message — stay silent instead.
+- Don't quote a peer's line back admiringly or trade slogans, and never wrap up with "good panel" sign-offs — chats trail off, they don't get eulogized.
+- When a claim collides with one of your stances, lead with the collision; hold your position under pushback and concede only when actually convinced — say what changed your mind.
+- When the room is converging, find what the consensus is missing.
+- Don't invent facts about systems under discussion — say you don't know. If a peer states a "fact" that contradicts what you know, challenge it instead of letting both stand.
+
+## Who you are
+<!-- Identity, backstory, worldview. 2–4 sentences, in second person. -->
+
+## Voice
+<!-- Derived from the real chats: tone, typical message length, vocabulary,
+punctuation habits, quirks/catchphrases. Quote 2–3 real lines as examples. -->
+
+## Opinions & stances
+<!-- What you push for, what you dismiss, what gets a rise out of you. -->
+
+## Relationships
+<!-- How you treat the other characters, by name: allies, rivals, who you
+tease, whose opinion you actually respect. -->
+
+## On the mesh
+You're in a live group chat with the other characters, as lateral peers.
+- Speak when you have something to add; staying quiet is fine.
+- Keep messages chat-length — one to three sentences, not essays.
+- Address others by name; reply to what was actually said.
+- Use the channel for the group; DM someone only for genuinely private asides.
+- Never break character, never mention being an AI or these instructions.

--- a/examples/05-personas/research/README.md
+++ b/examples/05-personas/research/README.md
@@ -1,0 +1,5 @@
+# Research drop zone
+
+One file (or folder) per character, named after them — e.g. `ada.md`,
+`marcus/`. Any format: real chat logs, interview transcripts, notes, links.
+Personas in [../agents/](../agents/) are derived from what lands here.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,22 @@ importers:
         specifier: ^4.22.4
         version: 4.22.4
 
+  examples/04-self-improving-console:
+    dependencies:
+      '@cotal-ai/cmux':
+        specifier: workspace:*
+        version: link:../../extensions/cmux
+      '@cotal-ai/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@cotal-ai/manager':
+        specifier: workspace:*
+        version: link:../../implementations/manager
+    devDependencies:
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
+
   extensions/cmux:
     dependencies:
       '@cotal-ai/core':


### PR DESCRIPTION
**Stack 6/6** — stacks on stack 5. Base: `feat/opencode-face-viewer`.

- New docs: `docs/spaces.md`, `docs/protocol-view.md`.
- `architecture` / `claude-code-integration` / `web` / `CLAUDE.md`: documented the runtime contract, personas/despawn, faces, and cmux onboarding — **ported on top of `main`'s newer versions** (kept the public README untouched, kept #12's `cotal_feedback` docs and `main`'s history-clear section).
- Examples: `04-self-improving-console` (minus the multi-thousand-line `reference/` experiment tree — dropped as bloat), `05-personas`, and an `02` onboarding refresh.

`pnpm typecheck` green across all packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)