### PR TITLE
feat(control-plane): manager-by-default + cotal_purge

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -263,12 +263,14 @@ dependency on them). Selectable backends:
   or types in via `cotal attach <name>` (stream the PTY), and the manager keeps full OS-signal
   control (group-kill, restart). No external software to install.
 - **`tmux` / `iTerm2` (opt-in)** — for users already living in a multiplexer who want native
-  panes / persistence; auto-detect (if already inside tmux, use it).
+  panes / persistence; auto-detect (if already inside tmux, use it). You watch it natively, so
+  `cotal attach` points you at `tmux attach -t cotal-<space>:<name>` rather than streaming.
 - **`cmux` (integration)** — each agent gets its own [cmux](https://github.com/) tab. This is a
   true plug-in: the `cmux` runtime lives in **`@cotal-ai/cmux`** and self-registers a `RuntimeProvider`
   on import, so the manager spawns into tabs without depending on the package — a composition root
   opts in with one `import "@cotal-ai/cmux"` (the `cotal` binary does). Like tmux you watch it
-  natively, so `attach` points you at the tab rather than streaming. Teardown is real: the runtime
+  natively, so `cotal attach` points you at the `cotal-<name>` tab rather than streaming (it is
+  *not* tmux — cmux is its own CLI/app). Teardown is real: the runtime
   keeps the tab's workspace + surface ids, so `stop` types `/exit` for a clean leave then closes the
   tab (graceful) or closes it outright (hard). The manager must run inside a live cmux surface (cmux
   only authorizes its control socket from a real pane). Drives

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -317,7 +317,8 @@ dashboard, or an agent) can send; spawning is policy-gated. `definePersona` writ
 **Emergent payoff:** an agent can grow *and* shape the team without a human — ask the manager for
 a teammate (`cotal_spawn`), mint a brand-new persona on the fly (`cotal_persona` → saved as config
 → spawnable), or tear one down (`cotal_despawn`, graceful or hard). The new agent is a *peer*, not
-a child.
+a child. Cleanup rides the same control plane: `cotal_purge` has the manager clear the space's
+retained chat backlog (the privileged `STREAM.PURGE` regular agents are denied).
 
 ## Hosting & onboarding
 
@@ -333,7 +334,7 @@ Under the hood the manager runs the *real* `claude` with the plugin attached and
 environment — an ordinary Claude Code terminal, no wrapper in front of it:
 
 ```
-COTAL_SPACE=demo COTAL_NAME=alice COTAL_ROLE=planner \
+COTAL_SPACE=main COTAL_NAME=alice COTAL_ROLE=planner \
   claude --dangerously-load-development-channels plugin:cotal@cotal-mesh
 ```
 

--- a/extensions/cmux/src/driver.ts
+++ b/extensions/cmux/src/driver.ts
@@ -66,6 +66,38 @@ export function closeWorkspace(workspace: string): void {
   cmux(["close-workspace", "--workspace", workspace]);
 }
 
+/** All open workspace lines (name + ref), or `[]` if cmux can't be reached. */
+export function listWorkspaces(): string[] {
+  try {
+    return cmux(["list-workspaces"]).split("\n").map((l) => l.trim()).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/** True if a workspace whose listing contains `name` is already open — used to keep
+ *  re-opening a session idempotent (don't spawn a second manager / duplicate tabs). */
+export function workspaceExists(name: string): boolean {
+  return listWorkspaces().some((l) => l.includes(name));
+}
+
+/** Workspace refs (e.g. "workspace:55") whose label is exactly `name`. cmux lists tabs as
+ *  "[*] <ref>  [glyph] <label> [\[selected\]]"; matching the whole label keeps "cotal-main" from
+ *  matching "cotal-manager". Used to close stale tabs that linger after their process exits. */
+export function workspaceRefs(name: string): string[] {
+  const refs: string[] = [];
+  for (const line of listWorkspaces()) {
+    const ref = (line.match(/workspace:\d+/) ?? line.match(UUID))?.[0];
+    if (!ref) continue;
+    const label = line
+      .slice(line.indexOf(ref) + ref.length)
+      .replace(/\s*\[selected\]\s*$/, "")
+      .trim();
+    if (label === name || label.endsWith(` ${name}`)) refs.push(ref);
+  }
+  return refs;
+}
+
 /** Split the focused pane; the new pane becomes focused. */
 export function newSplit(direction: "left" | "right" | "up" | "down"): void {
   cmux(["new-split", direction]);

--- a/extensions/connector-claude-code/src/extension.ts
+++ b/extensions/connector-claude-code/src/extension.ts
@@ -1,12 +1,23 @@
 import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { loadAgentFile, registry, type Connector, type LaunchOpts, type LaunchSpec } from "@cotal-ai/core";
 
-/** Channel ref for the locally-installed `cotal` plugin (marketplace `cotal-mesh`).
- *  `--dangerously-load-development-channels <ref>` turns on the plugin's
- *  `claude/channel` capability so an idle session wakes the instant a peer message
- *  arrives. The plugin must be *installed* (not `--plugin-dir`) for the channel to
- *  bind; the connector's identity guard keeps it inert in non-managed sessions. */
-const CHANNEL_REF = "plugin:cotal@cotal-mesh";
+/** Name the cotal MCP server is registered under via --mcp-config (see buildLaunch). */
+const MCP_SERVER_NAME = "cotal";
+/** Channel ref for `--dangerously-load-development-channels`, which turns on the cotal MCP server's
+ *  `claude/channel` capability so an idle session wakes the instant a peer message arrives. Because
+ *  we isolate the session with --strict-mcp-config the plugin's own MCP server is suppressed and
+ *  cotal is re-supplied via --mcp-config, so the ref is the manually-configured server tagged
+ *  `server:<name>` (the CLI rejects a plugin ref or a bare name here). The plugin stays installed
+ *  for its hooks, which do message delivery independent of this wake nudge. */
+const CHANNEL_REF = `server:${MCP_SERVER_NAME}`;
+
+/** Package root (parent of dist/), which doubles as the installable plugin dir: it carries
+ *  .claude-plugin/, .mcp.json, hooks/ and the dist/*.cjs bundles. */
+const PLUGIN_ROOT = fileURLToPath(new URL("..", import.meta.url));
+/** The cotal MCP server bundle, supplied explicitly so a spawned session can run with ONLY this
+ *  MCP server (see buildLaunch's --strict-mcp-config). */
+const MCP_CJS = resolve(PLUGIN_ROOT, "dist", "mcp.cjs");
 
 /**
  * The Claude Code connector: launches the real `claude` with the Cotal identity in
@@ -17,6 +28,7 @@ const CHANNEL_REF = "plugin:cotal@cotal-mesh";
 export const claudeConnector: Connector = {
   kind: "connector",
   name: "claude",
+  pluginRoot: PLUGIN_ROOT,
   buildLaunch(opts: LaunchOpts): LaunchSpec {
     const env: Record<string, string> = {
       COTAL_SPACE: opts.space,
@@ -33,7 +45,28 @@ export const claudeConnector: Connector = {
     if (opts.creds) env.COTAL_CREDS = opts.creds;
     if (opts.servers) env.COTAL_SERVERS = opts.servers;
 
-    const args = ["--dangerously-load-development-channels", CHANNEL_REF];
+    // A leading positional is claude's first message, auto-submitted on start —
+    // so a driving session can greet the operator the moment it joins.
+    const args = opts.prompt
+      ? [opts.prompt, "--dangerously-load-development-channels", CHANNEL_REF]
+      : ["--dangerously-load-development-channels", CHANNEL_REF];
+
+    // Pre-allow fetching the public Cotal docs so a doc-grounded persona (e.g. david)
+    // can look something up under `npx` (no repo on disk) without prompting the operator
+    // mid-demo. Additive under the default permission mode — leaves other tools as-is.
+    args.push("--allowedTools", "WebFetch(domain:github.com),WebFetch(domain:raw.githubusercontent.com)");
+
+    // Isolate the spawned session's MCP to ONLY the cotal server. --strict-mcp-config drops every
+    // other MCP source — including the operator's personal ~/.claude.json servers (e.g. a headless
+    // Chromium, a DB server) that a meshed teammate never needs and that, multiplied across several
+    // spawns on a busy machine, starve memory and kill the session before it registers presence —
+    // and --mcp-config re-supplies cotal so its tools + presence still load. The plugin itself stays
+    // enabled (its hooks + the dev-channels wake path are unaffected; only MCP config is scoped).
+    args.push(
+      "--strict-mcp-config",
+      "--mcp-config",
+      JSON.stringify({ mcpServers: { [MCP_SERVER_NAME]: { command: "node", args: [MCP_CJS] } } }),
+    );
 
     // An agent file carries identity (read in-session via COTAL_AGENT_FILE) plus
     // persona + model, which can only be applied to a `claude` session at launch.

--- a/extensions/connector-core/src/agent.ts
+++ b/extensions/connector-core/src/agent.ts
@@ -354,6 +354,16 @@ export class MeshAgent extends EventEmitter {
     });
   }
 
+  /** Ask the manager to purge the space's retained chat backlog (its `purge` op). Cleanup only —
+   *  it doesn't touch live agents or the anycast work queue. `includeDms` also clears DM history. */
+  async purgeHistory(opts?: { includeDms?: boolean }): Promise<ControlReply> {
+    this.assertConnected();
+    return this.ep.requestControl("manager", {
+      op: "purge",
+      args: { includeDms: opts?.includeDms ?? false },
+    });
+  }
+
   /** Define a persona and persist it as config (the manager's `definePersona` op writes
    *  .cotal/agents/<name>.md). On success, announce it on the channel — the "send it out"
    *  half — so peers see the new persona; `spawn(name)` then launches an agent wearing it. */

--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -453,6 +453,35 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
       },
     },
     {
+      name: "cotal_purge",
+      title: "Cotal: clear chat history",
+      description:
+        "Ask the manager to purge this space's retained chat backlog (channel history). Set includeDms to also clear direct-message history. Cleanup only — it does not affect live agents or the anycast work queue. Irreversible.",
+      schema: {
+        includeDms: z
+          .boolean()
+          .optional()
+          .describe("Default false: channel history only. true = also purge DM history."),
+      },
+      async run(agent, _config, { includeDms }: { includeDms?: boolean }) {
+        try {
+          const reply = await agent.purgeHistory({ includeDms });
+          if (!reply.ok) return err(`Couldn't purge history: ${reply.error ?? "manager refused"}`);
+          const d = reply.data as { chat?: number; dm?: number } | undefined;
+          const chat = d?.chat ?? 0;
+          const dm = d?.dm;
+          return ok(
+            `Cleared ${chat} channel message${chat === 1 ? "" : "s"}` +
+              `${dm === undefined ? "" : ` and ${dm} DM${dm === 1 ? "" : "s"}`} from "${_config.space}".`,
+          );
+        } catch (e) {
+          return err(
+            `Couldn't purge history: no manager reachable (${(e as Error).message}). Is the manager running?`,
+          );
+        }
+      },
+    },
+    {
       name: "cotal_persona",
       title: "Cotal: define a persona",
       description:

--- a/implementations/manager/attach.smoke.ts
+++ b/implementations/manager/attach.smoke.ts
@@ -1,0 +1,100 @@
+/**
+ * Runtime attach smoke (no NATS, no test runner) — run with: pnpm smoke:attach
+ *
+ * Guards that `cotal attach` gives runtime-correct guidance: only `pty` streams over the WS
+ * attach endpoint; `tmux`/`cmux` are watched natively, so each handle's attach() must throw its
+ * OWN hint (this is what manager.opAttach surfaces). Regression target: before, opAttach assumed
+ * "not pty == tmux" and told cmux users to run a tmux command. Spawns a throwaway `sleep` so it
+ * needs no claude/mesh; tmux/cmux are skipped (logged) when not present on the machine.
+ */
+import { execFileSync } from "node:child_process";
+import { createRuntime } from "./src/index.js";
+import "@cotal-ai/cmux"; // registers the `cmux` runtime provider
+import type { LaunchSpec } from "@cotal-ai/core";
+
+let failures = 0;
+function check(label: string, cond: boolean): void {
+  console.log(`${cond ? "✓" : "✗"} ${label}`);
+  if (!cond) failures++;
+}
+function skip(label: string, why: string): void {
+  console.log(`• ${label} skipped (${why})`);
+}
+function attachError(fn: () => unknown): string {
+  try {
+    fn();
+    return "";
+  } catch (e) {
+    return (e as Error).message;
+  }
+}
+
+const SESSION = "cotal-smoke";
+const spec: LaunchSpec = { command: "sleep", args: ["60"] };
+const cwd = process.cwd();
+
+// pty (default) — the one streamable backend: attach() returns a live session, never throws.
+{
+  const h = createRuntime("pty", SESSION).spawn("smoke-pty", spec, cwd);
+  let sess: { onData?: unknown; cols?: unknown } | undefined;
+  const err = attachError(() => (sess = h.attach()));
+  check(
+    "pty: attach() returns a live session (streams, no throw)",
+    err === "" && typeof sess?.onData === "function" && typeof sess?.cols === "number",
+  );
+  h.stop({ graceful: false });
+}
+
+// tmux — watched natively: attach() points you at `tmux attach -t <session>:<name>`.
+{
+  let rt: ReturnType<typeof createRuntime> | null = null;
+  try {
+    rt = createRuntime("tmux", SESSION);
+  } catch (e) {
+    skip("tmux", (e as Error).message);
+  }
+  if (rt) {
+    const h = rt.spawn("smoke-tmux", spec, cwd);
+    const err = attachError(() => h.attach());
+    check(
+      "tmux: attach() points to `tmux attach -t cotal-smoke:smoke-tmux` (not a stream)",
+      err.includes("tmux attach -t cotal-smoke:smoke-tmux"),
+    );
+    check("tmux: hint is tmux-specific, never a cmux tab", !err.includes("cmux tab"));
+    h.stop({ graceful: false });
+    try {
+      execFileSync("tmux", ["kill-session", "-t", SESSION], { stdio: "ignore" });
+    } catch {
+      /* session already gone */
+    }
+  }
+}
+
+// cmux — watched natively: attach() points you at the `cotal-<name>` tab, NOT tmux.
+{
+  let rt: ReturnType<typeof createRuntime> | null = null;
+  try {
+    rt = createRuntime("cmux", SESSION);
+  } catch (e) {
+    skip("cmux", (e as Error).message);
+  }
+  if (rt) {
+    let h: ReturnType<typeof rt.spawn> | null = null;
+    try {
+      h = rt.spawn("smoke-cmux", spec, cwd);
+    } catch (e) {
+      skip("cmux", `spawn: ${(e as Error).message}`); // e.g. not inside a live cmux surface
+    }
+    if (h) {
+      const err = attachError(() => h!.attach());
+      check(
+        'cmux: attach() points to the "cotal-smoke-cmux" tab (not tmux)',
+        err.includes('switch to the "cotal-smoke-cmux" cmux tab') && !err.includes("tmux attach"),
+      );
+      h.stop({ graceful: false });
+    }
+  }
+}
+
+console.log(failures ? `\n${failures} check(s) failed` : "\nall checks passed");
+process.exit(failures ? 1 : 0);

--- a/implementations/manager/src/commands.ts
+++ b/implementations/manager/src/commands.ts
@@ -1,5 +1,5 @@
 import { parseArgs } from "node:util";
-import { readFileSync } from "node:fs";
+import { readFileSync, existsSync, rmSync } from "node:fs";
 import { execFileSync, spawn } from "node:child_process";
 import { join } from "node:path";
 import {
@@ -7,6 +7,9 @@ import {
   isReachable,
   DEFAULT_SERVER,
   DEFAULT_SPACE,
+  authDir,
+  findCotalRoot,
+  loadSpaceAuth,
   registry,
   type Command,
   type ControlReply,
@@ -17,6 +20,12 @@ import { attachClient } from "./attach-client.js";
 import { c } from "./ui.js";
 
 type Values = Record<string, string | undefined>;
+
+/** The space to operate on: explicit `--space`, else this folder's `.cotal/auth` space, else the
+ *  default — so a manually-run manager matches the folder's mesh instead of assuming the default. */
+function spaceFor(v: Values): string {
+  return v.space ?? loadSpaceAuth(authDir(findCotalRoot()))?.space ?? DEFAULT_SPACE;
+}
 
 function parse(argv: string[]): Values {
   const { values, positionals } = parseArgs({
@@ -32,6 +41,7 @@ function parse(argv: string[]): Values {
       creds: { type: "string" },
       "console-port": { type: "string" },
       drive: { type: "boolean" },
+      spawn: { type: "string" }, // comma-separated agent names to pre-spawn at startup
     },
   });
   // These commands are flags-only — reject stray positionals instead of silently ignoring
@@ -93,7 +103,7 @@ async function start(argv: string[]): Promise<void> {
     console.error(c.red("--name is required"));
     process.exit(1);
   }
-  const reply = await ask(v.space ?? DEFAULT_SPACE, v.server ?? DEFAULT_SERVER, "start", {
+  const reply = await ask(spaceFor(v), v.server ?? DEFAULT_SERVER, "start", {
     name: v.name,
     role: v.role,
     agent: v.agent,
@@ -113,7 +123,7 @@ async function stop(argv: string[]): Promise<void> {
     console.error(c.red("--name is required"));
     process.exit(1);
   }
-  const reply = await ask(v.space ?? DEFAULT_SPACE, v.server ?? DEFAULT_SERVER, "stop", {
+  const reply = await ask(spaceFor(v), v.server ?? DEFAULT_SERVER, "stop", {
     name: v.name,
   }, v.creds);
   failIfNotOk(reply);
@@ -122,7 +132,7 @@ async function stop(argv: string[]): Promise<void> {
 
 async function ps(argv: string[]): Promise<void> {
   const v = parse(argv);
-  const reply = await ask(v.space ?? DEFAULT_SPACE, v.server ?? DEFAULT_SERVER, "ps", undefined, v.creds);
+  const reply = await ask(spaceFor(v), v.server ?? DEFAULT_SERVER, "ps", undefined, v.creds);
   failIfNotOk(reply);
   const rows =
     (reply.data as Array<{
@@ -161,7 +171,7 @@ async function attach(argv: string[]): Promise<void> {
     console.error(c.red("--name is required"));
     process.exit(1);
   }
-  const reply = await ask(v.space ?? DEFAULT_SPACE, v.server ?? DEFAULT_SERVER, "attach", {
+  const reply = await ask(spaceFor(v), v.server ?? DEFAULT_SERVER, "attach", {
     name: v.name,
   }, v.creds);
   failIfNotOk(reply);
@@ -176,7 +186,7 @@ async function attach(argv: string[]): Promise<void> {
  *  composition root (the `cotal` binary does). Stays alive until SIGINT/SIGTERM. */
 async function runManager(argv: string[], runtime: RuntimeMode): Promise<void> {
   const v = parse(argv);
-  const space = v.space ?? DEFAULT_SPACE;
+  const space = spaceFor(v);
   const server = v.server ?? DEFAULT_SERVER;
   if (!(await isReachable(server))) {
     console.error(c.red(`Can't reach NATS at ${server}. Run: cotal up`));
@@ -191,6 +201,25 @@ async function runManager(argv: string[], runtime: RuntimeMode): Promise<void> {
       `\n  console: ${mgr.consoleUrl}` +
       c.dim("\n  spawn: cotal start --name <n>   ·   stop: cotal stop --name <n>   (Ctrl-C to shut down)"),
   );
+  // Pre-spawn teammates the manager owns (e.g. the demo's david/sven), so they're despawnable.
+  // Stagger them: wait for each to register presence before launching the next, so several heavy
+  // Claude cold-starts don't boot simultaneously and spike memory. The last one needs no wait.
+  if (v.spawn) {
+    const names = v.spawn.split(",").map((s) => s.trim()).filter(Boolean);
+    for (let i = 0; i < names.length; i++) {
+      const name = names[i];
+      const reply = await mgr.startByName(name);
+      if (!reply.ok) {
+        console.error(c.red(`✗ couldn't spawn ${name}: ${reply.error ?? "unknown error"}`));
+        continue;
+      }
+      console.log(c.green(`✓ spawned ${name}`));
+      if (i < names.length - 1) {
+        const joined = await mgr.waitForPresence(name);
+        console.log(c.dim(joined ? `  ${name} joined; starting next` : `  ${name} still starting; continuing`));
+      }
+    }
+  }
   const shutdown = () => void mgr.stop().then(() => process.exit(0));
   process.on("SIGINT", shutdown);
   process.on("SIGTERM", shutdown);
@@ -202,7 +231,7 @@ async function runManager(argv: string[], runtime: RuntimeMode): Promise<void> {
  *  open a workspace with the console + a ready driving session. Orchestrates, then exits. */
 async function runDrive(argv: string[]): Promise<void> {
   const v = parse(argv);
-  const space = v.space ?? DEFAULT_SPACE;
+  const space = spaceFor(v);
   const name = v.name ?? "me";
   const server = v.server ?? DEFAULT_SERVER;
   // name/space get interpolated into the cmux pane's `bash -lc '…'` command; keep them bare
@@ -256,7 +285,8 @@ async function runDrive(argv: string[]): Promise<void> {
   }
 
   // Plugin (idempotent) so the spawned Claude sessions have the cotal_* tools.
-  execFileSync(tsx, [cotalBin, "setup"], { cwd: root, stdio: "inherit" });
+  // `--yes` runs the guided setup non-interactively (cmux go is one-shot onboarding).
+  execFileSync(tsx, [cotalBin, "setup", "--yes"], { cwd: root, stdio: "inherit" });
 
   // Mesh: start it in the background if it isn't already up (cotal up blocks in the foreground).
   if (!(await isReachable(server))) {
@@ -270,6 +300,21 @@ async function runDrive(argv: string[]): Promise<void> {
     }
   }
   console.log(c.green(`✓ mesh up at ${server}`));
+
+  // A prior interactive `cotal setup` may have left a detached (pty) manager; cmux go wants its
+  // own cmux-runtime manager, so stop that one first — queue-grouped control would otherwise split
+  // spawns between the two.
+  const pidFile = join(root, ".cotal", "manager.pid");
+  if (existsSync(pidFile)) {
+    const pid = Number(readFileSync(pidFile, "utf8").trim());
+    try {
+      process.kill(pid, "SIGTERM");
+      console.log(c.dim(`stopped a background manager (pid ${pid}) to use cmux tabs`));
+    } catch {
+      /* already gone */
+    }
+    rmSync(pidFile);
+  }
 
   // Manager in its own tab (skip if one is already running for this space).
   let mgrRunning = false;

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -2,8 +2,11 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import {
   CotalEndpoint,
+  DEFAULT_SERVER,
   agentFilePath,
   authDir,
+  clearSpaceHistory,
+  findCotalRoot,
   loadAgentFile,
   loadSpaceAuth,
   mintCreds,
@@ -15,7 +18,6 @@ import {
 import type { AgentDef, Connector, ControlReply, ControlRequest, SpaceAuth } from "@cotal-ai/core";
 import {
   createRuntime,
-  findWorkspaceRoot,
   type AgentHandle,
   type Runtime,
   type RuntimeMode,
@@ -68,7 +70,7 @@ export class Manager {
     this.space = opts.space;
     this.servers = opts.servers;
     this.name = opts.name ?? "manager";
-    this.workspaceRoot = opts.workspaceRoot ?? findWorkspaceRoot();
+    this.workspaceRoot = opts.workspaceRoot ?? findCotalRoot();
     this.runtime = createRuntime(opts.runtime ?? "auto", `cotal-${this.space}`);
     this.attach = new AttachEndpoint(
       (name) => this.agents.get(name)?.handle,
@@ -136,6 +138,8 @@ export class Manager {
         return this.opStop(args);
       case "definePersona":
         return this.opDefinePersona(args);
+      case "purge":
+        return this.opPurge(args);
       case "attach":
         return this.opAttach(args);
       case "ps":
@@ -156,6 +160,23 @@ export class Manager {
     return /^[A-Za-z0-9_-]+$/.test(name)
       ? undefined
       : `unsafe name ${JSON.stringify(name)} (allowed: letters, digits, _ -)`;
+  }
+
+  /** Spawn a teammate by name (loads `.cotal/agents/<name>.md`), as if a peer asked via the
+   *  control plane. Used to pre-spawn the demo's experts at startup so the manager owns them. */
+  async startByName(name: string): Promise<ControlReply> {
+    return this.opStart({ name });
+  }
+
+  /** Resolve once `name` shows up on the mesh roster (presence registered), or after `timeoutMs`.
+   *  Lets the pre-spawn loop stagger heavy agent cold-starts so they don't all boot at once. */
+  async waitForPresence(name: string, timeoutMs = 30_000): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (this.ep.getRoster().some((p) => p.card.name === name)) return true;
+      await new Promise((r) => setTimeout(r, 1_000));
+    }
+    return false;
   }
 
   private async opStart(args: Record<string, unknown>): Promise<ControlReply> {
@@ -235,6 +256,25 @@ export class Manager {
     a.handle.stop({ graceful });
     this.agents.delete(name);
     return { ok: true, data: { name, stopped: true, graceful } };
+  }
+
+  /** Purge the space's retained message backlog (chat, optionally DMs). Privileged — the
+   *  manager mints its own "manager" creds (same as `cotal history clear`); regular agents are
+   *  denied STREAM.PURGE under auth. Cleanup only: leaves live agents and the TASK queue alone. */
+  private async opPurge(args: Record<string, unknown>): Promise<ControlReply> {
+    const includeDms = args.includeDms === true;
+    try {
+      const creds = this.auth ? await mintCreds(this.auth, newIdentity(), "manager") : undefined;
+      const result = await clearSpaceHistory({
+        servers: this.servers ?? DEFAULT_SERVER,
+        space: this.space,
+        creds,
+        includeDms,
+      });
+      return { ok: true, data: result };
+    } catch (e) {
+      return { ok: false, error: (e as Error).message };
+    }
   }
 
   /** Persist a peer-defined persona as config. After this, `start name` auto-discovers

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -305,11 +305,15 @@ export class Manager {
     const name = String(args.name ?? "").trim();
     const a = this.agents.get(name);
     if (!a) return { ok: false, error: `no agent "${name}"` };
-    if (this.runtime.kind !== "pty") {
-      return {
-        ok: false,
-        error: `attach needs the pty runtime; under tmux run \`tmux attach -t cotal-${this.space}:${name}\``,
-      };
+    // Only pty streams over the WS attach endpoint. tmux/cmux are watched natively, and
+    // each handle's attach() throws with the right per-runtime guidance (tmux attach … /
+    // switch to the cmux tab) — surface that instead of assuming tmux.
+    if (a.handle.kind !== "pty") {
+      try {
+        a.handle.attach();
+      } catch (e) {
+        return { ok: false, error: (e as Error).message };
+      }
     }
     return { ok: true, data: { ws: this.attach.url(name) } };
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "smoke:channels:auth": "tsx packages/core/channels-auth.smoke.ts",
     "smoke:attention": "tsx extensions/connector-core/attention.smoke.ts",
     "smoke:attention:auth": "tsx extensions/connector-core/attention-auth.smoke.ts",
-    "smoke:feedback": "tsx extensions/connector-core/feedback.smoke.ts"
+    "smoke:feedback": "tsx extensions/connector-core/feedback.smoke.ts",
+    "smoke:attach": "tsx implementations/manager/attach.smoke.ts"
   },
   "dependencies": {
     "@cotal-ai/cli": "workspace:*",

--- a/packages/core/src/connector.ts
+++ b/packages/core/src/connector.ts
@@ -17,6 +17,10 @@ export interface LaunchOpts {
    *  passes it through (`COTAL_AGENT_FILE`) so the joined session reads its own
    *  card from it, and applies the file's persona/model at launch. */
   configPath?: string;
+  /** An initial message for the session to act on the moment it starts. Connectors
+   *  that support an auto-submitted first prompt (Claude Code) deliver it; others
+   *  ignore it. Used to make a driving session greet the operator on launch. */
+  prompt?: string;
 }
 
 /** A recipe for starting an agent as a mesh node — command, args, and extra env. */
@@ -42,4 +46,9 @@ export interface Connector extends Extension {
   readonly kind: "connector";
   readonly name: string;
   buildLaunch(opts: LaunchOpts): LaunchSpec;
+  /** Directory of installable editor-plugin assets shipped with the connector
+   *  (e.g. a Claude Code plugin dir), when the agent type needs a one-time
+   *  plugin install. Consumers (like `cotal setup`) resolve it via the registry
+   *  so they never import the extension package directly. */
+  readonly pluginRoot?: string;
 }

--- a/packages/core/src/provision.ts
+++ b/packages/core/src/provision.ts
@@ -15,7 +15,7 @@
  * trail. Revocation is deferred past Demo 1; minted creds currently have no TTL.
  */
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { join, dirname, resolve } from "node:path";
 import {
   encodeOperator,
   encodeAccount,
@@ -325,6 +325,19 @@ const AUTH_FILE = "auth.json";
 
 export function authDir(root: string): string {
   return join(root, ".cotal", "auth");
+}
+
+/** Find the project's `.cotal/` by walking up from `start` (like git finds `.git`), returning the
+ *  directory that *contains* `.cotal/`. Falls back to `start` when none is found up the tree (a
+ *  fresh setup creates `.cotal/` there). Lets `cotal` run from any subdirectory of a project. */
+export function findCotalRoot(start: string = process.cwd()): string {
+  let dir = resolve(start);
+  for (;;) {
+    if (existsSync(join(dir, ".cotal"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return resolve(start);
+    dir = parent;
+  }
 }
 
 /** Persist the space trust material. The file holds the signing seed — treat as a secret. */


### PR DESCRIPTION
Start the manager so the `cotal_*` control-plane tools work, add the `cotal_purge` tool (manager clears space chat backlog), and the core/connector/cmux plumbing it needs.
Part of splitting #22 (npx cotal-ai guided setup) into a reviewable stack:
1. split/01-package · 2. split/02-control-plane · 3. split/03-docs · 4. split/04-setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)