### PR TITLE
ci: keep release notes clean

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -52,6 +52,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
 
+      # Keep the "version packages" PR out of the generated release notes (excluded via .github/release.yml).
+      - name: Label the release PR
+        if: steps.changesets.outputs.pullRequestNumber
+        run: gh pr edit ${{ steps.changesets.outputs.pullRequestNumber }} --add-label skip-changelog
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+
       # ci:publish is `pnpm publish` (for OIDC provenance), which doesn't create git tags — so tag
       # the released versions ourselves whenever a publish actually happened. `changeset tag` creates
       # one tag per package at its current version (e.g. @cotal-ai/connector-core@0.1.3), skipping

--- a/.github/workflows/github-releases-to-discord.yml
+++ b/.github/workflows/github-releases-to-discord.yml
@@ -17,3 +17,4 @@ jobs:
           content: "||@everyone||"
           footer_title: "Changelog"
           reduce_headings: true
+          remove_github_reference_links: true


### PR DESCRIPTION
Two small cleanups so release notes + the Discord announcement stay tidy:

- **Drop the changeset noise** — the changesets workflow now auto-labels each `chore(release): version packages` PR with `skip-changelog`, and `.github/release.yml` excludes that label from generated notes.
- **Tidy the Discord post** — `remove_github_reference_links: true` strips the inline `…in https://github.com/…` links from every line.

Takes effect on the next release. (The big v0.3.1 list was a one-time first-release artifact — future releases only list PRs since the last one.)