### PR TITLE
fix(security): control-plane hardening follow-up + docs (re-targeted to main)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -329,7 +329,7 @@ owner for the actual pixels (same stream `cotal attach` consumes, just rendered 
   `cotal console` node that discovers managers over the mesh and aggregates their streams.
 
 **Control schema (first cut):** `start {role, name, agent}` · `stop {name, graceful?}` ·
-`definePersona {name, persona, role?, model?}` · `ps` · `status {instance}` · `attach {instance}` ·
+`definePersona {name, persona, model?}` · `ps` · `status {instance}` · `attach {instance}` ·
 `bind {instance, config}` — control-plane request/reply messages any authorized node (CLI,
 dashboard, or an agent) can send; spawning is policy-gated. `definePersona` writes
 `.cotal/agents/<name>.md` (via `saveAgentFile`), which a later `start` auto-discovers.
@@ -337,8 +337,8 @@ dashboard, or an agent) can send; spawning is policy-gated. `definePersona` writ
 **Emergent payoff:** an agent can grow *and* shape the team without a human — ask the manager for
 a teammate (`cotal_spawn`), mint a brand-new persona on the fly (`cotal_persona` → saved as config
 → spawnable), or tear one down (`cotal_despawn`, graceful or hard). The new agent is a *peer*, not
-a child. Cleanup rides the same control plane: `cotal_purge` has the manager clear the space's
-retained chat backlog (the privileged `STREAM.PURGE` regular agents are denied).
+a child. Clearing space history, by contrast, is **operator-only** — `cotal history clear` (or the
+admin-tier `purge` op), never an agent tool: the privileged `STREAM.PURGE` is denied to agents.
 
 ## Hosting & onboarding
 
@@ -656,8 +656,8 @@ server, not by agent goodwill. It is containment + authenticity for a single tru
   `STREAM.CREATE` under auth; open connects with no creds); the presence + channels KV buckets are
   streams too, pre-created the same way. Open mode also keeps the endpoint's lazy first-join create,
   so a mesh started without `cotal up` still works — but pre-creating means stream-touching ops that
-  run before any endpoint has joined (`cotal spawn`'s DM-inbox provisioning, `cotal_purge`,
-  `history clear`) find the streams instead of failing with `StreamNotFound`.
+  run before any endpoint has joined (`cotal spawn`'s DM-inbox provisioning, `cotal history clear`)
+  find the streams instead of failing with `StreamNotFound`.
 - **Denials are loud, never silent** — NATS publish permission violations surface only on the
   connection status stream, so the endpoint routes them to its `error` event with a "denied,
   not absent" message. This is why an over-tight ACL shows up as a logged denial, not a peer

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -7,8 +7,8 @@ session joins NATS, maps lifecycle hooks to presence, and exposes the mesh tools
 presence, and team supervision: `cotal_spawn` (grow the team; the new teammate joins as a
 lateral peer), `cotal_despawn` (tear one down — it leaves the mesh and its process/tab closes),
 and `cotal_persona` (define a persona on the fly; it's saved as config and becomes spawnable),
-plus `cotal_purge` (clear the space's retained chat backlog) and optional `cotal_feedback` for
-beta reports. The manager spawns it in a PTY; nothing wraps
+plus optional `cotal_feedback` for beta reports. (Clearing retained history is operator-only —
+`cotal history clear`, not an agent tool.) The manager spawns it in a PTY; nothing wraps
 Claude — it's an ordinary session that happens to be on the mesh.
 
 > The mesh runtime — agent, `cotal_*` tools, hook relay — lives in
@@ -118,10 +118,11 @@ differ only in how they *run* the spec:
 [`examples/01-lateral-coordination/agents/`](../examples/01-lateral-coordination/agents/) to point at
 with `--config`.
 
-- **Define one at runtime.** `cotal_persona(name, prompt, role?, model?)` sends the persona to the
+- **Define one at runtime.** `cotal_persona(name, prompt, model?)` sends the persona to the
   manager, which writes the same `.cotal/agents/<name>.md` file (via `saveAgentFile`) and announces
   it on the mesh. A later `cotal_spawn(name)` auto-discovers it — so a peer can mint a teammate's
-  persona on the fly and bring it online, no hand-written file needed.
+  persona on the fly and bring it online, no hand-written file needed. (Role is set at spawn —
+  `cotal_spawn` takes a role — not here: role is policy, not persona content.)
 
 ## Run it for your own project
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,7 +58,7 @@ cotal · ready
 ```
 
 It makes sure the mesh, the browser dashboard, **and** the manager (the control plane behind
-`cotal_spawn` / `despawn` / `purge` / `persona`) are running in the current folder, then prints
+`cotal_spawn` / `despawn` / `persona`) are running in the current folder, then prints
 your next steps. The dashboard auto-starts at `http://cotal.localhost:7799` (works in
 Chrome/Firefox/Edge; on Safari use `http://127.0.0.1:7799`). You drive Cotal through an agent:
 spawn one and talk to it (it has the tools to message peers, spawn teammates, and send
@@ -88,7 +88,7 @@ npx cotal-ai setup --yes
 
 `--yes` accepts every default with no prompts: it installs the plugin, writes the experts
 and your driving session, and starts the mesh, the web dashboard, and the background **manager**
-(so an agent can use the `cotal_*` tools — spawn/despawn/purge — right away). It never hands over
+(so an agent can use the `cotal_*` tools — spawn/despawn/persona — right away). It never hands over
 the terminal, never opens the demo, and exits non-zero with the log path if a step fails, so an
 agent or a CI job can check the result. `cotal down` stops the background processes.
 

--- a/extensions/connector-core/src/agent.ts
+++ b/extensions/connector-core/src/agent.ts
@@ -404,13 +404,13 @@ export class MeshAgent extends EventEmitter {
   async definePersona(def: {
     name: string;
     prompt: string;
-    role?: string;
     model?: string;
   }): Promise<ControlReply> {
     this.assertConnected();
     const reply = await this.ep.requestControl(CONTROL_PRIVILEGED, {
       op: "definePersona",
-      args: { name: def.name, role: def.role, model: def.model, persona: def.prompt },
+      // role is policy — set at spawn, never via definePersona; the manager ignores it regardless.
+      args: { name: def.name, model: def.model, persona: def.prompt },
     });
     if (reply.ok) await this.send(`persona \`${def.name}\` is now available — spawn it to bring it online`);
     return reply;

--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -459,55 +459,25 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
       },
     },
     {
-      name: "cotal_purge",
-      title: "Cotal: clear chat history",
-      description:
-        "Ask the manager to purge this space's retained chat backlog (channel history). Set includeDms to also clear direct-message history. Cleanup only — it does not affect live agents or the anycast work queue. Irreversible.",
-      schema: {
-        includeDms: z
-          .boolean()
-          .optional()
-          .describe("Default false: channel history only. true = also purge DM history."),
-      },
-      async run(agent, _config, { includeDms }: { includeDms?: boolean }) {
-        try {
-          const reply = await agent.purgeHistory({ includeDms });
-          if (!reply.ok) return err(`Couldn't purge history: ${reply.error ?? "manager refused"}`);
-          const d = reply.data as { chat?: number; dm?: number } | undefined;
-          const chat = d?.chat ?? 0;
-          const dm = d?.dm;
-          return ok(
-            `Cleared ${chat} channel message${chat === 1 ? "" : "s"}` +
-              `${dm === undefined ? "" : ` and ${dm} DM${dm === 1 ? "" : "s"}`} from "${_config.space}".`,
-          );
-        } catch (e) {
-          return err(
-            `Couldn't purge history: no manager reachable (${(e as Error).message}). Is the manager running?`,
-          );
-        }
-      },
-    },
-    {
       name: "cotal_persona",
       title: "Cotal: define a persona",
       description:
-        "Define a new persona and save it as config (the manager writes .cotal/agents/<name>.md), then announce it on the mesh. Afterwards cotal_spawn(name) launches a real agent wearing this persona/model. Use to grow the team with a custom role you describe on the fly.",
+        "Define a new persona and save it as config (the manager writes .cotal/agents/<name>.md), then announce it on the mesh. Afterwards cotal_spawn(name) launches a real agent wearing this persona/model. Use to grow the team with a custom persona you describe on the fly; set its role at spawn (cotal_spawn takes a role).",
       schema: {
         name: z
           .string()
           .regex(/^[A-Za-z0-9_-]+$/, "letters, digits, _ or - only")
           .describe("Unique name for the persona (also the spawn name): letters, digits, _ or -."),
         prompt: z.string().max(10_000).describe("The persona — an appended system prompt describing who this agent is."),
-        role: z.string().max(120).optional().describe("Optional role label (e.g. reviewer, scout)."),
         model: z.string().max(120).optional().describe("Optional model override (e.g. opus, sonnet)."),
       },
       async run(
         agent,
         _config,
-        { name, prompt, role, model }: { name: string; prompt: string; role?: string; model?: string },
+        { name, prompt, model }: { name: string; prompt: string; model?: string },
       ) {
         try {
-          const reply = await agent.definePersona({ name, prompt, role, model });
+          const reply = await agent.definePersona({ name, prompt, model });
           if (!reply.ok) return err(`Couldn't define ${name}: ${reply.error ?? "manager refused"}`);
           return ok(`Persona \`${name}\` saved — spawn it with cotal_spawn(name="${name}") to bring it online.`);
         } catch (e) {

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -490,9 +490,12 @@ export class Manager {
       } catch (e) {
         return { ok: false, error: (e as Error).message };
       }
-      if (!admin && def.owner !== caller)
-        return { ok: false, error: `not authorized to redefine ${name}: owned by ${def.owner ?? "(none)"} (admin tier required)` };
-      def.model = model;
+      if (!admin && def.owner !== caller) {
+        const owner = def.owner ? `owned by ${def.owner}` : "operator-owned (legacy file — no agent owner)";
+        return { ok: false, error: `not authorized to redefine ${name}: ${owner}; only its owner or an operator can` };
+      }
+      // PATCH content: overwrite model only when provided, so a persona-only redefine can't wipe an existing model.
+      if (model !== undefined) def.model = model;
       def.persona = persona;
     } else {
       // Fresh name: create with content + owner = caller. The privileged tier suffices (creating a


### PR DESCRIPTION
## Control-plane hardening follow-up (re-targeted to main)

**This is the content of #50, which merged into its base branch (`security/control-plane-hardening`, the already-merged #49 branch) instead of `main` — so its changes never reached main.** #49's hardening is on main; this PR lands the follow-up cleanup that #50 was meant to.

Same four changes (the review-thread cleanup), now correctly based on `main`:

1. **Drop `role` from `cotal_persona`** (tool spec + `agent.definePersona` threading) — role is policy (set at spawn), and `definePersona` never applied it, so advertising it was a silent no-op.
2. **Drop `cotal_purge` from the agent tool surface** — it's admin-only now (always-denied for agents); operator path is `cotal history clear`.
3. **`opDefinePersona`: PATCH `model` on redefine** — overwrite only when provided, so a persona-only edit can't silently clear an existing model.
4. **Denial wording** — ownerless file now reads "operator-owned (legacy file) … only its owner or an operator can".

Plus **docs** updated to match (`architecture.md`, `claude-code-integration.md`, `getting-started.md`): `cotal_purge` removed from agent-tool listings, `cotal_persona`/`definePersona` signatures drop `role`.

Verified: `pnpm typecheck` green across all packages. No backstop handler change (per the converged design).
