### PR TITLE
feat(cli): `cotal dm` operator command (non-interactive send)

### DIFF
--- a/implementations/cli/src/commands/dm.ts
+++ b/implementations/cli/src/commands/dm.ts
@@ -1,0 +1,134 @@
+import { parseArgs } from "node:util";
+import { readFileSync } from "node:fs";
+import { userInfo } from "node:os";
+import {
+  CotalEndpoint,
+  isReachable,
+  DEFAULT_SERVER,
+  DEFAULT_SPACE,
+  authDir,
+  loadSpaceAuth,
+  type Presence,
+} from "@cotal-ai/core";
+import { c } from "../ui.js";
+
+/** How long to wait for the presence roster to replay before giving up on a name lookup.
+ *  The observer's KV watch fills the roster asynchronously after start(); a target that's
+ *  truly present shows up well within this window. */
+const ROSTER_WAIT_MS = 3000;
+
+/** Resolve an agent name → its present instance id off the roster, waiting briefly for the
+ *  presence KV to replay. Case-insensitive, prefers a live (non-offline) peer. */
+async function resolveTarget(ep: CotalEndpoint, name: string): Promise<Presence | undefined> {
+  const t = name.toLowerCase();
+  const find = (): Presence | undefined => {
+    const roster = ep.getRoster();
+    const present = roster.filter((p) => p.status !== "offline");
+    return (
+      present.find((p) => p.card.name.toLowerCase() === t) ??
+      roster.find((p) => p.card.name.toLowerCase() === t)
+    );
+  };
+  const deadline = Date.now() + ROSTER_WAIT_MS;
+  for (;;) {
+    const hit = find();
+    if (hit) return hit;
+    if (Date.now() >= deadline) return undefined;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+}
+
+/**
+ * `cotal dm <name> "<message>"` — an operator sends a mesh DM to a running agent WITHOUT
+ * attaching to it or proxying through a `me` agent. It connects to NATS like `console`/`watch`
+ * (a presence-watching, off-roster client), resolves the target name → instance id off the
+ * roster, and publishes a normal unicast DM — the exact envelope/subject the agent-only
+ * `cotal_dm` tool produces, so the receiver's connector parses it as a regular DM.
+ *
+ * Open mesh: connect bare. Auth mode: a DM is a write, and the self-mintable `observer` cred is
+ * read-only — so the operator must pass `--creds <admin.creds>` (mint with `cotal mint <n>
+ * --profile admin`). We fail loudly rather than silently picking creds that can't publish.
+ */
+export async function dm(argv: string[]): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args: argv,
+    allowPositionals: true,
+    options: {
+      space: { type: "string" },
+      server: { type: "string" },
+      creds: { type: "string" },
+    },
+  });
+
+  const name = positionals[0];
+  const text = positionals[1];
+  if (!name || !text) {
+    console.error(c.red('usage: cotal dm <name> "<message>" [--space <s>] [--server <url>] [--creds <path>]'));
+    process.exit(1);
+  }
+
+  const server = values.server ?? DEFAULT_SERVER;
+  let creds = values.creds ? readFileSync(values.creds, "utf8") : undefined;
+  let space = values.space;
+
+  // Auth mode (.cotal/auth present): publishing a DM needs write perms, which only admin/agent
+  // creds carry — the self-mintable observer cred can't publish. Require an explicit admin cred.
+  if (!creds) {
+    const auth = loadSpaceAuth(authDir(process.cwd()));
+    if (auth) {
+      if (space && space !== auth.space) {
+        console.error(
+          c.red(`Auth here is for space "${auth.space}", not "${space}". Use --space ${auth.space}.`),
+        );
+        process.exit(1);
+      }
+      space = auth.space;
+      console.error(
+        c.red(
+          "This is an auth-mode space — sending a DM needs admin creds. " +
+            "Mint one: `cotal mint operator --profile admin`, then pass `--creds <path>`.",
+        ),
+      );
+      process.exit(1);
+    }
+  }
+
+  const s = space ?? DEFAULT_SPACE;
+  if (!(await isReachable(server, { creds }))) {
+    console.error(c.red(`Can't reach NATS at ${server}. Run: cotal up`));
+    process.exit(1);
+  }
+
+  // Operator identity for the DM's `from` — off the roster (invisible), like the console's sender.
+  const operator = (() => {
+    try {
+      return userInfo().username || "operator";
+    } catch {
+      return "operator";
+    }
+  })();
+
+  const ep = new CotalEndpoint({
+    space: s,
+    servers: server,
+    creds,
+    channels: [],
+    consume: false, // request/publish only — binds no durables
+    registerPresence: false, // invisible on the roster; the DM still carries `operator` as `from`
+    watchPresence: true, // need the roster to resolve name → instance id
+    card: { name: operator, kind: "endpoint" },
+  });
+  ep.on("error", (e: Error) => console.error(c.red("! " + e.message)));
+  await ep.start();
+  try {
+    const target = await resolveTarget(ep, name);
+    if (!target) {
+      console.error(c.red(`✗ no agent "${name}" present in space "${s}"`));
+      process.exit(1);
+    }
+    await ep.unicast(target.card.id, text);
+    console.log(c.green(`✓ DM → ${c.bold(target.card.name)}`) + c.dim(` (${target.card.id})`));
+  } finally {
+    await ep.stop();
+  }
+}

--- a/implementations/cli/src/commands/dm.ts
+++ b/implementations/cli/src/commands/dm.ts
@@ -8,9 +8,22 @@ import {
   DEFAULT_SPACE,
   authDir,
   loadSpaceAuth,
+  unicastSubject,
   type Presence,
+  type CotalMessage,
 } from "@cotal-ai/core";
 import { c } from "../ui.js";
+
+/** How long to wait for a reply with `--wait` before giving up (ms). */
+const DEFAULT_WAIT_MS = 60_000;
+
+/** Render a message's text parts into one line. */
+function renderText(msg: CotalMessage): string {
+  return msg.parts
+    .map((p) => (p.kind === "text" ? p.text : `[${p.kind}]`))
+    .join(" ")
+    .trim();
+}
 
 /** How long to wait for the presence roster to replay before giving up on a name lookup.
  *  The observer's KV watch fills the roster asynchronously after start(); a target that's
@@ -57,15 +70,22 @@ export async function dm(argv: string[]): Promise<void> {
       space: { type: "string" },
       server: { type: "string" },
       creds: { type: "string" },
+      wait: { type: "boolean" },
+      timeout: { type: "string" },
     },
   });
 
   const name = positionals[0];
   const text = positionals[1];
   if (!name || !text) {
-    console.error(c.red('usage: cotal dm <name> "<message>" [--space <s>] [--server <url>] [--creds <path>]'));
+    console.error(
+      c.red('usage: cotal dm <name> "<message>" [--wait] [--timeout <s>] [--space <s>] [--server <url>] [--creds <path>]'),
+    );
     process.exit(1);
   }
+
+  const waitForReply = values.wait ?? false;
+  const waitMs = values.timeout ? Number(values.timeout) * 1000 : DEFAULT_WAIT_MS;
 
   const server = values.server ?? DEFAULT_SERVER;
   let creds = values.creds ? readFileSync(values.creds, "utf8") : undefined;
@@ -114,7 +134,10 @@ export async function dm(argv: string[]): Promise<void> {
     creds,
     channels: [],
     consume: false, // request/publish only — binds no durables
-    registerPresence: false, // invisible on the roster; the DM still carries `operator` as `from`
+    // Invisible by default (the DM still carries `operator` as `from`). With --wait we must be
+    // addressable: the agent resolves its reply target off the roster, so register presence so
+    // it can DM us back — by name or id — for the duration of the wait.
+    registerPresence: waitForReply,
     watchPresence: true, // need the roster to resolve name → instance id
     card: { name: operator, kind: "endpoint" },
   });
@@ -126,8 +149,37 @@ export async function dm(argv: string[]): Promise<void> {
       console.error(c.red(`✗ no agent "${name}" present in space "${s}"`));
       process.exit(1);
     }
+
+    // With --wait, tap our own inbox (inst.<me>.*) BEFORE sending so we don't miss a fast reply.
+    let replied: Promise<CotalMessage | undefined> | undefined;
+    if (waitForReply) {
+      replied = new Promise<CotalMessage | undefined>((resolve) => {
+        const timer = setTimeout(() => resolve(undefined), waitMs);
+        ep.tap(
+          (_subject, msg) => {
+            // only the agent we DMed, and only its replies (not our own echo)
+            if (msg && msg.from.id === target.card.id) {
+              clearTimeout(timer);
+              resolve(msg);
+            }
+          },
+          { subject: unicastSubject(s, ep.ref().id, "*") },
+        );
+      });
+    }
+
     await ep.unicast(target.card.id, text);
     console.log(c.green(`✓ DM → ${c.bold(target.card.name)}`) + c.dim(` (${target.card.id})`));
+
+    if (replied) {
+      console.log(c.dim(`  waiting for reply (${Math.round(waitMs / 1000)}s)…`));
+      const reply = await replied;
+      if (reply) {
+        console.log(c.green(`← ${c.bold(target.card.name)}: `) + renderText(reply));
+      } else {
+        console.log(c.dim(`  no reply within ${Math.round(waitMs / 1000)}s — watch the feed: cotal watch --space ${s}`));
+      }
+    }
   } finally {
     await ep.stop();
   }

--- a/implementations/cli/src/index.ts
+++ b/implementations/cli/src/index.ts
@@ -3,6 +3,7 @@ import { up } from "./commands/up.js";
 import { join } from "./commands/join.js";
 import { watch } from "./commands/watch.js";
 import { console_ } from "./commands/console.js";
+import { dm } from "./commands/dm.js";
 import { demo } from "./commands/demo.js";
 import { web } from "./commands/web.js";
 import { spawn } from "./commands/spawn.js";
@@ -44,6 +45,14 @@ const baseCommands: Command[] = [
     group: "Mesh",
     summary: "live protocol view for a space — lazygit-style TUI, or a line stream on --plain — --space <s> [--plain]",
     run: console_,
+  },
+  {
+    kind: "command",
+    name: "dm",
+    group: "Mesh",
+    summary:
+      'send a direct message to a running agent as an operator — dm <name> "<message>" [--space <s>] [--creds <path>]',
+    run: dm,
   },
   {
     kind: "command",


### PR DESCRIPTION
## What

A first-class `cotal dm <name> "<message>"` operator command — send a mesh DM to a running agent without attaching to its terminal or proxying through a `me` agent.

```bash
cotal dm team2027 "what's your status?"
cotal dm team2027 "status?" --wait              # wait up to 60s, print the reply
cotal dm team2027 "status?" --wait --timeout 120
```

## Why

`cotal_dm` existed only as an agent-only MCP tool — no CLI counterpart. An operator's only options were (a) `cotal attach` and type raw into the PTY, or (b) spawn a `me` agent to relay. This closes that gap.

## How it works
- connects to NATS like `console`/`watch` (off-roster, presence-watching client; same server/creds resolution)
- resolves target name → instance id off the presence roster (case-insensitive, prefers a live peer, waits briefly for KV replay) — mirrors `MeshAgent.resolvePeer`
- publishes via `ep.unicast(targetId, text)` — the **same** subject (`cotal.<space>.inst.<targetId>.<senderId>`) and envelope the console's operator DM and the agent `cotal_dm` tool emit, so the receiver parses it as a normal DM (no schema drift by construction)
- `--space` / `--server` / `--creds` flags, consistent with other commands

### `--wait` (second commit)
- taps our own inbox (`inst.<me>.*`) **before** sending so a fast reply isn't missed
- registers presence for the wait window so the agent can resolve us as a reply target off the roster (by name or id) — invisible by default otherwise
- prints the first reply from the DMed agent, or a `cotal watch` hint on timeout
- `--timeout <s>` (default 60s)

## Auth mode
A DM is a write, and the self-mintable `observer` cred is read-only — so in auth mode the command requires an explicit admin cred (`cotal mint <n> --profile admin` → `--creds <path>`) and **fails loudly** rather than picking creds that can't publish. Open mesh connects bare. (A narrower publish-only operator profile in `provision.ts` would be a nice follow-up.)

## Test
Verified end-to-end against a live local mesh: `cotal dm team2027 "ping" --wait` resolved the agent, published the DM, and **printed team2027's reply inline** (`← team2027: ...`). Build + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
