### PR TITLE
feat(mcp-bridge): bridge external MCP tools onto the mesh

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,6 +8,7 @@
       "@cotal-ai/core",
       "@cotal-ai/cli",
       "@cotal-ai/manager",
+      "@cotal-ai/mcp-bridge",
       "@cotal-ai/cmux",
       "@cotal-ai/connector-core",
       "@cotal-ai/connector-claude-code",

--- a/.changeset/mcp-bridge.md
+++ b/.changeset/mcp-bridge.md
@@ -1,0 +1,10 @@
+---
+"@cotal-ai/mcp-bridge": minor
+"@cotal-ai/connector-core": minor
+---
+
+Add an MCP-bridge endpoint: connect to an MCP server once and serve its tools to the whole
+space over the control plane (`list`/`call` on the `mcp` service). Supports local stdio servers
+and remote HTTP/SSE servers, with static bearer/header auth or full interactive OAuth
+(`cotal mcp-bridge login`). Coding agents opt in via `COTAL_MCP_BRIDGE=1` to get the
+`cotal_tools` / `cotal_tool` tools.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ pnpm + TypeScript ESM monorepo — four dependency tiers, one-way deps, Node ≥
 - **`implementations/*` — opinionated surfaces** over core (self-contained; never import each other).
   - **@cotal-ai/cli** — mesh CLI: `up`, `join`, `watch`, `console` (thin NATS clients) plus `spawn` — a foreground agent launch reusing the connector's launch recipe.
   - **@cotal-ai/manager** — agent supervisor: a mesh endpoint that spawns/manages nodes via a pluggable `Runtime` (`pty` default / `tmux` / `cmux`), plus its own control-plane commands (`start`/`stop`/`ps`/`attach`) and a WS attach endpoint.
+  - **@cotal-ai/mcp-bridge** — a mesh endpoint that connects to an MCP server (stdio or remote HTTP/SSE, with static-token or OAuth auth) and serves its tools to the whole space over the control plane (`list`/`call` on the `mcp` service); the `mcp-bridge` command + a `login` sub-verb for OAuth. Agents opt into the `cotal_tools`/`cotal_tool` consumer tools via `COTAL_MCP_BRIDGE=1`.
 - **`bin/cotal.ts` — composition root** for the `cotal` binary: imports the implementations it wants (which self-register their commands) and runs them.
 - **`examples/*` — use-cases** (composition roots; private, never published).
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ concrete mechanism you can check against the code.
 | [`@cotal-ai/core`](packages/core) | Endpoint, subjects, message types, the NATS client layer, and the `Connector`/`Command` contracts. |
 | [`@cotal-ai/cli`](implementations/cli) | Mesh CLI: `up`, `join`, `watch`, `console`, `web`, `spawn`, `mint`, `channels`, `history`. |
 | [`@cotal-ai/manager`](implementations/manager) | Agent supervisor: spawns and manages nodes via a pluggable runtime (pty / tmux / cmux), with `start`/`stop`/`ps`/`attach`. |
+| [`@cotal-ai/mcp-bridge`](implementations/mcp-bridge) | Bridges an MCP server's tools (stdio or remote HTTP/SSE, token or OAuth) onto the mesh as a shared `list`/`call` service; agents opt in with `COTAL_MCP_BRIDGE=1`. |
 | [`@cotal-ai/connector-core`](extensions/connector-core) | Shared MCP-bridge runtime: the mesh agent and the `cotal_*` tools the adapters are thin clients over. |
 | [`@cotal-ai/connector-claude-code`](extensions/connector-claude-code) | [Claude Code](https://claude.com/product/claude-code) adapter: installed plugin + lifecycle hooks. |
 | [`@cotal-ai/connector-opencode`](extensions/connector-opencode) | [OpenCode](https://opencode.ai) adapter: native in-process plugin injected via config. |

--- a/bin/cotal.ts
+++ b/bin/cotal.ts
@@ -8,6 +8,7 @@
  */
 import { runCli } from "@cotal-ai/cli"; // self-registers up / down / join / watch / spawn / console / setup
 import "@cotal-ai/manager"; // self-registers supervise / cmux / start / stop / ps / attach
+import "@cotal-ai/mcp-bridge"; // self-registers mcp-bridge (external MCP tools as a shared mesh service)
 import "@cotal-ai/connector-claude-code"; // registers the `claude` connector that spawn / start resolve
 import "@cotal-ai/connector-opencode"; // registers the `opencode` connector (native in-process plugin)
 import "@cotal-ai/connector-hermes"; // registers the `hermes` connector (Nous Research gateway as a mesh peer)

--- a/bin/package.json
+++ b/bin/package.json
@@ -37,7 +37,8 @@
     "@cotal-ai/connector-hermes": "workspace:*",
     "@cotal-ai/connector-opencode": "workspace:*",
     "@cotal-ai/core": "workspace:*",
-    "@cotal-ai/manager": "workspace:*"
+    "@cotal-ai/manager": "workspace:*",
+    "@cotal-ai/mcp-bridge": "workspace:*"
   },
   "files": [
     "dist",

--- a/docs/release.md
+++ b/docs/release.md
@@ -11,7 +11,7 @@ OIDC tokens issued by GitHub Actions. Each published package must be
 configured once on npmjs.com.
 
 For **every** published package (`@cotal-ai/core`, `@cotal-ai/cli`,
-`@cotal-ai/manager`, `@cotal-ai/connector-core`,
+`@cotal-ai/manager`, `@cotal-ai/mcp-bridge`, `@cotal-ai/connector-core`,
 `@cotal-ai/connector-claude-code`, `@cotal-ai/connector-opencode`,
 `@cotal-ai/cmux`):
 

--- a/extensions/connector-core/src/agent.ts
+++ b/extensions/connector-core/src/agent.ts
@@ -382,6 +382,27 @@ export class MeshAgent extends EventEmitter {
     return reply;
   }
 
+  // ---- shared MCP tools (mcp-bridge) ---------------------------------------
+
+  /** List external MCP tools shared on the mesh by an mcp-bridge peer (its `list` op on the
+   *  "mcp" control service). Throws if no bridge answers. */
+  async listRemoteTools(): Promise<
+    { name: string; description?: string; inputSchema?: unknown }[]
+  > {
+    this.assertConnected();
+    const reply = await this.ep.requestControl("mcp", { op: "list" }, 10_000);
+    if (!reply.ok) throw new Error(reply.error ?? "mcp-bridge refused");
+    return (reply.data as { tools?: { name: string; description?: string; inputSchema?: unknown }[] })
+      ?.tools ?? [];
+  }
+
+  /** Call a shared MCP tool through the bridge (its `call` op). A longer timeout than the
+   *  control-plane default — bridged tools can be slow. */
+  async callRemoteTool(tool: string, args: Record<string, unknown>): Promise<ControlReply> {
+    this.assertConnected();
+    return this.ep.requestControl("mcp", { op: "call", args: { tool, arguments: args } }, 60_000);
+  }
+
   // ---- presence ------------------------------------------------------------
 
   /** The full roster, including ourselves. */

--- a/extensions/connector-core/src/config.ts
+++ b/extensions/connector-core/src/config.ts
@@ -40,6 +40,9 @@ export interface AgentConfig {
   feedbackKey?: string;
   /** Optional intake URL override (`COTAL_FEEDBACK_URL`) for self-hosted intakes. */
   feedbackUrl?: string;
+  /** When set (`COTAL_MCP_BRIDGE=1`), surface the `cotal_tools` / `cotal_tool` tools so this
+   *  agent can discover and call external MCP tools shared on the mesh by an mcp-bridge peer. */
+  mcpBridge?: boolean;
 }
 
 function splitList(v: string | undefined): string[] {
@@ -94,6 +97,7 @@ export function configFromEnv(env: NodeJS.ProcessEnv = process.env): AgentConfig
     tls: env.COTAL_TLS?.trim() === "1" || link?.tls || false,
     feedbackKey: env.COTAL_FEEDBACK_KEY?.trim() || undefined,
     feedbackUrl: env.COTAL_FEEDBACK_URL?.trim() || undefined,
+    mcpBridge: env.COTAL_MCP_BRIDGE?.trim() === "1",
   };
 }
 

--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -112,7 +112,7 @@ export function channelMeta(i: InboxItem): Record<string, string> {
 /** The full Cotal tool set for a given config. Renderers iterate this; `source` names the
  *  hosting connector and is stamped onto outgoing feedback. */
 export function cotalToolSpecs(config: AgentConfig, source = "connector"): CotalToolSpec[] {
-  return [
+  const specs: CotalToolSpec[] = [
     {
       name: "cotal_roster",
       title: "Cotal: who's present",
@@ -508,6 +508,60 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
           return err(
             `Couldn't define ${name}: no manager reachable (${(e as Error).message}). Is the manager running?`,
           );
+        }
+      },
+    },
+  ];
+  if (config.mcpBridge) specs.push(...mcpBridgeToolSpecs());
+  return specs;
+}
+
+/** Tools for calling external MCP tools shared on the mesh by an mcp-bridge peer. Added to the
+ *  surface only when `config.mcpBridge` is set. They reach the bridge over the "mcp" control
+ *  service: `cotal_tools` lists the catalog, `cotal_tool` invokes one — so a peer uses the whole
+ *  catalog through one shared connection instead of wiring up its own MCP servers. */
+function mcpBridgeToolSpecs(): CotalToolSpec[] {
+  return [
+    {
+      name: "cotal_tools",
+      title: "Cotal: list shared MCP tools",
+      description:
+        "List the external MCP tools shared on the mesh by an mcp-bridge peer, with each tool's input shape. Call one with cotal_tool.",
+      async run(agent) {
+        if (!agent.connected) return ok("Not connected to the mesh yet.");
+        try {
+          const tools = await agent.listRemoteTools();
+          if (!tools.length) return ok("No shared MCP tools available (no mcp-bridge present).");
+          const lines = tools.map(
+            (t) =>
+              `• ${t.name}${t.description ? ` — ${t.description}` : ""}\n  input: ${JSON.stringify(t.inputSchema ?? {})}`,
+          );
+          return ok(`Shared MCP tools (call with cotal_tool):\n${lines.join("\n")}`);
+        } catch (e) {
+          return err(`Couldn't list shared tools: ${(e as Error).message}`);
+        }
+      },
+    },
+    {
+      name: "cotal_tool",
+      title: "Cotal: call a shared MCP tool",
+      description:
+        "Invoke an external MCP tool shared on the mesh (discover names + input shapes with cotal_tools). The call runs on the mcp-bridge peer and the result comes back over the mesh.",
+      schema: {
+        tool: z.string().describe("The tool name, as listed by cotal_tools."),
+        arguments: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe("Arguments object matching the tool's input schema (omit for no-argument tools)."),
+      },
+      async run(agent, _config, { tool, arguments: a }: { tool: string; arguments?: Record<string, unknown> }) {
+        try {
+          const reply = await agent.callRemoteTool(tool, a ?? {});
+          if (!reply.ok) return err(`Tool ${tool} failed: ${reply.error ?? "error"}`);
+          const d = reply.data as { text?: string } | undefined;
+          return ok(d?.text || "(no output)");
+        } catch (e) {
+          return err(`Couldn't call ${tool}: ${(e as Error).message}`);
         }
       },
     },

--- a/implementations/mcp-bridge/fixtures/echo-mcp-server.mjs
+++ b/implementations/mcp-bridge/fixtures/echo-mcp-server.mjs
@@ -1,0 +1,33 @@
+/**
+ * A minimal stdio MCP server used by mcp-bridge.smoke.ts — one `echo` tool.
+ * Low-level Server API so the fixture needs no extra deps beyond the MCP SDK.
+ */
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+const server = new Server(
+  { name: "echo-fixture", version: "0.0.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: "echo",
+      description: "Echo back the message.",
+      inputSchema: {
+        type: "object",
+        properties: { message: { type: "string" } },
+        required: ["message"],
+      },
+    },
+  ],
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const message = String(req.params.arguments?.message ?? "");
+  return { content: [{ type: "text", text: message }] };
+});
+
+await server.connect(new StdioServerTransport());

--- a/implementations/mcp-bridge/fixtures/remote-mcp-server.d.mts
+++ b/implementations/mcp-bridge/fixtures/remote-mcp-server.d.mts
@@ -1,0 +1,9 @@
+export function startBearerServer(opts?: { token?: string }): Promise<{
+  url: string;
+  close: () => Promise<void>;
+}>;
+
+export function startOAuthServer(): Promise<{
+  url: string;
+  close: () => Promise<void>;
+}>;

--- a/implementations/mcp-bridge/fixtures/remote-mcp-server.mjs
+++ b/implementations/mcp-bridge/fixtures/remote-mcp-server.mjs
@@ -1,0 +1,168 @@
+/**
+ * Remote MCP server fixtures for mcp-bridge-remote.smoke.ts — started in-process.
+ *
+ * - startBearerServer(): a Streamable HTTP MCP server gated by a static bearer token.
+ * - startOAuthServer():  a fake OAuth authorization server + token-protected MCP endpoint
+ *   (DCR + PKCE authorize/token), enough to exercise the full interactive login flow.
+ *
+ * Both expose a single `echo` tool via the low-level Server API (no zod dependency).
+ */
+import { createServer } from "node:http";
+import { createHash, randomBytes } from "node:crypto";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+function makeMcpServer() {
+  const server = new Server({ name: "remote-fixture", version: "0.0.0" }, { capabilities: { tools: {} } });
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+      {
+        name: "echo",
+        description: "Echo back the message.",
+        inputSchema: { type: "object", properties: { message: { type: "string" } }, required: ["message"] },
+      },
+    ],
+  }));
+  server.setRequestHandler(CallToolRequestSchema, async (req) => ({
+    content: [{ type: "text", text: String(req.params.arguments?.message ?? "") }],
+  }));
+  return server;
+}
+
+/** Handle an MCP request with a fresh stateless transport (JSON responses, no sessions). */
+async function handleMcp(req, res) {
+  let body;
+  if (req.method === "POST") {
+    const chunks = [];
+    for await (const c of req) chunks.push(c);
+    const raw = Buffer.concat(chunks).toString("utf8");
+    body = raw ? JSON.parse(raw) : undefined;
+  }
+  const server = makeMcpServer();
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+    enableJsonResponse: true,
+  });
+  res.on("close", () => {
+    transport.close();
+    server.close();
+  });
+  await server.connect(transport);
+  await transport.handleRequest(req, res, body);
+}
+
+const listen = (srv) =>
+  new Promise((resolve) => srv.listen(0, "127.0.0.1", () => resolve(srv.address().port)));
+const sendJson = (res, status, obj) => {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify(obj));
+};
+const readBody = async (req) => {
+  const chunks = [];
+  for await (const c of req) chunks.push(c);
+  return Buffer.concat(chunks).toString("utf8");
+};
+
+/** Streamable HTTP MCP server requiring `Authorization: Bearer <token>`. */
+export async function startBearerServer({ token = "secret-token" } = {}) {
+  const srv = createServer(async (req, res) => {
+    const u = new URL(req.url, "http://127.0.0.1");
+    if (u.pathname !== "/mcp") return res.writeHead(404).end();
+    if (req.headers.authorization !== `Bearer ${token}`)
+      return res.writeHead(401, { "www-authenticate": 'Bearer error="invalid_token"' }).end();
+    await handleMcp(req, res);
+  });
+  const port = await listen(srv);
+  return {
+    url: `http://127.0.0.1:${port}/mcp`,
+    close: () => new Promise((r) => srv.close(() => r())),
+  };
+}
+
+/** Fake OAuth (DCR + PKCE) + token-protected MCP endpoint. Auto-approves `/authorize`. */
+export async function startOAuthServer() {
+  const codes = new Map(); // code -> { challenge, redirect }
+  const tokens = new Set(); // valid access tokens
+  let base = "";
+
+  const meta = () => ({
+    issuer: base,
+    authorization_endpoint: `${base}/authorize`,
+    token_endpoint: `${base}/token`,
+    registration_endpoint: `${base}/register`,
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    code_challenge_methods_supported: ["S256"],
+    token_endpoint_auth_methods_supported: ["none"],
+    scopes_supported: ["mcp"],
+  });
+
+  const srv = createServer(async (req, res) => {
+    const u = new URL(req.url, base);
+    const path = u.pathname;
+
+    if (path === "/.well-known/oauth-protected-resource")
+      return sendJson(res, 200, { resource: `${base}/mcp`, authorization_servers: [base] });
+    if (path === "/.well-known/oauth-authorization-server" || path === "/.well-known/openid-configuration")
+      return sendJson(res, 200, meta());
+
+    if (path === "/register" && req.method === "POST") {
+      const body = JSON.parse((await readBody(req)) || "{}");
+      return sendJson(res, 201, {
+        client_id: "test-client",
+        redirect_uris: body.redirect_uris ?? [],
+        token_endpoint_auth_method: "none",
+        grant_types: ["authorization_code", "refresh_token"],
+        response_types: ["code"],
+      });
+    }
+
+    if (path === "/authorize") {
+      const redirect = u.searchParams.get("redirect_uri");
+      const state = u.searchParams.get("state");
+      const code = randomBytes(16).toString("hex");
+      codes.set(code, { challenge: u.searchParams.get("code_challenge"), redirect });
+      const loc = new URL(redirect);
+      loc.searchParams.set("code", code);
+      if (state) loc.searchParams.set("state", state);
+      return res.writeHead(302, { location: loc.href }).end();
+    }
+
+    if (path === "/token" && req.method === "POST") {
+      const form = new URLSearchParams(await readBody(req));
+      const grant = form.get("grant_type");
+      const issue = () => {
+        const access = randomBytes(24).toString("hex");
+        tokens.add(access);
+        return { access_token: access, token_type: "Bearer", expires_in: 3600, refresh_token: randomBytes(24).toString("hex"), scope: "mcp" };
+      };
+      if (grant === "authorization_code") {
+        const rec = codes.get(form.get("code"));
+        if (!rec) return sendJson(res, 400, { error: "invalid_grant" });
+        const expect = createHash("sha256").update(form.get("code_verifier") ?? "").digest("base64url");
+        if (rec.challenge && rec.challenge !== expect)
+          return sendJson(res, 400, { error: "invalid_grant", error_description: "PKCE mismatch" });
+        codes.delete(form.get("code"));
+        return sendJson(res, 200, issue());
+      }
+      if (grant === "refresh_token") return sendJson(res, 200, issue());
+      return sendJson(res, 400, { error: "unsupported_grant_type" });
+    }
+
+    if (path === "/mcp") {
+      const auth = req.headers.authorization ?? "";
+      const tok = auth.startsWith("Bearer ") ? auth.slice(7) : "";
+      if (!tokens.has(tok))
+        return res
+          .writeHead(401, { "www-authenticate": `Bearer resource_metadata="${base}/.well-known/oauth-protected-resource"` })
+          .end();
+      return handleMcp(req, res);
+    }
+
+    res.writeHead(404).end();
+  });
+  const port = await listen(srv);
+  base = `http://127.0.0.1:${port}`;
+  return { url: `${base}/mcp`, close: () => new Promise((r) => srv.close(() => r())) };
+}

--- a/implementations/mcp-bridge/mcp-bridge-remote.smoke.ts
+++ b/implementations/mcp-bridge/mcp-bridge-remote.smoke.ts
@@ -1,0 +1,96 @@
+/**
+ * End-to-end smoke for the REMOTE mcp-bridge paths (no test runner, no network) —
+ * run with: pnpm smoke:mcp-bridge:remote. Requires a nats-server (pnpm cotal up).
+ *
+ * Part 1 — HTTP + static bearer: a Streamable HTTP MCP fixture gated by a bearer token;
+ *          the bridge attaches the header and a separate endpoint calls `echo` over the mesh.
+ * Part 2 — full OAuth: a fake auth+resource server (DCR + PKCE); drive `runOAuthLogin`
+ *          headlessly (the browser-open is replaced by a fetch that follows the redirect),
+ *          then run the bridge with `--oauth` off the cached token and call `echo`.
+ */
+import { randomUUID } from "node:crypto";
+import { rmSync } from "node:fs";
+import { CotalEndpoint, isReachable } from "@cotal-ai/core";
+import { McpBridge } from "./src/bridge.js";
+import { runOAuthLogin, mcpAuthDir } from "./src/oauth.js";
+import { startBearerServer, startOAuthServer } from "./fixtures/remote-mcp-server.mjs";
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+for (let i = 0; i < 50; i++) {
+  if (await isReachable()) break;
+  await wait(200);
+}
+if (!(await isReachable())) {
+  console.error("✗ no NATS reachable — start one with: pnpm cotal up");
+  process.exit(1);
+}
+
+let failed = false;
+const check = (cond: boolean, msg: string) => {
+  console.log(`${cond ? "✓" : "✗"} ${msg}`);
+  if (!cond) failed = true;
+};
+const text = (r: { data?: unknown }) => (r.data as { text?: string } | undefined)?.text;
+
+// ---- Part 1: HTTP + static bearer -----------------------------------------
+{
+  const server = await startBearerServer({ token: "secret-token" });
+  const space = `mcp-http-${randomUUID().slice(0, 8)}`;
+  const bridge = new McpBridge({
+    space,
+    mcp: [{ name: "bearer", url: server.url, headers: { Authorization: "Bearer secret-token" } }],
+  });
+  const caller = new CotalEndpoint({ space, card: { name: "caller", kind: "endpoint" }, consume: false });
+  try {
+    await bridge.start();
+    check(bridge.catalog.some((t) => t.name === "echo"), "HTTP+bearer: connected + discovered `echo`");
+    await caller.start();
+    await wait(200);
+    const call = await caller.requestControl("mcp", { op: "call", args: { tool: "echo", arguments: { message: "over http" } } });
+    check(call.ok && text(call) === "over http", `HTTP+bearer: call round-trips ("${text(call)}")`);
+  } finally {
+    await caller.stop().catch(() => {});
+    await bridge.stop().catch(() => {});
+    await server.close();
+  }
+}
+
+// ---- Part 2: full OAuth ----------------------------------------------------
+{
+  const server = await startOAuthServer();
+  const service = `smoke-oauth-${randomUUID().slice(0, 8)}`;
+  const dir = mcpAuthDir(service);
+  try {
+    // Headless login: the "browser" is a fetch that follows the 302 into the loopback callback.
+    const { tools } = await runOAuthLogin({
+      url: server.url,
+      service,
+      openUrl: (u) => void fetch(u).catch(() => {}),
+    });
+    check(tools >= 1, `OAuth: login cached a working token (${tools} tools)`);
+
+    const space = `mcp-oauth-${randomUUID().slice(0, 8)}`;
+    const bridge = new McpBridge({ space, mcp: [{ name: service, url: server.url, oauth: true }] });
+    const caller = new CotalEndpoint({ space, card: { name: "caller", kind: "endpoint" }, consume: false });
+    try {
+      await bridge.start();
+      check(bridge.catalog.some((t) => t.name === "echo"), "OAuth: daemon used cached token + discovered `echo`");
+      await caller.start();
+      await wait(200);
+      const call = await caller.requestControl("mcp", { op: "call", args: { tool: "echo", arguments: { message: "via oauth" } } });
+      check(call.ok && text(call) === "via oauth", `OAuth: call round-trips over the mesh ("${text(call)}")`);
+    } finally {
+      await caller.stop().catch(() => {});
+      await bridge.stop().catch(() => {});
+    }
+  } catch (e) {
+    check(false, `OAuth flow threw: ${(e as Error).message}`);
+  } finally {
+    await server.close();
+    rmSync(dir, { recursive: true, force: true }); // clean cached test tokens
+  }
+}
+
+console.log(failed ? "\nSMOKE FAILED" : "\nSMOKE PASSED");
+process.exit(failed ? 1 : 0);

--- a/implementations/mcp-bridge/mcp-bridge.smoke.ts
+++ b/implementations/mcp-bridge/mcp-bridge.smoke.ts
@@ -1,0 +1,65 @@
+/**
+ * End-to-end smoke for the MCP bridge (no test runner) — run with: pnpm smoke:mcp-bridge
+ * Requires a nats-server running locally (pnpm cotal up).
+ *
+ * Bridges a tiny stdio MCP server (fixtures/echo-mcp-server.mjs) onto the mesh, then — from a
+ * SEPARATE endpoint — lists and calls its tools over the control plane. Proves the whole path:
+ * external MCP tool → bridge peer → mesh → any caller.
+ */
+import { randomUUID } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import { CotalEndpoint, isReachable } from "@cotal-ai/core";
+import { McpBridge } from "./src/bridge.js";
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+for (let i = 0; i < 50; i++) {
+  if (await isReachable()) break;
+  await wait(200);
+}
+if (!(await isReachable())) {
+  console.error("✗ no NATS reachable — start one with: pnpm cotal up");
+  process.exit(1);
+}
+
+const space = `mcp-smoke-${randomUUID().slice(0, 8)}`;
+const fixture = fileURLToPath(new URL("./fixtures/echo-mcp-server.mjs", import.meta.url));
+
+const bridge = new McpBridge({
+  space,
+  mcp: [{ name: "echo-fixture", command: "node", args: [fixture] }],
+});
+const caller = new CotalEndpoint({ space, card: { name: "caller", kind: "endpoint" }, consume: false });
+
+let failed = false;
+const check = (cond: boolean, msg: string) => {
+  console.log(`${cond ? "✓" : "✗"} ${msg}`);
+  if (!cond) failed = true;
+};
+
+try {
+  await bridge.start();
+  check(bridge.catalog.some((t) => t.name === "echo"), "bridge connected to MCP server and discovered `echo`");
+  await caller.start();
+  await wait(200); // let the control subscription settle
+
+  const list = await caller.requestControl("mcp", { op: "list" });
+  const tools = (list.data as { tools?: { name: string }[] })?.tools ?? [];
+  check(list.ok && tools.some((t) => t.name === "echo"), "list op returns the `echo` tool over the mesh");
+
+  const call = await caller.requestControl("mcp", {
+    op: "call",
+    args: { tool: "echo", arguments: { message: "hello mesh" } },
+  });
+  const text = (call.data as { text?: string })?.text;
+  check(call.ok && text === "hello mesh", `call op round-trips the tool result ("${text}")`);
+
+  const missing = await caller.requestControl("mcp", { op: "call", args: { tool: "nope" } });
+  check(!missing.ok && /no such tool/.test(missing.error ?? ""), "unknown tool is rejected cleanly");
+} finally {
+  await caller.stop().catch(() => {});
+  await bridge.stop().catch(() => {});
+}
+
+console.log(failed ? "\nSMOKE FAILED" : "\nSMOKE PASSED");
+process.exit(failed ? 1 : 0);

--- a/implementations/mcp-bridge/package.json
+++ b/implementations/mcp-bridge/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@cotal-ai/mcp-bridge",
+  "version": "0.3.1",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Cotal-AI/Cotal.git",
+    "directory": "implementations/mcp-bridge"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "build": "tsc -p tsconfig.json",
+    "prepublishOnly": "pnpm run build"
+  },
+  "dependencies": {
+    "@cotal-ai/core": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/implementations/mcp-bridge/src/bridge.ts
+++ b/implementations/mcp-bridge/src/bridge.ts
@@ -1,0 +1,166 @@
+import { CotalEndpoint } from "@cotal-ai/core";
+import type { ControlReply, ControlRequest } from "@cotal-ai/core";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+/** One external MCP server to bridge onto the mesh (a stdio child process). */
+export interface McpServerSpec {
+  /** Logical name — namespaces tools as `<name>.<tool>` when more than one server is bridged. */
+  name: string;
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+export interface McpBridgeOptions {
+  space: string;
+  servers?: string;
+  /** Presence name on the mesh. Default "mcp-bridge". */
+  name?: string;
+  /** Creds file content (auth mode); the endpoint authenticates with it. Open mesh leaves it unset. */
+  creds?: string;
+  /** The external MCP server(s) to bridge. */
+  mcp: McpServerSpec[];
+  /** Control-plane service name peers address. Default "mcp". */
+  service?: string;
+}
+
+/** A tool discovered on a backing MCP server, plus where to route a call. */
+interface BridgedTool {
+  /** Mesh-facing name (namespaced `<server>.<tool>` when more than one server is bridged). */
+  name: string;
+  description?: string;
+  inputSchema: unknown;
+  client: Client;
+  /** The tool's name on its own server (un-namespaced). */
+  remoteName: string;
+}
+
+/** A backing MCP server connection. */
+interface Backend {
+  spec: McpServerSpec;
+  client: Client;
+  transport: StdioClientTransport;
+}
+
+/** Flatten an MCP tool result's content into plain text. */
+function resultText(content: unknown): string {
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((p): p is { type: string; text: string } => {
+      const c = p as { type?: unknown; text?: unknown };
+      return c.type === "text" && typeof c.text === "string";
+    })
+    .map((p) => p.text)
+    .join("\n");
+}
+
+/**
+ * A lateral mesh peer that connects to one or more external MCP servers and offers their
+ * tools to the whole space over the control plane. A `list` op returns the tool catalog;
+ * a `call` op runs a named tool on its backing server and returns the result — so any peer
+ * gets every bridged tool through one shared connection, rather than wiring up its own.
+ *
+ * Modeled on the manager: a {@link CotalEndpoint} with `consume:false` that serves a single
+ * control service. The control plane is already request/reply, queue-grouped (run several
+ * bridges of the same service to load-balance), and authenticated (the handler sees a verified
+ * `req.from.id`, the seam a future per-caller ACL would gate on).
+ */
+export class McpBridge {
+  private readonly opts: McpBridgeOptions;
+  private readonly service: string;
+  private readonly backends: Backend[] = [];
+  private readonly tools = new Map<string, BridgedTool>();
+  private ep!: CotalEndpoint;
+
+  constructor(opts: McpBridgeOptions) {
+    if (!opts.mcp.length) throw new Error("mcp-bridge: at least one MCP server is required");
+    this.opts = opts;
+    this.service = opts.service ?? "mcp";
+  }
+
+  /** The bridged tool catalog (mesh-facing names). */
+  get catalog(): { name: string; description?: string; inputSchema: unknown }[] {
+    return [...this.tools.values()].map((t) => ({
+      name: t.name,
+      description: t.description,
+      inputSchema: t.inputSchema,
+    }));
+  }
+
+  async start(): Promise<void> {
+    // Connect each backing MCP server first — fail loud before joining the mesh, so a broken
+    // server config never shows up as an empty, half-working bridge peer.
+    const multi = this.opts.mcp.length > 1;
+    for (const spec of this.opts.mcp) {
+      const transport = new StdioClientTransport({
+        command: spec.command,
+        args: spec.args,
+        env: spec.env,
+      });
+      const client = new Client({ name: "cotal-mcp-bridge", version: "0.3.1" });
+      await client.connect(transport);
+      this.backends.push({ spec, client, transport });
+      const { tools } = await client.listTools();
+      for (const t of tools) {
+        const name = multi ? `${spec.name}.${t.name}` : t.name;
+        if (this.tools.has(name))
+          throw new Error(`mcp-bridge: duplicate tool name "${name}" — namespace collision`);
+        this.tools.set(name, {
+          name,
+          description: t.description,
+          inputSchema: t.inputSchema,
+          client,
+          remoteName: t.name,
+        });
+      }
+    }
+
+    this.ep = new CotalEndpoint({
+      space: this.opts.space,
+      servers: this.opts.servers,
+      creds: this.opts.creds,
+      channels: [],
+      // Serves control + announces presence; it never consumes chat/dm/task.
+      consume: false,
+      card: { name: this.opts.name ?? "mcp-bridge", role: "mcp-bridge", kind: "endpoint" },
+    });
+    this.ep.on("error", (e: Error) => console.error(`! mcp-bridge endpoint: ${e.message}`));
+    await this.ep.start();
+    const servers = this.opts.mcp.map((s) => s.name).join(", ");
+    await this.ep.setActivity(`bridging ${servers} (${this.tools.size} tools)`);
+    this.ep.serveControl(this.service, (req) => this.handle(req));
+  }
+
+  async stop(): Promise<void> {
+    if (this.ep) await this.ep.stop();
+    for (const b of this.backends) await b.client.close();
+  }
+
+  private async handle(req: ControlRequest): Promise<ControlReply> {
+    const args = req.args ?? {};
+    switch (req.op) {
+      case "list":
+        return { ok: true, data: { tools: this.catalog } };
+      case "call":
+        return this.opCall(args);
+      default:
+        return { ok: false, error: `unknown op: ${req.op}` };
+    }
+  }
+
+  private async opCall(args: Record<string, unknown>): Promise<ControlReply> {
+    const name = String(args.tool ?? "");
+    const tool = this.tools.get(name);
+    if (!tool) return { ok: false, error: `no such tool "${name}" (use op "list")` };
+    const toolArgs = (args.arguments as Record<string, unknown> | undefined) ?? {};
+    try {
+      const res = await tool.client.callTool({ name: tool.remoteName, arguments: toolArgs });
+      const text = resultText(res.content);
+      if (res.isError) return { ok: false, error: text || `tool "${name}" failed` };
+      return { ok: true, data: { text, content: res.content } };
+    } catch (e) {
+      return { ok: false, error: `tool "${name}" threw: ${(e as Error).message}` };
+    }
+  }
+}

--- a/implementations/mcp-bridge/src/bridge.ts
+++ b/implementations/mcp-bridge/src/bridge.ts
@@ -1,16 +1,10 @@
 import { CotalEndpoint } from "@cotal-ai/core";
 import type { ControlReply, ControlRequest } from "@cotal-ai/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { buildClientTransport, isStdioSpec, type McpServerSpec } from "./transport.js";
+import { daemonOAuthProvider } from "./oauth.js";
 
-/** One external MCP server to bridge onto the mesh (a stdio child process). */
-export interface McpServerSpec {
-  /** Logical name — namespaces tools as `<name>.<tool>` when more than one server is bridged. */
-  name: string;
-  command: string;
-  args?: string[];
-  env?: Record<string, string>;
-}
+export type { McpServerSpec } from "./transport.js";
 
 export interface McpBridgeOptions {
   space: string;
@@ -40,7 +34,6 @@ interface BridgedTool {
 interface Backend {
   spec: McpServerSpec;
   client: Client;
-  transport: StdioClientTransport;
 }
 
 /** Flatten an MCP tool result's content into plain text. */
@@ -93,14 +86,14 @@ export class McpBridge {
     // server config never shows up as an empty, half-working bridge peer.
     const multi = this.opts.mcp.length > 1;
     for (const spec of this.opts.mcp) {
-      const transport = new StdioClientTransport({
-        command: spec.command,
-        args: spec.args,
-        env: spec.env,
-      });
+      // Remote OAuth servers authenticate from tokens cached by `cotal mcp-bridge login`; the
+      // daemon never opens a browser — it throws an actionable error if no token is cached.
+      const authProvider =
+        !isStdioSpec(spec) && spec.oauth ? daemonOAuthProvider(spec.name, spec.url) : undefined;
+      const transport = buildClientTransport(spec, authProvider);
       const client = new Client({ name: "cotal-mcp-bridge", version: "0.3.1" });
       await client.connect(transport);
-      this.backends.push({ spec, client, transport });
+      this.backends.push({ spec, client });
       const { tools } = await client.listTools();
       for (const t of tools) {
         const name = multi ? `${spec.name}.${t.name}` : t.name;

--- a/implementations/mcp-bridge/src/commands.ts
+++ b/implementations/mcp-bridge/src/commands.ts
@@ -12,10 +12,25 @@ import {
   type Command,
 } from "@cotal-ai/core";
 import { McpBridge } from "./bridge.js";
+import type { McpServerSpec } from "./transport.js";
+import { runOAuthLogin, DEFAULT_CALLBACK_PORT } from "./oauth.js";
+import { c } from "./ui.js";
 
-const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
-const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
-const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
+const OPTIONS = {
+  space: { type: "string" },
+  server: { type: "string" },
+  creds: { type: "string" },
+  name: { type: "string" }, // bridge presence name (default "mcp-bridge")
+  service: { type: "string" }, // control-plane service peers address (default "mcp")
+  "mcp-name": { type: "string" }, // logical server name: tool namespace + OAuth token key
+  url: { type: "string" }, // remote MCP server URL (alternative to a stdio `-- <command>`)
+  sse: { type: "boolean" }, // use the legacy SSE transport instead of Streamable HTTP
+  oauth: { type: "boolean" }, // authenticate with OAuth tokens cached by `login`
+  bearer: { type: "string" }, // static bearer token
+  header: { type: "string", multiple: true }, // static header(s): "Name: value"
+  scope: { type: "string" }, // OAuth scope (login)
+  "callback-port": { type: "string" }, // OAuth loopback port (login)
+} as const;
 
 /** The space to operate on: explicit `--space`, else this folder's `.cotal/auth` space, else the
  *  default — matching the manager so a manually-run bridge joins the folder's mesh. */
@@ -23,54 +38,109 @@ function spaceFor(space?: string): string {
   return space ?? loadSpaceAuth(authDir(findCotalRoot()))?.space ?? DEFAULT_SPACE;
 }
 
+/** Merge `--bearer` + `--header "Name: value"` into a headers object (undefined if empty). */
+function parseHeaders(list: string[] | undefined, bearer?: string): Record<string, string> | undefined {
+  const headers: Record<string, string> = {};
+  if (bearer) headers["Authorization"] = `Bearer ${bearer}`;
+  for (const item of list ?? []) {
+    const i = item.indexOf(":");
+    if (i < 0) throw new Error(`bad --header ${JSON.stringify(item)} (use "Name: value")`);
+    headers[item.slice(0, i).trim()] = item.slice(i + 1).trim();
+  }
+  return Object.keys(headers).length ? headers : undefined;
+}
+
+/** `cotal mcp-bridge login --url <oauth mcp server>` — interactive OAuth, caches tokens to disk. */
+async function runLogin(argv: string[]): Promise<void> {
+  const { values } = parseArgs({ args: argv, options: OPTIONS, allowPositionals: false });
+  if (!values.url) {
+    console.error(c.red("✗ --url <oauth mcp server> is required for login"));
+    process.exit(1);
+  }
+  const service = values["mcp-name"] ?? new URL(values.url).host;
+  const port = values["callback-port"] ? Number(values["callback-port"]) : DEFAULT_CALLBACK_PORT;
+  try {
+    const { tools } = await runOAuthLogin({
+      url: values.url,
+      service,
+      sse: values.sse,
+      scope: values.scope,
+      callbackPort: port,
+    });
+    console.log(
+      c.green(`✓ authorized ${service}`) +
+        c.dim(` — ${tools} tools; tokens cached.`) +
+        c.dim(`\n  run: cotal mcp-bridge --url ${values.url} --oauth --mcp-name ${service}`),
+    );
+  } catch (e) {
+    console.error(c.red(`✗ login failed: ${(e as Error).message}`));
+    process.exit(1);
+  }
+}
+
 /**
- * Run an mcp-bridge daemon: connect to one external MCP server and serve its tools on the
- * "mcp" control service, then block until SIGINT/SIGTERM.
+ * Run an mcp-bridge daemon: connect to one MCP server (stdio or remote) and serve its tools on
+ * the "mcp" control service, then block until SIGINT/SIGTERM.
  *
- * The MCP server command + its args are the positionals after `--`, e.g.
- *   cotal mcp-bridge --space demo -- npx -y @modelcontextprotocol/server-everything
+ *   stdio:  cotal mcp-bridge --space demo -- npx -y @modelcontextprotocol/server-everything
+ *   remote: cotal mcp-bridge --space demo --url https://host/mcp --oauth
  */
 async function runBridge(argv: string[]): Promise<void> {
-  const { values, positionals } = parseArgs({
-    args: argv,
-    allowPositionals: true,
-    options: {
-      space: { type: "string" },
-      server: { type: "string" },
-      creds: { type: "string" },
-      name: { type: "string" },
-      service: { type: "string" },
-      "mcp-name": { type: "string" },
-    },
-  });
-  if (!positionals.length) {
+  const { values, positionals } = parseArgs({ args: argv, options: OPTIONS, allowPositionals: true });
+  const remote = Boolean(values.url);
+  if (remote && positionals.length) {
+    console.error(c.red("✗ pass either --url (remote) OR `-- <command>` (stdio), not both"));
+    process.exit(1);
+  }
+  if (!remote && !positionals.length) {
     console.error(
-      red("✗ give the MCP server command after `--`") +
-        dim("\n  e.g. cotal mcp-bridge --space demo -- npx -y @modelcontextprotocol/server-everything"),
+      c.red("✗ give a stdio MCP command after `--`, or a remote server with --url") +
+        c.dim("\n  stdio:  cotal mcp-bridge --space demo -- npx -y @modelcontextprotocol/server-everything") +
+        c.dim("\n  remote: cotal mcp-bridge --space demo --url https://host/mcp --oauth"),
     );
     process.exit(1);
   }
   const space = spaceFor(values.space);
   const server = values.server ?? DEFAULT_SERVER;
   if (!(await isReachable(server))) {
-    console.error(red(`Can't reach NATS at ${server}. Run: cotal up`));
+    console.error(c.red(`Can't reach NATS at ${server}. Run: cotal up`));
     process.exit(1);
   }
   const creds = values.creds ? readFileSync(values.creds, "utf8") : undefined;
-  const [command, ...args] = positionals;
+
+  let spec: McpServerSpec;
+  if (remote) {
+    const url = values.url as string;
+    spec = {
+      name: values["mcp-name"] ?? new URL(url).host,
+      url,
+      sse: values.sse,
+      headers: parseHeaders(values.header, values.bearer),
+      oauth: values.oauth,
+    };
+  } else {
+    const [command, ...args] = positionals;
+    spec = { name: values["mcp-name"] ?? basename(command), command, args };
+  }
+
   const bridge = new McpBridge({
     space,
     servers: server,
     creds,
     name: values.name,
     service: values.service,
-    mcp: [{ name: values["mcp-name"] ?? basename(command), command, args }],
+    mcp: [spec],
   });
-  await bridge.start();
+  try {
+    await bridge.start();
+  } catch (e) {
+    console.error(c.red(`✗ ${(e as Error).message}`));
+    process.exit(1);
+  }
   console.log(
-    green("✓ mcp-bridge up") +
-      dim(` (space ${space} · ${bridge.catalog.length} tools on service "${values.service ?? "mcp"}")`) +
-      dim("\n  peers: cotal_tools to list · cotal_tool to call   (Ctrl-C to shut down)"),
+    c.green("✓ mcp-bridge up") +
+      c.dim(` (space ${space} · ${bridge.catalog.length} tools on service "${values.service ?? "mcp"}")`) +
+      c.dim("\n  peers: cotal_tools to list · cotal_tool to call   (Ctrl-C to shut down)"),
   );
   const shutdown = () => void bridge.stop().then(() => process.exit(0));
   process.on("SIGINT", shutdown);
@@ -83,9 +153,9 @@ const mcpBridgeCommand: Command = {
   name: "mcp-bridge",
   group: "Manager",
   summary:
-    "bridge an external MCP server's tools onto the mesh as a shared service — " +
-    "[--space <s>] [--server <url>] [--service <name>] -- <mcp-command> [args…]",
-  run: runBridge,
+    "bridge an MCP server's tools onto the mesh as a shared service — " +
+    "stdio: `-- <cmd> [args]`; remote: `--url <u> [--oauth | --bearer <t>]`; `login` for OAuth",
+  run: (argv) => (argv[0] === "login" ? runLogin(argv.slice(1)) : runBridge(argv)),
 };
 
 registry.register(mcpBridgeCommand);

--- a/implementations/mcp-bridge/src/commands.ts
+++ b/implementations/mcp-bridge/src/commands.ts
@@ -1,0 +1,91 @@
+import { parseArgs } from "node:util";
+import { readFileSync } from "node:fs";
+import { basename } from "node:path";
+import {
+  isReachable,
+  DEFAULT_SERVER,
+  DEFAULT_SPACE,
+  authDir,
+  findCotalRoot,
+  loadSpaceAuth,
+  registry,
+  type Command,
+} from "@cotal-ai/core";
+import { McpBridge } from "./bridge.js";
+
+const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
+const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
+const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
+
+/** The space to operate on: explicit `--space`, else this folder's `.cotal/auth` space, else the
+ *  default — matching the manager so a manually-run bridge joins the folder's mesh. */
+function spaceFor(space?: string): string {
+  return space ?? loadSpaceAuth(authDir(findCotalRoot()))?.space ?? DEFAULT_SPACE;
+}
+
+/**
+ * Run an mcp-bridge daemon: connect to one external MCP server and serve its tools on the
+ * "mcp" control service, then block until SIGINT/SIGTERM.
+ *
+ * The MCP server command + its args are the positionals after `--`, e.g.
+ *   cotal mcp-bridge --space demo -- npx -y @modelcontextprotocol/server-everything
+ */
+async function runBridge(argv: string[]): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args: argv,
+    allowPositionals: true,
+    options: {
+      space: { type: "string" },
+      server: { type: "string" },
+      creds: { type: "string" },
+      name: { type: "string" },
+      service: { type: "string" },
+      "mcp-name": { type: "string" },
+    },
+  });
+  if (!positionals.length) {
+    console.error(
+      red("✗ give the MCP server command after `--`") +
+        dim("\n  e.g. cotal mcp-bridge --space demo -- npx -y @modelcontextprotocol/server-everything"),
+    );
+    process.exit(1);
+  }
+  const space = spaceFor(values.space);
+  const server = values.server ?? DEFAULT_SERVER;
+  if (!(await isReachable(server))) {
+    console.error(red(`Can't reach NATS at ${server}. Run: cotal up`));
+    process.exit(1);
+  }
+  const creds = values.creds ? readFileSync(values.creds, "utf8") : undefined;
+  const [command, ...args] = positionals;
+  const bridge = new McpBridge({
+    space,
+    servers: server,
+    creds,
+    name: values.name,
+    service: values.service,
+    mcp: [{ name: values["mcp-name"] ?? basename(command), command, args }],
+  });
+  await bridge.start();
+  console.log(
+    green("✓ mcp-bridge up") +
+      dim(` (space ${space} · ${bridge.catalog.length} tools on service "${values.service ?? "mcp"}")`) +
+      dim("\n  peers: cotal_tools to list · cotal_tool to call   (Ctrl-C to shut down)"),
+  );
+  const shutdown = () => void bridge.stop().then(() => process.exit(0));
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+  await new Promise<void>(() => {});
+}
+
+const mcpBridgeCommand: Command = {
+  kind: "command",
+  name: "mcp-bridge",
+  group: "Manager",
+  summary:
+    "bridge an external MCP server's tools onto the mesh as a shared service — " +
+    "[--space <s>] [--server <url>] [--service <name>] -- <mcp-command> [args…]",
+  run: runBridge,
+};
+
+registry.register(mcpBridgeCommand);

--- a/implementations/mcp-bridge/src/index.ts
+++ b/implementations/mcp-bridge/src/index.ts
@@ -1,3 +1,5 @@
 import "./commands.js"; // self-registers the `mcp-bridge` command on import
 
-export { McpBridge, type McpBridgeOptions, type McpServerSpec } from "./bridge.js";
+export { McpBridge, type McpBridgeOptions } from "./bridge.js";
+export { buildClientTransport, buildRemoteTransport, type McpServerSpec } from "./transport.js";
+export { runOAuthLogin, FileOAuthProvider, mcpAuthDir, DEFAULT_CALLBACK_PORT } from "./oauth.js";

--- a/implementations/mcp-bridge/src/index.ts
+++ b/implementations/mcp-bridge/src/index.ts
@@ -1,0 +1,3 @@
+import "./commands.js"; // self-registers the `mcp-bridge` command on import
+
+export { McpBridge, type McpBridgeOptions, type McpServerSpec } from "./bridge.js";

--- a/implementations/mcp-bridge/src/oauth.ts
+++ b/implementations/mcp-bridge/src/oauth.ts
@@ -1,0 +1,255 @@
+import { createServer } from "node:http";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { spawn } from "node:child_process";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import type {
+  OAuthClientInformationMixed,
+  OAuthClientMetadata,
+  OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import { buildRemoteTransport } from "./transport.js";
+import { c } from "./ui.js";
+
+/** Default loopback port for the OAuth redirect — a stable redirect_uri so one dynamic client
+ *  registration stays valid across logins. Override with `--callback-port`. */
+export const DEFAULT_CALLBACK_PORT = 8976;
+
+/** Per-service OAuth cache dir: `~/.cotal/mcp-auth/<service>/` (user-global, like the control socket). */
+export function mcpAuthDir(service: string): string {
+  return join(homedir(), ".cotal", "mcp-auth", service.replace(/[^A-Za-z0-9_.-]/g, "_"));
+}
+
+/** Best-effort open of a URL in the default browser (the URL is also printed). */
+function openBrowser(url: string): void {
+  const [cmd, args] =
+    process.platform === "darwin"
+      ? ["open", [url]]
+      : process.platform === "win32"
+        ? ["cmd", ["/c", "start", "", url]]
+        : ["xdg-open", [url]];
+  try {
+    spawn(cmd as string, args as string[], { stdio: "ignore", detached: true }).unref();
+  } catch {
+    /* no opener on this platform — the printed URL is the fallback */
+  }
+}
+
+export interface OAuthProviderOpts {
+  /** Cache dir (from {@link mcpAuthDir}). */
+  dir: string;
+  /** The loopback redirect URL registered with the authorization server. */
+  redirectUrl: string;
+  scope?: string;
+  /** Invoked when the SDK needs the user to authorize — login opens a browser; the daemon throws. */
+  onRedirect(url: URL): void | Promise<void>;
+}
+
+/**
+ * A disk-backed {@link OAuthClientProvider}. The MCP SDK drives discovery, dynamic client
+ * registration, PKCE, code exchange, and token refresh; this only persists the artifacts
+ * (client registration, tokens, PKCE verifier, CSRF state) under `dir`, mode 0600.
+ */
+export class FileOAuthProvider implements OAuthClientProvider {
+  private readonly dir: string;
+  private readonly _redirectUrl: string;
+  private readonly scope?: string;
+  private readonly onRedirect: (url: URL) => void | Promise<void>;
+  private _state?: string;
+
+  constructor(opts: OAuthProviderOpts) {
+    this.dir = opts.dir;
+    this._redirectUrl = opts.redirectUrl;
+    this.scope = opts.scope;
+    this.onRedirect = opts.onRedirect;
+    mkdirSync(this.dir, { recursive: true });
+  }
+
+  get redirectUrl(): string {
+    return this._redirectUrl;
+  }
+
+  get clientMetadata(): OAuthClientMetadata {
+    return {
+      client_name: "cotal-mcp-bridge",
+      redirect_uris: [this._redirectUrl],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+      ...(this.scope ? { scope: this.scope } : {}),
+    };
+  }
+
+  private file(name: string): string {
+    return join(this.dir, name);
+  }
+  private readJson<T>(name: string): T | undefined {
+    const p = this.file(name);
+    return existsSync(p) ? (JSON.parse(readFileSync(p, "utf8")) as T) : undefined;
+  }
+  private writeJson(name: string, value: unknown): void {
+    writeFileSync(this.file(name), JSON.stringify(value, null, 2), { mode: 0o600 });
+  }
+
+  clientInformation(): OAuthClientInformationMixed | undefined {
+    return this.readJson<OAuthClientInformationMixed>("client.json");
+  }
+  saveClientInformation(info: OAuthClientInformationMixed): void {
+    this.writeJson("client.json", info);
+  }
+
+  tokens(): OAuthTokens | undefined {
+    return this.readJson<OAuthTokens>("tokens.json");
+  }
+  saveTokens(tokens: OAuthTokens): void {
+    this.writeJson("tokens.json", tokens);
+  }
+
+  saveCodeVerifier(verifier: string): void {
+    writeFileSync(this.file("verifier.txt"), verifier, { mode: 0o600 });
+  }
+  codeVerifier(): string {
+    const p = this.file("verifier.txt");
+    if (!existsSync(p)) throw new Error("no PKCE code verifier saved — restart the login");
+    return readFileSync(p, "utf8");
+  }
+
+  state(): string {
+    if (!this._state) {
+      this._state = randomBytes(16).toString("hex");
+      writeFileSync(this.file("state.txt"), this._state, { mode: 0o600 });
+    }
+    return this._state;
+  }
+  /** The state persisted for the in-flight authorization, read by the loopback callback. */
+  pendingState(): string | undefined {
+    const p = this.file("state.txt");
+    return existsSync(p) ? readFileSync(p, "utf8") : undefined;
+  }
+
+  redirectToAuthorization(url: URL): void | Promise<void> {
+    return this.onRedirect(url);
+  }
+
+  /** True once a token has been cached (the daemon refuses to start OAuth without this). */
+  hasTokens(): boolean {
+    return existsSync(this.file("tokens.json"));
+  }
+}
+
+/** Build a daemon-side provider: it never opens a browser — if the SDK needs interactive auth
+ *  (no cached/refreshable token), it throws an actionable error pointing at `login`. */
+export function daemonOAuthProvider(service: string, url: string, scope?: string): FileOAuthProvider {
+  return new FileOAuthProvider({
+    dir: mcpAuthDir(service),
+    redirectUrl: `http://127.0.0.1:${DEFAULT_CALLBACK_PORT}/callback`,
+    scope,
+    onRedirect() {
+      throw new Error(
+        `not authenticated for ${url} — run: cotal mcp-bridge login --url ${url}` +
+          (service ? ` --name ${service}` : ""),
+      );
+    },
+  });
+}
+
+/**
+ * Interactive OAuth login: start a loopback callback server, open the browser to the
+ * authorization URL the SDK builds, capture the redirect, finish the token exchange, and
+ * verify the cached token works. Tokens land in `~/.cotal/mcp-auth/<service>/`.
+ */
+export async function runOAuthLogin(opts: {
+  url: string;
+  service: string;
+  sse?: boolean;
+  scope?: string;
+  callbackPort?: number;
+  /** Override how the authorization URL is opened (defaults to the system browser; tests inject). */
+  openUrl?: (url: string) => void;
+}): Promise<{ tools: number }> {
+  const port = opts.callbackPort ?? DEFAULT_CALLBACK_PORT;
+  const redirectUrl = `http://127.0.0.1:${port}/callback`;
+  const dir = mcpAuthDir(opts.service);
+  const open = opts.openUrl ?? openBrowser;
+
+  const provider = new FileOAuthProvider({
+    dir,
+    redirectUrl,
+    scope: opts.scope,
+    onRedirect(url) {
+      console.log(c.dim(`\nOpening your browser to authorize…\n  ${url.href}\n`));
+      open(url.href);
+    },
+  });
+
+  const transport = buildRemoteTransport(opts.url, { sse: opts.sse, authProvider: provider });
+  const client = new Client({ name: "cotal-mcp-bridge", version: "0.3.1" });
+
+  // Loopback server resolves the authorization code (or "" if already authorized via cache).
+  const code = await new Promise<string>((resolve, reject) => {
+    const server = createServer((req, res) => {
+      const u = new URL(req.url ?? "/", redirectUrl);
+      if (u.pathname !== "/callback") {
+        res.writeHead(404).end();
+        return;
+      }
+      const done = (status: number, html: string) => {
+        res.writeHead(status, { "content-type": "text/html" });
+        res.end(`<!doctype html><meta charset=utf-8><body style="font-family:sans-serif">${html}</body>`);
+        server.close();
+      };
+      const error = u.searchParams.get("error");
+      if (error) {
+        done(400, `<h1>Authorization failed</h1><p>${error}</p>`);
+        reject(new Error(`authorization error: ${error}`));
+        return;
+      }
+      const want = provider.pendingState();
+      if (want && u.searchParams.get("state") !== want) {
+        done(400, "<h1>State mismatch</h1>");
+        reject(new Error("OAuth state mismatch — possible CSRF; aborting"));
+        return;
+      }
+      const got = u.searchParams.get("code");
+      if (!got) {
+        done(400, "<h1>No authorization code</h1>");
+        reject(new Error("no authorization code in callback"));
+        return;
+      }
+      done(200, "<h1>Authorized ✓</h1><p>You can close this tab and return to the terminal.</p>");
+      resolve(got);
+    });
+    server.on("error", reject);
+    server.listen(port, "127.0.0.1", () => {
+      // connect() triggers discovery + redirectToAuthorization (opens the browser). On REDIRECT
+      // it rejects with UnauthorizedError — expected; we then wait for the loopback callback.
+      client.connect(transport).then(
+        () => {
+          server.close();
+          resolve(""); // already authorized via a cached/refreshed token
+        },
+        (e) => {
+          if (e instanceof UnauthorizedError) return;
+          server.close();
+          reject(e);
+        },
+      );
+    });
+  });
+
+  if (code) await transport.finishAuth(code);
+  await client.close().catch(() => {});
+
+  // Verify the cached token actually works (fresh provider that refuses interactive auth).
+  const verifyProvider = daemonOAuthProvider(opts.service, opts.url, opts.scope);
+  const verifyTransport = buildRemoteTransport(opts.url, { sse: opts.sse, authProvider: verifyProvider });
+  const verifyClient = new Client({ name: "cotal-mcp-bridge", version: "0.3.1" });
+  await verifyClient.connect(verifyTransport);
+  const { tools } = await verifyClient.listTools();
+  await verifyClient.close();
+  return { tools: tools.length };
+}

--- a/implementations/mcp-bridge/src/transport.ts
+++ b/implementations/mcp-bridge/src/transport.ts
@@ -1,0 +1,54 @@
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+
+/** One external MCP server to bridge — a local stdio child, or a remote HTTP/SSE endpoint. */
+export type McpServerSpec =
+  | {
+      /** Logical name — namespaces tools as `<name>.<tool>` when more than one server is bridged. */
+      name: string;
+      command: string;
+      args?: string[];
+      env?: Record<string, string>;
+    }
+  | {
+      name: string;
+      url: string;
+      /** Use the legacy SSE transport instead of Streamable HTTP. */
+      sse?: boolean;
+      /** Static headers (e.g. a bearer token) attached to every request. */
+      headers?: Record<string, string>;
+      /** Authenticate via OAuth (uses tokens cached by `cotal mcp-bridge login`). */
+      oauth?: boolean;
+    };
+
+export const isStdioSpec = (s: McpServerSpec): s is Extract<McpServerSpec, { command: string }> =>
+  "command" in s;
+
+/** A remote transport — Streamable HTTP (preferred) or legacy SSE. Both expose `finishAuth`. */
+export type RemoteTransport = StreamableHTTPClientTransport | SSEClientTransport;
+
+/** Build a remote (HTTP/SSE) transport with optional OAuth provider + static headers. */
+export function buildRemoteTransport(
+  url: string,
+  opts: { sse?: boolean; headers?: Record<string, string>; authProvider?: OAuthClientProvider },
+): RemoteTransport {
+  const u = new URL(url);
+  const requestInit = opts.headers ? { headers: opts.headers } : undefined;
+  return opts.sse
+    ? new SSEClientTransport(u, { authProvider: opts.authProvider, requestInit })
+    : new StreamableHTTPClientTransport(u, { authProvider: opts.authProvider, requestInit });
+}
+
+/** Build the MCP client transport for a spec. `authProvider` is used only for remote specs. */
+export function buildClientTransport(
+  spec: McpServerSpec,
+  authProvider?: OAuthClientProvider,
+): Transport {
+  if (isStdioSpec(spec)) {
+    return new StdioClientTransport({ command: spec.command, args: spec.args, env: spec.env });
+  }
+  return buildRemoteTransport(spec.url, { sse: spec.sse, headers: spec.headers, authProvider });
+}

--- a/implementations/mcp-bridge/src/ui.ts
+++ b/implementations/mcp-bridge/src/ui.ts
@@ -1,0 +1,9 @@
+/** Minimal ANSI helpers — local to mcp-bridge so it never imports another implementation. */
+export const c = {
+  dim: (s: string) => `\x1b[2m${s}\x1b[0m`,
+  bold: (s: string) => `\x1b[1m${s}\x1b[0m`,
+  green: (s: string) => `\x1b[32m${s}\x1b[0m`,
+  cyan: (s: string) => `\x1b[36m${s}\x1b[0m`,
+  yellow: (s: string) => `\x1b[33m${s}\x1b[0m`,
+  red: (s: string) => `\x1b[31m${s}\x1b[0m`,
+};

--- a/implementations/mcp-bridge/tsconfig.json
+++ b/implementations/mcp-bridge/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "smoke:attention:auth": "tsx extensions/connector-core/attention-auth.smoke.ts",
     "smoke:feedback": "tsx extensions/connector-core/feedback.smoke.ts",
     "smoke:attach": "tsx implementations/manager/attach.smoke.ts",
+    "smoke:mcp-bridge": "tsx implementations/mcp-bridge/mcp-bridge.smoke.ts",
     "smoke:install": "tsx implementations/cli/install.smoke.ts",
     "smoke:send": "tsx implementations/cli/send.smoke.ts"
   },
@@ -42,7 +43,8 @@
     "@cotal-ai/connector-hermes": "workspace:*",
     "@cotal-ai/connector-opencode": "workspace:*",
     "@cotal-ai/core": "workspace:*",
-    "@cotal-ai/manager": "workspace:*"
+    "@cotal-ai/manager": "workspace:*",
+    "@cotal-ai/mcp-bridge": "workspace:*"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "smoke:feedback": "tsx extensions/connector-core/feedback.smoke.ts",
     "smoke:attach": "tsx implementations/manager/attach.smoke.ts",
     "smoke:mcp-bridge": "tsx implementations/mcp-bridge/mcp-bridge.smoke.ts",
+    "smoke:mcp-bridge:remote": "tsx implementations/mcp-bridge/mcp-bridge-remote.smoke.ts",
     "smoke:install": "tsx implementations/cli/install.smoke.ts",
     "smoke:send": "tsx implementations/cli/send.smoke.ts"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@cotal-ai/manager':
         specifier: workspace:*
         version: link:implementations/manager
+      '@cotal-ai/mcp-bridge':
+        specifier: workspace:*
+        version: link:implementations/mcp-bridge
     devDependencies:
       '@changesets/cli':
         specifier: ^2.31.0
@@ -69,6 +72,9 @@ importers:
       '@cotal-ai/manager':
         specifier: workspace:*
         version: link:../implementations/manager
+      '@cotal-ai/mcp-bridge':
+        specifier: workspace:*
+        version: link:../implementations/mcp-bridge
 
   examples/01-lateral-coordination:
     dependencies:
@@ -310,6 +316,15 @@ importers:
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
+
+  implementations/mcp-bridge:
+    dependencies:
+      '@cotal-ai/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
 
   packages/core:
     dependencies:


### PR DESCRIPTION
## What

A new standalone endpoint (`implementations/mcp-bridge`) that connects to an MCP server **once** and offers its tools to the **whole mesh** as a callable service — instead of each agent wiring up its own MCP servers. The MCP server becomes a lateral peer whose service is "run this tool"; Cotal's existing control plane is the call mechanism. No core-protocol changes.

Works with **any MCP-compatible server**: local **stdio**, or remote **HTTP / SSE**, with **static bearer/header** auth or **full interactive OAuth**.

## How it works

**Provider — `McpBridge` (`src/bridge.ts`, `src/transport.ts`)**
- Connects out to the MCP server as a **client**. Transport is chosen per spec (`src/transport.ts`): `StdioClientTransport`, `StreamableHTTPClientTransport`, or `SSEClientTransport`. `listTools()` populates the catalog (multiple servers namespace as `<server>.<tool>`).
- Joins the mesh like the `manager` (`CotalEndpoint`, `consume:false`, `role: mcp-bridge`) and `serveControl("mcp", …)` with two ops: `list` (catalog) and `call` (`{tool, arguments}` → `client.callTool` → result; MCP `isError` → `{ok:false}`).

**OAuth — `src/oauth.ts`**
- `cotal mcp-bridge login --url <server>` runs the interactive flow: a `node:http` loopback callback + browser open; the SDK does discovery (RFC 9728/8414), dynamic client registration, PKCE, and code exchange. Tokens cache to `~/.cotal/mcp-auth/<service>/` (0600).
- The daemon (`--oauth`) loads cached tokens (SDK auto-refreshes); if none, it throws an actionable error pointing at `login` — no interactive auth from a daemon.

**Wire path — the control plane** (`serveControl`/`requestControl`)
- Request/reply, **queue-grouped** (run several bridges of one service to load-balance), **authenticated** (handler sees a verified `req.from.id` — the seam a per-caller ACL hooks into). Consumer calls with a 60s timeout.

**Consumer — coding agents (`connector-core`, off by default)**
- Gated behind `COTAL_MCP_BRIDGE=1`. `cotalToolSpecs()` appends `cotal_tools` (list) + `cotal_tool` (call) via thin `MeshAgent` helpers — two generic tools, no per-tool JSON-Schema→Zod conversion, no renderer changes.

## CLI

```
cotal mcp-bridge --space <s> -- npx -y @modelcontextprotocol/server-everything   # stdio
cotal mcp-bridge --space <s> --url https://host/mcp --bearer <token>             # remote, static token
cotal mcp-bridge login       --url https://host/mcp                               # remote, OAuth (one-time)
cotal mcp-bridge --space <s> --url https://host/mcp --oauth                        # remote, OAuth (cached token)
```

## Verification

- `pnpm typecheck` — clean across all projects.
- `pnpm smoke:mcp-bridge` (stdio) — discover → list over mesh → call round-trips → unknown rejected. 4/4.
- `pnpm smoke:mcp-bridge:remote` (hermetic, no network):
  - HTTP + static bearer: bearer-gated Streamable HTTP fixture → list/call over the mesh.
  - Full OAuth: a fake auth+resource server (DCR + PKCE + authorize/token); headless `login` caches a token, then the daemon runs with `--oauth` off it and calls `echo`. 4/4.

## Conventions

Added `@cotal-ai/mcp-bridge` to the changeset `fixed` group + a changeset file, and to the README package table, CLAUDE.md Layout, and `docs/release.md`.

## Follow-ups (deferred)

- Per-caller ACLs on the `call` op (gate by the verified `req.from.id`).
- Streaming / long-running tool results (one-shot reply today).
- Multiple servers in one CLI invocation (run one bridge per server today).
- Deep protocol writeup in `docs/architecture.md` + SPEC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)