### PR TITLE
fix(opencode): release busy guard on any turn end so channel push survives human turns

### DIFF
--- a/extensions/connector-opencode/src/plugin.ts
+++ b/extensions/connector-opencode/src/plugin.ts
@@ -76,7 +76,8 @@ export const cotal: Plugin = async ({ client }) => {
   // replacement top-level session. We adopt that as a context reset while keeping the same MeshAgent
   // and creds alive. Used to match our turn-end (idle) vs subagent idles.
   let sessionID: string | undefined;
-  let busy = false; // a turn is running → don't prompt: opencode would COALESCE onto it (no reject)
+  let busy = false; // a turn is running (ours via drive(), OR the human's via session.status) → don't
+  // prompt: opencode would COALESCE onto it (no reject). Released at EVERY turn end (completeTurn).
   let driving = false; // re-entrancy guard around an in-flight promptAsync
   let primed = false; // persona is prepended to the first turn's text once
   let briefed = false; // the boot channel briefing is prepended once, on the first turn
@@ -198,14 +199,20 @@ export const cotal: Plugin = async ({ client }) => {
     surfaced = [];
   }
 
-  /** A turn ended (the sole ack site). Ignore a stray/duplicate idle that isn't our turn's end. Ack
-   *  what the turn consumed, then drive the next batch — mode-aware, so bare ambient (dnd/focus)
-   *  doesn't self-wake a turn (it rides the next directed turn or a human turn). */
+  /** A turn ended — ANY turn, ours (a driven inbox batch) OR the human's (typing into the attached
+   *  TUI, a `/reconnect`, etc). Clear `busy` regardless of who drove it: it's the COALESCE guard, so
+   *  a turn the connector didn't drive must still release it or every later push wedges behind a
+   *  finished turn. Ack only what WE surfaced (gated on awaitingTurnEnd — a human turn surfaced
+   *  nothing), then flush the next buffered batch — mode-aware, so bare ambient (dnd/focus) doesn't
+   *  self-wake (it rides the next directed/human turn). A truly stray idle (nothing was running and
+   *  we drove nothing) is ignored, so it can't mis-ack or empty-drive. */
   function completeTurn(): void {
-    if (!awaitingTurnEnd) return;
-    awaitingTurnEnd = false;
+    if (!busy && !awaitingTurnEnd) return; // stray/duplicate idle — no turn to close
     busy = false;
-    ackSurfaced();
+    if (awaitingTurnEnd) {
+      awaitingTurnEnd = false;
+      ackSurfaced(); // our driven turn: ack the surfaced batch (the sole ack site)
+    }
     if (pendingForWake() > 0) void drive();
   }
 
@@ -273,15 +280,17 @@ export const cotal: Plugin = async ({ client }) => {
         }
         case "session.error":
           // session.error's sessionID is OPTIONAL; skip only a DIFFERENT session's error — a
-          // session-less one (id undefined) during our in-flight turn must still complete it, else
-          // the surfaced batch is never acked and `busy` stays stuck.
+          // session-less one (id undefined) during an in-flight turn must still close it, else
+          // `busy` stays stuck and every later push is buffered behind a turn that already failed.
           if (event.properties.sessionID && !ours(event.properties.sessionID)) return;
-          if (!awaitingTurnEnd) return; // no in-flight turn to fail
-          awaitingTurnEnd = false;
+          if (!busy && !awaitingTurnEnd) return; // no turn to fail — stray error
           busy = false;
-          ackSurfaced(); // turn surfaced the batch but failed — ack (don't retry-loop) and move on
+          if (awaitingTurnEnd) {
+            awaitingTurnEnd = false;
+            ackSurfaced(); // our turn surfaced the batch but failed — ack (don't retry-loop) and move on
+          }
           await safeStatus("idle");
-          void drive();
+          if (pendingForWake() > 0) void drive();
           break;
         case "session.deleted":
           if (!ours(event.properties.info.id)) return;

--- a/extensions/connector-opencode/turn-wedge.smoke.ts
+++ b/extensions/connector-opencode/turn-wedge.smoke.ts
@@ -1,0 +1,108 @@
+/**
+ * OpenCode turn-state regression test (no test runner) — spins up its OWN nats-server and drives the
+ * plugin's turn state machine with a FAKE opencode `client` + real opencode bus events. It guards the
+ * wedge fixed in plugin.ts: `busy` is set true by `session.status: busy` for ANY turn (incl. a human
+ * typing into the attached TUI), but used to be cleared only on a connector-DRIVEN turn's end — so the
+ * first human turn left `busy` stuck true and every later channel/DM push was buffered forever.
+ *
+ * Flow (no model, no `opencode` binary — just the plugin closure + a real mesh):
+ *   1. a live channel message drives a turn (promptAsync #1)  — baseline push works;
+ *   2. that turn completes (session.idle);
+ *   3. a HUMAN turn runs on the same session (session.status busy → session.idle) — the wedge trigger;
+ *   4. a second channel message MUST still drive a turn (promptAsync #2) — pre-fix this never fires.
+ * Run: pnpm smoke:opencode
+ */
+import { strict as assert } from "node:assert";
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CotalEndpoint, seedChannelRegistry, isReachable } from "@cotal-ai/core";
+import { cotal } from "./src/plugin.js";
+
+const PORT = 14238;
+const servers = `nats://127.0.0.1:${PORT}`;
+const space = "ocwedge";
+const SID = "ses_test";
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const dir = mkdtempSync(join(tmpdir(), "cotal-ocwedge-"));
+const srv = spawn("nats-server", ["-js", "-p", String(PORT), "-sd", join(dir, "js")], { stdio: "ignore" });
+let pass = 0;
+const check = (name: string, cond: boolean, extra?: unknown) => {
+  assert.ok(cond, `${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
+  pass++;
+  console.log(`  ✓ ${name}`);
+};
+
+// The plugin reads its identity from COTAL_* env (it runs inside the opencode process).
+Object.assign(process.env, {
+  COTAL_NAME: "Otto",
+  COTAL_SPACE: space,
+  COTAL_SERVERS: servers,
+  COTAL_CHANNELS: "team",
+  COTAL_ROLE: "generalist",
+});
+
+// A fake opencode client: hand the plugin a session id and record every turn it drives.
+const prompts: { id: string }[] = [];
+const fakeClient = {
+  session: {
+    create: async (_: unknown) => ({ data: { id: SID } }),
+    promptAsync: async ({ path }: { path: { id: string } }) => {
+      prompts.push({ id: path.id });
+      return { data: {} };
+    },
+  },
+};
+
+// Fire one opencode bus event at the plugin's `event` hook.
+type Hooks = Awaited<ReturnType<typeof cotal>>;
+const fire = (hooks: Hooks, event: unknown) => hooks.event!({ event } as never);
+
+// A plain peer that posts ambient channel traffic at the agent.
+const pub = new CotalEndpoint({ space, servers, card: { name: "Pubby", kind: "agent", id: "pubby" }, channels: ["team"] });
+pub.on("error", () => {});
+
+// Poll until the plugin has driven `n` turns (push is event-driven + async).
+const waitForPrompts = async (n: number, ms = 5000): Promise<void> => {
+  for (let i = 0; i < ms / 100 && prompts.length < n; i++) await sleep(100);
+};
+
+let hooks: Hooks | undefined;
+try {
+  for (let i = 0; i < 50; i++) { if (await isReachable(servers)) break; await sleep(200); }
+  await seedChannelRegistry({ servers, space, file: { defaults: { replay: false }, channels: { team: { replay: false } } } });
+  await pub.start();
+
+  // Boot the plugin (it connects its mesh agent in the background and creates session SID).
+  hooks = await cotal({ client: fakeClient } as never);
+  await sleep(2000); // let the internal MeshAgent connect + subscribe to #team
+
+  // (1) a live channel message drives a turn — baseline push works.
+  await pub.multicast("hello team", { channel: "team" });
+  await waitForPrompts(1);
+  check("a channel message drives a turn (push works)", prompts.length === 1, prompts);
+
+  // (2) complete the connector's turn (acks it, returns the session to idle).
+  await fire(hooks, { type: "session.idle", properties: { sessionID: SID } });
+
+  // (3) a HUMAN turn on the same session — the exact thing that used to wedge `busy`.
+  await fire(hooks, { type: "session.status", properties: { sessionID: SID, status: { type: "busy" } } });
+  await fire(hooks, { type: "session.idle", properties: { sessionID: SID } });
+
+  // (4) a second channel message MUST still drive a turn. Pre-fix: `busy` is stuck true, so the
+  //     incoming message is buffered and this never fires — waitForPrompts times out at length 1.
+  await pub.multicast("still there?", { channel: "team" });
+  await waitForPrompts(2);
+  check("a channel message STILL drives after a human turn (no busy wedge)", prompts.length === 2, prompts);
+
+  console.log(`\nOPENCODE TURN-WEDGE TEST PASSED ✅  (${pass} checks)`);
+} finally {
+  await hooks?.dispose?.();
+  await pub.stop();
+  srv.kill("SIGKILL");
+  await sleep(150);
+  rmSync(dir, { recursive: true, force: true });
+}
+process.exit(0);

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "smoke:attention": "tsx extensions/connector-core/attention.smoke.ts",
     "smoke:attention:auth": "tsx extensions/connector-core/attention-auth.smoke.ts",
     "smoke:feedback": "tsx extensions/connector-core/feedback.smoke.ts",
+    "smoke:opencode": "tsx extensions/connector-opencode/turn-wedge.smoke.ts",
     "smoke:attach": "tsx implementations/manager/attach.smoke.ts",
     "smoke:env-isolate": "tsx implementations/manager/env-isolate.smoke.ts",
     "smoke:install": "tsx implementations/cli/install.smoke.ts",


### PR DESCRIPTION
## Problem

OpenCode channel (and DM) push silently stops working after the human interacts with the watchable TUI.

`busy` is the COALESCE guard that stops the connector from `promptAsync`-ing into a running turn. It was set **true** by `session.status: busy` for **any** turn — including a human typing into the attached TUI or running `/reconnect` — but only ever cleared inside `completeTurn()`, which bailed early unless `awaitingTurnEnd` (i.e. only for turns the connector itself drove).

So the first human turn set `busy = true`, ended, hit the early return, and left `busy` stuck `true` permanently. From then on every inbound peer message hit `if (busy) return` and was buffered but never driven — and `completeTurn`, the only re-drive site, also bailed. It reads as "channels not pushing" because ambient channel chatter is the constant traffic.

## Fix

- Clear `busy` at the end of **any** turn (ours or the human's) — it's a raw turn-running guard.
- Still ack only the batch **we** surfaced, gated on `awaitingTurnEnd` (a human turn surfaced nothing).
- Ignore a truly stray idle (`!busy && !awaitingTurnEnd`) so it can't mis-ack or empty-drive.
- Same shape applied to the `session.error` path.

## Test

`smoke:opencode` (`extensions/connector-opencode/turn-wedge.smoke.ts`) drives the real state machine with a fake opencode `client` over a real NATS broker — no model, no `opencode` binary:

1. a live channel message drives a turn (push works);
2. a simulated **human** turn runs (`session.status: busy` → `session.idle`);
3. a second channel message must still drive a turn.

Verified it fails on the pre-fix code (stuck at step 1) and passes after.

Note: the test fakes the bus events, so it locks the logic; it relies on real `opencode` emitting `session.status: busy` for human TUI turns (which is what drives the presence "working" indicator).