### PR TITLE
feat: per-spawn harness+model selection (CLI + MCP) and harness preflight

### DIFF
--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -134,10 +134,11 @@ point at with `--config`.
 
 **Define one at runtime.** `cotal_persona(name, prompt, model?)` sends the persona to the
 manager, which writes the same `.cotal/agents/<name>.md` file (via `saveAgentFile`) and
-announces it on the mesh. A later `cotal_spawn(name)` auto-discovers it, so a peer can mint a
-teammate's persona on the fly and bring it online with no hand-written file. (Role is set at
-spawn, since `cotal_spawn` takes a role; it is not set here, because role is policy, not
-persona content.)
+announces it on the mesh. A later `cotal_spawn(name, role?, agent?, model?)` auto-discovers it, so
+a peer can mint a teammate's persona on the fly and bring it online with no hand-written file. The
+agent spawn door carries the same knobs as the operator's `cotal start` — `role`, `agent` (harness)
+and `model` (overrides the persona file's `model:`) — set at spawn because they are policy, not
+persona content.
 
 **Manage the catalog from the CLI.** `cotal personas` is the operator-side counterpart to the
 runtime `cotal_persona` tool. It reads and writes the same `.cotal/agents/*.md` files

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -124,7 +124,7 @@ run`). They differ only in how they *run* the spec:
 
 | Launcher | How to point at a file |
 |---|---|
-| Manager (supervised PTY) | `cotal start --name dave` (auto-discovers `.cotal/agents/dave.md` in the manager's workspace) or `--config <path>`. Detached; view via console / `cotal attach`. |
+| Manager (supervised PTY) | `cotal start --name dave` (auto-discovers `.cotal/agents/dave.md` in the manager's workspace) or `--config <path>`; `--model <m>` overrides the file's `model:` for this launch. Detached; view via console / `cotal attach`. |
 | Foreground (`cotal spawn`) | `cotal spawn <name-or-path>`. The real Claude TUI takes over this terminal (run it inside a cmux/tmux pane to multiplex). |
 
 `.cotal/` is gitignored (user-local, like `.claude/`). The demo ships committed example

--- a/extensions/connector-claude-code/src/extension.ts
+++ b/extensions/connector-claude-code/src/extension.ts
@@ -32,6 +32,7 @@ export const claudeConnector: Connector = {
   kind: "connector",
   name: "claude",
   pluginRoot: PLUGIN_ROOT,
+  requires: ["claude"],
   buildLaunch(opts: LaunchOpts): LaunchSpec {
     // Operator MCP servers shared with this agent (default none — see the --mcp-config block).
     const shared = opts.mcpServers ?? {};
@@ -102,13 +103,16 @@ export const claudeConnector: Connector = {
 
     // An agent file carries identity (read in-session via COTAL_AGENT_FILE) plus
     // persona + model, which can only be applied to a `claude` session at launch.
+    let model = opts.model;
     if (opts.configPath) {
       const path = resolve(opts.configPath);
       env.COTAL_AGENT_FILE = path;
       const def = loadAgentFile(path);
       if (def.persona) args.push("--append-system-prompt", def.persona);
-      if (def.model) args.push("--model", def.model);
+      model ??= def.model;
     }
+    // The `--model` flag wins over the agent file, and applies even with no agent file.
+    if (model) args.push("--model", model);
 
     return {
       command: "claude",

--- a/extensions/connector-core/smoke/spawn-args.smoke.ts
+++ b/extensions/connector-core/smoke/spawn-args.smoke.ts
@@ -1,0 +1,47 @@
+/**
+ * cotal_spawn parity smoke — proves the MCP spawn door carries the same harness/model knobs as the
+ * operator's `cotal start`. The `cotal_spawn` tool forwards to MeshAgent.spawn, which puts `agent`
+ * and `model` into the manager's `start` control op; the manager's opStart already consumes both.
+ * No NATS: the MeshAgent constructor builds an endpoint but never connects, so we swap in a
+ * recording `ep` and mark connected. Run with: pnpm smoke:spawn-args
+ */
+import { MeshAgent } from "../src/agent.js";
+import type { AgentConfig } from "../src/config.js";
+import { CONTROL_PRIVILEGED, type ControlReply, type ControlRequest, type ControlTier } from "@cotal-ai/core";
+
+let failures = 0;
+function check(label: string, cond: boolean, extra?: unknown): void {
+  console.log(`${cond ? "✓" : "✗"} ${label}${cond ? "" : ` — ${extra ?? ""}`}`);
+  if (!cond) failures++;
+}
+
+const cfg: AgentConfig = {
+  space: "smoke", name: "caller", servers: "nats://127.0.0.1:1",
+  subscribe: [], allowSubscribe: [], allowPublish: [],
+};
+const a = new MeshAgent(cfg);
+
+// Record the control request instead of sending it; mark connected so assertConnected() passes.
+let rec: { tier: ControlTier; req: ControlRequest } | undefined;
+(a as unknown as { ep: { requestControl: (t: ControlTier, r: ControlRequest) => Promise<ControlReply> } }).ep = {
+  requestControl: (tier, req) => { rec = { tier, req }; return Promise.resolve({ ok: true, data: { name: req.args?.name } }); },
+};
+(a as unknown as { _connected: boolean })._connected = true;
+
+// Full knobs: harness + model ride through to the manager's `start` op.
+await a.spawn("rev", "reviewer", { agent: "opencode", model: "sonnet" });
+check("op is start", rec?.req.op === "start", rec?.req.op);
+check("rides the privileged control subject", rec?.tier === CONTROL_PRIVILEGED);
+check("name forwarded", rec?.req.args?.name === "rev");
+check("role forwarded", rec?.req.args?.role === "reviewer");
+check("agent (harness) forwarded", rec?.req.args?.agent === "opencode", rec?.req.args?.agent);
+check("model forwarded", rec?.req.args?.model === "sonnet", rec?.req.args?.model);
+
+// Name-only: agent/model absent → undefined, so the manager applies its defaults (Claude, file model).
+await a.spawn("plain");
+check("name-only: agent undefined", rec?.req.args?.agent === undefined);
+check("name-only: model undefined", rec?.req.args?.model === undefined);
+check("name-only: role undefined", rec?.req.args?.role === undefined);
+
+console.log(`\nSPAWN-ARGS SMOKE ${failures === 0 ? "OK ✅" : "FAILED ❌"}`);
+process.exit(failures === 0 ? 0 : 1);

--- a/extensions/connector-core/src/agent.ts
+++ b/extensions/connector-core/src/agent.ts
@@ -488,10 +488,16 @@ export class MeshAgent extends EventEmitter {
 
   /** Ask the manager to spawn a new teammate into this space (its `start` op).
    *  How it lands — a detached PTY, a tmux window, a cmux tab — is the manager's
-   *  runtime; from here it just joins the mesh as a lateral peer. */
-  async spawn(name: string, role?: string): Promise<ControlReply> {
+   *  runtime; from here it just joins the mesh as a lateral peer. `opts.agent` picks
+   *  the harness (default the manager's `cotal`/Claude) and `opts.model` overrides the
+   *  persona file's `model:` — the same knobs the operator's `cotal start` carries, so
+   *  the agent and operator spawn doors share one control-op contract. */
+  async spawn(name: string, role?: string, opts?: { agent?: string; model?: string }): Promise<ControlReply> {
     this.assertConnected();
-    return this.ep.requestControl(CONTROL_PRIVILEGED, { op: "start", args: { name, role } });
+    return this.ep.requestControl(CONTROL_PRIVILEGED, {
+      op: "start",
+      args: { name, role, agent: opts?.agent, model: opts?.model },
+    });
   }
 
   /** Ask the manager to tear a teammate down (its `stop` op). Graceful by default —

--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -455,10 +455,18 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
           .string()
           .optional()
           .describe("Optional role for the new peer (e.g. worker, reviewer)."),
+        agent: z
+          .string()
+          .optional()
+          .describe("Optional harness/agent type (e.g. claude, opencode, hermes). Defaults to the manager's default (Claude)."),
+        model: z
+          .string()
+          .optional()
+          .describe("Optional model override (e.g. opus, sonnet) — wins over the persona file's model:."),
       },
-      async run(agent, _config, { name, role }: { name: string; role?: string }) {
+      async run(agent, _config, { name, role, agent: agentType, model }: { name: string; role?: string; agent?: string; model?: string }) {
         try {
-          const reply = await agent.spawn(name, role);
+          const reply = await agent.spawn(name, role, { agent: agentType, model });
           if (!reply.ok) return err(`Couldn't spawn ${name}: ${reply.error ?? "manager refused"}`);
           const d = reply.data as { name?: string; mode?: string } | undefined;
           const actual = d?.name ?? name; // the manager auto-numbers on a collision — report what it spawned

--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -458,7 +458,7 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
         agent: z
           .string()
           .optional()
-          .describe("Optional harness/agent type (e.g. claude, opencode, hermes). Defaults to the manager's default (Claude)."),
+          .describe("Optional harness the new peer runs on — the agent/connector type (claude, opencode, hermes), NOT the peer's display name (that's `name`). Defaults to the manager's default (Claude)."),
         model: z
           .string()
           .optional()

--- a/extensions/connector-hermes/src/extension.ts
+++ b/extensions/connector-hermes/src/extension.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath } from "node:url";
-import { registry, type Connector, type LaunchOpts, type LaunchSpec } from "@cotal-ai/core";
+import { loadAgentFile, registry, type Connector, type LaunchOpts, type LaunchSpec } from "@cotal-ai/core";
 import { launchEnv, MODEL_PROVIDER_KEYS } from "@cotal-ai/connector-core";
 
 /** The launcher (run via tsx, which loads both) owns the mesh endpoint and supervises the Hermes
@@ -40,8 +40,11 @@ export const hermesConnector: Connector = {
     // An agent file carries identity + persona + model; the launcher applies the persona as
     // Hermes' SOUL.md (system prompt) at gateway startup, the one place it can be set.
     if (opts.configPath) env.COTAL_AGENT_FILE = opts.configPath;
-    // The `--model` flag wins over an ambient HERMES_MODEL; the launcher applies it as the gateway model.
-    const model = opts.model ?? process.env.HERMES_MODEL;
+    // Model precedence, at parity with the Claude/OpenCode connectors: the `--model` flag, else the
+    // agent file's `model:`, else an ambient HERMES_MODEL. The launcher reads HERMES_MODEL as the
+    // gateway model — resolving here is the one place that honors the file's model for Hermes.
+    const fileModel = opts.configPath ? loadAgentFile(opts.configPath).model : undefined;
+    const model = opts.model ?? fileModel ?? process.env.HERMES_MODEL;
     if (model) env.HERMES_MODEL = model;
     return { command: TSX, args: [LAUNCH_ENTRY], env };
   },

--- a/extensions/connector-hermes/src/extension.ts
+++ b/extensions/connector-hermes/src/extension.ts
@@ -23,6 +23,7 @@ const LAUNCH_ENTRY = fileURLToPath(new URL(`./launch.${ENTRY_EXT}`, import.meta.
 export const hermesConnector: Connector = {
   kind: "connector",
   name: "hermes",
+  requires: ["hermes"],
   buildLaunch(opts: LaunchOpts): LaunchSpec {
     // OS allow-list + the named model-provider key (Hermes is model-agnostic; any one unlocks a
     // provider), forwarded BY NAME — never `...process.env` — so the operator's unrelated secrets
@@ -39,7 +40,9 @@ export const hermesConnector: Connector = {
     // An agent file carries identity + persona + model; the launcher applies the persona as
     // Hermes' SOUL.md (system prompt) at gateway startup, the one place it can be set.
     if (opts.configPath) env.COTAL_AGENT_FILE = opts.configPath;
-    if (process.env.HERMES_MODEL) env.HERMES_MODEL = process.env.HERMES_MODEL!;
+    // The `--model` flag wins over an ambient HERMES_MODEL; the launcher applies it as the gateway model.
+    const model = opts.model ?? process.env.HERMES_MODEL;
+    if (model) env.HERMES_MODEL = model;
     return { command: TSX, args: [LAUNCH_ENTRY], env };
   },
 };

--- a/extensions/connector-opencode/src/extension.ts
+++ b/extensions/connector-opencode/src/extension.ts
@@ -30,6 +30,7 @@ const SERVE_SHIM = fileURLToPath(new URL("./serve.js", import.meta.url));
 export const opencodeConnector: Connector = {
   kind: "connector",
   name: "opencode",
+  requires: ["opencode"],
   buildLaunch(opts: LaunchOpts): LaunchSpec {
     // Tool-sharing isn't wired for opencode: its OPENCODE_CONFIG_CONTENT is a merge layer, so an
     // opencode agent already INHERITS the operator's MCP servers (the opposite default to Claude's
@@ -79,14 +80,17 @@ export const opencodeConnector: Connector = {
     // An agent file carries identity (read in-session via COTAL_AGENT_FILE) plus persona + model.
     // The model is a config default (the session — and the attached TUI — use it); the persona is
     // applied in-session by the plugin (opencode has no `--append-system-prompt`).
+    let model = opts.model;
     if (opts.configPath) {
       const path = resolve(opts.configPath);
       env.COTAL_AGENT_FILE = path; // plugin reads persona from it
       const def = loadAgentFile(path);
-      if (def.model) config.model = def.model;
+      model ??= def.model;
       const face = def.meta?.face;
       if (face) env.COTAL_FACE_PERSONA = face; // shim swaps the TUI for the face viewer
     }
+    // The `--model` flag wins over the agent file, and applies even with no agent file.
+    if (model) config.model = model;
 
     env.OPENCODE_CONFIG_CONTENT = JSON.stringify(config);
 

--- a/implementations/manager/smoke/start-model-preflight.smoke.ts
+++ b/implementations/manager/smoke/start-model-preflight.smoke.ts
@@ -1,0 +1,125 @@
+/**
+ * Start model-override + harness-preflight smoke — proves the two manager fixes end to end without
+ * a broker or a real harness launch. No NATS, no test runner — run with: pnpm smoke:start-model
+ *
+ * The Manager constructor opens no network (that happens in start()), so we drive the real
+ * `startAgent` spawn path directly, injecting a fake runtime + a minimal `ep` stub so the
+ * success branch never launches a child or needs a live mesh. Covers:
+ *   1. Preflight REJECT — a connector whose `requires` binary is off PATH fails before any
+ *      credential/side effect, with a stable, PATH-content-independent error.
+ *   2. Model THREADING — `--model` rides StartAgentOpts → buildLaunch's LaunchOpts verbatim.
+ *   3. Model PRECEDENCE — across the three real connectors: flag > agent-file `model:`, the flag
+ *      applies with no agent file, and the file is the fallback (the actual bug the fix closes).
+ */
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, delimiter } from "node:path";
+import { Manager } from "../src/manager.js";
+import { registry, type Connector, type LaunchOpts, type LaunchSpec, type AgentHandle } from "@cotal-ai/core";
+// Import the real connectors so they self-register (and expose their objects for the buildLaunch matrix).
+import { claudeConnector } from "@cotal-ai/connector-claude-code";
+import { opencodeConnector } from "@cotal-ai/connector-opencode";
+import { hermesConnector } from "@cotal-ai/connector-hermes";
+
+let failures = 0;
+function check(label: string, cond: boolean, extra?: unknown): void {
+  console.log(`${cond ? "✓" : "✗"} ${label}${cond ? "" : ` — ${extra ?? ""}`}`);
+  if (!cond) failures++;
+}
+
+// A workspace with no `.cotal/` so no agent file / cotal config is discovered for a bare name.
+const workspaceRoot = mkdtempSync(join(tmpdir(), "cotal-start-ws-"));
+const mgr = new Manager({ space: "smoke", servers: undefined, runtime: "pty", workspaceRoot });
+
+// Inert handle/runtime: the success branch records the built spec but launches nothing; the `ep`
+// stub only needs ref().id for the managed record. watchExit() calls attach().onExit — a no-op here.
+const fakeSession = {
+  cols: 80, rows: 24, backlog: () => Buffer.alloc(0),
+  onData: () => () => {}, onExit: () => () => {}, write: () => {}, resize: () => {},
+};
+const fakeHandle = (name: string): AgentHandle => ({
+  name, kind: "fake", status: () => "running", stop: () => {}, interrupt: () => {}, attach: () => fakeSession,
+});
+let lastSpec: LaunchSpec | undefined;
+(mgr as unknown as { runtime: { kind: string; spawn: (n: string, s: LaunchSpec) => AgentHandle } }).runtime = {
+  kind: "fake",
+  spawn: (name, spec) => { lastSpec = spec; return fakeHandle(name); },
+};
+(mgr as unknown as { ep: { ref: () => { id: string } } }).ep = { ref: () => ({ id: "smoke-mgr" }) };
+const agentCount = () => (mgr as unknown as { agents: Map<string, unknown> }).agents.size;
+
+// A recording connector that requires `node` (present whenever this smoke runs) — captures the
+// LaunchOpts the manager hands it, so we can assert the model threads through verbatim.
+let lastOpts: LaunchOpts | undefined;
+const recCon: Connector = {
+  kind: "connector",
+  name: "smoke-rec",
+  requires: ["node"],
+  buildLaunch: (o) => { lastOpts = o; return { command: "true", args: [], env: {} }; },
+};
+registry.register(recCon);
+
+// 1 — Preflight REJECT: hide PATH so `claude` can't be found; the real claude connector requires it.
+{
+  const savedPath = process.env.PATH;
+  process.env.PATH = mkdtempSync(join(tmpdir(), "cotal-empty-path-")); // a dir with no executables
+  const reply = await mgr.startAgent({ name: "reject1", agent: "claude" });
+  process.env.PATH = savedPath;
+  check("missing harness binary is rejected", reply.ok === false, reply);
+  check(
+    "reject error names the missing binary, no PATH contents",
+    reply.error === "claude harness needs claude on PATH — not found",
+    reply.error,
+  );
+  check("reject happens before any side effect (no agent recorded)", agentCount() === 0);
+}
+
+// 2 — Model THREADING through the manager into LaunchOpts (PATH restored → `node` present again).
+{
+  lastOpts = undefined;
+  const reply = await mgr.startAgent({ name: "rec1", agent: "smoke-rec", model: "sonnet" });
+  check("present-binary connector passes preflight + spawns", reply.ok === true, reply);
+  check("--model threads into LaunchOpts.model verbatim", lastOpts?.model === "sonnet", lastOpts?.model);
+  check("built spec was captured (success path ran)", lastSpec?.command === "true");
+
+  lastOpts = undefined;
+  await mgr.startAgent({ name: "rec2", agent: "smoke-rec" });
+  check("no --model → LaunchOpts.model undefined", lastOpts?.model === undefined, lastOpts?.model);
+}
+
+// 3 — Model PRECEDENCE across the three real connectors (direct buildLaunch; no PATH/broker need).
+{
+  const dir = mkdtempSync(join(tmpdir(), "cotal-start-af-"));
+  const af = join(dir, "tester.md");
+  writeFileSync(af, "---\nname: tester\nmodel: opus\n---\nbody persona\n");
+  const base = { space: "smoke", name: "tester" };
+  const claudeModel = (s: LaunchSpec) => { const i = s.args.indexOf("--model"); return i >= 0 ? s.args[i + 1] : undefined; };
+  const ocModel = (s: LaunchSpec) => JSON.parse(s.env!.OPENCODE_CONFIG_CONTENT).model as string | undefined;
+  const hermesModel = (s: LaunchSpec) => s.env!.HERMES_MODEL;
+
+  check("claude.requires == [claude]", JSON.stringify(claudeConnector.requires) === '["claude"]');
+  check("opencode.requires == [opencode]", JSON.stringify(opencodeConnector.requires) === '["opencode"]');
+  check("hermes.requires == [hermes]", JSON.stringify(hermesConnector.requires) === '["hermes"]');
+
+  // flag wins over the agent file's `model:`
+  check("claude: flag beats frontmatter", claudeModel(claudeConnector.buildLaunch({ ...base, configPath: af, model: "sonnet" })) === "sonnet");
+  check("opencode: flag beats frontmatter", ocModel(opencodeConnector.buildLaunch({ ...base, configPath: af, model: "sonnet" })) === "sonnet");
+  check("hermes: flag beats frontmatter", hermesModel(hermesConnector.buildLaunch({ ...base, configPath: af, model: "sonnet" })) === "sonnet");
+
+  // flag applies with NO agent file (the gap the fix closes)
+  check("claude: flag with no agent file", claudeModel(claudeConnector.buildLaunch({ ...base, model: "sonnet" })) === "sonnet");
+  check("opencode: flag with no agent file", ocModel(opencodeConnector.buildLaunch({ ...base, model: "sonnet" })) === "sonnet");
+  check("hermes: flag with no agent file", hermesModel(hermesConnector.buildLaunch({ ...base, model: "sonnet" })) === "sonnet");
+
+  // no flag → agent-file model is the fallback
+  check("claude: no flag → frontmatter opus", claudeModel(claudeConnector.buildLaunch({ ...base, configPath: af })) === "opus");
+  check("opencode: no flag → frontmatter opus", ocModel(opencodeConnector.buildLaunch({ ...base, configPath: af })) === "opus");
+
+  // nothing set → no model applied
+  check("claude: nothing → no --model", claudeModel(claudeConnector.buildLaunch({ ...base })) === undefined);
+  check("opencode: nothing → no config.model", ocModel(opencodeConnector.buildLaunch({ ...base })) === undefined);
+  check("hermes: nothing → no HERMES_MODEL", hermesModel(hermesConnector.buildLaunch({ ...base })) === undefined);
+}
+
+console.log(`\nSTART-MODEL/PREFLIGHT SMOKE ${failures === 0 ? "OK ✅" : "FAILED ❌"}`);
+process.exit(failures === 0 ? 0 : 1);

--- a/implementations/manager/smoke/start-model-preflight.smoke.ts
+++ b/implementations/manager/smoke/start-model-preflight.smoke.ts
@@ -111,9 +111,10 @@ registry.register(recCon);
   check("opencode: flag with no agent file", ocModel(opencodeConnector.buildLaunch({ ...base, model: "sonnet" })) === "sonnet");
   check("hermes: flag with no agent file", hermesModel(hermesConnector.buildLaunch({ ...base, model: "sonnet" })) === "sonnet");
 
-  // no flag → agent-file model is the fallback
+  // no flag → agent-file model is the fallback (incl. Hermes, whose launcher previously ignored it)
   check("claude: no flag → frontmatter opus", claudeModel(claudeConnector.buildLaunch({ ...base, configPath: af })) === "opus");
   check("opencode: no flag → frontmatter opus", ocModel(opencodeConnector.buildLaunch({ ...base, configPath: af })) === "opus");
+  check("hermes: no flag → frontmatter opus", hermesModel(hermesConnector.buildLaunch({ ...base, configPath: af })) === "opus");
 
   // nothing set → no model applied
   check("claude: nothing → no --model", claudeModel(claudeConnector.buildLaunch({ ...base })) === undefined);

--- a/implementations/manager/src/commands.ts
+++ b/implementations/manager/src/commands.ts
@@ -43,6 +43,7 @@ function parse(argv: string[]): Values {
       role: { type: "string" },
       agent: { type: "string" },
       config: { type: "string" },
+      model: { type: "string" }, // start: model override, wins over the agent file's `model:`
       roster: { type: "string" },
       creds: { type: "string" },
       runtime: { type: "string" }, // supervise: force pty | tmux | cmux (default auto-detects)
@@ -136,6 +137,7 @@ async function start(argv: string[]): Promise<void> {
     role: v.role,
     agent: v.agent,
     config: v.config,
+    model: v.model,
     // Opt-in: only sent when `--transcript` is given; absent => the daemon's default (mirror off).
     transcript: v.transcript ? true : undefined,
   }, v.creds);
@@ -304,7 +306,7 @@ const managerCommands: Command[] = [
     name: "start",
     group: "Control plane",
     summary:
-      "ask the manager to spawn an agent — --name <n> [--role <r>] [--agent <a>] [--config <file>] (auto-discovers .cotal/agents/<n>.md)",
+      "ask the manager to spawn an agent — --name <n> [--role <r>] [--agent <a>] [--config <file>] [--model <m>] (auto-discovers .cotal/agents/<n>.md)",
     run: start,
   },
   {

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -1,5 +1,5 @@
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { accessSync, constants, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join, dirname, delimiter } from "node:path";
 import {
   CotalEndpoint,
   DEFAULT_SERVER,
@@ -39,6 +39,31 @@ const MAX_AGENTS = 50;
  *  expires — so churn (spawn↔despawn or spawn↔fast-exit) can't outrun the concurrency bound. */
 const MIN_LIFETIME = 10_000;
 
+/** Is `bin` an executable on PATH? A side-effect-free preflight for a connector's `requires` —
+ *  scans PATH directly with `accessSync(X_OK)` rather than shelling out to `which`, so it can't
+ *  hang or run the harness. An absolute/relative path is checked as-is; a bare name is looked up
+ *  across PATH entries (empty entries skipped). POSIX-only (macOS/Linux); no PATHEXT handling. */
+function binOnPath(bin: string): boolean {
+  if (bin.includes("/")) {
+    try {
+      accessSync(bin, constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  for (const dir of (process.env.PATH ?? "").split(delimiter)) {
+    if (!dir) continue;
+    try {
+      accessSync(join(dir, bin), constants.X_OK);
+      return true;
+    } catch {
+      // not here — keep scanning
+    }
+  }
+  return false;
+}
+
 export interface ManagerOptions {
   space: string;
   servers?: string;
@@ -59,6 +84,8 @@ export interface StartAgentOpts {
   role?: string;
   /** Explicit agent-file name-or-path; otherwise `.cotal/agents/<name>.md` is discovered if present. */
   config?: string;
+  /** Model override (the `--model` flag). Takes precedence over the agent file's `model:`. */
+  model?: string;
   /** Mirror the session's transcript to `tr-<name>`. Defaults to off; `true` (the
    *  `--transcript` flag) opts in. */
   transcript?: boolean;
@@ -335,6 +362,7 @@ export class Manager {
         agent: args.agent ? String(args.agent) : undefined,
         role: args.role ? String(args.role) : undefined,
         config: args.config ? String(args.config) : undefined,
+        model: args.model ? String(args.model) : undefined,
         transcript: typeof args.transcript === "boolean" ? args.transcript : undefined,
       },
       caller,
@@ -390,6 +418,12 @@ export class Manager {
       let handle: AgentHandle;
       try {
         const connector = registry.resolve<Connector>("connector", agent);
+        // Preflight the harness binaries this connector invokes (its `requires`) BEFORE minting
+        // creds or building the launch — a missing `claude`/`opencode` should fail here with a
+        // clear name, not obscurely at process spawn. No fallback: throw if it isn't on PATH.
+        const missing = (connector.requires ?? []).filter((bin) => !binOnPath(bin));
+        if (missing.length)
+          throw new Error(`${agent} harness needs ${missing.join(", ")} on PATH — not found`);
         const def = configPath ? loadAgentFile(configPath) : undefined;
         if (!role) role = def?.role;
         allowSubscribe = def?.allowSubscribe ?? def?.subscribe ?? ["general"];
@@ -423,6 +457,7 @@ export class Manager {
           creds: credsPath,
           servers: this.servers,
           configPath,
+          model: opts.model,
           transcript: opts.transcript,
           mcpServers,
         });

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "smoke:attach": "tsx implementations/manager/smoke/attach.smoke.ts",
     "smoke:env-isolate": "tsx implementations/manager/smoke/env-isolate.smoke.ts",
     "smoke:start-model": "tsx implementations/manager/smoke/start-model-preflight.smoke.ts",
+    "smoke:spawn-args": "tsx extensions/connector-core/smoke/spawn-args.smoke.ts",
     "smoke:install": "tsx implementations/cli/smoke/install.smoke.ts",
     "smoke:send": "tsx implementations/cli/smoke/send.smoke.ts",
     "smoke:delivery-cred:auth": "tsx packages/core/smoke/delivery-cred-confinement.smoke.ts",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "smoke:opencode": "tsx extensions/connector-opencode/smoke/turn-wedge.smoke.ts",
     "smoke:attach": "tsx implementations/manager/smoke/attach.smoke.ts",
     "smoke:env-isolate": "tsx implementations/manager/smoke/env-isolate.smoke.ts",
+    "smoke:start-model": "tsx implementations/manager/smoke/start-model-preflight.smoke.ts",
     "smoke:install": "tsx implementations/cli/smoke/install.smoke.ts",
     "smoke:send": "tsx implementations/cli/smoke/send.smoke.ts",
     "smoke:delivery-cred:auth": "tsx packages/core/smoke/delivery-cred-confinement.smoke.ts",

--- a/packages/core/src/connector.ts
+++ b/packages/core/src/connector.ts
@@ -18,6 +18,10 @@ export interface LaunchOpts {
    *  passes it through (`COTAL_AGENT_FILE`) so the joined session reads its own
    *  card from it, and applies the file's persona/model at launch. */
   configPath?: string;
+  /** Explicit model override — the `cotal start --model <m>` flag. Takes precedence over the
+   *  agent file's `model:` and is applied even when no agent file is present. Each connector
+   *  renders it in its host form (Claude `--model`, OpenCode `config.model`, Hermes `HERMES_MODEL`). */
+  model?: string;
   /** An initial message for the session to act on the moment it starts. Connectors
    *  that support an auto-submitted first prompt (Claude Code) deliver it; others
    *  ignore it. Used to make a driving session greet the operator on launch. */
@@ -57,6 +61,12 @@ export interface Connector extends Extension {
   readonly kind: "connector";
   readonly name: string;
   buildLaunch(opts: LaunchOpts): LaunchSpec;
+  /** External executables this connector invokes beyond `LaunchSpec.command` (e.g. the
+   *  `claude` / `opencode` CLI). A preflight PATH hint, not a full environment validator: the
+   *  manager checks each is on PATH before spawning and fails with a clear error naming the
+   *  missing one, instead of an obscure process-spawn failure. Optional — omit for connectors
+   *  whose harness runs in-process. */
+  readonly requires?: readonly string[];
   /** Directory of installable editor-plugin assets shipped with the connector
    *  (e.g. a Claude Code plugin dir), when the agent type needs a one-time
    *  plugin install. Consumers (like `cotal setup`) resolve it via the registry


### PR DESCRIPTION
## What

Lets the manager spawn a **specific harness at a specific model**, ad-hoc, from either spawn door — and fails fast when a harness isn't installed. Four related changes:

### 1. `cotal start --model <m>` — launch-time model override
- `LaunchOpts.model`, threaded CLI `--model` → control `start` op → `StartAgentOpts.model` → `connector.buildLaunch`.
- Each connector resolves `opts.model ?? def.model` (flag wins, agent file is the fallback), applied **even with no agent file**: Claude `--model`, OpenCode `config.model`, Hermes `HERMES_MODEL`.

### 2. Harness preflight
- New optional `Connector.requires` — the external CLI(s) a harness invokes (`["claude"]`/`["opencode"]`/`["hermes"]`). A PATH preflight hint, not an env validator.
- Manager checks each is on PATH right after resolving the connector, **before minting credentials**, failing with a stable error: `<agent> harness needs <bin> on PATH — not found`. Side-effect-free `accessSync(X_OK)` scan, no `which`.
- Declarative because OpenCode's `spec.command` is `node` (serve shim) — the real `opencode` dep runs inside it.

### 3. Spawn-door parity (CLI ↔ MCP)
- The MCP `cotal_spawn` tool agents use took only `name`+`role`, while `cotal start` carried `--agent`/`--model` — the operator door was strictly more capable for the same `start` op.
- `MeshAgent.spawn(name, role, {agent, model})` now forwards both into the op args; `cotal_spawn` exposes `agent`/`model` in its schema. No manager change — `opStart` already parses them, so CLI, MCP, and roster boot share one parser. Unknown-agent validation stays solely in the manager (`registry.resolve`).

### 4. Hermes honors the agent file's `model:`
- Previously the Hermes launcher read the model only from `HERMES_MODEL` and ignored the file's `model:`. The connector now resolves `flag > file > ambient`, at parity with Claude/OpenCode.

## Tests
Two broker-free integration smokes (no real harness launch):
- `pnpm smoke:start-model` — drives the real `Manager.startAgent`: preflight reject *before side effects*, `--model` threading, and flag>frontmatter precedence (incl. no-agent-file + Hermes file-model) across all three connectors.
- `pnpm smoke:spawn-args` — constructs a `MeshAgent` with a recording `ep` and asserts `spawn` forwards `agent`/`model` into the privileged `start` op.

`pnpm typecheck` + `pnpm build` green. (Core `pnpm smoke` is unrelated — blocked only by a running auth broker on :4222.)

## Review
Reviewed on the mesh by `review-general-2`: the `requires` abstraction + guardrails, and the decision to expose `agent` on `cotal_spawn` (spawn capability is the auth boundary; manager preflight covers operational risk; validation not duplicated in MCP schema). All applied.