### PR TITLE
fix(cmux): make closeWorkspace idempotent so teardown can't crash the manager

### DIFF
--- a/extensions/cmux/src/driver.ts
+++ b/extensions/cmux/src/driver.ts
@@ -61,9 +61,22 @@ export function openWorkspace(name: string, layout: string, opts: { focus?: bool
   return id;
 }
 
-/** Close a workspace (tab) by id/ref. */
+/** cmux exits non-zero with `not_found: Workspace not found` once the tab is already gone. */
+function isWorkspaceNotFound(err: unknown): boolean {
+  const e = err as { stderr?: unknown; message?: unknown };
+  return /not_found: Workspace not found/i.test(`${String(e?.stderr ?? "")}${String(e?.message ?? "")}`);
+}
+
+/** Close a workspace (tab) by id/ref. Idempotent: closing an already-gone tab is a no-op, not an
+ *  error — both runtime teardown and stale-ref cleanup mean "ensure it's closed". Only cmux's
+ *  workspace-not-found is swallowed; other CLI/socket failures still throw. */
 export function closeWorkspace(workspace: string): void {
-  cmux(["close-workspace", "--workspace", workspace]);
+  try {
+    cmux(["close-workspace", "--workspace", workspace]);
+  } catch (err) {
+    if (isWorkspaceNotFound(err)) return;
+    throw err;
+  }
 }
 
 /** All open workspace lines (name + ref), or `[]` if cmux can't be reached. */

--- a/extensions/cmux/src/runtime.ts
+++ b/extensions/cmux/src/runtime.ts
@@ -111,7 +111,16 @@ export class CmuxRuntime implements Runtime {
         } catch {
           /* keystroke delivery failed — still ensure the tab is gone below */
         }
-        setTimeout(() => cmux.closeWorkspace(workspace), GRACE_MS);
+        // Deferred, so a throw here is uncaught in a timer and would crash the manager.
+        // closeWorkspace already no-ops on an already-gone tab; guard anyway and log a genuine
+        // cmux failure rather than let teardown cleanup take the process down.
+        setTimeout(() => {
+          try {
+            cmux.closeWorkspace(workspace);
+          } catch (err) {
+            console.error(`cmux runtime: failed to close tab for "${name}":`, err);
+          }
+        }, GRACE_MS);
       },
       interrupt: () => {
         cmux.sendKey("ctrl+c", { workspace });


### PR DESCRIPTION
## Problem

`cotal cmux` crashed the entire manager process on teardown:

```
Error: Command failed: cmux close-workspace --workspace workspace:36
Error: not_found: Workspace not found
    at cmux (extensions/cmux/dist/driver.js:12:12)
    at Module.closeWorkspace (...)
    at Timeout._onTimeout (extensions/cmux/dist/runtime.js:90:39)
```

Graceful `stop()` defers `closeWorkspace` into a `setTimeout`. By the time the grace timer fires, the tab has self-closed (the agent `/exit`'d and cmux auto-removed it). `closeWorkspace` → `execFileSync` then throws on cmux's non-zero exit (`not_found: Workspace not found`). Thrown from a bare timer callback, that's an **uncaught exception** → the whole manager process dies.

The earlier `send`/`sendKey` not-found errors are the same condition but swallowed by the `try/catch` above the timer; only the deferred close was unguarded.

## Fix

- **`closeWorkspace` is now idempotent.** It swallows *only* cmux's exact `not_found: Workspace not found`; every other CLI/socket failure still throws. "Ensure this tab is closed" now holds for both runtime teardown and `TerminalLayout.close` on stale refs (used by `setup` cleanup). This also makes the synchronous `--graceful:false` path safe.
- **Belt-and-suspenders guard** on the deferred close in `stop()`: a throw from a timer callback is process-fatal, so a genuine teardown failure now logs instead of taking the manager down.

## Notes

- Reviewed on the mesh (review-general) before implementation.
- `dist/` is gitignored — only the two `src` files change.
- `pnpm typecheck` + `pnpm --filter @cotal-ai/cmux build` both green.