### PR TITLE
feat(cli): seed a default persona and spawn it when none is named

### DIFF
--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -120,8 +120,9 @@ Full scenario and run steps:
   (an appended system prompt). `role` is the addressable **service** (anycast). The
   connector resolves it from `COTAL_AGENT_FILE`; a peer can mint one on the fly with
   `cotal_persona` (the manager writes the file), and an operator manages the local catalog
-  with `cotal personas` (list/show/edit/new/rm). Personas are **optional**, since Cotal
-  ships primitives, not prescribed personas.
+  with `cotal personas` (list/show/edit/new/rm). `cotal setup` seeds a generic `default.md`,
+  the persona `cotal spawn` launches when you don't name one. Personas are **optional**, since
+  Cotal ships primitives, not prescribed personas.
 - **Identity & authorization (on by default; `cotal up --open` to disable).** The mesh is
   a real boundary against untrusted peers in a shared space. The **sender is encoded in
   the subject** (server-policed, not self-asserted), so an agent can only emit **as

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -81,6 +81,7 @@ Prefer commands?
 
 ```bash
 cotal go                             # open or resume your session (reuses what is up)
+cotal spawn                          # the default agent (edit .cotal/agents/default.md)
 cotal spawn me                       # the session you drive (consults david/sven)
 cotal spawn david                    # ask the engineer (or sven, the guide)
 cotal console --space main           # live mesh view in the terminal (TUI)

--- a/implementations/cli/src/commands/setup.ts
+++ b/implementations/cli/src/commands/setup.ts
@@ -153,6 +153,7 @@ async function runFirstRun(yes: boolean, open: boolean): Promise<void> {
   for (const [name, body] of Object.entries(DEMO_AGENTS)) {
     writeDemoAgent(cotalPath("agents", `${name}.md`), body);
   }
+  seedDefaultAgent(); // the generic persona `cotal spawn` (no name) launches
   p.log.success("Added david (the engineer), sven (the guide), and your session (me); they join when you spawn them or open the demo");
   log.line("demo-agents: wrote david + sven + me");
 
@@ -421,6 +422,7 @@ function closeStaleTabs(term: TerminalLayout, name: string): void {
 
 /** The compact repeat-run: quietly ensure the mesh + web are up here, then a one-glance card. */
 async function runEnsure(): Promise<void> {
+  seedDefaultAgent(); // ensure `cotal spawn` (no name) always has a default to launch
   let mesh = await meshStatus(process.cwd());
   if (!mesh.reachable) {
     const s = p.spinner();
@@ -545,6 +547,33 @@ function writeDemoAgent(path: string, body: string): void {
     if (!cur.includes(MANAGED_MARKER)) writeFileSync(`${path}.bak`, cur); // preserve a user/pre-marker edit
   }
   writeFileSync(path, body);
+}
+
+/** The default persona `cotal spawn` (no name) launches: a generic mesh agent, seeded once and
+ *  then the user's to shape. Unlike the demo team it's never refreshed (seed-if-absent), so any
+ *  edits stand; deleting it just means the next `cotal setup`/`go` writes a fresh copy. */
+const DEFAULT_AGENT = `---
+name: default_agent
+role: default
+description: An agent on the mesh
+tags: []
+subscribe: [">"]
+allowPublish: [">"]
+capabilities: [spawn]
+---
+
+You are an agent on the Cotal mesh — a shared space where agents join, see who's around, and
+coordinate as peers rather than working in silos. Use the Cotal tools available to you to find
+your peers and work with them. Edit this file to give yourself a name, role, and purpose.
+`;
+
+/** Seed the default persona if it's missing (idempotent, seed-if-absent). Called from both the
+ *  first-run and repeat-run paths so `cotal spawn` always has a default on hand. */
+function seedDefaultAgent(): void {
+  const path = cotalPath("agents", "default.md");
+  if (existsSync(path)) return;
+  mkdirSync(cotalPath("agents"), { recursive: true });
+  writeFileSync(path, DEFAULT_AGENT);
 }
 
 const DEMO_AGENTS: Record<string, string> = {

--- a/implementations/cli/src/commands/spawn.ts
+++ b/implementations/cli/src/commands/spawn.ts
@@ -120,22 +120,22 @@ export async function spawn(argv: string[]): Promise<void> {
   // (`--no-transcript` is accepted too, to be explicit about the default).
   const transcript = values.transcript ? true : values["no-transcript"] ? false : false;
 
-  // Where the config lives: --config, else the positional <name-or-path>, else
-  // discover by --name (.cotal/agents/<name>.md). Same flags as `cotal start`.
-  const ref = values.config ?? positionals[0] ?? values.name;
-  if (!ref) {
-    console.error(
-      "usage: cotal spawn <name-or-path> | --config <path> | --name <n>  [--agent <a>] [--role <r>] [--space <s>] [--server <url>] [--prompt <text>] [--transcript] [--share-tools <names|none>]",
-    );
-    process.exit(1);
-  }
+  // Where the config lives: --config, else the positional <name-or-path>, else --name
+  // (.cotal/agents/<name>.md). With none of those, fall back to the seeded `default` persona:
+  // `cotal spawn` with no args launches `.cotal/agents/default.md` (same flags as `cotal start`).
+  const ref = values.config ?? positionals[0] ?? values.name ?? "default";
 
   const path = agentFilePath(cotalRoot(), ref);
   let def: AgentDef;
   try {
     def = loadAgentFile(path);
   } catch (e) {
-    console.error(`✗ ${(e as Error).message}`);
+    const noDefault = ref === "default" && (e as NodeJS.ErrnoException).code === "ENOENT";
+    console.error(
+      noDefault
+        ? "✗ no default persona yet — run `cotal setup` to seed one, or name a persona: `cotal spawn <name>`"
+        : `✗ ${(e as Error).message}`,
+    );
     process.exit(1);
   }
 

--- a/implementations/cli/src/index.ts
+++ b/implementations/cli/src/index.ts
@@ -116,7 +116,7 @@ const baseCommands: Command[] = [
     name: "spawn",
     group: "Agents",
     summary:
-      "launch an agent in this terminal from a file — spawn <name-or-path> | --name <n> --config <path> [--agent <a>] [--role <r>]",
+      "launch an agent in this terminal from a file — spawn [<name-or-path>] (defaults to the `default` persona) | --name <n> --config <path> [--agent <a>] [--role <r>]",
     run: spawn,
     complete: spawnComplete,
   },


### PR DESCRIPTION
## What

Adds a **default persona** so `cotal spawn` works with no arguments.

- **`cotal spawn` (no args) → the default persona.** Resolves to `.cotal/agents/default.md` (the same path as `cotal spawn default`). If no default is seeded yet, it prints a friendly hint (`run cotal setup to seed one, or name a persona`) instead of a raw `ENOENT`.
- **`cotal setup` / `cotal go` seed a generic `default.md`** on both the first-run and repeat-run paths. **Seed-if-absent**: the file is the user's to edit, so once written it's never overwritten — unlike the refreshed `david`/`sven`/`me` demo team.
- The seeded body is a generic "you are an agent on the mesh" starter (no enumerated `cotal_*` tools — the agent discovers those from the connector), keeping broad frontmatter (`role: default`, `>` ACLs, `spawn` capability).

## Scope

Intentionally limited to the foreground **`cotal spawn` CLI**. The mesh-side `cotal_spawn` tool and the manager's `cotal start` still require an explicit name (an agent/supervised spawn almost always wants a specific persona).

## Docs

`docs/OVERVIEW.md` (personas bullet), `docs/getting-started.md` (spawn list), and the `spawn` help line in `index.ts`.

## Verification

- Seeded `default.md` parses through `loadAgentFile` (wildcard ACLs + the subscribe ⊆ allowSubscribe invariant hold).
- No-args `cotal spawn` resolves to `default` and exits with the friendly hint when unseeded.
- Full `pnpm typecheck` green.
