### PR TITLE
fix(core): make wildcard channel subscriptions work (`c` + `c.>`)

### DIFF
--- a/packages/core/channels.smoke.ts
+++ b/packages/core/channels.smoke.ts
@@ -171,6 +171,25 @@ try {
   check("time window EXCLUDES messages older than it", has(W.got, "recent-old").length === 0);
   check("wider window INCLUDES them", W.got.filter((g) => g.channel === "archive" && g.historical).length === 1);
 
+  // ---- wildcard subscription: [c, c.>] delivers the parent AND its subtree ----
+  // Regression: `c.>` must not swallow bare `c` in the filter collapse (else the parent channel
+  // stops being delivered), and joining a wildcard channel must not do a per-channel registry
+  // get (`>` is an illegal KV key — `joinPolicyFresh` skips it). A flat sub gets no subtree.
+  const RW = recorder("RW", "RW_wild", ["review", "review.>"]); // flat parent + whole subtree
+  const RF = recorder("RF", "RF_flat", ["review"]);             // flat parent only
+  await RW.ep.start();
+  await RF.ep.start();
+  await sleep(300);
+  await A.multicast("rev-flat", { channel: "review" });
+  await A.multicast("rev-sec", { channel: "review.security" });
+  await A.multicast("rev-deep", { channel: "review.a.b" });
+  await sleep(400);
+  check("wildcard sub keeps the flat parent (collapse didn't drop it)", has(RW.got, "rev-flat").length === 1);
+  check("wildcard sub receives the subtree (review.>)", has(RW.got, "rev-sec").length === 1 && has(RW.got, "rev-deep").length === 1);
+  check("flat sub gets the parent but never the subtree", has(RF.got, "rev-flat").length === 1 && RF.got.every((g) => g.channel === "review"));
+  await RW.ep.stop();
+  await RF.ep.stop();
+
   await A.stop();
   await B3.ep.stop();
   await W.ep.stop();

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -1150,8 +1150,11 @@ export class CotalEndpoint extends EventEmitter {
    *  cache may not have caught up). Falls to the built-in default only with no registry open. */
   private async joinPolicyFresh(channel: string): Promise<{ replay: boolean; windowMs?: number }> {
     if (!this.channelKv) return { replay: effectiveReplay(undefined, undefined) };
+    // A wildcard subscription (`review.>`) has no single registry entry — and `>`/`*` are illegal
+    // KV keys, so a per-channel get would throw. Read only the space defaults for it; concrete
+    // channels still get their per-channel override.
     const [cfg, defaults] = await Promise.all([
-      readChannelConfig(this.channelKv, channel),
+      isConcreteChannel(channel) ? readChannelConfig(this.channelKv, channel) : Promise.resolve(undefined),
       readChannelDefaults(this.channelKv),
     ]);
     return { replay: effectiveReplay(cfg, defaults), windowMs: effectiveReplayWindowMs(cfg, defaults) };

--- a/packages/core/src/subjects.ts
+++ b/packages/core/src/subjects.ts
@@ -81,7 +81,7 @@ export function subjectMatches(pattern: string, subject: string): boolean {
   const p = pattern.split(".");
   const s = subject.split(".");
   for (let i = 0; i < p.length; i++) {
-    if (p[i] === ">") return true; // matches all remaining tokens
+    if (p[i] === ">") return i < s.length; // '>' matches one-or-more remaining tokens — NATS semantics: 'a.>' does NOT match bare 'a'
     if (i >= s.length) return false;
     if (p[i] === "*") continue;
     if (p[i] !== s[i]) return false;
@@ -91,7 +91,9 @@ export function subjectMatches(pattern: string, subject: string): boolean {
 
 /** Drop exact duplicates and any subject subsumed by a more-general one — JetStream
  *  rejects a consumer whose `filter_subjects` overlap, so `[team.>, team.backend]`
- *  must collapse to `[team.>]` before binding the chat consumer. */
+ *  must collapse to `[team.>]` before binding the chat consumer. A parent and its subtree
+ *  (`[review, review.>]`) are disjoint in NATS (`review.>` never matches bare `review`), so
+ *  both are kept — that's how a peer subscribes to a channel *and* everything under it. */
 export function collapseFilterSubjects(subjects: string[]): string[] {
   const uniq = [...new Set(subjects)];
   return uniq.filter((x) => !uniq.some((y) => y !== x && subjectMatches(y, x)));


### PR DESCRIPTION
## What

Makes wildcard channel subscriptions (`channels: [c, c.>]`) actually work, so a peer can subscribe to a channel **and** everything under it. This unblocks the reviewer use case (default-connect `review`, plus subscribe/publish under `review.>`).

## Two bugs fixed

1. **`subjectMatches` (`subjects.ts`)** treated `a.>` as covering bare `a`, unlike real NATS (`>` matches *one-or-more* tokens, never zero). So `collapseFilterSubjects([c, c.>])` collapsed the parent `c` away, and a peer subscribed to both silently stopped receiving the base channel. Now `>` requires ≥1 remaining token, so parent and subtree are kept as the disjoint filters JetStream accepts.

2. **`joinPolicyFresh` (`endpoint.ts`)** did a per-channel registry `kv.get(channel)` on join to read the replay policy. `>`/`*` are illegal KV keys, so joining a wildcard channel (`review.>`) threw `invalid key: review.>`. Now it skips the per-channel read for wildcards and uses the space defaults (concrete channels still get their per-channel override).

## Tests

- New `channels.smoke` scenario: a `[review, review.>]` subscriber receives the flat parent (`review`) and the whole subtree (`review.security`, `review.a.b`); a flat `[review]` subscriber receives neither sub-channel. `pnpm smoke:channels` → 24 checks pass.
- Also repairs the previously-failing `membership.smoke` `[A]` hierarchical/wildcard scenario (`pnpm smoke:membership` → 32/32 against an open mesh).

## Notes

No wire-format or API change; subject matching is now NATS-accurate across its other callers (membership, restart reconciliation, join watermark). Reviewer persona files (`.cotal/agents/`, gitignored) can now use `channels` / `publish` with `c.>` patterns.