### PR TITLE
feat(manager): auto-number spawn names on collision

### DIFF
--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -346,7 +346,7 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
       description:
         "Ask the manager to start a new peer endpoint in your space. It joins the mesh as a lateral peer (and, when the manager runs the cmux runtime, appears in its own tab). Use when the team needs another agent.",
       schema: {
-        name: z.string().describe("Unique name for the new peer."),
+        name: z.string().describe("Name for the new peer; auto-numbered (e.g. reviewer-2) if taken."),
         role: z
           .string()
           .optional()
@@ -356,10 +356,14 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
         try {
           const reply = await agent.spawn(name, role);
           if (!reply.ok) return err(`Couldn't spawn ${name}: ${reply.error ?? "manager refused"}`);
-          const mode = (reply.data as { mode?: string } | undefined)?.mode;
-          return ok(
-            `Spawning ${role ? `${name}/${role}` : name}${mode ? ` (${mode})` : ""} — it will appear in the roster shortly.`,
-          );
+          const d = reply.data as { name?: string; mode?: string } | undefined;
+          const actual = d?.name ?? name; // the manager auto-numbers on a collision — report what it spawned
+          const mode = d?.mode;
+          const who = role ? `${actual}/${role}` : actual;
+          // Make the rename unmissable: a colliding caller must see it asked for `name` but got
+          // `actual`, not silently address the wrong peer later (the tool result is the only channel).
+          const lead = actual !== name ? `"${name}" was taken — spawning ${who} instead` : `Spawning ${who}`;
+          return ok(`${lead}${mode ? ` (${mode})` : ""} — it will appear in the roster shortly.`);
         } catch (e) {
           return err(
             `Couldn't spawn ${name}: no manager reachable (${(e as Error).message}). Is the manager running?`,

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -285,6 +285,18 @@ export class Manager {
       : `unsafe name ${JSON.stringify(name)} (allowed: letters, digits, _ -)`;
   }
 
+  /** First free name in the series `base`, `base-2`, `base-3`, … — checked against both live and
+   *  in-flight (reserved) slots. Lets a colliding spawn auto-number instead of being rejected, so
+   *  callers never have to invent a unique name. */
+  private uniqueName(base: string): string {
+    const taken = (n: string) => this.agents.has(n) || this.reserved.has(n);
+    if (!taken(base)) return base;
+    for (let n = 2; ; n++) {
+      const candidate = `${base}-${n}`;
+      if (!taken(candidate)) return candidate;
+    }
+  }
+
   /** Spawn a teammate by name (loads `.cotal/agents/<name>.md`), as if a peer asked via the
    *  control plane. Used to pre-spawn the demo's experts at startup so the manager owns them. */
   async startByName(name: string): Promise<ControlReply> {
@@ -323,19 +335,25 @@ export class Manager {
    *  defaulting to the manager's own id for roster/pre-spawn — recorded for the spawner
    *  ledger (own-children despawn + reap-on-parent-exit). */
   async startAgent(opts: StartAgentOpts, spawner?: string): Promise<ControlReply> {
-    const name = opts.name.trim();
-    if (!name) return { ok: false, error: "name required" };
-    const nameErr = this.nameError(name);
+    const base = opts.name.trim();
+    if (!base) return { ok: false, error: "name required" };
+    const nameErr = this.nameError(base);
     if (nameErr) return { ok: false, error: nameErr };
     const agent = opts.agent ?? "cotal";
 
-    // Synchronous availability gate (P4a/P4c) — runs in one tick BEFORE any await, so two
-    // concurrent same-name spawns can't both pass (the latent dup-name TOCTOU between has() and
-    // set()), and the ceiling can't be overshot by fan-out racing the provision await.
-    if (this.agents.has(name) || this.reserved.has(name)) return { ok: false, error: `agent "${name}" already running` };
+    // Synchronous availability gate (P4a/P4c) — the free-name pick and the reserve run in one tick
+    // BEFORE any await, so two concurrent spawns can't land on the same name (no TOCTOU between the
+    // pick and the reserve), and the ceiling can't be overshot by fan-out racing the provision await.
     const cooling = this.coolingCount(); // prune expired stamps, then count live cooling slots
     if (this.agents.size + this.reserved.size + cooling >= MAX_AGENTS)
       return { ok: false, error: `at capacity (${MAX_AGENTS} agents incl. in-flight + cooling); despawn one or wait` };
+    // A taken name auto-numbers (reviewer → reviewer-2 → reviewer-3…) so callers never collide; the
+    // persona file is still discovered from the requested base name below, so reviewer-2 wears it.
+    // Deliberate semantics: this is create-new, not ensure-exists — a retried/redelivered identical
+    // spawn from the same caller yields a fresh numbered agent, not a no-op. Accepted (MAX_AGENTS
+    // bounds the blast radius). Follow-up: add a short per-(spawner,base,role) idempotency window if
+    // autonomous orchestration ever produces phantom spawns.
+    const name = this.uniqueName(base);
     this.reserved.add(name);
     try {
       // Resolve an agent file from the manager's own workspace — an explicit
@@ -345,7 +363,7 @@ export class Manager {
         configPath = agentFilePath(this.workspaceRoot, opts.config);
         if (!existsSync(configPath)) return { ok: false, error: `agent file not found: ${configPath}` };
       } else {
-        const f = agentFilePath(this.workspaceRoot, name);
+        const f = agentFilePath(this.workspaceRoot, base);
         if (existsSync(f)) configPath = f;
       }
       // --role overrides the file; the file fills it in for bookkeeping otherwise.


### PR DESCRIPTION
Spawning a teammate whose name was already taken failed with `agent "<name>" already running`, forcing callers to invent unique names. The single spawn funnel (`Manager.startAgent`) now auto-numbers instead: `reviewer` -> `reviewer-2` -> `reviewer-3`. Every spawn path (`cotal_spawn`, `cotal start`, `--spawn`, roster boot) benefits, since they all funnel through `startAgent`.

## How
- New `uniqueName(base)` picks the first free name, checked against both live (`agents`) and in-flight (`reserved`) slots.
- The pick + reserve stay synchronous before any `await`, preserving the existing P4a TOCTOU guarantee (concurrent same-name spawns cannot land on the same name). The capacity ceiling (`MAX_AGENTS`) still applies and is checked first, so `uniqueName` always has a free slot.
- The persona file is still discovered from the requested **base** name, so `reviewer-2` wears `reviewer.md`. Creds, identity, and launch use the deduped name.
- The `cotal_spawn` reply makes the rename explicit: `"reviewer" was taken - spawning reviewer-2 instead`.

## Semantics (deliberate)
Create-new, not ensure-exists: a retried or redelivered identical spawn yields a fresh numbered agent rather than a no-op. Accepted, since `MAX_AGENTS` bounds the blast radius. A per-`(spawner, base, role)` idempotency window is noted in-code as a follow-up if autonomous orchestration ever produces phantom spawns.

`pnpm typecheck` passes.