### PR TITLE
feat(connector): point OpenCode and Hermes agents at cotal_orientation too

### DIFF
--- a/extensions/connector-claude-code/src/mcp.ts
+++ b/extensions/connector-claude-code/src/mcp.ts
@@ -18,6 +18,7 @@ import {
   startControlServer,
   registerCotalTools,
   feedbackLine,
+  ORIENTATION_BOOTSTRAP,
   formatInjection,
   fmtFrom,
   channelMeta,
@@ -148,8 +149,7 @@ async function main(): Promise<void> {
       instructions:
         `You are connected to the Cotal mesh as "${config.name}"` +
         `${config.role ? ` (role: ${config.role})` : ""} in space "${config.space}". ` +
-        `Start with cotal_orientation — it shows your identity, the channels you can read and post to, ` +
-        `your capabilities, the tools available to you, and who's present. ` +
+        `${ORIENTATION_BOOTSTRAP} ` +
         feedbackLine(config) +
         `Other agents coordinate with you here as lateral peers. ` +
         `Peer messages may arrive as <channel source="cotal" from="<name>" role="<role>" ` +

--- a/extensions/connector-core/smoke/orientation.smoke.ts
+++ b/extensions/connector-core/smoke/orientation.smoke.ts
@@ -8,6 +8,7 @@ import {
   cotalToolSpecs,
   buildOrientation,
   renderOrientation,
+  ORIENTATION_BOOTSTRAP,
   type AgentConfig,
   type MeshAgent,
 } from "@cotal-ai/connector-core";
@@ -105,6 +106,12 @@ const presence = (id: string, name: string, role?: string, status = "idle") => (
   assert.match(o.peers.summary, /bob\/worker \(working\)/);
   assert.ok(!o.peers.summary.includes("alice"), "self not in the peer summary");
   assert.equal(o.unread.total, 3);
+}
+
+// 5 — the shared connector bootstrap is exported and points agents at the tool.
+{
+  assert.ok(ORIENTATION_BOOTSTRAP.length > 0, "bootstrap is non-empty");
+  assert.match(ORIENTATION_BOOTSTRAP, /cotal_orientation/);
 }
 
 console.log("✓ orientation smoke passed");

--- a/extensions/connector-core/src/orientation.ts
+++ b/extensions/connector-core/src/orientation.ts
@@ -13,6 +13,13 @@ import type { AttentionMode, PresenceStatus } from "@cotal-ai/core";
 import type { MeshAgent } from "./agent.js";
 import type { AgentConfig } from "./config.js";
 
+/** One-line connector bootstrap that points a joining agent at `cotal_orientation`. Folded into each
+ *  connector's system prompt / MCP instructions so every agent — Claude Code, OpenCode, Hermes — is
+ *  told to orient first, from a single source of truth. */
+export const ORIENTATION_BOOTSTRAP =
+  "Start with cotal_orientation — it shows your identity, the channels you can read and post to, " +
+  "your capabilities, the tools available to you, and who's present.";
+
 /** A tool the agent can actually call (already gated), as it appears in the card. */
 export interface OrientationTool {
   name: string;

--- a/extensions/connector-hermes/src/launch.ts
+++ b/extensions/connector-hermes/src/launch.ts
@@ -19,7 +19,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { loadAgentFile } from "@cotal-ai/core";
-import { hasIdentity, configFromEnv, controlSocketPath } from "@cotal-ai/connector-core";
+import { hasIdentity, configFromEnv, controlSocketPath, ORIENTATION_BOOTSTRAP } from "@cotal-ai/connector-core";
 import { startSidecar } from "./sidecar.js";
 
 /** Hermes API line this connector is written + pinned against (see pyproject.toml). A different
@@ -70,8 +70,10 @@ function setupProfile(home: string, opts: { model?: string; persona?: string }):
   if (opts.model) lines.push(`model: ${yamlStr(opts.model)}`);
   writeFileSync(join(home, "config.yaml"), lines.join("\n") + "\n");
 
-  // Persona → SOUL.md (Hermes' identity file) — the one place a system prompt can be set.
-  if (opts.persona) writeFileSync(join(home, "SOUL.md"), opts.persona.trim() + "\n");
+  // Persona → SOUL.md (Hermes' identity file) — the one place a system prompt can be set. Append the
+  // orientation bootstrap so the agent orients first; gated on persona so we don't clobber the default SOUL.
+  if (opts.persona)
+    writeFileSync(join(home, "SOUL.md"), `${opts.persona.trim()}\n\n${ORIENTATION_BOOTSTRAP}\n`);
 }
 
 /** Assert the installed hermes-agent is on the pinned API line, or throw. No silent degrade: a

--- a/extensions/connector-opencode/src/plugin.ts
+++ b/extensions/connector-opencode/src/plugin.ts
@@ -25,6 +25,7 @@ import {
   MeshAgent,
   formatInjection,
   fmtFrom,
+  ORIENTATION_BOOTSTRAP,
   type InboxItem,
 } from "@cotal-ai/connector-core";
 import type { Plugin, Hooks } from "@opencode-ai/plugin";
@@ -168,7 +169,9 @@ export const cotal: Plugin = async ({ client }) => {
       if (parts.length === 0) return;
       if (faceReminder) parts.push({ type: "text", text: faceReminder });
       const body: { parts: typeof parts; system?: string } = { parts };
-      if (!primed && persona) body.system = persona; // persona once, as system (no --append-system-prompt)
+      // persona once, as system (no --append-system-prompt). Append the orientation bootstrap so the
+      // agent is told to orient first — gated on persona so we never replace OpenCode's default system.
+      if (!primed && persona) body.system = `${persona}\n\n${ORIENTATION_BOOTSTRAP}`;
       busy = true;
       surfaced = ids;
       // Arm BEFORE the await: a turn-end signal can land before promptAsync resolves, and


### PR DESCRIPTION
## What

Follow-up to #90. The `cotal_orientation` **tool** already shipped on every connector (it's in the shared `cotalToolSpecs`), but only **Claude Code** told the agent to *call it first*. This adds that one-line nudge to **OpenCode** and **Hermes** as well.

## How

- Extract the sentence into a shared **`ORIENTATION_BOOTSTRAP`** constant in `connector-core` (single source).
- **Claude Code** (`mcp.ts`): now references the constant instead of an inline string.
- **OpenCode** (`plugin.ts`): appended to the persona system prompt.
- **Hermes** (`launch.ts`): appended to `SOUL.md`.

Both OpenCode and Hermes only have a single persona→system slot (no dedicated connector-instructions field like Claude Code's MCP `instructions`). So the bootstrap is **appended to the persona and gated on the persona existing** — we never replace the connector's default system prompt when no persona is set. (A no-persona agent on those connectors still has the tool; it just isn't explicitly told to call it first.)

## Verification

- `pnpm typecheck` — green.
- `pnpm smoke:orientation` — passing (now also guards the `ORIENTATION_BOOTSTRAP` export).
- Confirmed the constant is wired into each connector's compiled output (`mcp.js`, `plugin.js`, `launch.js`).