### PR TITLE
fix(opencode): reuse local auth for spawned agents

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -93,8 +93,9 @@ creds minted from the signer, and joined your mesh, with no host file access.
 ## Model auth (per agent type)
 
 Each agent authenticates to its LLM provider with credentials you set from **outside** the
-container as env. The supervisor passes its env to every agent it spawns, and each CLI reads
-only the vars it understands, so a mixed team sets one var per connector type:
+container as env. The supervisor forwards the named credential vars each connector declares,
+and each CLI reads only the vars it understands, so a mixed team sets one var per connector
+type:
 
 | connector | env | account |
 |-----------|-----|---------|
@@ -151,10 +152,10 @@ mounts, ephemeral fs.
 
 ### Caveats
 
-- **opencode needs an env-key provider headless.** OAuth-only providers (stored in
-  `auth.json`) do not work in-container: the connector isolates each agent's `XDG_DATA_HOME`,
-  where opencode keeps `auth.json`, so a mounted one is hidden. Use any provider whose key is an
-  env var, e.g. opencode's hosted models (`OPENCODE_API_KEY`) or `OPENAI_API_KEY`.
+- **opencode needs auth mounted or env-key providers headless.** OAuth providers are stored in
+  `XDG_DATA_HOME/opencode/auth.json`; mount that data root into the container if you want to
+  reuse them. Otherwise use a provider whose key is an env var, e.g. opencode's hosted models
+  (`OPENCODE_API_KEY`) or `OPENAI_API_KEY`.
 - **The container is the trust boundary.** Every agent in a team-container shares its env, so
   secrets are not isolated between agents in the same container. For hard per-agent isolation,
   run one agent per container (the `solo` service): same image, different command.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -189,8 +189,12 @@ Cotal `#feedback` channel for triage.
 **OpenCode.** OpenCode has a native plugin runtime, so its adapter is **not** an MCP server at
 all. A single plugin, injected at launch via `OPENCODE_CONFIG_CONTENT` (inline config merged
 into the operator's, never written to disk), runs inside the OpenCode process and does all four
-surfaces. The connector launches the real `opencode` **TUI** (foreground, watchable, like
-Claude Code launches `claude`), and the plugin:
+surfaces. The spawned process keeps the operator's normal home/config/auth roots (`HOME` / XDG on
+Unix, `USERPROFILE` / app-data roots on Windows);
+only the session SQLite DB is moved per agent with
+`OPENCODE_DB=.cotal/opencode/<name>/opencode.db` so concurrent managed agents do not lock each
+other. The connector launches the real `opencode` **TUI** (foreground, watchable, like Claude
+Code launches `claude`), and the plugin:
 
 - renders the shared `cotal_*` tools as native plugin tools (from `cotalToolSpecs`, the same
   source the MCP adapters render, so the surface cannot drift);

--- a/extensions/connector-core/src/launch.ts
+++ b/extensions/connector-core/src/launch.ts
@@ -11,21 +11,26 @@
  * exfil for key-based providers — the agent holds the key in its own process to do inference, so
  * a compromised agent exfils from its OWN env, spawn-gating the key only breaks the child's LLM
  * function (the real fix is per-agent model auth, a separate roadmap item); nor (ii) filesystem
- * secret access — HOME is forwarded, so a child can still read ~/.aws / ~/.ssh / ~/.config off
- * disk (needs a workspace sandbox, a separate control).
+ * secret access — HOME / XDG / platform config dirs are forwarded, so a child can still read
+ * ~/.aws / ~/.ssh / ~/.config off disk (needs a workspace sandbox, a separate control).
  */
 
 /** OS env a coding-agent TUI genuinely needs to run — find its binary (PATH), render (TERM /
- *  COLORTERM), resolve home/config/data dirs (HOME / XDG_CONFIG_HOME / XDG_DATA_HOME — where a tool
- *  finds its config and credential store), locale (LANG / LC_*), timezone (TZ), temp (TMPDIR),
- *  session/runtime dir (XDG_RUNTIME_DIR), and the shell it may invoke. NOT a model key, NOT an
- *  operator secret. A fixed, named allow-list. */
+ *  COLORTERM), resolve home/config/data roots (HOME / XDG_*_HOME on Unix,
+ *  USERPROFILE / APPDATA / LOCALAPPDATA on Windows), locale (LANG / LC_*), timezone (TZ), temp
+ *  dirs, session/runtime dir (XDG_RUNTIME_DIR), and the shell it may invoke. NOT a model key,
+ *  NOT an operator secret. A fixed, named allow-list. */
 const OS_ENV_ALLOW = [
   "PATH",
   "HOME",
+  "USERPROFILE",
+  "HOMEDRIVE",
+  "HOMEPATH",
   "USER",
   "LOGNAME",
   "SHELL",
+  "COMSPEC",
+  "PATHEXT",
   "TERM",
   "COLORTERM",
   "COLORFGBG",
@@ -34,10 +39,15 @@ const OS_ENV_ALLOW = [
   "LC_CTYPE",
   "LC_MESSAGES",
   "TZ",
+  "TEMP",
   "TMPDIR",
   "TMP",
   "XDG_CONFIG_HOME",
   "XDG_DATA_HOME",
+  "XDG_STATE_HOME",
+  "XDG_CACHE_HOME",
+  "APPDATA",
+  "LOCALAPPDATA",
   "XDG_RUNTIME_DIR",
 ] as const;
 

--- a/extensions/connector-opencode/src/serve.ts
+++ b/extensions/connector-opencode/src/serve.ts
@@ -21,16 +21,8 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { createServer } from "node:net";
 import { once } from "node:events";
 import { randomBytes } from "node:crypto";
-import {
-  existsSync,
-  lstatSync,
-  mkdirSync,
-  readFileSync,
-  readlinkSync,
-  rmSync,
-  symlinkSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 const BIN = process.env.COTAL_OPENCODE_BIN?.trim() || "opencode";
 
@@ -62,45 +54,17 @@ async function killServe(serve: ChildProcess): Promise<void> {
   }
 }
 
-/** opencode keeps provider logins (`auth.json`) and the opencode.ai account (`account.json`) under
- *  the DATA dir — the same XDG_DATA_HOME we redirect per-agent to isolate the session SQLite. opencode
- *  has no env to relocate auth on its own (sst/opencode#5423), so a redirected data dir starts the
- *  agent with an EMPTY auth store: the operator's openai/anthropic logins vanish ("logged out").
- *  Symlink the real files into the per-agent dir so the agent shares the operator's LIVE login (a
- *  later re-login / token refresh writes through), self-healing any stale copy a prior launch left. */
-function shareCredentials(dataHome: string): void {
-  const realDataHome = process.env.XDG_DATA_HOME?.trim() || `${process.env.HOME}/.local/share`;
-  const ocDir = `${dataHome}/opencode`;
-  mkdirSync(ocDir, { recursive: true });
-  for (const file of ["auth.json", "account.json"]) {
-    const src = `${realDataHome}/opencode/${file}`;
-    const dst = `${ocDir}/${file}`;
-    if (!existsSync(src)) continue;
-    let linked = false;
-    try {
-      linked = lstatSync(dst).isSymbolicLink() && readlinkSync(dst) === src;
-    } catch {
-      /* dst absent */
-    }
-    if (linked) continue;
-    rmSync(dst, { force: true }); // drop a stale regular-file copy a buggy launch left behind
-    symlinkSync(src, dst);
-  }
-}
-
 async function main(): Promise<void> {
   const port = process.env.COTAL_OPENCODE_PORT?.trim() || String(await freePort());
   const url = `http://127.0.0.1:${port}`;
-  // Own data dir per agent: opencode keeps sessions in one SQLite file under XDG_DATA_HOME,
-  // and concurrent serves sharing it stall session-create on the write lock (the "agent
-  // session never came up" failure). Per-peer session state is the right scoping anyway.
-  // CAVEAT: auth.json/account.json ALSO live under XDG_DATA_HOME, so redirecting it drops the
-  // operator's provider logins — shareCredentials() symlinks them back in (called below).
+  // Own SQLite DB per agent: opencode auth/config stay on the operator's normal HOME/XDG roots,
+  // while sessions avoid the global DB write lock that stalls concurrent `opencode serve`s.
   const name = process.env.COTAL_NAME?.trim() || "agent";
-  const dataHome = `${process.cwd()}/.cotal/opencode/${name}`;
+  const agentHome = join(process.cwd(), ".cotal", "opencode", name);
+  const dbPath = join(agentHome, "opencode.db");
 
-  // Two serves on one data dir share the SQLite file and stall each other — refuse up front.
-  const pidFile = `${dataHome}/serve.pid`;
+  // Two serves on one agent DB share the SQLite file and stall each other — refuse up front.
+  const pidFile = join(agentHome, "serve.pid");
   if (existsSync(pidFile)) {
     const pid = Number(readFileSync(pidFile, "utf8"));
     let alive = false;
@@ -114,10 +78,9 @@ async function main(): Promise<void> {
     rmSync(pidFile);
   }
 
-  shareCredentials(dataHome); // creates dataHome/opencode + symlinks the operator's logins in
-
+  mkdirSync(agentHome, { recursive: true });
   const serve = spawn(BIN, ["serve", "--hostname", "127.0.0.1", "--port", port], {
-    env: { ...process.env, OPENCODE_SERVER_PASSWORD: SECRET, XDG_DATA_HOME: dataHome },
+    env: { ...process.env, OPENCODE_SERVER_PASSWORD: SECRET, OPENCODE_DB: dbPath },
     stdio: ["ignore", "pipe", "pipe"],
   });
   writeFileSync(pidFile, String(serve.pid));
@@ -170,13 +133,17 @@ async function main(): Promise<void> {
   });
   if (!id) {
     process.stderr.write(
-      "[cotal-connector] serve: agent session never came up (~60s) — aborting. Check the boot log above for plugin/mesh errors (.cotal/opencode/<name>/opencode/log/)\n",
+      `[cotal-connector] serve: agent session never came up (~60s) — aborting. Check the boot log above for plugin/mesh errors (OPENCODE_DB=${dbPath})\n`,
     );
     await killServe(serve);
     process.exit(1);
   }
 
-  const tuiEnv: NodeJS.ProcessEnv = { ...process.env, OPENCODE_SERVER_PASSWORD: SECRET };
+  const tuiEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    OPENCODE_SERVER_PASSWORD: SECRET,
+    OPENCODE_DB: dbPath,
+  };
   delete tuiEnv.OPENCODE_CONFIG_CONTENT; // a viewer, not a peer — must NOT load the plugin again
   for (const k of Object.keys(tuiEnv)) if (k.startsWith("COTAL_")) delete tuiEnv[k];
   attached = true;


### PR DESCRIPTION
## Summary
- keep spawned OpenCode agents on the operator's normal home/config/auth roots, including XDG on Unix and app-data roots on Windows
- isolate only the per-agent session SQLite DB with OPENCODE_DB
- update OpenCode integration and deployment docs

## Tests
- pnpm --filter @cotal-ai/core build
- pnpm --filter @cotal-ai/connector-core build
- pnpm --filter @cotal-ai/connector-opencode build
- OPENCODE_DB=<temp-db> opencode db path
- OPENCODE_DB=<temp-db> opencode debug paths