### PR TITLE
feat(cli): npx cotal-ai guided setup

### DIFF
--- a/.changeset/cotal-ai-setup.md
+++ b/.changeset/cotal-ai-setup.md
@@ -21,4 +21,6 @@ step offers a Claude handoff (skippable with `COTAL_SKIP_ASSIST=1`) that carries
 context and resumes setup on `/exit`. Adds `cotal up --detach` + `cotal down` for a
 background mesh, a `Connector.pluginRoot` contract so consumers can find a connector's installable
 plugin assets without importing the extension, and ships the Claude Code connector's plugin
-manifest files in its published package.
+manifest files in its published package. When run via `npx` without a global `cotal`, setup offers
+to `npm i -g cotal-ai` (default yes; non-interactive takes the default), best-effort — and the
+status-card hints render the right prefix (`cotal` / `npx cotal-ai` / `pnpm cotal`) for how you ran it.

--- a/.changeset/cotal-ai-setup.md
+++ b/.changeset/cotal-ai-setup.md
@@ -1,0 +1,24 @@
+---
+"cotal-ai": minor
+"@cotal-ai/cli": minor
+"@cotal-ai/core": minor
+"@cotal-ai/connector-claude-code": patch
+---
+
+Add `cotal-ai` — a guided, two-tier setup. The composition root (`bin/`) ships as the
+publishable `cotal-ai` package, so `npm i -g cotal-ai` / `npx cotal-ai <cmd>` works (bare
+`cotal` runs `setup`). The **first run** is a narrated, branded flow (`@clack/prompts` UI,
+wordmark splash, a live pane that streams the mesh booting) that checks prerequisites, locates
+the NATS server (bundled platform binary via `@eplightning/nats-server-*`, or one already on
+PATH), then a **connector picker** (Claude / Codex / OpenCode — only Claude installs a plugin;
+Codex/OpenCode auto-wire at spawn), and writes two default Cotal experts you can chat with —
+**david — the engineer** (how it works) and **sven — the guide** (what to build). The finale is
+cmux-aware: inside cmux it opens both experts in split panes with a live dashboard, otherwise it
+hands the terminal to one. (It's "the web for agents".) **Later runs** are a compact ensure+status card; `cotal setup --full` forces the full flow,
+and `cotal setup --yes` runs it non-interactively (agents/CI) — installs the plugin, writes the
+experts, starts the web, and exits non-zero with the log path on failure. Each failed interactive
+step offers a Claude handoff (skippable with `COTAL_SKIP_ASSIST=1`) that carries the failure
+context and resumes setup on `/exit`. Adds `cotal up --detach` + `cotal down` for a
+background mesh, a `Connector.pluginRoot` contract so consumers can find a connector's installable
+plugin assets without importing the extension, and ships the Claude Code connector's plugin
+manifest files in its published package.

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -7,7 +7,8 @@ session joins NATS, maps lifecycle hooks to presence, and exposes the mesh tools
 presence, and team supervision: `cotal_spawn` (grow the team; the new teammate joins as a
 lateral peer), `cotal_despawn` (tear one down — it leaves the mesh and its process/tab closes),
 and `cotal_persona` (define a persona on the fly; it's saved as config and becomes spawnable),
-plus optional `cotal_feedback` for beta reports. The manager spawns it in a PTY; nothing wraps
+plus `cotal_purge` (clear the space's retained chat backlog) and optional `cotal_feedback` for
+beta reports. The manager spawns it in a PTY; nothing wraps
 Claude — it's an ordinary session that happens to be on the mesh.
 
 > The mesh runtime — agent, `cotal_*` tools, hook relay — lives in
@@ -21,14 +22,30 @@ Claude — it's an ordinary session that happens to be on the mesh.
 launch the manager runs:
 
 ```
-claude --dangerously-load-development-channels plugin:cotal@cotal-mesh
+claude --strict-mcp-config --mcp-config '{"mcpServers":{"cotal":{"command":"node","args":["<plugin>/dist/mcp.cjs"]}}}' \
+       --dangerously-load-development-channels server:cotal
 # env: COTAL_SPACE, COTAL_NAME, COTAL_ROLE, COTAL_SERVERS, COTAL_CHANNEL=1
 ```
 
+- **MCP isolation.** A spawned agent runs with **only** the cotal MCP server: `--strict-mcp-config`
+  ignores every other MCP source (crucially the operator's personal `~/.claude.json` servers — a
+  meshed teammate needs none of them, and several spawns each booting a Chromium/DB/etc. helper would
+  starve memory and kill the sessions before they register presence), and `--mcp-config` re-supplies
+  cotal. Because the plugin's own MCP server is suppressed, the channel ref is the manually-configured
+  server tagged `server:cotal` (not `plugin:cotal@cotal-mesh`); the plugin stays installed for its
+  hooks (message delivery), independent of the wake nudge.
 - **Installed, not `--plugin-dir`.** The plugin is installed once
-  (`claude plugin install cotal@cotal-mesh --scope local`) — the wake channel only binds to an
+  (`claude plugin install cotal@cotal-mesh --scope local`) — its hooks bind only to an
   *installed* plugin, so `--plugin-dir` (which loads but doesn't "install") isn't enough. Local
   scope keeps it to this repo (a gitignored `.claude/settings.local.json`), never user-global.
+  In a clone, the marketplace is the repo root's [`.claude-plugin/marketplace.json`](../.claude-plugin/marketplace.json);
+  `cotal setup` (npx, no clone) materializes the same marketplace at `~/.cotal/claude-plugin/`
+  from the published package's plugin assets and installs from there. The marketplace name is
+  `cotal-mesh` in both — the channel ref depends on it. `cotal setup` is two-tier: the first run
+  (no `~/.cotal/onboarded.json` marker) does this install as a narrated step; later runs just
+  verify it in the compact status. The plugin install is local-scope, so the enablement lives in
+  the working dir's `.claude/settings.local.json`. See [setup-internals.md](setup-internals.md)
+  for the full flow + the invariants that keep this install working.
 - **Bundled.** The MCP server and hooks are esbuild-bundled to `dist/*.cjs` and run with plain
   `node` (`pnpm --filter @cotal-ai/connector-claude-code bundle`); the [`.mcp.json`](../extensions/connector-claude-code/.mcp.json)
   and [`hooks.json`](../extensions/connector-claude-code/hooks/hooks.json) point at the bundles. Bundling is
@@ -70,6 +87,11 @@ You are a builder on a shared mesh of peer agents…   ← the body is the perso
   `configFromEnv`. Individual `COTAL_*` vars still override it.
 - **Persona is a short contract, not a title.** Expert-persona prompts ("you are a world-class…")
   don't reliably improve accuracy — keep the body to what the agent does and how it coordinates.
+  A persona that needs facts should point at the *source*, not assert them: the demo's `david`/`sven`
+  read the on-disk `docs/`/`examples/`/source (a managed session runs at the repo root) or, with no
+  repo present, fetch the public docs. `buildLaunch` pre-allows that fetch with
+  `--allowedTools "WebFetch(domain:github.com),WebFetch(domain:raw.githubusercontent.com)"` so the
+  lookup doesn't prompt the operator mid-session.
 - **The agent is told its lanes.** The MCP server `instructions` name the channels it reads and may
   post to (from `channels`/`publish`), so the model knows its scope up front instead of learning it
   from inbound tags and rejected sends.
@@ -284,8 +306,10 @@ Two things move a message from the inbox to the model — **one delivers, one on
   wakes an *idle* session into a turn, so the hook drain runs *now* instead of at the next prompt.
   The nudge never acks or removes anything — if the channel can't run, delivery still happens at the
   next turn. It takes three things together: the plugin's MCP declares the `claude/channel`
-  capability, the session is launched with `--dangerously-load-development-channels
-  plugin:cotal@cotal-mesh` (research preview), **and** `COTAL_CHANNEL=1`. The last one matters:
+  capability, the session is launched with `--dangerously-load-development-channels server:cotal`
+  (research preview; `server:<name>` because cotal is supplied via `--mcp-config` under MCP isolation
+  — a `plugin:…@…` ref would point at the strict-suppressed plugin server), **and** `COTAL_CHANNEL=1`.
+  The last one matters:
   Claude does not echo `claude/channel` back in its MCP client capabilities, so the connector would
   auto-detect the channel as *off* and never send the nudge — the env flag forces it on.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,100 @@
+# Getting started
+
+Cotal is the open web for agents: they join a shared space and work as lateral peers. This
+is the fastest way to a running local one.
+
+## Install & run
+
+```bash
+npm install -g cotal-ai   # recommended — puts `cotal` (and `cotal go`) on your PATH
+cotal                      # runs setup
+```
+
+`npx cotal-ai` works too (no global install); the cmux session still opens either way (it invokes
+its own resolved path, not a global `cotal`). You need Node ≥ 20. The `nats-server` binary ships
+with the package; if you already have one on your PATH, Cotal uses that instead.
+
+## First run
+
+`cotal` (with no command) runs `setup`. The first time, it walks you through it:
+
+1. **Checks** Node and locates NATS.
+2. **Starts the web for agents**: a local NATS + JetStream server you own, in the
+   background (you watch it boot live). It's an **open** local mesh (no auth, loopback-only) so
+   everything just works with no credentials; pass `cotal setup --auth` for a JWT-authed mesh
+   (sender-authenticity + per-agent ACLs) when you share it or go cross-machine.
+3. **Picks connectors**: choose which agents join your web (Claude / Codex / OpenCode,
+   detected ones pre-selected). Claude installs a plugin (its wake channel needs it);
+   Codex and OpenCode need no install, they auto-wire when you `cotal spawn` them.
+4. **Adds two experts plus your own session** by default: **david**, the engineer (how
+   Cotal works), **sven**, the guide (what to build), and **me**, the session you drive.
+   The experts can help you set up and experiment, and hand off to each other.
+5. **Offers a demo**: a Claude you drive, with david and sven (manager-owned teammates you can
+   `cotal_despawn`) helping. Inside [cmux](https://github.com/) they get their own tabs alongside
+   your focused `cotal-main` pane; otherwise david/sven + the manager run in the background and
+   your terminal is handed to the driving session. Either way the demo needs **Claude Code**; if
+   you decline or don't have it, you get the `cotal · ready` card. `cotal down` stops the mesh,
+   web, and the background manager (in cmux, also close the tabs / quit cmux).
+
+To **reopen the session later**, run **`cotal go`** from inside cmux (or just `cotal setup` again):
+it reuses the live manager + david/sven and opens only what's missing (no duplicate managers).
+`cotal go` is the friendly "open/resume" name; `cotal setup` is the same flow under its install/update
+name. (`cotal cmux go` is a dev-clone-only shortcut.)
+
+If a step fails, it offers to hand you to an interactive Claude session that has the
+failure context; type `/exit` to return and it retries.
+
+## After the first run
+
+Every later `cotal` is a quick status:
+
+```
+cotal · ready
+✓ NATS  ✓ plugin  ✓ mesh     nats://127.0.0.1:4222 · space main
+                  ✓ web      http://cotal.localhost:7799
+                  ✓ manager  running
+```
+
+It makes sure the mesh, the browser dashboard, **and** the manager (the control plane behind
+`cotal_spawn` / `despawn` / `purge` / `persona`) are running in the current folder, then prints
+your next steps. The dashboard auto-starts at `http://cotal.localhost:7799` (works in
+Chrome/Firefox/Edge; on Safari use `http://127.0.0.1:7799`). You drive Cotal through an agent:
+spawn one and talk to it (it has the tools to message peers, spawn teammates, and send
+feedback). Prefer commands?
+
+```bash
+cotal go                             # open or resume your session (reuses what's up)
+cotal spawn me                       # the session you drive (consults david/sven)
+cotal spawn david                    # ask the engineer (or sven, the guide)
+cotal console --space main           # live mesh view in the terminal (TUI)
+cotal web --space main               # (re)open the browser dashboard
+cotal down                           # stop the background mesh + dashboard + manager
+```
+
+Feedback flows through your agent too: tell it "send feedback: ..." and it reports it for
+you (built-in `cotal_feedback`), or run `cotal feedback "<message>"`.
+
+Run `cotal setup --full` to redo the full guided flow (e.g. to repair something).
+
+## For agents & CI
+
+A coding agent can set Cotal up for you with one non-interactive command:
+
+```bash
+npx cotal-ai setup --yes
+```
+
+`--yes` accepts every default with no prompts: it installs the plugin, writes the experts
+and your driving session, and starts the mesh, the web dashboard, and the background **manager**
+(so an agent can use the `cotal_*` tools — spawn/despawn/purge — right away). It never hands over
+the terminal, never opens the demo, and exits non-zero with the log path if a step fails, so an
+agent or a CI job can check the result. `cotal down` stops the background processes.
+
+## Troubleshooting
+
+- The full log is at `.cotal/setup.log` (and `.cotal/nats.log` for the server).
+- Re-running setup is safe; it reuses a running web and keeps your files.
+- Set `COTAL_SKIP_ASSIST=1` to disable the Claude handoff offer on failures.
+
+See [claude-code-integration.md](claude-code-integration.md) for the plugin details and
+[setup-internals.md](setup-internals.md) if you're changing how setup works.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,9 +10,11 @@ npm install -g cotal-ai   # recommended — puts `cotal` (and `cotal go`) on you
 cotal                      # runs setup
 ```
 
-`npx cotal-ai` works too (no global install); the cmux session still opens either way (it invokes
-its own resolved path, not a global `cotal`). You need Node ≥ 20. The `nats-server` binary ships
-with the package; if you already have one on your PATH, Cotal uses that instead.
+`npx cotal-ai` works too; setup then offers to install `cotal` globally (default yes) so you can
+just type `cotal` — decline and the hints stay `npx cotal-ai …` (everything still works, since the
+cmux session and background processes invoke their own resolved path, not a global `cotal`). You
+need Node ≥ 20. The `nats-server` binary ships with the package; if you already have one on your
+PATH, Cotal uses that instead.
 
 ## First run
 

--- a/docs/setup-internals.md
+++ b/docs/setup-internals.md
@@ -1,0 +1,86 @@
+# Setup internals (maintainer notes)
+
+How `cotal setup` works, and the cross-repo couplings it depends on. If you change one
+of the things in the **Invariants** table, update the listed siblings in the same change
+or setup silently breaks for npx users.
+
+## The flow
+
+`cotal setup` ([`implementations/cli/src/commands/setup.ts`](../implementations/cli/src/commands/setup.ts))
+is two-tier, gated on a machine marker:
+
+- **First run** (no `~/.cotal/onboarded.json`, or `--full`, or `--yes`) → `runFirstRun(yes, open)`:
+  the mesh runs **open** (no auth) by default — `--auth` flips it to a JWT-authed mesh. (Open means
+  no `.cotal/auth`, so every read/control CLI connects bare; matches `cotal cmux go`.) Then:
+  splash → intro → core steps (Node, NATS, start the mesh) → start the **web dashboard** in the
+  background → **connector picker** → write the two default experts (david/sven) → marker → demo
+  finale (`offerDemo`). The finale needs Claude Code and, if accepted: **in cmux**, opens a
+  **cmux-runtime manager** (`cotal cmux --spawn david,sven`, via `ensureCmuxSession`) that owns
+  david/sven plus a focused console + `me` pane; **otherwise**, a background **pty manager**
+  (`ensureManager({spawn:["david","sven"]})`) pre-spawns david/sven and the terminal is handed to a
+  foreground `cotal spawn me`. Declined / no Claude → a plain pty manager + the `cotal · ready`
+  card. **Under `--yes`** the demo is skipped but the background pty manager *is* started (control
+  plane for agents); `cotal cmux go` then SIGTERMs it (its `.cotal/manager.pid` guard) and runs its
+  own cmux manager.
+- **Later runs** → `runEnsure`: ensures the mesh + dashboard are up; **inside cmux** (gated on
+  `CMUX_SURFACE_ID`) it reopens the working session via `ensureCmuxSession` (idempotent — reuses the
+  live manager + david/sven, opens only missing tabs), otherwise it starts the background pty
+  manager. Then a compact status card. This is the "re-run `cotal setup` reopens your session" path.
+
+The **web dashboard** (`ensureWeb` in [`commands/web.ts`](../implementations/cli/src/commands/web.ts))
+auto-starts detached on the default port, addressed as `http://cotal.localhost:7799` (the server
+binds loopback; `*.localhost` resolves to it in Chrome/Firefox/Edge — Safari may need plain
+`127.0.0.1`). It re-execs the CLI (`process.execArgv` carries the tsx loader in dev, empty in prod).
+
+Steps run in-process via `runSteps` ([`lib/steps.ts`](../implementations/cli/src/lib/steps.ts)).
+A step can be `optional` (asked Y/n), carry a `confirm` consent prompt, or be `live`
+(draws its own pane via [`lib/live-window.ts`](../implementations/cli/src/lib/live-window.ts)).
+On failure, an interactive run offers a Claude handoff ([`lib/assist.ts`](../implementations/cli/src/lib/assist.ts)).
+
+The **connector picker** (`pickConnectors`) multiselects Claude / Codex / OpenCode (detected
+pre-checked). Only **Claude** runs an install (its wake channel binds to an *installed* plugin);
+**Codex/OpenCode auto-wire at spawn** (they inject MCP/plugin via `buildLaunch`, never writing
+the user's config) so the picker just marks them ready. Two experts (david, the engineer; sven,
+the guide) plus the operator's own driving session (`me`) are written by default; `me` also
+backs `cotal cmux go`'s `spawn me`.
+
+**`--yes`** forces non-interactive accept-all even on a TTY: optional + `confirm` steps
+run (so demo agents are written), the demo finale is skipped, the background **pty manager** is
+started (so an agent can use the `cotal_*` control tools immediately), and a failure aborts with
+the log path and a non-zero exit. This is the agent/CI contract; keep it working.
+
+## Invariants
+
+| Thing | Must stay in sync across | Why |
+|---|---|---|
+| Marketplace name **`cotal-mesh`** | `setup.ts` (materialized `marketplace.json`), `CHANNEL_REF` in [`extensions/connector-claude-code/src/extension.ts`](../extensions/connector-claude-code/src/extension.ts), repo [`.claude-plugin/marketplace.json`](../.claude-plugin/marketplace.json) | The wake channel ref `plugin:cotal@cotal-mesh` binds by this name |
+| Plugin assets | `setup.ts` copy list (`dist/mcp.cjs`, `dist/hook.cjs`, `.claude-plugin/plugin.json`, `.mcp.json`, `hooks/hooks.json`) and the connector `package.json` `files` field | Setup materializes the plugin from `Connector.pluginRoot`; missing/renamed assets break the install |
+| `Connector.pluginRoot` | [`packages/core/src/connector.ts`](../packages/core/src/connector.ts) (contract) + set in the claude connector's `extension.ts` | How setup finds the plugin dir without importing the extension |
+| `BUNDLED_PKG_PREFIX` | [`lib/nats-bin.ts`](../implementations/cli/src/lib/nats-bin.ts) ↔ the `@eplightning/nats-server-*` `optionalDependencies` in [`implementations/cli/package.json`](../implementations/cli/package.json) | The bundled NATS binary is resolved by `${prefix}-${platform}-${arch}`. (Future: swap the prefix to our own `@cotal-ai/nats-server-*`.) |
+| Onboard marker + `ONBOARD_VERSION` | `~/.cotal/onboarded.json` in [`lib/onboard.ts`](../implementations/cli/src/lib/onboard.ts); version const in `setup.ts` | Flips first-run vs ensure |
+| Demo-agent format | `DEMO_AGENTS` in `setup.ts` matches the frontmatter shape read by [`packages/core/src/agent-file.ts`](../packages/core/src/agent-file.ts) (same as `examples/01-lateral-coordination/agents/`) | `cotal spawn <name>` loads these |
+| Managed personas | each `DEMO_AGENTS` body carries a `# managed by cotal-setup` frontmatter marker; `writeDemoAgent` refreshes the file when the body changes, backing a marker-less (user-edited) file up to `<name>.md.bak` first | Edit `DEMO_AGENTS` + re-run setup to update david/sven/me; delete the marker line to take ownership |
+| `DEFAULT_SERVER` | [`packages/core/src/endpoint.ts`](../packages/core/src/endpoint.ts) | The address setup starts/checks |
+| cmux session | `CMUX_SURFACE_ID` gate + `cmuxManagerRunning`/`pgrepMatches` ([`lib/manager-proc.ts`](../implementations/cli/src/lib/manager-proc.ts)) + `workspaceRefs` ([`extensions/cmux/src/driver.ts`](../extensions/cmux/src/driver.ts)) | `ensureCmuxSession` opens a `cotal cmux --spawn david,sven` manager tab (owns david/sven so they're despawnable) + a focused `cotal-main` workspace. Gated on the **live process** (not just an open tab, which lingers after its process dies): if none runs it closes stale tabs and opens fresh. The manager staggers david/sven (waits for each to register presence before the next) so cold-starts don't spike memory |
+
+## Background processes
+
+Three detached processes back a folder, all stopped by `cotal down`:
+
+- **Mesh** — `startMeshDetached` ([`commands/up.ts`](../implementations/cli/src/commands/up.ts))
+  is the one place that boots a background nats-server (also used by `up --detach`). Writes
+  `.cotal/nats.pid` and tails `.cotal/nats.log` for the live pane.
+- **Web dashboard** — `startWebDetached` / `ensureWeb`
+  ([`commands/web.ts`](../implementations/cli/src/commands/web.ts)) re-execs `cotal web` detached.
+  Writes `.cotal/web.pid` and `.cotal/web.log`. `webUp()` probes the port for the status card.
+
+All re-execs and the cmux pane commands resolve this CLI via `selfArgv()` / `selfCotal()`
+([`lib/self-exec.ts`](../implementations/cli/src/lib/self-exec.ts)) = `[node, ...loaderFlags, entry]`
+(tsx loader in dev, compiled JS in prod) — so they never need `cotal` on PATH. The cmux session
+therefore opens identically via `npx`, `npm i -g`, and a dev clone. `cotal go` is an alias of
+`cotal setup` (open/resume vs install/update names).
+- **Manager** — `startManagerDetached` / `ensureManager`
+  ([`lib/manager-proc.ts`](../implementations/cli/src/lib/manager-proc.ts)) re-execs `cotal supervise`
+  detached (pty runtime); it answers the control plane (`cotal_spawn`/`despawn`/`purge`/`persona`).
+  Writes `.cotal/manager.pid` and `.cotal/manager.log`; `managerUp()` checks pid liveness for the
+  card. `cotal cmux go` SIGTERMs this pid first so its cmux-runtime manager is the only one.

--- a/docs/setup-internals.md
+++ b/docs/setup-internals.md
@@ -13,8 +13,8 @@ is two-tier, gated on a machine marker:
   the mesh runs **open** (no auth) by default — `--auth` flips it to a JWT-authed mesh. (Open means
   no `.cotal/auth`, so every read/control CLI connects bare; matches `cotal cmux go`.) Then:
   splash → intro → core steps (Node, NATS, start the mesh) → start the **web dashboard** in the
-  background → **connector picker** → write the two default experts (david/sven) → marker → demo
-  finale (`offerDemo`). The finale needs Claude Code and, if accepted: **in cmux**, opens a
+  background → **connector picker** → write the two default experts (david/sven) →
+  **offer a global install** (`offerGlobalInstall`) → marker → demo finale (`offerDemo`). The finale needs Claude Code and, if accepted: **in cmux**, opens a
   **cmux-runtime manager** (`cotal cmux --spawn david,sven`, via `ensureCmuxSession`) that owns
   david/sven plus a focused console + `me` pane; **otherwise**, a background **pty manager**
   (`ensureManager({spawn:["david","sven"]})`) pre-spawns david/sven and the terminal is handed to a
@@ -79,6 +79,13 @@ All re-execs and the cmux pane commands resolve this CLI via `selfArgv()` / `sel
 (tsx loader in dev, compiled JS in prod) — so they never need `cotal` on PATH. The cmux session
 therefore opens identically via `npx`, `npm i -g`, and a dev clone. `cotal go` is an alias of
 `cotal setup` (open/resume vs install/update names).
+
+For ergonomics only, an npx run with no global `cotal` offers to `npm i -g cotal-ai`
+(`offerGlobalInstall`, pinned to the running version): gated on `isNpx()` + a PATH scan
+(`cotalOnPath()` — not `onPath("cotal")`, since `cotal --version` isn't a real command), interactive
+prompt defaults to yes, non-interactive (`--yes` / no TTY) takes the default, and a failed install is
+non-fatal (warn + manual command). The same `self-exec.ts` exposes `displayCmd()` — the prefix
+(`cotal` / `npx cotal-ai` / `pnpm cotal`) used in the status-card hints so they match how you ran it.
 - **Manager** — `startManagerDetached` / `ensureManager`
   ([`lib/manager-proc.ts`](../implementations/cli/src/lib/manager-proc.ts)) re-execs `cotal supervise`
   detached (pty runtime); it answers the control plane (`cotal_spawn`/`despawn`/`purge`/`persona`).

--- a/implementations/cli/install.smoke.ts
+++ b/implementations/cli/install.smoke.ts
@@ -1,0 +1,62 @@
+/**
+ * Global-install offer smoke (no real install, no network) — run with: pnpm smoke:install
+ *
+ * Drives the real `offerGlobalInstall` from setup.ts in isolation: an unreachable npm registry +
+ * a throwaway prefix so any `npm i -g` fails fast and can never touch the real global install. It
+ * proves the gate (npx + no global `cotal`) and that a failed install is handled gracefully (the
+ * feature is best-effort and must never throw / abort setup).
+ */
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { isNpx, cotalOnPath } from "./src/lib/self-exec.js";
+import { offerGlobalInstall } from "./src/commands/setup.js";
+
+let failures = 0;
+function check(label: string, cond: boolean): void {
+  console.log(`${cond ? "✓" : "✗"} ${label}`);
+  if (!cond) failures++;
+}
+
+// Belt-and-suspenders: even if the gate let an install through, point npm at a dead registry and a
+// throwaway prefix so it fails fast and never writes to the real global location.
+const prefix = mkdtempSync(join(tmpdir(), "cotal-install-smoke-"));
+process.env.npm_config_prefix = prefix;
+process.env.npm_config_registry = "http://127.0.0.1:9"; // unreachable → fast fail
+process.env.npm_config_fetch_retries = "0";
+process.env.npm_config_fetch_timeout = "2000";
+// Make the PATH scan deterministic: a temp dir with no `cotal`, so cotalOnPath() is false.
+process.env.PATH = prefix;
+
+const realArgv1 = process.argv[1];
+const setArgv = (p: string) => (process.argv[1] = p);
+
+// 1) Gate closed: a normal (non-npx) invocation must no-op (return immediately, no install).
+setArgv("/Users/x/repo/bin/cotal.ts");
+check("not-npx ⇒ isNpx() false (gate closed)", isNpx() === false);
+let threw = false;
+try {
+  await offerGlobalInstall(false);
+} catch {
+  threw = true;
+}
+check("not-npx ⇒ offerGlobalInstall returns without throwing", !threw);
+
+// 2) Gate open: an npx invocation with no global `cotal`, non-TTY (takes the default = install).
+//    The install must fail fast (dead registry) and be handled gracefully — never throw.
+setArgv("/Users/x/.npm/_npx/abc123/node_modules/cotal-ai/dist/cotal.js");
+check("npx ⇒ isNpx() true (gate open)", isNpx() === true);
+check("cotal not resolvable on (temp) PATH ⇒ gate proceeds", cotalOnPath() === false);
+threw = false;
+try {
+  await offerGlobalInstall(false); // non-TTY here ⇒ takes default ⇒ attempts npm i -g
+} catch (e) {
+  threw = true;
+  console.log(`  unexpected throw: ${(e as Error).message}`);
+}
+check("npx install path: failed install handled gracefully (no throw)", !threw);
+check("nothing actually installed: `cotal` still not on PATH", cotalOnPath() === false);
+
+process.argv[1] = realArgv1;
+console.log(failures ? `\n${failures} check(s) failed` : "\nall checks passed");
+process.exit(failures ? 1 : 0);

--- a/implementations/cli/src/commands/channels.ts
+++ b/implementations/cli/src/commands/channels.ts
@@ -12,6 +12,8 @@ import {
   type ChannelDefaults,
   type ChannelRegistryFile,
 } from "@cotal-ai/core";
+import { cotalRoot } from "../lib/paths.js";
+import { resolveSpace } from "../lib/status.js";
 import { c } from "../ui.js";
 
 /**
@@ -38,7 +40,7 @@ export async function channels(argv: string[]): Promise<void> {
     },
   });
   const server = values.server ?? DEFAULT_SERVER;
-  const space = values.space ?? "demo";
+  const space = values.space ?? resolveSpace(process.cwd());
   // Tri-state replay: --replay → true, --no-replay → false, neither → leave unchanged.
   const replay = values["no-replay"] ? false : values.replay ? true : undefined;
   const creds = await managerCreds(); // undefined ⇒ open mode
@@ -84,7 +86,7 @@ export async function channels(argv: string[]): Promise<void> {
 /** Privileged creds for a registry write: mint ephemeral manager creds from the space auth
  *  (auth mode), or undefined to connect open. Throws nothing — open mode is the no-auth dev mesh. */
 async function managerCreds(): Promise<string | undefined> {
-  const auth = loadSpaceAuth(authDir(process.cwd()));
+  const auth = loadSpaceAuth(authDir(cotalRoot()));
   if (!auth) return undefined;
   return mintCreds(auth, newIdentity(), "manager");
 }

--- a/implementations/cli/src/commands/console.ts
+++ b/implementations/cli/src/commands/console.ts
@@ -6,13 +6,14 @@ import { render } from "ink";
 import {
   isReachable,
   DEFAULT_SERVER,
-  DEFAULT_SPACE,
   chatWildcard,
   authDir,
   loadSpaceAuth,
   mintCreds,
   newIdentity,
 } from "@cotal-ai/core";
+import { cotalRoot } from "../lib/paths.js";
+import { resolveSpace } from "../lib/status.js";
 import { c } from "../ui.js";
 import { runLog } from "../render.js";
 import { Root, makeObserver } from "../console/root.js";
@@ -38,12 +39,13 @@ export async function console_(argv: string[]): Promise<void> {
   let creds = values.creds ? readFileSync(values.creds, "utf8") : undefined;
   let space = values.space;
 
-  // Auth mode (.cotal/auth present): self-mint an observer cred for the local space so the console
-  // works without --creds (like `cotal web`). An authed server hosts exactly one space, so there's
-  // no overview — we enter it directly. Open mode (no auth): connect bare; with no --space, the TTY
-  // shows the space overview.
+  // Auth mode (.cotal/auth present): self-mint an admin cred for the local space so the console
+  // works without --creds — same god-view as `cotal web` (the console shows DMs/anycast, which the
+  // narrower `observer` profile denies → NATS Authorization Violation). An authed server hosts
+  // exactly one space, so there's no overview — we enter it directly. Open mode (no auth): connect
+  // bare; with no --space, the TTY shows the space overview.
   if (!creds) {
-    const auth = loadSpaceAuth(authDir(process.cwd()));
+    const auth = loadSpaceAuth(authDir(cotalRoot()));
     if (auth) {
       if (space && space !== auth.space) {
         console.error(
@@ -52,7 +54,7 @@ export async function console_(argv: string[]): Promise<void> {
         process.exit(1);
       }
       space = auth.space;
-      creds = await mintCreds(auth, newIdentity(), "observer");
+      creds = await mintCreds(auth, newIdentity(), "admin");
     }
   }
 
@@ -75,7 +77,7 @@ export async function console_(argv: string[]): Promise<void> {
   // No TTY (piped/headless) or --plain → the passive line stream; Ink needs a real terminal, and a
   // stream can't host the picker, so it falls back to the default space.
   if (values.plain || process.stdout.isTTY !== true) {
-    const s = space ?? DEFAULT_SPACE;
+    const s = space ?? resolveSpace(process.cwd());
     await runLog(makeObserver(s, server, creds, operator), s, creds ? chatWildcard(s) : undefined);
     return;
   }

--- a/implementations/cli/src/commands/demo.ts
+++ b/implementations/cli/src/commands/demo.ts
@@ -4,9 +4,9 @@ import {
   CotalEndpoint,
   isReachable,
   DEFAULT_SERVER,
-  DEFAULT_SPACE,
   type PresenceStatus,
 } from "@cotal-ai/core";
+import { resolveSpace } from "../lib/status.js";
 import { c } from "../ui.js";
 
 /**
@@ -78,7 +78,7 @@ export async function demo(argv: string[]): Promise<void> {
       creds: { type: "string" },
     },
   });
-  const space = values.space ?? DEFAULT_SPACE;
+  const space = values.space ?? resolveSpace(process.cwd());
   const server = values.server ?? DEFAULT_SERVER;
   const interval = values.interval ? Number(values.interval) : 1200;
   const creds = values.creds ? readFileSync(values.creds, "utf8") : undefined;

--- a/implementations/cli/src/commands/down.ts
+++ b/implementations/cli/src/commands/down.ts
@@ -1,0 +1,35 @@
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { c } from "../ui.js";
+import { cotalPath } from "../lib/paths.js";
+
+/** Stop the background processes started by `cotal up --detach` / `cotal setup`:
+ *  the manager, the web dashboard, and the mesh. */
+export async function down(): Promise<void> {
+  const targets: Array<[string, string]> = [
+    ["manager.pid", "manager"],
+    ["web.pid", "web dashboard"],
+    ["nats.pid", "nats-server"],
+  ];
+  let any = false;
+  for (const [file, label] of targets) {
+    const pidPath = cotalPath(file);
+    if (!existsSync(pidPath)) continue;
+    any = true;
+    stop(pidPath, label);
+  }
+  if (!any) {
+    console.error(c.red("Nothing running here (no .cotal/*.pid). Was it started with `cotal up` / `cotal setup`?"));
+    process.exit(1);
+  }
+}
+
+function stop(pidPath: string, label: string): void {
+  const pid = Number(readFileSync(pidPath, "utf8").trim());
+  try {
+    process.kill(pid, "SIGTERM");
+    console.log(c.green(`✓ stopped ${label} (pid ${pid})`));
+  } catch {
+    console.log(c.dim(`${label} (pid ${pid}) was not running.`));
+  }
+  rmSync(pidPath);
+}

--- a/implementations/cli/src/commands/history.ts
+++ b/implementations/cli/src/commands/history.ts
@@ -4,11 +4,12 @@ import {
   authDir,
   clearSpaceHistory,
   DEFAULT_SERVER,
-  DEFAULT_SPACE,
   loadSpaceAuth,
   mintCreds,
   newIdentity,
 } from "@cotal-ai/core";
+import { cotalRoot } from "../lib/paths.js";
+import { resolveSpace } from "../lib/status.js";
 import { c } from "../ui.js";
 
 /** Administrative history operations. Purges JetStream backlog only; live in-process
@@ -33,7 +34,7 @@ export async function history(argv: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const space = values.space ?? DEFAULT_SPACE;
+  const space = values.space ?? resolveSpace(process.cwd());
   const server = values.server ?? DEFAULT_SERVER;
   const creds = values.creds ? readFileSync(values.creds, "utf8") : await managerCreds();
   const result = await clearSpaceHistory({
@@ -48,7 +49,7 @@ export async function history(argv: string[]): Promise<void> {
 }
 
 async function managerCreds(): Promise<string | undefined> {
-  const auth = loadSpaceAuth(authDir(process.cwd()));
+  const auth = loadSpaceAuth(authDir(cotalRoot()));
   if (!auth) return undefined;
   return mintCreds(auth, newIdentity(), "manager");
 }

--- a/implementations/cli/src/commands/join.ts
+++ b/implementations/cli/src/commands/join.ts
@@ -7,12 +7,12 @@ import {
   isReachable,
   parseJoinLink,
   DEFAULT_SERVER,
-  DEFAULT_SPACE,
   type Delivery,
   type EndpointKind,
   type PresenceStatus,
   type CotalMessage,
 } from "@cotal-ai/core";
+import { resolveSpace } from "../lib/status.js";
 import { c, statusBadge } from "../ui.js";
 
 export async function join(argv: string[]): Promise<void> {
@@ -35,7 +35,7 @@ export async function join(argv: string[]): Promise<void> {
 
   // A join link carries server + auth + space; explicit flags still override it.
   const link = values.link ? parseJoinLink(values.link) : undefined;
-  const space = values.space ?? link?.space ?? DEFAULT_SPACE;
+  const space = values.space ?? link?.space ?? resolveSpace(process.cwd());
   const name = values.name ?? userInfo().username;
   const server = values.server ?? link?.servers ?? DEFAULT_SERVER;
   const channel = values.channel ?? link?.channels?.[0] ?? "general";

--- a/implementations/cli/src/commands/mint.ts
+++ b/implementations/cli/src/commands/mint.ts
@@ -10,6 +10,7 @@ import {
   newIdentity,
   type Profile,
 } from "@cotal-ai/core";
+import { cotalRoot } from "../lib/paths.js";
 import { c } from "../ui.js";
 
 /** Out-of-band cred minting: generate an identity, sign a profile-scoped user JWT with the
@@ -30,7 +31,7 @@ export async function mint(argv: string[]): Promise<void> {
     console.error(c.red(`unknown profile "${profile}" — expected agent, observer, or admin`));
     process.exit(1);
   }
-  const dir = authDir(process.cwd());
+  const dir = authDir(cotalRoot());
   const auth = loadSpaceAuth(dir);
   if (!auth) {
     console.error(c.red("no space auth found here — run `cotal up` first"));
@@ -42,7 +43,7 @@ export async function mint(argv: string[]): Promise<void> {
   let channels: string[] | undefined;
   let role: string | undefined;
   if (profile === "agent") {
-    const f = agentFilePath(process.cwd(), name);
+    const f = agentFilePath(cotalRoot(), name);
     if (existsSync(f)) {
       const def = loadAgentFile(f);
       channels = def.publish ?? def.channels;

--- a/implementations/cli/src/commands/setup.ts
+++ b/implementations/cli/src/commands/setup.ts
@@ -1,69 +1,546 @@
-import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
-import { c } from "../ui.js";
+import { spawnSync } from "node:child_process";
+import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { parseArgs } from "node:util";
+import * as p from "@clack/prompts";
+import { DEFAULT_SERVER, isReachable, registry, type Connector } from "@cotal-ai/core";
+import { cmux } from "@cotal-ai/cmux";
+import { brand, brandBold, dim, ok, note, splash } from "../lib/theme.js";
+import { LivePane } from "../lib/live-window.js";
+import { runSteps, type Step } from "../lib/steps.js";
+import { abortIfCancel } from "../lib/cancel.js";
+import { openSetupLog } from "../lib/setup-log.js";
+import { resolveNatsServer } from "../lib/nats-bin.js";
+import { isOnboarded, markOnboarded } from "../lib/onboard.js";
+import { machineStatus, meshStatus, onPath, resolveSpace } from "../lib/status.js";
+import { startMeshDetached, up } from "./up.js";
+import { ensureWeb, webUp, WEB_URL } from "./web.js";
+import { cmuxManagerRunning, ensureManager, managerUp, pgrepMatches, stopManager } from "../lib/manager-proc.js";
+import { selfCotal } from "../lib/self-exec.js";
+import { cotalPath, cotalRoot } from "../lib/paths.js";
+import { spawn } from "./spawn.js";
 
-/** Walk up to the cotal repo root (where the plugin marketplace manifest lives). */
-function repoRoot(start = process.cwd()): string {
-  let dir = resolve(start);
-  for (;;) {
-    if (existsSync(join(dir, ".claude-plugin", "marketplace.json"))) return dir;
-    const parent = dirname(dir);
-    if (parent === dir)
-      throw new Error("couldn't find the cotal repo root (.claude-plugin/marketplace.json)");
-    dir = parent;
-  }
-}
+const ONBOARD_VERSION = "1";
+/** The teammates the cmux/background demo pre-spawns (manager-owned, so they're despawnable). One
+ *  source of truth for both the `--spawn` list and the `cotal-<n>` tabs we clean up on restart. */
+const DEMO_TEAM = ["david", "sven"] as const;
+const README_URL = "https://github.com/Cotal-AI/Cotal/blob/main/README.md";
+const CC_DOCS_URL = "https://github.com/Cotal-AI/Cotal/blob/main/docs/claude-code-integration.md";
+const NATS_RELEASES_URL = "https://github.com/nats-io/nats-server/releases";
 
-/** Capture a command's stdout (for idempotency checks). */
-function read(cmd: string, args: string[]): string {
-  return execFileSync(cmd, args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
-}
-
-/**
- * One-time onboarding: make the repo's Claude sessions cotal-aware by installing the
- * cotal plugin (the `cotal_*` tools + presence hooks). Idempotent — safe to re-run.
- * `cotal cmux go` runs this for you; you can also run it standalone.
- */
-export async function setup(): Promise<void> {
-  const root = repoRoot();
-
-  // 1) The installed plugin runs the bundled dist/*.cjs — make sure it's built.
-  const bundle = join(root, "extensions", "connector-claude-code", "dist", "mcp.cjs");
-  if (!existsSync(bundle)) {
-    console.log(c.dim("Building the connector bundle…"));
-    execFileSync("pnpm", ["--filter", "@cotal-ai/connector-claude-code", "bundle"], {
-      cwd: root,
-      stdio: "inherit",
-    });
-  }
-
-  // 2) Register the cotal-mesh marketplace (+ install the plugin) via Claude Code's CLI.
-  let marketplaces: string;
-  try {
-    marketplaces = read("claude", ["plugin", "marketplace", "list"]);
-  } catch (e) {
-    console.error(c.red("Couldn't run `claude` — is Claude Code installed and on your PATH?"));
-    console.error(c.dim("Once it is, run these two commands manually:"));
-    console.error(c.dim(`  claude plugin marketplace add ${root}`));
-    console.error(c.dim("  claude plugin install cotal@cotal-mesh --scope local"));
-    throw e;
-  }
-  if (!/\bcotal-mesh\b/.test(marketplaces)) {
-    console.log(c.dim("Registering the cotal-mesh marketplace…"));
-    execFileSync("claude", ["plugin", "marketplace", "add", root], { stdio: "inherit" });
-  }
-
-  // 3) Install the plugin (repo-local scope) if it isn't already.
-  if (/\bcotal@cotal-mesh\b/.test(read("claude", ["plugin", "list"]))) {
-    console.log(c.green("✓ cotal plugin already set up"));
-    return;
-  }
-  console.log(c.dim("Installing the cotal plugin…"));
-  execFileSync("claude", ["plugin", "install", "cotal@cotal-mesh", "--scope", "local"], {
-    stdio: "inherit",
+/** `cotal setup`: guided setup. First run (no `~/.cotal/onboarded.json`) gets the full
+ *  narrated flow; later runs get a compact ensure+status. `--full` forces the full flow.
+ *  Each failed step offers an interactive Claude handoff (COTAL_SKIP_ASSIST=1 disables). */
+export async function setup(argv: string[]): Promise<void> {
+  const { values } = parseArgs({
+    args: argv,
+    allowPositionals: true,
+    options: {
+      full: { type: "boolean" },
+      yes: { type: "boolean", short: "y" },
+      auth: { type: "boolean" }, // opt into an authed mesh (JWT/ACLs); default is an open local mesh
+    },
   });
-  console.log(
-    c.green("✓ cotal plugin installed — Claude sessions in this repo now have the cotal tools"),
+  // `--yes` (agents/CI) always runs the full flow non-interactively. The local mesh is open by
+  // default (frictionless, loopback-only); `--auth` opts into JWT auth for shared/cross-machine use.
+  if (!isOnboarded() || values.full || values.yes) await runFirstRun(Boolean(values.yes), !values.auth);
+  else await runEnsure();
+}
+
+/** `cotal go` — open or resume your session. A friendlier-named alias of `cotal setup`: the first
+ *  run installs (full guided flow), later runs fast-forward to the ensure path and reopen your
+ *  cmux session. `cotal setup` stays the explicit install/update name. */
+export async function go(argv: string[]): Promise<void> {
+  return setup(argv);
+}
+
+/** The full, narrated first-run experience. `yes` = non-interactive accept-all; `open` = run the
+ *  mesh without auth (the frictionless local default; `--auth` flips it off). */
+async function runFirstRun(yes: boolean, open: boolean): Promise<void> {
+  splash();
+  p.intro(brandBold("Welcome to Cotal"));
+  note(
+    "Cotal is the open web for agents: they join a shared space, see who's around, and coordinate as peers instead of in silos. Build whole agent societies, even across different machines, on one open web. Let's set yours up.",
+    "Give your agents a place to work together",
+  );
+
+  const log = openSetupLog(process.cwd());
+
+  // Prerequisites + the local web (NATS). These never prompt.
+  const core: Step[] = [
+    {
+      name: "node-version",
+      title: "Check Node.js",
+      explain: "Cotal needs Node 20 or newer.",
+      context: [README_URL],
+      async run() {
+        const major = Number(process.versions.node.split(".")[0]);
+        if (major < 20) throw new Error(`Node ${process.versions.node} is too old; Cotal needs Node >= 20`);
+        return `Node ${process.versions.node}`;
+      },
+    },
+    {
+      name: "nats-binary",
+      title: "Locate the NATS server",
+      explain: "Cotal runs on NATS + JetStream, the wire your agents speak over.",
+      context: [NATS_RELEASES_URL, README_URL],
+      async run() {
+        const r = await resolveNatsServer();
+        return r.source === "path" ? "nats-server from PATH" : "bundled binary";
+      },
+    },
+    {
+      name: "start-mesh",
+      title: "Start the web for agents",
+      explain: "A local NATS + JetStream server you own; the web your agents join, in the background.",
+      live: true,
+      context: [cotalPath("nats.log"), cotalPath("auth/server.conf"), README_URL],
+      async run() {
+        if (await isReachable(DEFAULT_SERVER)) return `already running at ${DEFAULT_SERVER}`;
+        const pane = new LivePane();
+        pane.start("Booting nats-server");
+        try {
+          const { server } = await startMeshDetached({ onLine: (l) => pane.push(l), open });
+          return `running at ${server} (stop with: cotal down)`;
+        } finally {
+          pane.clear();
+        }
+      },
+    },
+  ];
+  if (!(await runSteps(core, log, { yes }))) return abort();
+
+  // The web dashboard, in the background, so it's just there (best-effort; never blocks setup).
+  try {
+    const web = await ensureWeb({ space: resolveSpace(process.cwd()), server: DEFAULT_SERVER });
+    if (web.running) {
+      p.log.success(`Web dashboard at ${web.url} (stop with: cotal down)`);
+      log.line(`web: ${web.url}`);
+    }
+  } catch {
+    /* non-fatal: the card still shows how to start it */
+  }
+
+  // Connectors: which agents should be able to join. Only Claude needs an install
+  // (its wake channel binds to an installed plugin); Codex/OpenCode auto-wire at spawn.
+  const found = { claude: onPath("claude"), codex: onPath("codex"), opencode: onPath("opencode") };
+  const selected = await pickConnectors(found, yes);
+  if (selected.has("claude")) {
+    if (!found.claude) p.log.warn("claude isn't on PATH. Install it (https://claude.com/claude-code), then re-run setup.");
+    else if (!(await runSteps([claudePluginStep()], log, { yes }))) return abort();
+  }
+  for (const name of ["codex", "opencode"] as const) {
+    if (selected.has(name) && found[name]) {
+      p.log.success(`${name} ready (auto-wired when you spawn it)`);
+      log.line(`connector ${name}: ready (no install)`);
+    }
+  }
+
+  // Two experts plus your own driving session, by default. These are setup-managed: refreshed when
+  // DEMO_AGENTS changes (so persona edits actually land), but a file you've taken ownership of is
+  // backed up first, never silently lost — see writeDemoAgent.
+  mkdirSync(cotalPath("agents"), { recursive: true });
+  for (const [name, body] of Object.entries(DEMO_AGENTS)) {
+    writeDemoAgent(cotalPath("agents", `${name}.md`), body);
+  }
+  p.log.success("Added david (the engineer), sven (the guide), and your session (me); they join when you spawn them or open the demo");
+  log.line("demo-agents: wrote david + sven + me");
+
+  markOnboarded(ONBOARD_VERSION);
+  note(
+    [
+      "Your agent has direct access to Cotal: spawn one and just talk to it (it can message peers, spawn teammates, and send feedback). Now any agent can join and collaborate. You can also use the CLI.",
+      "",
+      `${ok("✓")} drive a session     ${dim("cotal spawn me")}`,
+      `${ok("✓")} ask the engineer    ${dim("cotal spawn david")}`,
+      `${ok("✓")} ask the guide       ${dim("cotal spawn sven")}`,
+      `${ok("✓")} watch the mesh      ${dim("cotal console")}`,
+      `${ok("✓")} open the dashboard  ${dim(WEB_URL)}`,
+      `${ok("✓")} resume later        ${dim("cotal go")}`,
+      `${ok("✓")} stop everything     ${dim("cotal down")}`,
+      "",
+      dim('Cotal not working? Tell your agent to give us feedback and it sends it for you (built-in cotal_feedback), or run cotal feedback "<msg>".'),
+    ].join("\n"),
+    "You're set",
+  );
+
+  if (!yes) await offerDemo(found.claude);
+  else {
+    // Agents/CI: bring up the control plane so cotal_spawn / despawn / purge work right away.
+    try {
+      ensureManager({ space: resolveSpace(process.cwd()), server: DEFAULT_SERVER });
+    } catch {
+      /* non-fatal */
+    }
+  }
+  p.outro(brand(yes ? "Cotal is ready." : "Happy meshing."));
+
+  function abort() {
+    p.outro(brand("Setup paused. Fix the step above and run `cotal setup` again."));
+    process.exitCode = 1;
+  }
+}
+
+/** Pick which agent connectors to set up. Detected ones are pre-checked (= the "all"
+ *  default). Non-interactive / --yes selects all detected without prompting. */
+async function pickConnectors(
+  found: Record<"claude" | "codex" | "opencode", boolean>,
+  yes: boolean,
+): Promise<Set<string>> {
+  const all = (["claude", "codex", "opencode"] as const).filter((n) => found[n]);
+  if (yes || !process.stdin.isTTY) return new Set(all);
+  const labels: Record<string, string> = { claude: "Claude Code", codex: "Codex", opencode: "OpenCode" };
+
+  // Common case: show what was detected and offer a visible Continue button (clack's multiselect
+  // has no native one). Only "Customize" (or nothing detected) drops into the toggle list.
+  if (all.length) {
+    note(all.map((n) => labels[n]).join(", "), "Agents found");
+    const go = abortIfCancel(
+      await p.confirm({ message: "Set these up?", active: "Continue", inactive: "Customize", initialValue: true }),
+    );
+    if (go) return new Set(all);
+  }
+
+  const picked = abortIfCancel(
+    await p.multiselect({
+      message: "Pick the agents to set up (space toggles, enter continues)",
+      options: (["claude", "codex", "opencode"] as const).map((n) => ({
+        value: n,
+        label: labels[n],
+        hint: !found[n] ? "not on PATH" : n === "claude" ? "installs a plugin" : "ready at spawn",
+      })),
+      initialValues: all,
+      required: false,
+    }),
+  );
+  return new Set(picked as string[]);
+}
+
+/** The Claude Code plugin install, as a step (spinner + failure handling + handoff). */
+function claudePluginStep(): Step {
+  return {
+    name: "claude-plugin",
+    title: "Install the Claude Code plugin",
+    explain: "Lets a Claude Code session join the web and wake on peer messages.",
+    context: [join(homedir(), ".cotal/claude-plugin"), CC_DOCS_URL],
+    async run() {
+      installClaudePlugin();
+      return "cotal@cotal-mesh (local scope)";
+    },
+  };
+}
+
+/** Finale: a live demo — a Claude the operator drives, with david and sven (manager-owned
+ *  teammates) helping. In cmux they get their own tabs; otherwise they run in the background and
+ *  the terminal is handed to the driving session. The demo spawns Claude sessions, so it needs
+ *  Claude Code. If declined / no Claude, fall back to the `cotal · ready` card. Skipped under --yes. */
+async function offerDemo(haveClaude: boolean): Promise<void> {
+  const haveAgents = (["me", "david", "sven"] as const).every((n) => existsSync(cotalPath("agents", `${n}.md`)));
+  const isTTY = Boolean(process.stdin.isTTY);
+
+  if (haveClaude && haveAgents && isTTY) {
+    const cmux = inCmuxSurface();
+    const go = abortIfCancel(
+      await p.confirm({
+        message: cmux
+          ? "Open the cmux demo? A Claude you drive, with david and sven helping in cmux tabs."
+          : "Open the demo? A Claude you drive, with david and sven helping in the background.",
+        initialValue: true,
+      }),
+    );
+    if (go) {
+      if (cmux) {
+        ensureCmuxSession(cotalRoot());
+        p.log.success("Session open: drive the 'cotal-main' pane; david and sven are on the mesh in the background.");
+        return;
+      }
+      // Non-cmux: a background pty manager pre-spawns david/sven (managed, despawnable), then we
+      // hand this terminal to the driving session.
+      ensureManager({ space: resolveSpace(process.cwd()), server: DEFAULT_SERVER, spawn: [...DEMO_TEAM] });
+      p.outro(brand("Launching your session... david and sven are warming up in the background."));
+      await spawn(["me", "--prompt", ME_GREETING]);
+      process.exit(0);
+    }
+  } else if (isTTY && haveAgents && !haveClaude) {
+    p.log.info("The demo needs Claude Code. Install it (https://claude.com/claude-code), then run `cotal go`.");
+  }
+
+  // Declined, or no Claude: start the background (pty) control plane so cotal_spawn / despawn /
+  // purge still work, then leave them the quick-reference card.
+  try {
+    ensureManager({ space: resolveSpace(process.cwd()), server: DEFAULT_SERVER });
+  } catch {
+    /* non-fatal: the card still shows how to start it */
+  }
+  await readyCard(process.cwd());
+}
+
+/** Greeting the driving session auto-submits on start (no apostrophes — it rides through
+ *  cmux's `bash -lc '…'` quoting). Teaches the capabilities by telling, not by calling tools,
+ *  so it does not depend on david/sven having joined yet when this first turn runs. */
+const ME_GREETING =
+  "Greet the operator in a few short lines. Open with one line on what Cotal is: an open space where AI agents join and work together as peers. Say you are their Cotal session and that david (the engineer) and sven (the guide) are on the mesh to help. Then tell them what you can do for them: message david or sven, spawn new teammates and despawn them when done, and send feedback. End by asking what they want to build.";
+
+/** True when we're running inside a real cmux pane (cmux sets `CMUX_SURFACE_ID` per surface).
+ *  Opening/closing cmux workspaces is only authorized from a live pane, so this — not
+ *  `cmux.available()` (which only pings the app) — is the gate for opening the cmux session. */
+function inCmuxSurface(): boolean {
+  return Boolean(process.env.CMUX_SURFACE_ID);
+}
+
+/** (Re)open the cmux working session, idempotently. A background cmux-runtime manager pre-spawns
+ *  david/sven (so they're managed teammates you can `cotal_despawn`) into their own tabs; the
+ *  focused `cotal-main` workspace is the console + the driving session "me" (your foreground
+ *  driver). Re-running reuses whatever's already open — only missing tabs are created, so there's
+ *  never a second manager. The `me` pane presses Enter on its own cmux surface a few times to
+ *  auto-accept the one-time dev-channels prompt (the manager's cmux runtime does the same for
+ *  david/sven). */
+function ensureCmuxSession(cwd: string): void {
+  const sq = (s: string) => `'${s.replace(/'/g, "'\\''")}'`;
+  const enterLoop =
+    '( [ -n "$CMUX_SURFACE_ID" ] && [ -n "$CMUX_BUNDLED_CLI_PATH" ] && ' +
+    'for _ in 1 2 3 4 5; do sleep 1; "$CMUX_BUNDLED_CLI_PATH" send-key --surface "$CMUX_SURFACE_ID" enter >/dev/null 2>&1; done ) &';
+  const term = (cmd: string) => ({
+    pane: { surfaces: [{ type: "terminal", command: `bash -lc ${sq(`cd "${cwd}" && ${cmd}`)}` }] },
+  });
+  // A claude pane that auto-confirms the dev-channels prompt so the session joins the mesh.
+  const confirmTerm = (cmd: string) => ({
+    pane: { surfaces: [{ type: "terminal", command: `bash -lc ${sq(`cd "${cwd}" && ${enterLoop} ${cmd}`)}` }] },
+  });
+
+  // The cmux-tab manager becomes the control plane; drop any detached pty manager so they don't
+  // both answer control requests.
+  stopManager();
+
+  // Invoke this CLI by its resolved path, not bare `cotal`, so the panes work whether the user
+  // installed via npx, `npm i -g`, or a dev clone (no dependency on `cotal` being on PATH). The
+  // space follows the folder's auth so every pane matches the running mesh.
+  const cotal = selfCotal();
+  const space = resolveSpace(cwd);
+
+  // Control plane: a cmux-runtime manager that pre-spawns david/sven into their own tabs and owns
+  // them (so cotal_despawn / cotal_spawn work). A cmux tab persists after its process dies, so
+  // "workspace exists" != "manager running" — gate on the live process. When none is up, drop the
+  // dead manager + teammate tabs first, then open a fresh one; otherwise re-runs keep skipping a
+  // never-restarted manager and david/sven never join.
+  if (!cmuxManagerRunning(space)) {
+    for (const ws of ["cotal-manager", ...DEMO_TEAM.map((n) => `cotal-${n}`)]) closeStaleWorkspaces(ws);
+    cmux.openWorkspace(
+      "cotal-manager",
+      JSON.stringify(term(`${cotal} cmux --space ${space} --spawn ${DEMO_TEAM.join(",")}`)),
+      { focus: false },
+    );
+  }
+
+  // Your focused driver: console + the "me" session. Gate on the live driving session (not the
+  // persistent tab) so a session you're driving is never disturbed; a dead/closed one gets its stale
+  // tab dropped and reopened. cmux runs pane commands through the login shell (which may be nushell)
+  // before bash, so keep the command free of embedded single quotes: pass the greeting base64-encoded
+  // and decode it in bash.
+  if (!pgrepMatches(`spawn me --space ${space}`)) {
+    closeStaleWorkspaces("cotal-main");
+    const greetB64 = Buffer.from(ME_GREETING, "utf8").toString("base64");
+    const meCmd = `${cotal} spawn me --space ${space} --prompt "$(echo ${greetB64} | base64 -d)"`;
+    const main = JSON.stringify({
+      direction: "vertical",
+      split: 0.34,
+      children: [term(`${cotal} console --space ${space}`), confirmTerm(meCmd)],
+    });
+    cmux.openWorkspace("cotal-main", main, { focus: true });
+  }
+}
+
+/** Close any lingering cmux tabs labelled `name` (dead tabs persist in the workspace list after
+ *  their process exits) so a freshly opened one is the only instance. */
+function closeStaleWorkspaces(name: string): void {
+  for (const ref of cmux.workspaceRefs(name)) {
+    try {
+      cmux.closeWorkspace(ref);
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+/** The compact repeat-run: quietly ensure the mesh + web are up here, then a one-glance card. */
+async function runEnsure(): Promise<void> {
+  let mesh = await meshStatus(process.cwd());
+  if (!mesh.reachable) {
+    const s = p.spinner();
+    s.start("Starting the web for agents");
+    try {
+      await up(["--detach"]);
+      s.stop("Web for agents started");
+    } catch (e) {
+      s.stop(`Couldn't start it: ${(e as Error).message}`);
+      process.exitCode = 1;
+      return;
+    }
+    mesh = await meshStatus(process.cwd());
+  }
+  await ensureWeb({ space: mesh.space, server: mesh.server }).catch(() => {});
+  // Inside cmux, re-running setup reopens your session (idempotent: reuse the live manager +
+  // david/sven, open only missing tabs). Otherwise bring up the background pty control plane.
+  try {
+    if (inCmuxSurface()) ensureCmuxSession(cotalRoot());
+    else ensureManager({ space: mesh.space, server: mesh.server });
+  } catch {
+    /* non-fatal */
+  }
+  await readyCard(process.cwd());
+}
+
+/** The `cotal · ready` one-glance card: machine + mesh + web + manager status, plus the key
+ *  commands. Shared by the repeat-run ensure and the first-run no-demo finale. */
+async function readyCard(cwd: string): Promise<void> {
+  const mesh = await meshStatus(cwd);
+  const m = await machineStatus();
+  const web = await webUp();
+  // The control plane is either the detached pty manager (pid file) or a live cmux-tab manager
+  // (its tab lingers after it exits, so check the process, not the workspace list).
+  const mgr = managerUp() || (inCmuxSurface() && cmuxManagerRunning(mesh.space));
+  const line = (on: boolean, text: string) => `${on ? ok("✓") : dim("○")} ${text}`;
+  note(
+    [
+      line(m.nats !== "missing", `NATS     ${dim(m.nats === "missing" ? "missing" : m.nats)}`),
+      line(m.claudePlugin, `plugin   ${dim(m.claudePlugin ? "installed" : "not installed")}`),
+      line(mesh.reachable, `mesh     ${dim(`${mesh.server} · space ${mesh.space}`)}`),
+      line(web, `web      ${dim(WEB_URL)}`),
+      line(mgr, `manager  ${dim(mgr ? "running" : "not running")}`),
+      "",
+      `resume:    ${dim("cotal go")}   ${dim("(reopen this session anytime)")}`,
+      `watch it:  ${dim("cotal console")}   ${dim("(live TUI in this terminal)")}`,
+      `drive it:  ${dim("cotal spawn me")}   ${dim("(or david / sven)")}`,
+      `more:      ${dim('cotal web · cotal down · cotal feedback "<msg>" · cotal --help')}`,
+    ].join("\n"),
+    brandBold("cotal · ready"),
   );
 }
+
+/** Materialize a stable plugin marketplace under ~/.cotal/claude-plugin (surviving
+ *  npx cache eviction) and install the plugin from it. The marketplace name must stay
+ *  `cotal-mesh` (the connector's channel ref `plugin:cotal@cotal-mesh` depends on it). */
+function installClaudePlugin(): void {
+  const { pluginRoot } = registry.resolve<Connector>("connector", "claude");
+  if (!pluginRoot) throw new Error('the registered "claude" connector ships no plugin assets');
+  for (const f of ["dist/mcp.cjs", "dist/hook.cjs", ".claude-plugin/plugin.json", ".mcp.json", "hooks/hooks.json"]) {
+    if (!existsSync(join(pluginRoot, f))) {
+      throw new Error(
+        `plugin asset missing: ${join(pluginRoot, f)} (in a dev clone, build it with: pnpm --filter @cotal-ai/connector-claude-code bundle)`,
+      );
+    }
+  }
+
+  const marketDir = join(homedir(), ".cotal", "claude-plugin");
+  const pluginDir = join(marketDir, "cotal");
+  for (const f of [".claude-plugin", ".mcp.json", "hooks", "dist/mcp.cjs", "dist/hook.cjs"]) {
+    cpSync(join(pluginRoot, f), join(pluginDir, f), { recursive: true });
+  }
+  mkdirSync(join(marketDir, ".claude-plugin"), { recursive: true });
+  writeFileSync(
+    join(marketDir, ".claude-plugin", "marketplace.json"),
+    JSON.stringify(
+      {
+        name: "cotal-mesh",
+        description: "The Cotal mesh adapter for Claude Code: join a shared pub/sub space as a lateral peer.",
+        owner: { name: "Cotal" },
+        plugins: [{ name: "cotal", source: "./cotal" }],
+      },
+      null,
+      2,
+    ),
+  );
+
+  // `add` fails when the marketplace is already registered; refresh it instead.
+  const add = claude("plugin", "marketplace", "add", marketDir);
+  if (add.status !== 0) {
+    const update = claude("plugin", "marketplace", "update", "cotal-mesh");
+    if (update.status !== 0) throw new Error(`couldn't register the plugin marketplace:\n${add.output}\n${update.output}`);
+  }
+  const install = claude("plugin", "install", "cotal@cotal-mesh", "--scope", "local");
+  if (install.status !== 0 && !/already installed/i.test(install.output)) {
+    throw new Error(`plugin install failed:\n${install.output}`);
+  }
+  const list = claude("plugin", "list");
+  if (!list.output.includes("cotal")) throw new Error(`plugin not visible in \`claude plugin list\`:\n${list.output}`);
+}
+
+function claude(...args: string[]): { status: number | null; output: string } {
+  const r = spawnSync("claude", args, { encoding: "utf8" });
+  return { status: r.status, output: `${r.stdout ?? ""}${r.stderr ?? ""}`.trim() };
+}
+
+/** Frontmatter marker (a comment line — the parser ignores `#` lines) stamping a demo persona as
+ *  setup-managed, so re-runs may refresh it; remove the line to take ownership. */
+const MANAGED_MARKER = "# managed by cotal-setup";
+
+/** Write a setup-managed demo persona, refreshing it when its DEMO_AGENTS body changes — but never
+ *  silently clobber a file the user has taken ownership of (one without the marker): back it up to
+ *  `<name>.md.bak` first. Missing or marker-carrying files are written in place. */
+function writeDemoAgent(path: string, body: string): void {
+  if (existsSync(path)) {
+    const cur = readFileSync(path, "utf8");
+    if (cur === body) return; // already current
+    if (!cur.includes(MANAGED_MARKER)) writeFileSync(`${path}.bak`, cur); // preserve a user/pre-marker edit
+  }
+  writeFileSync(path, body);
+}
+
+const DEMO_AGENTS: Record<string, string> = {
+  david: `---
+${MANAGED_MARKER} — edit DEMO_AGENTS in the cotal CLI; delete this line to keep local changes
+name: david
+role: cotal-tech
+description: "the engineer: how Cotal works (the wire, NATS, connectors, integration)."
+tags: [cotal, technical, help]
+channels: [general]
+---
+
+You are david, Cotal's engineer, live on the web for agents with the operator who just set Cotal
+up. You help them set up and experiment. Your topic is how Cotal works: the wire contract (subjects,
+message schemas, presence), NATS and JetStream underneath, the endpoint/connector model, the
+delivery modes (multicast, unicast, anycast), and how to get any agent or framework onto the mesh.
+You ground every answer in the real thing, never a guess. Start from \`docs/OVERVIEW.md\` (what Cotal
+is and its core primitives) and \`docs/getting-started.md\`, then read the source for your topic —
+\`docs/architecture.md\`, \`docs/claude-code-integration.md\`, \`docs/setup-internals.md\`, and, in a
+source checkout, \`packages/\` and \`extensions/\`. Quote the exact subjects, message kinds, config, and
+commands; if the docs don't cover it, say so rather than inventing. If they aren't on disk, look
+them up at https://github.com/Cotal-AI/Cotal. If a question is really about use-cases or what to
+build, hand it to your peer sven.
+`,
+  sven: `---
+${MANAGED_MARKER} — edit DEMO_AGENTS in the cotal CLI; delete this line to keep local changes
+name: sven
+role: cotal-guide
+description: "the guide: what to build with Cotal (examples, setups, getting the most out of it)."
+tags: [cotal, examples, help]
+channels: [general]
+---
+
+You are sven, Cotal's guide, live on the web for agents with the operator who just set Cotal up.
+You help them set up and experiment. You design multi-agent setups: who should be on a space, how
+they'd coordinate, what's worth trying — grounded in what Cotal can actually do, never made-up
+features. Start from \`docs/OVERVIEW.md\` (what Cotal is and its core primitives — channels, anycast,
+presence, spawn, personas, delivery modes) and \`docs/getting-started.md\`; read the matching example
+in \`examples/*/README.md\` (indexed in \`docs/examples.md\`) before sketching, and reach for
+\`docs/architecture.md\` when you need a primitive to design something new. Cite the example or
+primitive you're drawing on. If they aren't on disk, look them up at https://github.com/Cotal-AI/Cotal.
+For deep how-it-works or integration details, pull in your peer david.
+`,
+  me: `---
+${MANAGED_MARKER} — edit DEMO_AGENTS in the cotal CLI; delete this line to keep local changes
+name: me
+role: operator
+description: "your own session on the Cotal mesh."
+tags: [cotal]
+channels: [general]
+---
+
+You are the operator's own session on the Cotal mesh: the agent they drive. Do what they ask and
+use the mesh to get it done. Two experts are here to help you set up and experiment: david (the
+engineer, how Cotal works) and sven (the guide, what to build). Reach them with cotal_dm or
+cotal_anycast, grow the team with cotal_spawn, and if Cotal misbehaves send a report with
+cotal_feedback. Docs: https://github.com/Cotal-AI/Cotal
+`,
+};

--- a/implementations/cli/src/commands/setup.ts
+++ b/implementations/cli/src/commands/setup.ts
@@ -190,7 +190,7 @@ async function runFirstRun(yes: boolean, open: boolean): Promise<void> {
  *  `cotal`. Interactive: a Y/n prompt (default yes). Non-interactive (`--yes` / no TTY): takes the
  *  default and installs. Best-effort — `npm i -g` fails a lot (EACCES, nvm/fnm/volta), so on failure
  *  we warn with the manual command and continue; setup never aborts over a PATH convenience. */
-async function offerGlobalInstall(yes: boolean): Promise<void> {
+export async function offerGlobalInstall(yes: boolean): Promise<void> {
   if (!isNpx() || cotalOnPath()) return; // already have `cotal`, or not an npx run
 
   if (!yes && process.stdin.isTTY) {

--- a/implementations/cli/src/commands/setup.ts
+++ b/implementations/cli/src/commands/setup.ts
@@ -17,7 +17,7 @@ import { machineStatus, meshStatus, onPath, resolveSpace } from "../lib/status.j
 import { startMeshDetached, up } from "./up.js";
 import { ensureWeb, webUp, WEB_URL } from "./web.js";
 import { cmuxManagerRunning, ensureManager, managerUp, pgrepMatches, stopManager } from "../lib/manager-proc.js";
-import { selfCotal } from "../lib/self-exec.js";
+import { cotalOnPath, displayCmd, isNpx, selfCotal } from "../lib/self-exec.js";
 import { cotalPath, cotalRoot } from "../lib/paths.js";
 import { spawn } from "./spawn.js";
 
@@ -102,7 +102,7 @@ async function runFirstRun(yes: boolean, open: boolean): Promise<void> {
         pane.start("Booting nats-server");
         try {
           const { server } = await startMeshDetached({ onLine: (l) => pane.push(l), open });
-          return `running at ${server} (stop with: cotal down)`;
+          return `running at ${server} (stop with: ${displayCmd()} down)`;
         } finally {
           pane.clear();
         }
@@ -115,7 +115,7 @@ async function runFirstRun(yes: boolean, open: boolean): Promise<void> {
   try {
     const web = await ensureWeb({ space: resolveSpace(process.cwd()), server: DEFAULT_SERVER });
     if (web.running) {
-      p.log.success(`Web dashboard at ${web.url} (stop with: cotal down)`);
+      p.log.success(`Web dashboard at ${web.url} (stop with: ${displayCmd()} down)`);
       log.line(`web: ${web.url}`);
     }
   } catch {
@@ -127,7 +127,8 @@ async function runFirstRun(yes: boolean, open: boolean): Promise<void> {
   const found = { claude: onPath("claude"), codex: onPath("codex"), opencode: onPath("opencode") };
   const selected = await pickConnectors(found, yes);
   if (selected.has("claude")) {
-    if (!found.claude) p.log.warn("claude isn't on PATH. Install it (https://claude.com/claude-code), then re-run setup.");
+    if (!found.claude)
+      p.log.warn(`claude isn't on PATH. Install it (https://claude.com/claude-code), then re-run ${displayCmd()} setup.`);
     else if (!(await runSteps([claudePluginStep()], log, { yes }))) return abort();
   }
   for (const name of ["codex", "opencode"] as const) {
@@ -147,20 +148,23 @@ async function runFirstRun(yes: boolean, open: boolean): Promise<void> {
   p.log.success("Added david (the engineer), sven (the guide), and your session (me); they join when you spawn them or open the demo");
   log.line("demo-agents: wrote david + sven + me");
 
+  await offerGlobalInstall(yes);
+
   markOnboarded(ONBOARD_VERSION);
+  const cmd = displayCmd();
   note(
     [
       "Your agent has direct access to Cotal: spawn one and just talk to it (it can message peers, spawn teammates, and send feedback). Now any agent can join and collaborate. You can also use the CLI.",
       "",
-      `${ok("✓")} drive a session     ${dim("cotal spawn me")}`,
-      `${ok("✓")} ask the engineer    ${dim("cotal spawn david")}`,
-      `${ok("✓")} ask the guide       ${dim("cotal spawn sven")}`,
-      `${ok("✓")} watch the mesh      ${dim("cotal console")}`,
+      `${ok("✓")} drive a session     ${dim(`${cmd} spawn me`)}`,
+      `${ok("✓")} ask the engineer    ${dim(`${cmd} spawn david`)}`,
+      `${ok("✓")} ask the guide       ${dim(`${cmd} spawn sven`)}`,
+      `${ok("✓")} watch the mesh      ${dim(`${cmd} console`)}`,
       `${ok("✓")} open the dashboard  ${dim(WEB_URL)}`,
-      `${ok("✓")} resume later        ${dim("cotal go")}`,
-      `${ok("✓")} stop everything     ${dim("cotal down")}`,
+      `${ok("✓")} resume later        ${dim(`${cmd} go`)}`,
+      `${ok("✓")} stop everything     ${dim(`${cmd} down`)}`,
       "",
-      dim('Cotal not working? Tell your agent to give us feedback and it sends it for you (built-in cotal_feedback), or run cotal feedback "<msg>".'),
+      dim(`Cotal not working? Tell your agent to give us feedback and it sends it for you (built-in cotal_feedback), or run ${cmd} feedback "<msg>".`),
     ].join("\n"),
     "You're set",
   );
@@ -177,8 +181,51 @@ async function runFirstRun(yes: boolean, open: boolean): Promise<void> {
   p.outro(brand(yes ? "Cotal is ready." : "Happy meshing."));
 
   function abort() {
-    p.outro(brand("Setup paused. Fix the step above and run `cotal setup` again."));
+    p.outro(brand(`Setup paused. Fix the step above and run \`${displayCmd()} setup\` again.`));
     process.exitCode = 1;
+  }
+}
+
+/** When run via `npx` without a global `cotal`, offer to install it so the user can just type
+ *  `cotal`. Interactive: a Y/n prompt (default yes). Non-interactive (`--yes` / no TTY): takes the
+ *  default and installs. Best-effort — `npm i -g` fails a lot (EACCES, nvm/fnm/volta), so on failure
+ *  we warn with the manual command and continue; setup never aborts over a PATH convenience. */
+async function offerGlobalInstall(yes: boolean): Promise<void> {
+  if (!isNpx() || cotalOnPath()) return; // already have `cotal`, or not an npx run
+
+  if (!yes && process.stdin.isTTY) {
+    const go = abortIfCancel(
+      await p.confirm({ message: "Install `cotal` globally so you can just type `cotal`?", initialValue: true }),
+    );
+    if (!go) {
+      p.log.info(`No problem — keep using ${dim("npx cotal-ai")}. Install later with ${dim("npm i -g cotal-ai")}.`);
+      return;
+    }
+  }
+
+  const pkg = `cotal-ai@${runningVersion() ?? "latest"}`;
+  const s = p.spinner();
+  s.start("Installing cotal globally");
+  const r = spawnSync("npm", ["install", "-g", pkg], { encoding: "utf8" });
+  if (r.status === 0) {
+    s.stop("Installed — you can now run `cotal`");
+  } else {
+    s.stop("Couldn't install globally");
+    const tail = `${r.stdout ?? ""}${r.stderr ?? ""}`.trim().split("\n").slice(-3).join("\n");
+    p.log.warn(
+      `${tail ? `${tail}\n\n` : ""}Install it yourself with ${dim("npm i -g cotal-ai")}, or keep using ${dim("npx cotal-ai")}.`,
+    );
+  }
+}
+
+/** The version of the running `cotal-ai` package (from the package.json next to the entry script),
+ *  so a global install pins the same version npx just ran. Null if it can't be read. */
+function runningVersion(): string | null {
+  try {
+    const pkg = JSON.parse(readFileSync(join(process.argv[1], "..", "..", "package.json"), "utf8"));
+    return typeof pkg.version === "string" ? pkg.version : null;
+  } catch {
+    return null;
   }
 }
 
@@ -263,7 +310,7 @@ async function offerDemo(haveClaude: boolean): Promise<void> {
       process.exit(0);
     }
   } else if (isTTY && haveAgents && !haveClaude) {
-    p.log.info("The demo needs Claude Code. Install it (https://claude.com/claude-code), then run `cotal go`.");
+    p.log.info(`The demo needs Claude Code. Install it (https://claude.com/claude-code), then run \`${displayCmd()} go\`.`);
   }
 
   // Declined, or no Claude: start the background (pty) control plane so cotal_spawn / despawn /
@@ -400,6 +447,7 @@ async function readyCard(cwd: string): Promise<void> {
   // The control plane is either the detached pty manager (pid file) or a live cmux-tab manager
   // (its tab lingers after it exits, so check the process, not the workspace list).
   const mgr = managerUp() || (inCmuxSurface() && cmuxManagerRunning(mesh.space));
+  const cmd = displayCmd();
   const line = (on: boolean, text: string) => `${on ? ok("✓") : dim("○")} ${text}`;
   note(
     [
@@ -409,10 +457,10 @@ async function readyCard(cwd: string): Promise<void> {
       line(web, `web      ${dim(WEB_URL)}`),
       line(mgr, `manager  ${dim(mgr ? "running" : "not running")}`),
       "",
-      `resume:    ${dim("cotal go")}   ${dim("(reopen this session anytime)")}`,
-      `watch it:  ${dim("cotal console")}   ${dim("(live TUI in this terminal)")}`,
-      `drive it:  ${dim("cotal spawn me")}   ${dim("(or david / sven)")}`,
-      `more:      ${dim('cotal web · cotal down · cotal feedback "<msg>" · cotal --help')}`,
+      `resume:    ${dim(`${cmd} go`)}   ${dim("(reopen this session anytime)")}`,
+      `watch it:  ${dim(`${cmd} console`)}   ${dim("(live TUI in this terminal)")}`,
+      `drive it:  ${dim(`${cmd} spawn me`)}   ${dim("(or david / sven)")}`,
+      `more:      ${dim(`${cmd} web · ${cmd} down · ${cmd} feedback "<msg>" · ${cmd} --help`)}`,
     ].join("\n"),
     brandBold("cotal · ready"),
   );

--- a/implementations/cli/src/commands/spawn.ts
+++ b/implementations/cli/src/commands/spawn.ts
@@ -16,6 +16,8 @@ import {
   type AgentDef,
   type Connector,
 } from "@cotal-ai/core";
+import { cotalRoot } from "../lib/paths.js";
+import { resolveSpace } from "../lib/status.js";
 
 /**
  * `cotal spawn <name-or-path>` — launch an agent in the FOREGROUND of this
@@ -41,6 +43,7 @@ export async function spawn(argv: string[]): Promise<void> {
       server: { type: "string" },
       agent: { type: "string" },
       role: { type: "string" },
+      prompt: { type: "string" },
     },
   });
 
@@ -49,12 +52,12 @@ export async function spawn(argv: string[]): Promise<void> {
   const ref = values.config ?? positionals[0] ?? values.name;
   if (!ref) {
     console.error(
-      "usage: cotal spawn <name-or-path> | --config <path> | --name <n>  [--agent <a>] [--role <r>] [--space <s>] [--server <url>]",
+      "usage: cotal spawn <name-or-path> | --config <path> | --name <n>  [--agent <a>] [--role <r>] [--space <s>] [--server <url>] [--prompt <text>]",
     );
     process.exit(1);
   }
 
-  const path = agentFilePath(process.cwd(), ref);
+  const path = agentFilePath(cotalRoot(), ref);
   let def: AgentDef;
   try {
     def = loadAgentFile(path);
@@ -66,7 +69,7 @@ export async function spawn(argv: string[]): Promise<void> {
   // --name / --role override the file (name defaults from the file's frontmatter).
   const name = values.name ?? def.name;
   const role = values.role ?? def.role;
-  const space = values.space ?? "demo";
+  const space = values.space ?? resolveSpace(process.cwd());
   const server = values.server ?? DEFAULT_SERVER;
 
   // Auth mode (`.cotal/auth` present): mint a stable identity + scoped creds for this agent
@@ -75,7 +78,7 @@ export async function spawn(argv: string[]): Promise<void> {
   // Open mode (no `.cotal/auth`): unchanged — the session connects without creds.
   let id: string | undefined;
   let credsPath: string | undefined;
-  const auth = loadSpaceAuth(authDir(process.cwd()));
+  const auth = loadSpaceAuth(authDir(cotalRoot()));
   if (auth) {
     const identity = newIdentity();
     const prov = new CotalEndpoint({
@@ -95,7 +98,7 @@ export async function spawn(argv: string[]): Promise<void> {
       role,
     });
     await prov.stop();
-    credsPath = join(authDir(process.cwd()), "creds", `${name}.creds`);
+    credsPath = join(authDir(cotalRoot()), "creds", `${name}.creds`);
     mkdirSync(dirname(credsPath), { recursive: true });
     writeFileSync(credsPath, creds, { mode: 0o600 });
     id = identity.id;
@@ -111,6 +114,7 @@ export async function spawn(argv: string[]): Promise<void> {
     creds: credsPath,
     servers: server,
     configPath: path,
+    prompt: values.prompt,
   });
 
   console.error(

--- a/implementations/cli/src/commands/up.ts
+++ b/implementations/cli/src/commands/up.ts
@@ -1,11 +1,19 @@
 import { spawn } from "node:child_process";
-import { mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import {
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  openSync,
+  statSync,
+  readSync,
+  closeSync,
+} from "node:fs";
 import { resolve } from "node:path";
 import { parseArgs } from "node:util";
 import {
   isReachable,
   DEFAULT_SERVER,
-  DEFAULT_SPACE,
   authDir,
   createSpaceAuth,
   loadSpaceAuth,
@@ -18,7 +26,10 @@ import {
   type SpaceAuth,
   type ChannelRegistryFile,
 } from "@cotal-ai/core";
+import { resolveSpace } from "../lib/status.js";
 import { c } from "../ui.js";
+import { resolveNatsServer } from "../lib/nats-bin.js";
+import { cotalPath, cotalRoot } from "../lib/paths.js";
 
 export async function up(argv: string[]): Promise<void> {
   const { values } = parseArgs({
@@ -30,6 +41,7 @@ export async function up(argv: string[]): Promise<void> {
       space: { type: "string" },
       open: { type: "boolean" }, // disable auth — run an open dev mesh
       channels: { type: "string" }, // seed the channel registry from this JSON file
+      detach: { type: "boolean" }, // run the server in the background (pid in .cotal/nats.pid)
     },
   });
   const server = values.server ?? DEFAULT_SERVER;
@@ -37,32 +49,39 @@ export async function up(argv: string[]): Promise<void> {
     console.log(c.green(`✓ NATS already running at ${server}`));
     return;
   }
-  const storeDir = resolve(values["store-dir"] ?? ".cotal/nats");
-  mkdirSync(storeDir, { recursive: true });
 
-  // Secure by default: start the server in decentralized-JWT mode so agents must present
-  // minted creds. `--open` runs the unauthenticated dev mesh instead.
+  if (values.detach) {
+    const { pid, source } = await startMeshDetached({
+      server,
+      storeDir: values["store-dir"],
+      space: values.space,
+      open: values.open,
+      channels: values.channels,
+    });
+    console.log(c.dim(`Started nats-server (${source}).`));
+    console.log(c.green(`✓ mesh running in the background (pid ${pid}) — stop with: cotal down`));
+    return;
+  }
+
+  const storeDir = values["store-dir"] ? resolve(values["store-dir"]) : cotalPath("nats");
+  mkdirSync(storeDir, { recursive: true });
   const useAuth = !values.open;
-  const space = values.space ?? DEFAULT_SPACE;
+  const space = values.space ?? resolveSpace(process.cwd());
   const seedFile = loadChannelsFile(values.channels);
   const setup = useAuth ? await authSetup(storeDir, server, space) : undefined;
-  // Auth mode's port comes from the generated config; open mode must pass it explicitly, else
-  // nats-server ignores --server's port and binds the default 4222.
   const port = Number(new URL(server).port) || 4222;
   const args = setup ? ["-c", setup.confPath] : ["-js", "-sd", storeDir, "-p", String(port)];
+  const { bin, source } = await resolveNatsServer();
 
   console.log(
     c.dim(
-      useAuth
-        ? `Starting nats-server (JetStream, JWT auth) — store: ${storeDir}`
-        : `Starting nats-server (JetStream, OPEN/no-auth) — store: ${storeDir}`,
+      `Starting nats-server (JetStream, ${useAuth ? "JWT auth" : "OPEN/no-auth"}, ${source}) — store: ${storeDir}`,
     ),
   );
   console.log(c.dim("Press Ctrl-C to stop.\n"));
-  const child = spawn("nats-server", args, { stdio: "inherit" });
+  const child = spawn(bin, args, { stdio: "inherit" });
   child.on("error", (err) => {
     console.error(c.red(`Failed to start nats-server: ${err.message}`));
-    console.error(c.dim("Install it with: brew install nats-server"));
     process.exit(1);
   });
   const stop = () => child.kill("SIGTERM");
@@ -70,36 +89,114 @@ export async function up(argv: string[]): Promise<void> {
   process.on("SIGTERM", stop);
   child.on("exit", (code) => process.exit(code ?? 0));
 
-  // Auth mode: streams are space infrastructure that agents are denied STREAM.CREATE for,
-  // so pre-create them here (once, privileged) as soon as the server accepts connections.
-  if (setup) {
-    for (let i = 0; i < 50; i++) {
-      if (await isReachable(server, { creds: setup.creds })) break;
-      await new Promise((r) => setTimeout(r, 200));
-    }
-    await setupSpaceStreams({ servers: server, space, creds: setup.creds });
-    console.log(c.dim("Pre-created CHAT/DM/TASK streams for the space."));
-    if (seedFile) {
-      await seedChannelRegistry({ servers: server, space, creds: setup.creds, file: seedFile });
-      console.log(c.dim("Seeded the channel registry."));
-    }
-  } else if (seedFile) {
-    // Open mode: the bucket is created lazily — wait for the server, then seed it (no creds).
-    for (let i = 0; i < 50; i++) {
-      if (await isReachable(server)) break;
-      await new Promise((r) => setTimeout(r, 200));
-    }
-    await seedChannelRegistry({ servers: server, space, file: seedFile });
-    console.log(c.dim("Seeded the channel registry."));
+  if (await waitReady(server, setup?.creds)) {
+    await postStart(server, space, setup, seedFile);
   }
   await new Promise<void>(() => {});
+}
+
+export interface DetachOpts {
+  server?: string;
+  storeDir?: string;
+  space?: string;
+  open?: boolean;
+  channels?: string;
+  /** Live boot lines, tailed from the server's log file (safe for a detached child). */
+  onLine?: (line: string) => void;
+}
+
+/**
+ * Start a background nats-server (JetStream), wait until it's reachable, pre-create the
+ * space's streams, and leave it running detached (pid in `.cotal/nats.pid`). Shared by
+ * `up --detach` and `cotal setup`. When `onLine` is given, boot output is tailed from the
+ * log file and forwarded — the child writes to the file (not a pipe), so it survives the
+ * parent exiting.
+ */
+export async function startMeshDetached(opts: DetachOpts = {}): Promise<{ server: string; pid: number; source: string }> {
+  const server = opts.server ?? DEFAULT_SERVER;
+  const storeDir = opts.storeDir ? resolve(opts.storeDir) : cotalPath("nats");
+  mkdirSync(storeDir, { recursive: true });
+  const useAuth = !opts.open;
+  const space = opts.space ?? resolveSpace(process.cwd());
+  const seedFile = loadChannelsFile(opts.channels);
+  const setup = useAuth ? await authSetup(storeDir, server, space) : undefined;
+  const port = Number(new URL(server).port) || 4222;
+  const args = setup ? ["-c", setup.confPath] : ["-js", "-sd", storeDir, "-p", String(port)];
+  const { bin, source } = await resolveNatsServer();
+
+  const logPath = cotalPath("nats.log");
+  const startOffset = existsSync(logPath) ? statSync(logPath).size : 0;
+  const fd = openSync(logPath, "a");
+  const child = spawn(bin, args, { detached: true, stdio: ["ignore", fd, fd] });
+  closeSync(fd);
+  child.unref();
+
+  let tailing = Boolean(opts.onLine);
+  if (opts.onLine) tailLines(logPath, startOffset, opts.onLine, () => !tailing);
+
+  const ready = await waitReady(server, setup?.creds);
+  tailing = false;
+  if (!ready) {
+    child.kill("SIGTERM");
+    throw new Error(`nats-server did not become reachable at ${server} — see ${logPath}`);
+  }
+  writeFileSync(cotalPath("nats.pid"), String(child.pid));
+  await postStart(server, space, setup, seedFile);
+  return { server, pid: child.pid ?? 0, source };
+}
+
+/** Poll a growing log file and forward newly-appended lines until `stopped()` is true. */
+function tailLines(path: string, from: number, onLine: (l: string) => void, stopped: () => boolean): void {
+  let offset = from;
+  const tick = () => {
+    if (stopped()) return;
+    try {
+      const size = statSync(path).size;
+      if (size > offset) {
+        const fd = openSync(path, "r");
+        const buf = Buffer.alloc(size - offset);
+        readSync(fd, buf, 0, buf.length, offset);
+        closeSync(fd);
+        offset = size;
+        for (const line of buf.toString("utf8").split("\n")) if (line.trim()) onLine(line);
+      }
+    } catch {
+      // file may not exist yet on the first ticks — keep polling
+    }
+    setTimeout(tick, 150);
+  };
+  setTimeout(tick, 150);
+}
+
+async function waitReady(server: string, creds?: string): Promise<boolean> {
+  for (let i = 0; i < 50; i++) {
+    if (await isReachable(server, creds ? { creds } : undefined)) return true;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  return false;
+}
+
+/** One-time space infrastructure once the server accepts connections: pre-create the
+ *  streams agents are denied STREAM.CREATE for (auth mode), and seed the channel registry. */
+async function postStart(
+  server: string,
+  space: string,
+  setup?: { creds: string },
+  seedFile?: ChannelRegistryFile,
+): Promise<void> {
+  if (setup) {
+    await setupSpaceStreams({ servers: server, space, creds: setup.creds });
+  }
+  if (seedFile) {
+    await seedChannelRegistry({ servers: server, space, creds: setup?.creds, file: seedFile });
+  }
 }
 
 /** Load the declarative channels-config file to seed the registry. An explicit `--channels`
  *  path that's missing is a hard error; the default `.cotal/channels.json` is optional (absent
  *  ⇒ nothing to seed). */
 function loadChannelsFile(explicit?: string): ChannelRegistryFile | undefined {
-  const path = resolve(explicit ?? ".cotal/channels.json");
+  const path = explicit ? resolve(explicit) : cotalPath("channels.json");
   if (!existsSync(path)) {
     if (explicit) {
       console.error(c.red(`channels file not found: ${path}`));
@@ -118,12 +215,11 @@ async function authSetup(
   server: string,
   space: string,
 ): Promise<{ confPath: string; creds: string }> {
-  const dir = authDir(process.cwd());
+  const dir = authDir(cotalRoot());
   let auth: SpaceAuth | undefined = loadSpaceAuth(dir);
   if (!auth) {
     auth = await createSpaceAuth(space);
     saveSpaceAuth(dir, auth);
-    console.log(c.dim(`Generated space auth for "${space}" → ${dir}/auth.json (keep the signing key safe)`));
   }
   const port = Number(new URL(server).port) || 4222;
   const confPath = resolve(dir, "server.conf");

--- a/implementations/cli/src/commands/web.ts
+++ b/implementations/cli/src/commands/web.ts
@@ -1,14 +1,14 @@
 import { parseArgs } from "node:util";
 import { spawn } from "node:child_process";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { readFileSync } from "node:fs";
+import { connect } from "node:net";
+import { readFileSync, writeFileSync, openSync, closeSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import {
   CotalEndpoint,
   isReachable,
   DEFAULT_SERVER,
-  DEFAULT_SPACE,
   deliveryOf,
   parseSubject,
   spaceWildcard,
@@ -17,11 +17,21 @@ import {
   mintCreds,
   newIdentity,
   clearChannel,
-  type CotalMessage,
 } from "@cotal-ai/core";
+import { resolveSpace } from "../lib/status.js";
+import { cotalPath, cotalRoot } from "../lib/paths.js";
 import { c } from "../ui.js";
+import { selfArgv } from "../lib/self-exec.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
+
+/** The dashboard's default port and its branded address. The server binds loopback
+ *  (127.0.0.1) but serves any Host, so `cotal.localhost` — which Chrome/Firefox/Edge
+ *  resolve to loopback with no DNS setup — just works. (Safari may not resolve
+ *  `*.localhost`; plain http://127.0.0.1:7799 always does.) */
+export const WEB_PORT = 7799;
+export const WEB_URL = `http://cotal.localhost:${WEB_PORT}/`;
+
 const PAGE: Record<string, { path: string; type: string }> = {
   "/": { path: join(here, "../web/index.html"), type: "text/html; charset=utf-8" },
   "/app.js": { path: join(here, "../web/app.js"), type: "text/javascript; charset=utf-8" },
@@ -42,16 +52,16 @@ export async function web(argv: string[]): Promise<void> {
       creds: { type: "string" },
     },
   });
-  const space = values.space ?? DEFAULT_SPACE;
+  const space = values.space ?? resolveSpace(process.cwd());
   const server = values.server ?? DEFAULT_SERVER;
-  const port = values.port ? Number(values.port) : 7799;
+  const port = values.port ? Number(values.port) : WEB_PORT;
   // The dashboard is always an admin god-view (no read-only viewer mode) so it can show DMs
   // and anycast. Auth mode (`.cotal/auth` present): self-mint an `admin` cred so it joins the
   // authed mesh with no manual --creds — like `cotal spawn`, it holds the space signing key.
   // An explicit --creds still wins. Open mode (no auth): connect bare.
   // Loaded once at function scope: the observer connects with a read-only `admin` cred, but
   // the channel-delete write path mints an ephemeral `manager` cred from this same material.
-  const auth = loadSpaceAuth(authDir(process.cwd()));
+  const auth = loadSpaceAuth(authDir(cotalRoot()));
   let creds = values.creds ? readFileSync(values.creds, "utf8") : undefined;
   if (!creds && auth) {
     if (auth.space !== space) {
@@ -188,8 +198,9 @@ export async function web(argv: string[]): Promise<void> {
     process.exit(1);
   });
 
-  await new Promise<void>((resolve) => httpServer.listen(port, "127.0.0.1", resolve));
-  const url = `http://127.0.0.1:${port}/`;
+  await new Promise<void>((ready) => httpServer.listen(port, "127.0.0.1", ready));
+  // Branded URL only when on the default port; a custom --port keeps the plain loopback address.
+  const url = port === WEB_PORT ? WEB_URL : `http://127.0.0.1:${port}/`;
   console.log(`${c.bold("Cotal web")} — observing space ${c.bold(space)}`);
   console.log(c.dim("  god-view — DMs + anycast visible"));
   console.log(`  ${c.cyan(url)}  ${c.dim("(Ctrl-C to stop)")}`);
@@ -210,6 +221,53 @@ export async function web(argv: string[]): Promise<void> {
 function json(res: ServerResponse, data: unknown): void {
   res.writeHead(200, { "content-type": "application/json" });
   res.end(JSON.stringify(data));
+}
+
+/** True if something is already listening on the dashboard port (loopback). */
+export function webUp(port: number = WEB_PORT): Promise<boolean> {
+  return new Promise((res) => {
+    const sock = connect(port, "127.0.0.1");
+    sock.setTimeout(400);
+    const done = (up: boolean) => {
+      sock.destroy();
+      res(up);
+    };
+    sock.once("connect", () => done(true));
+    sock.once("timeout", () => done(false));
+    sock.once("error", () => done(false));
+  });
+}
+
+/** Start the dashboard in the background (pid in `.cotal/web.pid`, output to `.cotal/web.log`),
+ *  stopped by `cotal down`. Re-execs this same CLI — `process.execArgv` carries the tsx loader in
+ *  dev, and is empty in prod where `node <entry.js> web …` runs the compiled binary. */
+export function startWebDetached(o: { space?: string; server?: string } = {}): { pid: number; url: string } {
+  const fd = openSync(cotalPath("web.log"), "a");
+  const [node, ...self] = selfArgv();
+  const args = [
+    ...self,
+    "web",
+    "--no-open",
+    "--port",
+    String(WEB_PORT),
+    "--space",
+    o.space ?? resolveSpace(process.cwd()),
+    ...(o.server ? ["--server", o.server] : []),
+  ];
+  const child = spawn(node, args, { detached: true, stdio: ["ignore", fd, fd] });
+  closeSync(fd);
+  child.unref();
+  writeFileSync(cotalPath("web.pid"), String(child.pid));
+  return { pid: child.pid ?? 0, url: WEB_URL };
+}
+
+/** Make the dashboard available: reuse one already listening, else start it detached and wait
+ *  briefly for it to come up. Best-effort — callers treat a non-running result as non-fatal. */
+export async function ensureWeb(o: { space?: string; server?: string } = {}): Promise<{ url: string; running: boolean }> {
+  if (await webUp()) return { url: WEB_URL, running: true };
+  startWebDetached(o);
+  for (let i = 0; i < 20 && !(await webUp()); i++) await new Promise((r) => setTimeout(r, 150));
+  return { url: WEB_URL, running: await webUp() };
 }
 
 async function readBody(req: IncomingMessage): Promise<{ channel?: string }> {

--- a/implementations/cli/src/index.ts
+++ b/implementations/cli/src/index.ts
@@ -1,5 +1,7 @@
 import { registry, type Command } from "@cotal-ai/core";
 import { up } from "./commands/up.js";
+import { down } from "./commands/down.js";
+import { setup, go } from "./commands/setup.js";
 import { join } from "./commands/join.js";
 import { watch } from "./commands/watch.js";
 import { console_ } from "./commands/console.js";
@@ -7,7 +9,6 @@ import { demo } from "./commands/demo.js";
 import { web } from "./commands/web.js";
 import { spawn } from "./commands/spawn.js";
 import { mint } from "./commands/mint.js";
-import { setup } from "./commands/setup.js";
 import { channels } from "./commands/channels.js";
 import { history } from "./commands/history.js";
 import { feedback } from "./commands/feedback.js";
@@ -19,10 +20,31 @@ import { feedback } from "./commands/feedback.js";
 const baseCommands: Command[] = [
   {
     kind: "command",
+    name: "setup",
+    group: "Setup",
+    summary: "guided setup — first run walks you through it; --yes for non-interactive (agents/CI), --full to redo",
+    run: setup,
+  },
+  {
+    kind: "command",
+    name: "go",
+    group: "Setup",
+    summary: "open or resume your session (mesh + web + manager + your cmux tabs); first run installs",
+    run: go,
+  },
+  {
+    kind: "command",
     name: "up",
     group: "Mesh",
     summary: "start a local nats-server (JetStream, JWT auth by default; --open for an unauthenticated dev mesh)",
     run: up,
+  },
+  {
+    kind: "command",
+    name: "down",
+    group: "Mesh",
+    summary: "stop a background mesh started with `up --detach`",
+    run: down,
   },
   {
     kind: "command",
@@ -58,13 +80,6 @@ const baseCommands: Command[] = [
     group: "Mesh",
     summary: "browser observability dashboard — presence, channels, live feed — --space <s> [--port <n>] [--no-open]",
     run: web,
-  },
-  {
-    kind: "command",
-    name: "setup",
-    group: "Agents",
-    summary: "install the cotal plugin into Claude Code so this repo's sessions get the cotal tools (idempotent)",
-    run: setup,
   },
   {
     kind: "command",

--- a/implementations/cli/src/lib/assist.ts
+++ b/implementations/cli/src/lib/assist.ts
@@ -1,0 +1,66 @@
+import { spawn, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import * as p from "@clack/prompts";
+import { dim } from "./theme.js";
+
+export interface AssistContext {
+  /** Failed step slug (as shown to the user and written to the log). */
+  step: string;
+  error: Error;
+  /** Local paths and doc URLs Claude should read for context: referenced in the
+   *  prompt, never inlined, so it works without a repo clone. */
+  context: string[];
+  logPath: string;
+}
+
+/** Interactive Claude is offered only when it can actually run: a TTY, the
+ *  `claude` binary on PATH, and not opted out via COTAL_SKIP_ASSIST=1 (CI). */
+export function assistAvailable(): boolean {
+  if (process.env.COTAL_SKIP_ASSIST === "1") return false;
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return false;
+  const probe = spawnSync("claude", ["--version"], { stdio: "ignore" });
+  return !probe.error && probe.status === 0;
+}
+
+// All handoffs in one setup run share a single Claude session: the first spawn pins
+// a generated UUID (--session-id), later spawns --resume it, so Claude keeps the
+// context of earlier failures. stdio is inherited, so pinning our own id is the only
+// way to find the session again.
+let sessionId: string | undefined;
+
+/** Hand the terminal to an interactive Claude session primed with the failure
+ *  context. Resolves when the user exits Claude (/exit) and setup resumes. */
+export async function runHandoff(ctx: AssistContext): Promise<void> {
+  const sessionArgs = sessionId ? ["--resume", sessionId] : ["--session-id", (sessionId = randomUUID())];
+  p.note(
+    `Failed step: ${ctx.step}\n${ctx.error.message}\n\nType ${dim("/exit")} when you're done; setup resumes here.`,
+    "Handing off to Claude",
+  );
+  const child = spawn("claude", [buildPrompt(ctx), "--permission-mode", "auto", ...sessionArgs], {
+    stdio: "inherit",
+  });
+  await new Promise<void>((resolve) => {
+    child.on("exit", () => resolve());
+    child.on("error", () => {
+      p.log.error("Couldn't launch Claude; continuing without it.");
+      resolve();
+    });
+  });
+  p.log.info("Back from Claude.");
+}
+
+function buildPrompt(ctx: AssistContext): string {
+  return [
+    "I'm running `cotal setup` (Cotal: a mesh where AI agents coordinate as lateral",
+    "peers over NATS/JetStream) and a setup step failed. Help me diagnose and fix it.",
+    "",
+    `Failed step: ${ctx.step}`,
+    `Error: ${ctx.error.message}`,
+    "",
+    "Read these for context as needed (don't assume their contents):",
+    ...[ctx.logPath, ...ctx.context].map((f) => `  - ${f}`),
+    "",
+    "Be concise. When the issue is fixed, remind me to type /exit, and I'll land back",
+    "in the setup flow, which will offer to retry the failed step.",
+  ].join("\n");
+}

--- a/implementations/cli/src/lib/cancel.ts
+++ b/implementations/cli/src/lib/cancel.ts
@@ -1,0 +1,12 @@
+import * as p from "@clack/prompts";
+
+/** Treat a clack cancel (Ctrl-C / Esc) as quitting setup, cleanly. clack traps SIGINT
+ *  inside a prompt and returns its cancel symbol instead of exiting; route those here so
+ *  Ctrl-C aborts setup rather than falling through to a default. */
+export function abortIfCancel<T>(value: T): Exclude<T, symbol> {
+  if (p.isCancel(value)) {
+    p.cancel("Setup cancelled.");
+    process.exit(130);
+  }
+  return value as Exclude<T, symbol>;
+}

--- a/implementations/cli/src/lib/live-window.ts
+++ b/implementations/cli/src/lib/live-window.ts
@@ -1,0 +1,69 @@
+import { brand, dim, fit, fmtDuration } from "./theme.js";
+
+const WINDOW = 3; // lines of rolling tail under the spinner header
+const FRAMES = ["◒", "◐", "◓", "◑"];
+const HIDE = "\x1b[?25l";
+const SHOW = "\x1b[?25h";
+
+/**
+ * A fixed-height rolling tail under a spinner header, so a slow step shows live
+ * progress instead of a frozen spinner. Modeled on nanoclaw's windowed-runner.
+ *
+ * Purely transient: `start` opens the pane, `push` feeds it lines, `clear` wipes it
+ * and restores the cursor. The caller (the step runner) emits the permanent ✓/✗ line,
+ * so the pane never competes with clack's log output. On a non-TTY (CI/piped) every
+ * method is a no-op and lines are dropped; the runner's plain status line is enough.
+ */
+export class LivePane {
+  private readonly tty = Boolean(process.stdout.isTTY);
+  private readonly lines: string[] = [];
+  private label = "";
+  private start0 = 0;
+  private frame = 0;
+  private ticker?: ReturnType<typeof setInterval>;
+
+  start(label: string): void {
+    if (!this.tty) return;
+    this.label = label;
+    this.start0 = Date.now();
+    const out = process.stdout;
+    out.write(HIDE);
+    for (let i = 0; i < WINDOW + 1; i++) out.write("\n");
+    this.redraw();
+    process.once("exit", () => out.write(SHOW));
+    this.ticker = setInterval(() => {
+      this.frame++;
+      this.redraw();
+    }, 200);
+  }
+
+  push(chunk: string): void {
+    if (!this.tty) return;
+    for (const raw of chunk.split("\n")) {
+      // eslint-disable-next-line no-control-regex
+      const clean = raw.replace(/\x1b\[[0-9;?]*[A-Za-z]/g, "").trim();
+      if (clean) this.lines.push(clean);
+    }
+    this.redraw();
+  }
+
+  clear(): void {
+    if (!this.tty) return;
+    if (this.ticker) clearInterval(this.ticker);
+    const out = process.stdout;
+    out.write(`\x1b[${WINDOW + 1}A`);
+    for (let i = 0; i < WINDOW + 1; i++) out.write("\x1b[2K\n");
+    out.write(`\x1b[${WINDOW + 1}A${SHOW}`);
+  }
+
+  private redraw(): void {
+    const out = process.stdout;
+    out.write(`\x1b[${WINDOW + 1}A`);
+    const suffix = ` (${fmtDuration(Date.now() - this.start0)})`;
+    out.write(`\x1b[2K${brand(FRAMES[this.frame % FRAMES.length])}  ${this.label}${dim(suffix)}\n`);
+    for (let i = 0; i < WINDOW; i++) {
+      const line = this.lines[this.lines.length - WINDOW + i] ?? "";
+      out.write(`\x1b[2K${line ? `${dim("│")}  ${dim(fit(line))}` : dim("│")}\n`);
+    }
+  }
+}

--- a/implementations/cli/src/lib/manager-proc.ts
+++ b/implementations/cli/src/lib/manager-proc.ts
@@ -1,0 +1,86 @@
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, openSync, closeSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { DEFAULT_SERVER } from "@cotal-ai/core";
+import { selfArgv } from "./self-exec.js";
+import { resolveSpace } from "./status.js";
+import { cotalPath } from "./paths.js";
+
+const PID_PATH = () => cotalPath("manager.pid");
+
+function alive(pid: number): boolean {
+  try {
+    process.kill(pid, 0); // signal 0: liveness probe, doesn't actually signal
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** True if the manager we started for this folder is still running (pid file + liveness). */
+export function managerUp(): boolean {
+  const p = PID_PATH();
+  if (!existsSync(p)) return false;
+  const pid = Number(readFileSync(p, "utf8").trim());
+  return Number.isFinite(pid) && alive(pid);
+}
+
+/** True if any process's full command line matches `pattern` (`pgrep -f`). Detects processes that
+ *  have no pid file — the cmux-tab manager and the driving session — which live in cmux tabs. */
+export function pgrepMatches(pattern: string): boolean {
+  return spawnSync("pgrep", ["-f", pattern], { stdio: "ignore" }).status === 0;
+}
+
+/** True if a cmux-runtime manager is live for this space. Its cmux tab persists after the process
+ *  exits, so a workspace listing isn't proof — the process is. Matches prod `cotal.js` and dev
+ *  `cotal.ts` (both carry `cmux --space <space>`). */
+export function cmuxManagerRunning(space: string): boolean {
+  return pgrepMatches(`cmux --space ${space}`);
+}
+
+/** Start the control-plane manager detached (pid in `.cotal/manager.pid`, output to
+ *  `.cotal/manager.log`), stopped by `cotal down`. Re-execs this same CLI's `supervise` — the
+ *  composed `cotal` binary registers it; `process.execArgv` carries the tsx loader in dev and is
+ *  empty in prod. `supervise`'s auto runtime resolves to pty when detached, which answers the
+ *  control plane (`cotal_spawn`/`despawn`/`purge`/`persona`) with no tmux/cmux needed. */
+export function startManagerDetached(o: { space?: string; server?: string; spawn?: string[] } = {}): number {
+  const fd = openSync(cotalPath("manager.log"), "a");
+  const [node, ...self] = selfArgv();
+  const args = [
+    ...self,
+    "supervise",
+    "--space",
+    o.space ?? resolveSpace(process.cwd()),
+    "--server",
+    o.server ?? DEFAULT_SERVER,
+    ...(o.spawn?.length ? ["--spawn", o.spawn.join(",")] : []),
+  ];
+  const child = spawn(node, args, { detached: true, stdio: ["ignore", fd, fd] });
+  closeSync(fd);
+  child.unref();
+  writeFileSync(PID_PATH(), String(child.pid));
+  return child.pid ?? 0;
+}
+
+/** Make the control plane available: reuse a manager already running for this folder, else start
+ *  one detached. Best-effort — callers treat it as non-fatal. */
+export function ensureManager(o: { space?: string; server?: string; spawn?: string[] } = {}): { running: boolean } {
+  if (managerUp()) return { running: true };
+  startManagerDetached(o);
+  return { running: true };
+}
+
+/** Stop the detached (pty) manager if we started one. Used when switching to the cmux-tab manager
+ *  so the two don't both answer the control plane (queue-grouped requests would split between them). */
+export function stopManager(): void {
+  const p = PID_PATH();
+  if (!existsSync(p)) return;
+  const pid = Number(readFileSync(p, "utf8").trim());
+  if (Number.isFinite(pid)) {
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {
+      /* already gone */
+    }
+  }
+  rmSync(p);
+}

--- a/implementations/cli/src/lib/nats-bin.ts
+++ b/implementations/cli/src/lib/nats-bin.ts
@@ -1,0 +1,23 @@
+import { spawnSync } from "node:child_process";
+
+/** Platform-package prefix the bundled binary ships under. Swapping providers
+ *  (e.g. to our own @cotal-ai/nats-server-*) is a one-line change here. */
+const BUNDLED_PKG_PREFIX = "@eplightning/nats-server";
+
+/** Resolve the nats-server binary: PATH first (an operator-installed server always
+ *  wins), then the bundled platform package. Throws when neither is available. */
+export async function resolveNatsServer(): Promise<{ bin: string; source: "path" | "bundled" }> {
+  const onPath = spawnSync("nats-server", ["--version"], { stdio: "ignore" });
+  if (!onPath.error && onPath.status === 0) return { bin: "nats-server", source: "path" };
+
+  const pkg = `${BUNDLED_PKG_PREFIX}-${process.platform}-${process.arch}`;
+  try {
+    const mod = (await import(pkg)) as { getBinaryPath(): string };
+    return { bin: mod.getBinaryPath(), source: "bundled" };
+  } catch {
+    throw new Error(
+      `nats-server not found on PATH and no bundled binary for ${process.platform}/${process.arch} (${pkg}). ` +
+        "Install nats-server (https://github.com/nats-io/nats-server/releases) and put it on PATH.",
+    );
+  }
+}

--- a/implementations/cli/src/lib/onboard.ts
+++ b/implementations/cli/src/lib/onboard.ts
@@ -1,0 +1,17 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** Machine-level "I've onboarded before" marker. Its presence flips `cotal` from the
+ *  full first-run flow to the compact ensure+status run. Lives next to the materialized
+ *  plugin marketplace under ~/.cotal. */
+const MARKER = join(homedir(), ".cotal", "onboarded.json");
+
+export function isOnboarded(): boolean {
+  return existsSync(MARKER);
+}
+
+export function markOnboarded(version: string): void {
+  mkdirSync(join(homedir(), ".cotal"), { recursive: true });
+  writeFileSync(MARKER, JSON.stringify({ version, ts: new Date().toISOString() }, null, 2));
+}

--- a/implementations/cli/src/lib/paths.ts
+++ b/implementations/cli/src/lib/paths.ts
@@ -1,0 +1,14 @@
+import { join } from "node:path";
+import { findCotalRoot } from "@cotal-ai/core";
+
+/** The project's `.cotal/` root, found by walking up from cwd (like git finds `.git`), so every
+ *  command resolves the same `.cotal/` whether you're at the project root or a subdirectory. */
+export function cotalRoot(): string {
+  return findCotalRoot();
+}
+
+/** A path inside the project's `.cotal/` directory. Use instead of `resolve(".cotal/…")` so paths
+ *  don't break when `cotal` runs from a subdirectory. */
+export function cotalPath(...segments: string[]): string {
+  return join(cotalRoot(), ".cotal", ...segments);
+}

--- a/implementations/cli/src/lib/self-exec.ts
+++ b/implementations/cli/src/lib/self-exec.ts
@@ -1,0 +1,16 @@
+/** This CLI's own invocation as argv: `[node, ...loaderFlags, entryScript]`. The loader flags carry
+ *  tsx in dev (so a re-exec can run the `.ts` entry) and are empty in prod (entry = compiled JS).
+ *  Re-execed children (web, manager) and cmux pane commands use this so they never depend on
+ *  `cotal` being on PATH — works the same via `npx`, `npm i -g`, and a dev clone. */
+export function selfArgv(): string[] {
+  return [process.execPath, ...process.execArgv, process.argv[1]];
+}
+
+/** The self-invocation as a shell-ready, double-quoted command prefix (for cmux pane commands).
+ *  Tokens are absolute paths with no single quotes, so the surrounding `bash -lc '…'` single-quote
+ *  wrapping stays intact through a login shell (e.g. nushell) before bash. */
+export function selfCotal(): string {
+  return selfArgv()
+    .map((a) => `"${a}"`)
+    .join(" ");
+}

--- a/implementations/cli/src/lib/self-exec.ts
+++ b/implementations/cli/src/lib/self-exec.ts
@@ -1,9 +1,43 @@
+import { accessSync, constants } from "node:fs";
+import { delimiter, join } from "node:path";
+
 /** This CLI's own invocation as argv: `[node, ...loaderFlags, entryScript]`. The loader flags carry
  *  tsx in dev (so a re-exec can run the `.ts` entry) and are empty in prod (entry = compiled JS).
  *  Re-execed children (web, manager) and cmux pane commands use this so they never depend on
  *  `cotal` being on PATH — works the same via `npx`, `npm i -g`, and a dev clone. */
 export function selfArgv(): string[] {
   return [process.execPath, ...process.execArgv, process.argv[1]];
+}
+
+/** True when launched via `npx` — the package is unpacked under `~/.npm/_npx/<hash>/…`. */
+export function isNpx(): boolean {
+  return /[/\\]_npx[/\\]/.test(process.argv[1] ?? "");
+}
+
+/** Is a `cotal` executable resolvable on PATH? A pure PATH scan (no exec): `cotal --version`
+ *  isn't a real command, so probing it via `onPath` would always report cotal as missing. */
+export function cotalOnPath(): boolean {
+  const exts = process.platform === "win32" ? ["", ".cmd", ".exe", ".bat"] : [""];
+  for (const dir of (process.env.PATH ?? "").split(delimiter)) {
+    if (!dir) continue;
+    for (const ext of exts) {
+      try {
+        accessSync(join(dir, `cotal${ext}`), constants.X_OK);
+        return true;
+      } catch {
+        /* not here */
+      }
+    }
+  }
+  return false;
+}
+
+/** The copy-paste command prefix for user-facing hints: `cotal` when it's on PATH, `npx cotal-ai`
+ *  for an npx run, `pnpm cotal` in a dev clone. (Display only — re-execs use {@link selfArgv}.) */
+export function displayCmd(): string {
+  if (cotalOnPath()) return "cotal";
+  if (isNpx()) return "npx cotal-ai";
+  return "pnpm cotal";
 }
 
 /** The self-invocation as a shell-ready, double-quoted command prefix (for cmux pane commands).

--- a/implementations/cli/src/lib/setup-log.ts
+++ b/implementations/cli/src/lib/setup-log.ts
@@ -1,0 +1,22 @@
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { cotalPath } from "./paths.js";
+
+export interface SetupLog {
+  path: string;
+  line(s: string): void;
+}
+
+/** Timestamped append log for `cotal setup` — one file, also the first thing a
+ *  Claude handoff is pointed at. Resolves the project's `.cotal/` (walks up from cwd). */
+export function openSetupLog(_cwd: string): SetupLog {
+  const path = cotalPath("setup.log");
+  mkdirSync(dirname(path), { recursive: true });
+  appendFileSync(path, `\n=== cotal setup — ${new Date().toISOString()} ===\n`);
+  return {
+    path,
+    line(s: string) {
+      appendFileSync(path, `${new Date().toISOString()} ${s}\n`);
+    },
+  };
+}

--- a/implementations/cli/src/lib/status.ts
+++ b/implementations/cli/src/lib/status.ts
@@ -1,0 +1,74 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { DEFAULT_SERVER, DEFAULT_SPACE, authDir, findCotalRoot, isReachable, loadSpaceAuth } from "@cotal-ai/core";
+import { resolveNatsServer } from "./nats-bin.js";
+
+export interface MeshStatus {
+  reachable: boolean;
+  server: string;
+  space: string; // from .cotal/auth if present, else the default
+  auth: boolean; // auth mode (trust material on disk) vs open
+}
+
+/** The space this folder operates on: its `.cotal/auth` space if set up, else the default.
+ *  A folder has exactly one space (its auth) — commands resolve it through here so they always
+ *  match the folder's mesh instead of assuming the global default. */
+export function resolveSpace(cwd: string): string {
+  return loadSpaceAuth(authDir(findCotalRoot(cwd)))?.space ?? DEFAULT_SPACE;
+}
+
+/** Cheap, connectionless-ish snapshot of the mesh for this folder: is a server up,
+ *  and what space/auth does the local `.cotal/` describe (found by walking up from `cwd`). */
+export async function meshStatus(cwd: string): Promise<MeshStatus> {
+  const server = DEFAULT_SERVER;
+  const auth = loadSpaceAuth(authDir(findCotalRoot(cwd)));
+  return {
+    reachable: await isReachable(server),
+    server,
+    space: auth?.space ?? DEFAULT_SPACE,
+    auth: Boolean(auth),
+  };
+}
+
+export interface MachineStatus {
+  nats: "path" | "bundled" | "missing";
+  claudePlugin: boolean;
+  agents: { claude: boolean; codex: boolean; opencode: boolean };
+}
+
+/** Machine-level readiness: the once-per-machine setup pieces. */
+export async function machineStatus(): Promise<MachineStatus> {
+  let nats: MachineStatus["nats"] = "missing";
+  try {
+    nats = (await resolveNatsServer()).source;
+  } catch {
+    nats = "missing";
+  }
+  return {
+    nats,
+    claudePlugin: claudePluginInstalled(),
+    agents: {
+      claude: onPath("claude"),
+      codex: onPath("codex"),
+      opencode: onPath("opencode"),
+    },
+  };
+}
+
+export function onPath(bin: string): boolean {
+  const r = spawnSync(bin, ["--version"], { stdio: "ignore" });
+  return !r.error && r.status === 0;
+}
+
+function claudePluginInstalled(): boolean {
+  if (!onPath("claude")) return false;
+  const r = spawnSync("claude", ["plugin", "list"], { encoding: "utf8" });
+  return r.status === 0 && /cotal@cotal-mesh/.test(`${r.stdout ?? ""}${r.stderr ?? ""}`);
+}
+
+/** True once the machine-level setup has completed at least once. */
+export function hasLocalMesh(cwd: string): boolean {
+  const root = findCotalRoot(cwd);
+  return existsSync(join(root, ".cotal", "auth", "auth.json")) || existsSync(join(root, ".cotal", "nats"));
+}

--- a/implementations/cli/src/lib/steps.ts
+++ b/implementations/cli/src/lib/steps.ts
@@ -1,0 +1,111 @@
+import * as p from "@clack/prompts";
+import { dim } from "./theme.js";
+import { abortIfCancel } from "./cancel.js";
+import { assistAvailable, runHandoff } from "./assist.js";
+import type { SetupLog } from "./setup-log.js";
+
+export interface Step {
+  /** Slug used in the log and the Claude handoff prompt. */
+  name: string;
+  /** Human line shown while the step runs. */
+  title: string;
+  /** One-line plain-language narration shown before the step runs. */
+  explain?: string;
+  /** Ask before running (Y/n); a declined optional step is simply skipped. */
+  optional?: boolean;
+  /** Consent prompt shown (Y/n, default yes) before the step runs on a TTY; a "no"
+   *  skips the step. Non-TTY runs without asking. For steps that change the user's
+   *  system (e.g. installing the Claude Code plugin). */
+  confirm?: string;
+  /** The step draws its own live pane; the runner shows no spinner, just the result line. */
+  live?: boolean;
+  /** Paths/URLs Claude should read when this step fails. */
+  context?: string[];
+  /** Throw to fail; a returned string becomes the detail on the result line. */
+  run(): Promise<string | void>;
+}
+
+/** Run steps in order with a failure loop per step: offer a Claude handoff, then
+ *  retry / skip / quit. Returns false on abort.
+ *
+ *  `yes` is non-interactive accept-all (agents/CI): optional and `confirm` steps run
+ *  without prompting (so e.g. demo agents are written), and a failure aborts with the
+ *  log path instead of opening the recovery menu/handoff, even on a TTY. */
+export async function runSteps(steps: Step[], log: SetupLog, opts: { yes?: boolean } = {}): Promise<boolean> {
+  const interactive = process.stdin.isTTY && !opts.yes;
+  for (const step of steps) {
+    if (step.optional && !opts.yes && (!interactive || !(await ask(`${step.title}?`)))) {
+      p.log.info(dim(`skipped: ${step.title}`));
+      log.line(`${step.name}: skipped (declined)`);
+      continue;
+    }
+    // Consent before a system-changing step (interactive only); a "no" skips it.
+    if (step.confirm && interactive && !(await ask(step.confirm))) {
+      p.log.info(dim(`skipped: ${step.title}`));
+      log.line(`${step.name}: skipped (declined consent)`);
+      continue;
+    }
+    if (!(await runOne(step, log, interactive))) return false;
+  }
+  return true;
+}
+
+async function runOne(step: Step, log: SetupLog, interactive: boolean): Promise<boolean> {
+  for (;;) {
+    if (step.explain) p.log.step(step.explain);
+    const spin = step.live ? undefined : p.spinner();
+    spin?.start(step.title);
+    try {
+      const detail = await step.run();
+      const line = `${step.title}${detail ? dim(` · ${detail}`) : ""}`;
+      if (spin) spin.stop(line);
+      else p.log.success(line);
+      log.line(`${step.name}: ok${detail ? ` · ${detail}` : ""}`);
+      return true;
+    } catch (e) {
+      const err = e as Error;
+      if (spin) spin.stop(`${step.title}: failed`);
+      p.log.error(err.message);
+      log.line(`${step.name}: FAILED · ${err.message}`);
+
+      // Non-interactive (CI, piped, or --yes): no recovery loop; abort with the log path.
+      if (!interactive) {
+        p.log.message(dim(`See ${log.path}`));
+        return false;
+      }
+
+      const choice = await failureMenu(step);
+      if (choice === "debug") {
+        await runHandoff({ step: step.name, error: err, context: step.context ?? [], logPath: log.path });
+        continue;
+      }
+      if (choice === "retry") continue;
+      if (choice === "skip") {
+        if (!step.optional) {
+          p.log.warn(`Setup can't continue without "${step.title}". Fix it and re-run: cotal setup`);
+          return false;
+        }
+        log.line(`${step.name}: skipped (after failure)`);
+        return true;
+      }
+      return false; // quit
+    }
+  }
+}
+
+type Choice = "retry" | "debug" | "skip" | "quit";
+
+async function failureMenu(step: Step): Promise<Choice> {
+  const options: { value: Choice; label: string }[] = [{ value: "retry", label: "Retry this step" }];
+  if (assistAvailable()) options.push({ value: "debug", label: "Debug it with Claude" });
+  options.push({ value: "skip", label: step.optional ? "Skip it" : "Skip (may abort)" });
+  options.push({ value: "quit", label: "Quit setup" });
+  const choice = await p.select({ message: "What now?", options });
+  if (p.isCancel(choice)) return "quit";
+  return choice as Choice;
+}
+
+async function ask(message: string): Promise<boolean> {
+  // A real "No" returns false (skip the step); Ctrl-C aborts setup.
+  return abortIfCancel(await p.confirm({ message, initialValue: true }));
+}

--- a/implementations/cli/src/lib/theme.ts
+++ b/implementations/cli/src/lib/theme.ts
@@ -1,0 +1,69 @@
+/**
+ * Cotal brand palette for the terminal setup flow. Colors match the web dashboard
+ * (implementations/cli/src/web/index.html): brand blue #58a6ff, success green #3fb950.
+ *
+ * Rendering gates (same as the rest of the CLI's color story):
+ *   - No TTY (piped/redirected) or NO_COLOR → plain text, no ANSI
+ *   - COLORTERM truecolor/24bit            → 24-bit ANSI (exact brand color)
+ *   - otherwise                            → 16-color fallback
+ */
+import * as p from "@clack/prompts";
+
+const USE_ANSI = Boolean(process.stdout.isTTY) && !process.env.NO_COLOR;
+const TRUECOLOR =
+  USE_ANSI && (process.env.COLORTERM === "truecolor" || process.env.COLORTERM === "24bit");
+
+const BRAND = [88, 166, 255] as const; // #58a6ff
+const GREEN = [63, 185, 80] as const; // #3fb950
+
+function rgb([r, g, b]: readonly [number, number, number], s: string, bold = false): string {
+  if (!USE_ANSI) return s;
+  if (TRUECOLOR) return `\x1b[${bold ? "1;" : ""}38;2;${r};${g};${b}m${s}\x1b[0m`;
+  return `\x1b[${bold ? "1;" : ""}34m${s}\x1b[0m`; // 16-color blue/green fallback
+}
+
+export const brand = (s: string) => rgb(BRAND, s);
+export const brandBold = (s: string) => rgb(BRAND, s, true);
+export const ok = (s: string) => (USE_ANSI ? (TRUECOLOR ? rgb(GREEN, s) : `\x1b[32m${s}\x1b[0m`) : s);
+export const dim = (s: string) => (USE_ANSI ? `\x1b[2m${s}\x1b[0m` : s);
+export const bold = (s: string) => (USE_ANSI ? `\x1b[1m${s}\x1b[0m` : s);
+
+/** Multi-line strings get colored line-by-line so the SGR reset doesn't bleed across
+ *  clack's `│` gutter prefix. Used as the `format` callback for `note()` bodies. */
+export const brandBody = (s: string): string =>
+  s
+    .split("\n")
+    .map((line) => (line.length ? brand(line) : line))
+    .join("\n");
+
+/** Elapsed-time suffix for spinners: `47s` under a minute, `2m 34s` above. */
+export function fmtDuration(ms: number): string {
+  const total = Math.round(ms / 1000);
+  if (total < 60) return `${total}s`;
+  return `${Math.floor(total / 60)}m ${total % 60}s`;
+}
+
+/** Truncate to the terminal width (minus a gutter) so live-pane lines never wrap. */
+export function fit(s: string, gutter = 4): string {
+  const width = Math.max(20, (process.stdout.columns ?? 80) - gutter);
+  return s.length > width ? `${s.slice(0, width - 1)}…` : s;
+}
+
+/** A branded `p.note` (body in brand color). */
+export function note(message: string, title?: string): void {
+  p.note(message, title, { format: brandBody });
+}
+
+const WORDMARK = String.raw`
+            _        _
+   ___ ___ | |_ __ _| |
+  / __/ _ \| __/ _` + "`" + String.raw`| |
+ | (_| (_) | || (_| | |
+  \___\___/ \__\__,_|_|`;
+
+/** First-run splash: brand wordmark + tagline + rule. No-op detail when ANSI is off
+ *  still prints the plain wordmark so piped logs stay legible. */
+export function splash(): void {
+  const rule = "─".repeat(Math.min(44, (process.stdout.columns ?? 80) - 2));
+  process.stdout.write(`${brand(WORDMARK)}\n\n   ${dim("the web for agents")}\n  ${brand(rule)}\n\n`);
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "smoke:attention": "tsx extensions/connector-core/attention.smoke.ts",
     "smoke:attention:auth": "tsx extensions/connector-core/attention-auth.smoke.ts",
     "smoke:feedback": "tsx extensions/connector-core/feedback.smoke.ts",
-    "smoke:attach": "tsx implementations/manager/attach.smoke.ts"
+    "smoke:attach": "tsx implementations/manager/attach.smoke.ts",
+    "smoke:install": "tsx implementations/cli/install.smoke.ts"
   },
   "dependencies": {
     "@cotal-ai/cli": "workspace:*",


### PR DESCRIPTION
The first-run guided flow (`cotal` / `cotal go` / `setup --full` / `--yes`): checks, open local mesh, connector picker, experts + driving session, ready card, plus the subdir-safe path/space resolution it relies on. Setup docs included.
Part of splitting #22 (npx cotal-ai guided setup) into a reviewable stack:
1. split/01-package · 2. split/02-control-plane · 3. split/03-docs · 4. split/04-setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)