### PR TITLE
fix(manager): clear all Claude startup gates in the pty runtime (#34)

### DIFF
--- a/.changeset/pty-startup-gates.md
+++ b/.changeset/pty-startup-gates.md
@@ -1,0 +1,7 @@
+---
+"@cotal-ai/manager": patch
+---
+
+fix(manager): clear all Claude startup gates in the pty runtime
+
+Claude ≥2.1.178 shows two back-to-back Enter-to-confirm gates on a fresh workspace (folder trust, then the dev-channels warning); the one-shot auto-confirm cleared only the first and hung managed agents at `starting…`. The pty runtime now presses Enter on a short timer during startup (matching the cmux runtime) instead of matching prompt text, so it clears the variable number of gates and the agent joins the mesh.

--- a/implementations/manager/src/runtime/pty.ts
+++ b/implementations/manager/src/runtime/pty.ts
@@ -5,20 +5,17 @@ const DEFAULT_COLS = 120;
 const DEFAULT_ROWS = 32;
 /** How much terminal output to retain for late-attach scrollback replay. */
 const SCROLLBACK_BYTES = 256 * 1024;
-/** Stop watching for a spawn-confirm prompt after this long (it appears at startup). */
-const CONFIRM_WINDOW_MS = 20_000;
+/** Spacing between auto-confirm Enter presses, and how many to send. Claude's startup gates
+ *  (workspace-trust, then the dev-channels warning) each wait for Enter and neither has a headless
+ *  override. The count is variable — a fresh folder shows both, a re-launch on a now-trusted folder
+ *  shows only the channels gate — and each gate's screen is static once rendered, so we don't match
+ *  text or count prompts: press Enter blindly a few times, spaced so each press lands on the next
+ *  gate and a dropped press is retried. Both gates default-highlight "proceed", so Enter accepts the
+ *  safe option; any extra press lands on Claude's empty input as a no-op. */
+const CONFIRM_INTERVAL_MS = 1_000;
+const MAX_CONFIRMS = 5;
 /** Grace window for a clean exit before a graceful stop escalates to SIGKILL. */
 const GRACE_MS = 3_000;
-
-/** Strip ANSI control sequences and whitespace so a confirm prompt matches regardless
- *  of how a TUI positions its text (cursor moves between words, not spaces). */
-function normalizeForMatch(s: string): string {
-  return s
-    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, "") // OSC
-    .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "") // CSI
-    .replace(/\x1b[@-Z\\-_]/g, "") // other escapes
-    .replace(/\s+/g, "");
-}
 
 /**
  * The default runtime: the manager spawns the agent in a pseudo-terminal it owns
@@ -46,12 +43,21 @@ export class PtyRuntime implements Runtime {
     let cols = DEFAULT_COLS;
     let rows = DEFAULT_ROWS;
 
-    // Auto-clear a one-time spawn prompt (e.g. Claude's dev-channel confirmation):
-    // watch early output for `spec.confirm` and press Enter once when it appears.
-    const confirmTarget = spec.confirm ? normalizeForMatch(spec.confirm) : "";
-    let confirmArmed = Boolean(confirmTarget);
-    let confirmBuf = "";
-    if (confirmArmed) setTimeout(() => (confirmArmed = false), CONFIRM_WINDOW_MS);
+    // Clear Claude's startup gates (workspace-trust, dev-channels warning) by pressing Enter on a
+    // timer during the startup window — see CONFIRM_INTERVAL_MS for why this is blind, not output-
+    // driven. A spawn that opts in sets `spec.confirm` truthy.
+    let confirmTimer: ReturnType<typeof setInterval> | undefined;
+    if (spec.confirm) {
+      let presses = 0;
+      confirmTimer = setInterval(() => {
+        if (!alive || presses++ >= MAX_CONFIRMS) {
+          clearInterval(confirmTimer);
+          confirmTimer = undefined;
+          return;
+        }
+        proc.write("\r");
+      }, CONFIRM_INTERVAL_MS);
+    }
 
     proc.onData((d) => {
       const b = Buffer.from(d, "utf8");
@@ -60,19 +66,11 @@ export class PtyRuntime implements Runtime {
       while (ringBytes > SCROLLBACK_BYTES && ring.length > 1) {
         ringBytes -= ring.shift()!.length;
       }
-      if (confirmArmed) {
-        confirmBuf = (confirmBuf + d).slice(-8192);
-        if (normalizeForMatch(confirmBuf).includes(confirmTarget)) {
-          confirmArmed = false;
-          // Let the TUI finish wiring up its raw-mode input loop (it may flush
-          // stdin on init) before pressing Enter, or the keypress is dropped.
-          setTimeout(() => alive && proc.write("\r"), 500);
-        }
-      }
       for (const fn of dataSubs) fn(b);
     });
     proc.onExit(() => {
       alive = false;
+      if (confirmTimer) clearInterval(confirmTimer);
       for (const fn of exitSubs) fn();
     });
 


### PR DESCRIPTION
## Problem (#34)
Managed (pty) agents hang at `starting…` on Claude Code ≥2.1.178 and never join the mesh.

## Root cause
On a fresh/untrusted workspace, Claude ≥2.1.178 shows **two** back-to-back `Enter to confirm` gates at startup: the workspace **trust** prompt, then the **dev-channels warning** (`--dangerously-load-development-channels`). The pty runtime's auto-confirm was **one-shot** — its single Enter cleared the trust prompt and then it blocked forever on the channels warning, so the cotal MCP never loaded and presence never registered.

The gate count is also **variable**: a fresh folder shows both, but a re-launch on an already-trusted folder shows only the channels gate (Enter on the trust screen persists the trust).

## Fix
`implementations/manager/src/runtime/pty.ts`: drop the output-watching/text-match logic and press Enter on a short timer during the startup window (1s spacing, capped), exactly like the **cmux runtime** already does. This:

- is **wording-independent** — it never reads the screen, so it can't break when Anthropic tweaks the `Enter to confirm` footer (the failure mode there is a silent hang);
- **self-retries a dropped press** — a press lost before the TUI's raw-mode input is wired up is repeated on the next tick;
- handles the **variable gate count** — extra Enters land on Claude's empty input as no-ops;
- **unifies the two runtimes** on one mechanism and deletes ~40 lines of match/cooldown/buffer machinery.

Both gates default-highlight the "proceed" option, so a blind Enter accepts the safe choice.

## Verified on real Claude 2.1.181
Drove the real `PtyRuntime` against `claude` in a fresh (untrusted) temp dir:

- **Before (one-shot):** cleared the trust gate, then sat frozen on the dev-channels warning — identical screen from t=2s through t=16s. Reproduces #34.
- **After (this change):** cleared trust at t≈1s and channels at t≈2s, reached the live interactive UI by t≈4s with `Channels (experimental) … inject directly in this session` (the cotal channel loaded). The extra blind Enters were no-ops — the live UI was byte-identical from t=4s to t=16s, no stray submits.
- `pnpm --filter @cotal-ai/manager typecheck` green.

## Relationship to #35
Same bug, same fix point. #35 keeps text-matching `"Enter to confirm"` on a timer with a cooldown and buffer-clear. This is the simpler, more robust alternative: no screen-scraping (so no dependence on a string Anthropic controls), natural retry of a dropped press, and parity with the cmux runtime instead of a second, different prompt-clearing path. Suggest closing #35 in favor of this.

Closes #34.