### PR TITLE
feat(connector-claude-code): auto-detect session model into presence

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -65,8 +65,9 @@ The skeleton is the same on every view: **left** is navigation (roster, channels
   name (a short identity id only when it's unknown), not the raw instance id.
 - **Agent Detail:** a per-agent drill-down (from the roster or a NEEDS YOU card) rendering the
   peer's AgentCard — name, role, kind, the **harness** it runs on (`meta.connector`, shown as a
-  brand logo pill: claude / opencode / hermes), the **model** when the operator pinned one
-  (`meta.model`), description, capability tags, current activity / what it's blocked on, and its
+  brand logo pill: claude / opencode / hermes), the **model** when known (`meta.model` — the
+  operator's pin, else auto-detected from Claude's SessionStart hook), description, capability
+  tags, current activity / what it's blocked on, and its
   full instance id. Fields absent from the card are simply omitted.
 - **Needs you:** agents currently blocked or waiting, newest first. **Persistent on the
   right** across every view, so the attention lane never disappears on drill-in.

--- a/extensions/connector-claude-code/src/mcp.ts
+++ b/extensions/connector-claude-code/src/mcp.ts
@@ -57,6 +57,11 @@ const claudeHandle: HookHandle = async (agent, ev) => {
     switch (event) {
       case "SessionStart": {
         mirror?.adopt(ev.transcript_path); // mirror from HERE — a resumed session never rebroadcasts
+        // Claude Code reports the session's actual model here (the ONLY hook that carries it; absent
+        // after /clear or conversation recovery, so guard on string). Surface it in presence when the
+        // operator didn't pin one. A mid-session /model switch fires no hook, so this holds until the
+        // next (re)start — acceptable for a display-only discovery field. setModel keeps the pin wins.
+        if (typeof ev.model === "string") await agent.setModel(ev.model);
         await agent.setStatus("idle");
         await agent.setAttention("open"); // F3: reset to fail-open on every (re)start — a crashed/restarted agent must not stay silently deaf
         // Boot push: a one-line note per subscribed channel (if the registry has loaded),

--- a/extensions/connector-core/src/agent.ts
+++ b/extensions/connector-core/src/agent.ts
@@ -523,6 +523,16 @@ export class MeshAgent extends EventEmitter {
     await this.ep.setStatus(status);
   }
 
+  /** Record the host's *actual* model — learned after launch (e.g. from Claude Code's `SessionStart`
+   *  hook payload) — into the card's display-only `meta.model`, so peers see it in `cotal_roster` and
+   *  the web roster even when the operator never pinned one. An explicit pin (`config.model`, from the
+   *  agent file's `model:` or `COTAL_MODEL`) is authoritative and wins; this only fills the gap. Best-
+   *  effort presence mirror (no `assertConnected` — safe pre-connect; it rides the first publish). */
+  async setModel(model: string): Promise<void> {
+    if (this.config.model) return; // operator pin is authoritative — never override it with the runtime value
+    await this.ep.setCardModel(model);
+  }
+
   // ---- channel registry ----------------------------------------------------
 
   /** The boot-time "push" half of channel onboarding: a fenced, one-line description per

--- a/implementations/cli/src/web/app.js
+++ b/implementations/cli/src/web/app.js
@@ -570,8 +570,8 @@ function renderAgentDetail() {
         .map((s) => `<div class="d-skill"><span class="nm">${esc(s.name || s.id)}</span>${s.description ? `<span class="dsc">${esc(s.description)}</span>` : ""}</div>`)
         .join("")}</div>`
     : "";
-  // Any other meta beyond the harness badge, generically rendered (escaped, key-sorted).
-  const extra = Object.entries(meta).filter(([k]) => k !== "connector").sort(([a], [b]) => a.localeCompare(b));
+  // Any other meta beyond the badges (connector → harness, model), generically rendered (escaped, key-sorted).
+  const extra = Object.entries(meta).filter(([k]) => k !== "connector" && k !== "model").sort(([a], [b]) => a.localeCompare(b));
   const metaKv = extra.length
     ? `<div class="d-kv">${extra
         .map(([k, v]) => `<div class="row"><span class="k">${esc(k)}</span><span class="v">${esc(typeof v === "string" ? v : JSON.stringify(v))}</span></div>`)

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -694,6 +694,18 @@ export class CotalEndpoint extends EventEmitter {
     await this.publishPresence();
   }
 
+  /** Overlay the host's live model onto the card's display-only `meta.model` and republish presence.
+   *  For connectors that learn the actual model only *after* launch (e.g. Claude Code's `SessionStart`
+   *  hook payload) rather than from an operator pin. Display-only discovery metadata; a no-op when the
+   *  value is empty or already current (no redundant publish). The mutated card is read live by every
+   *  later publish, so even a pre-connect call surfaces on the first presence write. */
+  async setCardModel(model: string): Promise<void> {
+    const m = model.trim();
+    if (!m || this.card.meta?.model === m) return;
+    this.card.meta = { ...(this.card.meta ?? {}), model: m };
+    await this.publishPresence();
+  }
+
   // ---- channel discovery ---------------------------------------------------
 
   /** This channel's registry config from the live local cache (undefined if unset). */


### PR DESCRIPTION
## What

The web roster (and `cotal_roster`) showed no model for un-pinned sessions. `card.meta.model` is only populated from an operator pin (the agent file's `model:` or `COTAL_MODEL`), and Claude Code doesn't expose its running model anywhere except the `SessionStart` hook payload. This captures it there and mirrors it into presence, so the roster shows the live model even when nothing was pinned — an explicit pin still wins.

## How

- **core** (`endpoint.ts`): `setCardModel()` overlays `meta.model` and republishes presence; no-op on empty/unchanged.
- **connector-core** (`agent.ts`): `MeshAgent.setModel()` — operator pin (`config.model`) is authoritative; no `assertConnected` (SessionStart races background connect, and a pre-connect call rides the first publish).
- **connector-claude-code** (`mcp.ts`): `SessionStart` reads `ev.model` (guarded — absent on `/clear`/recovery, so it never clears an existing value).
- **web** (`app.js`): exclude `model` from the generic Metadata list (it's already rendered as a badge).

The `docs/claude-code-integration.md` presence-mapping update is already on `main`; `docs/web.md` wording is updated here.

## Behaviour / limits

Display-only discovery metadata. Shows the model **id** (e.g. `claude-opus-4-8`), not a pretty name. A mid-session `/model` switch fires no hook, so the value holds until the next session (re)start; an explicit pin always wins over the reported value.

## Testing

- `pnpm typecheck` + `pnpm build` pass.
- **End-to-end**: launched the built connector (`dist/mcp.cjs`) against a throwaway open broker, pushed `SessionStart` JSON into its control socket (the real hook-relay path), and read `meta.model` back via an observer endpoint. Verified (A) unpinned -> auto-detect, (B) pinned -> pin wins, (C) absent model -> doesn't clear.
- Design reviewed on the mesh by review-general (sign-off).
