### PR TITLE
docs: README, CLAUDE.md, and web/example polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,9 @@ tree. The wire contract (subjects, message schemas, presence/discovery conventio
 *is* the standard; libraries are thin clients over it. Transport is **NATS + JetStream**;
 reference implementation is **TypeScript**.
 
+New here? [docs/getting-started.md](docs/getting-started.md) is the fastest path to a
+running mesh; [docs/setup-internals.md](docs/setup-internals.md) documents the `cotal setup`
+flow + the invariants a repo change must keep in sync.
 See [docs/OVERVIEW.md](docs/OVERVIEW.md) for *what* it does,
 [docs/architecture.md](docs/architecture.md) for *how*, and
 [docs/claude-code-integration.md](docs/claude-code-integration.md) for the Claude Code
@@ -21,15 +24,15 @@ pnpm + TypeScript ESM monorepo — four dependency tiers, one-way deps, Node ≥
 - **`packages/*` — the protocol** (generic, the standard).
   - **@cotal-ai/core** — endpoint, subjects, message types; the NATS client layer + extension contracts (`Connector`, `Command`) and the `Registry` they self-register into.
 - **`extensions/*` — pluggable adapters** (peer-depend core; self-register on import).
-  - **@cotal-ai/connector-core** — shared MCP-bridge runtime (mesh agent, `cotal_*` tool specs incl. `cotal_spawn` / `cotal_persona` / `cotal_despawn`, hook relay); the adapters are thin clients over it.
+  - **@cotal-ai/connector-core** — shared MCP-bridge runtime (mesh agent, `cotal_*` tool specs incl. `cotal_spawn` / `cotal_persona` / `cotal_despawn` / `cotal_purge`, hook relay); the adapters are thin clients over it.
   - **@cotal-ai/connector-claude-code** — Claude Code adapter (installed plugin + `claude/channel` push).
   - **@cotal-ai/connector-codex** — Codex adapter (pull-only MCP server injected via `codex -c`; no plugin, no hooks).
   - **@cotal-ai/connector-opencode** — OpenCode adapter (native in-process plugin injected via `OPENCODE_CONFIG_CONTENT`; renders the shared `cotal_*` tool specs as plugin tools).
   - **@cotal-ai/cmux** — the cmux integration: a thin driver over the [cmux](https://github.com/) CLI (open/close a tab, send keys) **plus a self-registering `cmux` Runtime**. Importing it registers the runtime with the core `Registry`, so the manager spawns into cmux tabs without depending on this package (opt-in via one import; the `cotal` binary does it).
 - **`implementations/*` — opinionated surfaces** over core (self-contained; never import each other).
-  - **@cotal-ai/cli** — mesh CLI: `up`, `join`, `watch`, `console` (thin NATS clients) plus `spawn` — a foreground agent launch reusing the connector's launch recipe.
+  - **@cotal-ai/cli** — mesh CLI: `up`/`down`, `join`, `watch`, `console` (thin NATS clients), `spawn` — a foreground agent launch reusing the connector's launch recipe — and `setup`, the two-tier guided flow (bundled NATS binary, Claude plugin install, interactive Claude handoff on failures). First run (no `~/.cotal/onboarded.json`) is the full narrated/clack flow; later runs are a compact ensure+status; `setup --full` forces the full flow.
   - **@cotal-ai/manager** — agent supervisor: a mesh endpoint that spawns/manages nodes via a pluggable `Runtime` (`pty` default / `tmux` / `cmux`), plus its own control-plane commands (`start`/`stop`/`ps`/`attach`) and a WS attach endpoint.
-- **`bin/cotal.ts` — composition root** for the `cotal` binary: imports the implementations it wants (which self-register their commands) and runs them.
+- **`bin/` — the published `cotal-ai` package**: `cotal.ts` is the composition root for the `cotal` binary — imports the implementations it wants (which self-register their commands) and runs them. `npx cotal-ai` with no args runs the guided `setup`.
 - **`examples/*` — use-cases** (composition roots; private, never published).
 
 Tiers depend one-way: `examples → implementations → packages ← (peer) extensions`. An

--- a/README.md
+++ b/README.md
@@ -80,24 +80,47 @@ JetStream has run in production for years. We didn't invent the hard parts.
 
 ## Quick start
 
-Two peers in one shared space, in three steps.
+```bash
+# install globally, then run setup
+npm install -g cotal-ai
+cotal
 
-> [!IMPORTANT]
-> You need Node ≥20 and `nats-server` with JetStream (v2.11+). On macOS:
-> `brew install nats-server`. `cotal up` starts a local one, or reuses one already
-> listening on `:4222`.
+# ...or set up in one command, no install
+npx cotal-ai setup --full
+```
 
-<!-- TODO(bin): publish the `cotal` bin before this section goes live; no package ships a `bin` field yet. Until then the honest invocation is `pnpm cotal <cmd>` from a clone. -->
+One command, guided setup. The **first run** checks prerequisites, starts a local mesh
+you own (bundled `nats-server`, or your own on PATH), lets you pick connectors (Claude
+installs a plugin; Codex/OpenCode auto-wire at spawn), and adds two experts plus your
+session: **david** the engineer, **sven** the guide, and **me**, the one you drive. It
+then offers a Claude-driven demo with david and sven helping. If a step fails, it hands
+you to an interactive Claude with the failure context, then retries.
+
+The mesh is **open** by default (no auth, loopback-only); add `cotal setup --auth` for a
+JWT-authed mesh when you share it or go cross-machine.
+
+**Every run after** is a quick `cotal · ready` status that ensures the mesh, the browser
+dashboard, and the control-plane manager are up, then prints your next steps. Use
+`cotal go` to reopen or resume the session, `cotal setup --full` to redo the full flow,
+or `npx cotal-ai setup --yes` to set up non-interactively (CI or a coding agent: mesh,
+dashboard, and manager, so the `cotal_*` tools work right away). See
+[docs/getting-started.md](docs/getting-started.md) for the full walkthrough.
+
+Or do it by hand — two peers in one shared space, in three steps:
+
+> [!NOTE]
+> Node ≥20 required. `cotal up` starts a local NATS (JetStream) or reuses one
+> already listening on `:4222`.
 
 ```bash
 # 1. start a local mesh (NATS + JetStream, open dev mode)
-npx cotal up --open
+npx cotal-ai up --open
 
 # 2. join as alice (second terminal)
-npx cotal join --space demo --name alice --role coder
+npx cotal-ai join --space main --name alice --role coder
 
 # 3. join as bob (third terminal) and watch presence light up in both
-npx cotal join --space demo --name bob --role reviewer
+npx cotal-ai join --space main --name bob --role reviewer
 ```
 
 Bob's terminal greets him with who's already there:
@@ -105,14 +128,14 @@ Bob's terminal greets him with who's already there:
 <!-- TODO(asset): VHS terminal GIF. assets/quickstart.tape committed, rendered to assets/quickstart.gif; replace this block with the rendered recording so it can't drift from the real CLI. -->
 
 ```
-Joined demo as bob/reviewer on #general.
+Joined main as bob/reviewer on #general.
 Present: alice ○ idle
 ```
 
 Alice's terminal prints `→ bob/reviewer joined ○ idle` as he arrives. Type a line in
 either terminal and it lands in the other's `#general`. That is the whole primitive.
 
-`npx cotal web --space demo` opens the space in a browser, with the roster, channels,
+`npx cotal-ai web --space main` opens the space in a browser, with the roster, channels,
 and live feed:
 
 <p align="center"><img src="assets/dashboard.png" width="860" alt="The Cotal web dashboard: live roster on the left, the all-activity feed in the middle, attention queue on the right"></p>

--- a/docs/web.md
+++ b/docs/web.md
@@ -5,9 +5,9 @@ channels, the direct messages, and the live feed. It sees everything (chat, DMs,
 but never publishes, needs no manager, and binds only to loopback.
 
 ```bash
-pnpm cotal web --space demo            # opens http://127.0.0.1:7799 in your browser
-pnpm cotal web --space demo --port 8080 --no-open
-pnpm cotal web --space demo --creds ./admin.creds   # use a cred you minted yourself
+pnpm cotal web --space main            # opens http://127.0.0.1:7799 in your browser
+pnpm cotal web --space main --port 8080 --no-open
+pnpm cotal web --space main --creds ./admin.creds   # use a cred you minted yourself
 ```
 
 In **auth mode** (`.cotal/auth` present) `web` self-mints its own read-only **admin** cred —

--- a/examples/01-lateral-coordination/README.md
+++ b/examples/01-lateral-coordination/README.md
@@ -27,7 +27,7 @@ who delegates to whom — is just how you set it up.
 
 ## Prerequisites
 
-- Node ≥ 20, pnpm, and `nats-server` (v2.11+). macOS: `brew install nats-server`.
+- Node ≥ 20 and pnpm. (`cotal up` finds `nats-server` on PATH or uses the bundled binary.)
 - Install deps once, from the repo root: `pnpm install`.
 
 ## Run it


### PR DESCRIPTION
General docs polish (README, CLAUDE.md, docs/web, examples).
Part of splitting #22 (npx cotal-ai guided setup) into a reviewable stack:
1. split/01-package · 2. split/02-control-plane · 3. split/03-docs · 4. split/04-setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)