### PR TITLE
docs: fill package.json descriptions and list cmux + hermes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ concrete mechanism you can check against the code.
 | [`@cotal-ai/connector-core`](extensions/connector-core) | Shared MCP-bridge runtime: the mesh agent and the `cotal_*` tools the adapters are thin clients over. |
 | [`@cotal-ai/connector-claude-code`](extensions/connector-claude-code) | [Claude Code](https://claude.com/product/claude-code) adapter: installed plugin + lifecycle hooks. |
 | [`@cotal-ai/connector-opencode`](extensions/connector-opencode) | [OpenCode](https://opencode.ai) adapter: native in-process plugin injected via config. |
+| [`@cotal-ai/connector-hermes`](extensions/connector-hermes) | Hermes (Nous Research) adapter: connects the Hermes agent to the mesh. |
+| [`@cotal-ai/cmux`](extensions/cmux) | cmux integration: a `cmux` runtime and terminal-layout provider for spawning agents into cmux tabs. |
 
 The connectors attach differently but expose the same `cotal_*` tools. Claude Code and
 OpenCode both push: a peer message wakes an idle agent the instant it arrives.

--- a/extensions/cmux/package.json
+++ b/extensions/cmux/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@cotal-ai/cmux",
+  "description": "Cotal cmux integration: a cmux Runtime and TerminalLayout provider for spawning agents into cmux tabs.",
   "version": "0.3.2",
   "license": "Apache-2.0",
   "repository": {

--- a/extensions/connector-claude-code/package.json
+++ b/extensions/connector-claude-code/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@cotal-ai/connector-claude-code",
+  "description": "Cotal connector for Claude Code: an installed plugin that joins a session to the mesh.",
   "version": "0.3.2",
   "license": "Apache-2.0",
   "repository": {

--- a/extensions/connector-core/package.json
+++ b/extensions/connector-core/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@cotal-ai/connector-core",
+  "description": "Shared MCP-bridge runtime for Cotal connectors: the mesh agent, cotal_* tools, and hook relay.",
   "version": "0.3.2",
   "license": "Apache-2.0",
   "repository": {

--- a/extensions/connector-hermes/package.json
+++ b/extensions/connector-hermes/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@cotal-ai/connector-hermes",
+  "description": "Cotal connector for the Hermes (Nous Research) agent.",
   "version": "0.3.2",
   "license": "Apache-2.0",
   "repository": {

--- a/extensions/connector-opencode/package.json
+++ b/extensions/connector-opencode/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@cotal-ai/connector-opencode",
+  "description": "Cotal connector for OpenCode: a native in-process plugin that joins a session to the mesh.",
   "version": "0.3.2",
   "license": "Apache-2.0",
   "repository": {

--- a/implementations/cli/package.json
+++ b/implementations/cli/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@cotal-ai/cli",
+  "description": "Cotal mesh CLI: up, join, watch, console, web, spawn, mint, channels, history.",
   "version": "0.3.2",
   "license": "Apache-2.0",
   "repository": {

--- a/implementations/manager/package.json
+++ b/implementations/manager/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@cotal-ai/manager",
+  "description": "Cotal agent supervisor: spawns and manages mesh nodes via a pluggable runtime (pty/tmux/cmux).",
   "version": "0.3.2",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@cotal-ai/core",
+  "description": "The Cotal protocol: endpoint, subjects, message types, the NATS client layer, and the extension contracts.",
   "version": "0.3.2",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Follow-up to #53. These two cheap wins were pushed to the branch just after #53 merged, so they missed that merge window.

- Add a one-line `description` to each published package's `package.json` (the machine-readable field agents and tooling read first; all were empty).
- Add the `connector-hermes` and `cmux` rows to the README ecosystem table so it matches `AGENTS.md`.

Verified afterward with a cold Sonnet agent dropped into the repo: it navigated `CLAUDE.md` to `AGENTS.md` to `docs/architecture.md` to `SPEC.md` and answered three non-trivial questions correctly with no dead ends.