### PR TITLE
feat(cli): personas edit + list --running, declared-data completion, completion install

### DIFF
--- a/bin/cotal.ts
+++ b/bin/cotal.ts
@@ -15,6 +15,15 @@ import "@cotal-ai/cmux"; // opt into the cmux integration — registers the `cmu
 import { claudeConnector } from "@cotal-ai/connector-claude-code";
 import { registry } from "@cotal-ai/core";
 
+// A CLI must exit quietly when its stdout is closed early — piped to `head`, a pager that quits,
+// or a shell's process substitution (`source <(cotal completion bash)`). Node otherwise turns the
+// closed-pipe write into a fatal unhandled 'error' event with a stack trace. Mirror SIGPIPE: exit
+// 0. Registered before any command can write.
+process.stdout.on("error", (e: NodeJS.ErrnoException) => {
+  if (e.code === "EPIPE") process.exit(0);
+  throw e;
+});
+
 // The manager's default agent type is "cotal"; make it a real Claude coder so a bare
 // cotal_spawn / `cotal start --name x` (no --agent) brings up a Claude Code session.
 registry.register({ ...claudeConnector, name: "cotal" });

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -115,12 +115,12 @@ Full scenario and run steps:
   path. Accepted limits: no mid-turn interrupt in attach mode, and channel push is
   research-preview-gated. Detail in [architecture.md](architecture.md).
 - **Agent files (identity + persona).** An agent is defined by `.cotal/agents/<name>.md`:
-  YAML frontmatter (name, role, description, tags, channels, publish, model, capabilities)
-  that produces an A2A `AgentCard`, plus an optional Markdown body that is the **persona**
+  YAML frontmatter (name, role, description, tags, subscribe, allowSubscribe, allowPublish,
+  model, capabilities) that produces an A2A `AgentCard`, plus an optional Markdown body that is the **persona**
   (an appended system prompt). `role` is the addressable **service** (anycast). The
   connector resolves it from `COTAL_AGENT_FILE`; a peer can mint one on the fly with
   `cotal_persona` (the manager writes the file), and an operator manages the local catalog
-  with `cotal personas` (list/show/new/rm). Personas are **optional**, since Cotal
+  with `cotal personas` (list/show/edit/new/rm). Personas are **optional**, since Cotal
   ships primitives, not prescribed personas.
 - **Identity & authorization (on by default; `cotal up --open` to disable).** The mesh is
   a real boundary against untrusted peers in a shared space. The **sender is encoded in

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -146,8 +146,10 @@ on save (a save that breaks the frontmatter fails loud, never ships a bad card),
 <name> --force` deletes it.
 
 **Tab completion.** `cotal completion <bash|zsh|fish|powershell>` prints a shell stub to
-stdout and writes nothing else; `cotal completion install [shell]` wires it in for you
-(auto-detects `$SHELL`, idempotent, opt-in — never run by `setup`). Each `<TAB>` then forwards
+stdout for a manual or one-shot `source`; `cotal completion install [shell]` installs it
+persistently — it caches the stub (`~/.config/cotal/completion.<shell>`, or fish's completions
+dir) and sources that from your shell rc (auto-detects `$SHELL`, idempotent, opt-in — never run
+by `setup`). Each `<TAB>` then forwards
 to a hidden `cotal __complete`, so completion sees real data: `cotal spawn <TAB>` lists your
 personas, `cotal msg <TAB>` the channels your agent files **declare**, `cotal ask <TAB>` the
 declared roles. By contract `__complete` reads only local files — never the mesh — so a

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -138,17 +138,26 @@ persona content.)
 runtime `cotal_persona` tool. It reads and writes the same `.cotal/agents/*.md` files
 **directly** — instant, offline, no mesh — where the tool path goes over the wire with the
 manager's ownership checks; two trust contexts, kept separate. `cotal personas` (or `list`)
-shows the catalog, `show <name>` prints a card, `new <name> (--prompt <text> | --from
-<file|->) [--role <r>] [--model <m>] [--force]` writes one, and `rm <name> --force` deletes
-it.
+shows the catalog — `--running` adds a live ● marker for personas an agent of that name is
+currently running, an explicit overlay that connects and **fails loud** if the mesh is
+unreachable. `show <name>` prints a card, `edit <name>` opens one in `$EDITOR` and re-validates
+on save (a save that breaks the frontmatter fails loud, never ships a bad card), `new <name>
+(--prompt <text> | --from <file|->) [--role <r>] [--model <m>] [--force]` writes one, and `rm
+<name> --force` deletes it.
 
 **Tab completion.** `cotal completion <bash|zsh|fish|powershell>` prints a shell stub to
-stdout and writes nothing else. Install it once; each `<TAB>` then forwards to a hidden
-`cotal __complete`, so completion sees live data — `cotal spawn <TAB>` lists your actual
-personas. Enable it for the current shell with `source <(cotal completion zsh)` (fish: `cotal
-completion fish | source`; PowerShell: `cotal completion powershell | Out-String |
-Invoke-Expression`), or save the stub into the shell's completion directory to persist it. A
-command provides its candidates through the optional `complete()` on the
+stdout and writes nothing else; `cotal completion install [shell]` wires it in for you
+(auto-detects `$SHELL`, idempotent, opt-in — never run by `setup`). Each `<TAB>` then forwards
+to a hidden `cotal __complete`, so completion sees real data: `cotal spawn <TAB>` lists your
+personas, `cotal msg <TAB>` the channels your agent files **declare**, `cotal ask <TAB>` the
+declared roles. By contract `__complete` reads only local files — never the mesh — so a
+keystroke never blocks on the network, and there is **no fallback**: a completer that can't
+produce its authoritative answer (e.g. a malformed agent file) fails the process (nothing
+emitted, non-zero exit) rather than offer a silently-partial set, with the broken file named
+loudly by `cotal personas list` (set `COTAL_COMPLETE_DEBUG` to see why on stderr). Enable it
+for the current shell with `source <(cotal completion zsh)` (fish: `cotal completion fish |
+source`; PowerShell: `cotal completion powershell | Out-String | Invoke-Expression`). A command
+provides its candidates through the optional `complete()` on the
 [`Command`](../packages/core/src/command.ts) contract, the same way it owns `run()`.
 
 ## One-link join

--- a/implementations/cli/src/commands/completion.ts
+++ b/implementations/cli/src/commands/completion.ts
@@ -164,9 +164,15 @@ function install(shell?: string): void {
     return;
   }
   if (sh === "bash" || sh === "zsh") {
-    // bash/zsh load completion from their rc — append a single marked source line, once.
+    // Write the stub to a cached file and source THAT from the rc — deterministic (process
+    // substitution is slower and empirically flaky on macOS bash) and fast (no `cotal` spawn on
+    // every shell start). Re-running regenerates the stub; the rc line is added at most once.
+    const dir = join(process.env.XDG_CONFIG_HOME || join(homedir(), ".config"), "cotal");
+    const stub = join(dir, `completion.${sh}`);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(stub, SCRIPTS[sh]);
     const rc = sh === "zsh" ? join(process.env.ZDOTDIR || homedir(), ".zshrc") : join(homedir(), ".bashrc");
-    const line = `source <(cotal completion ${sh})`;
+    const line = `source "${stub}"`;
     let current = "";
     try {
       current = readFileSync(rc, "utf8");
@@ -175,11 +181,12 @@ function install(shell?: string): void {
     }
     if (current.includes(line)) {
       console.log(c.dim(`already installed in ${rc}`));
+      console.log(c.dim(`  refreshed ${stub}`));
       return;
     }
     appendFileSync(rc, `${current && !current.endsWith("\n") ? "\n" : ""}# cotal shell completion\n${line}\n`);
     console.log(c.green(`✓ installed ${sh} completion`));
-    console.log(c.dim(`  appended to ${rc}\n  open a new shell (or: ${line})`));
+    console.log(c.dim(`  ${stub}\n  appended to ${rc}\n  open a new shell (or: source ${stub})`));
     return;
   }
   // powershell: $PROFILE isn't resolvable from here, so print the exact line rather than guess.

--- a/implementations/cli/src/commands/completion.ts
+++ b/implementations/cli/src/commands/completion.ts
@@ -1,3 +1,6 @@
+import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
 import {
   registry,
   type Command,
@@ -16,10 +19,14 @@ import { c } from "../ui.js";
  * tolerant (unknown lines are ignored), so it can grow without anyone re-installing the stub.
  *
  *   cotal completion bash|zsh|fish|powershell   # print the stub to stdout
+ *   cotal completion install [shell]            # install it persistently (auto-detects $SHELL)
  *   cotal __complete <words…>                   # internal: emit candidates for the cursor
  *
- * `__complete` is import-light and side-effect-free by contract — persona completion is a
- * filesystem read, never a mesh connection — so a keystroke never blocks on the network.
+ * `__complete` is import-light and side-effect-free by contract — completion reads only local
+ * files (your personas and their declared channels/roles), never the mesh — so a keystroke never
+ * blocks on the network. And there is no fallback: a completer that can't produce its authoritative
+ * answer (e.g. a malformed agent file) fails the process — nothing on stdout, non-zero exit — so a
+ * partial set is never mistaken for a complete one. Set COTAL_COMPLETE_DEBUG to see why on stderr.
  */
 
 /** Wire format: one `value\tdescription` (or bare `value`) per line, then a `:directive`
@@ -47,8 +54,13 @@ export async function complete(argv: string[]): Promise<void> {
   try {
     const res = await cmd.complete(argv.slice(1));
     emit(res.items, res.directive ?? "nofiles");
-  } catch {
-    emit([], "default"); // a throwing completer yields nothing — never noisy on stderr/stdout
+  } catch (e) {
+    // No fallback: a completer that can't produce its authoritative set (e.g. a malformed agent
+    // file) fails the process — nothing on stdout, non-zero exit — so the shell offers nothing and
+    // never mistakes a failure for a successful empty result. Silent unless explicitly debugging.
+    if (process.env.COTAL_COMPLETE_DEBUG)
+      process.stderr.write(`cotal __complete: ${(e as Error).message}\n`);
+    process.exit(1);
   }
 }
 
@@ -118,22 +130,73 @@ const SCRIPTS: Record<string, string> = {
 };
 
 export async function completion(argv: string[]): Promise<void> {
+  if (argv[0] === "install") return install(argv[1]);
   const script = argv[0] ? SCRIPTS[argv[0]] : undefined;
   if (!script) {
-    console.error(c.red("usage: cotal completion <bash|zsh|fish|powershell>"));
+    console.error(c.red("usage: cotal completion <bash|zsh|fish|powershell | install [shell]>"));
     console.error(c.dim("  enable it now (this shell):"));
     console.error(c.dim("    bash/zsh:  source <(cotal completion bash)"));
     console.error(c.dim("    fish:      cotal completion fish | source"));
     console.error(c.dim("    pwsh:      cotal completion powershell | Out-String | Invoke-Expression"));
+    console.error(c.dim("  or install it persistently:  cotal completion install"));
     process.exit(1);
   }
   process.stdout.write(script);
 }
 
-/** Argument completion for `cotal completion` itself: the supported shells. */
+/** `cotal completion install [shell]` — wire the stub into your shell persistently. Opt-in (never
+ *  run by `setup`). Auto-detects the shell from $SHELL when omitted; fails loud on an unknown or
+ *  unsupported one (no silent guess). Idempotent — re-running once installed is a no-op. */
+function install(shell?: string): void {
+  const sh = shell ?? basename(process.env.SHELL ?? "");
+  if (!SCRIPTS[sh]) {
+    console.error(c.red(`can't install for "${sh || "unknown shell"}" — pass one of: bash, zsh, fish`));
+    process.exit(1);
+  }
+  if (sh === "fish") {
+    // Fish auto-loads files from its completions dir — drop the stub straight in (no rc edit).
+    const dir = join(process.env.XDG_CONFIG_HOME || join(homedir(), ".config"), "fish", "completions");
+    const file = join(dir, "cotal.fish");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(file, SCRIPTS.fish);
+    console.log(c.green("✓ installed fish completion"));
+    console.log(c.dim(`  ${file}\n  open a new shell (or: source ${file})`));
+    return;
+  }
+  if (sh === "bash" || sh === "zsh") {
+    // bash/zsh load completion from their rc — append a single marked source line, once.
+    const rc = sh === "zsh" ? join(process.env.ZDOTDIR || homedir(), ".zshrc") : join(homedir(), ".bashrc");
+    const line = `source <(cotal completion ${sh})`;
+    let current = "";
+    try {
+      current = readFileSync(rc, "utf8");
+    } catch {
+      /* rc doesn't exist yet — appendFileSync creates it */
+    }
+    if (current.includes(line)) {
+      console.log(c.dim(`already installed in ${rc}`));
+      return;
+    }
+    appendFileSync(rc, `${current && !current.endsWith("\n") ? "\n" : ""}# cotal shell completion\n${line}\n`);
+    console.log(c.green(`✓ installed ${sh} completion`));
+    console.log(c.dim(`  appended to ${rc}\n  open a new shell (or: ${line})`));
+    return;
+  }
+  // powershell: $PROFILE isn't resolvable from here, so print the exact line rather than guess.
+  console.error(c.red("auto-install isn't supported for powershell."));
+  console.error(c.dim("  add to your $PROFILE:  cotal completion powershell | Out-String | Invoke-Expression"));
+  process.exit(1);
+}
+
+/** Argument completion for `cotal completion` itself: the supported shells, plus `install`. */
 export function completionComplete(argv: string[]): CompletionResult {
+  const shells = Object.keys(SCRIPTS).map((value) => ({ value }));
   if (argv.length <= 1)
-    return { items: Object.keys(SCRIPTS).map((value) => ({ value })), directive: "nofiles" };
+    return {
+      items: [...shells, { value: "install", description: "install for your shell" }],
+      directive: "nofiles",
+    };
+  if (argv[0] === "install") return { items: shells, directive: "nofiles" };
   return { items: [], directive: "nofiles" };
 }
 

--- a/implementations/cli/src/commands/personas.ts
+++ b/implementations/cli/src/commands/personas.ts
@@ -1,15 +1,18 @@
+import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, renameSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { parseArgs } from "node:util";
 import {
   agentFilePath,
   assertValidName,
+  loadAgentFile,
   saveAgentFile,
   type AgentDef,
   type CompletionResult,
 } from "@cotal-ai/core";
 import { cotalRoot } from "../lib/paths.js";
 import { listPersonas, listPersonaNames, personasDir } from "../lib/personas.js";
+import { openTransient, type ConnectValues } from "../lib/transient.js";
 import { c } from "../ui.js";
 
 /**
@@ -18,8 +21,9 @@ import { c } from "../ui.js";
  * and writes the files directly (instant, works offline). The privileged, ownership-checked
  * path stays in the manager's `definePersona` for *agents* defining personas over the wire.
  *
- *   cotal personas [list] [--verbose]
+ *   cotal personas [list] [--verbose] [--running]
  *   cotal personas show <name>
+ *   cotal personas edit <name>
  *   cotal personas new <name> (--prompt <text> | --from <file|->) [--role <r>] [--model <m>] [--force]
  *   cotal personas rm <name> --force
  */
@@ -38,14 +42,20 @@ export async function personas(argv: string[]): Promise<void> {
       from: { type: "string" },
       verbose: { type: "boolean", short: "v" },
       force: { type: "boolean" },
+      running: { type: "boolean" },
+      space: { type: "string" },
+      server: { type: "string" },
+      creds: { type: "string" },
     },
   });
 
   switch (positionals[0] ?? "list") {
     case "list":
-      return list(values.verbose === true);
+      return list(values.verbose === true, values.running === true, values);
     case "show":
       return show(positionals[1]);
+    case "edit":
+      return edit(positionals[1]);
     case "new":
       return create(positionals[1], values);
     case "rm":
@@ -61,18 +71,19 @@ export function personasComplete(argv: string[]): CompletionResult {
     items: [
       { value: "list", description: "list the persona catalog" },
       { value: "show", description: "print a persona's card" },
+      { value: "edit", description: "open a persona in $EDITOR" },
       { value: "new", description: "create a persona" },
       { value: "rm", description: "delete a persona" },
     ],
     directive: "nofiles",
   };
   if (argv.length <= 1) return subs; // completing the subcommand
-  if (argv[0] === "show" || argv[0] === "rm")
+  if (argv[0] === "show" || argv[0] === "edit" || argv[0] === "rm")
     return { items: listPersonaNames().map((value) => ({ value })), directive: "nofiles" };
   return { items: [], directive: "nofiles" };
 }
 
-function list(verbose: boolean): void {
+async function list(verbose: boolean, running: boolean, values: ConnectValues): Promise<void> {
   const entries = listPersonas();
   if (!entries.length) {
     console.log(
@@ -81,6 +92,9 @@ function list(verbose: boolean): void {
     );
     return;
   }
+  // `--running` is an explicit live overlay: connect, snapshot who's present, and mark each persona.
+  // Fails loud if the mesh is unreachable (presentNames exits) — never a silent best-effort.
+  const present = running ? await presentNames(values) : undefined;
   const pad = Math.max(...entries.map((e) => e.name.length));
   for (const e of entries) {
     if (e.error) {
@@ -88,13 +102,35 @@ function list(verbose: boolean): void {
       continue;
     }
     const d = e.def!;
-    const meta = [d.role && c.cyan(d.role), d.model && c.dim(`model=${d.model}`), d.owner && c.dim(`owner=${d.owner}`)]
+    const live = present ? (present.has(e.name) ? c.green("● running") : c.dim("○")) : undefined;
+    const meta = [d.role && c.cyan(d.role), d.model && c.dim(`model=${d.model}`), d.owner && c.dim(`owner=${d.owner}`), live]
       .filter(Boolean)
       .join("  ");
     console.log(`${c.bold(e.name.padEnd(pad))}  ${meta}`.trimEnd());
     const desc = d.description ?? firstLine(d.persona);
     if (desc) console.log(c.dim(`  ${truncate(desc, 100)}`));
     if (verbose && d.persona) console.log(d.persona.replace(/^/gm, "    ") + "\n");
+  }
+}
+
+/** Snapshot the names currently present on the mesh — the live overlay behind `personas list
+ *  --running`. Presence is a KV watch that replays asynchronously after connect (no synced signal),
+ *  so let the roster settle (snapshot once its size holds steady) under a hard deadline so it never
+ *  hangs. A name is "running" when an agent of exactly that name is present and not offline. */
+async function presentNames(values: ConnectValues): Promise<Set<string>> {
+  const { ep } = await openTransient(values, "personas");
+  try {
+    let last = -1;
+    let stable = 0;
+    for (let i = 0; i < 20 && stable < 3; i++) {
+      const n = ep.getRoster().length;
+      stable = n === last ? stable + 1 : 0;
+      last = n;
+      await new Promise((r) => setTimeout(r, 75));
+    }
+    return new Set(ep.getRoster().filter((p) => p.status !== "offline").map((p) => p.card.name));
+  } finally {
+    await ep.stop();
   }
 }
 
@@ -105,6 +141,39 @@ function show(name?: string): void {
   // Print the file verbatim — the canonical card (frontmatter + persona body).
   console.log(c.dim(path));
   process.stdout.write(readFileSync(path, "utf8"));
+}
+
+/** `cotal personas edit <name>` — open the card in $EDITOR (or $VISUAL), then re-validate on exit
+ *  so a save that breaks the frontmatter fails loud instead of silently shipping a bad card. */
+function edit(name?: string): void {
+  if (!name) return usage();
+  const path = agentFilePath(cotalRoot(), name);
+  if (!existsSync(path)) return notFound(name, path);
+  const editor = process.env.VISUAL || process.env.EDITOR;
+  if (!editor) {
+    console.error(c.red("no editor set — export EDITOR (or VISUAL), e.g. export EDITOR=vim"));
+    process.exit(1);
+  }
+  // Hand the terminal to the editor (inherit stdio so it draws). $EDITOR may carry flags
+  // (e.g. "code --wait"), so go through the shell.
+  const res = spawnSync(`${editor} "${path}"`, { stdio: "inherit", shell: true });
+  if (res.error) {
+    console.error(c.red(`couldn't launch editor "${editor}": ${res.error.message}`));
+    process.exit(1);
+  }
+  if (res.status !== 0) {
+    console.error(c.red(`editor exited ${res.signal ? `on ${res.signal}` : `with status ${res.status}`} — not saved`));
+    process.exit(1);
+  }
+  // Re-validate: a save that breaks the frontmatter must fail loud, not ship a broken card.
+  try {
+    loadAgentFile(path);
+  } catch (e) {
+    console.error(c.red(`⨯ "${name}" is now unparseable — fix it:`));
+    console.error(c.dim(`  ${(e as Error).message}`));
+    process.exit(1);
+  }
+  console.log(c.green(`✓ saved "${name}"`));
 }
 
 function create(name: string | undefined, v: { role?: string; model?: string; prompt?: string; from?: string; force?: boolean }): void {
@@ -180,7 +249,7 @@ function notFound(name: string, path: string): never {
 function usage(): never {
   console.error(
     c.red(
-      "usage: cotal personas <list [--verbose] | show <name> | " +
+      "usage: cotal personas <list [--verbose] [--running] | show <name> | edit <name> | " +
         'new <name> (--prompt <text> | --from <file|->) [--role <r>] [--model <m>] [--force] | rm <name> --force>',
     ),
   );

--- a/implementations/cli/src/commands/send.ts
+++ b/implementations/cli/src/commands/send.ts
@@ -1,20 +1,13 @@
 import { parseArgs } from "node:util";
-import { readFileSync } from "node:fs";
 import {
-  CotalEndpoint,
-  isReachable,
   resolvePeer,
   AmbiguousPeerError,
-  DEFAULT_SERVER,
-  DEFAULT_SPACE,
-  authDir,
-  loadSpaceAuth,
-  mintCreds,
-  newIdentity,
   type Presence,
+  type CompletionResult,
 } from "@cotal-ai/core";
 import { c } from "../ui.js";
-import { cotalRoot } from "../lib/paths.js";
+import { openTransient } from "../lib/transient.js";
+import { listDeclaredChannels, listDeclaredRoles } from "../lib/personas.js";
 import { mentionsIn } from "../lib/mentions.js";
 
 /**
@@ -31,47 +24,6 @@ const SEND_OPTS = {
 
 type SendValues = { space?: string; server?: string; creds?: string };
 
-/** Resolve space/server/creds and open a transient, write-capable sender, the way `cotal web` does:
- *  an explicit `--creds` wins; else self-mint from `.cotal/auth` so the send is allowed; else
- *  connect bare on an open mesh. The endpoint never registers on the roster and binds no inbox; it
- *  watches presence so name→id resolution works (`dm`). The caller stops it. */
-async function connectSender(values: SendValues): Promise<{ ep: CotalEndpoint; space: string }> {
-  const server = values.server ?? DEFAULT_SERVER;
-  let creds = values.creds ? readFileSync(values.creds, "utf8") : undefined;
-  let space = values.space;
-  if (!creds) {
-    const auth = loadSpaceAuth(authDir(cotalRoot()));
-    if (auth) {
-      if (space && space !== auth.space) {
-        console.error(
-          c.red(`Auth here is for space "${auth.space}", not "${space}". Use --space ${auth.space} (or pass --creds).`),
-        );
-        process.exit(1);
-      }
-      space = auth.space;
-      creds = await mintCreds(auth, newIdentity(), "manager");
-    }
-  }
-  space = space ?? DEFAULT_SPACE;
-  if (!(await isReachable(server, { creds }))) {
-    console.error(c.red(`Can't reach NATS at ${server}. Run: cotal up`));
-    process.exit(1);
-  }
-  const ep = new CotalEndpoint({
-    space,
-    servers: server,
-    creds,
-    channels: [],
-    consume: false,
-    registerPresence: false,
-    watchPresence: true,
-    card: { name: "send", kind: "endpoint" },
-  });
-  ep.on("error", (e: Error) => console.error(c.red("! " + e.message)));
-  await ep.start();
-  return { ep, space };
-}
-
 /** Split `<target> <text…>` positionals, stripping a leading `@`/`#` from the target. */
 function targetAndText(positionals: string[], strip: RegExp): { target?: string; text: string } {
   return { target: positionals[0]?.replace(strip, ""), text: positionals.slice(1).join(" ").trim() };
@@ -85,7 +37,7 @@ export async function dm(argv: string[]): Promise<void> {
     console.error('usage: cotal dm <agent> "<text>"  [--space <s>] [--server <url>] [--creds <path>]');
     process.exit(1);
   }
-  const { ep, space } = await connectSender(values);
+  const { ep, space } = await openTransient(values, "send");
   // Presence arrives asynchronously after connect; poll briefly (≤2s) for the target to appear.
   // resolvePeer is fail-loud: an exact id or a unique name resolves, a same-name collision throws.
   let peer: Presence | undefined;
@@ -120,7 +72,7 @@ export async function msg(argv: string[]): Promise<void> {
     console.error('usage: cotal msg <channel> "<text>"  [--space <s>] [--server <url>] [--creds <path>]');
     process.exit(1);
   }
-  const { ep } = await connectSender(values);
+  const { ep } = await openTransient(values, "send");
   await ep.multicast(text, { channel, mentions: mentionsIn(text) });
   console.log(c.green(`→ #${channel}`) + c.dim(`  ${text}`));
   await ep.stop();
@@ -134,8 +86,33 @@ export async function ask(argv: string[]): Promise<void> {
     console.error('usage: cotal ask <role> "<text>"  [--space <s>] [--server <url>] [--creds <path>]');
     process.exit(1);
   }
-  const { ep } = await connectSender(values);
+  const { ep } = await openTransient(values, "send");
   await ep.anycast(role, text);
   console.log(c.green(`→ @${role}`) + c.dim(`  ${text}`));
   await ep.stop();
+}
+
+/** Complete `cotal msg <channel>` from the channels the local persona files *declare* — never the
+ *  live broker (a <TAB> stays offline by contract). The label says "declared" because these are
+ *  workspace intent, not a claim about what exists on the mesh. Only the channel position
+ *  completes; the message text offers nothing. Fail-closed: a malformed agent file throws, so the
+ *  completer declines rather than offering a silently-partial set (see {@link listDeclaredChannels}). */
+export function msgComplete(argv: string[]): CompletionResult {
+  if (argv.length <= 1)
+    return {
+      items: listDeclaredChannels().map((value) => ({ value, description: "declared channel" })),
+      directive: "nofiles",
+    };
+  return { items: [], directive: "nofiles" };
+}
+
+/** Complete `cotal ask <role>` from the roles the local persona files declare — same local-only,
+ *  fail-closed contract as {@link msgComplete}. */
+export function askComplete(argv: string[]): CompletionResult {
+  if (argv.length <= 1)
+    return {
+      items: listDeclaredRoles().map((value) => ({ value, description: "declared role" })),
+      directive: "nofiles",
+    };
+  return { items: [], directive: "nofiles" };
 }

--- a/implementations/cli/src/index.ts
+++ b/implementations/cli/src/index.ts
@@ -15,7 +15,7 @@ import { signer } from "./commands/signer.js";
 import { channels } from "./commands/channels.js";
 import { history } from "./commands/history.js";
 import { feedback } from "./commands/feedback.js";
-import { dm, msg, ask } from "./commands/send.js";
+import { dm, msg, ask, msgComplete, askComplete } from "./commands/send.js";
 
 /** The minimal mesh CLI: thin NATS clients (up/join/watch), plus `spawn` — a
  *  foreground agent launch that reuses the connector's launch recipe. Self-registers
@@ -79,6 +79,7 @@ const baseCommands: Command[] = [
     summary: "broadcast a message to a channel",
     usage: 'msg <channel> "<text>"  [--space <s>] [--server <url>] [--creds <path>]',
     run: msg,
+    complete: msgComplete,
   },
   {
     kind: "command",
@@ -87,6 +88,7 @@ const baseCommands: Command[] = [
     summary: "anycast a message to a role (one instance answers)",
     usage: 'ask <role> "<text>"  [--space <s>] [--server <url>] [--creds <path>]',
     run: ask,
+    complete: askComplete,
   },
   {
     kind: "command",
@@ -123,7 +125,7 @@ const baseCommands: Command[] = [
     name: "personas",
     group: "Agents",
     summary:
-      "list/manage local personas (.cotal/agents) — personas <list [-v] | show <name> | new <name> (--prompt <t>|--from <f>) [--role <r>] [--model <m>] | rm <name> --force>",
+      "list/manage local personas (.cotal/agents) — personas <list [-v] [--running] | show <name> | edit <name> | new <name> (--prompt <t>|--from <f>) [--role <r>] [--model <m>] | rm <name> --force>",
     run: personas,
     complete: personasComplete,
   },
@@ -131,7 +133,7 @@ const baseCommands: Command[] = [
     kind: "command",
     name: "completion",
     group: "Agents",
-    summary: "print a shell-completion script — completion <bash|zsh|fish|powershell>",
+    summary: "shell completion — completion <bash|zsh|fish|powershell | install [shell]>",
     run: completion,
     complete: completionComplete,
   },

--- a/implementations/cli/src/lib/personas.ts
+++ b/implementations/cli/src/lib/personas.ts
@@ -49,3 +49,34 @@ export function listPersonas(root = cotalRoot()): PersonaEntry[] {
 export function listPersonaNames(root = cotalRoot()): string[] {
   return listPersonas(root).map((p) => p.name);
 }
+
+/** Collect a deduped, sorted set of values declared across every persona file, via `pick`.
+ *  Fail-closed: a single malformed file throws — the aggregate can't be trusted, so a derived
+ *  completer must decline rather than offer a silently-partial set. The broken file is named loudly
+ *  by `cotal personas list`, so the error stays visible; it's just not buried in a <TAB>. */
+function declaredValues(root: string, pick: (def: AgentDef) => (string | undefined)[]): string[] {
+  const out = new Set<string>();
+  for (const e of listPersonas(root)) {
+    if (e.error) throw new Error(`persona "${e.name}" is unparseable: ${e.error}`);
+    for (const v of pick(e.def!)) if (v) out.add(v);
+  }
+  return [...out].sort();
+}
+
+/** Channels the persona files declare (`subscribe` ∪ `allowSubscribe` ∪ `allowPublish`), as the
+ *  completion source for `cotal msg`/`send`. Wildcard ACL scopes (`team.>`, `*`) are excluded —
+ *  they're read/post patterns, not concrete send targets. Authoritative-for-intent, not a claim the
+ *  channel exists on the broker. Fail-closed via {@link declaredValues}. Filesystem-only — no mesh. */
+export function listDeclaredChannels(root = cotalRoot()): string[] {
+  return declaredValues(root, (d) => [
+    ...(d.subscribe ?? []),
+    ...(d.allowSubscribe ?? []),
+    ...(d.allowPublish ?? []),
+  ]).filter((ch) => !ch.includes(">") && !ch.includes("*"));
+}
+
+/** Roles the persona files declare (the `role:` field), as the completion source for
+ *  `cotal ask`/`anycast`. Fail-closed via {@link declaredValues}. Filesystem-only — no mesh. */
+export function listDeclaredRoles(root = cotalRoot()): string[] {
+  return declaredValues(root, (d) => [d.role]);
+}

--- a/implementations/cli/src/lib/transient.ts
+++ b/implementations/cli/src/lib/transient.ts
@@ -1,0 +1,78 @@
+import { readFileSync } from "node:fs";
+import {
+  CotalEndpoint,
+  isReachable,
+  DEFAULT_SERVER,
+  DEFAULT_SPACE,
+  authDir,
+  loadSpaceAuth,
+  mintCreds,
+  newIdentity,
+} from "@cotal-ai/core";
+import { c } from "../ui.js";
+import { cotalRoot } from "./paths.js";
+
+/**
+ * A one-shot, write-capable connection for the headless commands that touch the live mesh
+ * (`dm`/`msg`/`ask`, and `personas list --running`). Resolve space/server/creds the same way
+ * everywhere, open a transient endpoint that never joins the roster, do the one thing, stop.
+ * Fail-loud throughout — an unreachable server or a space mismatch exits, never degrades.
+ */
+
+export interface ConnectValues {
+  space?: string;
+  server?: string;
+  creds?: string;
+}
+
+/** Resolve where to connect and with what credentials: an explicit `--creds` wins; else self-mint
+ *  from `.cotal/auth` so an AUTH-mode mesh admits us; else connect bare on an open mesh. Exits with
+ *  a clear message on a `--space` that contradicts the local auth, or an unreachable server. */
+export async function resolveConnect(
+  values: ConnectValues,
+): Promise<{ server: string; space: string; creds?: string }> {
+  const server = values.server ?? DEFAULT_SERVER;
+  let creds = values.creds ? readFileSync(values.creds, "utf8") : undefined;
+  let space = values.space;
+  if (!creds) {
+    const auth = loadSpaceAuth(authDir(cotalRoot()));
+    if (auth) {
+      if (space && space !== auth.space) {
+        console.error(
+          c.red(`Auth here is for space "${auth.space}", not "${space}". Use --space ${auth.space} (or pass --creds).`),
+        );
+        process.exit(1);
+      }
+      space = auth.space;
+      creds = await mintCreds(auth, newIdentity(), "manager");
+    }
+  }
+  space = space ?? DEFAULT_SPACE;
+  if (!(await isReachable(server, { creds }))) {
+    console.error(c.red(`Can't reach NATS at ${server}. Run: cotal up`));
+    process.exit(1);
+  }
+  return { server, space, creds };
+}
+
+/** Open a transient endpoint: it watches presence (so name→id resolution and the live roster work)
+ *  but never registers itself, binds no inbox, and consumes no channels. The caller stops it. */
+export async function openTransient(
+  values: ConnectValues,
+  name: string,
+): Promise<{ ep: CotalEndpoint; space: string }> {
+  const { server, space, creds } = await resolveConnect(values);
+  const ep = new CotalEndpoint({
+    space,
+    servers: server,
+    creds,
+    channels: [],
+    consume: false,
+    registerPresence: false,
+    watchPresence: true,
+    card: { name, kind: "endpoint" },
+  });
+  ep.on("error", (e: Error) => console.error(c.red("! " + e.message)));
+  await ep.start();
+  return { ep, space };
+}


### PR DESCRIPTION
Phase 2 of `cotal personas` + shell completion (phase 1 = PR #65). Design reviewed back-and-forth with `review-general-2` on the mesh; scope chosen by the operator ("full phase-2").

## The governing principle — no fallbacks
A `<TAB>` press can't surface an error (the shell would dump a stack trace mid-line), so any network call in the completion path would have to silently swallow failures into an empty result — and that swallow *is* a fallback. So the rule we settled on: **completion draws only on sources that are authoritative, cheap, and don't fail in normal operation** — today, the local `.cotal/agents/*.md` files. Never the mesh.

## What's in it
- **`personas edit <name>`** — open in `$EDITOR`/`$VISUAL`, re-validate via `loadAgentFile` on save; a save that breaks the frontmatter fails loud rather than shipping a bad card.
- **`personas list --running`** — an explicit live overlay that connects, snapshots the presence roster, and marks personas whose exact name is currently present as `● running`. **Fails loud** if the mesh is unreachable. Default `list` stays pure-local and instant.
- **Declared-data completion** — `cotal msg`/`send <TAB>` → channels the agent files *declare* (`subscribe` ∪ `allowSubscribe` ∪ `allowPublish`, wildcard ACL scopes excluded as non-targets); `cotal ask`/`anycast <TAB>` → declared roles. Labelled "declared", not a claim about live broker state. **Fail-closed**: a single malformed agent file makes the completer decline (non-zero exit, nothing emitted) rather than offer a silently-partial set. Persona-*name* completion stays immune — the name is the filename stem — so a broken file never blocks `spawn`/`show`/`edit`/`rm`.
- **`__complete` error protocol** — removed the old `catch { emit([], "default") }` swallow. A completer that can't produce its authoritative answer fails the process (nothing on stdout, non-zero exit), so the shell never mistakes a failure for a successful empty result. Silent unless `COTAL_COMPLETE_DEBUG`.
- **`completion install [shell]`** — auto-detects `$SHELL`; fish → writes the completions file; bash/zsh → idempotent marked `source` line in the rc; powershell → prints the `$PROFILE` line (no profile-path guess). Opt-in, never wired into `cotal setup`.
- Extract the shared transient connect (`resolveConnect`/`openTransient`) out of `send.ts` so `send` and `personas list --running` share one cred-resolution path.

## Deliberately dropped
**Running-agent completion** (`attach`/`stop --name`). There's no local source of truth for "is it running", so completing persona names there would be a misleading guess — also a fallback. Better to offer nothing.

## Testing
`pnpm typecheck` + `pnpm build` green. Every completion position exercised in a scratch workspace, including the fail-closed path (malformed file → name completion intact, channel/role completion exits 1, `COTAL_COMPLETE_DEBUG` names the culprit); `personas edit` happy/corrupt/no-editor paths; `completion install` across bash/zsh/fish/powershell/unknown incl. idempotency; `personas list --running` fail-loud on a dead server **and** a true live-mesh read (correctly marked the present `review-general`).

Plan + STATUS recorded on the internal `plan/cli-personas-phase2` branch. No `.internal` gitlink bump here (separate chore, matching phase 1).