### PR TITLE
feat(cli): spawn from any directory via a running-mesh registry

### DIFF
--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -61,6 +61,16 @@ Under the hood it is the existing pieces, so you can also run them by hand:
 - `cotal spawn <name> --space <s>` (a foreground Claude on the mesh; a bare name with no
   agent file launches a personaless session)
 
+**Spawning from anywhere.** `cotal up` records each running mesh in a machine-local registry
+(`~/.cotal/meshes/<space>.json` — the broker URL, the project root that holds its creds and
+personas, and its mode), so a bare `cotal spawn <persona>` from *any* directory joins the running
+mesh with the right credentials and persona instead of mistaking `~/.cotal` for a space. One mesh
+up → used automatically; inside a project with its own `.cotal/`, that project wins. With several
+up, pick one with `--space <name>` or set a default with `cotal use <name>`; `cotal meshes` lists
+them (a `*` marks the default). `cotal down` removes the entry. The registry stores a *path*, never
+a secret — trust material stays in each project's `.cotal/auth`. If the mesh is down or won't take
+your creds, spawn fails with one sentence, never a raw NATS trace.
+
 cmux is opt-in: the `cotal` binary registers it, and a build without `import "@cotal-ai/cmux"`
 has no `cmux` runtime. To ship to others instead, the plugin path is the same `cotal setup`
 install.
@@ -132,7 +142,7 @@ run`). They differ only in how they *run* the spec:
 | Launcher | How to point at a file |
 |---|---|
 | Manager (supervised PTY) | `cotal start --name dave` (auto-discovers `.cotal/agents/dave.md` in the manager's workspace) or `--config <path>`; `--model <m>` overrides the file's `model:` for this launch. Detached; view via console / `cotal attach`. |
-| Foreground (`cotal spawn`) | `cotal spawn <name-or-path>`. The real Claude TUI takes over this terminal (run it inside a cmux/tmux pane to multiplex). |
+| Foreground (`cotal spawn`) | `cotal spawn <name-or-path>`. The real Claude TUI takes over this terminal (run it inside a cmux/tmux pane to multiplex). Works from **any directory** — it joins the running mesh via the registry (see below), no `cd` into the project that ran `cotal up`. |
 
 `.cotal/` is gitignored (user-local, like `.claude/`). The demo ships committed example
 files under
@@ -163,9 +173,10 @@ stdout for a manual or one-shot `source`; `cotal completion install [shell]` ins
 persistently — it caches the stub (`~/.config/cotal/completion.<shell>`, or fish's completions
 dir) and sources that from your shell rc (auto-detects `$SHELL`, idempotent, opt-in — never run
 by `setup`). Each `<TAB>` then forwards
-to a hidden `cotal __complete`, so completion sees real data: `cotal spawn <TAB>` lists your
-personas, `cotal send msg <TAB>` the channels your agent files **declare**, `cotal send ask <TAB>`
-the declared roles. By contract `__complete` reads only local files — never the mesh — so a
+to a hidden `cotal __complete`, so completion sees real data: `cotal spawn <TAB>` lists the
+personas of the mesh that spawn would join (resolved offline from the registry, not the cwd's
+catalog), `cotal spawn --space <TAB>` the running meshes, `cotal send msg <TAB>` the channels your
+agent files **declare**, `cotal send ask <TAB>` the declared roles. By contract `__complete` reads only local files — never the mesh — so a
 keystroke never blocks on the network, and there is **no fallback**: a completer that can't
 produce its authoritative answer (e.g. a malformed agent file) fails the process (nothing
 emitted, non-zero exit) rather than offer a silently-partial set, with the broken file named

--- a/implementations/cli/smoke/spawn-from-anywhere-live.smoke.ts
+++ b/implementations/cli/smoke/spawn-from-anywhere-live.smoke.ts
@@ -1,0 +1,124 @@
+/**
+ * LIVE-broker e2e for `cotal spawn` from anywhere — the half the hermetic smoke can't reach.
+ * `spawn-from-anywhere.smoke.ts` probes a CLOSED port; this spins REAL nats-server processes on
+ * isolated ports (COTAL_HOME sandboxed) and proves the resolver + preflight against them:
+ *
+ *  A. the round-4 fix end-to-end: an in-project target uses the RECORDED non-default server and
+ *     actually CONNECTS to it (not the hardcoded DEFAULT_SERVER).
+ *  B. probeConnect's split against REAL brokers: ok (live, open) vs auth-required (real auth broker)
+ *     vs unreachable (killed) — the input that drives preflight's error routing.
+ *  C. prune-on-real-death: a killed broker's entry is dropped by pruneStaleMeshes.
+ *  D. the registry dir is really 0700 after a real recordMesh.
+ *
+ * Needs `nats-server` on PATH (like the other broker smokes). Kills ONLY the PIDs it spawns —
+ * never pkill, so a co-running broker on :4222 is untouched. Run: pnpm smoke:spawn-from-anywhere:live
+ */
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Sandbox the machine-home BEFORE importing core — homeCotalDir() reads COTAL_HOME per call, so the
+// real ~/.cotal is never touched.
+const home = mkdtempSync(join(tmpdir(), "cotal-live-home-"));
+process.env.COTAL_HOME = home;
+
+const { resolveMeshTarget, recordMesh, loadMeshes, probeConnect, meshesDir } = await import(
+  "@cotal-ai/core"
+);
+const { pruneStaleMeshes } = await import("../src/lib/meshes.js");
+
+let pass = 0;
+const kids: ChildProcess[] = [];
+const ok = (name: string, cond: boolean, extra?: unknown) => {
+  if (!cond) throw new Error(`FAIL: ${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
+  pass++;
+  console.log(`  ✓ ${name}`);
+};
+
+/** A real nats-server on an isolated port; `auth` requires user/pass so a credless probe is rejected. */
+function startBroker(port: number, auth: boolean): ChildProcess {
+  const args = ["-a", "127.0.0.1", "-p", String(port)];
+  if (auth) args.push("--user", "u", "--pass", "p");
+  const cp = spawn("nats-server", args, { stdio: "ignore" });
+  kids.push(cp);
+  return cp;
+}
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+async function waitReady(server: string, want: "ok" | "auth-required"): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    const p = await probeConnect(server, { timeoutMs: 400 });
+    if (want === "ok" && p.ok) return;
+    if (want === "auth-required" && !p.ok && p.reason === "auth-required") return;
+    await sleep(100);
+  }
+  throw new Error(`broker ${server} never reached ${want}`);
+}
+
+/** A genuine local project (has its own `.cotal/agents`). */
+function project(label: string): string {
+  const root = mkdtempSync(join(tmpdir(), `cotal-${label}-`));
+  mkdirSync(join(root, ".cotal", "agents"), { recursive: true });
+  writeFileSync(join(root, ".cotal", "agents", "default.md"), "---\nname: rev\nrole: reviewer\n---\n");
+  return root;
+}
+
+const projA = project("projA");
+const SRV_OPEN = "nats://127.0.0.1:4455";
+const SRV_AUTH = "nats://127.0.0.1:4456";
+const ts = "2026-06-22T00:00:00.000Z";
+
+try {
+  // A + B(live ok) + D: open broker on a NON-default port, recorded for projA.
+  startBroker(4455, false);
+  await waitReady(SRV_OPEN, "ok");
+  recordMesh({ space: "alpha", server: SRV_OPEN, root: projA, mode: "open", ts });
+
+  ok(
+    "D: registry dir is really 0700 after recordMesh",
+    (statSync(meshesDir()).mode & 0o777) === 0o700,
+    (statSync(meshesDir()).mode & 0o777).toString(8),
+  );
+
+  const t = resolveMeshTarget(join(projA, "nested", "dir"));
+  ok("A: in-project resolves to the RECORDED :4455, not DEFAULT_SERVER", t.server === SRV_OPEN, t.server);
+  ok("A: source is local-recorded (registry-owned, quiet)", t.source === "local-recorded", t.source);
+  ok("A: open mesh resolves credless", t.auth === undefined, t.auth);
+
+  // Preflight's core against the LIVE broker (open → no creds): must connect.
+  const live = await probeConnect(t.server, {});
+  ok("B: probeConnect to the LIVE recorded broker → ok", live.ok === true, live);
+
+  // B(auth-required): the unreachable-vs-auth split against a REAL auth broker.
+  startBroker(4456, true);
+  await waitReady(SRV_AUTH, "auth-required");
+  const credless = await probeConnect(SRV_AUTH, { timeoutMs: 800 });
+  ok(
+    "B: credless probe to a REAL auth broker → auth-required (not unreachable)",
+    !credless.ok && credless.reason === "auth-required",
+    credless,
+  );
+
+  // C: prune-on-real-death. Kill ONLY our 4455 child, then the entry must prune.
+  const opener = kids[0]!;
+  opener.kill("SIGTERM");
+  for (let i = 0; i < 50 && opener.exitCode === null && opener.signalCode === null; i++) await sleep(100);
+  const dead = await probeConnect(SRV_OPEN, { timeoutMs: 800 });
+  ok("C: probeConnect to the killed broker → unreachable", !dead.ok && dead.reason === "unreachable", dead);
+  ok("C: registry still holds alpha before prune", loadMeshes().some((m) => m.space === "alpha"));
+  await pruneStaleMeshes();
+  ok("C: pruneStaleMeshes drops the dead entry", !loadMeshes().some((m) => m.space === "alpha"), loadMeshes());
+
+  console.log(`\nspawn-from-anywhere live e2e: ${pass} checks passed`);
+} finally {
+  for (const cp of kids) {
+    try {
+      cp.kill("SIGKILL");
+    } catch {
+      /* already gone */
+    }
+  }
+  await sleep(300);
+  for (const d of [home, projA]) rmSync(d, { recursive: true, force: true });
+}
+process.exit(0);

--- a/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
+++ b/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
@@ -122,6 +122,25 @@ try {
   removeMesh("openmesh");
   removeMesh("authmesh");
 
+  // Fix A (HIGH): a local project whose mesh is in the registry resolves to the RECORDED server +
+  // mode, not the hardcoded DEFAULT_SERVER — so `cotal up --server …:4333` then an in-project spawn
+  // targets :4333, not :4222. And an open-recorded mesh mints NO creds even with auth files left on
+  // its root's disk (closes the local-path mode gap truthium flagged).
+  const ALT = "nats://127.0.0.1:4333";
+  recordMesh({ ...entry("teamA", projA, ALT), mode: "open" });
+  const localReg = resolveMeshTarget(join(projA, "nested", "dir"));
+  check(
+    "local project uses the RECORDED server, not DEFAULT_SERVER",
+    localReg.server === ALT && localReg.source === "local-space",
+    localReg,
+  );
+  check(
+    "local project honors recorded OPEN mode despite auth files on disk",
+    localReg.auth === undefined,
+    localReg.auth,
+  );
+  recordMesh(entry("teamA", projA)); // restore (default server, open) for the remaining checks
+
   // Offline completion: lists the RESOLVED mesh's personas (current=teamB → projB), and is
   // synchronous — it cannot have awaited a network probe.
   const prevCwd = process.cwd();

--- a/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
+++ b/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
@@ -9,7 +9,7 @@
  * and that a dead registry entry probes `unreachable` and is pruned.
  */
 import { strict as assert } from "node:assert";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -21,6 +21,7 @@ process.env.COTAL_HOME = home;
 const {
   clearCurrent,
   loadMeshes,
+  meshesDir,
   probeConnect,
   recordMesh,
   removeMesh,
@@ -71,6 +72,13 @@ try {
 
   // 1 mesh → used automatically (source 'registry'), with its root + personas.
   recordMesh(entry("teamA", projA));
+  // Hardening: the registry dir is 0700 — its filenames are space names, so it must not be
+  // world-traversable even though the file contents are already 0600.
+  check(
+    "registry dir is created 0700 (space names not world-readable)",
+    (statSync(meshesDir()).mode & 0o777) === 0o700,
+    (statSync(meshesDir()).mode & 0o777).toString(8),
+  );
   const one = resolveMeshTarget(neutral);
   check("1 mesh: source is 'registry'", one.source === "registry", one.source);
   check("1 mesh: resolves to its root", one.root === projA, one.root);

--- a/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
+++ b/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
@@ -109,7 +109,7 @@ try {
   const sub = join(projA, "nested", "dir");
   mkdirSync(sub, { recursive: true });
   const local = resolveMeshTarget(sub);
-  check("local project wins: source is 'local-space' on its own root", local.source === "local-space" && local.root === projA, local);
+  check("local project wins: source is 'local-recorded' (matched a registry entry by root)", local.source === "local-recorded" && local.root === projA, local);
 
   // Registry `mode` is authoritative for auth: an OPEN mesh resolves credlessly EVEN IF its root
   // still has auth material on disk; an AUTH mesh loads it. Same root, opposite outcomes.
@@ -131,7 +131,7 @@ try {
   const localReg = resolveMeshTarget(join(projA, "nested", "dir"));
   check(
     "local project uses the RECORDED server, not DEFAULT_SERVER",
-    localReg.server === ALT && localReg.source === "local-space",
+    localReg.server === ALT && localReg.source === "local-recorded",
     localReg,
   );
   check(
@@ -140,6 +140,28 @@ try {
     localReg.auth,
   );
   recordMesh(entry("teamA", projA)); // restore (default server, open) for the remaining checks
+
+  // A recorded local project resolves as `local-recorded`: registry-owned (so a stale entry prunes
+  // on auth-required) yet quiet on the success line (the target is self-evident from cwd).
+  check(
+    "recorded local project → source 'local-recorded' (registry-owned for pruning, quiet UX)",
+    resolveMeshTarget(join(projA, "nested", "dir")).source === "local-recorded",
+  );
+  // A target built by localTarget (flag-server with no registry hit) stays `flag-server` — a
+  // non-registry escape hatch, so it is NOT pruned on failure.
+  check(
+    "localTarget (flag-server, no registry match) → source 'flag-server' (not registry-owned)",
+    resolveMeshTarget(neutral, { server: "nats://127.0.0.1:9999" }).source === "flag-server",
+  );
+  // Silent-wrong-mesh guard: a genuine local project with NO entry of its own must NOT fall back
+  // onto another mesh already recorded on DEFAULT_SERVER — it errors instead of joining it.
+  const projC = project("projC", ["x"]);
+  assert.throws(
+    () => resolveMeshTarget(projC),
+    (e: Error) => /another mesh/.test(e.message) && /is running at/.test(e.message),
+  );
+  check("local project w/o its own entry won't silently join a mesh on the default port", true);
+  rmSync(projC, { recursive: true, force: true });
 
   // Offline completion: lists the RESOLVED mesh's personas (current=teamB → projB), and is
   // synchronous — it cannot have awaited a network probe.

--- a/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
+++ b/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
@@ -1,0 +1,125 @@
+/**
+ * `cotal spawn` from any directory — the mesh registry + resolver + offline completion + the
+ * connect preflight's stale-detection. Hermetic (no broker needed): COTAL_HOME is sandboxed to a
+ * temp dir, "meshes" are recorded straight into the registry, and reachability is probed against a
+ * closed port. Run: pnpm smoke:spawn-from-anywhere
+ *
+ * Covers every `resolveMeshTarget` source branch (0 / 1 / N+current / --space / local-project),
+ * that completion lists the RESOLVED mesh's personas (not the cwd's) without opening the network,
+ * and that a dead registry entry probes `unreachable` and is pruned.
+ */
+import { strict as assert } from "node:assert";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Sandbox the machine-home BEFORE touching the registry — homeCotalDir() reads COTAL_HOME per call,
+// so the real ~/.cotal is never touched.
+const home = mkdtempSync(join(tmpdir(), "cotal-home-"));
+process.env.COTAL_HOME = home;
+
+const {
+  clearCurrent,
+  loadMeshes,
+  probeConnect,
+  recordMesh,
+  removeMesh,
+  resolveMeshTarget,
+  setCurrent,
+} = await import("@cotal-ai/core");
+const { spawnComplete } = await import("../src/commands/spawn.js");
+const { listPersonas } = await import("../src/lib/personas.js");
+const { pruneStaleMeshes } = await import("../src/lib/meshes.js");
+
+let pass = 0;
+const check = (name: string, cond: boolean, extra?: unknown) => {
+  assert.ok(cond, `${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
+  pass++;
+  console.log(`  ✓ ${name}`);
+};
+
+/** A project root with a `.cotal/agents/<persona>.md` catalog. */
+function project(label: string, personas: string[]): string {
+  const root = mkdtempSync(join(tmpdir(), `cotal-${label}-`));
+  const dir = join(root, ".cotal", "agents");
+  mkdirSync(dir, { recursive: true });
+  for (const p of personas) writeFileSync(join(dir, `${p}.md`), `# ${p}\n`);
+  return root;
+}
+
+const projA = project("projA", ["reviewer", "researcher"]);
+const projB = project("projB", ["builder"]);
+const neutral = mkdtempSync(join(tmpdir(), "cotal-neutral-")); // no .cotal up-tree
+const SERVER = "nats://127.0.0.1:4222";
+const DEAD = "nats://127.0.0.1:1"; // nothing listens here
+const entry = (space: string, root: string, server = SERVER) =>
+  ({ space, server, root, mode: "open" as const, ts: "2026-06-22T00:00:00.000Z" });
+
+try {
+  // 0 meshes → a bare resolve fails with one sentence, not a crash.
+  assert.throws(() => resolveMeshTarget(neutral), /no mesh running/);
+  check("0 meshes: resolve throws 'no mesh running'", true);
+
+  // 1 mesh → used automatically (source 'registry'), with its root + personas.
+  recordMesh(entry("teamA", projA));
+  const one = resolveMeshTarget(neutral);
+  check("1 mesh: source is 'registry'", one.source === "registry", one.source);
+  check("1 mesh: resolves to its root", one.root === projA, one.root);
+  check(
+    "1 mesh: personas come from the TARGET mesh",
+    listPersonas(one.root).map((p) => p.name).join(",") === "researcher,reviewer",
+    listPersonas(one.root).map((p) => p.name),
+  );
+
+  // 2 meshes, no current → ambiguous: error names both spaces AND their roots.
+  recordMesh(entry("teamB", projB));
+  assert.throws(() => resolveMeshTarget(neutral), (e: Error) => /multiple meshes/.test(e.message) && e.message.includes(projA) && e.message.includes(projB));
+  check("N meshes, no current: error names both meshes + roots", true);
+
+  // --space picks one explicitly (source 'flag-space').
+  const flagged = resolveMeshTarget(neutral, { space: "teamB" });
+  check("--space: source is 'flag-space' on the right root", flagged.source === "flag-space" && flagged.root === projB, flagged);
+  assert.throws(() => resolveMeshTarget(neutral, { space: "ghost" }), /no mesh named "ghost"/);
+  check("--space ghost: errors with the unknown name", true);
+
+  // current set → bare resolve uses it (source 'current').
+  setCurrent("teamB");
+  const cur = resolveMeshTarget(neutral);
+  check("N meshes + current: source is 'current' on the chosen root", cur.source === "current" && cur.root === projB, cur);
+
+  // A genuine local project always wins over the registry (source 'local-space').
+  const sub = join(projA, "nested", "dir");
+  mkdirSync(sub, { recursive: true });
+  const local = resolveMeshTarget(sub);
+  check("local project wins: source is 'local-space' on its own root", local.source === "local-space" && local.root === projA, local);
+
+  // Offline completion: lists the RESOLVED mesh's personas (current=teamB → projB), and is
+  // synchronous — it cannot have awaited a network probe.
+  const prevCwd = process.cwd();
+  process.chdir(neutral);
+  try {
+    const personas = spawnComplete([""]); // CompletionResult, not a Promise
+    check("completion: lists the resolved mesh's personas (not cwd's)", personas.items.map((i) => i.value).join(",") === "builder", personas.items);
+    const spaces = spawnComplete(["--space", ""]);
+    check("completion: --space lists the running spaces", spaces.items.map((i) => i.value).sort().join(",") === "teamA,teamB", spaces.items);
+  } finally {
+    process.chdir(prevCwd);
+  }
+
+  // Preflight probe: a closed port is 'unreachable' (distinct from an auth broker's 'auth-required').
+  const dead = await probeConnect(DEAD, { timeoutMs: 500 });
+  check("probeConnect(closed port) → unreachable", !dead.ok && dead.reason === "unreachable", dead);
+
+  // Stale prune: an entry whose broker is gone is dropped; live-looking ones are left to their probe.
+  clearCurrent();
+  removeMesh("teamA");
+  removeMesh("teamB");
+  recordMesh(entry("ghost", projA, DEAD));
+  await pruneStaleMeshes();
+  check("pruneStaleMeshes drops the dead entry", loadMeshes().every((m) => m.space !== "ghost"), loadMeshes());
+
+  console.log(`\nspawn-from-anywhere smoke: ${pass} checks passed`);
+} finally {
+  for (const d of [home, projA, projB, neutral]) rmSync(d, { recursive: true, force: true });
+}
+process.exit(0);

--- a/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
+++ b/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
@@ -60,6 +60,15 @@ try {
   assert.throws(() => resolveMeshTarget(neutral), /no mesh running/);
   check("0 meshes: resolve throws 'no mesh running'", true);
 
+  // …but completion must FAIL CLOSED, never throw — offer nothing rather than crash the shell.
+  const prevCwd0 = process.cwd();
+  process.chdir(neutral);
+  try {
+    check("0 meshes: completion returns no items (no throw)", spawnComplete([""]).items.length === 0);
+  } finally {
+    process.chdir(prevCwd0);
+  }
+
   // 1 mesh → used automatically (source 'registry'), with its root + personas.
   recordMesh(entry("teamA", projA));
   const one = resolveMeshTarget(neutral);
@@ -75,6 +84,15 @@ try {
   recordMesh(entry("teamB", projB));
   assert.throws(() => resolveMeshTarget(neutral), (e: Error) => /multiple meshes/.test(e.message) && e.message.includes(projA) && e.message.includes(projB));
   check("N meshes, no current: error names both meshes + roots", true);
+
+  // …and completion still fails CLOSED in the ambiguous state, rather than throwing.
+  const prevCwdN = process.cwd();
+  process.chdir(neutral);
+  try {
+    check("N meshes, no current: completion returns no items (no throw)", spawnComplete([""]).items.length === 0);
+  } finally {
+    process.chdir(prevCwdN);
+  }
 
   // --space picks one explicitly (source 'flag-space').
   const flagged = resolveMeshTarget(neutral, { space: "teamB" });

--- a/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
+++ b/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
@@ -111,6 +111,17 @@ try {
   const local = resolveMeshTarget(sub);
   check("local project wins: source is 'local-space' on its own root", local.source === "local-space" && local.root === projA, local);
 
+  // Registry `mode` is authoritative for auth: an OPEN mesh resolves credlessly EVEN IF its root
+  // still has auth material on disk; an AUTH mesh loads it. Same root, opposite outcomes.
+  mkdirSync(join(projA, ".cotal", "auth"), { recursive: true });
+  writeFileSync(join(projA, ".cotal", "auth", "auth.json"), JSON.stringify({ space: "alpha" }));
+  recordMesh(entry("openmesh", projA, SERVER)); // entry() is mode:"open"
+  check("open mesh resolves with NO auth despite auth files in its root", resolveMeshTarget(neutral, { space: "openmesh" }).auth === undefined);
+  recordMesh({ ...entry("authmesh", projA, SERVER), mode: "auth" });
+  check("auth mesh resolves WITH auth from its root", Boolean(resolveMeshTarget(neutral, { space: "authmesh" }).auth));
+  removeMesh("openmesh");
+  removeMesh("authmesh");
+
   // Offline completion: lists the RESOLVED mesh's personas (current=teamB → projB), and is
   // synchronous — it cannot have awaited a network probe.
   const prevCwd = process.cwd();

--- a/implementations/cli/src/commands/down.ts
+++ b/implementations/cli/src/commands/down.ts
@@ -1,6 +1,8 @@
 import { existsSync, readFileSync, rmSync } from "node:fs";
+import { clearCurrent, getCurrent, removeMesh } from "@cotal-ai/core";
 import { c } from "../ui.js";
 import { cotalPath } from "../lib/paths.js";
+import { resolveSpace } from "../lib/status.js";
 
 /** Stop the background processes started by `cotal up --detach` / `cotal setup`:
  *  the manager, the delivery daemon, the web dashboard, and the mesh. */
@@ -21,6 +23,10 @@ export async function down(): Promise<void> {
   // Non-pid control-plane artifacts: the delivery daemon's scoped creds + the manager's delivery-aware
   // marker. Drop them with the processes so a stale creds file / marker never lingers.
   for (const f of ["delivery.creds", "manager.delivery-aware"]) rmSync(cotalPath(f), { force: true });
+  // Drop this folder's mesh from the registry (and the `current` pointer if it was the default).
+  const space = resolveSpace(process.cwd());
+  removeMesh(space);
+  if (getCurrent() === space) clearCurrent();
   if (!any) {
     console.error(c.red("Nothing running here (no .cotal/*.pid). Was it started with `cotal up` / `cotal setup`?"));
     process.exit(1);

--- a/implementations/cli/src/commands/meshes.ts
+++ b/implementations/cli/src/commands/meshes.ts
@@ -1,0 +1,21 @@
+import { getCurrent, loadMeshes } from "@cotal-ai/core";
+import { c } from "../ui.js";
+import { pruneStaleMeshes } from "../lib/meshes.js";
+
+/** `cotal meshes` — list the running meshes (one `cotal up` each), with a `*` on the `current`
+ *  default. The kubectl `get-contexts` analogue: how you see what a bare `cotal spawn` would join,
+ *  and which `--space` names are available. Prunes dead entries first. */
+export async function meshes(): Promise<void> {
+  await pruneStaleMeshes();
+  const all = loadMeshes();
+  if (all.length === 0) {
+    console.log(c.dim("no meshes running — start one with `cotal up`"));
+    return;
+  }
+  const current = getCurrent();
+  const pad = Math.max(...all.map((m) => m.space.length));
+  for (const m of all) {
+    const marker = m.space === current ? c.green("*") : " ";
+    console.log(`${marker} ${m.space.padEnd(pad)}  ${c.dim(`${m.server}  ${m.mode}  ${m.root}`)}`);
+  }
+}

--- a/implementations/cli/src/commands/spawn.ts
+++ b/implementations/cli/src/commands/spawn.ts
@@ -3,7 +3,6 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { parseArgs } from "node:util";
 import {
-  DEFAULT_SERVER,
   agentFilePath,
   authDir,
   connectorServers,
@@ -11,27 +10,38 @@ import {
   isReachable,
   loadAgentFile,
   loadCotalConfig,
-  loadSpaceAuth,
+  loadMeshes,
   mintCreds,
   newIdentity,
   parseShareSelection,
+  probeConnect,
   provisionAgent,
   registry,
+  removeMesh,
+  resolveMeshTarget,
   CotalEndpoint,
   type AgentDef,
   type CompletionResult,
   type Connector,
+  type MeshTarget,
   type SpaceAuth,
 } from "@cotal-ai/core";
-import { cotalRoot } from "../lib/paths.js";
-import { listPersonaNames } from "../lib/personas.js";
-import { resolveSpace } from "../lib/status.js";
+import { c } from "../ui.js";
+import { pruneStaleMeshes } from "../lib/meshes.js";
+import { listPersonas } from "../lib/personas.js";
 
-/** Completion for `cotal spawn <name>` — the first positional is a persona; the rest are flags
- *  we leave to the shell. Filesystem-only (the persona catalog), so it never opens the mesh. */
+/** Completion for `cotal spawn` — `--space <TAB>` lists the running meshes, and the first positional
+ *  is a persona from the mesh this spawn would target. Resolved OFFLINE (registry + `current`, no
+ *  probe — a <TAB> must stay cheap and never open the network), so it lists the *target* mesh's
+ *  personas, not the cwd's. */
 export function spawnComplete(argv: string[]): CompletionResult {
-  if (argv.length <= 1)
-    return { items: listPersonaNames().map((value) => ({ value })), directive: "nofiles" };
+  if (argv[argv.length - 2] === "--space")
+    return { items: loadMeshes().map((m) => ({ value: m.space })), directive: "nofiles" };
+  // Only the first word after `spawn` is the persona positional; once it's typed, defer to the shell.
+  if (argv.length <= 1) {
+    const target = resolveMeshTarget(process.cwd());
+    return { items: listPersonas(target.root).map((p) => ({ value: p.name })), directive: "nofiles" };
+  }
   return { items: [], directive: "nofiles" };
 }
 
@@ -47,6 +57,10 @@ export function spawnComplete(argv: string[]): CompletionResult {
  * shared with the manager); only *how the spec runs* differs — foreground exec
  * here vs. a supervised runtime in the manager. The connector is resolved from
  * the registry by agent type, composed at the root.
+ *
+ * The mesh it joins — creds and personas together — is resolved by {@link resolveMeshTarget}, so a
+ * bare `cotal spawn <persona>` from any directory finds the running mesh (one up, or the `current`
+ * default) instead of mistaking `~/.cotal` for a space.
  */
 /**
  * Auto-number `requested` past any peer already present on the mesh (foo → foo-2 → foo-3) — the same
@@ -95,6 +109,43 @@ async function uniqueMeshName(
   }
 }
 
+/** Resolve the mesh this spawn targets, exiting with one human sentence on an unresolved/ambiguous
+ *  registry rather than a stack trace. Prunes dead registry entries first so a crashed mesh doesn't
+ *  block a bare spawn or get offered by `--space`. */
+async function resolveTargetOrExit(flags: { server?: string; space?: string }): Promise<MeshTarget> {
+  await pruneStaleMeshes();
+  try {
+    return resolveMeshTarget(process.cwd(), flags);
+  } catch (e) {
+    console.error(c.red(`✗ ${(e as Error).message}`));
+    process.exit(1);
+  }
+}
+
+/** Confirm the resolved mesh is actually up and accepts our creds — replaces the raw NATS
+ *  "Authorization Violation" trace with one sentence, and prunes the entry if the broker is gone. */
+async function preflightOrExit(target: MeshTarget): Promise<void> {
+  const creds = target.auth ? await mintCreds(target.auth, newIdentity(), "manager") : undefined;
+  const probe = await probeConnect(target.server, creds ? { creds } : {});
+  if (probe.ok) return;
+  if (probe.reason === "unreachable") {
+    const fromRegistry = target.source === "registry" || target.source === "current";
+    if (fromRegistry) removeMesh(target.space); // the entry was stale — drop it
+    console.error(
+      c.red(
+        `✗ no mesh running at ${target.server}${fromRegistry ? " (stale registry entry — removed)" : ""} — run \`cotal up\``,
+      ),
+    );
+  } else {
+    console.error(
+      c.red(
+        `✗ mesh "${target.space}" at ${target.server} requires credentials this folder can't provide — its trust material is in ${authDir(target.root)}; spawn from there, or use \`--space <name>\` for another mesh`,
+      ),
+    );
+  }
+  process.exit(1);
+}
+
 export async function spawn(argv: string[]): Promise<void> {
   const { values, positionals } = parseArgs({
     args: argv,
@@ -120,31 +171,42 @@ export async function spawn(argv: string[]): Promise<void> {
   // (`--no-transcript` is accepted too, to be explicit about the default).
   const transcript = values.transcript ? true : values["no-transcript"] ? false : false;
 
-  // Where the config lives: --config, else the positional <name-or-path>, else --name
-  // (.cotal/agents/<name>.md). With none of those, fall back to the seeded `default` persona:
-  // `cotal spawn` with no args launches `.cotal/agents/default.md` (same flags as `cotal start`).
-  const ref = values.config ?? positionals[0] ?? values.name ?? "default";
+  // Which mesh this spawn joins — creds + personas together, resolved from --server/--space, a local
+  // project, or the registry (the running mesh / the `current` default).
+  const target = await resolveTargetOrExit({ server: values.server, space: values.space });
+  const { space, server, auth } = target;
 
-  const path = agentFilePath(cotalRoot(), ref);
+  // Where the config lives: --config, else the positional <name-or-path>, else --name
+  // (.cotal/agents/<name>.md under the TARGET mesh's root). With none, fall back to its `default`
+  // persona — `cotal spawn` with no args launches `<root>/.cotal/agents/default.md`.
+  const ref = values.config ?? positionals[0] ?? values.name ?? "default";
+  const path = agentFilePath(target.root, ref);
   let def: AgentDef;
   try {
     def = loadAgentFile(path);
   } catch (e) {
-    const noDefault = ref === "default" && (e as NodeJS.ErrnoException).code === "ENOENT";
-    console.error(
-      noDefault
-        ? "✗ no default persona yet — run `cotal setup` to seed one, or name a persona: `cotal spawn <name>`"
-        : `✗ ${(e as Error).message}`,
-    );
+    const code = (e as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      console.error(
+        c.red(
+          ref === "default"
+            ? "✗ no default persona yet — run `cotal setup` to seed one, or name a persona: `cotal spawn <name>`"
+            : `✗ no persona "${ref}" in ${target.space}'s ${target.personaRoot} — use \`--config <path>\` for a file elsewhere`,
+        ),
+      );
+    } else {
+      console.error(c.red(`✗ ${(e as Error).message}`));
+    }
     process.exit(1);
   }
 
   // --name / --role override the file (name defaults from the file's frontmatter).
   const requested = values.name ?? def.name;
   const role = values.role ?? def.role;
-  const space = values.space ?? resolveSpace(process.cwd());
-  const server = values.server ?? DEFAULT_SERVER;
-  const auth = loadSpaceAuth(authDir(cotalRoot()));
+
+  // Preflight: fail with one sentence if the mesh is down or won't take our creds, instead of
+  // crashing mid-connect with a raw NATS Authorization Violation.
+  await preflightOrExit(target);
 
   // A second `cotal spawn` of the same agent would otherwise join under a duplicate mesh identity:
   // auto-number the name past anyone already present (best-effort — this path bypasses the manager's
@@ -152,6 +214,12 @@ export async function spawn(argv: string[]): Promise<void> {
   const name = await uniqueMeshName(requested, { space, server, auth });
   if (name !== requested)
     console.error(`"${requested}" is already on the mesh — spawning as ${name} instead`);
+
+  // When the target was auto-resolved (one mesh up, or the `current` default), say which mesh we
+  // picked — it isn't obvious from the cwd. An explicit --space/--server or a local project is
+  // self-evident, so stay quiet there.
+  if (target.source === "registry" || target.source === "current")
+    console.error(c.dim(`→ joining mesh ${space} (${server}) as ${name}`));
 
   // Auth mode (`.cotal/auth` present): mint a stable identity + scoped creds for this agent
   // and pre-create its bind-only durables, via a short-lived privileged provisioner — the
@@ -188,7 +256,7 @@ export async function spawn(argv: string[]): Promise<void> {
       durableMembership: false,
     });
     await prov.stop();
-    credsPath = join(authDir(cotalRoot()), "creds", `${name}.creds`);
+    credsPath = join(authDir(target.root), "creds", `${name}.creds`);
     mkdirSync(dirname(credsPath), { recursive: true });
     writeFileSync(credsPath, creds, { mode: 0o600 });
     id = identity.id;
@@ -196,11 +264,11 @@ export async function spawn(argv: string[]): Promise<void> {
   }
 
   // Which of the operator's personal MCP servers to share with this agent: declared in the cotal
-  // config (global ~/.config/cotal + space-local .cotal), narrowed by an optional --share-tools
-  // selection. Default (no config) is none — the connector launches isolated.
+  // config (global ~/.config/cotal + the target mesh's .cotal), narrowed by an optional
+  // --share-tools selection. Default (no config) is none — the connector launches isolated.
   const agentType = values.agent ?? "claude";
   const mcpServers = connectorServers(
-    loadCotalConfig(cotalRoot()),
+    loadCotalConfig(target.root),
     agentType,
     parseShareSelection(values["share-tools"]),
   );

--- a/implementations/cli/src/commands/spawn.ts
+++ b/implementations/cli/src/commands/spawn.ts
@@ -145,7 +145,7 @@ async function preflightOrExit(target: MeshTarget): Promise<void> {
         `✗ no mesh running at ${target.server}${fromRegistry ? " (stale registry entry — removed)" : ""} — run \`cotal up\``,
       ),
     );
-  } else if (target.auth && fromRegistry) {
+  } else if (fromRegistry && target.auth) {
     // We DID present creds minted from the registry's own trust material and the broker rejected
     // them — so the entry now points at a DIFFERENT broker on that port. The fix isn't "spawn from
     // the root" (we just used it); it's that the registry entry is stale. Drop it and say so.
@@ -155,12 +155,29 @@ async function preflightOrExit(target: MeshTarget): Promise<void> {
         `✗ mesh "${target.space}" at ${target.server} no longer matches its registry entry (credentials rejected — port reused?) — re-run \`cotal up\` from ${target.root}, or \`cotal meshes\` to see what's live`,
       ),
     );
-  } else {
-    // Open/local resolution against a broker that wants auth (or a non-registry target): the trust
-    // material genuinely isn't where we looked.
+  } else if (fromRegistry) {
+    // An OPEN-mode registry target probed credlessly, but the broker now wants auth — the recorded
+    // open mesh is gone (its port was reused by an auth broker). Same stale class; drop the entry.
+    removeMesh(target.space);
     console.error(
       c.red(
-        `✗ mesh "${target.space}" at ${target.server} requires credentials this folder can't provide — its trust material is in ${authDir(target.root)}; spawn from there, or use \`--space <name>\` for another mesh`,
+        `✗ open mesh "${target.space}" at ${target.server} no longer matches its registry entry (broker now requires auth — port reused?) — re-run \`cotal up\` from ${target.root}, or \`cotal meshes\` to see what's live`,
+      ),
+    );
+  } else if (target.auth) {
+    // Creds were presented and rejected, but the target is a local project / --server we don't own
+    // in the registry. A different mesh is likely on that port — the user owns the diagnosis, so we
+    // don't prune; we point at the likely cause. "Can't provide" would be wrong: the folder DID.
+    console.error(
+      c.red(
+        `✗ credentials for "${target.space}" were rejected at ${target.server} — a different mesh may be running there. Run \`cotal meshes\` to check, or \`cotal up\` here to start yours`,
+      ),
+    );
+  } else {
+    // No creds to present (open, non-registry) and the broker wants auth.
+    console.error(
+      c.red(
+        `✗ broker at ${target.server} requires auth, but this mesh is open (no trust material) — use \`--space <name>\` for an auth mesh, or run \`cotal up\` here without \`--open\``,
       ),
     );
   }

--- a/implementations/cli/src/commands/spawn.ts
+++ b/implementations/cli/src/commands/spawn.ts
@@ -39,8 +39,14 @@ export function spawnComplete(argv: string[]): CompletionResult {
     return { items: loadMeshes().map((m) => ({ value: m.space })), directive: "nofiles" };
   // Only the first word after `spawn` is the persona positional; once it's typed, defer to the shell.
   if (argv.length <= 1) {
-    const target = resolveMeshTarget(process.cwd());
-    return { items: listPersonas(target.root).map((p) => ({ value: p.name })), directive: "nofiles" };
+    try {
+      const target = resolveMeshTarget(process.cwd());
+      return { items: listPersonas(target.root).map((p) => ({ value: p.name })), directive: "nofiles" };
+    } catch {
+      // No single target (no mesh, or several with no `current`) — fail CLOSED: offer no personas
+      // rather than throw. `cotal spawn --space <TAB>` still lists the running meshes.
+      return { items: [], directive: "nofiles" };
+    }
   }
   return { items: [], directive: "nofiles" };
 }
@@ -128,15 +134,30 @@ async function preflightOrExit(target: MeshTarget): Promise<void> {
   const creds = target.auth ? await mintCreds(target.auth, newIdentity(), "manager") : undefined;
   const probe = await probeConnect(target.server, creds ? { creds } : {});
   if (probe.ok) return;
+  // A target picked FROM the registry (vs an explicit local project / --server) owns its entry, so
+  // a definitive failure prunes it.
+  const fromRegistry =
+    target.source === "registry" || target.source === "current" || target.source === "flag-space";
   if (probe.reason === "unreachable") {
-    const fromRegistry = target.source === "registry" || target.source === "current";
-    if (fromRegistry) removeMesh(target.space); // the entry was stale — drop it
+    if (fromRegistry) removeMesh(target.space); // the broker is gone — drop the stale entry
     console.error(
       c.red(
         `✗ no mesh running at ${target.server}${fromRegistry ? " (stale registry entry — removed)" : ""} — run \`cotal up\``,
       ),
     );
+  } else if (target.auth && fromRegistry) {
+    // We DID present creds minted from the registry's own trust material and the broker rejected
+    // them — so the entry now points at a DIFFERENT broker on that port. The fix isn't "spawn from
+    // the root" (we just used it); it's that the registry entry is stale. Drop it and say so.
+    removeMesh(target.space);
+    console.error(
+      c.red(
+        `✗ mesh "${target.space}" at ${target.server} no longer matches its registry entry (credentials rejected — port reused?) — re-run \`cotal up\` from ${target.root}, or \`cotal meshes\` to see what's live`,
+      ),
+    );
   } else {
+    // Open/local resolution against a broker that wants auth (or a non-registry target): the trust
+    // material genuinely isn't where we looked.
     console.error(
       c.red(
         `✗ mesh "${target.space}" at ${target.server} requires credentials this folder can't provide — its trust material is in ${authDir(target.root)}; spawn from there, or use \`--space <name>\` for another mesh`,

--- a/implementations/cli/src/commands/spawn.ts
+++ b/implementations/cli/src/commands/spawn.ts
@@ -134,10 +134,14 @@ async function preflightOrExit(target: MeshTarget): Promise<void> {
   const creds = target.auth ? await mintCreds(target.auth, newIdentity(), "manager") : undefined;
   const probe = await probeConnect(target.server, creds ? { creds } : {});
   if (probe.ok) return;
-  // A target picked FROM the registry (vs an explicit local project / --server) owns its entry, so
-  // a definitive failure prunes it.
+  // A target whose server + mode came from a registry record owns that record, so a definitive
+  // failure prunes the stale entry. `local-recorded` (a local project matched to an entry by root)
+  // is registry-owned for pruning even though the success line treats it as a quiet local target.
   const fromRegistry =
-    target.source === "registry" || target.source === "current" || target.source === "flag-space";
+    target.source === "registry" ||
+    target.source === "current" ||
+    target.source === "flag-space" ||
+    target.source === "local-recorded";
   if (probe.reason === "unreachable") {
     if (fromRegistry) removeMesh(target.space); // the broker is gone — drop the stale entry
     console.error(

--- a/implementations/cli/src/commands/up.ts
+++ b/implementations/cli/src/commands/up.ts
@@ -24,6 +24,7 @@ import {
   setupSpaceStreams,
   seedChannelRegistry,
   clearCurrent,
+  findMesh,
   getCurrent,
   loadMeshes,
   recordMesh,
@@ -58,21 +59,23 @@ export async function up(argv: string[]): Promise<void> {
   if (await isReachable(server)) {
     const space = values.space ?? resolveSpace(process.cwd());
     const root = cotalRoot();
-    // A broker is already on this port. If the registry says it's a DIFFERENT space, the new mesh
-    // did not start — fail loudly rather than let the user believe it did (a later `spawn --space`
-    // would then fail with a stale-looking error). If it's ours (or unrecorded), adopt/refresh it.
+    // A broker is already on this port. Only treat it as a no-op refresh when the registry confirms
+    // it's THIS exact mesh (same server + root + space). Anything else — a different space/root, or a
+    // broker we never recorded — we must NOT adopt: recording our space over it would let a later
+    // `spawn --space <s>` load the wrong root's creds. Fail loudly and tell the user to free the port.
     const held = loadMeshes().find((m) => m.server === server);
-    if (held && held.root !== root) {
-      console.error(
-        c.red(
-          `✗ ${server} is held by mesh "${held.space}" (${held.root}) — to run "${space}" too, pass \`--server nats://${host}:<port>\``,
-        ),
-      );
-      process.exit(1);
+    if (held && held.root === root && held.space === space) {
+      recordOurMesh({ space, server, root, mode: values.open ? "open" : "auth", ts: new Date().toISOString() });
+      console.log(c.green(`✓ NATS already running at ${server}`));
+      return;
     }
-    recordOurMesh({ space, server, root, mode: values.open ? "open" : "auth", ts: new Date().toISOString() });
-    console.log(c.green(`✓ NATS already running at ${server}`));
-    return;
+    const who = held ? `mesh "${held.space}" (${held.root})` : "a broker not started here";
+    console.error(
+      c.red(
+        `✗ ${server} is already in use by ${who} — to run "${space}" use \`--server nats://${host}:<port>\` with a free port`,
+      ),
+    );
+    process.exit(1);
   }
 
   if (values.detach) {
@@ -93,6 +96,7 @@ export async function up(argv: string[]): Promise<void> {
   mkdirSync(storeDir, { recursive: true });
   const useAuth = !values.open;
   const space = values.space ?? resolveSpace(process.cwd());
+  await claimSpace(space, server, cotalRoot());
   const seedFile = loadChannelsFile(values.channels);
   const setup = useAuth ? await authSetup(storeDir, server, space, host) : undefined;
   const port = Number(new URL(server).port) || 4222;
@@ -170,6 +174,7 @@ export async function startMeshDetached(opts: DetachOpts = {}): Promise<{ server
   mkdirSync(storeDir, { recursive: true });
   const useAuth = !opts.open;
   const space = opts.space ?? resolveSpace(process.cwd());
+  await claimSpace(space, server, cotalRoot());
   const seedFile = loadChannelsFile(opts.channels);
   const host = opts.host ?? "127.0.0.1";
   const setup = useAuth ? await authSetup(storeDir, server, space, host) : undefined;
@@ -200,6 +205,24 @@ export async function startMeshDetached(opts: DetachOpts = {}): Promise<{ server
   // Detached: the registry entry outlives this process — `cotal down` removes it.
   recordOurMesh({ space, server, root: cotalRoot(), mode: useAuth ? "auth" : "open", ts: new Date().toISOString() });
   return { server, pid: child.pid ?? 0, source };
+}
+
+/** A space name identifies at most one mesh in the registry (it's the key `--space`/`use`/`down` act
+ *  on). Before starting a broker, refuse to reuse a space already claimed by a DIFFERENT mesh —
+ *  unless that prior holder's broker is gone (stale), in which case reclaim the name. Re-`up`ping the
+ *  same mesh (same server + root) is fine; that's a refresh, handled by the port-reachable path. */
+async function claimSpace(space: string, server: string, root: string): Promise<void> {
+  const existing = findMesh(space);
+  if (!existing || (existing.server === server && existing.root === root)) return;
+  if (await isReachable(existing.server)) {
+    console.error(
+      c.red(
+        `✗ space "${space}" is already in use by a mesh at ${existing.server} (${existing.root}) — pick a different \`--space\`, or \`cotal down\` it first`,
+      ),
+    );
+    process.exit(1);
+  }
+  removeMesh(space); // the prior holder's broker is gone — reclaim the name
 }
 
 /** Record this mesh in the registry, and make it the `current` default ONLY when it's the first one

--- a/implementations/cli/src/commands/up.ts
+++ b/implementations/cli/src/commands/up.ts
@@ -67,7 +67,9 @@ export async function up(argv: string[]): Promise<void> {
     // user to free the port. (Hosting several spaces on one broker is the planned multi-space work.)
     const held = loadMeshes().find((m) => m.server === server);
     if (held && held.root === root && held.space === space) {
-      recordOurMesh({ space, server, root, mode: values.open ? "open" : "auth", ts: new Date().toISOString() });
+      // A refresh of the SAME already-running mesh — its mode is fixed by how the live broker was
+      // started; preserve `held.mode` rather than relabel it from this invocation's `--open`.
+      recordOurMesh({ space, server, root, mode: held.mode, ts: new Date().toISOString() });
       console.log(c.green(`✓ NATS already running at ${server}`));
       return;
     }

--- a/implementations/cli/src/commands/up.ts
+++ b/implementations/cli/src/commands/up.ts
@@ -62,7 +62,9 @@ export async function up(argv: string[]): Promise<void> {
     // A broker is already on this port. Only treat it as a no-op refresh when the registry confirms
     // it's THIS exact mesh (same server + root + space). Anything else — a different space/root, or a
     // broker we never recorded — we must NOT adopt: recording our space over it would let a later
-    // `spawn --space <s>` load the wrong root's creds. Fail loudly and tell the user to free the port.
+    // `spawn --space <s>` load the wrong root's creds. Today one broker serves one space (auth binds
+    // them), so a different space on this port can't be added to it yet — fail loudly and tell the
+    // user to free the port. (Hosting several spaces on one broker is the planned multi-space work.)
     const held = loadMeshes().find((m) => m.server === server);
     if (held && held.root === root && held.space === space) {
       recordOurMesh({ space, server, root, mode: values.open ? "open" : "auth", ts: new Date().toISOString() });
@@ -96,6 +98,7 @@ export async function up(argv: string[]): Promise<void> {
   mkdirSync(storeDir, { recursive: true });
   const useAuth = !values.open;
   const space = values.space ?? resolveSpace(process.cwd());
+  assertAuthMatchesSpace(useAuth, space);
   await claimSpace(space, server, cotalRoot());
   const seedFile = loadChannelsFile(values.channels);
   const setup = useAuth ? await authSetup(storeDir, server, space, host) : undefined;
@@ -174,6 +177,7 @@ export async function startMeshDetached(opts: DetachOpts = {}): Promise<{ server
   mkdirSync(storeDir, { recursive: true });
   const useAuth = !opts.open;
   const space = opts.space ?? resolveSpace(process.cwd());
+  assertAuthMatchesSpace(useAuth, space);
   await claimSpace(space, server, cotalRoot());
   const seedFile = loadChannelsFile(opts.channels);
   const host = opts.host ?? "127.0.0.1";
@@ -207,10 +211,29 @@ export async function startMeshDetached(opts: DetachOpts = {}): Promise<{ server
   return { server, pid: child.pid ?? 0, source };
 }
 
-/** A space name identifies at most one mesh in the registry (it's the key `--space`/`use`/`down` act
- *  on). Before starting a broker, refuse to reuse a space already claimed by a DIFFERENT mesh —
- *  unless that prior holder's broker is gone (stale), in which case reclaim the name. Re-`up`ping the
- *  same mesh (same server + root) is fine; that's a refresh, handled by the port-reachable path. */
+/** Today a root's `.cotal/auth` is created for one space (its account is space-bound), so starting it
+ *  under a *different* explicit `--space` would run that space's name against the other space's trust
+ *  material — the registry would then point a `spawn --space` at mismatched creds. Reject it. (When
+ *  multi-space-per-root lands, this becomes provision-the-new-space instead of an error.) */
+function assertAuthMatchesSpace(useAuth: boolean, space: string): void {
+  if (!useAuth) return;
+  const existing = loadSpaceAuth(authDir(cotalRoot()));
+  if (existing && existing.space !== space) {
+    console.error(
+      c.red(
+        `✗ this root's trust material is for space "${existing.space}", not "${space}" — drop \`--space\` (it defaults to "${existing.space}"), or run "${space}" from its own root`,
+      ),
+    );
+    process.exit(1);
+  }
+}
+
+/** A space name maps to one mesh in the registry (the key `--space`/`use`/`down` act on). Before
+ *  starting a broker, refuse to reuse a space already claimed by a DIFFERENT live mesh — a stale/dead
+ *  holder is reclaimed. Re-`up`ping the same mesh (same server + root) is a refresh (port-reachable
+ *  path). NOTE: this is a best-effort sequential guard — two `cotal up --space X` racing from
+ *  different roots within the same instant can both pass the check before either records; that
+ *  concurrent case is out of scope (a single-operator CLI action), not synchronized with a lock. */
 async function claimSpace(space: string, server: string, root: string): Promise<void> {
   const existing = findMesh(space);
   if (!existing || (existing.server === server && existing.root === root)) return;
@@ -225,19 +248,20 @@ async function claimSpace(space: string, server: string, root: string): Promise<
   removeMesh(space); // the prior holder's broker is gone — reclaim the name
 }
 
-/** Record this mesh in the registry, and make it the `current` default ONLY when it's the first one
- *  running — never silently redirect a `current` the user already chose. When another mesh is current,
- *  say so and how to switch. */
+/** Record this mesh in the registry, and set it as the `current` default when there's no usable one
+ *  — i.e. the first mesh, OR when `current` dangles at a space that's no longer in the registry (a
+ *  ghost pointer is not a default). Never silently redirect a `current` that still resolves to a live
+ *  mesh; just say another is the default and how to switch. */
 function recordOurMesh(m: MeshEntry): void {
-  const first = loadMeshes().length === 0;
+  const cur = getCurrent();
+  const usableCurrent = cur && findMesh(cur) ? cur : undefined; // compute before recording m
   recordMesh(m);
-  if (first) {
+  if (!usableCurrent) {
     setCurrent(m.space);
     return;
   }
-  const current = getCurrent();
-  if (current && current !== m.space)
-    console.log(c.dim(`"${m.space}" up; current is still "${current}" — \`cotal use ${m.space}\` to switch`));
+  if (usableCurrent !== m.space)
+    console.log(c.dim(`"${m.space}" up; current is still "${usableCurrent}" — \`cotal use ${m.space}\` to switch`));
 }
 
 /** Poll a growing log file and forward newly-appended lines until `stopped()` is true. */

--- a/implementations/cli/src/commands/up.ts
+++ b/implementations/cli/src/commands/up.ts
@@ -23,6 +23,13 @@ import {
   newIdentity,
   setupSpaceStreams,
   seedChannelRegistry,
+  clearCurrent,
+  getCurrent,
+  loadMeshes,
+  recordMesh,
+  removeMesh,
+  setCurrent,
+  type MeshEntry,
   type SpaceAuth,
   type ChannelRegistryFile,
 } from "@cotal-ai/core";
@@ -49,6 +56,21 @@ export async function up(argv: string[]): Promise<void> {
   const server = values.server ?? DEFAULT_SERVER;
   const host = values.host ?? "127.0.0.1";
   if (await isReachable(server)) {
+    const space = values.space ?? resolveSpace(process.cwd());
+    const root = cotalRoot();
+    // A broker is already on this port. If the registry says it's a DIFFERENT space, the new mesh
+    // did not start — fail loudly rather than let the user believe it did (a later `spawn --space`
+    // would then fail with a stale-looking error). If it's ours (or unrecorded), adopt/refresh it.
+    const held = loadMeshes().find((m) => m.server === server);
+    if (held && held.root !== root) {
+      console.error(
+        c.red(
+          `✗ ${server} is held by mesh "${held.space}" (${held.root}) — to run "${space}" too, pass \`--server nats://${host}:<port>\``,
+        ),
+      );
+      process.exit(1);
+    }
+    recordOurMesh({ space, server, root, mode: values.open ? "open" : "auth", ts: new Date().toISOString() });
     console.log(c.green(`✓ NATS already running at ${server}`));
     return;
   }
@@ -93,13 +115,21 @@ export async function up(argv: string[]): Promise<void> {
   const stop = () => { stopDelivery(); child.kill("SIGTERM"); };
   process.on("SIGINT", stop);
   process.on("SIGTERM", stop);
-  child.on("exit", (code) => { stopDelivery(); process.exit(code ?? 0); });
+  // The broker is gone — drop it from the registry (and the `current` pointer if it was the default)
+  // so a later `cotal spawn` doesn't try to join a dead mesh.
+  child.on("exit", (code) => {
+    stopDelivery();
+    removeMesh(space);
+    if (getCurrent() === space) clearCurrent();
+    process.exit(code ?? 0);
+  });
 
   if (await waitReady(server, setup?.creds)) {
     await postStart(server, space, setup, seedFile);
     // Bring up the delivery daemon WITH the server (auth mode only — it self-gates on `.cotal/auth`).
     // It is part of the server, so `cotal up` starts it by default; open dev mode has no daemon.
     await startDeliveryWithBroker(space, server);
+    recordOurMesh({ space, server, root: cotalRoot(), mode: useAuth ? "auth" : "open", ts: new Date().toISOString() });
   }
   await new Promise<void>(() => {});
 }
@@ -167,7 +197,24 @@ export async function startMeshDetached(opts: DetachOpts = {}): Promise<{ server
   await postStart(server, space, setup, seedFile);
   // Bring up the delivery daemon WITH the detached broker (auth mode only; `cotal down` tears both down).
   await startDeliveryWithBroker(space, server);
+  // Detached: the registry entry outlives this process — `cotal down` removes it.
+  recordOurMesh({ space, server, root: cotalRoot(), mode: useAuth ? "auth" : "open", ts: new Date().toISOString() });
   return { server, pid: child.pid ?? 0, source };
+}
+
+/** Record this mesh in the registry, and make it the `current` default ONLY when it's the first one
+ *  running — never silently redirect a `current` the user already chose. When another mesh is current,
+ *  say so and how to switch. */
+function recordOurMesh(m: MeshEntry): void {
+  const first = loadMeshes().length === 0;
+  recordMesh(m);
+  if (first) {
+    setCurrent(m.space);
+    return;
+  }
+  const current = getCurrent();
+  if (current && current !== m.space)
+    console.log(c.dim(`"${m.space}" up; current is still "${current}" — \`cotal use ${m.space}\` to switch`));
 }
 
 /** Poll a growing log file and forward newly-appended lines until `stopped()` is true. */

--- a/implementations/cli/src/commands/up.ts
+++ b/implementations/cli/src/commands/up.ts
@@ -128,8 +128,14 @@ export async function up(argv: string[]): Promise<void> {
   // so a later `cotal spawn` doesn't try to join a dead mesh.
   child.on("exit", (code) => {
     stopDelivery();
-    removeMesh(space);
-    if (getCurrent() === space) clearCurrent();
+    // Only unrecord if the registry still points at THIS broker. A newer broker for the same space
+    // (a concurrent `up`, or a different-port re-up that recorded after us) may have replaced our
+    // record — removing by name would clobber the live winner and hide it from the registry.
+    const mine = findMesh(space);
+    if (mine && mine.server === server && mine.root === cotalRoot()) {
+      removeMesh(space);
+      if (getCurrent() === space) clearCurrent();
+    }
     process.exit(code ?? 0);
   });
 

--- a/implementations/cli/src/commands/use.ts
+++ b/implementations/cli/src/commands/use.ts
@@ -1,0 +1,28 @@
+import { findMesh, loadMeshes, setCurrent, type CompletionResult } from "@cotal-ai/core";
+import { c } from "../ui.js";
+import { pruneStaleMeshes } from "../lib/meshes.js";
+
+/** `cotal use <space>` — set the default mesh a bare `cotal spawn` (and friends) targets when more
+ *  than one is running. The kubectl `use-context` analogue. Validated against the live registry, so
+ *  you can't point `current` at a mesh that isn't up. */
+export async function use(argv: string[]): Promise<void> {
+  const space = argv[0];
+  if (!space) {
+    console.error(c.red("usage: cotal use <space>"));
+    process.exit(1);
+  }
+  await pruneStaleMeshes();
+  const m = findMesh(space);
+  if (!m) {
+    console.error(c.red(`✗ no mesh named "${space}" is running — see \`cotal meshes\``));
+    process.exit(1);
+  }
+  setCurrent(space);
+  console.log(c.green(`✓ current mesh → ${space}`), c.dim(`(${m.server})`));
+}
+
+export function useComplete(argv: string[]): CompletionResult {
+  if (argv.length <= 1)
+    return { items: loadMeshes().map((m) => ({ value: m.space })), directive: "nofiles" };
+  return { items: [], directive: "nofiles" };
+}

--- a/implementations/cli/src/index.ts
+++ b/implementations/cli/src/index.ts
@@ -1,6 +1,8 @@
 import { registry, type Command } from "@cotal-ai/core";
 import { up } from "./commands/up.js";
 import { down } from "./commands/down.js";
+import { use, useComplete } from "./commands/use.js";
+import { meshes } from "./commands/meshes.js";
 import { setup, go } from "./commands/setup.js";
 import { join } from "./commands/join.js";
 import { console_ } from "./commands/console.js";
@@ -47,6 +49,21 @@ const baseCommands: Command[] = [
     group: "Mesh",
     summary: "stop a background mesh started with `up --detach`",
     run: down,
+  },
+  {
+    kind: "command",
+    name: "meshes",
+    group: "Mesh",
+    summary: "list the running meshes (a `*` marks the `current` default a bare spawn joins)",
+    run: meshes,
+  },
+  {
+    kind: "command",
+    name: "use",
+    group: "Mesh",
+    summary: "set the default mesh for a bare `cotal spawn` when several are running — use <space>",
+    run: use,
+    complete: useComplete,
   },
   {
     kind: "command",

--- a/implementations/cli/src/lib/meshes.ts
+++ b/implementations/cli/src/lib/meshes.ts
@@ -1,0 +1,16 @@
+import { loadMeshes, probeConnect, removeMesh } from "@cotal-ai/core";
+
+/**
+ * Drop registry entries whose broker is gone — a `cotal up` that crashed or was `kill -9`'d without
+ * `cotal down` leaves a record behind. Probe each in parallel; only `unreachable` (refused/timeout)
+ * is stale, an auth broker answering `auth-required` is alive. Called by `spawn`/`use`/`meshes`
+ * before they act on the registry — never by completion (a `<TAB>` must not open the network).
+ */
+export async function pruneStaleMeshes(): Promise<void> {
+  await Promise.all(
+    loadMeshes().map(async (m) => {
+      const r = await probeConnect(m.server);
+      if (!r.ok && r.reason === "unreachable") removeMesh(m.space);
+    }),
+  );
+}

--- a/implementations/cli/src/lib/onboard.ts
+++ b/implementations/cli/src/lib/onboard.ts
@@ -12,6 +12,6 @@ export function isOnboarded(): boolean {
 }
 
 export function markOnboarded(version: string): void {
-  mkdirSync(homeCotalDir(), { recursive: true });
+  mkdirSync(homeCotalDir(), { recursive: true, mode: 0o700 });
   writeFileSync(MARKER(), JSON.stringify({ version, ts: new Date().toISOString() }, null, 2));
 }

--- a/implementations/cli/src/lib/onboard.ts
+++ b/implementations/cli/src/lib/onboard.ts
@@ -1,17 +1,17 @@
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
+import { homeCotalDir } from "@cotal-ai/core";
 
 /** Machine-level "I've onboarded before" marker. Its presence flips `cotal` from the
  *  full first-run flow to the compact ensure+status run. Lives next to the materialized
- *  plugin marketplace under ~/.cotal. */
-const MARKER = join(homedir(), ".cotal", "onboarded.json");
+ *  plugin marketplace under ~/.cotal (COTAL_HOME-overridable, via {@link homeCotalDir}). */
+const MARKER = () => join(homeCotalDir(), "onboarded.json");
 
 export function isOnboarded(): boolean {
-  return existsSync(MARKER);
+  return existsSync(MARKER());
 }
 
 export function markOnboarded(version: string): void {
-  mkdirSync(join(homedir(), ".cotal"), { recursive: true });
-  writeFileSync(MARKER, JSON.stringify({ version, ts: new Date().toISOString() }, null, 2));
+  mkdirSync(homeCotalDir(), { recursive: true });
+  writeFileSync(MARKER(), JSON.stringify({ version, ts: new Date().toISOString() }, null, 2));
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "smoke:install": "tsx implementations/cli/smoke/install.smoke.ts",
     "smoke:send": "tsx implementations/cli/smoke/send.smoke.ts",
     "smoke:spawn-from-anywhere": "tsx implementations/cli/smoke/spawn-from-anywhere.smoke.ts",
+    "smoke:spawn-from-anywhere:live": "tsx implementations/cli/smoke/spawn-from-anywhere-live.smoke.ts",
     "smoke:delivery-cred:auth": "tsx packages/core/smoke/delivery-cred-confinement.smoke.ts",
     "smoke:delivery-reply-injection:auth": "tsx packages/core/smoke/delivery-reply-injection.smoke.ts",
     "smoke:delivery-shards-reject": "tsx implementations/delivery/smoke/delivery-shards-reject.smoke.ts",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "smoke:spawn-args": "tsx extensions/connector-core/smoke/spawn-args.smoke.ts",
     "smoke:install": "tsx implementations/cli/smoke/install.smoke.ts",
     "smoke:send": "tsx implementations/cli/smoke/send.smoke.ts",
+    "smoke:spawn-from-anywhere": "tsx implementations/cli/smoke/spawn-from-anywhere.smoke.ts",
     "smoke:delivery-cred:auth": "tsx packages/core/smoke/delivery-cred-confinement.smoke.ts",
     "smoke:delivery-reply-injection:auth": "tsx packages/core/smoke/delivery-reply-injection.smoke.ts",
     "smoke:delivery-shards-reject": "tsx implementations/delivery/smoke/delivery-shards-reject.smoke.ts",

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -2550,3 +2550,37 @@ export async function isReachable(
     return e instanceof AuthorizationError || e instanceof UserAuthenticationExpiredError;
   }
 }
+
+/** What a connect attempt told us about the server — the distinction {@link isReachable} flattens.
+ *  `auth-required` means a server answered but rejected these creds (so it IS up); `unreachable`
+ *  means nothing answered (refused / timeout / a stale registry entry). */
+export type ProbeResult =
+  | { ok: true }
+  | { ok: false; reason: "auth-required" }
+  | { ok: false; reason: "unreachable" };
+
+/** Like {@link isReachable}, but distinguishes "up but won't take these creds" from "nothing there".
+ *  `spawn` needs the difference: auth-required → name the trust dir + next step; unreachable → the
+ *  mesh is down (prune the stale entry, tell the user to `cotal up`). Pass `creds` to confirm a
+ *  specific identity is accepted (`ok`); omit them to probe mere liveness (an auth broker answers
+ *  `auth-required`, which still proves it's up). */
+export async function probeConnect(
+  server: string = DEFAULT_SERVER,
+  opts: AuthOpts & { timeoutMs?: number } = {},
+): Promise<ProbeResult> {
+  try {
+    const nc = await connect({
+      servers: server,
+      timeout: opts.timeoutMs ?? 1000,
+      reconnect: false,
+      maxReconnectAttempts: 0,
+      ...authOpts(opts),
+    });
+    await nc.close();
+    return { ok: true };
+  } catch (e) {
+    if (e instanceof AuthorizationError || e instanceof UserAuthenticationExpiredError)
+      return { ok: false, reason: "auth-required" };
+    return { ok: false, reason: "unreachable" };
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,8 @@ export * from "./resolve.js";
 export * from "./link.js";
 export * from "./identity.js";
 export * from "./provision.js";
+export * from "./mesh-registry.js";
+export * from "./mesh-target.js";
 export * from "./streams.js";
 export * from "./channels.js";
 export * from "./members.js";

--- a/packages/core/src/mesh-registry.ts
+++ b/packages/core/src/mesh-registry.ts
@@ -56,7 +56,9 @@ function currentFile(): string {
 
 /** Record (or refresh) a running mesh — atomic write, 0600 (the file points at a secrets dir). */
 export function recordMesh(m: MeshEntry): void {
-  mkdirSync(meshesDir(), { recursive: true });
+  // 0700: the filenames in here ARE the space names, so a world-traversable dir would leak them to
+  // other local users even though the file contents are 0600. Keep the dir readable only by us.
+  mkdirSync(meshesDir(), { recursive: true, mode: 0o700 });
   const file = meshFile(m.space);
   // Per-process temp name so two concurrent `up`s for the same space can't stomp each other's
   // half-written file before the rename.
@@ -106,7 +108,7 @@ export function getCurrent(): string | undefined {
 }
 
 export function setCurrent(space: string): void {
-  mkdirSync(homeCotalDir(), { recursive: true });
+  mkdirSync(homeCotalDir(), { recursive: true, mode: 0o700 });
   writeFileSync(currentFile(), space, { mode: 0o600 });
 }
 

--- a/packages/core/src/mesh-registry.ts
+++ b/packages/core/src/mesh-registry.ts
@@ -58,7 +58,9 @@ function currentFile(): string {
 export function recordMesh(m: MeshEntry): void {
   mkdirSync(meshesDir(), { recursive: true });
   const file = meshFile(m.space);
-  const tmp = `${file}.tmp`;
+  // Per-process temp name so two concurrent `up`s for the same space can't stomp each other's
+  // half-written file before the rename.
+  const tmp = `${file}.${process.pid}.tmp`;
   writeFileSync(tmp, JSON.stringify(m, null, 2), { mode: 0o600 });
   renameSync(tmp, file); // atomic replace — a reader never sees a half-written record
 }

--- a/packages/core/src/mesh-registry.ts
+++ b/packages/core/src/mesh-registry.ts
@@ -1,0 +1,113 @@
+import {
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * The registry of running meshes: one record per broker `cotal up` started on this machine, so a
+ * `cotal spawn` from *any* directory can find which mesh to join, with which creds and personas.
+ *
+ * Stored as **one JSON file per mesh** (`~/.cotal/meshes/<space>.json`) rather than a single
+ * `meshes.json`: concurrent `up`/`down` never read-modify-write the same file (no lost-update race),
+ * a crash damages at most one entry, and it mirrors the existing per-process pid files under
+ * `~/.cotal`. A separate `~/.cotal/current-mesh` holds the default space for the N-running case
+ * (the kubectl `current-context` analogue).
+ *
+ * Each record stores the mesh's **root path**, not its secrets — trust material stays in that
+ * project's `.cotal/auth`; the registry just makes it findable from elsewhere.
+ */
+export interface MeshEntry {
+  /** The space name — also the registry filename stem. */
+  space: string;
+  /** The broker URL, e.g. `nats://127.0.0.1:4222`. */
+  server: string;
+  /** Absolute path whose `.cotal/{auth,agents}` hold this mesh's trust material + personas. */
+  root: string;
+  mode: "auth" | "open";
+  /** ISO timestamp of when the record was written. */
+  ts: string;
+}
+
+/** The cotal machine-home dir (`~/.cotal`), overridable via `COTAL_HOME` so tests sandbox it and
+ *  never touch the real one. The single source of that path for the registry, the current pointer,
+ *  and the onboard marker. */
+export function homeCotalDir(): string {
+  return process.env.COTAL_HOME ?? join(homedir(), ".cotal");
+}
+
+/** Directory holding the per-mesh registry files (`~/.cotal/meshes`). */
+export function meshesDir(): string {
+  return join(homeCotalDir(), "meshes");
+}
+
+function meshFile(space: string): string {
+  return join(meshesDir(), `${encodeURIComponent(space)}.json`);
+}
+
+function currentFile(): string {
+  return join(homeCotalDir(), "current-mesh");
+}
+
+/** Record (or refresh) a running mesh — atomic write, 0600 (the file points at a secrets dir). */
+export function recordMesh(m: MeshEntry): void {
+  mkdirSync(meshesDir(), { recursive: true });
+  const file = meshFile(m.space);
+  const tmp = `${file}.tmp`;
+  writeFileSync(tmp, JSON.stringify(m, null, 2), { mode: 0o600 });
+  renameSync(tmp, file); // atomic replace — a reader never sees a half-written record
+}
+
+/** Drop a mesh from the registry (on `cotal down` / a stale-entry prune). Absent ⇒ no-op. */
+export function removeMesh(space: string): void {
+  rmSync(meshFile(space), { force: true });
+}
+
+/** All currently-recorded meshes. An unparseable/partially-written entry is skipped, not fatal —
+ *  one bad file must not hide the rest. */
+export function loadMeshes(): MeshEntry[] {
+  let files: string[];
+  try {
+    files = readdirSync(meshesDir()).filter((f) => f.endsWith(".json"));
+  } catch {
+    return []; // no registry yet
+  }
+  const out: MeshEntry[] = [];
+  for (const f of files.sort()) {
+    try {
+      out.push(JSON.parse(readFileSync(join(meshesDir(), f), "utf8")) as MeshEntry);
+    } catch {
+      /* skip a corrupt/half-written entry rather than fail the whole listing */
+    }
+  }
+  return out;
+}
+
+export function findMesh(space: string): MeshEntry | undefined {
+  return loadMeshes().find((m) => m.space === space);
+}
+
+/** The default mesh's space name, set by `cotal use` (and by the first `cotal up`). Undefined when
+ *  unset or empty. The pointer can dangle (its mesh went down); callers treat a `findMesh` miss as
+ *  "no current". */
+export function getCurrent(): string | undefined {
+  try {
+    return readFileSync(currentFile(), "utf8").trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function setCurrent(space: string): void {
+  mkdirSync(homeCotalDir(), { recursive: true });
+  writeFileSync(currentFile(), space, { mode: 0o600 });
+}
+
+export function clearCurrent(): void {
+  rmSync(currentFile(), { force: true });
+}

--- a/packages/core/src/mesh-target.ts
+++ b/packages/core/src/mesh-target.ts
@@ -28,7 +28,18 @@ export interface MeshTarget {
   auth?: SpaceAuth;
   /** `<root>/.cotal/agents` — the persona catalog for this mesh. */
   personaRoot: string;
-  source: "flag-server" | "flag-space" | "local-space" | "registry" | "current";
+  /** Where the target came from — this also carries OWNERSHIP for pruning. Every value except
+   *  `local-space` and `flag-server` (the two non-registry escape hatches) means the server + mode
+   *  came from a registry record, so a stale-broker failure prunes it. `local-recorded` is a local
+   *  project matched to a registry entry by root: registry-owned for pruning, but quiet on the
+   *  success line (the target is self-evident from cwd, like `local-space`). */
+  source:
+    | "flag-server"
+    | "flag-space"
+    | "local-space"
+    | "local-recorded"
+    | "registry"
+    | "current";
 }
 
 export interface ResolveFlags {
@@ -97,7 +108,18 @@ export function resolveMeshTarget(cwd: string, flags: ResolveFlags = {}): MeshTa
     // and a recorded OPEN mesh must not mint creds off stale `.cotal/auth` left on disk. Fall back
     // to the local default only when nothing is recorded for this root.
     const recorded = loadMeshes().find((m) => resolve(m.root) === resolve(root));
-    if (recorded) return targetFromEntry(recorded, recorded.server, "local-space");
+    if (recorded) return targetFromEntry(recorded, recorded.server, "local-recorded");
+    // No record for this root (migration, or our broker went down and the entry was just pruned).
+    // Before guessing DEFAULT_SERVER, refuse if a DIFFERENT mesh is recorded there — otherwise the
+    // fallback would silently join someone else's mesh on the default port with our persona (the
+    // exact silent-wrong-mesh outcome this feature exists to prevent).
+    const onDefault = loadMeshes().find(
+      (m) => m.server === DEFAULT_SERVER && resolve(m.root) !== resolve(root),
+    );
+    if (onDefault)
+      throw new Error(
+        `another mesh ("${onDefault.space}") is running at ${DEFAULT_SERVER} — run \`cotal up\` here to start yours, or \`--space ${onDefault.space}\` to join it`,
+      );
     return localTarget(root, DEFAULT_SERVER, "local-space");
   }
 

--- a/packages/core/src/mesh-target.ts
+++ b/packages/core/src/mesh-target.ts
@@ -47,7 +47,10 @@ function targetFromEntry(m: MeshEntry, server: string, source: MeshTarget["sourc
     root: m.root,
     server,
     space: m.space,
-    auth: loadSpaceAuth(authDir(m.root)),
+    // Honor the recorded mode: an OPEN mesh connects credlessly even if its root still has auth
+    // material on disk (e.g. a root that once ran auth mode). Loading it would make `spawn` mint
+    // creds against a broker that takes none.
+    auth: m.mode === "auth" ? loadSpaceAuth(authDir(m.root)) : undefined,
     personaRoot: personaRoot(m.root),
     source,
   };

--- a/packages/core/src/mesh-target.ts
+++ b/packages/core/src/mesh-target.ts
@@ -91,7 +91,15 @@ export function resolveMeshTarget(cwd: string, flags: ResolveFlags = {}): MeshTa
   }
 
   const root = findCotalRoot(cwd);
-  if (isGenuineSpace(root)) return localTarget(root, DEFAULT_SERVER, "local-space");
+  if (isGenuineSpace(root)) {
+    // Local project wins by root — but if its mesh is in the registry, use the RECORDED server +
+    // mode, not DEFAULT_SERVER: a project started with `--server …:4333` must spawn against :4333,
+    // and a recorded OPEN mesh must not mint creds off stale `.cotal/auth` left on disk. Fall back
+    // to the local default only when nothing is recorded for this root.
+    const recorded = loadMeshes().find((m) => resolve(m.root) === resolve(root));
+    if (recorded) return targetFromEntry(recorded, recorded.server, "local-space");
+    return localTarget(root, DEFAULT_SERVER, "local-space");
+  }
 
   const meshes = loadMeshes();
   if (meshes.length === 0)

--- a/packages/core/src/mesh-target.ts
+++ b/packages/core/src/mesh-target.ts
@@ -1,0 +1,104 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { DEFAULT_SERVER, DEFAULT_SPACE } from "./endpoint.js";
+import { authDir, findCotalRoot, loadSpaceAuth, type SpaceAuth } from "./provision.js";
+import {
+  findMesh,
+  getCurrent,
+  homeCotalDir,
+  loadMeshes,
+  type MeshEntry,
+} from "./mesh-registry.js";
+
+/**
+ * One coherent answer to "which mesh does this command act on, and where do its creds + personas
+ * live" — resolved identically for both, so a spawn can never authenticate to mesh A while loading
+ * mesh B's persona. Replaces the scattered `loadSpaceAuth(authDir(cotalRoot()))` + `resolveSpace` +
+ * `DEFAULT_SERVER` guesswork that silently mistook `~/.cotal` for a space.
+ *
+ * Pure and offline (no network): `<TAB>` completion uses it as-is; `spawn` adds a reachability
+ * preflight (`probeConnect`) on top.
+ */
+export interface MeshTarget {
+  /** Absolute dir whose `.cotal/{auth,agents}` hold trust + personas. */
+  root: string;
+  server: string;
+  space: string;
+  /** Trust material, or undefined for an open mesh. */
+  auth?: SpaceAuth;
+  /** `<root>/.cotal/agents` — the persona catalog for this mesh. */
+  personaRoot: string;
+  source: "flag-server" | "flag-space" | "local-space" | "registry" | "current";
+}
+
+export interface ResolveFlags {
+  /** `--server <url>` — raw broker escape hatch. */
+  server?: string;
+  /** `--space <name>` — pick a specific running mesh from the registry. */
+  space?: string;
+}
+
+function personaRoot(root: string): string {
+  return join(root, ".cotal", "agents");
+}
+
+function targetFromEntry(m: MeshEntry, server: string, source: MeshTarget["source"]): MeshTarget {
+  return {
+    root: m.root,
+    server,
+    space: m.space,
+    auth: loadSpaceAuth(authDir(m.root)),
+    personaRoot: personaRoot(m.root),
+    source,
+  };
+}
+
+function localTarget(root: string, server: string, source: MeshTarget["source"]): MeshTarget {
+  const auth = loadSpaceAuth(authDir(root));
+  return { root, server, space: auth?.space ?? DEFAULT_SPACE, auth, personaRoot: personaRoot(root), source };
+}
+
+/** A `.cotal/` that a user actually created here — not the machine-home dir the cwd walk-up lands on
+ *  from outside any project (which has no space, just the daemon's pid/onboard files). */
+function isGenuineSpace(root: string): boolean {
+  return join(root, ".cotal") !== homeCotalDir() && existsSync(join(root, ".cotal"));
+}
+
+/**
+ * Resolve the mesh target by precedence (first match wins):
+ *  1. `--space` — registry lookup (errors if that space isn't running).
+ *  2. `--server` — registry entry on that server (for creds/personas), else the local project.
+ *  3. A genuine local project (`cwd` walks up to a real `.cotal/`) — local wins, like `git config`.
+ *  4. The registry: 0 ⇒ error; 1 ⇒ use it; N ⇒ `current` if set, else error naming each + its root.
+ * No silent fallback — an unresolved target throws one human sentence.
+ */
+export function resolveMeshTarget(cwd: string, flags: ResolveFlags = {}): MeshTarget {
+  if (flags.space) {
+    const m = findMesh(flags.space);
+    if (!m) throw new Error(`no mesh named "${flags.space}" is running — see \`cotal meshes\``);
+    return targetFromEntry(m, flags.server ?? m.server, "flag-space");
+  }
+
+  if (flags.server) {
+    const m = loadMeshes().find((e) => e.server === flags.server);
+    if (m) return targetFromEntry(m, flags.server, "flag-server");
+    return localTarget(findCotalRoot(cwd), flags.server, "flag-server");
+  }
+
+  const root = findCotalRoot(cwd);
+  if (isGenuineSpace(root)) return localTarget(root, DEFAULT_SERVER, "local-space");
+
+  const meshes = loadMeshes();
+  if (meshes.length === 0)
+    throw new Error("no mesh running — run `cotal up` in a project, or pass `--server`");
+  if (meshes.length === 1) return targetFromEntry(meshes[0], meshes[0].server, "registry");
+
+  const current = getCurrent();
+  const cur = current ? findMesh(current) : undefined;
+  if (cur) return targetFromEntry(cur, cur.server, "current");
+
+  const names = meshes.map((m) => `${m.space} (${m.root})`).join(", ");
+  throw new Error(
+    `multiple meshes running — ${names}. Pick one with \`--space <name>\` or set a default with \`cotal use <name>\`.`,
+  );
+}

--- a/packages/core/src/mesh-target.ts
+++ b/packages/core/src/mesh-target.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { DEFAULT_SERVER, DEFAULT_SPACE } from "./endpoint.js";
 import { authDir, findCotalRoot, loadSpaceAuth, type SpaceAuth } from "./provision.js";
 import {
@@ -61,7 +61,9 @@ function localTarget(root: string, server: string, source: MeshTarget["source"])
 /** A `.cotal/` that a user actually created here — not the machine-home dir the cwd walk-up lands on
  *  from outside any project (which has no space, just the daemon's pid/onboard files). */
 function isGenuineSpace(root: string): boolean {
-  return join(root, ".cotal") !== homeCotalDir() && existsSync(join(root, ".cotal"));
+  // Normalize both sides — COTAL_HOME may be relative or non-canonical, and a raw string compare
+  // would then let the real `~/.cotal` masquerade as a project space (or vice-versa).
+  return resolve(join(root, ".cotal")) !== resolve(homeCotalDir()) && existsSync(join(root, ".cotal"));
 }
 
 /**


### PR DESCRIPTION
## What

`cotal spawn <persona>` now joins an already-running mesh from **any** working directory — launched as the named persona, authed with that mesh's credentials and personas — without `cd`-ing into the project that ran `cotal up`.

## Why

Both auth (`loadSpaceAuth(authDir(cotalRoot()))`) and the persona catalog (`<cotalRoot()>/.cotal/agents`) keyed off a git-style cwd walk-up. From outside the project that lands on `$HOME/.cotal` (no `auth/`, no `agents/`) → a credless connect → a raw `Authorization Violation` NATS crash (unguarded `ep.start()`), or a persona ENOENT. The bar: no silent degradation, no wrong persona, no raw crash.

## Design

- **Registry of running meshes** — one file per mesh `~/.cotal/meshes/<space>.json` (no read-modify-write race; a crash damages ≤1 entry) + a `~/.cotal/current-mesh` pointer (the kubectl `current-context` analogue).
- **One resolver** `resolveMeshTarget` returns creds + personas + server together, so a spawn can never auth to mesh A while loading mesh B's persona. Precedence: `--space` → `--server` → genuine local project → registry (0 ⇒ error, 1 ⇒ use, N ⇒ `current` or error naming each root). No silent fallback.
- **`probeConnect` preflight** distinguishes `unreachable` from `auth-required` (the trap `isReachable` fell into) and replaces the raw NATS trace with one sentence; prunes stale entries.
- **New commands** `cotal meshes` (list, `*` = current) and `cotal use <space>` (set default). Port-collision on `up` now errors instead of warning.
- Multi-space-forward: the registry is keyed by space and entries may share a server.

## Review

Reviewed across five lenses on the mesh (`#review.spawn-from-anywhere`), six fix rounds total:

- **correctness** (review-general / review-general-2) · **UX** (norman) · **fact-check** (truthium) · **security** (mitnick) · **senior-eng** (fowler).
- Fixes landed: recorded `--server`/mode honored in-project (was hardcoded `:4222`, a wrong-mesh bug); `auth-required` errors split four ways (each names the real situation, prunes only when registry-owned); `local-recorded` source so a stale recorded-local entry prunes instead of lingering; a default-port guard refusing a silent wrong-mesh fallback; registry dir tightened to `0700` (its filenames are space names).

## Tests

- Hermetic smoke `spawn-from-anywhere` (**23 checks**, `COTAL_HOME`-sandboxed, no broker): every resolver branch, offline completion, open-vs-auth mode gating, the wrong-mesh guard, `0700` perms, stale prune.
- Auth-mode e2e on isolated ports; `pnpm typecheck` green across all 16 projects.

## Follow-on (immediate next PR)

Migrate `dm` / `watch` / `join` / `web` off `cotalRoot()` to `resolveMeshTarget` — they still crash the same way from outside a project, so "spawn works, watch doesn't" is a half-fixed tree. That PR also folds in the deferred review notes: assert `auth.space === m.space` in `targetFromEntry`; the in-project `localTarget` open/auth mint-vs-credless residual; probe-timeout handling for remote brokers; `removeMesh` self-clearing `current`; the stale-`current` dim line; `down`-help / dangling-`current` notes.

The `mesh-registry` / `homeCotalDir` placement in `@cotal-ai/core` is a deliberate pragmatic call — cli and manager can't import each other, so core is their only shared home, following the existing `cotalRoot` / `provision.ts` precedent. Revisit a `packages/host` tier only if host-local state keeps growing.
