### PR TITLE
fix(security): control-plane hardening follow-up — connector tool cleanup + definePersona PATCH

### DIFF
--- a/extensions/connector-core/src/agent.ts
+++ b/extensions/connector-core/src/agent.ts
@@ -404,13 +404,13 @@ export class MeshAgent extends EventEmitter {
   async definePersona(def: {
     name: string;
     prompt: string;
-    role?: string;
     model?: string;
   }): Promise<ControlReply> {
     this.assertConnected();
     const reply = await this.ep.requestControl(CONTROL_PRIVILEGED, {
       op: "definePersona",
-      args: { name: def.name, role: def.role, model: def.model, persona: def.prompt },
+      // role is policy — set at spawn, never via definePersona; the manager ignores it regardless.
+      args: { name: def.name, model: def.model, persona: def.prompt },
     });
     if (reply.ok) await this.send(`persona \`${def.name}\` is now available — spawn it to bring it online`);
     return reply;

--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -459,55 +459,25 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
       },
     },
     {
-      name: "cotal_purge",
-      title: "Cotal: clear chat history",
-      description:
-        "Ask the manager to purge this space's retained chat backlog (channel history). Set includeDms to also clear direct-message history. Cleanup only — it does not affect live agents or the anycast work queue. Irreversible.",
-      schema: {
-        includeDms: z
-          .boolean()
-          .optional()
-          .describe("Default false: channel history only. true = also purge DM history."),
-      },
-      async run(agent, _config, { includeDms }: { includeDms?: boolean }) {
-        try {
-          const reply = await agent.purgeHistory({ includeDms });
-          if (!reply.ok) return err(`Couldn't purge history: ${reply.error ?? "manager refused"}`);
-          const d = reply.data as { chat?: number; dm?: number } | undefined;
-          const chat = d?.chat ?? 0;
-          const dm = d?.dm;
-          return ok(
-            `Cleared ${chat} channel message${chat === 1 ? "" : "s"}` +
-              `${dm === undefined ? "" : ` and ${dm} DM${dm === 1 ? "" : "s"}`} from "${_config.space}".`,
-          );
-        } catch (e) {
-          return err(
-            `Couldn't purge history: no manager reachable (${(e as Error).message}). Is the manager running?`,
-          );
-        }
-      },
-    },
-    {
       name: "cotal_persona",
       title: "Cotal: define a persona",
       description:
-        "Define a new persona and save it as config (the manager writes .cotal/agents/<name>.md), then announce it on the mesh. Afterwards cotal_spawn(name) launches a real agent wearing this persona/model. Use to grow the team with a custom role you describe on the fly.",
+        "Define a new persona and save it as config (the manager writes .cotal/agents/<name>.md), then announce it on the mesh. Afterwards cotal_spawn(name) launches a real agent wearing this persona/model. Use to grow the team with a custom persona you describe on the fly; set its role at spawn (cotal_spawn takes a role).",
       schema: {
         name: z
           .string()
           .regex(/^[A-Za-z0-9_-]+$/, "letters, digits, _ or - only")
           .describe("Unique name for the persona (also the spawn name): letters, digits, _ or -."),
         prompt: z.string().max(10_000).describe("The persona — an appended system prompt describing who this agent is."),
-        role: z.string().max(120).optional().describe("Optional role label (e.g. reviewer, scout)."),
         model: z.string().max(120).optional().describe("Optional model override (e.g. opus, sonnet)."),
       },
       async run(
         agent,
         _config,
-        { name, prompt, role, model }: { name: string; prompt: string; role?: string; model?: string },
+        { name, prompt, model }: { name: string; prompt: string; model?: string },
       ) {
         try {
-          const reply = await agent.definePersona({ name, prompt, role, model });
+          const reply = await agent.definePersona({ name, prompt, model });
           if (!reply.ok) return err(`Couldn't define ${name}: ${reply.error ?? "manager refused"}`);
           return ok(`Persona \`${name}\` saved — spawn it with cotal_spawn(name="${name}") to bring it online.`);
         } catch (e) {

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -490,9 +490,12 @@ export class Manager {
       } catch (e) {
         return { ok: false, error: (e as Error).message };
       }
-      if (!admin && def.owner !== caller)
-        return { ok: false, error: `not authorized to redefine ${name}: owned by ${def.owner ?? "(none)"} (admin tier required)` };
-      def.model = model;
+      if (!admin && def.owner !== caller) {
+        const owner = def.owner ? `owned by ${def.owner}` : "operator-owned (legacy file — no agent owner)";
+        return { ok: false, error: `not authorized to redefine ${name}: ${owner}; only its owner or an operator can` };
+      }
+      // PATCH content: overwrite model only when provided, so a persona-only redefine can't wipe an existing model.
+      if (model !== undefined) def.model = model;
       def.persona = persona;
     } else {
       // Fresh name: create with content + owner = caller. The privileged tier suffices (creating a


### PR DESCRIPTION
## Control-plane hardening follow-up

The small cleanup items from the #49 review thread, kept out of #49 to keep it a clean cred-layer unit. **Stacks on `security/control-plane-hardening` (#49)** — items 3–4 modify code that lands in #49, so merge #49 first.

1. **Drop `role` from `cotal_persona`** (tool spec + the `agent.definePersona` threading). `role` is *policy* now — set at spawn (`cotal_spawn` takes it) or in the agent file — and `definePersona` never applied it, so the connector advertising it was a silent no-op (caller sets a role, it vanishes). Removing it at the source fixes that; role-setting stays where it belongs.
2. **Drop `cotal_purge` from the agent tool surface.** `purge` is admin-only now (a spawn-capable agent reaching it is denied), so it's an always-failing affordance — worse than absent. The operator path is `cotal history clear`.
3. **`opDefinePersona`: PATCH `model` on redefine** — overwrite only when provided, so a persona-only edit can't silently clear an existing model (the one real data-loss fowler caught).
4. **Denial wording** — an ownerless file now reads "operator-owned (legacy file) … only its owner or an operator can", instead of the bare `(none) (admin tier required)`.

No handler backstop — the team converged that the structural "only read content" guarantee already makes policy non-escalatable, so a generic content-guard would be permanent surface for a transient drift window.

**Verification:** `pnpm typecheck` green across all packages. (`agent.purgeHistory` is now unused — left in place; removing the method is a trivial later cleanup.)
