### PR TITLE
feat(cli): per-command --help and friendly arg errors

### DIFF
--- a/implementations/cli/src/command.ts
+++ b/implementations/cli/src/command.ts
@@ -16,6 +16,18 @@ function help(commands: Command[]): void {
   console.log(out);
 }
 
+/** One-line help for a single command: its usage (or summary as fallback). */
+function commandHelp(cmd: Command): void {
+  console.log(`${c.bold(`cotal ${cmd.name}`)} — ${cmd.summary}`);
+  if (cmd.usage) console.log(c.dim(cmd.usage));
+}
+
+/** node's parseArgs throws these for unknown/malformed flags; treat as a usage error. */
+function isArgError(e: unknown): boolean {
+  const code = (e as { code?: string })?.code;
+  return typeof code === "string" && code.startsWith("ERR_PARSE_ARGS");
+}
+
 /** Dispatch `argv` against the commands self-registered in a {@link Registry}.
  *  The single entry point a composition root calls — no hardcoded command list. */
 export async function runCli(registry: Registry, argv: string[]): Promise<void> {
@@ -31,5 +43,22 @@ export async function runCli(registry: Registry, argv: string[]): Promise<void> 
     help(commands);
     process.exit(1);
   }
-  await cmd.run(rest);
+  // `cotal <cmd> --help` / `-h` → that command's help, never run it.
+  if (rest.includes("--help") || rest.includes("-h")) {
+    commandHelp(cmd);
+    return;
+  }
+  try {
+    await cmd.run(rest);
+  } catch (e) {
+    // A bad flag/arg prints the command's help, not a stack trace. Trim node's verbose
+    // "To specify a positional argument starting with a '-' …" tail to the first sentence.
+    if (isArgError(e)) {
+      const msg = (e as Error).message.split(".")[0];
+      console.error(c.red(`✗ ${msg}`));
+      commandHelp(cmd);
+      process.exit(1);
+    }
+    throw e;
+  }
 }

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -11,5 +11,8 @@ export interface Command extends Extension {
   readonly summary: string;
   /** Help grouping header (e.g. "Mesh", "Control plane"). Defaults to "Commands". */
   readonly group?: string;
+  /** One-line usage shown by `cotal <cmd> --help` and on an invalid-argument error.
+   *  Falls back to `summary` when unset. */
+  readonly usage?: string;
   run(argv: string[]): Promise<void>;
 }


### PR DESCRIPTION
## What

Two CLI UX fixes, handled generically in the dispatcher so **every** command (cli + manager) gets them with no per-command wiring:

1. **`cotal <cmd> --help` / `-h`** prints that command's help instead of running it.
2. **An invalid flag/arg** prints a one-line error + the command's help — not node's `ERR_PARSE_ARGS_*` stack trace.

## Why

Today a wrong flag dumps a raw stack trace:

```
$ cotal spawn foo --bogus
TypeError [ERR_PARSE_ARGS_UNKNOWN_OPTION]: Unknown option '--bogus'...
    at parseArgs (node:internal/util/parse_args/parse_args:102:13)
    ...
```

…and there's no `cotal <cmd> --help`. After:

```
$ cotal spawn foo --bogus
✗ Unknown option '--bogus'
cotal spawn — launch an agent in this terminal from a file
```

## How

All in `runCli` (the single dispatch entry point), so it covers cli + manager commands uniformly:
- intercept `--help`/`-h` for a resolved command → print its help, don't run
- wrap `cmd.run()` and catch `ERR_PARSE_ARGS_*` → print a trimmed one-liner + the command's help, exit 1; re-throw anything else
- add optional `Command.usage?` (core) — a one-line usage string shown by help / on error, falling back to `summary` when unset

No per-command changes required; commands opt into a richer usage line by setting `usage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
