### PR TITLE
feat(cli): auto-number `cotal spawn` names against the live mesh

### DIFF
--- a/implementations/cli/src/commands/spawn.ts
+++ b/implementations/cli/src/commands/spawn.ts
@@ -6,6 +6,8 @@ import {
   DEFAULT_SERVER,
   agentFilePath,
   authDir,
+  firstFreeName,
+  isReachable,
   loadAgentFile,
   loadSpaceAuth,
   mintCreds,
@@ -15,6 +17,7 @@ import {
   CotalEndpoint,
   type AgentDef,
   type Connector,
+  type SpaceAuth,
 } from "@cotal-ai/core";
 import { cotalRoot } from "../lib/paths.js";
 import { resolveSpace } from "../lib/status.js";
@@ -32,6 +35,53 @@ import { resolveSpace } from "../lib/status.js";
  * here vs. a supervised runtime in the manager. The connector is resolved from
  * the registry by agent type, composed at the root.
  */
+/**
+ * Auto-number `requested` past any peer already present on the mesh (foo → foo-2 → foo-3) — the same
+ * series the manager's spawn funnel uses (firstFreeName). Foreground `cotal spawn` doesn't go through
+ * the manager, so it has no name reservation: this is a best-effort, advisory check. It connects a
+ * transient presence-watching endpoint, lets the roster settle, and snapshots the live names; two
+ * simultaneous `cotal spawn`s can still race onto the same number. If the mesh is unreachable the
+ * agent couldn't join it anyway, so dedup is skipped and the requested name stands.
+ */
+async function uniqueMeshName(
+  requested: string,
+  { space, server, auth }: { space: string; server: string; auth?: SpaceAuth },
+): Promise<string> {
+  // Reading presence in auth mode needs a credential (the bucket is OPEN-only for agents): a
+  // short-lived manager cred, the same throwaway `cotal dm` mints to resolve a name → id.
+  const creds = auth ? await mintCreds(auth, newIdentity(), "manager") : undefined;
+  if (!(await isReachable(server, { creds }))) return requested;
+  const ep = new CotalEndpoint({
+    space,
+    servers: server,
+    creds,
+    channels: [],
+    consume: false,
+    registerPresence: false, // an invisible probe — don't add ourselves to the roster we're reading
+    watchPresence: true,
+    card: { name: "spawn-probe", kind: "endpoint" },
+  });
+  ep.on("error", () => {}); // advisory: a presence-read hiccup must never block the spawn
+  await ep.start();
+  try {
+    // Presence replays from the KV bucket right after connect; settle until the roster count holds
+    // steady across two polls (≤1s), then snapshot the names of the peers that are actually live.
+    let prev = -1;
+    for (let i = 0; i < 10; i++) {
+      await new Promise((r) => setTimeout(r, 100));
+      const n = ep.getRoster().length;
+      if (n === prev) break;
+      prev = n;
+    }
+    const taken = new Set(
+      ep.getRoster().filter((p) => p.status !== "offline").map((p) => p.card.name),
+    );
+    return firstFreeName(requested, (n) => taken.has(n));
+  } finally {
+    await ep.stop();
+  }
+}
+
 export async function spawn(argv: string[]): Promise<void> {
   const { values, positionals } = parseArgs({
     args: argv,
@@ -72,10 +122,18 @@ export async function spawn(argv: string[]): Promise<void> {
   }
 
   // --name / --role override the file (name defaults from the file's frontmatter).
-  const name = values.name ?? def.name;
+  const requested = values.name ?? def.name;
   const role = values.role ?? def.role;
   const space = values.space ?? resolveSpace(process.cwd());
   const server = values.server ?? DEFAULT_SERVER;
+  const auth = loadSpaceAuth(authDir(cotalRoot()));
+
+  // A second `cotal spawn` of the same agent would otherwise join under a duplicate mesh identity:
+  // auto-number the name past anyone already present (best-effort — this path bypasses the manager's
+  // race-free reservation; see uniqueMeshName). Everything below (creds path, launch) uses `name`.
+  const name = await uniqueMeshName(requested, { space, server, auth });
+  if (name !== requested)
+    console.error(`"${requested}" is already on the mesh — spawning as ${name} instead`);
 
   // Auth mode (`.cotal/auth` present): mint a stable identity + scoped creds for this agent
   // and pre-create its bind-only durables, via a short-lived privileged provisioner — the
@@ -83,7 +141,6 @@ export async function spawn(argv: string[]): Promise<void> {
   // Open mode (no `.cotal/auth`): unchanged — the session connects without creds.
   let id: string | undefined;
   let credsPath: string | undefined;
-  const auth = loadSpaceAuth(authDir(cotalRoot()));
   if (auth) {
     const identity = newIdentity();
     const prov = new CotalEndpoint({

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -7,6 +7,7 @@ import {
   authDir,
   clearSpaceHistory,
   findCotalRoot,
+  firstFreeName,
   loadAgentFile,
   loadSpaceAuth,
   mintCreds,
@@ -289,12 +290,7 @@ export class Manager {
    *  in-flight (reserved) slots. Lets a colliding spawn auto-number instead of being rejected, so
    *  callers never have to invent a unique name. */
   private uniqueName(base: string): string {
-    const taken = (n: string) => this.agents.has(n) || this.reserved.has(n);
-    if (!taken(base)) return base;
-    for (let n = 2; ; n++) {
-      const candidate = `${base}-${n}`;
-      if (!taken(candidate)) return candidate;
-    }
+    return firstFreeName(base, (n) => this.agents.has(n) || this.reserved.has(n));
   }
 
   /** Spawn a teammate by name (loads `.cotal/agents/<name>.md`), as if a peer asked via the

--- a/packages/core/src/agent-file.ts
+++ b/packages/core/src/agent-file.ts
@@ -185,3 +185,15 @@ export function agentFilePath(root: string, nameOrPath: string): string {
   if (nameOrPath.includes("/") || nameOrPath.endsWith(".md")) return resolve(root, nameOrPath);
   return join(root, ".cotal", "agents", `${nameOrPath}.md`);
 }
+
+/** First free name in the series `base`, `base-2`, `base-3`, … — the first candidate for which
+ *  `taken` returns false. The single source of the spawn auto-numbering scheme, shared by the
+ *  manager's funnel (checked against its live + reserved slots) and `cotal spawn` (checked against
+ *  the live mesh roster), so a colliding name numbers up identically whichever path spawns it. */
+export function firstFreeName(base: string, taken: (name: string) => boolean): string {
+  if (!taken(base)) return base;
+  for (let n = 2; ; n++) {
+    const candidate = `${base}-${n}`;
+    if (!taken(candidate)) return candidate;
+  }
+}


### PR DESCRIPTION
## Problem

The collision auto-numbering added to the manager funnel in fd32d55 only covers manager-supervised spawns (`cotal start`, `cotal_spawn`, roster boot). Foreground `cotal spawn` bypasses the manager entirely and launches the child directly, so it never deduped: a second `cotal spawn default` joined the mesh under a **duplicate identity** (`default_agent`) instead of becoming `default_agent-2`.

## Change

- **Single-source the numbering scheme.** Lift the `base`, `base-2`, `base-3`, … series out of `Manager.uniqueName` into a pure `firstFreeName(base, taken)` in `@cotal-ai/core`. The manager now calls it, so every spawn path numbers identically from one source.
- **Dedup `cotal spawn` against the live mesh.** Before launch, resolve the requested name against the current roster via a transient, **non-registering** presence probe, then number past any present (non-`offline`) peer. In auth mode it mints a throwaway read cred (same pattern as `cotal dm`). On a rename it prints: `"default_agent" is already on the mesh — spawning as default_agent-2 instead`.

## Caveats (by design)

- **Advisory, not race-free.** The foreground path has no name reservation like the manager's synchronous reserve, so two simultaneous `cotal spawn`s can still land on the same number. The manager funnel remains the race-free path.
- **Unreachable mesh skips dedup** and keeps the requested name — the agent couldn't join the mesh anyway, so this preserves today's "launch even if NATS is down" behavior with no new hard failure.

## Test

- `pnpm typecheck` green across all packages.
- `pnpm smoke` not run here: the local environment has an **auth-mode** NATS server up while smoke connects bare (open mode), so it fails at NATS authz before reaching any touched code.
- Manual: `cotal spawn default` twice against a running mesh — the second renames to `default_agent-2`.