### PR TITLE
feat(cli): cotal personas management + dynamic shell completion

### DIFF
--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -119,7 +119,8 @@ Full scenario and run steps:
   that produces an A2A `AgentCard`, plus an optional Markdown body that is the **persona**
   (an appended system prompt). `role` is the addressable **service** (anycast). The
   connector resolves it from `COTAL_AGENT_FILE`; a peer can mint one on the fly with
-  `cotal_persona` (the manager writes the file). Personas are **optional**, since Cotal
+  `cotal_persona` (the manager writes the file), and an operator manages the local catalog
+  with `cotal personas` (list/show/new/rm). Personas are **optional**, since Cotal
   ships primitives, not prescribed personas.
 - **Identity & authorization (on by default; `cotal up --open` to disable).** The mesh is
   a real boundary against untrusted peers in a shared space. The **sender is encoded in

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -134,6 +134,23 @@ teammate's persona on the fly and bring it online with no hand-written file. (Ro
 spawn, since `cotal_spawn` takes a role; it is not set here, because role is policy, not
 persona content.)
 
+**Manage the catalog from the CLI.** `cotal personas` is the operator-side counterpart to the
+runtime `cotal_persona` tool. It reads and writes the same `.cotal/agents/*.md` files
+**directly** — instant, offline, no mesh — where the tool path goes over the wire with the
+manager's ownership checks; two trust contexts, kept separate. `cotal personas` (or `list`)
+shows the catalog, `show <name>` prints a card, `new <name> (--prompt <text> | --from
+<file|->) [--role <r>] [--model <m>] [--force]` writes one, and `rm <name> --force` deletes
+it.
+
+**Tab completion.** `cotal completion <bash|zsh|fish|powershell>` prints a shell stub to
+stdout and writes nothing else. Install it once; each `<TAB>` then forwards to a hidden
+`cotal __complete`, so completion sees live data — `cotal spawn <TAB>` lists your actual
+personas. Enable it for the current shell with `source <(cotal completion zsh)` (fish: `cotal
+completion fish | source`; PowerShell: `cotal completion powershell | Out-String |
+Invoke-Expression`), or save the stub into the shell's completion directory to persist it. A
+command provides its candidates through the optional `complete()` on the
+[`Command`](../packages/core/src/command.ts) contract, the same way it owns `run()`.
+
 ## One-link join
 
 A single **join link** carries server, auth, and space, so a peer joins by pasting one

--- a/implementations/cli/src/command.ts
+++ b/implementations/cli/src/command.ts
@@ -2,12 +2,14 @@ import type { Command, Registry } from "@cotal-ai/core";
 import { c } from "./ui.js";
 
 function help(commands: Command[]): void {
+  // `__`-prefixed commands are internal (e.g. `__complete`, the completion dispatcher) — hide them.
+  const visible = commands.filter((cmd) => !cmd.name.startsWith("__"));
   const groups = new Map<string, Command[]>();
-  for (const cmd of commands) {
+  for (const cmd of visible) {
     const g = cmd.group ?? "Commands";
     (groups.get(g) ?? groups.set(g, []).get(g)!).push(cmd);
   }
-  const pad = Math.max(...commands.map((c) => c.name.length));
+  const pad = Math.max(...visible.map((c) => c.name.length));
   let out = `${c.bold("cotal")} — lateral agent coordination over NATS\n`;
   for (const [group, cmds] of groups) {
     out += `\n${c.bold(group)}\n`;

--- a/implementations/cli/src/commands/completion.ts
+++ b/implementations/cli/src/commands/completion.ts
@@ -1,0 +1,142 @@
+import {
+  registry,
+  type Command,
+  type CompletionItem,
+  type CompletionResult,
+} from "@cotal-ai/core";
+import { c } from "../ui.js";
+
+/**
+ * Shell completion, the standard two-layer way (Cobra/Click/clap): a thin per-shell stub —
+ * printed to stdout by `cotal completion <shell>`, installed once — that forwards each <TAB>
+ * to the hidden `cotal __complete` dispatcher. The dispatcher returns live candidates, so
+ * completion sees real data (your personas) that a static script never could.
+ *
+ * The stub is installed once; the protocol between it and `__complete` is line-oriented and
+ * tolerant (unknown lines are ignored), so it can grow without anyone re-installing the stub.
+ *
+ *   cotal completion bash|zsh|fish|powershell   # print the stub to stdout
+ *   cotal __complete <words…>                   # internal: emit candidates for the cursor
+ *
+ * `__complete` is import-light and side-effect-free by contract — persona completion is a
+ * filesystem read, never a mesh connection — so a keystroke never blocks on the network.
+ */
+
+/** Wire format: one `value\tdescription` (or bare `value`) per line, then a `:directive`
+ *  trailer the stub reads (`:nofiles` / `:nospace` / `:default`). */
+function emit(items: CompletionItem[], directive: NonNullable<CompletionResult["directive"]>): void {
+  const lines = items.map((i) => (i.description ? `${i.value}\t${i.description}` : i.value));
+  lines.push(`:${directive}`);
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+/** The hidden dispatcher the shell stubs call. `argv` is the words after `cotal`, up to and
+ *  including the (possibly empty) word being completed. */
+export async function complete(argv: string[]): Promise<void> {
+  const commands = registry.all<Command>("command").filter((cmd) => !cmd.name.startsWith("__"));
+  // Word 0 (the command name itself): offer the command names.
+  if (argv.length <= 1) {
+    emit(commands.map((cmd) => ({ value: cmd.name, description: cmd.summary })), "nofiles");
+    return;
+  }
+  const cmd = commands.find((cmd) => cmd.name === argv[0]);
+  if (!cmd?.complete) {
+    emit([], "default"); // unknown command, or one with no completer → defer to the shell
+    return;
+  }
+  try {
+    const res = await cmd.complete(argv.slice(1));
+    emit(res.items, res.directive ?? "nofiles");
+  } catch {
+    emit([], "default"); // a throwing completer yields nothing — never noisy on stderr/stdout
+  }
+}
+
+const SCRIPTS: Record<string, string> = {
+  bash: lines(
+    "# cotal bash completion — forwards each <TAB> to `cotal __complete` (dynamic).",
+    "_cotal_complete() {",
+    '  local cur out line',
+    '  cur="${COMP_WORDS[COMP_CWORD]}"',
+    '  local -a args=("${COMP_WORDS[@]:1:COMP_CWORD}")',
+    '  out="$(cotal __complete "${args[@]}" 2>/dev/null)" || return',
+    "  local -a values=()",
+    "  while IFS= read -r line; do",
+    '    [ -z "$line" ] && continue',
+    '    case "$line" in',
+    "      :nospace) compopt -o nospace 2>/dev/null ;;",
+    "      :*) ;;",
+    `      *) values+=("\${line%%$'\\t'*}") ;;`,
+    "    esac",
+    '  done <<< "$out"',
+    '  COMPREPLY=($(compgen -W "${values[*]}" -- "$cur"))',
+    "}",
+    "complete -F _cotal_complete cotal",
+  ),
+  zsh: lines(
+    "#compdef cotal",
+    "# cotal zsh completion — forwards each <TAB> to `cotal __complete` (dynamic).",
+    "_cotal() {",
+    "  local -a args; args=(\"${(@)words[2,CURRENT]}\")",
+    '  local out line val desc',
+    '  out="$(cotal __complete "${args[@]}" 2>/dev/null)"',
+    "  local -a descs",
+    "  while IFS= read -r line; do",
+    '    [[ -z "$line" || "$line" == :* ]] && continue',
+    `    val="\${line%%$'\\t'*}"; desc="\${line#*$'\\t'}"`,
+    '    if [[ "$desc" != "$line" ]]; then descs+=("$val:$desc"); else descs+=("$val"); fi',
+    '  done <<< "$out"',
+    "  (( ${#descs} )) && _describe -t cotal cotal descs",
+    "}",
+    "compdef _cotal cotal",
+  ),
+  fish: lines(
+    "# cotal fish completion — forwards each <TAB> to `cotal __complete` (dynamic).",
+    "function __cotal_complete",
+    "    set -l tokens (commandline -opc) (commandline -ct)",
+    "    cotal __complete $tokens[2..-1] 2>/dev/null | string match -rv '^:'",
+    "end",
+    "complete -c cotal -f -a '(__cotal_complete)'",
+  ),
+  powershell: lines(
+    "# cotal PowerShell completion — forwards each <TAB> to `cotal __complete` (dynamic).",
+    "Register-ArgumentCompleter -Native -CommandName cotal -ScriptBlock {",
+    "    param($wordToComplete, $commandAst, $cursorPosition)",
+    '    $elements = @($commandAst.CommandElements | Select-Object -Skip 1 | ForEach-Object { "$_" })',
+    "    if (-not $wordToComplete) { $elements += '' }",
+    "    $out = & cotal __complete @elements 2>$null",
+    "    foreach ($line in $out) {",
+    "        if ([string]::IsNullOrEmpty($line) -or $line.StartsWith(':')) { continue }",
+    '        $parts = $line -split "`t", 2',
+    "        $val = $parts[0]",
+    '        if ($val -notlike "$wordToComplete*") { continue }',
+    "        $desc = if ($parts.Length -gt 1) { $parts[1] } else { $val }",
+    "        [System.Management.Automation.CompletionResult]::new($val, $val, 'ParameterValue', $desc)",
+    "    }",
+    "}",
+  ),
+};
+
+export async function completion(argv: string[]): Promise<void> {
+  const script = argv[0] ? SCRIPTS[argv[0]] : undefined;
+  if (!script) {
+    console.error(c.red("usage: cotal completion <bash|zsh|fish|powershell>"));
+    console.error(c.dim("  enable it now (this shell):"));
+    console.error(c.dim("    bash/zsh:  source <(cotal completion bash)"));
+    console.error(c.dim("    fish:      cotal completion fish | source"));
+    console.error(c.dim("    pwsh:      cotal completion powershell | Out-String | Invoke-Expression"));
+    process.exit(1);
+  }
+  process.stdout.write(script);
+}
+
+/** Argument completion for `cotal completion` itself: the supported shells. */
+export function completionComplete(argv: string[]): CompletionResult {
+  if (argv.length <= 1)
+    return { items: Object.keys(SCRIPTS).map((value) => ({ value })), directive: "nofiles" };
+  return { items: [], directive: "nofiles" };
+}
+
+function lines(...l: string[]): string {
+  return `${l.join("\n")}\n`;
+}

--- a/implementations/cli/src/commands/personas.ts
+++ b/implementations/cli/src/commands/personas.ts
@@ -1,0 +1,188 @@
+import { existsSync, readFileSync, renameSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { parseArgs } from "node:util";
+import {
+  agentFilePath,
+  assertValidName,
+  saveAgentFile,
+  type AgentDef,
+  type CompletionResult,
+} from "@cotal-ai/core";
+import { cotalRoot } from "../lib/paths.js";
+import { listPersonas, listPersonaNames, personasDir } from "../lib/personas.js";
+import { c } from "../ui.js";
+
+/**
+ * `cotal personas` — list and manage the local persona catalog (`.cotal/agents/*.md`),
+ * modelled on `cotal channels`. Workspace-local file editing, NOT a mesh operation: it reads
+ * and writes the files directly (instant, works offline). The privileged, ownership-checked
+ * path stays in the manager's `definePersona` for *agents* defining personas over the wire.
+ *
+ *   cotal personas [list] [--verbose]
+ *   cotal personas show <name>
+ *   cotal personas new <name> (--prompt <text> | --from <file|->) [--role <r>] [--model <m>] [--force]
+ *   cotal personas rm <name> --force
+ */
+
+/** Persona names are also filenames and spawn names — mirror the `cotal_persona` tool's pattern. */
+const NAME_RE = /^[A-Za-z0-9_-]+$/;
+
+export async function personas(argv: string[]): Promise<void> {
+  const { values, positionals } = parseArgs({
+    args: argv,
+    allowPositionals: true,
+    options: {
+      role: { type: "string" },
+      model: { type: "string" },
+      prompt: { type: "string" },
+      from: { type: "string" },
+      verbose: { type: "boolean", short: "v" },
+      force: { type: "boolean" },
+    },
+  });
+
+  switch (positionals[0] ?? "list") {
+    case "list":
+      return list(values.verbose === true);
+    case "show":
+      return show(positionals[1]);
+    case "new":
+      return create(positionals[1], values);
+    case "rm":
+      return remove(positionals[1], values.force === true);
+    default:
+      return usage();
+  }
+}
+
+/** Argument completion: subcommands, then persona names for `show`/`rm`. */
+export function personasComplete(argv: string[]): CompletionResult {
+  const subs: CompletionResult = {
+    items: [
+      { value: "list", description: "list the persona catalog" },
+      { value: "show", description: "print a persona's card" },
+      { value: "new", description: "create a persona" },
+      { value: "rm", description: "delete a persona" },
+    ],
+    directive: "nofiles",
+  };
+  if (argv.length <= 1) return subs; // completing the subcommand
+  if (argv[0] === "show" || argv[0] === "rm")
+    return { items: listPersonaNames().map((value) => ({ value })), directive: "nofiles" };
+  return { items: [], directive: "nofiles" };
+}
+
+function list(verbose: boolean): void {
+  const entries = listPersonas();
+  if (!entries.length) {
+    console.log(
+      c.dim(`no personas in ${personasDir()}\n`) +
+        c.dim('create one:  cotal personas new <name> --prompt "<who they are>"'),
+    );
+    return;
+  }
+  const pad = Math.max(...entries.map((e) => e.name.length));
+  for (const e of entries) {
+    if (e.error) {
+      console.log(`${c.red(e.name.padEnd(pad))}  ${c.red("⨯ unparseable")} ${c.dim(e.error)}`);
+      continue;
+    }
+    const d = e.def!;
+    const meta = [d.role && c.cyan(d.role), d.model && c.dim(`model=${d.model}`), d.owner && c.dim(`owner=${d.owner}`)]
+      .filter(Boolean)
+      .join("  ");
+    console.log(`${c.bold(e.name.padEnd(pad))}  ${meta}`.trimEnd());
+    const desc = d.description ?? firstLine(d.persona);
+    if (desc) console.log(c.dim(`  ${truncate(desc, 100)}`));
+    if (verbose && d.persona) console.log(d.persona.replace(/^/gm, "    ") + "\n");
+  }
+}
+
+function show(name?: string): void {
+  if (!name) return usage();
+  const path = agentFilePath(cotalRoot(), name);
+  if (!existsSync(path)) return notFound(name, path);
+  // Print the file verbatim — the canonical card (frontmatter + persona body).
+  console.log(c.dim(path));
+  process.stdout.write(readFileSync(path, "utf8"));
+}
+
+function create(name: string | undefined, v: { role?: string; model?: string; prompt?: string; from?: string; force?: boolean }): void {
+  if (!name) return usage();
+  if (!NAME_RE.test(name)) {
+    console.error(c.red(`invalid persona name "${name}": use letters, digits, "_" or "-"`));
+    process.exit(1);
+  }
+  assertValidName(name); // shared reserved-character guard (also rejects "/")
+
+  const path = agentFilePath(cotalRoot(), name);
+  if (existsSync(path) && !v.force) {
+    console.error(c.red(`persona "${name}" already exists — pass --force to overwrite`));
+    console.error(c.dim(path));
+    process.exit(1);
+  }
+
+  // Body from --prompt <text>, or --from <file|-> (- = stdin). No fallback — one must be given.
+  let persona: string;
+  if (v.prompt !== undefined) persona = v.prompt;
+  else if (v.from !== undefined) persona = readFileSync(v.from === "-" ? 0 : v.from, "utf8");
+  else {
+    console.error(c.red('provide the persona body: --prompt "<text>"  or  --from <file|->'));
+    process.exit(1);
+  }
+  persona = persona.trim();
+  if (!persona) {
+    console.error(c.red("persona body is empty"));
+    process.exit(1);
+  }
+
+  const def: AgentDef = { name, role: v.role, model: v.model, persona };
+  saveAtomic(path, def);
+  console.log(c.green(`✓ wrote persona "${name}"`));
+  console.log(c.dim(`${path}\nspawn it:  cotal spawn ${name}${v.role ? ` --role ${v.role}` : ""}`));
+}
+
+function remove(name: string | undefined, force: boolean): void {
+  if (!name) return usage();
+  const path = agentFilePath(cotalRoot(), name);
+  if (!existsSync(path)) return notFound(name, path);
+  if (!force) {
+    console.error(c.red(`refusing to delete "${name}" without --force`));
+    console.error(c.dim(`cotal personas rm ${name} --force`));
+    process.exit(1);
+  }
+  rmSync(path);
+  console.log(c.green(`✓ removed persona "${name}"`));
+}
+
+/** Write through a sibling temp file + rename so a concurrent reader never sees a half-written
+ *  card (rename is atomic within the same directory). `saveAgentFile` creates the parent dir. */
+function saveAtomic(path: string, def: AgentDef): void {
+  const tmp = join(dirname(path), `.${def.name}.tmp-${process.pid}`);
+  saveAgentFile(tmp, def);
+  renameSync(tmp, path);
+}
+
+function firstLine(s?: string): string | undefined {
+  return s?.split("\n").find((l) => l.trim())?.trim();
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? `${s.slice(0, n - 1)}…` : s;
+}
+
+function notFound(name: string, path: string): never {
+  console.error(c.red(`no persona "${name}"`));
+  console.error(c.dim(path));
+  process.exit(1);
+}
+
+function usage(): never {
+  console.error(
+    c.red(
+      "usage: cotal personas <list [--verbose] | show <name> | " +
+        'new <name> (--prompt <text> | --from <file|->) [--role <r>] [--model <m>] [--force] | rm <name> --force>',
+    ),
+  );
+  process.exit(1);
+}

--- a/implementations/cli/src/commands/spawn.ts
+++ b/implementations/cli/src/commands/spawn.ts
@@ -19,11 +19,21 @@ import {
   registry,
   CotalEndpoint,
   type AgentDef,
+  type CompletionResult,
   type Connector,
   type SpaceAuth,
 } from "@cotal-ai/core";
 import { cotalRoot } from "../lib/paths.js";
+import { listPersonaNames } from "../lib/personas.js";
 import { resolveSpace } from "../lib/status.js";
+
+/** Completion for `cotal spawn <name>` — the first positional is a persona; the rest are flags
+ *  we leave to the shell. Filesystem-only (the persona catalog), so it never opens the mesh. */
+export function spawnComplete(argv: string[]): CompletionResult {
+  if (argv.length <= 1)
+    return { items: listPersonaNames().map((value) => ({ value })), directive: "nofiles" };
+  return { items: [], directive: "nofiles" };
+}
 
 /**
  * `cotal spawn <name-or-path>` — launch an agent in the FOREGROUND of this

--- a/implementations/cli/src/index.ts
+++ b/implementations/cli/src/index.ts
@@ -7,7 +7,9 @@ import { watch } from "./commands/watch.js";
 import { console_ } from "./commands/console.js";
 import { demo } from "./commands/demo.js";
 import { web } from "./commands/web.js";
-import { spawn } from "./commands/spawn.js";
+import { spawn, spawnComplete } from "./commands/spawn.js";
+import { personas, personasComplete } from "./commands/personas.js";
+import { completion, completionComplete, complete } from "./commands/completion.js";
 import { mint } from "./commands/mint.js";
 import { signer } from "./commands/signer.js";
 import { channels } from "./commands/channels.js";
@@ -114,6 +116,31 @@ const baseCommands: Command[] = [
     summary:
       "launch an agent in this terminal from a file — spawn <name-or-path> | --name <n> --config <path> [--agent <a>] [--role <r>]",
     run: spawn,
+    complete: spawnComplete,
+  },
+  {
+    kind: "command",
+    name: "personas",
+    group: "Agents",
+    summary:
+      "list/manage local personas (.cotal/agents) — personas <list [-v] | show <name> | new <name> (--prompt <t>|--from <f>) [--role <r>] [--model <m>] | rm <name> --force>",
+    run: personas,
+    complete: personasComplete,
+  },
+  {
+    kind: "command",
+    name: "completion",
+    group: "Agents",
+    summary: "print a shell-completion script — completion <bash|zsh|fish|powershell>",
+    run: completion,
+    complete: completionComplete,
+  },
+  {
+    kind: "command",
+    name: "__complete",
+    group: "Agents",
+    summary: "(internal) emit completion candidates for the current command line",
+    run: complete,
   },
   {
     kind: "command",

--- a/implementations/cli/src/lib/personas.ts
+++ b/implementations/cli/src/lib/personas.ts
@@ -1,0 +1,51 @@
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+import { loadAgentFile, type AgentDef } from "@cotal-ai/core";
+import { cotalRoot } from "./paths.js";
+
+/**
+ * The persona catalog: the local `.cotal/agents/*.md` files an operator manages with
+ * `cotal personas` and spawns by name. Filesystem-only and side-effect-free — it never
+ * touches the mesh — so it is safe to call from a <TAB> completion as well as from `list`.
+ * The single source of truth for "what personas exist", shared by both surfaces.
+ */
+export interface PersonaEntry {
+  /** The filename stem (`.cotal/agents/<name>.md`), which is also the spawn name. */
+  name: string;
+  path: string;
+  /** Parsed definition, or undefined when the file failed to parse (see `error`). */
+  def?: AgentDef;
+  /** Parse error message, if the file is malformed — surfaced rather than crashing the list. */
+  error?: string;
+}
+
+/** The directory persona files live in: `<root>/.cotal/agents`. */
+export function personasDir(root = cotalRoot()): string {
+  return join(root, ".cotal", "agents");
+}
+
+/** List the persona files, each parsed (a malformed file becomes an entry with `error`, not a
+ *  throw). Returns `[]` when the directory is absent. Filesystem-only — no mesh, no network. */
+export function listPersonas(root = cotalRoot()): PersonaEntry[] {
+  const dir = personasDir(root);
+  let files: string[];
+  try {
+    files = readdirSync(dir).filter((f) => f.endsWith(".md"));
+  } catch {
+    return []; // no .cotal/agents yet — an empty catalog, not an error
+  }
+  return files.sort().map((f) => {
+    const name = f.slice(0, -3);
+    const path = join(dir, f);
+    try {
+      return { name, path, def: loadAgentFile(path) };
+    } catch (e) {
+      return { name, path, error: (e as Error).message };
+    }
+  });
+}
+
+/** Just the persona names — the completion source for `cotal spawn` and `personas show/rm`. */
+export function listPersonaNames(root = cotalRoot()): string[] {
+  return listPersonas(root).map((p) => p.name);
+}

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -1,5 +1,22 @@
 import type { Extension } from "./registry.js";
 
+/** One shell-completion candidate. `value` is inserted on the command line; `description`
+ *  is a one-line hint shown by shells that support it (zsh, fish) and ignored by bash. */
+export interface CompletionItem {
+  value: string;
+  description?: string;
+}
+
+/** What a command's {@link Command.complete} returns for the current cursor position: the
+ *  candidates, plus a directive telling the shell glue how to treat them.
+ *  - `nofiles` (the norm for our completions): don't fall back to filename completion.
+ *  - `nospace`: don't append a trailing space (the value is a prefix, e.g. `owner/`).
+ *  - `default`: normal behaviour (a trailing space is added; files may be offered). */
+export interface CompletionResult {
+  items: CompletionItem[];
+  directive?: "default" | "nospace" | "nofiles";
+}
+
 /**
  * The contract for a composable CLI command — an {@link Extension} of kind
  * `"command"`. An implementation (the mesh CLI, the manager …) self-registers its
@@ -15,4 +32,10 @@ export interface Command extends Extension {
    *  Falls back to `summary` when unset. */
   readonly usage?: string;
   run(argv: string[]): Promise<void>;
+  /** Optional shell-completion provider, owned by the command exactly as `run` is. Given the
+   *  args typed so far (everything after the command name; the last element is the word being
+   *  completed, possibly empty), returns the candidates for that position. Runs on every <TAB>
+   *  via the hidden `__complete` dispatcher, so it MUST be import-light and side-effect-free —
+   *  no network, no spawns. Omit it to offer no argument completion for this command. */
+  complete?(argv: string[]): CompletionResult | Promise<CompletionResult>;
 }


### PR DESCRIPTION
## Summary

Two new CLI surfaces:

- **`cotal personas`** — `list` / `show` / `new` / `rm` for the local persona catalog
  (`.cotal/agents/*.md`). The operator-side counterpart to the over-the-wire `cotal_persona`
  tool: it reads and writes the files **directly** — instant, offline, no mesh — where the tool
  path goes through the manager with ownership checks. Two trust contexts kept separate. Atomic
  writes (temp + rename), name validation shared with the persona tool, no overwrite without
  `--force`, `rm` requires `--force`.
- **Dynamic shell completion** — an optional `complete()` on the core `Command` contract (a
  command owns its completion the way it owns `run`), a hidden `cotal __complete` dispatcher, and
  `cotal completion <bash|zsh|fish|powershell>` stubs printed to stdout. So `cotal spawn <TAB>`
  completes from your actual persona catalog. **Filesystem-only on the completion path** — a
  keystroke never opens NATS. `__`-prefixed commands are hidden from help.

Completion follows the standard two-layer pattern (Cobra/Click/clap): a thin per-shell stub,
installed once, forwarding each `<TAB>` to the binary; the wire format is line-oriented and
versionable, so the stub never needs reinstalling as capabilities grow.

## Testing

- `pnpm typecheck` green across all packages (on the rebased base).
- Generated bash/zsh stubs pass `bash -n` / `zsh -n`; a live `<TAB>` simulation verified every
  position (command names, spawn personas, subcommands, completion shells) with prefix filtering.
- Full `personas` lifecycle plus edge cases (invalid name, missing body, no-clobber,
  refuse-`rm`-without-`--force`, stdin via `--from -`).

## Notes

- Deferred fast-follows (they share the mesh-roster machinery): `personas edit` (`$EDITOR`),
  live-data completion (`attach`/`stop --name` → running agents, `msg` → channels, `ask` →
  roles), and the `personas list` "running" marker.
- Plan doc lives on the `.internal` branch `plan/cli-personas-completion`; the submodule gitlink
  bump is left for a follow-up chore (the repo's pattern).