### PR TITLE
chore: drop changeset for graph offline fix (no standalone release)

### DIFF
--- a/.changeset/graph-drop-offline-nodes.md
+++ b/.changeset/graph-drop-offline-nodes.md
@@ -1,7 +1,0 @@
----
-"@cotal-ai/cli": patch
----
-
-web graph: drop nodes as soon as they go offline. Offline presence records stay
-in the roster indefinitely, so the previous prune (only when a node left the
-roster) never fired for them and offline agents accumulated on the graph forever.


### PR DESCRIPTION
Removes the changeset added in #94. The web-graph offline-node fix doesn't need its own npm release; deleting the changeset makes the Changesets bot auto-close the version-packages PR (#95). No code change.