### PR TITLE
ci: gate the GitHub Release cut on an actual npm publish

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -59,22 +59,38 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
 
+      # Cut the GitHub Release ONLY when this push actually published a new version to npm.
       # ci:publish is `pnpm publish` (for OIDC provenance), whose output the changesets action
-      # can't parse — so `outputs.published` is unreliable and we can't gate on it. Instead, detect
-      # a fresh release by whether the just-published umbrella version (the `cotal-ai` package in
-      # bin/) already has a `vX.Y.Z` GitHub Release: if not, this push just published it, so cut the
-      # tag + Release with GitHub's auto-generated PR notes (honours .github/release.yml). The step
-      # is idempotent — it runs on every push but no-ops once the Release exists. Uses GH_PAT (not
-      # the default GITHUB_TOKEN) so the published Release still triggers the Discord webhook.
+      # can't parse — so `outputs.published` is unreliable and we can't gate on it. The naive
+      # `node -p "require('./bin/package.json').version"` is ALSO wrong: the `version` step above
+      # runs `changeset version`, which bumps the WORKSPACE package.json to the *staged next*
+      # version even on a version-PR push that publishes nothing — that read once cut a phantom
+      # `v0.6.0` Release with no npm artifact. So gate on two facts: (1) the version COMMITTED on
+      # the merge commit (immune to the workspace bump), and (2) that exact `cotal-ai` version being
+      # live on npm (a short retry covers post-publish registry propagation). The step stays
+      # idempotent — it no-ops once the Release exists. Uses GH_PAT (not the default GITHUB_TOKEN)
+      # so the published Release still triggers the Discord webhook.
       - name: Tag and cut the GitHub Release on publish
         if: success() && github.event_name == 'push'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
-          version=$(node -p "require('./bin/package.json').version")
+          # Read the COMMITTED version, not the workspace (which `changeset version` may have bumped).
+          version=$(git show "$GITHUB_SHA:bin/package.json" | jq -r .version)
           tag="v$version"
           if gh release view "$tag" >/dev/null 2>&1; then
             echo "Release $tag already exists — nothing to do."
+            exit 0
+          fi
+          # Only cut a Release for a version that actually published to npm — guards a staged-but-
+          # unpublished bump; retry briefly for registry propagation right after publish.
+          published=
+          for i in 1 2 3 4 5; do
+            if npm view "cotal-ai@$version" version >/dev/null 2>&1; then published=1; break; fi
+            echo "cotal-ai@$version not yet on npm (attempt $i/5) — waiting…"; sleep 5
+          done
+          if [ -z "$published" ]; then
+            echo "cotal-ai@$version is not on npm — this push published nothing; skipping the Release."
             exit 0
           fi
           notes=$(gh api "repos/$GITHUB_REPOSITORY/releases/generate-notes" \


### PR DESCRIPTION
## The bug
The `Tag and cut the GitHub Release` step in `changesets.yml` read the version from the **workspace** `bin/package.json`. But the prior `version` step runs `changeset version`, which bumps the workspace to the **staged next** version (0.6.0) on a version-PR push that **publishes nothing**. So it cut a phantom `v0.6.0` GitHub Release + tag (and fired the Discord `@everyone` ping) with no npm artifact behind it.

Run `27937611441` is the receipt: `pnpm ci:version` bumps → the step reads 0.6.0 → `Created GitHub Release v0.6.0`, while npm never received 0.6.0.

## The fix
Two guards so the Release is cut **only on a real publish**:
1. Read the version from the **committed merge commit** (`git show $GITHUB_SHA:bin/package.json`) — immune to the workspace bump.
2. Confirm that exact `cotal-ai` version is **live on npm** before cutting (5×5s retry for post-publish registry propagation).

On a version-staging push the committed version is still the already-released one (Release exists → no-op) **and** the next version isn't on npm — both guards agree: no phantom. On a real publish push (version PR merged, npm published) both pass and the Release is cut as before. Idempotent and YAML-validated.