### PR TITLE
feat(connector): resume a prior claude-code session into the mesh

### DIFF
--- a/extensions/connector-claude-code/src/extension.ts
+++ b/extensions/connector-claude-code/src/extension.ts
@@ -35,6 +35,11 @@ export const claudeConnector: Connector = {
 
     const args = ["--dangerously-load-development-channels", CHANNEL_REF];
 
+    // Resume a prior conversation into the mesh. `--fork-session` makes claude mint a
+    // fresh session id from the resumed history, so the original session this id points
+    // at keeps running untouched (we adopt its context, not its identity).
+    if (opts.resume) args.push("--resume", opts.resume, "--fork-session");
+
     // An agent file carries identity (read in-session via COTAL_AGENT_FILE) plus
     // persona + model, which can only be applied to a `claude` session at launch.
     if (opts.configPath) {

--- a/implementations/cli/src/commands/spawn.ts
+++ b/implementations/cli/src/commands/spawn.ts
@@ -41,6 +41,7 @@ export async function spawn(argv: string[]): Promise<void> {
       server: { type: "string" },
       agent: { type: "string" },
       role: { type: "string" },
+      resume: { type: "string" },
     },
   });
 
@@ -49,7 +50,7 @@ export async function spawn(argv: string[]): Promise<void> {
   const ref = values.config ?? positionals[0] ?? values.name;
   if (!ref) {
     console.error(
-      "usage: cotal spawn <name-or-path> | --config <path> | --name <n>  [--agent <a>] [--role <r>] [--space <s>] [--server <url>]",
+      "usage: cotal spawn <name-or-path> | --config <path> | --name <n>  [--agent <a>] [--role <r>] [--resume <id>] [--space <s>] [--server <url>]",
     );
     process.exit(1);
   }
@@ -111,6 +112,7 @@ export async function spawn(argv: string[]): Promise<void> {
     creds: credsPath,
     servers: server,
     configPath: path,
+    resume: values.resume,
   });
 
   console.error(

--- a/implementations/manager/src/commands.ts
+++ b/implementations/manager/src/commands.ts
@@ -30,6 +30,7 @@ function parse(argv: string[]): Values {
       agent: { type: "string" },
       config: { type: "string" },
       creds: { type: "string" },
+      resume: { type: "string" },
       "console-port": { type: "string" },
       drive: { type: "boolean" },
     },
@@ -98,6 +99,7 @@ async function start(argv: string[]): Promise<void> {
     role: v.role,
     agent: v.agent,
     config: v.config,
+    resume: v.resume,
   }, v.creds);
   failIfNotOk(reply);
   const d = reply.data as { name: string; role?: string; agent: string; mode: string };
@@ -333,7 +335,7 @@ const managerCommands: Command[] = [
     name: "start",
     group: "Control plane",
     summary:
-      "ask the manager to spawn an agent — --name <n> [--role <r>] [--agent <a>] [--config <file>] (auto-discovers .cotal/agents/<n>.md)",
+      "ask the manager to spawn an agent — --name <n> [--role <r>] [--agent <a>] [--config <file>] [--resume <id>] (auto-discovers .cotal/agents/<n>.md)",
     run: start,
   },
   {

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -210,6 +210,7 @@ export class Manager {
         creds: credsPath,
         servers: this.servers,
         configPath,
+        resume: args.resume ? String(args.resume) : undefined,
       });
       handle = this.runtime.spawn(name, spec, this.workspaceRoot);
     } catch (e) {

--- a/packages/core/src/connector.ts
+++ b/packages/core/src/connector.ts
@@ -17,6 +17,11 @@ export interface LaunchOpts {
    *  passes it through (`COTAL_AGENT_FILE`) so the joined session reads its own
    *  card from it, and applies the file's persona/model at launch. */
   configPath?: string;
+  /** Resume a prior session of this agent type instead of starting fresh — the
+   *  connector-specific session id to reattach (claude-code: a `--resume` id,
+   *  forked so the original session isn't hijacked). Connectors that can't resume
+   *  ignore it. */
+  resume?: string;
 }
 
 /** A recipe for starting an agent as a mesh node — command, args, and extra env. */


### PR DESCRIPTION
## What

Adds an optional `resume` to the connector `LaunchOpts` so a `cotal spawn`/`start` can reattach a prior claude-code conversation instead of always starting a fresh session.

When set, the claude-code connector pushes `--resume <id> --fork-session` into the launch args (fork so the original session id isn't hijacked — we adopt its *context*, not its *identity*). All existing args (dev-channels, MCP config, persona, model) are preserved, so the resumed process still joins the mesh normally.

## Why

Today every spawn is a cold session — an operator doing real work in a claude session can't pull that context into the mesh. This is the minimal change to allow it. `claude --resume`, `--fork-session`, and `--strict-mcp-config` compose cleanly (verified against `claude --help`).

Closes #23.

## Changes
- `core`: `LaunchOpts.resume?` (connector-specific session id)
- `connector-claude-code`: emit `--resume <id> --fork-session` when set
- `manager`: `opStart` threads `args.resume` into `buildLaunch`; `--resume` flag on `start`
- `cli`: `--resume <id>` flag on `spawn`
- codex/opencode connectors ignore `resume` (claude-specific no-op)

## Test
Build + typecheck clean (`pnpm -r build`, `pnpm -r typecheck`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
