### PR TITLE
ci: Discord release announcements

### DIFF
--- a/.github/workflows/github-releases-to-discord.yml
+++ b/.github/workflows/github-releases-to-discord.yml
@@ -1,0 +1,19 @@
+on:
+  release:
+    types: [published]
+
+jobs:
+  github-releases-to-discord:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: GitHub Releases to Discord
+        uses: SethCohen/github-releases-to-discord@v1
+        with:
+          webhook_url: ${{ secrets.WEBHOOK_URL }}
+          color: "2105893"
+          username: "Release Changelog"
+          content: "||@everyone||"
+          footer_title: "Changelog"
+          reduce_headings: true


### PR DESCRIPTION
Adds `SethCohen/github-releases-to-discord`, firing only on `release: [published]`. Posts a formatted changelog to Discord.

**Required before this works:** a `WEBHOOK_URL` repo secret holding the **raw** Discord webhook URL (no `/github` suffix — that's only for GitHub's native webhook).

**Avoid double-posting:** uncheck the **Releases** event on the existing native GitHub→Discord webhook (the `/github` one) so releases only come through this Action.