### PR TITLE
fix(core): make peer name resolution deterministic and fail-loud

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -452,6 +452,16 @@ handle (see *Instance continuity*). `role` is the SLIM **service** (the addressa
 role label is therefore *load-bearing*: it is the **anycast** address, so `svc.reviewer` reaches
 "whoever is a reviewer," not just a roster label.
 
+**Addressing by name.** The instance id is the authoritative address; a `name` is a best-effort
+convenience a client resolves against its observed roster. Resolution is deterministic and
+fail-loud — an exact id wins, a unique name resolves (a live peer beats a stale offline one),
+and a same-name collision among live peers **throws** with the candidates' ids instead of
+silently picking the wrong one (re-address by id). With no live match a unique offline peer
+still resolves best-effort, but multiple offline ghosts of one name also throw. Names carry no
+uniqueness guarantee (the
+manager auto-numbers its own spawns, `reviewer → reviewer-2`), and `/` is reserved in a name for
+a future owner-scoped `owner/name` handle.
+
 A **role** is a reusable template that produces a card, in three layers:
 
 - **Advertisement** (A2A): `role`, `description`, and `skills[]` (each `id` / `name` / `tags` /

--- a/extensions/connector-core/src/agent.ts
+++ b/extensions/connector-core/src/agent.ts
@@ -3,6 +3,7 @@ import {
   normalizeMentions,
   subjectMatches,
   isConcreteChannel,
+  resolvePeer as resolvePeerInRoster,
   CotalEndpoint,
   CONTROL_PRIVILEGED,
   CONTROL_SELF_SERVICE,
@@ -349,17 +350,11 @@ export class MeshAgent extends EventEmitter {
     return this.ep.anycast(role, text, { contextId: this._contextId });
   }
 
-  /** Resolve a peer by instance id (exact) or display name (case-insensitive, prefer present). */
+  /** Resolve a peer by instance id (exact) or display name. Deterministic and fail-loud: returns
+   *  one peer, `undefined` if none match, or throws `AmbiguousPeerError` on a same-name collision —
+   *  it never silently picks. See `resolvePeer` in @cotal-ai/core. */
   resolvePeer(target: string): Presence | undefined {
-    const roster = this.ep.getRoster().filter((p) => p.card.id !== this.id);
-    const byId = roster.find((p) => p.card.id === target);
-    if (byId) return byId;
-    const t = target.toLowerCase();
-    const present = roster.filter((p) => p.status !== "offline");
-    return (
-      present.find((p) => p.card.name.toLowerCase() === t) ??
-      roster.find((p) => p.card.name.toLowerCase() === t)
-    );
+    return resolvePeerInRoster(this.ep.getRoster(), target, { selfId: this.id });
   }
 
   async dm(target: string, text: string): Promise<{ msg: CotalMessage; peer: Presence }> {

--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -9,7 +9,7 @@
  */
 import { execFileSync } from "node:child_process";
 import { z } from "zod";
-import { isConcreteChannel, type PresenceStatus } from "@cotal-ai/core";
+import { isConcreteChannel, AmbiguousPeerError, type PresenceStatus } from "@cotal-ai/core";
 import type { MeshAgent, InboxItem } from "./agent.js";
 import { FEEDBACK_URL, PUBLIC_FEEDBACK_URL, type AgentConfig } from "./config.js";
 
@@ -122,13 +122,21 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
         if (!agent.connected) return ok(`Not connected to the mesh yet (${config.servers}).`);
         const roster = agent.roster();
         if (!roster.length) return ok(`No one is present in "${config.space}" yet.`);
+        // Names aren't unique. Where one repeats, append the instance id so a DM can target the
+        // exact peer (the id is the only authoritative address); keep unique rows clean.
+        const counts = new Map<string, number>();
+        for (const p of roster) {
+          const n = p.card.name.toLowerCase();
+          counts.set(n, (counts.get(n) ?? 0) + 1);
+        }
         const lines = roster.map((p) => {
           const who = p.card.role ? `${p.card.name}/${p.card.role}` : p.card.name;
           const me =
             p.card.id === agent.id
               ? ` (you${agent.attention !== "open" ? `, ${agent.attention}` : ""})`
               : "";
-          return `${statusGlyph(p.status)} ${who} — ${p.status}${p.activity ? `: ${p.activity}` : ""}${me}`;
+          const id = (counts.get(p.card.name.toLowerCase()) ?? 0) > 1 ? ` — id: ${p.card.id}` : "";
+          return `${statusGlyph(p.status)} ${who} — ${p.status}${p.activity ? `: ${p.activity}` : ""}${me}${id}`;
         });
         return ok(`Present in "${config.space}" (${roster.length}):\n${lines.join("\n")}`);
       },
@@ -210,6 +218,15 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
           const { peer } = await agent.dm(to, stripFaceTags(msg));
           return ok(`DM sent to ${peer.card.name}.`);
         } catch (e) {
+          if (e instanceof AmbiguousPeerError) {
+            const who = e.candidates
+              .map((c) => `  • ${c.name}${c.role ? `/${c.role}` : ""} (${c.status}) — id: ${c.id}`)
+              .join("\n");
+            return err(
+              `"${e.target}" is ambiguous — ${e.candidates.length} peers share that name. ` +
+                `Re-send cotal_dm with the exact instance id as "to":\n${who}`,
+            );
+          }
           return err(`Couldn't DM: ${(e as Error).message}`);
         }
       },

--- a/implementations/cli/src/commands/join.ts
+++ b/implementations/cli/src/commands/join.ts
@@ -6,6 +6,8 @@ import {
   CotalEndpoint,
   isReachable,
   parseJoinLink,
+  resolvePeer,
+  AmbiguousPeerError,
   DEFAULT_SERVER,
   type Delivery,
   type EndpointKind,
@@ -199,16 +201,17 @@ export async function join(argv: string[]): Promise<void> {
         else {
           const target = rest.slice(0, sp);
           const text = rest.slice(sp + 1);
-          const peer = ep
-            .getRoster()
-            .find(
-              (p) =>
-                p.card.name.toLowerCase() === target.toLowerCase() && p.card.id !== me,
-            );
-          if (!peer) print(c.red(`no peer named "${target}" present`));
-          else {
-            await ep.unicast(peer.card.id, text);
-            print(`${c.magenta("(DM)")} ${c.dim("you →")} ${c.bold(peer.card.name)}: ${text}`);
+          try {
+            const peer = resolvePeer(ep.getRoster(), target, { selfId: me });
+            if (!peer) print(c.red(`no peer named "${target}" present`));
+            else {
+              await ep.unicast(peer.card.id, text);
+              print(`${c.magenta("(DM)")} ${c.dim("you →")} ${c.bold(peer.card.name)}: ${text}`);
+            }
+          } catch (e) {
+            if (!(e instanceof AmbiguousPeerError)) throw e;
+            print(c.red(`"${target}" is ambiguous — DM by instance id:`));
+            for (const cand of e.candidates) print(c.dim(`  ${cand.name} (${cand.status})  ${cand.id}`));
           }
         }
       } else if (line.startsWith("/anycast ")) {

--- a/implementations/cli/src/commands/send.ts
+++ b/implementations/cli/src/commands/send.ts
@@ -3,12 +3,15 @@ import { readFileSync } from "node:fs";
 import {
   CotalEndpoint,
   isReachable,
+  resolvePeer,
+  AmbiguousPeerError,
   DEFAULT_SERVER,
   DEFAULT_SPACE,
   authDir,
   loadSpaceAuth,
   mintCreds,
   newIdentity,
+  type Presence,
 } from "@cotal-ai/core";
 import { c } from "../ui.js";
 import { cotalRoot } from "../lib/paths.js";
@@ -84,21 +87,28 @@ export async function dm(argv: string[]): Promise<void> {
   }
   const { ep, space } = await connectSender(values);
   // Presence arrives asynchronously after connect; poll briefly (≤2s) for the target to appear.
-  const want = target.toLowerCase();
-  const find = (): string | undefined =>
-    ep.getRoster().find((p) => p.card.name.toLowerCase() === want)?.card.id;
-  let id = find();
-  for (let i = 0; i < 20 && !id; i++) {
-    await new Promise((r) => setTimeout(r, 100));
-    id = find();
+  // resolvePeer is fail-loud: an exact id or a unique name resolves, a same-name collision throws.
+  let peer: Presence | undefined;
+  for (let i = 0; i < 20 && !peer; i++) {
+    try {
+      peer = resolvePeer(ep.getRoster(), target);
+    } catch (e) {
+      if (!(e instanceof AmbiguousPeerError)) throw e;
+      console.error(c.red(`"${target}" is ambiguous — DM by instance id instead:`));
+      for (const cand of e.candidates)
+        console.error(c.dim(`  ${cand.name} (${cand.status})  ${cand.id}`));
+      await ep.stop();
+      process.exit(1);
+    }
+    if (!peer) await new Promise((r) => setTimeout(r, 100));
   }
-  if (!id) {
+  if (!peer) {
     console.error(c.red(`no agent "${target}" present in space ${space}`));
     await ep.stop();
     process.exit(1);
   }
-  await ep.unicast(id, text);
-  console.log(c.green(`→ ${target}`) + c.dim(`  ${text}`));
+  await ep.unicast(peer.card.id, text);
+  console.log(c.green(`→ ${peer.card.name}`) + c.dim(`  ${text}`));
   await ep.stop();
 }
 

--- a/implementations/cli/src/console/commands.ts
+++ b/implementations/cli/src/console/commands.ts
@@ -2,7 +2,7 @@
 // the CLI `Command` registry, which is argv/process-exit shaped). The catalog drives both execution
 // and the palette's autocomplete. Write commands publish over the mesh via the observer endpoint;
 // they are gated on `canWrite` (open mode, or a privileged --creds).
-import { CONTROL_PRIVILEGED, type CotalEndpoint } from "@cotal-ai/core";
+import { CONTROL_PRIVILEGED, resolvePeer, AmbiguousPeerError, type CotalEndpoint } from "@cotal-ai/core";
 import type { MeshSnapshot } from "../view/mesh-view.js";
 import { mentionsIn } from "../lib/mentions.js";
 
@@ -27,10 +27,16 @@ export interface ConsoleCommand {
   run(ctx: CommandCtx, rest: string): Promise<void> | void;
 }
 
-/** Resolve an agent/endpoint name (with or without a leading @) to its instance id. */
+/** Resolve an agent/endpoint name (with or without a leading @) to its instance id. Fail-loud:
+ *  an exact id or a unique name resolves; a same-name collision throws `AmbiguousPeerError`
+ *  (the caller renders {@link ambiguityNote}). */
 function idOf(snap: MeshSnapshot, name: string): string | undefined {
-  const n = name.replace(/^@/, "").toLowerCase();
-  return [...snap.agents, ...snap.endpoints].find((p) => p.card.name.toLowerCase() === n)?.card.id;
+  return resolvePeer([...snap.agents, ...snap.endpoints], name.replace(/^@/, ""))?.card.id;
+}
+
+/** One-line note for the transient status bar when a name matched several peers. */
+function ambiguityNote(e: AmbiguousPeerError): string {
+  return `"${e.target}" is ambiguous — dm by id: ${e.candidates.map((c) => `${c.name} ${c.id}`).join(", ")}`;
 }
 
 export const COMMANDS: ConsoleCommand[] = [
@@ -60,7 +66,13 @@ export const COMMANDS: ConsoleCommand[] = [
     run: async (ctx, rest) => {
       const m = rest.match(/^@?(\S+)\s+([\s\S]+)/);
       if (!m) return ctx.notify("usage: dm <@agent> <text>");
-      const id = idOf(ctx.snapshot, m[1]);
+      let id: string | undefined;
+      try {
+        id = idOf(ctx.snapshot, m[1]);
+      } catch (e) {
+        if (e instanceof AmbiguousPeerError) return ctx.notify(ambiguityNote(e));
+        throw e;
+      }
       if (!id) return ctx.notify(`no agent "${m[1]}"`);
       await ctx.ep.unicast(id, m[2]);
       ctx.notify(`→ ${m[1].replace(/^@/, "")}`);
@@ -73,7 +85,13 @@ export const COMMANDS: ConsoleCommand[] = [
     write: true,
     run: async (ctx, rest) => {
       const name = rest.replace(/^@/, "").trim().split(/\s+/)[0] ?? "";
-      const id = idOf(ctx.snapshot, name);
+      let id: string | undefined;
+      try {
+        id = idOf(ctx.snapshot, name);
+      } catch (e) {
+        if (e instanceof AmbiguousPeerError) return ctx.notify(ambiguityNote(e));
+        throw e;
+      }
       if (!id) return ctx.notify(`no agent "${name}"`);
       await ctx.ep.unicast(id, "👋 ping");
       ctx.setMode("dm");

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -300,7 +300,10 @@ export class Manager {
   }
 
   /** Resolve once `name` shows up on the mesh roster (presence registered), or after `timeoutMs`.
-   *  Lets the pre-spawn loop stagger heavy agent cold-starts so they don't all boot at once. */
+   *  Lets the pre-spawn loop stagger heavy agent cold-starts so they don't all boot at once.
+   *  Best-effort, keyed on the manager-owned (auto-numbered, unique) spawn name — NOT identity
+   *  resolution: a same-named *unmanaged* peer already present could satisfy this early. That's
+   *  acceptable for cold-start staggering; it never routes anything. */
   async waitForPresence(name: string, timeoutMs = 30_000): Promise<boolean> {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json",
+    "test": "tsx resolve.smoke.ts",
     "prepublishOnly": "pnpm run build"
   },
   "dependencies": {

--- a/packages/core/resolve.smoke.ts
+++ b/packages/core/resolve.smoke.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure-function smoke for peer name resolution + validation (no NATS) — run with: pnpm -r test
+ * Asserts the deterministic, fail-loud rules in src/resolve.ts.
+ */
+import assert from "node:assert/strict";
+import { resolvePeer, AmbiguousPeerError, assertValidName } from "./src/resolve.js";
+import type { Presence, PresenceStatus } from "./src/types.js";
+
+let seq = 0;
+function p(name: string, status: PresenceStatus = "idle", id = `id-${++seq}`): Presence {
+  return { card: { id, name, kind: "agent" }, status, ts: 0 };
+}
+function expectAmbiguous(fn: () => unknown, count: number): void {
+  assert.throws(fn, (e: unknown) => e instanceof AmbiguousPeerError && e.candidates.length === count);
+}
+
+// exact id beats a same-name peer
+{
+  const a = p("bob", "idle", "ID1");
+  const b = p("bob", "idle", "ID2");
+  assert.equal(resolvePeer([a, b], "ID2")?.card.id, "ID2");
+}
+
+// unique live name resolves (case-insensitively)
+{
+  const a = p("Alice");
+  assert.equal(resolvePeer([a, p("bob")], "alice")?.card.id, a.card.id);
+}
+
+// 2 live same-name → throws with both candidates
+expectAmbiguous(() => resolvePeer([p("bob"), p("bob")], "bob"), 2);
+
+// 1 live + 1 stale offline → resolves the live one (reconnect grace)
+{
+  const live = p("bob", "working", "LIVE");
+  const ghost = p("bob", "offline", "GHOST");
+  assert.equal(resolvePeer([ghost, live], "bob")?.card.id, "LIVE");
+}
+
+// unique offline → resolves (best-effort convenience)
+assert.equal(resolvePeer([p("bob", "offline", "OFF")], "bob")?.card.id, "OFF");
+
+// 2 offline same-name → throws (stale ghosts don't mask a real ambiguity)
+expectAmbiguous(() => resolvePeer([p("bob", "offline"), p("bob", "offline")], "bob"), 2);
+
+// self is excluded; no other match → undefined
+assert.equal(resolvePeer([p("me", "idle", "ME")], "me", { selfId: "ME" }), undefined);
+
+// no match → undefined
+assert.equal(resolvePeer([p("alice")], "nobody"), undefined);
+
+// name validation: accept human display names + roster names; reject reserved/edge shapes
+assert.doesNotThrow(() => assertValidName("review-general"));
+assert.doesNotThrow(() => assertValidName("Ada Lovelace"));
+for (const bad of ["", " bob", "bob ", "a/b", "a\nb"]) assert.throws(() => assertValidName(bad));
+
+console.log("resolve.smoke: all assertions passed");

--- a/packages/core/src/agent-file.ts
+++ b/packages/core/src/agent-file.ts
@@ -24,6 +24,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import type { EndpointKind } from "./types.js";
+import { assertValidName } from "./resolve.js";
 
 export interface AgentDef {
   name: string;
@@ -111,6 +112,7 @@ export function loadAgentFile(path: string): AgentDef {
 
   const name = str("name");
   if (!name) throw new Error(`agent file ${path}: "name" is required`);
+  assertValidName(name);
   const kind = str("kind");
   if (kind && kind !== "agent" && kind !== "endpoint")
     throw new Error(`agent file ${path}: "kind" must be "agent" or "endpoint"`);
@@ -143,6 +145,7 @@ export function loadAgentFile(path: string): AgentDef {
  *  persist a peer-defined agent as config. */
 export function saveAgentFile(path: string, def: AgentDef): void {
   if (!def.name) throw new Error('saveAgentFile: "name" is required');
+  assertValidName(def.name);
   const lines = ["---", `name: ${fmScalar(def.name)}`];
   if (def.role) lines.push(`role: ${fmScalar(def.role)}`);
   if (def.kind) lines.push(`kind: ${fmScalar(def.kind)}`);

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -11,6 +11,7 @@ import {
   type Subscription,
 } from "@nats-io/transport-node";
 import { idFromCreds } from "./identity.js";
+import { assertValidName } from "./resolve.js";
 import { createSpaceStreams, dmDurableConfig, taskDurableConfig, MAX_MSGS_PER_SUBJECT } from "./streams.js";
 import {
   jetstream,
@@ -190,6 +191,10 @@ export class CotalEndpoint extends EventEmitter {
   constructor(opts: EndpointOptions) {
     super();
     this.space = opts.space;
+    // A display name is the client-side handle a peer is addressed by; reject the reserved `/`
+    // (the future owner/name separator) and surrounding whitespace at the one identity choke
+    // point every join/spawn path flows through.
+    assertValidName(opts.card.name);
     // Identity precedence: an explicit card.id, else the creds' identity, else a random
     // uuid. When both an id and creds are given they MUST name the same nkey — otherwise
     // the subject sender token wouldn't match the authenticated user and every publish

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./types.js";
 export * from "./subjects.js";
+export * from "./resolve.js";
 export * from "./link.js";
 export * from "./identity.js";
 export * from "./provision.js";

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -1,0 +1,92 @@
+/**
+ * Peer name resolution + name validation — the client-side half of addressing.
+ *
+ * The wire routes on the unforgeable instance id (the nkey carried in the subject); a human
+ * **name** is only a convenience this resolves to an id. Resolution is deterministic and
+ * fail-loud: it returns exactly one peer or throws {@link AmbiguousPeerError} — it never
+ * silently picks among same-named peers. The id is authoritative; the name is best-effort.
+ *
+ * `owner/name` handles (per-owner namespaces) land with the accounts/auth feature; until then
+ * `/` is reserved in a name ({@link assertValidName}) so they slot in without a migration.
+ * See .internal/plans/peer-addressing.md.
+ */
+import type { Presence, PresenceStatus } from "./types.js";
+
+/** A peer that matched an ambiguous name — structural, so each surface renders it itself
+ *  (core never formats UI strings). The full `id` is the authoritative, routable address. */
+export interface PeerCandidate {
+  id: string;
+  name: string;
+  role?: string;
+  status: PresenceStatus;
+  /** Epoch ms of the peer's last heartbeat. */
+  ts: number;
+}
+
+/** Thrown when a name resolves to two or more peers that could each be the target. Carries the
+ *  candidates structurally so a caller can show them and re-address by the exact `id`. */
+export class AmbiguousPeerError extends Error {
+  constructor(
+    readonly target: string,
+    readonly candidates: PeerCandidate[],
+  ) {
+    super(
+      `"${target}" is ambiguous — ${candidates.length} peers share that name: ` +
+        candidates.map((c) => `${c.name} (${c.id}, ${c.status})`).join("; ") +
+        `. Re-send to the exact instance id.`,
+    );
+    this.name = "AmbiguousPeerError";
+  }
+}
+
+function candidate(p: Presence): PeerCandidate {
+  return { id: p.card.id, name: p.card.name, role: p.card.role, status: p.status, ts: p.ts };
+}
+
+/**
+ * Resolve a `target` (an exact instance id, or a display name) to one peer on `roster`.
+ *
+ * - an exact instance-id match wins (any status — an id is unambiguous);
+ * - otherwise a case-insensitive name match, preferring live peers over stale offline ghosts:
+ *   one live match resolves; **2+ live matches throw**; with no live match a unique offline peer
+ *   resolves (best-effort), but **2+ offline duplicates throw**;
+ * - no match → `undefined` (the caller renders "no such peer").
+ *
+ * `opts.selfId`, when given, is excluded (you don't DM yourself). Throws
+ * {@link AmbiguousPeerError} rather than ever silently picking.
+ */
+export function resolvePeer(
+  roster: Presence[],
+  target: string,
+  opts: { selfId?: string } = {},
+): Presence | undefined {
+  const peers = opts.selfId ? roster.filter((p) => p.card.id !== opts.selfId) : roster;
+
+  const byId = peers.find((p) => p.card.id === target);
+  if (byId) return byId;
+
+  const want = target.trim().toLowerCase();
+  if (!want) return undefined;
+  const matches = peers.filter((p) => p.card.name.toLowerCase() === want);
+  if (matches.length === 0) return undefined;
+
+  const live = matches.filter((p) => p.status !== "offline");
+  const pool = live.length > 0 ? live : matches;
+  if (pool.length === 1) return pool[0];
+  throw new AmbiguousPeerError(target, pool.map(candidate));
+}
+
+/**
+ * Validate a display name. A name must be non-empty, single-line, and free of surrounding
+ * whitespace; `/` is reserved as the future `owner/name` separator (and already means "a path"
+ * to the agent-file loader). Throws — no silent rewrite (per AGENTS.md, no fallbacks). Internal
+ * spaces are allowed (human display names like "Ada Lovelace").
+ */
+export function assertValidName(name: string): void {
+  if (name.length === 0 || name !== name.trim())
+    throw new Error(`invalid name ${JSON.stringify(name)}: must be non-empty with no surrounding whitespace`);
+  if (/[\r\n]/.test(name))
+    throw new Error(`invalid name ${JSON.stringify(name)}: must be a single line`);
+  if (name.includes("/"))
+    throw new Error(`invalid name ${JSON.stringify(name)}: "/" is reserved (the owner/name separator)`);
+}


### PR DESCRIPTION
## What

Addressing a peer **by name** resolved silently and non-deterministically: the
resolver used `.find()` over the roster, so a same-name collision picked the
first match and told no one. The wire already routes on the unforgeable instance
id (the nkey in the subject); the name is only a client-side convenience.

This makes name→id resolution **deterministic and fail-loud**, and consolidates
the four duplicated resolvers onto one.

## Changes

- **New `packages/core/src/resolve.ts`** — pure `resolvePeer(roster, target, {selfId?})`
  + structural `AmbiguousPeerError` (carries `{id,name,role,status,ts}`; no UI
  strings) + `assertValidName`. Rule: exact id wins → one live name-match resolves
  (a live peer beats a stale offline one) → 2+ live throws → a unique offline peer
  resolves best-effort → 2+ offline ghosts throw → else `undefined`.
- **Consolidated** the connector (`agent.ts`), CLI (`cotal dm`, interactive `/dm`),
  and console (`idOf`) by-name lookups onto it. Each renders the ambiguity error
  with full ids; none silently picks.
- **Surfacing** — `cotal_dm` lists candidate ids on a collision; `cotal_roster`
  appends a full id only on duplicated names (short ids aren't routable).
- **`/` reserved** in display names (`assertValidName`) for the future owner-scoped
  `owner/name` handle, enforced at the endpoint card choke point and in agent-file
  load/save. Manager spawn already excluded `/` via its stricter name check.
- Docs (`architecture.md`) + a pure-function smoke (`resolve.smoke.ts`, wired as the
  core `test`).

## Verification

- `pnpm typecheck` — green (14 projects)
- `pnpm --filter @cotal-ai/core test` — green (exact-id, live/offline ladders,
  case-insensitive, self-excluded, `/` rejection)

## Notes

Owner-scoped `owner/name` handles and their signed bindings land later with the
accounts/auth work; this slice only reserves the grammar. Reviewed on the mesh —
no blocking findings.