### PR TITLE
feat(connector-core): gate manager-op tools by spawn capability

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -696,7 +696,12 @@ later).
   - `ctl.manager.<id>` (**privileged**, default-denied to agents, granted only when the agent
     file declares `capabilities: [spawn]`): spawn, plus stop/despawn/attach of the caller's
     **own** children (`spawner == caller`) and redefining its own personas. So spawn is a
-    *declared capability*, off by default, enforced by nats-server, not a handler.
+    *declared capability*, off by default, enforced by nats-server, not a handler. The **tool
+    surface mirrors this**: the `cotal_spawn` / `cotal_persona` tools are injected only to agents
+    that hold `capabilities: [spawn]`, so the advertised toolset matches what each agent can
+    actually invoke instead of failing at call time (`cotal_despawn` stays — its no-name
+    self-despawn is on `ctl.self`, granted to all). The cred is still the boundary; in open mode
+    (no creds minted) the gate is permissive, since nothing is enforced there anyway.
   - `ctl.admin.<id>` (reached only by the manager's allow-all profile, **no agent ever gets
     it**): the destructive / cross-agent operator ops: `purge`, and stop/despawn/attach/
     `definePersona` of *any* agent. Admin is transport-proven (reaching the subject = holding

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -15,6 +15,11 @@ exposes the mesh tools: messaging, presence, and team supervision.
   spawnable.
 - **`cotal_feedback`** (optional) sends beta reports.
 
+In auth mode `cotal_spawn` and `cotal_persona` are injected **only** for personas declaring
+`capabilities: [spawn]` — the same grant that opens the privileged `ctl.manager` subject — so an
+agent's toolset matches what it can actually invoke (`cotal_despawn` stays; its no-name
+self-despawn is granted to all). Open mode mints no creds, so the surface is permissive there.
+
 Clearing retained history is operator-only (`cotal history clear`), not an agent tool. The
 manager spawns the session in a PTY. Nothing wraps Claude; it is an ordinary session that
 happens to be on the mesh.
@@ -73,7 +78,7 @@ tags: [edit, test]      # → card.tags ("what it can do")
 subscribe: [general, team.backend]  # → COTAL_SUBSCRIBE; channels it reads at boot (hierarchical)
 allowSubscribe: [general, team.>]   # read ACL: channels it MAY read (omit = same as subscribe)
 allowPublish: [general, team.backend]  # post ACL → pub-ACL; omit = none (default-deny)
-model: opus             # optional → claude --model
+model: opus             # optional → claude --model + card.meta.model (else auto-detected at SessionStart)
 ---
 You are a builder on a shared mesh of peer agents…   ← the body is the persona
 ```
@@ -402,13 +407,19 @@ boundary move it. "What it is doing" rides on channel updates, not presence.
 
 | Hook | → state |
 |---|---|
-| `SessionStart` | `idle` (join; also drains the inbox) |
+| `SessionStart` | `idle` (join; drains the inbox; also captures the session's live model into `meta.model` when the operator didn't pin one) |
 | `UserPromptSubmit` | `working` (turn starts; drains the inbox) |
 | `PreToolUse` | no state change; records *what* the turn is about to run, so a following permission `Notification` can name it |
 | `Notification` (`permission_prompt` / `elicitation_dialog`) | `waiting` (blocked on a human) |
 | `Stop` | `idle` (turn done) |
 | `StopFailure` | `idle` (turn died on an API error, so `Stop` will not fire) |
 | `SessionEnd` | `offline` (graceful leave) |
+
+`SessionStart` is also the one hook whose payload carries the session's `model` (a model id like
+`claude-opus-4-8`; absent after `/clear` or conversation recovery). When the operator pinned no model
+(`model:` / `COTAL_MODEL`), the connector mirrors it into the card's display-only `meta.model` so the
+roster shows the live model. A mid-session `/model` switch fires no hook, so the value holds until the
+next (re)start; an explicit pin always wins over the reported value.
 
 The `waiting` `activity` says *what* the session is blocked on. For a tool-permission prompt
 it leads with the pending `PreToolUse`, for example `Bash: git push --force origin main`, so a

--- a/extensions/connector-core/src/config.ts
+++ b/extensions/connector-core/src/config.ts
@@ -27,6 +27,12 @@ export interface AgentConfig {
   /** Display-only metadata from unmodelled agent-file frontmatter keys (for example `face`).
    *  Connector-owned keys such as `connector` and `model` are overlaid later and cannot be spoofed here. */
   meta?: Record<string, string>;
+  /** Control-plane capabilities this session declares (from the agent file's `capabilities:`); today
+   *  only `spawn`. Used to gate the manager-op tools (cotal_spawn / cotal_persona) so the advertised
+   *  surface matches what the agent can actually invoke. The cred layer is the real boundary (auth
+   *  mode); open mode mints no creds, so the gate is permissive there. Same file the manager minted
+   *  creds from, so the tool gate mirrors the wire grant exactly. */
+  capabilities?: string[];
   servers: string;
   /** The *active* read set — channels this agent actually subscribes to (read). May include
    *  wildcard subtrees (`team.>`). Maps to the endpoint's live filter. ⊆ {@link allowSubscribe}. */
@@ -132,6 +138,7 @@ export function configFromEnv(env: NodeJS.ProcessEnv = process.env): AgentConfig
     description: def?.description,
     tags: def?.tags,
     meta: def?.meta,
+    capabilities: def?.capabilities,
     model: env.COTAL_MODEL?.trim() || def?.model || undefined,
     servers: env.COTAL_SERVERS?.trim() || link?.servers || DEFAULT_SERVER,
     subscribe: resolvedSubscribe,

--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -128,7 +128,14 @@ export function channelMeta(i: InboxItem): Record<string, string> {
 /** The full Cotal tool set for a given config. Renderers iterate this; `source` names the
  *  hosting connector and is stamped onto outgoing feedback. */
 export function cotalToolSpecs(config: AgentConfig, source = "connector"): CotalToolSpec[] {
-  return [
+  // Manager-op tools (cotal_spawn / cotal_persona) ride the `spawn` capability — publish to the
+  // privileged control subject. The cred layer is the real boundary: in auth mode an agent without
+  // it is denied at the wire (nats-server); open mode mints no creds, so anyone may spawn. Mirror
+  // that here so the advertised surface is truthful — an agent only sees these when it can actually
+  // use them, instead of discovering the denial by trying. cotal_despawn stays (its no-name
+  // self-despawn is granted to all). controlFailure remains the backstop if a wire denial slips by.
+  const canSpawn = !config.creds || (config.capabilities?.includes("spawn") ?? false);
+  const specs: CotalToolSpec[] = [
     {
       name: "cotal_roster",
       title: "Cotal: who's present",
@@ -575,4 +582,5 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
       },
     },
   ];
+  return specs.filter((spec) => canSpawn || (spec.name !== "cotal_spawn" && spec.name !== "cotal_persona"));
 }


### PR DESCRIPTION
## What

Capability-gate the manager-op tools so an agent's advertised toolset matches what it can actually invoke.

`cotal_spawn` and `cotal_persona` were injected to **every** agent regardless of capability. In auth mode a non-spawn-capable agent saw those tools but was denied at the wire (the privileged `ctl.manager` subject is granted only with `capabilities: [spawn]`), so it only learned it couldn't spawn by **failing at call time**. The advertised surface didn't match the cred boundary.

## Change

- **`connector-core/src/config.ts`** — add `AgentConfig.capabilities`, populated from `def.capabilities` in `configFromEnv`. This rides the **existing** `COTAL_AGENT_FILE` def read (the same agent file the manager minted creds from), so there's **no new env var, `LaunchOpts`, connector, or manager change**.
- **`connector-core/src/tool-specs.ts`** — `cotalToolSpecs` hides `cotal_spawn` / `cotal_persona` unless `canSpawn = !config.creds || capabilities.includes("spawn")`.
  - **Open mode** (no creds minted) stays permissive — there's no transport-enforced grant to mirror.
  - **Auth mode** mirrors the `ctl.manager` grant exactly.
  - `cotal_despawn` stays visible (its no-name self-despawn is on `ctl.self`, granted to all); `controlFailure` remains the backstop for the wire boundary.
- **Docs** — `docs/architecture.md` (authz section) and `docs/claude-code-integration.md` document the gate.

This is an **advertised-surface alignment**, not a new authority boundary — the cred is still the boundary. Completes the deferred connector tool-gating sub-item of `control-plane-hardening` P5. **No wire/SPEC change.**

## Verification

- `pnpm typecheck` green across all packages.
- `hermes` tool-parity + `connector-core` feedback smoke tests pass.
- Gate verified across **auth / no-cap** (privileged tools hidden, 14 tools), **auth / spawn-cap** (16), and **open** (16, permissive).

## Review

Signed off by a mesh reviewer (`review-general`): confirmed the open-vs-auth signal, gating `cotal_persona` alongside `cotal_spawn`, and that all three connectors (Claude / OpenCode / Hermes) render from the same `cotalToolSpecs(config)` with no call-site hole (fails closed when an auth agent has no agent file).

## Out of scope

Active *push* discoverability — the manager broadcasting a machine-readable op catalog on its presence card, or a `describe` control op — is a separate, larger feature with no consumer surface yet, and is not pursued here.
