### PR TITLE
feat(connector): add cotal_orientation self/context card for agents

### DIFF
--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -7,6 +7,9 @@
 A bundled plugin inside the session joins NATS, maps lifecycle hooks to presence, and
 exposes the mesh tools: messaging, presence, and team supervision.
 
+- **`cotal_orientation`** is the orient-first entry point: a read-only card of identity, the
+  channels it reads and may post to, capabilities, the tools available to it, present peers, and
+  unread counts. The connector `instructions` tell the agent to call it first.
 - **`cotal_spawn`** grows the team. The new teammate joins as a lateral peer. A taken
   name auto-numbers (`reviewer` → `reviewer-2`), so you never collide; the requested name
   still picks the persona file.
@@ -102,9 +105,13 @@ You are a builder on a shared mesh of peer agents…   ← the body is the perso
   `buildLaunch` pre-allows that fetch with `--allowedTools
   "WebFetch(domain:github.com),WebFetch(domain:raw.githubusercontent.com)"` so the lookup
   does not prompt the operator mid-session.
-- **The agent is told its lanes.** The MCP server `instructions` name the channels it reads
-  and may post to (from `channels`/`publish`), so the model knows its scope up front instead
-  of learning it from inbound tags and rejected sends.
+- **The agent orients via one tool.** The MCP server `instructions` point the model at
+  `cotal_orientation` — a read-only card with its identity, the channels it reads and may post
+  to (from `channels`/`publish`), its capabilities, the tools available to it (grouped into a
+  core loop plus the rest), who's present, and unread counts — so it knows its scope up front
+  instead of learning it from inbound tags and rejected sends. Built from the same config and
+  gated tool set that drive the tools, so it can't claim access the agent doesn't have. The
+  same card surfaces on every connector (OpenCode, Hermes), not just Claude Code.
 - **Channel purpose is pulled, not pushed.** `cotal_channel_info(channel)` returns a
   channel's `{ description, instructions, replay }` from the registry at point of use. Read it
   before first posting to an unfamiliar channel. The text is rendered as *attributed,

--- a/extensions/connector-claude-code/src/mcp.ts
+++ b/extensions/connector-claude-code/src/mcp.ts
@@ -17,7 +17,6 @@ import {
   controlSocketPath,
   startControlServer,
   registerCotalTools,
-  laneLine,
   feedbackLine,
   formatInjection,
   fmtFrom,
@@ -149,7 +148,8 @@ async function main(): Promise<void> {
       instructions:
         `You are connected to the Cotal mesh as "${config.name}"` +
         `${config.role ? ` (role: ${config.role})` : ""} in space "${config.space}". ` +
-        laneLine(config) +
+        `Start with cotal_orientation — it shows your identity, the channels you can read and post to, ` +
+        `your capabilities, the tools available to you, and who's present. ` +
         feedbackLine(config) +
         `Other agents coordinate with you here as lateral peers. ` +
         `Peer messages may arrive as <channel source="cotal" from="<name>" role="<role>" ` +

--- a/extensions/connector-core/smoke/orientation.smoke.ts
+++ b/extensions/connector-core/smoke/orientation.smoke.ts
@@ -1,0 +1,110 @@
+/**
+ * Smoke for cotal_orientation — pure (no broker). Covers the plan's §6 checks that don't need a
+ * live mesh: identity + access mapping, auth-vs-open, the gated tool list, the core/more grouping,
+ * and the live-context snapshot. Run: `pnpm smoke:orientation`.
+ */
+import assert from "node:assert/strict";
+import {
+  cotalToolSpecs,
+  buildOrientation,
+  renderOrientation,
+  type AgentConfig,
+  type MeshAgent,
+} from "@cotal-ai/connector-core";
+
+function cfg(over: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    space: "demo",
+    name: "alice",
+    role: "reviewer",
+    servers: "nats://127.0.0.1:4222",
+    subscribe: ["general"],
+    allowSubscribe: ["general"],
+    allowPublish: ["general"],
+    kind: "agent",
+    tls: false,
+    ...over,
+  } as AgentConfig;
+}
+
+// A minimal MeshAgent stub — buildOrientation only reads id/status/attention/roster/inboxCount.
+function agentStub(over: { roster?: any[]; unread?: number } = {}): MeshAgent {
+  return {
+    id: "ALICEID0000000000000000000000000000000000000",
+    status: "working",
+    attention: "open",
+    connected: true,
+    roster: () => over.roster ?? [],
+    inboxCount: () => over.unread ?? 0,
+  } as unknown as MeshAgent;
+}
+
+const presence = (id: string, name: string, role?: string, status = "idle") => ({
+  card: { id, name, role },
+  status,
+});
+
+// 1 — gated tool list: orientation is first; spawn/persona hidden without the capability, shown with it.
+{
+  const open = cotalToolSpecs(cfg({ creds: undefined }));
+  assert.equal(open[0].name, "cotal_orientation", "orientation should be the first tool");
+
+  const noSpawn = cotalToolSpecs(cfg({ creds: "CREDS", capabilities: [] })).map((s) => s.name);
+  assert.ok(!noSpawn.includes("cotal_spawn"), "no spawn cap ⇒ cotal_spawn hidden");
+  assert.ok(!noSpawn.includes("cotal_persona"), "no spawn cap ⇒ cotal_persona hidden");
+
+  const withSpawn = cotalToolSpecs(cfg({ creds: "CREDS", capabilities: ["spawn"] })).map((s) => s.name);
+  assert.ok(withSpawn.includes("cotal_spawn") && withSpawn.includes("cotal_persona"), "spawn cap ⇒ both shown");
+}
+
+// 2 — identity + access mapping, and auth vs open.
+{
+  const authCfg = cfg({ creds: "CREDS", subscribe: ["general"], allowSubscribe: ["general", "incident"], allowPublish: [] });
+  const visible = cotalToolSpecs(authCfg).map((s) => ({ name: s.name, title: s.title }));
+  const o = buildOrientation(agentStub(), authCfg, visible, 1_700_000_000_000);
+
+  assert.deepEqual(o.identity, { name: "alice", role: "reviewer", space: "demo", id: "ALICEID0000000000000000000000000000000000000" });
+  assert.equal(o.access.authMode, true);
+  assert.deepEqual(o.access.read, ["general"]);
+  assert.deepEqual(o.access.readAcl, ["general", "incident"]); // read ACL wider than active read
+  assert.deepEqual(o.access.post, []); // default-deny ⇒ read-only
+  assert.equal(o.generatedAt, 1_700_000_000_000);
+
+  const openO = buildOrientation(agentStub(), cfg({ creds: undefined }), [], 1);
+  assert.equal(openO.access.authMode, false);
+
+  // read-only renders explicitly; readAcl line appears only when it differs from read.
+  const text = renderOrientation(o);
+  assert.match(text, /read-only/);
+  assert.match(text, /may join \(read ACL\)/);
+}
+
+// 3 — core/more grouping covers exactly the gated set (minus orientation itself), no dupes.
+{
+  const c = cfg({ creds: "CREDS", capabilities: ["spawn"] });
+  const gated = cotalToolSpecs(c).map((s) => s.name).filter((n) => n !== "cotal_orientation");
+  const visible = cotalToolSpecs(c).map((s) => ({ name: s.name, title: s.title }));
+  const o = buildOrientation(agentStub(), c, visible, 1);
+
+  const grouped = [...o.tools.core, ...o.tools.more].map((t) => t.name);
+  assert.ok(!grouped.includes("cotal_orientation"), "the card omits the orientation tool itself");
+  assert.equal(new Set(grouped).size, grouped.length, "no duplicate tools across core/more");
+  assert.deepEqual([...grouped].sort(), [...gated].sort(), "core ∪ more == gated tool set");
+  assert.ok(o.tools.core.every((t) => ["cotal_inbox", "cotal_send", "cotal_dm", "cotal_anycast", "cotal_roster", "cotal_status"].includes(t.name)));
+}
+
+// 4 — live context: peers exclude self, unread = inboxCount.
+{
+  const roster = [
+    presence("ALICEID0000000000000000000000000000000000000", "alice", "reviewer"), // self
+    presence("BOBID00000000000000000000000000000000000000", "bob", "worker", "working"),
+    presence("CARID00000000000000000000000000000000000000", "carol"),
+  ];
+  const o = buildOrientation(agentStub({ roster, unread: 3 }), cfg({ creds: "CREDS" }), [], 1);
+  assert.equal(o.peers.present, 2, "self excluded from peer count");
+  assert.match(o.peers.summary, /bob\/worker \(working\)/);
+  assert.ok(!o.peers.summary.includes("alice"), "self not in the peer summary");
+  assert.equal(o.unread.total, 3);
+}
+
+console.log("✓ orientation smoke passed");

--- a/extensions/connector-core/src/config.ts
+++ b/extensions/connector-core/src/config.ts
@@ -149,7 +149,7 @@ export function configFromEnv(env: NodeJS.ProcessEnv = process.env): AgentConfig
     subscribe: resolvedSubscribe,
     allowSubscribe: resolvedAllowSub,
     // Post ACL is default-DENY: only what's explicitly declared (env > agent-file). The broker
-    // enforces it under auth; in open mode posting is unrestricted regardless (see laneLine).
+    // enforces it under auth; in open mode posting is unrestricted regardless.
     allowPublish: resolvedAllowPub,
     quiet: resolvedQuiet,
     muted: resolvedMuted,
@@ -161,25 +161,6 @@ export function configFromEnv(env: NodeJS.ProcessEnv = process.env): AgentConfig
     feedbackKey: env.COTAL_FEEDBACK_KEY?.trim() || undefined,
     feedbackUrl: env.COTAL_FEEDBACK_URL?.trim() || undefined,
   };
-}
-
-/** One sentence telling the agent its channel lanes — what it reads and where it may post —
- *  so it knows its scope up front instead of discovering it from inbound tags and send errors.
- *  Folded into each connector's MCP `instructions`. It must match the broker truth: under auth the
- *  post ACL is default-deny, so an undeclared agent genuinely cannot post (state it plainly rather
- *  than promise a lane the broker will reject). In open mode there is no cred, so posting is
- *  unrestricted regardless of the (display-only) post ACL. */
-export function laneLine(config: AgentConfig): string {
-  const fmt = (cs: string[]) => cs.map((c) => `#${c}`).join(", ");
-  const subs = config.subscribe;
-  // Open mode (no creds) ⇒ nothing is enforced; the agent reads and posts to its channels freely.
-  if (!config.creds) return `You read and may post to ${fmt(subs)}. `;
-  const pubs = config.allowPublish;
-  if (!pubs.length) return `You read ${fmt(subs)}; you may not post to any channel (no publish channels granted). `;
-  const same = subs.length === pubs.length && subs.every((c) => pubs.includes(c));
-  return same
-    ? `You read and may post to ${fmt(subs)}. `
-    : `You read ${fmt(subs)}; you may post only to ${fmt(pubs)} (posts to other channels are rejected). `;
 }
 
 /** Beta-feedback guidance folded into connector instructions. */

--- a/extensions/connector-core/src/index.ts
+++ b/extensions/connector-core/src/index.ts
@@ -3,6 +3,7 @@ export * from "./agent.js";
 export * from "./runtime.js";
 export * from "./launch.js";
 export * from "./tool-specs.js";
+export * from "./orientation.js";
 export * from "./tools.js";
 export * from "./control.js";
 export * from "./relay.js";

--- a/extensions/connector-core/src/orientation.ts
+++ b/extensions/connector-core/src/orientation.ts
@@ -1,0 +1,142 @@
+/**
+ * The `cotal_orientation` card — a structured, versioned self/context snapshot an agent reads to
+ * orient: who it is, what it may read/post, what it can do, and what's around it.
+ *
+ * Built from the SAME {@link AgentConfig} (+ the gated tool list the connector exposes) that gates the
+ * tools, so it can never drift from what's actually enforced. Connector-local introspection — an agent
+ * reading its own minted grants — NOT a wire/SPEC capability handshake.
+ *
+ * The typed {@link Orientation} object is the source of truth; {@link renderOrientation} is one view of
+ * it (the text the model reads). A future MCP resource can JSON-stringify the object directly.
+ */
+import type { AttentionMode, PresenceStatus } from "@cotal-ai/core";
+import type { MeshAgent } from "./agent.js";
+import type { AgentConfig } from "./config.js";
+
+/** A tool the agent can actually call (already gated), as it appears in the card. */
+export interface OrientationTool {
+  name: string;
+  title: string;
+}
+
+export interface Orientation {
+  /** Schema version — bump on a breaking shape change so future renderers/resources can adapt. */
+  v: 1;
+  /** Snapshot stamp. The live fields below (peers / status / attention / unread) are as of this time;
+   *  the identity/access/capabilities/tools fields are static for the session. */
+  generatedAt: number;
+  identity: { name: string; role?: string; space: string; id: string };
+  access: {
+    /** auth mode → these grants are broker-enforced; open mode → advisory (host-trusted) only. */
+    authMode: boolean;
+    /** Active read set — channels you currently receive. */
+    read: string[];
+    /** Read ACL — channels you MAY join (equals `read` when no creds). */
+    readAcl: string[];
+    /** Post ACL — channels you may broadcast to. Empty ⇒ read-only (default-deny). */
+    post: string[];
+  };
+  /** Control-plane capabilities (e.g. `spawn`). Empty ⇒ none beyond the defaults granted to all. */
+  capabilities: string[];
+  /** The tools available to you, grouped so the surface reads small: `core` is the everyday loop. */
+  tools: { core: OrientationTool[]; more: OrientationTool[] };
+  peers: { present: number; summary: string };
+  status: PresenceStatus;
+  attention: AttentionMode;
+  unread: { total: number };
+  /** A factual map from intent → tool. Not a prescribed sequence. */
+  actions: { read: string; replyChannel: string; replyPrivate: string; askRole: string };
+}
+
+/** The everyday loop (the `core` group); every other tool falls into `more`. Keep in sync with the
+ *  reply/loop tools an agent reaches for each turn. An unknown/new tool defaults to `more`. */
+const CORE_TOOLS = new Set([
+  "cotal_inbox",
+  "cotal_send",
+  "cotal_dm",
+  "cotal_anycast",
+  "cotal_roster",
+  "cotal_status",
+]);
+
+/** Assemble the card. `visibleTools` is the already-gated tool list the connector exposes (pass the
+ *  result of `cotalToolSpecs(config)` mapped to name/title) — the orientation tool itself is dropped.
+ *  Pure: `generatedAt` is supplied by the caller so it's testable and deterministic. */
+export function buildOrientation(
+  agent: MeshAgent,
+  config: AgentConfig,
+  visibleTools: OrientationTool[],
+  generatedAt: number,
+): Orientation {
+  const core: OrientationTool[] = [];
+  const more: OrientationTool[] = [];
+  for (const t of visibleTools) {
+    if (t.name === "cotal_orientation") continue; // don't list the orientation tool in its own card
+    (CORE_TOOLS.has(t.name) ? core : more).push(t);
+  }
+
+  const peers = agent.roster().filter((p) => p.card.id !== agent.id);
+  const shown = peers
+    .slice(0, 8)
+    .map((p) => `${p.card.role ? `${p.card.name}/${p.card.role}` : p.card.name} (${p.status})`);
+  const summary = peers.length
+    ? shown.join(", ") + (peers.length > shown.length ? `, +${peers.length - shown.length} more` : "")
+    : "no other peers present";
+
+  return {
+    v: 1,
+    generatedAt,
+    identity: { name: config.name, role: config.role, space: config.space, id: agent.id },
+    access: {
+      authMode: !!config.creds,
+      read: config.subscribe,
+      readAcl: config.allowSubscribe,
+      post: config.allowPublish,
+    },
+    capabilities: config.capabilities ?? [],
+    tools: { core, more },
+    peers: { present: peers.length, summary },
+    status: agent.status,
+    attention: agent.attention,
+    unread: { total: agent.inboxCount() },
+    actions: {
+      read: "cotal_inbox",
+      replyChannel: "cotal_send",
+      replyPrivate: "cotal_dm",
+      askRole: "cotal_anycast",
+    },
+  };
+}
+
+/** Render the card as compact, glanceable text — the view the model reads. */
+export function renderOrientation(o: Orientation): string {
+  const fmt = (cs: string[]) => (cs.length ? cs.map((c) => `#${c}`).join(", ") : "—");
+  const who = o.identity.role ? `${o.identity.name}/${o.identity.role}` : o.identity.name;
+  const aclDiffers =
+    o.access.readAcl.length !== o.access.read.length ||
+    o.access.readAcl.some((c) => !o.access.read.includes(c));
+
+  const lines: string[] = [
+    `You are ${who} in space "${o.identity.space}" (id ${o.identity.id.slice(0, 8)}…).`,
+    "",
+    `Access — ${o.access.authMode ? "auth mode (grants are broker-enforced)" : "open mode (grants advisory, host-trusted)"}:`,
+    `  • read: ${fmt(o.access.read)}`,
+  ];
+  if (aclDiffers) lines.push(`  • may join (read ACL): ${fmt(o.access.readAcl)}`);
+  lines.push(
+    `  • post: ${o.access.post.length ? fmt(o.access.post) : "— (read-only; no post channels)"}`,
+    `  • capabilities: ${o.capabilities.length ? o.capabilities.join(", ") : "none beyond defaults"}`,
+    "",
+    `Tools — core loop: ${o.tools.core.map((t) => t.name).join(", ") || "—"}`,
+    `Tools — more: ${o.tools.more.map((t) => t.name).join(", ") || "—"}`,
+    "",
+    `Right now (snapshot @ ${new Date(o.generatedAt).toISOString()}):`,
+    `  • status: ${o.status} · attention: ${o.attention}`,
+    `  • peers present: ${o.peers.present} — ${o.peers.summary}`,
+    `  • unread: ${o.unread.total}`,
+    "",
+    `Act → read: ${o.actions.read} · reply on a channel: ${o.actions.replyChannel} · ` +
+      `private: ${o.actions.replyPrivate} · ask a role: ${o.actions.askRole}`,
+  );
+  return lines.join("\n");
+}

--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 import { isConcreteChannel, channelInAllow, AmbiguousPeerError, isPermissionDenied, type PresenceStatus } from "@cotal-ai/core";
 import type { MeshAgent, InboxItem } from "./agent.js";
 import { FEEDBACK_URL, PUBLIC_FEEDBACK_URL, type AgentConfig } from "./config.js";
+import { buildOrientation, renderOrientation, type OrientationTool } from "./orientation.js";
 
 /** What a Cotal tool returns: text to show the model, flagged on failure. MCP wraps it in
  *  `content`; the OpenCode plugin returns the string. */
@@ -136,6 +137,29 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
   // self-despawn is granted to all). controlFailure remains the backstop if a wire denial slips by.
   const canSpawn = !config.creds || (config.capabilities?.includes("spawn") ?? false);
   const specs: CotalToolSpec[] = [
+    {
+      name: "cotal_orientation",
+      title: "Cotal: orient — who you are & what you can do",
+      description:
+        "Your orientation card: who you are (name/role/space), the channels you can read and post to, " +
+        "your capabilities, the tools available to you (grouped into a core loop plus the rest), who's " +
+        "present, your status/attention, and how many messages are unread. Call this first to get your " +
+        "bearings; it's read-only and safe to re-check anytime.",
+      run(agent) {
+        // Reflect the SAME gated tool list the connector exposes (cotalToolSpecs already filters
+        // spawn/persona by capability), so the card can't claim a tool the agent can't call.
+        const visible: OrientationTool[] = cotalToolSpecs(config, source).map((s) => ({
+          name: s.name,
+          title: s.title,
+        }));
+        const card = renderOrientation(buildOrientation(agent, config, visible, Date.now()));
+        return ok(
+          agent.connected
+            ? card
+            : `(not connected to the mesh yet — the live context below is empty)\n\n${card}`,
+        );
+      },
+    },
     {
       name: "cotal_roster",
       title: "Cotal: who's present",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "ci:publish": "pnpm build && pnpm publish -r --provenance --access=public --no-git-checks",
     "smoke": "tsx packages/core/smoke.ts",
     "smoke:auth": "tsx packages/core/smoke-auth.ts",
+    "smoke:orientation": "tsx extensions/connector-core/smoke/orientation.smoke.ts",
     "smoke:view": "tsx implementations/cli/smoke/view.smoke.ts",
     "smoke:members": "tsx packages/core/smoke/members.smoke.ts",
     "smoke:plane3:auth": "tsx packages/core/smoke/plane3-auth.smoke.ts",


### PR DESCRIPTION
## What

Adds **`cotal_orientation`** — a single read-only tool an agent calls to orient itself on the mesh: identity (name/role/space), the channels it reads and may post to, its capabilities, the tools available to it (grouped into a **core loop** plus the rest), who's present, status/attention, and unread counts.

The card is built from the **same config + gated tool list that drive the tools**, so it can't claim access the agent doesn't have. It's connector-local introspection (an agent reading its own minted grants) — **no SPEC/wire change**.

## Why

Today an agent's identity/access is surfaced only as prose in the **Claude Code** connector's `instructions` blurb (`laneLine`), and not at all on OpenCode/Hermes. This gives every connector one structured, re-queryable orientation surface.

## Changes

- `extensions/connector-core/src/orientation.ts` (new): typed/versioned `Orientation` + `buildOrientation` (pure) + `renderOrientation`.
- `tool-specs.ts`: `cotal_orientation` is the **first** tool; reflects the gated `cotalToolSpecs` set (so `spawn`/`persona` only appear when the agent has the capability).
- `config.ts`: removed the now-dead `laneLine` (its access facts moved into the card).
- `connector-claude-code/src/mcp.ts`: swapped the lane prose for a one-line bootstrap pointing at `cotal_orientation`.
- `index.ts`: exports the module (shared across connectors; reusable by a future MCP resource).
- `smoke/orientation.smoke.ts` + `smoke:orientation` script: no-broker smoke — identity/access mapping, auth-vs-open, the gated tool list, the core/more grouping (`core ∪ more` == gated set), self-excluded peers.
- `docs/claude-code-integration.md`: updated.

## Design notes

A tool-surface bloat audit (with reviewer) **rejected** merging `channel_info`→`channels` to offset the count — optional-arg polymorphism costs agents more than a clearly-named +1 tool. Perceived bloat is handled by **grouping** tools in the card instead. Lands as +1 (15 visible for a non-manager), no API change to existing tools.

## Verification

- `pnpm typecheck` — green across all packages.
- `pnpm smoke:orientation` — passing.