### PR TITLE
fix: operator persona can spawn, and spawn errors name the real cause

### DIFF
--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -9,7 +9,7 @@
  */
 import { execFileSync } from "node:child_process";
 import { z } from "zod";
-import { isConcreteChannel, AmbiguousPeerError, type PresenceStatus } from "@cotal-ai/core";
+import { isConcreteChannel, AmbiguousPeerError, isPermissionDenied, type PresenceStatus } from "@cotal-ai/core";
 import type { MeshAgent, InboxItem } from "./agent.js";
 import { FEEDBACK_URL, PUBLIC_FEEDBACK_URL, type AgentConfig } from "./config.js";
 
@@ -22,6 +22,22 @@ export interface ToolResult {
 
 const ok = (text: string): ToolResult => ({ text });
 const err = (text: string): ToolResult => ({ text, isError: true });
+
+/** Error for a failed privileged control request (spawn / despawn-other / definePersona). A
+ *  *permission denial* — this session's creds can't publish to the manager control subject
+ *  because its persona lacks `capabilities: [spawn]` — is a different failure with a different
+ *  fix than an *absent/unreachable manager*. Report them apart instead of always blaming the
+ *  manager (which sent the operator chasing a non-existent "manager down"). */
+function controlFailure(action: string, e: unknown): ToolResult {
+  const detail = (e as Error)?.message ?? String(e);
+  if (isPermissionDenied(e)) {
+    return err(
+      `${action}: this session isn't allowed to — its persona needs \`capabilities: [spawn]\` ` +
+        `(which grants the privileged manager control subject). Add it and respawn so its creds re-mint. [${detail}]`,
+    );
+  }
+  return err(`${action}: no manager reachable (${detail}). Is the manager running?`);
+}
 
 /** One Cotal tool, independent of any host's tool API. */
 export interface CotalToolSpec {
@@ -382,9 +398,7 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
           const lead = actual !== name ? `"${name}" was taken — spawning ${who} instead` : `Spawning ${who}`;
           return ok(`${lead}${mode ? ` (${mode})` : ""} — it will appear in the roster shortly.`);
         } catch (e) {
-          return err(
-            `Couldn't spawn ${name}: no manager reachable (${(e as Error).message}). Is the manager running?`,
-          );
+          return controlFailure(`Couldn't spawn ${name}`, e);
         }
       },
     },
@@ -473,9 +487,7 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
           const who = name ?? "self";
           return ok(`Stopping ${who}${graceful === false ? " (hard)" : ""} — it will leave the roster shortly.`);
         } catch (e) {
-          return err(
-            `Couldn't despawn ${name ?? "self"}: no manager reachable (${(e as Error).message}). Is the manager running?`,
-          );
+          return controlFailure(`Couldn't despawn ${name ?? "self"}`, e);
         }
       },
     },
@@ -502,9 +514,7 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
           if (!reply.ok) return err(`Couldn't define ${name}: ${reply.error ?? "manager refused"}`);
           return ok(`Persona \`${name}\` saved — spawn it with cotal_spawn(name="${name}") to bring it online.`);
         } catch (e) {
-          return err(
-            `Couldn't define ${name}: no manager reachable (${(e as Error).message}). Is the manager running?`,
-          );
+          return controlFailure(`Couldn't define ${name}`, e);
         }
       },
     },

--- a/implementations/cli/src/commands/setup.ts
+++ b/implementations/cli/src/commands/setup.ts
@@ -595,6 +595,7 @@ role: operator
 description: "your own session on the Cotal mesh."
 tags: [cotal]
 channels: [general]
+capabilities: [spawn]
 ---
 
 You are the operator's own session on the Cotal mesh: the agent they drive. Do what they ask and

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -1514,6 +1514,18 @@ function describeStatusError(err: Error): Error {
   return err;
 }
 
+/** True when a failure is a NATS *permission denial* — the subject is forbidden to this
+ *  endpoint's creds — rather than a missing responder or a timeout. The two need opposite
+ *  fixes (grant the capability vs. start/await the service), so callers (e.g. a control
+ *  request that can't reach the manager) must tell them apart instead of defaulting to
+ *  "service down". Unwraps a wrapped `cause` and falls back to the server's error text, since
+ *  a denied publish can surface either as the typed error or inside a request rejection. */
+export function isPermissionDenied(e: unknown): boolean {
+  if (e instanceof PermissionViolationError) return true;
+  if ((e as { cause?: unknown } | null)?.cause instanceof PermissionViolationError) return true;
+  return /permissions?\s+violation/i.test(String((e as { message?: unknown } | null)?.message ?? ""));
+}
+
 /** Whether a NATS server is *running* at `servers`. True on a successful connect AND on an
  *  auth rejection — an auth error means a server is there, just refusing these creds (so the
  *  caller should surface the real auth failure, not a misleading "server down", and `up`


### PR DESCRIPTION
Two related fixes around `cotal_spawn` on an authed mesh, surfaced while testing the demo.

## 1. The operator persona couldn't actually spawn
`cotal setup` writes a `me` persona (the operator's own driving session) whose body says *"grow the team with cotal_spawn"* — but its frontmatter never declared `capabilities: [spawn]`. The capability path is fully wired (agent-file → `mintCreds` → `ctl.manager` publish grant; `default.md` already uses it), so the omission meant `me`'s minted creds default-denied the privileged control subject and every spawn bounced with a `Permissions Violation`. Now `me` declares the capability; the advisor personas (`david`/`sven`) intentionally stay without it (least privilege).

## 2. The error blamed a missing manager for a permission denial
`cotal_spawn` / `cotal_despawn` / `cotal_persona` wrapped *every* control-request failure as *"no manager reachable … Is the manager running?"*. A NATS publish-permission denial happens before the manager is ever consulted, so a capability problem was mislabeled as a missing-manager problem — pointing the operator at the wrong fix. Added `isPermissionDenied()` in core (mirrors the existing `describeStatusError`) and routed the three control tools through a shared `controlFailure()`:

- **denied** → *"this session isn't allowed to — its persona needs `capabilities: [spawn]` … add it and respawn"*
- **absent / timeout** → keeps *"no manager reachable. Is the manager running?"*

## Verification
- Minted creds with vs without `capabilities: [spawn]` → `ctl.manager` grant present only with it.
- `isPermissionDenied` checked: `Permissions Violation` → true; `503` / `no responders` / `TIMEOUT` → false.
- `pnpm build` + `pnpm -r typecheck` clean.
- Live: a respawned `me` can now spawn teammates.

## Not included
- **No changeset** — work in progress, not publishing to npm yet.