### PR TITLE
fix(release): lockstep versioning so connectors stop jumping to 1.0.0

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,19 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [
+    [
+      "cotal-ai",
+      "@cotal-ai/core",
+      "@cotal-ai/cli",
+      "@cotal-ai/manager",
+      "@cotal-ai/cmux",
+      "@cotal-ai/connector-core",
+      "@cotal-ai/connector-claude-code",
+      "@cotal-ai/connector-hermes",
+      "@cotal-ai/connector-opencode"
+    ]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",
@@ -10,6 +22,9 @@
     "useCalculatedVersion": true
   },
   "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  },
   "ignore": [
     "@cotal-ai/example-01-lateral-coordination",
     "@cotal-ai/example-02-cmux-handoff",

--- a/extensions/connector-claude-code/package.json
+++ b/extensions/connector-claude-code/package.json
@@ -27,7 +27,7 @@
     "@cotal-ai/connector-core": "workspace:*"
   },
   "peerDependencies": {
-    "@cotal-ai/core": "workspace:*"
+    "@cotal-ai/core": ">=0.1.0"
   },
   "devDependencies": {
     "@cotal-ai/core": "workspace:*",

--- a/extensions/connector-core/package.json
+++ b/extensions/connector-core/package.json
@@ -26,7 +26,7 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@cotal-ai/core": "workspace:*"
+    "@cotal-ai/core": ">=0.1.0"
   },
   "devDependencies": {
     "@cotal-ai/core": "workspace:*"

--- a/extensions/connector-hermes/package.json
+++ b/extensions/connector-hermes/package.json
@@ -32,7 +32,7 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@cotal-ai/core": "workspace:*"
+    "@cotal-ai/core": ">=0.1.0"
   },
   "devDependencies": {
     "@cotal-ai/core": "workspace:*",

--- a/extensions/connector-opencode/package.json
+++ b/extensions/connector-opencode/package.json
@@ -26,7 +26,7 @@
     "@cotal-ai/connector-core": "workspace:*"
   },
   "peerDependencies": {
-    "@cotal-ai/core": "workspace:*",
+    "@cotal-ai/core": ">=0.1.0",
     "@opencode-ai/plugin": "^1.16.2",
     "@opencode-ai/sdk": "^1.16.2"
   },


### PR DESCRIPTION
## What

The Changesets release PR (#38) bumped all four connectors to **1.0.0** even though nobody asked for a major release.

## Why it happened

The connectors peer-depend on `@cotal-ai/core` via `workspace:*`. Changesets has a default rule: **when a package's peer dependency changes, force-major the dependent** (a changed peer range is treated as breaking). So a routine `core` minor bump (0.1.3 → 0.2.0) dragged every connector to `1.0.0` — and connector-hermes / connector-opencode were pulled along even though they weren't in the changeset.

Verified that the config flag *alone* does **not** fix this: Changesets converts `workspace:*` to the **exact** old core version, so any bump is always "out of range" and still force-majors.

## The fix (3 parts)

1. **`fixed` lockstep group** — all nine publishable packages now share one version, matching how they already release together.
2. **`onlyUpdatePeerDependentsWhenOutOfRange: true`** — a peer dependent is only bumped when the new core version actually leaves its declared range.
3. **Core peer dependency `workspace:*` → `>=0.1.0`** in all four connectors — a real range the new core satisfies. Local linking is preserved by the existing `workspace:*` devDependency.

## Result (proven via `changeset version` dry run)

Every package versions at **`0.3.0`** instead of `1.0.0`:

| package | before fix | after fix |
|---|---|---|
| cotal-ai, core, cli, manager, cmux | 0.1.0–0.3.0 | **0.3.0** |
| connector-core, -claude-code, -hermes, -opencode | **1.0.0** | **0.3.0** |

`pnpm install` (lockfile unchanged), core stays linked into every connector, and full `pnpm typecheck` passes.

## After merge

Merging this to `main` triggers the Changesets action to regenerate the release PR (#38) with the corrected `0.3.0` versions. This is also permanent — future `core` releases will no longer inflate the connectors into spurious majors.