### PR TITLE
feat(opencode): adopt /new as a context reset and keep operator logins

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -219,9 +219,10 @@ surface (unlike Claude Code's `/mcp reconnect`), and a plugin cannot register a 
 via the Hooks API, so the connector injects one through the `OPENCODE_CONFIG_CONTENT` config
 layer: a tool-forcing template whose only move is to call the shared `cotal_reconnect` tool,
 which tears down and rebuilds the connection **in-process** (it never rides the wedged link).
-Because the connector binds one mesh identity to one owned OpenCode session, it also overrides
-OpenCode's built-in `/new` with an explanatory prompt; a fresh context should be launched as a
-fresh Cotal-managed agent, not as a bare replacement session under the old identity.
+The connector binds one mesh identity to one live OpenCode process, not one immutable chat: if the
+human runs OpenCode's built-in `/new` in that same TUI/process, the plugin adopts the new top-level
+session as a context reset, keeps the existing mesh connection/creds alive, and stamps outgoing
+messages with the new OpenCode session id as `contextId`.
 The rebuild is serialized: manual `/reconnect`, the supervisor's `closed()`, and the retry loop
 all funnel through one in-flight rebuild (a second trigger coalesces, never races a second
 `connectAndBind`), and a manual reconnect kicks an in-flight backoff to retry immediately.
@@ -497,6 +498,11 @@ tells peers "same agent, same memory" when the new session has none, breaking re
 mis-delivering messages meant for the original, and wrongly inheriting its leases and
 obligations. Rule: **same context ⇒ same id; new context ⇒ new id**, with `name` as the stable
 handle that may map to different instances over time.
+
+OpenCode has one explicit reset-in-place exception: `/new` inside the same managed OpenCode
+process keeps the same mesh identity/creds but advances `contextId` to the new OpenCode session
+id. That is process continuity, not credential reuse by a second process; two live processes must
+never share the same creds.
 
 **CLI (optional ergonomics).**
 

--- a/extensions/connector-core/src/agent.ts
+++ b/extensions/connector-core/src/agent.ts
@@ -86,6 +86,7 @@ export class MeshAgent extends EventEmitter {
   private _connected = false;
   private _status: PresenceStatus = "idle";
   private _attention: AttentionMode = "open"; // F3: fail-open default; reset to open on SessionStart
+  private _contextId: string | undefined;
   /** Chat-stream frontier captured when this agent entered `focus` — recall surfaces ambient
    *  published after it ("since you entered focus"). Undefined unless in focus. */
   private focusSince?: number;
@@ -128,6 +129,12 @@ export class MeshAgent extends EventEmitter {
     return this._connected;
   }
 
+  /** Correlates outgoing messages to the host agent's current context/window. */
+  setContextId(contextId: string | undefined): void {
+    const clean = contextId?.trim();
+    this._contextId = clean ? clean : undefined;
+  }
+
   /** Begin connecting (with background retry). Returns immediately. */
   start(retryMs = 3000): void {
     void this.connectLoop(retryMs);
@@ -162,7 +169,12 @@ export class MeshAgent extends EventEmitter {
    *  interruptible. Returns a one-line status for the caller to surface (e.g. the
    *  cotal_reconnect tool → TUI); on failure the endpoint keeps retrying in the background. */
   async reconnect(): Promise<{ ok: boolean; message: string }> {
-    if (this.stopping) throw new Error("agent stopping — cannot reconnect");
+    if (this.stopping) {
+      return {
+        ok: false,
+        message: "This session is shutting down, so its Cotal mesh connection cannot be reconnected. Start a new session instead.",
+      };
+    }
     try {
       await this.ep.reconnect();
       // _connected is set by the endpoint's "connection" event on the successful rebind, not here.
@@ -314,7 +326,7 @@ export class MeshAgent extends EventEmitter {
     this.assertConnected();
     const clean = normalizeMentions(mentions);
     if (clean) this.assertKnownMentions(clean);
-    return this.ep.multicast(text, { channel, mentions: clean });
+    return this.ep.multicast(text, { channel, mentions: clean, contextId: this._contextId });
   }
 
   /** Throw if any name isn't a peer we've observed. Validates against the FULL roster
@@ -334,7 +346,7 @@ export class MeshAgent extends EventEmitter {
 
   async anycast(role: string, text: string): Promise<CotalMessage> {
     this.assertConnected();
-    return this.ep.anycast(role, text);
+    return this.ep.anycast(role, text, { contextId: this._contextId });
   }
 
   /** Resolve a peer by instance id (exact) or display name (case-insensitive, prefer present). */
@@ -354,7 +366,7 @@ export class MeshAgent extends EventEmitter {
     this.assertConnected();
     const peer = this.resolvePeer(target);
     if (!peer) throw new Error(`no peer "${target}" in space "${this.config.space}"`);
-    const msg = await this.ep.unicast(peer.card.id, text);
+    const msg = await this.ep.unicast(peer.card.id, text, { contextId: this._contextId });
     return { msg, peer };
   }
 

--- a/extensions/connector-core/src/launch.ts
+++ b/extensions/connector-core/src/launch.ts
@@ -16,7 +16,8 @@
  */
 
 /** OS env a coding-agent TUI genuinely needs to run — find its binary (PATH), render (TERM /
- *  COLORTERM), resolve home/config (HOME), locale (LANG / LC_*), timezone (TZ), temp (TMPDIR),
+ *  COLORTERM), resolve home/config/data dirs (HOME / XDG_CONFIG_HOME / XDG_DATA_HOME — where a tool
+ *  finds its config and credential store), locale (LANG / LC_*), timezone (TZ), temp (TMPDIR),
  *  session/runtime dir (XDG_RUNTIME_DIR), and the shell it may invoke. NOT a model key, NOT an
  *  operator secret. A fixed, named allow-list. */
 const OS_ENV_ALLOW = [
@@ -35,6 +36,8 @@ const OS_ENV_ALLOW = [
   "TZ",
   "TMPDIR",
   "TMP",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
   "XDG_RUNTIME_DIR",
 ] as const;
 

--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -495,7 +495,7 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
       name: "cotal_reconnect",
       title: "Cotal: reconnect to the mesh",
       description:
-        "Tear down and rebuild this session's mesh connection in-process — the manual recovery path when the connection has wedged (the counterpart to Claude Code's /mcp reconnect, and a complement to the automatic self-heal). Zero-argument; local only — it does not ride the mesh link. Returns a one-line status (Reconnected ✓ / Reconnect failed — still retrying automatically, or run /reconnect to retry now).",
+        "Tear down and rebuild this session's mesh connection in-process — the manual recovery path when the connection has wedged (the counterpart to Claude Code's /mcp reconnect, and a complement to the automatic self-heal). Zero-argument; local only — it does not ride the mesh link. Returns a one-line status (Reconnected ✓ / Reconnect failed — still retrying automatically, or this session is shutting down).",
       async run(agent) {
         const r = await agent.reconnect();
         return r.ok ? ok(r.message) : err(r.message);

--- a/extensions/connector-opencode/src/plugin.ts
+++ b/extensions/connector-opencode/src/plugin.ts
@@ -71,9 +71,10 @@ export const cotal: Plugin = async ({ client }) => {
     ? "(avatar: begin your cotal_send/cotal_dm text with [[face:X]] — neutral|happy|sad|angry|surprised — and add another tag when your mood shifts)"
     : undefined;
 
-  // This agent OWNS one session, created at boot. The serve shim attaches the foreground TUI to it
-  // (`opencode attach --session <id>`), so what the human watches IS the session we drive — no
-  // phantom home-screen, no stale-session guessing. Used to match our turn-end (idle) vs subagent idles.
+  // This agent OWNS one top-level OpenCode session at a time. The serve shim attaches the foreground
+  // TUI to the boot session; if the human runs `/new` in that same TUI/process, OpenCode creates a
+  // replacement top-level session. We adopt that as a context reset while keeping the same MeshAgent
+  // and creds alive. Used to match our turn-end (idle) vs subagent idles.
   let sessionID: string | undefined;
   let busy = false; // a turn is running → don't prompt: opencode would COALESCE onto it (no reject)
   let driving = false; // re-entrancy guard around an in-flight promptAsync
@@ -90,6 +91,27 @@ export const cotal: Plugin = async ({ client }) => {
     }
   };
 
+  function pendingForWake(): number {
+    return agent.attention === "open" ? agent.inboxCount() : agent.directedPendingCount();
+  }
+
+  function adoptSession(id: string, reason: string): void {
+    if (sessionID === id) return;
+    const previous = sessionID;
+    sessionID = id;
+    agent.setContextId(id);
+    busy = false;
+    driving = false;
+    primed = false;
+    briefed = false;
+    surfaced = [];
+    awaitingTurnEnd = false;
+    if (previous) {
+      log(`adopted opencode session ${id} after ${reason}; mesh identity unchanged`);
+      if (pendingForWake() > 0) void drive();
+    }
+  }
+
   /** Create the session this agent owns and announce its id to the serve shim, which attaches the
    *  foreground TUI to it. The handshake line on stderr (`[cotal-session] <id>`) is how the shim
    *  learns *which* session to open — by exact id, so a stale same-titled session from a prior run
@@ -97,9 +119,11 @@ export const cotal: Plugin = async ({ client }) => {
   const sessionReady: Promise<string | undefined> = (async () => {
     try {
       const res = await client.session.create({ body: { title: `cotal:${config.space}:${config.name}` } });
-      sessionID = res.data?.id;
-      if (sessionID) process.stderr.write(`[cotal-session] ${sessionID}\n`);
-      else log("session.create returned no id");
+      const id = res.data?.id;
+      if (id) {
+        adoptSession(id, "boot");
+        process.stderr.write(`[cotal-session] ${id}\n`);
+      } else log("session.create returned no id");
     } catch (e) {
       log(`session.create failed: ${(e as Error).message}`);
     }
@@ -182,8 +206,7 @@ export const cotal: Plugin = async ({ client }) => {
     awaitingTurnEnd = false;
     busy = false;
     ackSurfaced();
-    const pending = agent.attention === "open" ? agent.inboxCount() : agent.directedPendingCount();
-    if (pending > 0) void drive();
+    if (pendingForWake() > 0) void drive();
   }
 
   // Inbound mesh → drive (never interrupt a running turn — matches Claude). A directed message
@@ -203,11 +226,11 @@ export const cotal: Plugin = async ({ client }) => {
     if (!busy) void drive();
   });
 
-  /** Match an event's session against the one we drive. Adopt the first session id we see (a fresh
-   *  spawn has exactly one — the visible session our first submit creates), then filter to it. */
+  /** Match an event's session against the one we drive. Adopt the first session id we see, then
+   *  filter to it; later top-level `session.created` events adopt explicitly as reset-in-place. */
   const ours = (id?: string): boolean => {
     if (!id) return !sessionID; // a session-less event counts as ours only before we've adopted one
-    if (!sessionID) sessionID = id;
+    if (!sessionID) adoptSession(id, "first event");
     return id === sessionID;
   };
 
@@ -225,8 +248,9 @@ export const cotal: Plugin = async ({ client }) => {
       }
       switch (event.type) {
         case "session.created":
-          // Adopt the visible (top-level) session as soon as it's born; ignore subagent children.
-          if (!event.properties.info.parentID) ours(event.properties.info.id);
+          // Adopt every top-level session created in this OpenCode process. That makes `/new` a
+          // Cotal-aware context reset: same mesh identity, new OpenCode context/session id.
+          if (!event.properties.info.parentID) adoptSession(event.properties.info.id, "top-level session create");
           break;
         case "session.idle":
           if (!ours(event.properties.sessionID)) return;

--- a/extensions/connector-opencode/src/serve.ts
+++ b/extensions/connector-opencode/src/serve.ts
@@ -21,7 +21,16 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { createServer } from "node:net";
 import { once } from "node:events";
 import { randomBytes } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 
 const BIN = process.env.COTAL_OPENCODE_BIN?.trim() || "opencode";
 
@@ -53,13 +62,40 @@ async function killServe(serve: ChildProcess): Promise<void> {
   }
 }
 
+/** opencode keeps provider logins (`auth.json`) and the opencode.ai account (`account.json`) under
+ *  the DATA dir — the same XDG_DATA_HOME we redirect per-agent to isolate the session SQLite. opencode
+ *  has no env to relocate auth on its own (sst/opencode#5423), so a redirected data dir starts the
+ *  agent with an EMPTY auth store: the operator's openai/anthropic logins vanish ("logged out").
+ *  Symlink the real files into the per-agent dir so the agent shares the operator's LIVE login (a
+ *  later re-login / token refresh writes through), self-healing any stale copy a prior launch left. */
+function shareCredentials(dataHome: string): void {
+  const realDataHome = process.env.XDG_DATA_HOME?.trim() || `${process.env.HOME}/.local/share`;
+  const ocDir = `${dataHome}/opencode`;
+  mkdirSync(ocDir, { recursive: true });
+  for (const file of ["auth.json", "account.json"]) {
+    const src = `${realDataHome}/opencode/${file}`;
+    const dst = `${ocDir}/${file}`;
+    if (!existsSync(src)) continue;
+    let linked = false;
+    try {
+      linked = lstatSync(dst).isSymbolicLink() && readlinkSync(dst) === src;
+    } catch {
+      /* dst absent */
+    }
+    if (linked) continue;
+    rmSync(dst, { force: true }); // drop a stale regular-file copy a buggy launch left behind
+    symlinkSync(src, dst);
+  }
+}
+
 async function main(): Promise<void> {
   const port = process.env.COTAL_OPENCODE_PORT?.trim() || String(await freePort());
   const url = `http://127.0.0.1:${port}`;
   // Own data dir per agent: opencode keeps sessions in one SQLite file under XDG_DATA_HOME,
   // and concurrent serves sharing it stall session-create on the write lock (the "agent
-  // session never came up" failure). Per-peer session state is the right scoping anyway;
-  // provider config/auth lives under XDG_CONFIG_HOME, untouched.
+  // session never came up" failure). Per-peer session state is the right scoping anyway.
+  // CAVEAT: auth.json/account.json ALSO live under XDG_DATA_HOME, so redirecting it drops the
+  // operator's provider logins — shareCredentials() symlinks them back in (called below).
   const name = process.env.COTAL_NAME?.trim() || "agent";
   const dataHome = `${process.cwd()}/.cotal/opencode/${name}`;
 
@@ -78,11 +114,12 @@ async function main(): Promise<void> {
     rmSync(pidFile);
   }
 
+  shareCredentials(dataHome); // creates dataHome/opencode + symlinks the operator's logins in
+
   const serve = spawn(BIN, ["serve", "--hostname", "127.0.0.1", "--port", port], {
     env: { ...process.env, OPENCODE_SERVER_PASSWORD: SECRET, XDG_DATA_HOME: dataHome },
     stdio: ["ignore", "pipe", "pipe"],
   });
-  mkdirSync(dataHome, { recursive: true });
   writeFileSync(pidFile, String(serve.pid));
   serve.on("exit", () => rmSync(pidFile, { force: true }));
 


### PR DESCRIPTION
Makes OpenCode's `/new` work seamlessly under the connector, instead of being blocked. Two related connector changes plus supporting bits.

## /new as a context reset
Previously the connector bound one mesh identity to one fixed OpenCode session and discouraged `/new`. Now `/new` (a new top-level session in the same process) is adopted as a context reset:
- same mesh identity and creds, presence never drops;
- `contextId` advances to the new session id and is stamped on outgoing messages;
- persona + channel briefing re-inject on the next driven turn (the fresh context needs them again).

Invariant preserved: same context => same id, new context => new id. Two live processes still never share creds.

## Keep operator logins under a per-agent data dir
Each agent gets its own `XDG_DATA_HOME` so concurrent serves don't stall on one SQLite file. But OpenCode keeps `auth.json`/`account.json` there too (no env to relocate auth, sst/opencode#5423), so a redirected data dir starts the agent logged out. `shareCredentials()` symlinks the operator's real login files into the per-agent dir (write-through on re-login, self-healing a stale copy).

## Supporting
- `XDG_CONFIG_HOME` / `XDG_DATA_HOME` added to the launch OS env allow-list.
- `reconnect()` while the session is stopping returns a clear status instead of throwing.

## Notes for review
- Hinges on OpenCode emitting a top-level (`parentID == null`) `session.created` on `/new`; worth a manual smoke test against real `opencode`.
- Mid-turn `/new` is at-least-once: an in-flight inbox batch is re-surfaced after the reset (re-answered, never lost). Left as-is since `/new` is a manual action no one triggers mid-reply.
- macOS: `shareCredentials` falls back to `~/.local/share`; if OpenCode stores auth elsewhere there, sharing silently no-ops (no harm).

`pnpm typecheck` passes (connector-core, connector-opencode).