### PR TITLE
feat(security): control-plane hardening — three-tier authz, definePersona policy split, spawn bounding

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -593,7 +593,9 @@ server, not by agent goodwill. It is containment + authenticity for a single tru
   builders so the ACLs can't drift from the wire layout):
   - **agent** — publish only `chat.<ownId>.<declared-channel>` (the `publish:` list in the
     agent file, falling back to `channels:`; wildcard subtrees like `team.>` flow through),
-    plus `inst.*.<ownId>` / `svc.*.<ownId>` / `ctl.<mgr>.<ownId>`. Presence PUT scoped to its
+    plus `inst.*.<ownId>` / `svc.*.<ownId>`, and `ctl.self.<ownId>` (self-service control, every
+    agent) — the privileged `ctl.manager.<ownId>` **only** when the agent file declares
+    `capabilities: [spawn]` (default-deny otherwise). Presence PUT scoped to its
     own key. `$JS.API` scoped to its own chat/task/DM durables (chat & task self-created
     name-scoped; **DM and TASK bind-only** — create denied). `sub.allow = [_INBOX_<ownId>.>]`.
   - **observer** — read-only: `sub.allow = [chat.>, _INBOX_<ownId>.>]`, pub = CHAT + presence
@@ -607,6 +609,40 @@ server, not by agent goodwill. It is containment + authenticity for a single tru
     `DM_<space>` is the DM-confidentiality surface, granted here only for this profile.
   - **manager** — privileged (broad), the provisioner host; pre-creates others' DM/TASK
     durables. (Eventually should be scoped too — see limitations.)
+- **The control plane is split into three privilege tiers**, op↔tier routed **fail-closed** by the
+  manager (a misrouted op is rejected before anything acts — the cred gates *who reaches* a subject,
+  this gates *what each subject honors*):
+  - `ctl.self.<id>` (every agent) — only the no-name self stop/despawn; the target resolves from the
+    authenticated sender, so there's no field to forge.
+  - `ctl.manager.<id>` (**privileged**, default-denied to agents — granted only when the agent file
+    declares `capabilities: [spawn]`) — spawn, plus stop/despawn/attach of the caller's **own**
+    children (`spawner == caller`) and redefining its own personas. So spawn is a *declared
+    capability*, off by default, enforced by nats-server, not a handler.
+  - `ctl.admin.<id>` (reached only by the manager's allow-all profile — **no agent ever gets it**) —
+    the destructive / cross-agent operator ops: `purge`, and stop/despawn/attach/`definePersona` of
+    *any* agent. Admin is transport-proven (reaching the subject = holding manager creds), so the
+    handler never guesses it. `purge` lives here on purpose: on the privileged tier any spawn-capable
+    agent could wipe space history.
+- **`definePersona` separates content from policy.** Its write path takes only content
+  (`model` / `persona`) — `role` / `publish` / `capabilities` / `owner` are policy and have no slot,
+  so a peer can't grant itself a capability or seize ownership by redefining. A fresh name records
+  its creator as `owner`; redefining an existing file preserves all policy and is allowed on the
+  privileged tier only if `owner == caller`, else admin. Fail-closed: an ownerless (legacy /
+  operator-written) file is admin-only.
+- **Spawn is bounded (availability).** A synchronous gate caps concurrent + in-flight agents
+  (`MAX_AGENTS`), and a minimum-lifetime "cooling" floor bounds spawn↔despawn churn — so a
+  capability-holding-but-compromised peer can't fork-bomb the host. The ceiling holds under **every**
+  runtime. *Caveat:* reaping a self-**exited** agent's slot is wired only where the runtime streams an
+  exit signal (pty/tmux); under cmux a self-exited agent lingers until explicitly despawned — the cap
+  still holds (it counts the corpse), only the reaping is deferred. Runtime-agnostic exit-reaping
+  (cmux liveness → sweep-at-gate) is a tracked follow-up.
+- **Spawned children get a declared env, not the manager's.** Runtimes pass only an explicit
+  allow-list (`launchEnv()` — PATH / HOME / locale / TERM, plus the one model key the connector
+  needs), never `process.env`, so the operator's *unrelated* secrets (cloud creds, tokens) stop
+  bleeding into every agent. Honest scope: this closes **env-var** bleed only. It does **not** close
+  model-key exfil (the agent holds the key in-process to do inference — needs per-agent model auth)
+  or filesystem reads (`HOME` is forwarded, so a child can still read `~/.aws` / `~/.ssh` off disk —
+  needs a workspace sandbox).
 - **DM & TASK confidentiality close two leak paths.** *Delivery path:* all NATS delivery rides
   the connection inbox, and NATS delivers a subject to every subscriber, so a wildcard
   `_INBOX.>` subscribe would sniff peers' deliveries. Fix: a **per-identity inbox prefix**
@@ -634,7 +670,12 @@ server, not by agent goodwill. It is containment + authenticity for a single tru
 - **Signing key + operator seed are hot** in `.cotal/auth` (the mint/manager box) — not yet
   key-confined; the "real boundary" holds only given operator-controlled cred distribution.
   Operator seed should be cold-stored (it's the root; only needed for account setup/rotation).
-- **No revocation / TTL** on minted creds yet.
+- **No credential revocation / TTL** on minted creds yet — and this bounds containment:
+  `cotal_despawn` cuts an agent's **session**, not its **credential**. A compromised agent that
+  copied its own (no-TTL bearer) creds can reconnect afterward, from any host, until the space
+  signing key is **rotated** (which re-mints *everyone* — the only per-cred revocation today) or it's
+  cut at the network. Despawn is the immediate lever, not full containment of a compromised identity;
+  per-cred TTL/rotation is the deferred fix (auth-callout, below).
 - `isReachable` conflates auth-failure with server-down (misleading "run cotal up").
 - The **manager profile is allow-all** — fine for Demo 1, but the most-privileged identity
   should eventually be scoped for the full untrusted-peer claim.

--- a/implementations/manager/env-isolate.smoke.ts
+++ b/implementations/manager/env-isolate.smoke.ts
@@ -65,7 +65,9 @@ if (tmuxOk) {
   const h = runtime.spawn("p3-tmux", spec, cwd);
   await new Promise((r) => setTimeout(r, 900)); // let printenv run + render
   let out = "";
-  try { out = execFileSync("tmux", ["capture-pane", "-p", "-t", "cotal-p3-smoke:p3-tmux"], { encoding: "utf8" }); } catch { /* window gone */ }
+  // `-S -` captures the FULL scrollback, not just the visible screen — printenv dumps the whole
+  // allow-list (~20 lines) and PATH (an early line) would otherwise scroll off a short pane.
+  try { out = execFileSync("tmux", ["capture-pane", "-p", "-S", "-", "-t", "cotal-p3-smoke:p3-tmux"], { encoding: "utf8" }); } catch { /* window gone */ }
   console.log("tmux runtime:");
   check("sentinel ABSENT from child env (env -i cleared inheritance)", !out.includes(SENTINEL));
   check("PATH present (OS allow-list set after -i)", /PATH=/.test(out));

--- a/implementations/manager/src/commands.ts
+++ b/implementations/manager/src/commands.ts
@@ -14,8 +14,10 @@ import {
   newIdentity,
   registry,
   CONTROL_PRIVILEGED,
+  CONTROL_ADMIN,
   type Command,
   type ControlReply,
+  type ControlTier,
 } from "@cotal-ai/core";
 import { Manager } from "./manager.js";
 import { loadRoster } from "./roster.js";
@@ -63,13 +65,17 @@ function parse(argv: string[]): Values {
   return values as Values;
 }
 
-/** Connect a short-lived client, send one control request to the manager, disconnect. */
+/** Connect a short-lived client, send one control request to the manager, disconnect. `tier` picks
+ *  the control subject: privileged for spawn/ps; admin for the operator's cross-agent ops
+ *  (stop/attach/purge), which the manager refuses on the privileged subject for a non-owner. The
+ *  CLI mints a "manager" cred (allow-all), so it can reach either subject. */
 async function ask(
   space: string,
   server: string,
   op: string,
   args?: Record<string, unknown>,
   credsPath?: string,
+  tier: ControlTier = CONTROL_PRIVILEGED,
 ): Promise<ControlReply> {
   // An explicit --creds wins; else self-mint a privileged "manager" cred from .cotal/auth so the
   // operator's start/stop/ps reach the privileged control subject (P5: only spawn-capable/admin/
@@ -105,7 +111,7 @@ async function ask(
   ep.on("error", (e: Error) => console.error(c.red("! " + e.message)));
   await ep.start();
   try {
-    return await ep.requestControl(CONTROL_PRIVILEGED, { op, args });
+    return await ep.requestControl(tier, { op, args });
   } catch (e) {
     return { ok: false, error: `no manager reachable (${(e as Error).message})` };
   } finally {
@@ -148,9 +154,11 @@ async function stop(argv: string[]): Promise<void> {
     console.error(c.red("--name is required"));
     process.exit(1);
   }
+  // Operator stop is a cross-agent (admin) op — the CLI operator isn't the agent's spawner, so the
+  // privileged subject would reject it; admin (its allow-all "manager" cred reaches it) is correct.
   const reply = await ask(spaceFor(v), v.server ?? DEFAULT_SERVER, "stop", {
     name: v.name,
-  }, v.creds);
+  }, v.creds, CONTROL_ADMIN);
   failIfNotOk(reply);
   console.log(c.dim(`✓ stopped ${v.name}`));
 }
@@ -196,9 +204,11 @@ async function attach(argv: string[]): Promise<void> {
     console.error(c.red("--name is required"));
     process.exit(1);
   }
+  // Operator attach is a cross-agent (admin) op — same reasoning as stop (the operator isn't the
+  // spawner; admin reaches any agent).
   const reply = await ask(spaceFor(v), v.server ?? DEFAULT_SERVER, "attach", {
     name: v.name,
-  }, v.creds);
+  }, v.creds, CONTROL_ADMIN);
   failIfNotOk(reply);
   const { ws } = reply.data as { ws: string };
   console.error(c.dim(`attached to ${v.name} — Ctrl-] to detach`));

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -16,6 +16,7 @@ import {
   saveAgentFile,
   CONTROL_PRIVILEGED,
   CONTROL_SELF_SERVICE,
+  CONTROL_ADMIN,
 } from "@cotal-ai/core";
 import type { AgentDef, Connector, ControlReply, ControlRequest, ControlTier, SpaceAuth } from "@cotal-ai/core";
 import {
@@ -25,6 +26,14 @@ import {
   type RuntimeMode,
 } from "./runtime/index.js";
 import { AttachEndpoint } from "./attach-endpoint.js";
+
+/** Concurrency ceiling — the manager refuses to hold more than this many live + in-flight +
+ *  cooling slots at once (P4a). Bounds a fork-bomb: spawn is a full agent process per call. */
+const MAX_AGENTS = 50;
+/** Minimum slot lifetime for rate-flooring (P4c). A slot freed (by despawn OR natural exit/reap)
+ *  before living this long leaves a cooling stamp that still counts toward the ceiling until it
+ *  expires — so churn (spawn↔despawn or spawn↔fast-exit) can't outrun the concurrency bound. */
+const MIN_LIFETIME = 10_000;
 
 export interface ManagerOptions {
   space: string;
@@ -80,6 +89,12 @@ export class Manager {
   private readonly workspaceRoot: string;
   private readonly runtime: Runtime;
   private readonly agents = new Map<string, ManagedAgent>();
+  /** Names whose spawn is in flight (reserved synchronously before the provision await) — counted
+   *  toward the ceiling so two concurrent same-name spawns can't both pass the gate (P4a). */
+  private readonly reserved = new Set<string>();
+  /** Expiry stamps (`startedAt + MIN_LIFETIME`) for slots that freed while still young — a
+   *  count-only, lazily-pruned recycle floor (P4c). Pruned + summed into the ceiling gate. */
+  private cooling: number[] = [];
   private readonly attach: AttachEndpoint;
   private ep!: CotalEndpoint;
   /** Space trust material when the mesh runs in auth mode (`.cotal/auth` present);
@@ -141,13 +156,15 @@ export class Manager {
     this.ep.on("error", (e: Error) => console.error(`! manager endpoint: ${e.message}`));
     await this.ep.start();
     await this.ep.setActivity(`supervisor (${this.runtime.kind})`);
-    // Serve both control tiers (P2a): the privileged subject (start/purge/definePersona/named
-    // stop) and the self-service subject (self stop/despawn). The cred layer grants self-service
-    // to every agent and privileged only to spawn-capable ones (default-deny); the handler then
-    // routes by op↔tier (fail-closed on mismatch) so a privileged op on the self-service subject
-    // — or a self op on the privileged subject — is rejected before anything acts.
+    // Serve all three control tiers (P2a): self-service (no-name self stop/despawn), privileged
+    // (start / own-child stop-despawn-attach / own definePersona), and admin (purge / cross-agent
+    // stop-despawn-attach / cross-agent definePersona). The cred layer grants self-service to every
+    // agent, privileged only to spawn-capable ones, and admin only to the manager's own profile
+    // (no agent ever reaches it); the handler then routes by op↔tier (fail-closed on mismatch) so a
+    // misrouted op is rejected before anything acts.
     this.ep.serveControl(CONTROL_PRIVILEGED, (req) => this.handle(req, CONTROL_PRIVILEGED));
     this.ep.serveControl(CONTROL_SELF_SERVICE, (req) => this.handle(req, CONTROL_SELF_SERVICE));
+    this.ep.serveControl(CONTROL_ADMIN, (req) => this.handle(req, CONTROL_ADMIN));
   }
 
   async stop(): Promise<void> {
@@ -163,42 +180,56 @@ export class Manager {
     // advisory in open mode (consistent with "open = single-trusted-host"). Thread it to every op
     // so authz (P2c) and the spawner ledger (P4b) can act on it.
     const caller = req.from.id;
+    const name = String(args.name ?? "").trim();
     // Op↔tier binding — the real enforcement per the split. The cred gates WHO can reach each
     // subject; this gates WHAT each subject will honor, fail-closed. A privileged op arriving on
     // the self-service subject (publishable by all) must be rejected or the split does nothing.
     if (tier === CONTROL_SELF_SERVICE) {
       // Self-service honors ONLY a no-name stop (self-despawn). Any other op — including a named
-      // stop (belongs on privileged) — is a misroute and rejected.
+      // stop (belongs on privileged/admin) — is a misroute and rejected.
       if (req.op !== "stop") return { ok: false, error: `op "${req.op}" not allowed on self-service control subject` };
-      const name = String(args.name ?? "").trim();
       if (name) return { ok: false, error: "named stop not allowed on self-service subject; send it on the privileged subject" };
       return this.opStopSelf(caller, args);
     }
-    // Privileged tier. A no-name stop is a self-op and belongs on the self-service subject.
+    const admin = tier === CONTROL_ADMIN;
+    // Privileged + admin tiers. A no-name stop is a self-op and belongs on the self-service subject.
     switch (req.op) {
       case "start":
+        // Spawn is a privileged-tier op; reaching it via admin is fine (admin ⊇ privileged powers).
         return this.opStart(args, caller);
       case "stop": {
-        const name = String(args.name ?? "").trim();
         if (!name) return { ok: false, error: "self-stop not allowed on privileged subject; send it on the self-service subject" };
-        return this.opStop(args, caller);
+        return this.opStop(args, caller, admin);
       }
       case "definePersona":
-        return this.opDefinePersona(args, caller);
+        return this.opDefinePersona(args, caller, admin);
       case "purge":
+        // SECURITY: purge clears space history incl. DMs — admin-only. On the privileged tier any
+        // spawn-capable agent could wipe the space, so it must not be honored there.
+        if (!admin) return { ok: false, error: "purge is admin-only; not allowed on the privileged subject" };
         return this.opPurge(args, caller);
       case "attach":
-        return this.opAttach(args);
+        return this.opAttach(args, caller, admin);
       case "ps":
         return { ok: true, data: this.list() };
       case "status": {
-        const name = String(args.name ?? "");
         const a = this.list().find((x) => x.name === name);
         return a ? { ok: true, data: a } : { ok: false, error: `no agent "${name}"` };
       }
       default:
         return { ok: false, error: `unknown op: ${req.op}` };
     }
+  }
+
+  /** Collapsed despawn/attach authorization (P4b). The caller already reached the privileged or
+   *  admin tier (cred-gated). On the admin tier any named target is allowed (operator). On the
+   *  privileged tier a named target is allowed ONLY if it's the caller's OWN child
+   *  (`spawner == caller`) — so a spawn-capable peer can tear down what it spawned, never a peer's.
+   *  Returns an error string when denied, `undefined` when allowed. */
+  private authorizeNamed(target: ManagedAgent, caller: string, admin: boolean): string | undefined {
+    if (admin) return undefined;
+    if (target.spawner === caller) return undefined;
+    return `not authorized: ${target.name} was not spawned by ${caller} (admin tier required)`;
   }
 
   /** Self-despawn (P2b): stop the managed agent whose id == the authenticated caller. The
@@ -211,8 +242,39 @@ export class Manager {
     if (!target) return { ok: false, error: `self-stop: caller ${callerId} is not a managed agent` };
     const graceful = args.graceful !== false;
     target.handle.stop({ graceful });
-    this.agents.delete(target.name);
+    this.freeSlot(target, true); // self-despawn is rate-floored (recycle churn)
     return { ok: true, data: { name: target.name, stopped: true, graceful } };
+  }
+
+  /** Drop a live agent's slot. When `floor` is set and the agent died young (lived less than
+   *  MIN_LIFETIME), push a cooling stamp so the freed slot still counts toward the ceiling until it
+   *  expires — flooring the RECYCLE, not the call, so both free paths (despawn + exit/reap) are
+   *  covered (P4c). Floor self + own-child despawn and natural exit; NEVER admin despawn (operator
+   *  emergency-kill stays unthrottled) and NEVER the reserved-rollback path (no cold-start paid). */
+  private freeSlot(a: ManagedAgent, floor: boolean): void {
+    if (this.agents.get(a.name) !== a) return; // already freed (exit raced despawn, etc.)
+    this.agents.delete(a.name);
+    if (floor && Date.now() - a.startedAt < MIN_LIFETIME) this.cooling.push(a.startedAt + MIN_LIFETIME);
+  }
+
+  /** Reap a parent's children on its exit (P4b): stop + free every agent whose `spawner` is the
+   *  exited agent's id, so orphans don't ratchet the ceiling shut. Recursive — a reaped child's
+   *  own children are reaped too. Exit-driven, so each freed slot is rate-floored like a despawn. */
+  private reapChildrenOf(parentId: string): void {
+    for (const child of [...this.agents.values()]) {
+      if (child.spawner !== parentId) continue;
+      child.handle.stop({ graceful: false });
+      this.freeSlot(child, true);
+      this.reapChildrenOf(child.id);
+    }
+  }
+
+  /** A managed agent's process exited on its own (crash, /exit, finished). Free its slot
+   *  (rate-floored — exit-driven churn counts) and reap any children it spawned. Idempotent via
+   *  freeSlot's identity guard, so a later graceful-stop SIGKILL firing exit again is a no-op. */
+  private onAgentExit(a: ManagedAgent): void {
+    this.freeSlot(a, true);
+    this.reapChildrenOf(a.id);
   }
 
   /** Agent names become `.cotal/agents/<name>.md` paths and mesh identities, so they must be bare
@@ -265,80 +327,121 @@ export class Manager {
     if (!name) return { ok: false, error: "name required" };
     const nameErr = this.nameError(name);
     if (nameErr) return { ok: false, error: nameErr };
-    if (this.agents.has(name)) return { ok: false, error: `agent "${name}" already running` };
     const agent = opts.agent ?? "cotal";
 
-    // Resolve an agent file from the manager's own workspace — an explicit
-    // --config must exist; otherwise discover .cotal/agents/<name>.md if present.
-    let configPath: string | undefined;
-    if (opts.config) {
-      configPath = agentFilePath(this.workspaceRoot, opts.config);
-      if (!existsSync(configPath)) return { ok: false, error: `agent file not found: ${configPath}` };
-    } else {
-      const f = agentFilePath(this.workspaceRoot, name);
-      if (existsSync(f)) configPath = f;
-    }
-    // --role overrides the file; the file fills it in for bookkeeping otherwise.
-    let role = opts.role;
-    // A stable nkey identity assigned at spawn: the public key is the agent's card.id
-    // (threaded via COTAL_ID); the seed is retained to mint matching creds later.
-    const identity = newIdentity();
-    let handle: AgentHandle;
+    // Synchronous availability gate (P4a/P4c) — runs in one tick BEFORE any await, so two
+    // concurrent same-name spawns can't both pass (the latent dup-name TOCTOU between has() and
+    // set()), and the ceiling can't be overshot by fan-out racing the provision await.
+    if (this.agents.has(name) || this.reserved.has(name)) return { ok: false, error: `agent "${name}" already running` };
+    const cooling = this.coolingCount(); // prune expired stamps, then count live cooling slots
+    if (this.agents.size + this.reserved.size + cooling >= MAX_AGENTS)
+      return { ok: false, error: `at capacity (${MAX_AGENTS} agents incl. in-flight + cooling); despawn one or wait` };
+    this.reserved.add(name);
     try {
-      const connector = registry.resolve<Connector>("connector", agent);
-      const def = configPath ? loadAgentFile(configPath) : undefined;
-      if (!role) role = def?.role;
-      // In auth mode, mint the agent's creds from the space signing key and write them
-      // where the spawned session reads them (COTAL_CREDS path). Open mesh → no creds.
-      // The publish allow-list is the file's `publish:`, falling back to `channels:`.
-      let credsPath: string | undefined;
-      if (this.auth) {
-        // Pre-create the agent's bind-only DM (+ role TASK) durables and mint its scoped
-        // creds — the shared onboarding step (provisionAgent), the manager just supplies its
-        // own connected endpoint as the privileged provisioner.
-        const creds = await provisionAgent(this.ep, this.auth, identity, {
-          channels: def?.publish ?? def?.channels,
-          role,
-          capabilities: def?.capabilities,
-        });
-        credsPath = join(authDir(this.workspaceRoot), "creds", `${name}.creds`);
-        mkdirSync(dirname(credsPath), { recursive: true });
-        writeFileSync(credsPath, creds, { mode: 0o600 });
+      // Resolve an agent file from the manager's own workspace — an explicit
+      // --config must exist; otherwise discover .cotal/agents/<name>.md if present.
+      let configPath: string | undefined;
+      if (opts.config) {
+        configPath = agentFilePath(this.workspaceRoot, opts.config);
+        if (!existsSync(configPath)) return { ok: false, error: `agent file not found: ${configPath}` };
+      } else {
+        const f = agentFilePath(this.workspaceRoot, name);
+        if (existsSync(f)) configPath = f;
       }
-      const spec = connector.buildLaunch({
-        space: this.space,
+      // --role overrides the file; the file fills it in for bookkeeping otherwise.
+      let role = opts.role;
+      // A stable nkey identity assigned at spawn: the public key is the agent's card.id
+      // (threaded via COTAL_ID); the seed is retained to mint matching creds later.
+      const identity = newIdentity();
+      let handle: AgentHandle;
+      try {
+        const connector = registry.resolve<Connector>("connector", agent);
+        const def = configPath ? loadAgentFile(configPath) : undefined;
+        if (!role) role = def?.role;
+        // In auth mode, mint the agent's creds from the space signing key and write them
+        // where the spawned session reads them (COTAL_CREDS path). Open mesh → no creds.
+        // The publish allow-list is the file's `publish:`, falling back to `channels:`.
+        let credsPath: string | undefined;
+        if (this.auth) {
+          // Pre-create the agent's bind-only DM (+ role TASK) durables and mint its scoped
+          // creds — the shared onboarding step (provisionAgent), the manager just supplies its
+          // own connected endpoint as the privileged provisioner.
+          const creds = await provisionAgent(this.ep, this.auth, identity, {
+            channels: def?.publish ?? def?.channels,
+            role,
+            capabilities: def?.capabilities,
+          });
+          credsPath = join(authDir(this.workspaceRoot), "creds", `${name}.creds`);
+          mkdirSync(dirname(credsPath), { recursive: true });
+          writeFileSync(credsPath, creds, { mode: 0o600 });
+        }
+        const spec = connector.buildLaunch({
+          space: this.space,
+          name,
+          role,
+          id: identity.id,
+          creds: credsPath,
+          servers: this.servers,
+          configPath,
+          transcript: opts.transcript,
+        });
+        handle = this.runtime.spawn(name, spec, this.workspaceRoot);
+      } catch (e) {
+        // Pre-set failure: the slot was never live, so no cold-start was paid — the reserved
+        // rollback (finally) is enough, no cooling stamp.
+        return { ok: false, error: (e as Error).message };
+      }
+      const managed: ManagedAgent = {
         name,
         role,
+        agent,
         id: identity.id,
-        creds: credsPath,
-        servers: this.servers,
-        configPath,
-        transcript: opts.transcript,
-      });
-      handle = this.runtime.spawn(name, spec, this.workspaceRoot);
-    } catch (e) {
-      return { ok: false, error: (e as Error).message };
+        seed: identity.seed,
+        spawner: spawner ?? this.ep.ref().id,
+        startedAt: Date.now(),
+        handle,
+      };
+      this.agents.set(name, managed);
+      // Wire the runtime exit signal so a natural exit (crash / /exit / finished) frees the slot
+      // (rate-floored) and reaps any children — keeps the ceiling from ratcheting shut with orphans.
+      this.watchExit(managed);
+      return { ok: true, data: { name, role, agent, id: identity.id, mode: handle.kind } };
+    } finally {
+      this.reserved.delete(name);
     }
-    this.agents.set(name, {
-      name,
-      role,
-      agent,
-      id: identity.id,
-      seed: identity.seed,
-      spawner: spawner ?? this.ep.ref().id,
-      startedAt: Date.now(),
-      handle,
-    });
-    return { ok: true, data: { name, role, agent, id: identity.id, mode: handle.kind } };
   }
 
-  private opStop(args: Record<string, unknown>, _caller: string): ControlReply {
+  /** Subscribe to a managed agent's process-exit so a self-driven exit frees its slot and reaps
+   *  its children (P4b/P4c). Only pty streams exit (via the attach session's `onExit`); tmux/cmux
+   *  attach() throws, so this is a no-op there — a self-EXITED agent under those runtimes is reaped
+   *  by nothing until it's explicitly despawned (graceful-stop runs on despawn, not self-exit). The
+   *  cap still holds (a lingering corpse counts toward it); runtime-agnostic exit-reaping (a real
+   *  per-runtime `status()` → exited-sweep at the availability gate) is a tracked follow-up. */
+  private watchExit(a: ManagedAgent): void {
+    try {
+      a.handle.attach().onExit(() => this.onAgentExit(a));
+    } catch {
+      /* runtime doesn't stream an exit signal (tmux/cmux) — nothing to wire */
+    }
+  }
+
+  /** Prune expired cooling stamps (drop those at/before now) and return the live count — the
+   *  recycle floor's contribution to the ceiling (P4c). Lazy: pruned only when the gate consults it. */
+  private coolingCount(): number {
+    const now = Date.now();
+    this.cooling = this.cooling.filter((stamp) => stamp > now);
+    return this.cooling.length;
+  }
+
+  private opStop(args: Record<string, unknown>, caller: string, admin: boolean): ControlReply {
     const name = String(args.name ?? "").trim();
     const a = this.agents.get(name);
     if (!a) return { ok: false, error: `no agent "${name}"` };
+    const denied = this.authorizeNamed(a, caller, admin);
+    if (denied) return { ok: false, error: denied };
     const graceful = args.graceful !== false;
     a.handle.stop({ graceful });
-    this.agents.delete(name);
+    this.freeSlot(a, !admin); // own-child despawn is rate-floored; admin emergency-kill is not
     return { ok: true, data: { name, stopped: true, graceful } };
   }
 
@@ -362,21 +465,40 @@ export class Manager {
   }
 
   /** Persist a peer-defined persona as config. After this, `start name` auto-discovers
-   *  .cotal/agents/<name>.md and the connector applies its persona/model at spawn. */
-  private opDefinePersona(args: Record<string, unknown>, _caller: string): ControlReply {
+   *  .cotal/agents/<name>.md and the connector applies its persona/model at spawn.
+   *
+   *  CONTENT vs POLICY (P6): the write path accepts ONLY content from args — {name, model,
+   *  persona}. role/publish/capabilities/owner are POLICY and have no slot here, so a peer can
+   *  never grant itself a capability or claim ownership by redefining. A fresh name is created with
+   *  owner = caller (the creator). Redefining an EXISTING file overwrites ONLY model + persona and
+   *  preserves everything else — and is allowed on the privileged tier only if `file.owner == caller`,
+   *  else admin is required. Fail-closed: an ownerless file (legacy / operator-written) is admin-only. */
+  private opDefinePersona(args: Record<string, unknown>, caller: string, admin: boolean): ControlReply {
     const name = String(args.name ?? "").trim();
     if (!name) return { ok: false, error: "name required" };
     const nameErr = this.nameError(name);
     if (nameErr) return { ok: false, error: nameErr };
     const persona = String(args.persona ?? "").trim();
     if (!persona) return { ok: false, error: "persona required" };
-    const def: AgentDef = {
-      name,
-      role: args.role ? String(args.role) : undefined,
-      model: args.model ? String(args.model) : undefined,
-      persona,
-    };
+    const model = args.model ? String(args.model) : undefined;
     const path = agentFilePath(this.workspaceRoot, name);
+    let def: AgentDef;
+    if (existsSync(path)) {
+      // Redefine: load, authorize by ownership, then overwrite ONLY content; preserve all policy.
+      try {
+        def = loadAgentFile(path);
+      } catch (e) {
+        return { ok: false, error: (e as Error).message };
+      }
+      if (!admin && def.owner !== caller)
+        return { ok: false, error: `not authorized to redefine ${name}: owned by ${def.owner ?? "(none)"} (admin tier required)` };
+      def.model = model;
+      def.persona = persona;
+    } else {
+      // Fresh name: create with content + owner = caller. The privileged tier suffices (creating a
+      // brand-new persona isn't admin-only); the creator becomes its owner.
+      def = { name, model, persona, owner: caller };
+    }
     try {
       saveAgentFile(path, def);
     } catch (e) {
@@ -385,10 +507,14 @@ export class Manager {
     return { ok: true, data: { name, path } };
   }
 
-  private opAttach(args: Record<string, unknown>): ControlReply {
+  private opAttach(args: Record<string, unknown>, caller: string, admin: boolean): ControlReply {
     const name = String(args.name ?? "").trim();
     const a = this.agents.get(name);
     if (!a) return { ok: false, error: `no agent "${name}"` };
+    // attach grants terminal read+write — same own/admin scoping as despawn: own child on the
+    // privileged tier, any agent on admin.
+    const denied = this.authorizeNamed(a, caller, admin);
+    if (denied) return { ok: false, error: denied };
     // Only pty streams over the WS attach endpoint. tmux/cmux are watched natively, and
     // each handle's attach() throws with the right per-runtime guidance (tmux attach … /
     // switch to the cmux tab) — surface that instead of assuming tmux.

--- a/packages/core/control-auth.smoke.ts
+++ b/packages/core/control-auth.smoke.ts
@@ -2,9 +2,11 @@
  * Control-plane authz smoke (P2a/P5) — the transport boundary, verified at runtime.
  *
  * Spins up its OWN JWT-auth nats-server and proves nats-server — not a handler — enforces the
- * privileged / self-service control-subject split:
- *   - non-capable agent: publish to ctl.self.<id> ALLOWED; publish to ctl.manager.<id> DENIED
- *   - spawn-capable agent (capabilities:["spawn"]): publish to ctl.manager.<id> ALLOWED
+ * three-tier admin / privileged / self-service control-subject split:
+ *   - non-capable agent: publish to ctl.self.<id> ALLOWED; ctl.manager.<id> + ctl.admin.<id> DENIED
+ *   - spawn-capable agent (capabilities:["spawn"]): ctl.manager.<id> ALLOWED; ctl.admin.<id> DENIED
+ * Admin is manager-profile-only — no agent cred, capable or not, may reach it (default-deny by
+ * omission), so purge + cross-agent ops can't be published by a compromised peer at all.
  * A denied publish rejects the request with an Authorization Violation; an allowed publish with
  * no manager running rejects with "No Responders" / timeout — the error type tells them apart.
  *
@@ -27,6 +29,7 @@ import {
   controlServiceSubject,
   CONTROL_PRIVILEGED,
   CONTROL_SELF_SERVICE,
+  CONTROL_ADMIN,
 } from "./src/index.js";
 
 const PORT = 14226;
@@ -96,14 +99,18 @@ try {
 
   const plainSelf = controlServiceSubject(space, CONTROL_SELF_SERVICE, plainId.id);
   const plainPriv = controlServiceSubject(space, CONTROL_PRIVILEGED, plainId.id);
+  const plainAdmin = controlServiceSubject(space, CONTROL_ADMIN, plainId.id);
   const capPriv = controlServiceSubject(space, CONTROL_PRIVILEGED, capId.id);
+  const capAdmin = controlServiceSubject(space, CONTROL_ADMIN, capId.id);
 
   console.log("non-capable agent:");
   check("publish ctl.self.<id> ALLOWED", await tryPublish(plainCreds, plainSelf, plainId.id) === "allowed");
   check("publish ctl.manager.<id> DENIED by nats-server", await tryPublish(plainCreds, plainPriv, plainId.id) === "denied");
+  check("publish ctl.admin.<id> DENIED by nats-server", await tryPublish(plainCreds, plainAdmin, plainId.id) === "denied");
 
   console.log("spawn-capable agent (capabilities:[spawn]):");
   check("publish ctl.manager.<id> ALLOWED", await tryPublish(capCreds, capPriv, capId.id) === "allowed");
+  check("publish ctl.admin.<id> DENIED by nats-server", await tryPublish(capCreds, capAdmin, capId.id) === "denied");
 
   console.log(`\nCONTROL-AUTH SMOKE ${fail === 0 ? "OK ✅" : "FAILED ❌"}  (${pass} passed, ${fail} failed)`);
   if (fail) process.exitCode = 1;

--- a/packages/core/src/agent-file.ts
+++ b/packages/core/src/agent-file.ts
@@ -44,6 +44,12 @@ export interface AgentDef {
    *  absent — nats-server, not a handler, is the boundary. Granting authority is operator-level
    *  (`definePersona` is itself privileged), so no peer can self-grant via its own agent file. */
   capabilities?: string[];
+  /** Authenticated id of the agent that first defined this persona via `definePersona` (P6). A
+   *  POLICY field, not content: the privileged tier may *redefine* an existing file only if its
+   *  `owner` equals the caller; everyone else needs the admin tier. Fail-closed — an ownerless
+   *  file (legacy / operator-written) is admin-only, and a caller can never claim ownership of an
+   *  existing file. Set once at creation (owner = creator), preserved on every later redefine. */
+  owner?: string;
   /** Frontmatter keys not modelled above, kept verbatim so a connector can read its own launcher
    *  hints without core knowing about each one (e.g. the OpenCode face viewer's `face:` avatar id). */
   meta?: Record<string, string>;
@@ -111,7 +117,7 @@ export function loadAgentFile(path: string): AgentDef {
 
   // Sweep every scalar frontmatter key we don't model into meta, verbatim — connector hints
   // (face, etc.) ride here so core stays ignorant of surface-specific keys.
-  const known = new Set(["name", "role", "kind", "description", "tags", "channels", "publish", "model", "capabilities"]);
+  const known = new Set(["name", "role", "kind", "description", "tags", "channels", "publish", "model", "capabilities", "owner"]);
   const meta: Record<string, string> = {};
   for (const [k, v] of Object.entries(fm)) if (!known.has(k) && typeof v === "string") meta[k] = v;
 
@@ -125,6 +131,7 @@ export function loadAgentFile(path: string): AgentDef {
     publish: list("publish"),
     model: str("model"),
     capabilities: list("capabilities"),
+    owner: str("owner"),
     meta: Object.keys(meta).length ? meta : undefined,
     persona: persona || undefined,
   };
@@ -145,6 +152,7 @@ export function saveAgentFile(path: string, def: AgentDef): void {
   if (def.publish?.length) lines.push(`publish: [${def.publish.map(fmItem).join(", ")}]`);
   if (def.model) lines.push(`model: ${fmScalar(def.model)}`);
   if (def.capabilities?.length) lines.push(`capabilities: [${def.capabilities.map(fmItem).join(", ")}]`);
+  if (def.owner) lines.push(`owner: ${fmScalar(def.owner)}`);
   if (def.meta) for (const [k, v] of Object.entries(def.meta)) lines.push(`${k}: ${fmScalar(v)}`);
   lines.push("---");
   const body = def.persona ? `${def.persona.trim()}\n` : "";

--- a/packages/core/src/subjects.ts
+++ b/packages/core/src/subjects.ts
@@ -113,18 +113,21 @@ export function controlServiceSubject(space: string, service: string, sender: st
   return `${spacePrefix(space)}.ctl.${routeToken(service)}.${routeToken(sender)}`;
 }
 
-/** Control-plane service names — the privileged / self-service split (P2a). The manager
- *  subscribes to BOTH; the cred layer grants {@link CONTROL_SELF_SERVICE} to every agent and
- *  {@link CONTROL_PRIVILEGED} only to spawn-capable agents (default-deny otherwise), so
- *  nats-server — not a handler — is the coarse boundary. The handler then routes by op↔service
- *  (fail-closed on mismatch) and refines own-child vs admin among holders of the privileged
- *  subject. `CONTROL_PRIVILEGED` is the existing `manager` service; `CONTROL_SELF_SERVICE`
- *  carries only the no-name self stop/despawn. */
+/** Control-plane service names — the three-tier split (P2a). The manager subscribes to ALL
+ *  three; the cred layer grants {@link CONTROL_SELF_SERVICE} to every agent and
+ *  {@link CONTROL_PRIVILEGED} only to spawn-capable agents (default-deny otherwise), while
+ *  {@link CONTROL_ADMIN} is reached only by the manager's own allow-all profile (no agent ever
+ *  gets it). nats-server — not a handler — is the coarse boundary. The handler then routes by
+ *  op↔service (fail-closed on mismatch) and refines own-child vs admin among holders of the
+ *  privileged subject. `CONTROL_PRIVILEGED` is the existing `manager` service; `CONTROL_SELF_SERVICE`
+ *  carries only the no-name self stop/despawn; `CONTROL_ADMIN` carries the operator-only ops
+ *  (purge, cross-agent stop/despawn/attach/definePersona). */
 export const CONTROL_PRIVILEGED = "manager" as const;
 export const CONTROL_SELF_SERVICE = "self" as const;
-/** The two control-plane tiers the manager serves — values tie to {@link CONTROL_PRIVILEGED}
- *  / {@link CONTROL_SELF_SERVICE} so handler routing can't drift from the subject names. */
-export type ControlTier = typeof CONTROL_PRIVILEGED | typeof CONTROL_SELF_SERVICE;
+export const CONTROL_ADMIN = "admin" as const;
+/** The three control-plane tiers the manager serves — values tie to the `CONTROL_*` service
+ *  names so handler routing can't drift from the subject names. */
+export type ControlTier = typeof CONTROL_PRIVILEGED | typeof CONTROL_SELF_SERVICE | typeof CONTROL_ADMIN;
 
 export function traceSubject(space: string, agentId: string): string {
   return `${spacePrefix(space)}.trace.${token(agentId)}`;


### PR DESCRIPTION
## Control-plane hardening (finalization)

Completes the manager control-plane security hardening. The **P0–P3/P5 foundation** (loopback-by-default bind, the env allow-list, the privileged/self-service control-subject split, spawn-as-a-capability) is already on `main`; this PR adds the remaining tier, the policy split, and spawn bounding.

Came out of a multi-agent `#review` thread (security / senior-engineer / ux), with every finding traced to the line and each fix pushed down to the cred/transport layer rather than handler-only checks.

### What's in this PR

**Three-tier control plane** (`ctl.self` / `ctl.manager` / `ctl.admin`), op↔tier routed **fail-closed**:
- `ctl.self` (every agent) — no-name self stop/despawn; target derived from the authenticated sender (no field to forge).
- `ctl.manager` (spawn-capable only) — spawn, plus stop/despawn/attach of the caller's **own** children and redefining its own personas.
- `ctl.admin` (manager-creds only, **never** granted to an agent) — destructive / cross-agent ops: `purge`, and stop/despawn/attach/`definePersona` of any agent. Admin is transport-proven, so the handler never guesses it.

**`purge` moved to admin-only** — it rode the privileged tier, where any spawn-capable agent could wipe space history (incl. DMs).

**`attach` scoping** — terminal read+write gated to own children (privileged) or admin.

**`definePersona` content/policy split + persistent `owner`** — the write path takes only content (`model`/`persona`); `role`/`publish`/`capabilities`/`owner` are policy with no arg slot, so a peer can't grant itself a capability or seize ownership. A fresh name records its creator as `owner`; redefining is privileged only if `owner == caller`, else admin. Fail-closed: an ownerless (legacy/operator) file is admin-only.

**Spawn bounding (availability)** — a synchronous reserved-set ceiling (`MAX_AGENTS`) + a minimum-lifetime cooling floor + recursive child reaping bound a fork-bomb and spawn↔despawn churn. The cap holds under **every** runtime.

**Operator CLI** — `cotal stop`/`attach` route to `ctl.admin` (the operator isn't the agent's spawner, so the privileged tier would reject them).

**Docs + smokes** — `architecture.md` documents the tiers + honest caveats; `control-auth` asserts both non-capable and capable agents are denied `ctl.admin` by nats-server; `env-isolate` verifies no env bleed.

### Verification
- `pnpm typecheck` — clean (all packages)
- `pnpm smoke:control-auth` — 5/5 (admin denied to non-capable **and** capable agents)
- `pnpm smoke:env-isolate` — green (sentinel absent under pty + tmux; PATH/HOME carried)

### Known limitations / follow-ups (documented, not blockers)
- **cmux exit-reaping** — self-exit reaping is wired only where the runtime streams an exit signal (pty/tmux); under cmux a self-exited agent lingers until despawned (the cap still holds, it counts the corpse). Runtime-agnostic exit-reaping (real `status()` → sweep-at-gate) is a follow-up.
- **Connector cleanup** — `cotal_purge` is now correctly unreachable by agents and `cotal_persona`'s `role` arg is a no-op (role is policy); both want connector-side tool cleanup.
- **No per-credential revocation / TTL** — `despawn` cuts a *session*, not the *credential* (no-TTL bearer JWTs). Full containment today = rotate the space signing key or cut at the network. Per-cred TTL is deferred.
- **Model-key exfil** not closed for key-based providers (the agent holds the key to do inference) — needs per-agent model auth.
