### PR TITLE
feat(delivery): daemon on cotal up + auth-by-default, rebased onto main (0.6.0)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,6 +8,7 @@
       "@cotal-ai/core",
       "@cotal-ai/cli",
       "@cotal-ai/manager",
+      "@cotal-ai/delivery",
       "@cotal-ai/cmux",
       "@cotal-ai/connector-core",
       "@cotal-ai/connector-claude-code",

--- a/.changeset/server-side-delivery-daemon.md
+++ b/.changeset/server-side-delivery-daemon.md
@@ -1,0 +1,28 @@
+---
+"@cotal-ai/core": minor
+"@cotal-ai/delivery": minor
+"@cotal-ai/cli": minor
+"@cotal-ai/manager": minor
+"@cotal-ai/connector-core": minor
+"cotal-ai": minor
+---
+
+feat(delivery): server-side delivery daemon for the Plane-3 durable backstop, + auth-by-default
+
+Extracts the durable backstop (the offline catch-up tier) out of the manager into a standalone,
+least-privilege, server-side **delivery daemon** (`@cotal-ai/delivery`, the `deliver` command). The
+manager is now lifecycle-only (spawn/despawn/stop/attach/ps); the daemon owns all of Plane-3 — the
+fan-out writer + trusted reader, the durable-membership registry, the runtime durable join/leave/list
+ops (on a new `ctl.delivery` control service), activation catch-up, and a single-flight lease — and
+re-authorizes durable delivery against a durable read-ACL registry. Live channel reads are unchanged
+(native NATS, broker-enforced). No wire break (`protocolVersion` stays 0.2).
+
+- The daemon is part of the server: `cotal up` starts it by default and it is coupled to the broker
+  (it exits if the broker is gone; `cotal down` / `cotal up` shutdown stop it).
+- **The mesh is now JWT-authed by default** — `cotal setup`/`go`/`up` bring up an authed mesh with the
+  durable backstop; pass `--open` for the previous frictionless open, live-only mesh.
+- `cotal_channels` reports honest durable-delivery health (membership + lease aware).
+
+Hardened over multiple review rounds (sender-bound `ctl.delivery` replies, reconnect-safe responder +
+KV handles, ACL-independent leave so revocation closes the §7 boundary, signer-free daemon runtime,
+responder-after-bind readiness, pid-bound cutover marker), each with a guard smoke.

--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ session: **david** the engineer, **sven** the guide, and **me**, the one you dri
 then offers a Claude-driven demo with david and sven helping. If a step fails, it hands
 you to an interactive Claude with the failure context, then retries.
 
-The mesh is **open** by default (no auth, loopback-only); add `cotal setup --auth` for a
-JWT-authed mesh when you share it or go cross-machine.
+The mesh is **JWT-authed** by default (sender authenticity + per-agent ACLs, with the
+server-side delivery daemon for the durable backstop); pass `cotal setup --open` for a
+frictionless open, loopback-only, live-only mesh (no auth, no daemon).
 
 Or start it manually.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,10 +27,11 @@ Requirements:
 
 1. **Checks.** Verifies Node and locates NATS.
 2. **Starts the web for agents.** A local NATS + JetStream server you own, running in the
-   background (you watch it boot live). It is an **open** local mesh (no auth,
-   loopback-only), so everything works with no credentials. Pass `cotal setup --auth` for a
-   JWT-authed mesh (sender authenticity plus per-agent ACLs) when you share it or go
-   cross-machine.
+   background (you watch it boot live). By default it is a **JWT-authed** mesh (sender
+   authenticity + per-agent ACLs), and the **server-side delivery daemon** comes up with it to
+   provide the durable backstop. Pass `cotal setup --open` for a frictionless **open** local
+   mesh (no auth, loopback-only, live-only — no daemon) when you just want zero-setup local
+   poking.
 3. **Picks connectors.** Choose which agents join your web (Claude or OpenCode; detected
    ones are pre-selected). Claude installs a plugin, because its wake channel needs one.
    OpenCode needs no install; it auto-wires when you `cotal spawn` it.

--- a/docs/setup-internals.md
+++ b/docs/setup-internals.md
@@ -13,8 +13,10 @@ is two-tier, gated on a machine marker.
 **First run** (no `~/.cotal/onboarded.json`, or `--full`, or `--yes`) runs
 `runFirstRun(yes, open)`:
 
-- The mesh runs **open** (no auth) by default; `--auth` flips it to a JWT-authed mesh. Open
-  means no `.cotal/auth`, so every read/control CLI connects bare. This matches `cotal go`.
+- The mesh runs **JWT-authed** by default; `--open` flips it to an open (no-auth) mesh. Open
+  means no `.cotal/auth`, so every read/control CLI connects bare and there is no durable
+  backstop. Auth mode also brings up the **delivery daemon** with the broker (`cotal up` starts
+  it; `cotal down` stops it). This matches `cotal go`.
 - Then: splash → intro → core steps (Node, NATS, start the mesh) → start the **web dashboard**
   in the background → **connector picker** → write the two default experts (david/sven) →
   **offer a global install** (`offerGlobalInstall`) → marker → demo finale (`offerDemo`).

--- a/implementations/cli/src/commands/setup.ts
+++ b/implementations/cli/src/commands/setup.ts
@@ -48,12 +48,14 @@ export async function setup(argv: string[]): Promise<void> {
     options: {
       full: { type: "boolean" },
       yes: { type: "boolean", short: "y" },
-      auth: { type: "boolean" }, // opt into an authed mesh (JWT/ACLs); default is an open local mesh
+      auth: { type: "boolean" }, // (now the DEFAULT; kept for back-compat / explicitness)
+      open: { type: "boolean" }, // opt OUT of auth — a frictionless loopback-only open mesh (no JWT/ACLs, no durable backstop)
     },
   });
-  // `--yes` (agents/CI) always runs the full flow non-interactively. The local mesh is open by
-  // default (frictionless, loopback-only); `--auth` opts into JWT auth for shared/cross-machine use.
-  if (!isOnboarded() || values.full || values.yes) await runFirstRun(Boolean(values.yes), !values.auth);
+  // `--yes` (agents/CI) always runs the full flow non-interactively. The mesh is AUTHED by default
+  // (JWT/ACLs — the trust-first default, and what the server-side delivery daemon needs to run); `--open`
+  // opts out to a frictionless loopback-only open mesh with no auth (and so no durable backstop).
+  if (!isOnboarded() || values.full || values.yes) await runFirstRun(Boolean(values.yes), Boolean(values.open));
   else await runEnsure();
 }
 
@@ -64,8 +66,9 @@ export async function go(argv: string[]): Promise<void> {
   return setup(argv);
 }
 
-/** The full, narrated first-run experience. `yes` = non-interactive accept-all; `open` = run the
- *  mesh without auth (the frictionless local default; `--auth` flips it off). */
+/** The full, narrated first-run experience. `yes` = non-interactive accept-all; `open` = run the mesh
+ *  WITHOUT auth (the `--open` opt-out; auth is the default). Auth mode also brings up the server-side
+ *  delivery daemon (durable backstop); open mode is live-only. */
 async function runFirstRun(yes: boolean, open: boolean): Promise<void> {
   splash();
   p.intro(brandBold("Welcome to Cotal"));

--- a/implementations/cli/src/commands/up.ts
+++ b/implementations/cli/src/commands/up.ts
@@ -30,6 +30,7 @@ import { resolveSpace } from "../lib/status.js";
 import { c } from "../ui.js";
 import { resolveNatsServer } from "../lib/nats-bin.js";
 import { cotalPath, cotalRoot } from "../lib/paths.js";
+import { ensureDelivery, stopDelivery, stopOldHostingManagerIfPresent } from "../lib/delivery-proc.js";
 
 export async function up(argv: string[]): Promise<void> {
   const { values } = parseArgs({
@@ -87,15 +88,32 @@ export async function up(argv: string[]): Promise<void> {
     console.error(c.red(`Failed to start nats-server: ${err.message}`));
     process.exit(1);
   });
-  const stop = () => child.kill("SIGTERM");
+  // The delivery daemon is coupled to the broker: stop it when this `up` stops (Ctrl-C), so the daemon
+  // never outlives the broker it serves.
+  const stop = () => { stopDelivery(); child.kill("SIGTERM"); };
   process.on("SIGINT", stop);
   process.on("SIGTERM", stop);
-  child.on("exit", (code) => process.exit(code ?? 0));
+  child.on("exit", (code) => { stopDelivery(); process.exit(code ?? 0); });
 
   if (await waitReady(server, setup?.creds)) {
     await postStart(server, space, setup, seedFile);
+    // Bring up the delivery daemon WITH the server (auth mode only — it self-gates on `.cotal/auth`).
+    // It is part of the server, so `cotal up` starts it by default; open dev mode has no daemon.
+    await startDeliveryWithBroker(space, server);
   }
   await new Promise<void>(() => {});
+}
+
+/** Start the server-side delivery daemon alongside the broker (auth mode only): old-manager preflight
+ *  first (so an old hosting manager can't double-bind), then the auth-gated daemon (a no-op in open
+ *  mode). Coupled to the broker by the daemon's own broker-gone watchdog + the `up`/`down` teardown. */
+async function startDeliveryWithBroker(space: string, server: string): Promise<void> {
+  try {
+    stopOldHostingManagerIfPresent();
+    await ensureDelivery({ space, server });
+  } catch {
+    /* non-fatal — durable delivery degrades, live delivery is unaffected */
+  }
 }
 
 export interface DetachOpts {
@@ -147,6 +165,8 @@ export async function startMeshDetached(opts: DetachOpts = {}): Promise<{ server
   }
   writeFileSync(cotalPath("nats.pid"), String(child.pid));
   await postStart(server, space, setup, seedFile);
+  // Bring up the delivery daemon WITH the detached broker (auth mode only; `cotal down` tears both down).
+  await startDeliveryWithBroker(space, server);
   return { server, pid: child.pid ?? 0, source };
 }
 

--- a/implementations/delivery/smoke/delivery-broker-coupling.smoke.ts
+++ b/implementations/delivery/smoke/delivery-broker-coupling.smoke.ts
@@ -1,0 +1,73 @@
+/**
+ * delivery broker-coupling smoke. The delivery daemon is part of the server: it should survive a brief
+ * broker blip (the endpoint reconnects), but if the broker is truly GONE it must EXIT rather than loop
+ * reconnect-attempts forever — so it never outlives the broker it serves. This spawns the real daemon
+ * (`cotal deliver`) against a throwaway broker with a short broker-gone window, confirms it comes up,
+ * kills the broker, and asserts the daemon process exits on its own.
+ *
+ * Run: pnpm smoke:delivery-broker-coupling   (needs `nats-server` on PATH; auth/JetStream, local-only)
+ */
+import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { isReachable, createSpaceAuth, mintCreds, serverConfig, newIdentity, setupSpaceStreams } from "@cotal-ai/core";
+
+const PORT = 20000 + Math.floor(Math.random() * 40000);
+const SERVERS = `nats://127.0.0.1:${PORT}`;
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const repoRoot = join(import.meta.dirname, "..", "..", "..");
+let pass = 0, fail = 0;
+const check = (name: string, cond: boolean) => { if (cond) { pass++; console.log(`  ✓ ${name}`); } else { fail++; console.log(`  ✗ FAIL: ${name}`); } };
+
+const space = `delivery-couple-${randomUUID().slice(0, 8)}`;
+const auth = await createSpaceAuth(space);
+const dir = mkdtempSync(join(tmpdir(), "cotal-couple-"));
+writeFileSync(join(dir, "server.conf"), serverConfig(auth, { port: PORT, storeDir: join(dir, "js") }));
+let srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const credsPath = join(dir, "delivery.creds");
+
+let daemon: ReturnType<typeof spawn> | undefined;
+let daemonExited = false;
+try {
+  let up = false;
+  for (let i = 0; i < 50; i++) { if (await isReachable(SERVERS)) { up = true; break; } await wait(200); }
+  if (!up) throw new Error(`auth nats-server did not come up on ${PORT}`);
+  const mgrCreds = await mintCreds(auth, newIdentity(), "manager");
+  await setupSpaceStreams({ servers: SERVERS, space, creds: mgrCreds });
+  writeFileSync(credsPath, await mintCreds(auth, newIdentity(), "delivery"), { mode: 0o600 });
+
+  // Spawn the real daemon with a SHORT broker-gone window so the test is fast.
+  daemon = spawn("pnpm", ["cotal", "deliver", "--space", space, "--server", SERVERS, "--creds", credsPath], {
+    cwd: repoRoot,
+    stdio: "ignore",
+    env: { ...process.env, COTAL_DELIVERY_BROKER_GONE_MS: "2000" },
+  });
+  daemon.on("exit", () => { daemonExited = true; });
+
+  // Give the daemon time to connect + bind. If it couldn't reach the broker it would have exited
+  // (runDelivery process.exit), so "still alive after the startup window" means it came up and is serving.
+  await wait(5000);
+  check("the daemon comes up + stays running against a live broker", !daemonExited);
+
+  // Kill the broker. The daemon should give up reconnecting after the short window and EXIT.
+  srv.kill("SIGKILL");
+  let exitedInTime = false;
+  for (let i = 0; i < 40; i++) { // up to ~10s (window 2s + reconnect attempts + margin)
+    if (daemonExited) { exitedInTime = true; break; }
+    await wait(250);
+  }
+  check("the daemon EXITS on its own when the broker is gone (coupled to the broker)", exitedInTime);
+
+  console.log(`\nDELIVERY-BROKER-COUPLING SMOKE ${fail === 0 ? "OK ✅" : "FAILED ❌"}  (${pass} passed, ${fail} failed)`);
+  if (fail) process.exitCode = 1;
+} catch (e) {
+  fail++;
+  console.error("  ✗ scenario threw:", (e as Error).message);
+  process.exitCode = 1;
+} finally {
+  try { if (daemon && !daemonExited) daemon.kill("SIGKILL"); } catch { /* gone */ }
+  try { srv.kill("SIGKILL"); } catch { /* gone */ }
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/implementations/delivery/src/delivery.ts
+++ b/implementations/delivery/src/delivery.ts
@@ -128,11 +128,15 @@ export async function runDelivery(argv: string[]): Promise<void> {
     if (stopping) return;
     stopping = true;
     clearInterval(renew);
-    void ep
-      .releaseDeliveryLease(shard)
-      .catch(() => {})
-      .then(() => ep.stop())
-      .then(() => process.exit(code));
+    clearInterval(brokerWatch);
+    // Hard-exit fallback: a graceful release/stop talks to the broker, which may be DEAD (the broker-gone
+    // exit path) — don't let that hang the process. Force exit if the graceful path doesn't finish quickly.
+    setTimeout(() => process.exit(code), 2000);
+    void (async () => {
+      try { await ep.releaseDeliveryLease(shard); } catch { /* broker may be gone */ }
+      try { await ep.stop(); } catch { /* broker may be gone */ }
+      process.exit(code);
+    })();
   };
   // Renew the lease at ~half the TTL so a healthy holder never self-evicts; losing the CAS means
   // another daemon took over (we exit rather than double-deliver).
@@ -144,6 +148,25 @@ export async function runDelivery(argv: string[]): Promise<void> {
         shutdown(1);
       });
   }, Math.max(1000, Math.floor(LEASE_TTL_MS / 2)));
+
+  // Coupled to the broker: POLL its reachability. Survive brief blips (the endpoint reconnects on its
+  // own), but EXIT if the broker has been gone for BROKER_GONE_MS — the endpoint would otherwise retry
+  // reconnect forever (its terminal-close never fires), so this is what stops the daemon outliving the
+  // server it serves. (`cotal up`/`down` teardown stops it too.) The window is env-overridable for tests.
+  const BROKER_GONE_MS = Number(process.env.COTAL_DELIVERY_BROKER_GONE_MS) || 15_000;
+  let lastReachable = Date.now();
+  const brokerWatch = setInterval(() => {
+    if (stopping) return;
+    void isReachable(server, { creds })
+      .then((ok) => {
+        if (ok) { lastReachable = Date.now(); return; }
+        if (Date.now() - lastReachable > BROKER_GONE_MS) {
+          console.error(`✗ delivery: broker unreachable for >${BROKER_GONE_MS / 1000}s — exiting (coupled to the broker)`);
+          shutdown(1);
+        }
+      })
+      .catch(() => {});
+  }, 2000);
 
   process.on("SIGINT", () => shutdown(0));
   process.on("SIGTERM", () => shutdown(0));

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "smoke:delivery-lease:auth": "tsx packages/core/smoke/delivery-lease.smoke.ts",
     "smoke:delivery-boot-retry:auth": "tsx packages/core/smoke/delivery-boot-retry.smoke.ts",
     "smoke:delivery-old-manager": "tsx implementations/cli/smoke/delivery-old-manager-preflight.smoke.ts",
-    "smoke:delivery-reconnect:auth": "tsx packages/core/smoke/delivery-reconnect.smoke.ts"
+    "smoke:delivery-reconnect:auth": "tsx packages/core/smoke/delivery-reconnect.smoke.ts",
+    "smoke:delivery-broker-coupling": "tsx implementations/delivery/smoke/delivery-broker-coupling.smoke.ts"
   },
   "dependencies": {
     "@cotal-ai/cli": "workspace:*",


### PR DESCRIPTION
## Why

`@cotal-ai/delivery` is now published (`0.5.0`, first-published manually since OIDC can't create a brand-new package), and the trusted publisher is configured. This PR lands the remaining pieces to cut the **0.6.0** release.

It also fixes a stacked-PR base mix-up: **#86 merged into `feat/delivery-daemon` instead of `main`**, so its auth-default feature + the `0.6` changeset never reached `main`. Merging that branch wholesale would have **reverted main's #84 release-pipeline fix** (the phantom-`v0.6.0` guard in `changesets.yml`) and re-introduced an already-consumed `cli-declutter` changeset. So this is a clean **cherry-pick of just the #86 feature commit** onto current `main`, not a branch merge.

## What

1. **#86's feature, rebased onto main** (`3bf077e`, clean cherry-pick): the delivery daemon starts with `cotal up`, the mesh is **JWT-authed by default** (`--open` opts out), and the daemon is **coupled to the broker** (exits if the broker is gone past a window). Carries the `server-side-delivery-daemon.md` changeset (minor across the set).
2. **`@cotal-ai/delivery` added to the `fixed` lockstep group** — it was missing, so it wouldn't version in step with the rest. Now the whole `@cotal-ai` line releases at one version.

## Release effect

`changeset status` → all 10 published packages bump **minor: `0.5.0 → 0.6.0`** (delivery included). On merge, the Changesets action opens the "version packages" PR; merging that publishes `0.6.0` to npm via OIDC trusted publishing and cuts the GitHub Release.

## Testing

- `pnpm typecheck` (full build + per-package typecheck): green.
- `pnpm smoke:delivery-broker-coupling`: 2/2 (daemon comes up against a live broker; exits on its own when the broker is killed).
- `changeset status`: confirms the 0.6.0 minor bump across all 10 packages.
