### PR TITLE
ci: auto-tag and cut the GitHub Release on publish

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -59,15 +59,36 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
 
-      # ci:publish is `pnpm publish` (for OIDC provenance), which doesn't create git tags — so tag
-      # the released versions ourselves whenever a publish actually happened. `changeset tag` creates
-      # one tag per package at its current version (e.g. @cotal-ai/connector-core@0.1.3), skipping
-      # any that already exist.
-      - name: Tag released versions
-        if: steps.changesets.outputs.published == 'true'
+      # ci:publish is `pnpm publish` (for OIDC provenance), whose output the changesets action
+      # can't parse — so `outputs.published` is unreliable and we can't gate on it. Instead, detect
+      # a fresh release by whether the just-published umbrella version (the `cotal-ai` package in
+      # bin/) already has a `vX.Y.Z` GitHub Release: if not, this push just published it, so cut the
+      # tag + Release with GitHub's auto-generated PR notes (honours .github/release.yml). The step
+      # is idempotent — it runs on every push but no-ops once the Release exists. Uses GH_PAT (not
+      # the default GITHUB_TOKEN) so the published Release still triggers the Discord webhook.
+      - name: Tag and cut the GitHub Release on publish
+        if: success() && github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
-          pnpm changeset tag
-          git push origin --tags
+          version=$(node -p "require('./bin/package.json').version")
+          tag="v$version"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "Release $tag already exists — nothing to do."
+            exit 0
+          fi
+          notes=$(gh api "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+            -f tag_name="$tag" -f target_commitish="$GITHUB_SHA" --jq .body)
+          {
+            printf '🚀 **Cotal %s is out!**\n\nGrab it: `npm i cotal-ai@%s`\n\n' "$version" "$version"
+            printf '%s\n' "$notes"
+          } > "$RUNNER_TEMP/release-notes.md"
+          gh release create "$tag" \
+            --target "$GITHUB_SHA" \
+            --title "$tag" \
+            --latest \
+            --notes-file "$RUNNER_TEMP/release-notes.md"
+          echo "Created GitHub Release $tag."
 
   # Snapshot release from any ref — publishes <version>-<tag>-<datetime> under the given npm
   # dist-tag so a branch can be tried out without merging. No commits, no git tags.


### PR DESCRIPTION
## Problem
The npm publish is automated, but **git tags and GitHub Releases are not** — they've been cut by hand (only `v0.3.2` and `v0.4.0` ever were). Root cause: the `Tag released versions` step was gated on `steps.changesets.outputs.published == 'true'`, which is **never true** in this repo. `ci:publish` runs `pnpm publish --provenance` (for OIDC provenance), and the Changesets action only detects publishes from `changeset publish`'s output — so `published` stays `false` and the step is silently skipped on every release.

## Fix
Replace that dead step with an idempotent one that:
1. Reads the just-published umbrella version from `bin/package.json` (the `cotal-ai` package — all 9 packages are a fixed group, so this is the release version).
2. If a `vX.Y.Z` GitHub Release already exists, no-ops. (So it's safe to run on every push: feature pushes and version-PR pushes both see the current version already released and skip.)
3. Otherwise — i.e. this push just published a new version — creates the `vX.Y.Z` tag **at the published commit** (`$GITHUB_SHA`, avoiding the "main advanced" mis-tag) and cuts the GitHub Release with:
   - a short `npm i cotal-ai@X.Y.Z` intro, plus
   - GitHub's **auto-generated "What's Changed" PR list** (via the generate-notes API, honouring `.github/release.yml` so the `skip-changelog` version-packages PR is excluded).

Runs via `GH_PAT` (not the default `GITHUB_TOKEN`) so the published Release still fires the existing `github-releases-to-discord` workflow.

## Notes
- This produces **one umbrella `vX.Y.Z` Release** per version (the established convention), not 9 per-package releases.
- Verified locally: version read, the existing/missing-release gate, and the generate-notes API all behave as expected; YAML parses clean.
- Can't fully exercise it without a real publish; it takes effect on the next release (e.g. 0.4.1 / 0.5.0).