### PR TITLE
feat(connector): opt-in per-connector MCP server sharing for spawned agents

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -693,7 +693,8 @@ later).
   Runtime-agnostic exit-reaping (cmux liveness → sweep-at-gate) is a tracked follow-up.
 - **Spawned children get a declared env, not the manager's.** Runtimes pass only an explicit
   allow-list (`launchEnv()`: PATH / HOME / locale / TERM, plus the one model key the connector
-  needs), never `process.env`, so the operator's *unrelated* secrets (cloud creds, tokens) stop
+  needs, plus the named `${VAR}` secrets any opted-in shared MCP server declares — all forwarded
+  *by name*), never `process.env`, so the operator's *unrelated* secrets (cloud creds, tokens) stop
   bleeding into every agent. Honest scope: this closes **env-var** bleed only. It does **not**
   close model-key exfil (the agent holds the key in-process to do inference, which needs per-agent
   model auth) or filesystem reads (`HOME` is forwarded, so a child can still read `~/.aws` /

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -241,9 +241,9 @@ Hermes has no MCP), so it lives in connector settings, not the
   config file is safe to keep in `~/.config` or a gitignored `.cotal/`. At launch the connector
   forwards *only* the named vars the chosen servers declare (from the operator's env, by name —
   never the whole environment, preserving the P3 env allow-list) and passes the merged config as a
-  `0600` file (in a private `0700` temp dir) so Claude expands the references itself; the secret
-  never lands on disk or the command line. `--strict-mcp-config` stays on, so only cotal + the
-  explicitly-shared servers ever load.
+  `0600` file (in a private `0700` temp dir); Claude expands the references from that env at launch,
+  so the secret never lands on disk or the command line. `--strict-mcp-config` stays on, so only
+  cotal + the explicitly-shared servers ever load.
 - **Sharing a server grants its credential to the agent.** The forwarded var lives in the *Claude
   process's* environment (that's how Claude expands the `${VAR}` and the server reads it), so an
   agent with shell/tool access can read it directly — not only through the server's tools. Keeping

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -241,8 +241,14 @@ Hermes has no MCP), so it lives in connector settings, not the
   config file is safe to keep in `~/.config` or a gitignored `.cotal/`. At launch the connector
   forwards *only* the named vars the chosen servers declare (from the operator's env, by name —
   never the whole environment, preserving the P3 env allow-list) and passes the merged config as a
-  `0600` file so Claude expands the references itself; the secret never lands on disk or the command
-  line. `--strict-mcp-config` stays on, so only cotal + the explicitly-shared servers ever load.
+  `0600` file (in a private `0700` temp dir) so Claude expands the references itself; the secret
+  never lands on disk or the command line. `--strict-mcp-config` stays on, so only cotal + the
+  explicitly-shared servers ever load.
+- **Sharing a server grants its credential to the agent.** The forwarded var lives in the *Claude
+  process's* environment (that's how Claude expands the `${VAR}` and the server reads it), so an
+  agent with shell/tool access can read it directly — not only through the server's tools. Keeping
+  it off disk/argv is about the host's exposure, not the agent's: share a server only when you're
+  fine with that teammate holding the key.
 - **Per-spawn override.** `cotal spawn <name> --share-tools tavily,figma` shares only those
   (they must be declared); `--share-tools none` shares nothing. Absent, all declared servers are
   shared. Manager-spawned agents (`cotal start`) use the config as-is. Default — no config file —

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -166,14 +166,15 @@ claude --strict-mcp-config --mcp-config '{"mcpServers":{"cotal":{"command":"node
 # env: COTAL_SPACE, COTAL_NAME, COTAL_ROLE, COTAL_SERVERS, COTAL_CHANNEL=1
 ```
 
-- **MCP isolation.** A spawned agent runs with **only** the cotal MCP server.
+- **MCP isolation.** By default a spawned agent runs with **only** the cotal MCP server.
   `--strict-mcp-config` ignores every other MCP source, crucially the operator's personal
   `~/.claude.json` servers. A meshed teammate needs none of them, and several spawns each
   booting a Chromium/DB/etc. helper would starve memory and kill the sessions before they
-  register presence. `--mcp-config` re-supplies cotal. Because the plugin's own MCP server is
-  suppressed, the channel ref is the manually-configured server tagged `server:cotal` (not
-  `plugin:cotal@cotal-mesh`); the plugin stays installed for its hooks (message delivery),
-  independent of the wake nudge.
+  register presence. `--mcp-config` re-supplies cotal (plus any servers the operator opted to
+  share — see [Sharing personal MCP servers](#sharing-personal-mcp-servers)). Because the
+  plugin's own MCP server is suppressed, the channel ref is the manually-configured server
+  tagged `server:cotal` (not `plugin:cotal@cotal-mesh`); the plugin stays installed for its
+  hooks (message delivery), independent of the wake nudge.
 - **Installed, not `--plugin-dir`.** The plugin is installed once (`claude plugin install
   cotal@cotal-mesh --scope local`). Its hooks bind only to an *installed* plugin, so
   `--plugin-dir` (which loads but does not "install") is not enough. Local scope keeps it to
@@ -201,6 +202,53 @@ claude --strict-mcp-config --mcp-config '{"mcpServers":{"cotal":{"command":"node
 - **Hands-free spawn.** The dev-channels flag prints a one-time "Enter to confirm" prompt.
   The PTY runtime auto-clears it via `LaunchSpec.confirm`, so a supervised launch needs no
   keypress.
+
+## Sharing personal MCP servers
+
+Isolation is the default, but sometimes a meshed teammate genuinely needs one of your own tools
+(say web search). The **cotal config file** is the opt-in. It's per-connector — MCP passthrough
+isn't a portable agent concept (OpenCode inherits the operator's servers via its merge layer;
+Hermes has no MCP), so it lives in connector settings, not the
+[agent file](#agent-files-persona-and-identity).
+
+```jsonc
+// ~/.config/cotal/config.json   (operator-level, every space)
+// or  <root>/.cotal/config.json (space-local, layered on top — same shape)
+{
+  "connectors": {
+    "claude": {
+      "mcpServers": {
+        "tavily": {
+          "command": "npx",
+          "args": ["-y", "tavily-mcp"],
+          "env": { "TAVILY_API_KEY": "${TAVILY_API_KEY}" }
+        }
+      }
+    }
+  }
+}
+```
+
+- **Where it lives.** Two layers, merged by server name (more specific wins):
+  `~/.config/cotal/config.json` (or `$XDG_CONFIG_HOME/cotal/config.json`) as the operator-level
+  base, and a space-local `.cotal/config.json` on top. Personal servers are an operator concern,
+  so the global file is the usual home; the space file is for project-specific overrides.
+- **How servers are written.** Each entry is the de-facto `.mcp.json` shape, so you can copy one
+  straight out of your own Claude / VS Code / Cursor config. Spelled out in full (command/args/env)
+  — not referenced by name — because the heaviest servers (e.g. a plugin/npx-sourced Chromium) are
+  invisible to a by-name lookup of `~/.claude.json`.
+- **Secrets stay references.** Write keys as `${VAR}` / `${VAR:-default}`, never literals — the
+  config file is safe to keep in `~/.config` or a gitignored `.cotal/`. At launch the connector
+  forwards *only* the named vars the chosen servers declare (from the operator's env, by name —
+  never the whole environment, preserving the P3 env allow-list) and passes the merged config as a
+  `0600` file so Claude expands the references itself; the secret never lands on disk or the command
+  line. `--strict-mcp-config` stays on, so only cotal + the explicitly-shared servers ever load.
+- **Per-spawn override.** `cotal spawn <name> --share-tools tavily,figma` shares only those
+  (they must be declared); `--share-tools none` shares nothing. Absent, all declared servers are
+  shared. Manager-spawned agents (`cotal start`) use the config as-is. Default — no config file —
+  is unchanged: a spawned agent gets only cotal.
+- **Mind the memory.** Sharing re-opens the cost isolation guards: a heavy server booted once per
+  spawn multiplies across a team. Share lean servers; keep the Chromium-class ones out.
 
 ## Message delivery (stream-backed)
 

--- a/extensions/connector-claude-code/src/extension.ts
+++ b/extensions/connector-claude-code/src/extension.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -77,15 +77,20 @@ export const claudeConnector: Connector = {
     // cotal is spread LAST so a shared server can never shadow the mesh server by reusing its name.
     const mcpServers = { ...shared, [MCP_SERVER_NAME]: { command: "node", args: [MCP_CJS] } };
     // Default (no shared servers): pass the config inline, unchanged. With shared servers we write
-    // it to a 0600 file instead and pass the path: a shared spec carries `${VAR}` secret refs, and
-    // Claude only expands those in an --mcp-config *file* (not an inline string), so the file form
-    // keeps secrets as references (never resolved onto disk or the command line) while still loading.
+    // it to a file instead and pass the path: a shared spec carries `${VAR}` secret refs, and Claude
+    // only expands those in an --mcp-config *file* (not an inline string), so the file form keeps
+    // secrets as references (never resolved onto disk or the command line) while still loading.
     let mcpConfig: string;
     if (Object.keys(shared).length === 0) {
       mcpConfig = JSON.stringify({ mcpServers });
     } else {
-      const safe = `${opts.space}-${opts.name}`.replace(/[^A-Za-z0-9._-]/g, "_");
-      mcpConfig = join(tmpdir(), `cotal-mcp-${safe}.json`);
+      // A private 0700 temp dir (unique per spawn) holds the 0600 config. mkdtemp can't be raced
+      // by a pre-created or symlinked path the way a predictable name in the world-writable tmpdir
+      // could, and a fresh file guarantees the 0600 mode applies on creation (mode is ignored on an
+      // overwrite). Left for the OS to reap: the file must outlive this call (Claude reads it at
+      // startup and on /mcp reconnect), and buildLaunch doesn't own the child's lifecycle.
+      const dir = mkdtempSync(join(tmpdir(), "cotal-mcp-"));
+      mcpConfig = join(dir, "mcp.json");
       writeFileSync(mcpConfig, JSON.stringify({ mcpServers }, null, 2), { mode: 0o600 });
     }
     args.push("--strict-mcp-config", "--mcp-config", mcpConfig);

--- a/extensions/connector-claude-code/src/extension.ts
+++ b/extensions/connector-claude-code/src/extension.ts
@@ -76,10 +76,15 @@ export const claudeConnector: Connector = {
     // The plugin itself stays enabled (its hooks + the dev-channels wake path are unaffected).
     // cotal is spread LAST so a shared server can never shadow the mesh server by reusing its name.
     const mcpServers = { ...shared, [MCP_SERVER_NAME]: { command: "node", args: [MCP_CJS] } };
-    // Default (no shared servers): pass the config inline, unchanged. With shared servers we write
-    // it to a file instead and pass the path: a shared spec carries `${VAR}` secret refs, and Claude
-    // only expands those in an --mcp-config *file* (not an inline string), so the file form keeps
-    // secrets as references (never resolved onto disk or the command line) while still loading.
+    // Default (no shared servers): pass the config inline, unchanged. With shared servers, write it
+    // to a file instead and pass the path. Either way the secret stays a `${VAR}` reference (Claude
+    // expands it from the child env at launch — see the mcpKeys forwarding above), never the resolved
+    // value, so nothing secret reaches disk or argv. We prefer the file when sharing because env
+    // expansion is only *documented* for --mcp-config files (inline expansion does work today, but
+    // isn't contracted), and a file keeps a potentially multi-server config off the process argv.
+    // Verified end-to-end on claude 2.1.183: ${VAR} expands in the --mcp-config file and the value
+    // is handed to the shared server. This is host-version behavior — if a future claude stops
+    // expanding here, a shared server would receive a literal `${VAR}`; re-check on host upgrades.
     let mcpConfig: string;
     if (Object.keys(shared).length === 0) {
       mcpConfig = JSON.stringify({ mcpServers });

--- a/extensions/connector-claude-code/src/extension.ts
+++ b/extensions/connector-claude-code/src/extension.ts
@@ -1,7 +1,9 @@
-import { resolve } from "node:path";
+import { writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { loadAgentFile, registry, type Connector, type LaunchOpts, type LaunchSpec } from "@cotal-ai/core";
-import { launchEnv } from "@cotal-ai/connector-core";
+import { launchEnv, mcpServerEnvKeys } from "@cotal-ai/connector-core";
 
 /** Name the cotal MCP server is registered under via --mcp-config (see buildLaunch). */
 const MCP_SERVER_NAME = "cotal";
@@ -31,11 +33,14 @@ export const claudeConnector: Connector = {
   name: "claude",
   pluginRoot: PLUGIN_ROOT,
   buildLaunch(opts: LaunchOpts): LaunchSpec {
+    // Operator MCP servers shared with this agent (default none — see the --mcp-config block).
+    const shared = opts.mcpServers ?? {};
     // claude auths via macOS Keychain / an OAuth token, not an env key → forward NO provider key.
-    // The OS allow-list (PATH/HOME/TERM/…) is the only thing inherited from the manager env; the
-    // operator's unrelated secrets don't reach the child (P3).
+    // The OS allow-list (PATH/HOME/TERM/…) is the only thing inherited from the manager env, plus
+    // — only when a shared server declares them via `${VAR}` — the named secrets it needs (mcpKeys,
+    // by name). The operator's unrelated secrets don't reach the child (P3).
     const env: Record<string, string> = {
-      ...launchEnv(),
+      ...launchEnv({ mcpKeys: mcpServerEnvKeys(shared) }),
       COTAL_SPACE: opts.space,
       COTAL_NAME: opts.name,
       // Force the connector to emit channel wake-nudges: Claude doesn't advertise the
@@ -62,17 +67,28 @@ export const claudeConnector: Connector = {
     // mid-demo. Additive under the default permission mode — leaves other tools as-is.
     args.push("--allowedTools", "WebFetch(domain:github.com),WebFetch(domain:raw.githubusercontent.com)");
 
-    // Isolate the spawned session's MCP to ONLY the cotal server. --strict-mcp-config drops every
-    // other MCP source — including the operator's personal ~/.claude.json servers (e.g. a headless
-    // Chromium, a DB server) that a meshed teammate never needs and that, multiplied across several
-    // spawns on a busy machine, starve memory and kill the session before it registers presence —
-    // and --mcp-config re-supplies cotal so its tools + presence still load. The plugin itself stays
-    // enabled (its hooks + the dev-channels wake path are unaffected; only MCP config is scoped).
-    args.push(
-      "--strict-mcp-config",
-      "--mcp-config",
-      JSON.stringify({ mcpServers: { [MCP_SERVER_NAME]: { command: "node", args: [MCP_CJS] } } }),
-    );
+    // Isolate the spawned session's MCP. --strict-mcp-config drops every ambient MCP source —
+    // including the operator's personal ~/.claude.json servers (e.g. a headless Chromium, a DB
+    // server) that a meshed teammate never needs and that, multiplied across several spawns on a
+    // busy machine, starve memory and kill the session before it registers presence — so the ONLY
+    // servers that load are the ones we name in --mcp-config: cotal (always, for its tools +
+    // presence) plus any the operator explicitly opted to share (`shared`, from the cotal config).
+    // The plugin itself stays enabled (its hooks + the dev-channels wake path are unaffected).
+    // cotal is spread LAST so a shared server can never shadow the mesh server by reusing its name.
+    const mcpServers = { ...shared, [MCP_SERVER_NAME]: { command: "node", args: [MCP_CJS] } };
+    // Default (no shared servers): pass the config inline, unchanged. With shared servers we write
+    // it to a 0600 file instead and pass the path: a shared spec carries `${VAR}` secret refs, and
+    // Claude only expands those in an --mcp-config *file* (not an inline string), so the file form
+    // keeps secrets as references (never resolved onto disk or the command line) while still loading.
+    let mcpConfig: string;
+    if (Object.keys(shared).length === 0) {
+      mcpConfig = JSON.stringify({ mcpServers });
+    } else {
+      const safe = `${opts.space}-${opts.name}`.replace(/[^A-Za-z0-9._-]/g, "_");
+      mcpConfig = join(tmpdir(), `cotal-mcp-${safe}.json`);
+      writeFileSync(mcpConfig, JSON.stringify({ mcpServers }, null, 2), { mode: 0o600 });
+    }
+    args.push("--strict-mcp-config", "--mcp-config", mcpConfig);
 
     // An agent file carries identity (read in-session via COTAL_AGENT_FILE) plus
     // persona + model, which can only be applied to a `claude` session at launch.

--- a/extensions/connector-core/src/launch.ts
+++ b/extensions/connector-core/src/launch.ts
@@ -14,6 +14,7 @@
  * secret access — HOME / XDG / platform config dirs are forwarded, so a child can still read
  * ~/.aws / ~/.ssh / ~/.config off disk (needs a workspace sandbox, a separate control).
  */
+import type { McpServerSpec } from "@cotal-ai/core";
 
 /** OS env a coding-agent TUI genuinely needs to run — find its binary (PATH), render (TERM /
  *  COLORTERM), resolve home/config/data roots (HOME / XDG_*_HOME on Unix,
@@ -64,18 +65,43 @@ export const MODEL_PROVIDER_KEYS = [
   "NOUS_API_KEY",
 ] as const;
 
-/** Build the base env a spawned agent runs with: the OS allow-list plus any named model-provider
- *  keys the connector declares the agent needs (`providerKeys`). Entries are copied from the
- *  manager's env BY NAME and only when present — never required, never spread wholesale. */
-export function launchEnv(opts: { providerKeys?: readonly string[] } = {}): Record<string, string> {
+/** Build the base env a spawned agent runs with: the OS allow-list plus any named keys the
+ *  connector declares the agent needs — `providerKeys` (the model-provider key) and `mcpKeys`
+ *  (the `${VAR}` secrets a shared MCP server references, see {@link mcpServerEnvKeys}). Every
+ *  entry is copied from the manager's env BY NAME and only when present — never required, never
+ *  spread wholesale, so the operator's unrelated secrets don't bleed into the child (P3). */
+export function launchEnv(
+  opts: { providerKeys?: readonly string[]; mcpKeys?: readonly string[] } = {},
+): Record<string, string> {
   const env: Record<string, string> = {};
   for (const k of OS_ENV_ALLOW) {
     const v = process.env[k];
     if (v !== undefined) env[k] = v;
   }
-  for (const k of opts.providerKeys ?? []) {
+  for (const k of [...(opts.providerKeys ?? []), ...(opts.mcpKeys ?? [])]) {
     const v = process.env[k];
     if (v !== undefined) env[k] = v;
   }
   return env;
+}
+
+/** The environment-variable NAMES a set of shared MCP server specs reference via `${VAR}` /
+ *  `${VAR:-default}` (in command/args/env/url/headers). The single source of which operator vars
+ *  a shared server needs: forwarded BY NAME through {@link launchEnv} (`mcpKeys`), never
+ *  `...process.env`, so secret keys keep living in the operator's env (and the `.mcp.json`-style
+ *  config stays a `${VAR}` reference, not a plaintext secret). */
+export function mcpServerEnvKeys(servers: Record<string, McpServerSpec>): string[] {
+  const names = new Set<string>();
+  const scan = (s: string | undefined): void => {
+    if (!s) return;
+    for (const m of s.matchAll(/\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-[^}]*)?\}/g)) names.add(m[1]);
+  };
+  for (const spec of Object.values(servers)) {
+    scan(spec.command);
+    spec.args?.forEach(scan);
+    if (spec.env) for (const v of Object.values(spec.env)) scan(v);
+    scan(spec.url);
+    if (spec.headers) for (const v of Object.values(spec.headers)) scan(v);
+  }
+  return [...names];
 }

--- a/extensions/connector-opencode/src/extension.ts
+++ b/extensions/connector-opencode/src/extension.ts
@@ -37,8 +37,10 @@ export const opencodeConnector: Connector = {
     // semantics that don't exist yet — throw rather than silently ignore it (no fallbacks).
     if (opts.mcpServers && Object.keys(opts.mcpServers).length > 0)
       throw new Error(
-        "opencode connector: tool-sharing (connectors.opencode.mcpServers) is not implemented — " +
-          "opencode agents already inherit the operator's MCP servers via OPENCODE_CONFIG_CONTENT.",
+        "opencode connector: tool-sharing (connectors.opencode.mcpServers) is not implemented. " +
+          "opencode agents currently inherit the operator's MCP servers through its config merge " +
+          "layer; restricting that down to a chosen subset needs an inverse opt-out filter, which " +
+          "is a separate feature.",
       );
     // Identity rides the process env: the plugin runs in the opencode process and inherits it
     // (unlike the Claude Code MCP server, which gets none of the parent env). The OS allow-list +

--- a/extensions/connector-opencode/src/extension.ts
+++ b/extensions/connector-opencode/src/extension.ts
@@ -31,6 +31,15 @@ export const opencodeConnector: Connector = {
   kind: "connector",
   name: "opencode",
   buildLaunch(opts: LaunchOpts): LaunchSpec {
+    // Tool-sharing isn't wired for opencode: its OPENCODE_CONFIG_CONTENT is a merge layer, so an
+    // opencode agent already INHERITS the operator's MCP servers (the opposite default to Claude's
+    // strict isolation). A `connectors.opencode.mcpServers` entry would need inverse (opt-OUT)
+    // semantics that don't exist yet — throw rather than silently ignore it (no fallbacks).
+    if (opts.mcpServers && Object.keys(opts.mcpServers).length > 0)
+      throw new Error(
+        "opencode connector: tool-sharing (connectors.opencode.mcpServers) is not implemented — " +
+          "opencode agents already inherit the operator's MCP servers via OPENCODE_CONFIG_CONTENT.",
+      );
     // Identity rides the process env: the plugin runs in the opencode process and inherits it
     // (unlike the Claude Code MCP server, which gets none of the parent env). The OS allow-list +
     // the named model-provider key (opencode's hosted models read OPENCODE_API_KEY; other

--- a/implementations/cli/src/commands/spawn.ts
+++ b/implementations/cli/src/commands/spawn.ts
@@ -6,12 +6,15 @@ import {
   DEFAULT_SERVER,
   agentFilePath,
   authDir,
+  connectorServers,
   firstFreeName,
   isReachable,
   loadAgentFile,
+  loadCotalConfig,
   loadSpaceAuth,
   mintCreds,
   newIdentity,
+  parseShareSelection,
   provisionAgent,
   registry,
   CotalEndpoint,
@@ -96,6 +99,7 @@ export async function spawn(argv: string[]): Promise<void> {
       prompt: { type: "string" },
       transcript: { type: "boolean" },
       "no-transcript": { type: "boolean" },
+      "share-tools": { type: "string" },
     },
   });
   // Transcript mirroring to `tr-<name>` is OFF by default; `--transcript` opts in
@@ -107,7 +111,7 @@ export async function spawn(argv: string[]): Promise<void> {
   const ref = values.config ?? positionals[0] ?? values.name;
   if (!ref) {
     console.error(
-      "usage: cotal spawn <name-or-path> | --config <path> | --name <n>  [--agent <a>] [--role <r>] [--space <s>] [--server <url>] [--prompt <text>] [--transcript]",
+      "usage: cotal spawn <name-or-path> | --config <path> | --name <n>  [--agent <a>] [--role <r>] [--space <s>] [--server <url>] [--prompt <text>] [--transcript] [--share-tools <names|none>]",
     );
     process.exit(1);
   }
@@ -168,7 +172,17 @@ export async function spawn(argv: string[]): Promise<void> {
     console.error(`minted creds for ${name} (auth mode) → ${credsPath}`);
   }
 
-  const connector = registry.resolve<Connector>("connector", values.agent ?? "claude");
+  // Which of the operator's personal MCP servers to share with this agent: declared in the cotal
+  // config (global ~/.config/cotal + space-local .cotal), narrowed by an optional --share-tools
+  // selection. Default (no config) is none — the connector launches isolated.
+  const agentType = values.agent ?? "claude";
+  const mcpServers = connectorServers(
+    loadCotalConfig(cotalRoot()),
+    agentType,
+    parseShareSelection(values["share-tools"]),
+  );
+
+  const connector = registry.resolve<Connector>("connector", agentType);
   const spec = connector.buildLaunch({
     space,
     name,
@@ -179,6 +193,7 @@ export async function spawn(argv: string[]): Promise<void> {
     configPath: path,
     prompt: values.prompt,
     transcript,
+    mcpServers,
   });
 
   console.error(

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -6,9 +6,11 @@ import {
   agentFilePath,
   authDir,
   clearSpaceHistory,
+  connectorServers,
   findCotalRoot,
   firstFreeName,
   loadAgentFile,
+  loadCotalConfig,
   loadSpaceAuth,
   mintCreds,
   newIdentity,
@@ -389,6 +391,9 @@ export class Manager {
           mkdirSync(dirname(credsPath), { recursive: true });
           writeFileSync(credsPath, creds, { mode: 0o600 });
         }
+        // Personal MCP servers the operator opted to share with manager-spawned agents of this
+        // type (cotal config; default none → isolated, the memory-safe default this guards).
+        const mcpServers = connectorServers(loadCotalConfig(this.workspaceRoot), agent);
         const spec = connector.buildLaunch({
           space: this.space,
           name,
@@ -398,6 +403,7 @@ export class Manager {
           servers: this.servers,
           configPath,
           transcript: opts.transcript,
+          mcpServers,
         });
         handle = this.runtime.spawn(name, spec, this.workspaceRoot);
       } catch (e) {

--- a/packages/core/src/connector-config.ts
+++ b/packages/core/src/connector-config.ts
@@ -1,0 +1,133 @@
+/**
+ * The cotal config file — per-connector launch settings, the first general config notion in
+ * the repo (alongside `.cotal/{auth,agents,creds}`, which are about identity, not settings).
+ *
+ *   ~/.config/cotal/config.json   (operator-level, every space)   ← base layer
+ *   <root>/.cotal/config.json     (space-local override)          ← higher precedence
+ *
+ * Today it carries one thing: which of the operator's personal MCP servers a connector should
+ * SHARE with the agents it spawns. By default a spawned agent gets none — the Claude connector
+ * launches with `--strict-mcp-config`, dropping every operator server, because they're heavy
+ * (a headless Chromium server alone can climb past a gigabyte) and useless to a meshed teammate.
+ * This file is the explicit opt-in to pass named ones through.
+ *
+ * Each server is written in the de-facto `.mcp.json` shape, so an operator can copy an entry
+ * straight out of their own Claude / VS Code / Cursor config. Secrets ride as `${VAR}` references
+ * resolved from the operator's environment at launch — never literals — so the file stays safe to
+ * keep in `~/.config` or a gitignored `.cotal/`.
+ *
+ * This is deliberately NOT in the agent file ({@link AgentDef}): that's the connector-agnostic
+ * identity, portable across Claude Code / OpenCode / Hermes, and MCP-passthrough isn't a shared
+ * concept (Claude uses `--mcp-config`, OpenCode inherits via a merge layer, Hermes has no MCP).
+ * The caller (both spawn paths) resolves this once and hands the chosen servers to the connector,
+ * which renders them into its own host format.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/** One MCP server, in the de-facto `.mcp.json` shape. Secrets belong in `env` (or `headers`) as
+ *  `${VAR}` references, resolved from the operator's environment at launch. Remote-transport
+ *  fields (`type`/`url`/`headers`) are carried verbatim for connectors that support them. */
+export interface McpServerSpec {
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  type?: string;
+  url?: string;
+  headers?: Record<string, string>;
+}
+
+/** Per-connector settings. `mcpServers` are the operator servers SHARED with agents this connector
+ *  spawns, keyed by server name (`.mcp.json`-style). */
+export interface ConnectorConfig {
+  mcpServers?: Record<string, McpServerSpec>;
+}
+
+/** The parsed cotal config file: a section per connector, keyed by connector name ("claude", …). */
+export interface CotalConfig {
+  connectors?: Record<string, ConnectorConfig>;
+}
+
+/** Operator-level config path: `$XDG_CONFIG_HOME/cotal/config.json`, else `~/.config/cotal/config.json`. */
+export function globalConfigPath(): string {
+  const base = process.env.XDG_CONFIG_HOME?.trim() || join(homedir(), ".config");
+  return join(base, "cotal", "config.json");
+}
+
+/** Space-local config path: `<root>/.cotal/config.json`. */
+export function spaceConfigPath(root: string): string {
+  return join(root, ".cotal", "config.json");
+}
+
+/** Parse one config file. A missing file is empty (no config is a valid state); malformed JSON or a
+ *  non-object top level throws — a typo in your settings should be loud, not silently ignored. */
+function readConfigFile(path: string): CotalConfig {
+  if (!existsSync(path)) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch (e) {
+    throw new Error(`cotal config ${path}: invalid JSON — ${(e as Error).message}`);
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed))
+    throw new Error(`cotal config ${path}: top level must be a JSON object`);
+  return parsed as CotalConfig;
+}
+
+/** Layer `over` onto `base`: per connector, a server in `over` replaces the same-named server in
+ *  `base` (whole-spec replace, by name — the same merge the MCP clients do); servers/connectors
+ *  present in only one side are kept. */
+function mergeConfig(base: CotalConfig, over: CotalConfig): CotalConfig {
+  const connectors: Record<string, ConnectorConfig> = {};
+  const names = new Set([...Object.keys(base.connectors ?? {}), ...Object.keys(over.connectors ?? {})]);
+  for (const name of names) {
+    const b = base.connectors?.[name];
+    const o = over.connectors?.[name];
+    connectors[name] = { ...b, ...o, mcpServers: { ...(b?.mcpServers ?? {}), ...(o?.mcpServers ?? {}) } };
+  }
+  return { connectors };
+}
+
+/** Load the merged cotal config: the operator-level file as the base, the space-local file layered
+ *  on top (more specific wins, per connector + server name). */
+export function loadCotalConfig(root: string): CotalConfig {
+  return mergeConfig(readConfigFile(globalConfigPath()), readConfigFile(spaceConfigPath(root)));
+}
+
+/** The MCP servers a connector should share with an agent it spawns, after applying an optional
+ *  per-spawn `selection` (the parsed `--share-tools` value):
+ *    `undefined` → every server declared for the connector (the config default)
+ *    `[]`        → none (e.g. `--share-tools none`)
+ *    `[a, b]`    → only those named, which MUST be declared (throws otherwise — no silent drop). */
+export function connectorServers(
+  config: CotalConfig,
+  connector: string,
+  selection?: readonly string[],
+): Record<string, McpServerSpec> {
+  const declared = config.connectors?.[connector]?.mcpServers ?? {};
+  if (selection === undefined) return { ...declared };
+  const chosen: Record<string, McpServerSpec> = {};
+  for (const name of selection) {
+    const spec = declared[name];
+    if (!spec)
+      throw new Error(
+        `--share-tools: "${name}" is not a shared server for connector "${connector}" ` +
+          `(declared: ${Object.keys(declared).join(", ") || "none"})`,
+      );
+    chosen[name] = spec;
+  }
+  return chosen;
+}
+
+/** Parse a `--share-tools` flag value into a selection for {@link connectorServers}: flag absent
+ *  → `undefined` (share all declared); `none` or empty → `[]` (share nothing); else the comma list. */
+export function parseShareSelection(value: string | undefined): readonly string[] | undefined {
+  if (value === undefined) return undefined;
+  const trimmed = value.trim();
+  if (trimmed === "" || trimmed.toLowerCase() === "none") return [];
+  return trimmed
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}

--- a/packages/core/src/connector-config.ts
+++ b/packages/core/src/connector-config.ts
@@ -27,8 +27,11 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 /** One MCP server, in the de-facto `.mcp.json` shape. Secrets belong in `env` (or `headers`) as
- *  `${VAR}` references, resolved from the operator's environment at launch. Remote-transport
- *  fields (`type`/`url`/`headers`) are carried verbatim for connectors that support them. */
+ *  `${VAR}` references, resolved from the operator's environment at launch. Remote-transport fields
+ *  (`type`/`url`/`headers`) are carried verbatim for connectors that support them. Any other
+ *  `.mcp.json` key an operator copies in (e.g. `timeout`) passes through to the rendered config
+ *  unchanged but gets NO `${VAR}` expansion — Claude only expands command/args/env/url/headers,
+ *  which is exactly the set {@link mcpServerEnvKeys} scans for secret names to forward. */
 export interface McpServerSpec {
   command?: string;
   args?: string[];
@@ -36,6 +39,8 @@ export interface McpServerSpec {
   type?: string;
   url?: string;
   headers?: Record<string, string>;
+  /** Pass-through for any other `.mcp.json` key (carried verbatim, no env expansion). */
+  [key: string]: unknown;
 }
 
 /** Per-connector settings. `mcpServers` are the operator servers SHARED with agents this connector

--- a/packages/core/src/connector.ts
+++ b/packages/core/src/connector.ts
@@ -1,4 +1,5 @@
 import type { Extension } from "./registry.js";
+import type { McpServerSpec } from "./connector-config.js";
 
 /** Identity + mesh coordinates the manager hands a connector to launch an agent. */
 export interface LaunchOpts {
@@ -25,6 +26,12 @@ export interface LaunchOpts {
    *  the agent actually did (sets `COTAL_TRANSCRIPT`). Defaults to OFF; set `true` to
    *  opt in — surfaced as the `--transcript` flag on `cotal spawn` / `cotal start`. */
   transcript?: boolean;
+  /** Operator MCP servers to SHARE with this agent, resolved from the cotal config by the caller
+   *  (see {@link connectorServers}). Keyed by server name, `.mcp.json`-shaped, with `${VAR}`
+   *  secret refs intact. A connector renders them into its own host format; the default is none
+   *  (Claude launches isolated with `--strict-mcp-config`). Connectors that don't support sharing
+   *  throw on a non-empty map rather than silently dropping it. */
+  mcpServers?: Record<string, McpServerSpec>;
 }
 
 /** A recipe for starting an agent as a mesh node — command, args, and extra env. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export * from "./provision.js";
 export * from "./streams.js";
 export * from "./channels.js";
 export * from "./agent-file.js";
+export * from "./connector-config.js";
 export * from "./endpoint.js";
 export * from "./spaces.js";
 export * from "./connector.js";


### PR DESCRIPTION
## What

Spawned Claude agents launch isolated (`--strict-mcp-config`) and get only the cotal mesh server — none of the operator's personal MCP servers, which are heavy (a headless Chromium server alone can climb past a gigabyte) and useless to a meshed teammate. This adds an opt-in so an operator can share *specific* servers back in.

It introduces the first general **cotal config file** and resolves it in both spawn paths (`cotal spawn` and the manager's `start`), handing the chosen servers to the connector via a new `LaunchOpts.mcpServers`.

```jsonc
// ~/.config/cotal/config.json   (operator-level, every space)   — base
// or  <root>/.cotal/config.json (space-local override)          — same shape, layered on top
{
  "connectors": {
    "claude": {
      "mcpServers": {
        "tavily": {
          "command": "npx",
          "args": ["-y", "tavily-mcp"],
          "env": { "TAVILY_API_KEY": "${TAVILY_API_KEY}" }
        }
      }
    }
  }
}
```

Per-spawn override: `cotal spawn <name> --share-tools tavily,figma` (subset), `--share-tools none` (nothing). Absent → all declared. Default (no config file) is unchanged: a spawned agent gets only cotal.

## Design

- **Per-connector, not in the agent file.** MCP passthrough isn't a portable agent concept (Claude uses `--mcp-config`; OpenCode inherits via a merge layer; Hermes has no MCP), so it lives in connector settings, not the connector-agnostic identity.
- **Inline server specs** in the de-facto `.mcp.json` shape (copy an entry straight from your own Claude/VS Code/Cursor config) — not name-references into `~/.claude.json`, which can't see plugin/npx-sourced servers.
- **Layered + merged by name** (global base < space override < `--share-tools`), mirroring how every MCP client scopes config.
- **Claude-first, connector-generic schema.** OpenCode throws on a non-empty `mcpServers` rather than silently ignoring it (it already inherits the operator's servers; an inverse opt-out filter is a separate feature). Hermes: n/a.

## Security

- **`${VAR}` secret refs, never literals.** The config carries the variable *name*; the connector forwards *only* the named vars the chosen servers declare, by name, from the operator's env — never `...process.env`, preserving the P3 env allow-list. The merged config is written to a `0600` file inside a private `0700` `mkdtemp` dir, so a secret never lands on disk or argv, and there's no predictable-path/overwrite-mode race. `--strict-mcp-config` stays on, so only cotal + explicitly-shared servers load.
- Sharing a server **does** grant its credential to the agent (the forwarded var lives in the Claude process env, so an agent with shell/tool access can read it). Documented explicitly.

## Testing

- `pnpm typecheck` + `pnpm build` green.
- End-to-end against real `claude` 2.1.183 with a minimal stdio MCP probe that records the env Claude hands it:
  - `${VAR}` in an `--mcp-config` **file** expands and the value reaches the server.
  - Full connector path: the generated `0600` file's `${VAR}` expands from the forwarded env; an unrelated operator secret is filtered out end-to-end.
  - Connector-spec assertions (default→inline cotal-only; shared→`0600` file in `0700` dir, `${VAR}` literal on disk, referenced var forwarded / unrelated+model keys not, cotal never shadowed) and unit coverage of `connectorServers`/`parseShareSelection`/`mcpServerEnvKeys`/`loadCotalConfig` merge.
  - Note: inline `--mcp-config` also expands `${VAR}` in 2.1.183; the file form is kept because expansion is only *documented* for files and a file keeps a multi-server config off argv (recorded in-code with the verified version).

## Docs

- `docs/claude-code-integration.md` → new "Sharing personal MCP servers" section.
- `docs/architecture.md` → env allow-list note updated for the named MCP-key forwarding.