### PR TITLE
fix(web): drop offline agents from the graph immediately

### DIFF
--- a/.changeset/graph-drop-offline-nodes.md
+++ b/.changeset/graph-drop-offline-nodes.md
@@ -1,0 +1,7 @@
+---
+"@cotal-ai/cli": patch
+---
+
+web graph: drop nodes as soon as they go offline. Offline presence records stay
+in the roster indefinitely, so the previous prune (only when a node left the
+roster) never fired for them and offline agents accumulated on the graph forever.

--- a/implementations/cli/src/web/graph.js
+++ b/implementations/cli/src/web/graph.js
@@ -139,7 +139,7 @@
       a.status = p.status; a.activity = p.activity || ""; a.role = p.card.role; a.harness = p.card.meta?.connector; a.ts = p.ts;
       seen.add(a.id);
     }
-    for (const [id, a] of agents) if (!seen.has(id) && a.status === "offline") { agents.delete(id); for (const k of [...edges.keys()]) if (edges.get(k).a === a) edges.delete(k); for (const k of [...dms.keys()]) { const d = dms.get(k); if (d.a === a || d.b === a) dms.delete(k); } reheat(); if (sel === a) closeDetail(); }
+    for (const [id, a] of agents) if (!seen.has(id) || a.status === "offline") { agents.delete(id); for (const k of [...edges.keys()]) if (edges.get(k).a === a) edges.delete(k); for (const k of [...dms.keys()]) { const d = dms.get(k); if (d.a === a || d.b === a) dms.delete(k); } reheat(); if (sel === a) closeDetail(); }
   }
 
   // ── render loop ──


### PR DESCRIPTION
## What

The live force-directed graph view kept showing stale **offline** agents indefinitely.

## Why

Two layers conspired:

1. Core's roster **retains offline presence records forever** — when an agent's heartbeat lapses (`sweep()`) or it disconnects, the record is *marked* offline via `toOffline()` but never deleted (`getRoster()` returns it).
2. `graph.js` only pruned a node when it was **absent from the roster** *and* already offline (`!seen.has(id) && a.status === "offline"`). Since offline agents stay in the roster, `seen.has(id)` is always true, so the branch never fired and ghosts piled up.

## Change

Flip the prune condition to `!seen.has(id) || a.status === "offline"` — a node drops the instant it goes offline or leaves the roster.

Graph-only fix; no wire/protocol change. CLI `watch`/`roster` still surface offline agents (core retains them); a durable core-level eviction is a separate follow-up.