### PR TITLE
fix(manager): unhang managed agents on Claude ≥2.1.178 (clear all startup prompts)

### DIFF
--- a/implementations/manager/channels-confirm.smoke.ts
+++ b/implementations/manager/channels-confirm.smoke.ts
@@ -1,0 +1,68 @@
+/**
+ * Issue #34 regression: a managed (pty) Claude session hangs at "starting…" on Claude Code
+ * ≥ 2.1.178 because startup now shows TWO back-to-back "Enter to confirm" screens (workspace
+ * trust, then the dev-channels warning) and the old one-shot auto-confirm cleared only the first.
+ *
+ * This drives the REAL PtyRuntime with the connector's LaunchSpec against a real `claude`, in a
+ * fresh (untrusted) workspace so both prompts appear, and asserts the session gets past them to
+ * the live UI instead of stalling on the channels warning.
+ *
+ * Run: COTAL_TEST_CLAUDE_BIN=/path/to/claude-2.1.178 pnpm smoke:channels
+ * Skips cleanly if no claude binary is available (e.g. CI without auth).
+ */
+import { spawnSync } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PtyRuntime } from "./src/runtime/pty.js";
+
+const claudeBin = process.env.COTAL_TEST_CLAUDE_BIN ?? "claude";
+const probe = spawnSync(claudeBin, ["--version"], { encoding: "utf8" });
+if (probe.status !== 0) {
+  console.log(`SKIP channels-confirm smoke — no runnable claude at "${claudeBin}"`);
+  process.exit(0);
+}
+console.log(`claude: ${probe.stdout.trim()}`);
+
+const strip = (s: string): string =>
+  s
+    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, "")
+    .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "")
+    .replace(/\x1b[@-Z\\-_]/g, "");
+
+// Mirrors the claude connector's launch recipe (origin/main): the dev-channels flag (which on a
+// fresh workspace triggers trust + warning prompts) and the confirm token the runtime auto-clears.
+const spec = {
+  command: claudeBin,
+  args: ["--dangerously-load-development-channels", "plugin:cotal@cotal-mesh"],
+  env: { COTAL_SPACE: "smoke34", COTAL_NAME: "smoke34", COTAL_CHANNEL: "1" },
+  confirm: "Enter to confirm",
+};
+const cwd = mkdtempSync(join(tmpdir(), "cotal-ch34-")); // fresh dir ⇒ untrusted ⇒ trust prompt fires
+
+const handle = new PtyRuntime().spawn("smoke34", spec, cwd);
+let out = "";
+const att = handle.attach();
+att.onData((b) => (out += b.toString("utf8")));
+
+// TUIs position text with cursor moves, so once ANSI is stripped the words run together
+// ("auto mode on" → "automodeon"). Match against a whitespace-collapsed view, like the runtime does.
+const flat = (s: string): string => strip(s).replace(/\s+/g, "");
+const STARTED = /automode|foragents|esctointerrupt/i; // only present once the live UI is up
+const BLOCKED = /Loadingdevelopmentchannels/i; // the warning screen we must get past
+
+await new Promise((r) => setTimeout(r, 18_000));
+const tail = strip(out).replace(/\n{2,}/g, "\n").slice(-700);
+handle.stop({ graceful: false });
+
+const started = STARTED.test(flat(out));
+const stuck = BLOCKED.test(flat(out.slice(-4000))); // still showing the warning at the end = stalled
+if (started && !stuck) {
+  console.log("✓ session cleared both startup prompts and reached the live UI");
+  console.log(`\nchannels-confirm smoke: passed`);
+  process.exit(0);
+}
+console.error("✗ session did not reach the live UI past the startup prompts");
+console.error(`started=${started} stuckOnWarning=${stuck}`);
+console.error("--- final screen tail ---\n" + tail);
+process.exit(1);

--- a/implementations/manager/channels-confirm.smoke.ts
+++ b/implementations/manager/channels-confirm.smoke.ts
@@ -7,7 +7,7 @@
  * fresh (untrusted) workspace so both prompts appear, and asserts the session gets past them to
  * the live UI instead of stalling on the channels warning.
  *
- * Run: COTAL_TEST_CLAUDE_BIN=/path/to/claude-2.1.178 pnpm smoke:channels
+ * Run: COTAL_TEST_CLAUDE_BIN=/path/to/claude-2.1.178 pnpm smoke:confirm
  * Skips cleanly if no claude binary is available (e.g. CI without auth).
  */
 import { spawnSync } from "node:child_process";

--- a/implementations/manager/src/runtime/pty.ts
+++ b/implementations/manager/src/runtime/pty.ts
@@ -5,8 +5,12 @@ const DEFAULT_COLS = 120;
 const DEFAULT_ROWS = 32;
 /** How much terminal output to retain for late-attach scrollback replay. */
 const SCROLLBACK_BYTES = 256 * 1024;
-/** Stop watching for a spawn-confirm prompt after this long (it appears at startup). */
+/** Stop watching for spawn-confirm prompts after this long (they appear at startup). */
 const CONFIRM_WINDOW_MS = 20_000;
+/** Min gap between auto-confirm keypresses, so one rendered prompt isn't pressed twice. */
+const CONFIRM_COOLDOWN_MS = 700;
+/** Safety cap on auto-confirm presses — startup shows a small fixed set of prompts, never a loop. */
+const MAX_CONFIRMS = 6;
 /** Grace window for a clean exit before a graceful stop escalates to SIGKILL. */
 const GRACE_MS = 3_000;
 
@@ -46,12 +50,38 @@ export class PtyRuntime implements Runtime {
     let cols = DEFAULT_COLS;
     let rows = DEFAULT_ROWS;
 
-    // Auto-clear a one-time spawn prompt (e.g. Claude's dev-channel confirmation):
-    // watch early output for `spec.confirm` and press Enter once when it appears.
+    // Auto-clear one-time spawn prompts. Claude shows up to two back-to-back "Enter to confirm"
+    // screens on a fresh workspace (the trust-folder prompt, then the dev-channels warning), each
+    // waiting for input. So matching can't be one-shot (it would clear only the first and hang on
+    // the second), nor purely output-driven (a prompt renders then goes quiet — no data to react
+    // to). Instead poll on a timer within the startup window: when `spec.confirm` is on screen and
+    // the cooldown has elapsed, press Enter and clear the buffer so the SAME screen isn't pressed
+    // twice; the next prompt re-populates it. Capped, so it can never become an Enter loop.
     const confirmTarget = spec.confirm ? normalizeForMatch(spec.confirm) : "";
-    let confirmArmed = Boolean(confirmTarget);
     let confirmBuf = "";
-    if (confirmArmed) setTimeout(() => (confirmArmed = false), CONFIRM_WINDOW_MS);
+    let confirmPresses = 0;
+    let lastConfirmAt = 0;
+    let confirmTimer: ReturnType<typeof setInterval> | undefined;
+    const stopConfirm = () => {
+      confirmBuf = "";
+      if (confirmTimer) {
+        clearInterval(confirmTimer);
+        confirmTimer = undefined;
+      }
+    };
+    const tryConfirm = () => {
+      if (!alive || !confirmTimer) return;
+      if (Date.now() - lastConfirmAt < CONFIRM_COOLDOWN_MS) return;
+      if (!normalizeForMatch(confirmBuf).includes(confirmTarget)) return;
+      lastConfirmAt = Date.now();
+      confirmBuf = "";
+      proc.write("\r");
+      if (++confirmPresses >= MAX_CONFIRMS) stopConfirm();
+    };
+    if (confirmTarget) {
+      confirmTimer = setInterval(tryConfirm, 250);
+      setTimeout(stopConfirm, CONFIRM_WINDOW_MS);
+    }
 
     proc.onData((d) => {
       const b = Buffer.from(d, "utf8");
@@ -60,19 +90,15 @@ export class PtyRuntime implements Runtime {
       while (ringBytes > SCROLLBACK_BYTES && ring.length > 1) {
         ringBytes -= ring.shift()!.length;
       }
-      if (confirmArmed) {
+      if (confirmTimer) {
         confirmBuf = (confirmBuf + d).slice(-8192);
-        if (normalizeForMatch(confirmBuf).includes(confirmTarget)) {
-          confirmArmed = false;
-          // Let the TUI finish wiring up its raw-mode input loop (it may flush
-          // stdin on init) before pressing Enter, or the keypress is dropped.
-          setTimeout(() => alive && proc.write("\r"), 500);
-        }
+        tryConfirm();
       }
       for (const fn of dataSubs) fn(b);
     });
     proc.onExit(() => {
       alive = false;
+      stopConfirm();
       for (const fn of exitSubs) fn();
     });
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "smoke:channels:auth": "tsx packages/core/channels-auth.smoke.ts",
     "smoke:attention": "tsx extensions/connector-core/attention.smoke.ts",
     "smoke:attention:auth": "tsx extensions/connector-core/attention-auth.smoke.ts",
-    "smoke:feedback": "tsx extensions/connector-core/feedback.smoke.ts"
+    "smoke:feedback": "tsx extensions/connector-core/feedback.smoke.ts",
+    "smoke:confirm": "tsx implementations/manager/channels-confirm.smoke.ts"
   },
   "dependencies": {
     "@cotal-ai/cli": "workspace:*",

--- a/packages/core/src/connector.ts
+++ b/packages/core/src/connector.ts
@@ -24,10 +24,11 @@ export interface LaunchSpec {
   command: string;
   args: string[];
   env?: Record<string, string>;
-  /** Auto-clear a one-time spawn prompt: when this text appears in the agent's
-   *  early output, the runtime presses Enter once so a supervised launch stays
-   *  non-interactive. Matched after stripping ANSI + whitespace (TUIs position
-   *  text with cursor moves, not spaces). */
+  /** Auto-clear startup confirm prompts: while this text is on screen during the agent's
+   *  first seconds, the runtime presses Enter to accept it, so a supervised launch stays
+   *  non-interactive. Fires once per prompt (Claude can show several back-to-back — workspace
+   *  trust, then the dev-channels warning). Matched after stripping ANSI + whitespace (TUIs
+   *  position text with cursor moves, not spaces). */
   confirm?: string;
 }
 


### PR DESCRIPTION
## Problem (#34)
Managed (pty) agents hang at `starting…` on Claude Code ≥2.1.178 and never join the mesh.

## Root cause
On a fresh/untrusted workspace, Claude ≥2.1.178 shows **two** back-to-back confirm screens at startup, both footered `Enter to confirm · Esc to cancel`:
1. the workspace **trust** prompt, then
2. the **dev-channels warning** (`--dangerously-load-development-channels`).

The pty runtime's auto-confirm was **one-shot**: its single Enter cleared the trust prompt and the channels warning then blocked forever — so the cotal MCP never loaded, presence never registered, and `cotal ps` stayed `starting…`.

## Fix
`implementations/manager/src/runtime/pty.ts`: make the auto-confirm **timer-driven, firing once per prompt** instead of one-shot. While the `Enter to confirm` footer is on screen during the startup window, press Enter, clear the buffer so the same screen isn't pressed twice, and re-arm for the next — capped so it can never loop. No connector change.

## Verified on real Claude 2.1.179
- **Captured startup**: a fresh workspace shows trust → channels-warning, both with `Enter to confirm`; two Enters reach the live UI (channel injected). No further approval gate.
- **A/B via `pnpm smoke:confirm`**: the **old** runtime stalls on the channels warning; the **fixed** runtime clears both and reaches the live UI. ✅
- `pnpm build` + `pnpm typecheck` green.

`smoke:confirm` skips cleanly when no `claude` is available; point it at a build with `COTAL_TEST_CLAUDE_BIN=/path/to/claude`.

Closes #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
