### PR TITLE
fix(manager): spawn by persona filename, identity from the file's name:

### DIFF
--- a/.changeset/manager-persona-acl.md
+++ b/.changeset/manager-persona-acl.md
@@ -1,0 +1,14 @@
+---
+"@cotal-ai/manager": patch
+"@cotal-ai/connector-core": patch
+---
+
+fix(manager): spawn by persona filename, identity from the file's `name:`
+
+A manager spawn (`start` op / `cotal_spawn` / roster boot) resolved the persona by the spawn
+name but, on a miss, silently minted default creds (read `general` only, default-deny publish, no
+capabilities) — so a persona spawned by its display name, a typo, or a renamed file became a live
+agent with silently-wrong ACLs. The manager now matches `cotal spawn`: the argument is a persona
+ref (a filename in `.cotal/agents`, the unique key), the mesh identity comes from the file's
+`name:` (auto-numbered on collision), a missing persona fails loud, and the read/post ACL is always
+provisioned from the loaded persona — never a default.

--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -474,15 +474,15 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
       description:
         "Ask the manager to start a new peer endpoint in your space. It joins the mesh as a lateral peer (and, when the manager runs the cmux runtime, appears in its own tab). Use when the team needs another agent.",
       schema: {
-        name: z.string().describe("Name for the new peer; auto-numbered (e.g. reviewer-2) if taken."),
+        name: z.string().describe("Which persona to spawn — the persona FILENAME in .cotal/agents (e.g. `review-critic`), without the .md. The new peer joins under the persona's own `name:` (auto-numbered, e.g. socrates-2, if that's taken). Fails if no such persona file exists — spawn an existing persona, don't invent a name."),
         role: z
           .string()
           .optional()
-          .describe("Optional role for the new peer (e.g. worker, reviewer)."),
+          .describe("Optional role for the new peer (e.g. worker, reviewer); overrides the persona file's role."),
         agent: z
           .string()
           .optional()
-          .describe("Optional harness the new peer runs on — the agent/connector type (claude, opencode, hermes), NOT the peer's display name (that's `name`). Defaults to the manager's default (Claude)."),
+          .describe("Optional harness the new peer runs on — the agent/connector type (claude, opencode, hermes), NOT the persona to spawn (that's `name`). Defaults to the manager's default (Claude)."),
         model: z
           .string()
           .optional()

--- a/implementations/manager/smoke/persona-identity-acl.smoke.ts
+++ b/implementations/manager/smoke/persona-identity-acl.smoke.ts
@@ -1,0 +1,89 @@
+/**
+ * Persona identity + ACL smoke — proves a manager spawn resolves the persona by FILENAME but takes
+ * the mesh IDENTITY from inside the file (`name:`), and mints the file's read/post ACL — never a
+ * silent default. Regression guard for the "spawned-by-display-name → default-ACL agent" bug.
+ * No broker, no real harness: real crypto (createSpaceAuth + the manager's mint path), a fake
+ * runtime + a no-op DurableProvisioner ep stub, and we DECODE the written creds JWT to read the ACL.
+ * Run with: pnpm smoke:persona-acl
+ */
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Manager } from "../src/manager.js";
+import { createSpaceAuth, registry, type Connector, type LaunchSpec, type AgentHandle } from "@cotal-ai/core";
+
+let failures = 0;
+function check(label: string, cond: boolean, extra?: unknown): void {
+  console.log(`${cond ? "✓" : "✗"} ${label}${cond ? "" : ` — ${extra ?? ""}`}`);
+  if (!cond) failures++;
+}
+
+// Decode the `nats` permission block out of a minted creds file (the JWT is the first line after the
+// BEGIN marker; its middle segment is base64url JSON).
+function credAcl(path: string): { sub: string[]; pub: string[] } {
+  const jwt = readFileSync(path, "utf8").split("\n").find((l) => l && !l.startsWith("-") && l.split(".").length === 3)!;
+  const claims = JSON.parse(Buffer.from(jwt.split(".")[1], "base64url").toString("utf8"));
+  const nats = claims.nats ?? {};
+  const chat = (arr: string[] | undefined, keepJs: boolean) =>
+    (arr ?? []).filter((s) => s.includes(".chat.") && (keepJs || !s.startsWith("$JS")));
+  return { sub: chat(nats.sub?.allow, true), pub: chat(nats.pub?.allow, false) };
+}
+
+const workspaceRoot = mkdtempSync(join(tmpdir(), "cotal-persona-acl-"));
+const agentsDir = join(workspaceRoot, ".cotal", "agents");
+mkdirSync(agentsDir, { recursive: true });
+// Filename (review-critic) ≠ in-file name (socrates); a non-default read/post ACL.
+writeFileSync(
+  join(agentsDir, "review-critic.md"),
+  "---\nname: socrates\nrole: critic\nsubscribe: [review]\nallowSubscribe: [review, review.>]\nallowPublish: [review.>]\n---\nbody\n",
+);
+
+const mgr = new Manager({ space: "demo", servers: undefined, runtime: "pty", workspaceRoot });
+// Real space trust material so the mint path runs end to end (pure crypto, no broker).
+(mgr as unknown as { auth: unknown }).auth = await createSpaceAuth("demo");
+
+// Fake runtime (records the spec, launches nothing) + an ep stub that is both ref() and a no-op
+// DurableProvisioner (the manager hands its ep to provisionAgent).
+const fakeSession = { cols: 80, rows: 24, backlog: () => Buffer.alloc(0), onData: () => () => {}, onExit: () => () => {}, write: () => {}, resize: () => {} };
+const fakeHandle = (name: string): AgentHandle => ({ name, kind: "fake", status: () => "running", stop: () => {}, interrupt: () => {}, attach: () => fakeSession });
+(mgr as unknown as { runtime: { kind: string; spawn: (n: string, s: LaunchSpec) => AgentHandle } }).runtime = {
+  kind: "fake",
+  spawn: (name) => fakeHandle(name),
+};
+(mgr as unknown as { ep: Record<string, unknown> }).ep = {
+  ref: () => ({ id: "smoke-mgr" }),
+  provisionDmInbox: async () => {},
+  provisionDlvInbox: async () => {},
+  commitAcl: async () => {},
+  provisionTaskQueue: async () => {},
+};
+
+const recCon: Connector = { kind: "connector", name: "smoke-rec2", requires: ["node"], buildLaunch: () => ({ command: "true", args: [], env: {} }) };
+registry.register(recCon);
+
+// 1 — Spawn by FILENAME; identity comes from the file's name:, ACL from the file (not default).
+{
+  const reply = await mgr.startAgent({ name: "review-critic", agent: "smoke-rec2" });
+  check("spawn by filename succeeds", reply.ok === true, reply);
+  check("identity is the file's name: (socrates), not the filename", reply.ok && reply.data?.name === "socrates", reply.ok && reply.data?.name);
+
+  const acl = credAcl(join(workspaceRoot, ".cotal", "auth", "creds", "socrates.creds"));
+  check("read ACL is the persona's review scope", acl.sub.some((s) => s.endsWith(".review")) && acl.sub.some((s) => s.endsWith(".review.>")), acl.sub);
+  check("post ACL is the persona's review.> (not default-deny)", acl.pub.some((s) => s.includes(".review.>")), acl.pub);
+  check("NOT the silent default (general-only read)", !(acl.sub.length === 1 && acl.sub[0].endsWith(".general")), acl.sub);
+}
+
+// 2 — Spawning by the DISPLAY name (socrates) fails loud — there is no socrates.md; you spawn by file.
+{
+  const reply = await mgr.startAgent({ name: "socrates", agent: "smoke-rec2" });
+  check("spawn by display-name fails loud (no socrates.md)", reply.ok === false && /no persona "socrates"/.test(reply.error ?? ""), reply);
+}
+
+// 3 — A second spawn of the same persona auto-numbers the IDENTITY (socrates → socrates-2).
+{
+  const reply = await mgr.startAgent({ name: "review-critic", agent: "smoke-rec2" });
+  check("second spawn auto-numbers the identity", reply.ok && reply.data?.name === "socrates-2", reply.ok && reply.data?.name);
+}
+
+console.log(`\nPERSONA-IDENTITY/ACL SMOKE ${failures === 0 ? "OK ✅" : "FAILED ❌"}`);
+process.exit(failures === 0 ? 0 : 1);

--- a/implementations/manager/smoke/start-model-preflight.smoke.ts
+++ b/implementations/manager/smoke/start-model-preflight.smoke.ts
@@ -11,7 +11,7 @@
  *   3. Model PRECEDENCE — across the three real connectors: flag > agent-file `model:`, the flag
  *      applies with no agent file, and the file is the fallback (the actual bug the fix closes).
  */
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, delimiter } from "node:path";
 import { Manager } from "../src/manager.js";
@@ -27,8 +27,13 @@ function check(label: string, cond: boolean, extra?: unknown): void {
   if (!cond) failures++;
 }
 
-// A workspace with no `.cotal/` so no agent file / cotal config is discovered for a bare name.
+// A workspace with no cotal *config*. A manager spawn now REQUIRES a discoverable persona (no
+// silent default-ACL fallback), so seed a minimal `.cotal/agents/<name>.md` per spawned name —
+// this test's subject is harness preflight + model threading, not persona/ACL resolution.
 const workspaceRoot = mkdtempSync(join(tmpdir(), "cotal-start-ws-"));
+const agentsDir = join(workspaceRoot, ".cotal", "agents");
+mkdirSync(agentsDir, { recursive: true });
+for (const n of ["reject1", "rec1", "rec2"]) writeFileSync(join(agentsDir, `${n}.md`), `---\nname: ${n}\n---\n`);
 const mgr = new Manager({ space: "smoke", servers: undefined, runtime: "pty", workspaceRoot });
 
 // Inert handle/runtime: the success branch records the built spec but launches nothing; the `ep`

--- a/implementations/manager/src/commands.ts
+++ b/implementations/manager/src/commands.ts
@@ -252,7 +252,7 @@ async function runManager(argv: string[], defaultRuntime: RuntimeMode): Promise<
     c.green("✓ manager up") +
       c.dim(` (space ${space} · ${mgr.runtimeKind})`) +
       `\n  console: ${mgr.consoleUrl}` +
-      c.dim("\n  spawn: cotal start --name <n>   ·   stop: cotal stop --name <n>   (Ctrl-C to shut down)"),
+      c.dim("\n  spawn: cotal start --name <persona>   ·   stop: cotal stop --name <n>   (Ctrl-C to shut down)"),
   );
   // Register shutdown handlers before any spawning, so a Ctrl-C during the (possibly slow,
   // staggered) boot tears the manager and its spawned teammates down rather than orphaning them.
@@ -264,7 +264,9 @@ async function runManager(argv: string[], defaultRuntime: RuntimeMode): Promise<
   // fix the roster without the supervisor crash-looping.
   for (const entry of roster) {
     const reply = await mgr.startAgent(entry);
-    if (reply.ok) console.log(c.green(`✓ started ${c.bold(entry.name)}`) + c.dim(` (${entry.agent})`));
+    // Log the spawned IDENTITY (the persona's name:), which can differ from entry.name (the file ref).
+    const spawned = (reply.data as { name?: string } | undefined)?.name ?? entry.name;
+    if (reply.ok) console.log(c.green(`✓ started ${c.bold(spawned)}`) + c.dim(` (${entry.agent})`));
     else console.error(c.red(`✗ ${entry.name}: ${reply.error}`));
   }
   // Pre-spawn teammates the manager owns (e.g. the demo's david/sven), so they're despawnable.
@@ -273,16 +275,20 @@ async function runManager(argv: string[], defaultRuntime: RuntimeMode): Promise<
   if (v.spawn) {
     const names = v.spawn.split(",").map((s) => s.trim()).filter(Boolean);
     for (let i = 0; i < names.length; i++) {
-      const name = names[i];
-      const reply = await mgr.startByName(name);
+      const ref = names[i];
+      const reply = await mgr.startByName(ref);
       if (!reply.ok) {
-        console.error(c.red(`✗ couldn't spawn ${name}: ${reply.error ?? "unknown error"}`));
+        console.error(c.red(`✗ couldn't spawn ${ref}: ${reply.error ?? "unknown error"}`));
         continue;
       }
-      console.log(c.green(`✓ spawned ${name}`));
+      // The peer joins under its persona's name: (the spawned identity), which may differ from the
+      // ref filename — wait on (and log) THAT, or staggering blocks the full timeout on a name that
+      // never appears (e.g. ref review-critic → identity socrates).
+      const spawned = (reply.data as { name?: string } | undefined)?.name ?? ref;
+      console.log(c.green(`✓ spawned ${spawned}`));
       if (i < names.length - 1) {
-        const joined = await mgr.waitForPresence(name);
-        console.log(c.dim(joined ? `  ${name} joined; starting next` : `  ${name} still starting; continuing`));
+        const joined = await mgr.waitForPresence(spawned);
+        console.log(c.dim(joined ? `  ${spawned} joined; starting next` : `  ${spawned} still starting; continuing`));
       }
     }
   }
@@ -306,7 +312,7 @@ const managerCommands: Command[] = [
     name: "start",
     group: "Control plane",
     summary:
-      "ask the manager to spawn an agent — --name <n> [--role <r>] [--agent <a>] [--config <file>] [--model <m>] (auto-discovers .cotal/agents/<n>.md)",
+      "ask the manager to spawn a persona — --name <persona> [--role <r>] [--agent <a>] [--config <file>] [--model <m>] (loads .cotal/agents/<persona>.md; the peer joins under its name:)",
     run: start,
   },
   {

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -78,11 +78,15 @@ export interface ManagerOptions {
 /** A spawn request, typed. The control-plane `start` op parses one of these out of an
  *  untyped request; roster boot constructs them directly. Both funnel into {@link Manager.startAgent}. */
 export interface StartAgentOpts {
+  /** The persona REF to spawn — a filename in `.cotal/agents` (the unique spawn key), discovered as
+   *  `.cotal/agents/<name>.md`. NOT the mesh identity: the spawned peer presents under the file's
+   *  own `name:` (auto-numbered on collision). The file must exist (no silent default-ACL fallback). */
   name: string;
   /** Connector / agent type — resolved from the registry. Defaults to `"cotal"`. */
   agent?: string;
   role?: string;
-  /** Explicit agent-file name-or-path; otherwise `.cotal/agents/<name>.md` is discovered if present. */
+  /** Explicit agent-file path that overrides the `name` ref for *which file to load* (identity still
+   *  comes from that file's `name:`). The file must exist. */
   config?: string;
   /** Model override (the `--model` flag). Takes precedence over the agent file's `model:`. */
   model?: string;
@@ -334,8 +338,9 @@ export class Manager {
     return firstFreeName(base, (n) => this.agents.has(n) || this.reserved.has(n));
   }
 
-  /** Spawn a teammate by name (loads `.cotal/agents/<name>.md`), as if a peer asked via the
-   *  control plane. Used to pre-spawn the demo's experts at startup so the manager owns them. */
+  /** Spawn a teammate by persona ref (`name` loads `.cotal/agents/<name>.md`; the peer presents
+   *  under that file's own `name:`), as if a peer asked via the control plane. Used to pre-spawn the
+   *  demo's experts at startup so the manager owns them. */
   async startByName(name: string): Promise<ControlReply> {
     return this.startAgent({ name });
   }
@@ -376,97 +381,115 @@ export class Manager {
    *  defaulting to the manager's own id for roster/pre-spawn — recorded for the spawner
    *  ledger (own-children despawn + reap-on-parent-exit). */
   async startAgent(opts: StartAgentOpts, spawner?: string): Promise<ControlReply> {
-    const base = opts.name.trim();
-    if (!base) return { ok: false, error: "name required" };
-    const nameErr = this.nameError(base);
-    if (nameErr) return { ok: false, error: nameErr };
+    // The spawn argument is a persona REF — a filename in `.cotal/agents` (the unique spawn KEY), or
+    // a path via `--config`. It is NOT the mesh identity: the identity comes from inside the file
+    // (`name:`), so a persona can be filed descriptively (review-critic.md) yet present under a
+    // free-form name (socrates) — the same model `cotal spawn` already uses. You always spawn by
+    // filename (unique on disk); two files can't collide on the key.
+    const ref = opts.name.trim();
+    if (!ref) return { ok: false, error: "name required" };
+    // A bare ref maps to `.cotal/agents/<ref>.md`, so it must be a safe token (no path traversal); a
+    // `--config` path is validated by existsSync below instead.
+    if (!opts.config) {
+      const refErr = this.nameError(ref);
+      if (refErr) return { ok: false, error: refErr };
+    }
     const agent = opts.agent ?? "cotal";
 
-    // Synchronous availability gate (P4a/P4c) — the free-name pick and the reserve run in one tick
-    // BEFORE any await, so two concurrent spawns can't land on the same name (no TOCTOU between the
-    // pick and the reserve), and the ceiling can't be overshot by fan-out racing the provision await.
+    // Capacity check first (cheap, fail-fast). Everything from here to the reserve below is
+    // SYNCHRONOUS (existsSync / registry / accessSync / readFileSync — no await), so the gate stays
+    // atomic: the capacity snapshot and the reserve land in one tick (P4a/P4c), and two concurrent
+    // spawns can't overshoot the ceiling or pick the same name.
     const cooling = this.coolingCount(); // prune expired stamps, then count live cooling slots
     if (this.agents.size + this.reserved.size + cooling >= MAX_AGENTS)
       return { ok: false, error: `at capacity (${MAX_AGENTS} agents incl. in-flight + cooling); despawn one or wait` };
-    // A taken name auto-numbers (reviewer → reviewer-2 → reviewer-3…) so callers never collide; the
-    // persona file is still discovered from the requested base name below, so reviewer-2 wears it.
-    // Deliberate semantics: this is create-new, not ensure-exists — a retried/redelivered identical
-    // spawn from the same caller yields a fresh numbered agent, not a no-op. Accepted (MAX_AGENTS
-    // bounds the blast radius). Follow-up: add a short per-(spawner,base,role) idempotency window if
-    // autonomous orchestration ever produces phantom spawns.
-    const name = this.uniqueName(base);
+
+    // Resolve the persona file (fail loud — NO silent default-ACL fallback). A missing persona used
+    // to mint DEFAULT creds (read `general` only, default-deny publish, no capabilities), so a
+    // typo'd / renamed / spawned-by-display-name agent became live with silently-wrong ACLs — a
+    // behavioral/security bug. Fail loud instead, matching `cotal spawn` (loadAgentFile throws).
+    let configPath: string;
+    if (opts.config) {
+      configPath = agentFilePath(this.workspaceRoot, opts.config);
+      if (!existsSync(configPath)) return { ok: false, error: `agent file not found: ${configPath}` };
+    } else {
+      configPath = agentFilePath(this.workspaceRoot, ref);
+      if (!existsSync(configPath))
+        return { ok: false, error: `no persona "${ref}" — ${configPath} not found; create it or pass --config (see \`cotal personas list\`)` };
+    }
+
+    // Connector + harness preflight before reserving a slot or minting — a missing connector or a
+    // missing `claude`/`opencode` binary fails here with a clear name, not obscurely at process
+    // spawn. No fallback. All synchronous, so the reserve gate stays atomic.
+    let connector: Connector;
+    try {
+      connector = registry.resolve<Connector>("connector", agent);
+    } catch (e) {
+      return { ok: false, error: (e as Error).message };
+    }
+    const missing = (connector.requires ?? []).filter((bin) => !binOnPath(bin));
+    if (missing.length)
+      return { ok: false, error: `${agent} harness needs ${missing.join(", ")} on PATH — not found` };
+
+    // Load the persona. IDENTITY = its free-form `name:`, validated as a safe mesh/creds-file token;
+    // role + read/post ACL come from the file too (`--role` overrides). The number rides the IDENTITY
+    // (socrates → socrates-2), not the file ref — a redelivered identical spawn yields a fresh
+    // numbered agent (create-new, not ensure-exists; MAX_AGENTS bounds the blast radius).
+    let def: AgentDef;
+    try {
+      def = loadAgentFile(configPath);
+    } catch (e) {
+      return { ok: false, error: (e as Error).message };
+    }
+    const idErr = this.nameError(def.name);
+    if (idErr) return { ok: false, error: `persona ${configPath}: ${idErr}` };
+    const role = opts.role ?? def.role;
+    // The agent's read ACL, defaulted the same way the loader/provisioner do — minted into the
+    // creds below (the broker boundary); runtime durable joins are re-authorized against it by the
+    // delivery daemon, which reads the committed ACL, so the manager keeps no copy on its record.
+    const allowSubscribe = def.allowSubscribe ?? def.subscribe ?? ["general"];
+
+    const name = this.uniqueName(def.name);
     this.reserved.add(name);
     try {
-      // Resolve an agent file from the manager's own workspace — an explicit
-      // --config must exist; otherwise discover .cotal/agents/<name>.md if present.
-      let configPath: string | undefined;
-      if (opts.config) {
-        configPath = agentFilePath(this.workspaceRoot, opts.config);
-        if (!existsSync(configPath)) return { ok: false, error: `agent file not found: ${configPath}` };
-      } else {
-        const f = agentFilePath(this.workspaceRoot, base);
-        if (existsSync(f)) configPath = f;
-      }
-      // --role overrides the file; the file fills it in for bookkeeping otherwise.
-      let role = opts.role;
-      // A stable nkey identity assigned at spawn: the public key is the agent's card.id
-      // (threaded via COTAL_ID); the seed is retained to mint matching creds later.
+      // A stable nkey identity assigned at spawn: the public key is the agent's card.id (threaded via
+      // COTAL_ID); the seed is retained to mint matching creds later.
       const identity = newIdentity();
-      // The agent's read ACL, defaulted the same way the loader/provisioner do — retained on the
-      // managed record so the mediated join/leave op can validate channels ⊆ allowSubscribe.
-      let allowSubscribe: string[] = ["general"];
-      let handle: AgentHandle;
-      try {
-        const connector = registry.resolve<Connector>("connector", agent);
-        // Preflight the harness binaries this connector invokes (its `requires`) BEFORE minting
-        // creds or building the launch — a missing `claude`/`opencode` should fail here with a
-        // clear name, not obscurely at process spawn. No fallback: throw if it isn't on PATH.
-        const missing = (connector.requires ?? []).filter((bin) => !binOnPath(bin));
-        if (missing.length)
-          throw new Error(`${agent} harness needs ${missing.join(", ")} on PATH — not found`);
-        const def = configPath ? loadAgentFile(configPath) : undefined;
-        if (!role) role = def?.role;
-        allowSubscribe = def?.allowSubscribe ?? def?.subscribe ?? ["general"];
-        // In auth mode, mint the agent's creds from the space signing key and write them where the
-        // spawned session reads them (COTAL_CREDS path). Open mesh → no creds. Read scope = the
-        // file's subscribe/allowSubscribe; post scope = its allowPublish (default-deny).
-        let credsPath: string | undefined;
-        if (this.auth) {
-          // Pre-create the agent's bind-only chat (+ DM + role TASK) durables and mint its scoped
-          // creds — the shared onboarding step (provisionAgent), the manager just supplies its
-          // own connected endpoint as the privileged provisioner.
-          const creds = await provisionAgent(this.ep, this.auth, identity, {
-            subscribe: def?.subscribe,
-            allowSubscribe,
-            allowPublish: def?.allowPublish,
-            role,
-            capabilities: def?.capabilities,
-          });
-          credsPath = join(authDir(this.workspaceRoot), "creds", `${name}.creds`);
-          mkdirSync(dirname(credsPath), { recursive: true });
-          writeFileSync(credsPath, creds, { mode: 0o600 });
-        }
-        // Personal MCP servers the operator opted to share with manager-spawned agents of this
-        // type (cotal config; default none → isolated, the memory-safe default this guards).
-        const mcpServers = connectorServers(loadCotalConfig(this.workspaceRoot), agent);
-        const spec = connector.buildLaunch({
-          space: this.space,
-          name,
+      // In auth mode, mint the agent's creds from the space signing key and write them where the
+      // spawned session reads them (COTAL_CREDS path). Open mesh → no creds. Read scope = the file's
+      // subscribe/allowSubscribe; post scope = its allowPublish (default-deny).
+      let credsPath: string | undefined;
+      if (this.auth) {
+        // Pre-create the agent's bind-only chat (+ DM + role TASK) durables and mint its scoped creds
+        // — the shared onboarding step (provisionAgent); the manager supplies its own connected
+        // endpoint as the privileged provisioner.
+        const creds = await provisionAgent(this.ep, this.auth, identity, {
+          subscribe: def.subscribe,
+          allowSubscribe,
+          allowPublish: def.allowPublish,
           role,
-          id: identity.id,
-          creds: credsPath,
-          servers: this.servers,
-          configPath,
-          model: opts.model,
-          transcript: opts.transcript,
-          mcpServers,
+          capabilities: def.capabilities,
         });
-        handle = this.runtime.spawn(name, spec, this.workspaceRoot);
-      } catch (e) {
-        // Pre-set failure: the slot was never live, so no cold-start was paid — the reserved
-        // rollback (finally) is enough, no cooling stamp.
-        return { ok: false, error: (e as Error).message };
+        credsPath = join(authDir(this.workspaceRoot), "creds", `${name}.creds`);
+        mkdirSync(dirname(credsPath), { recursive: true });
+        writeFileSync(credsPath, creds, { mode: 0o600 });
       }
+      // Personal MCP servers the operator opted to share with manager-spawned agents of this type
+      // (cotal config; default none → isolated, the memory-safe default this guards).
+      const mcpServers = connectorServers(loadCotalConfig(this.workspaceRoot), agent);
+      const spec = connector.buildLaunch({
+        space: this.space,
+        name,
+        role,
+        id: identity.id,
+        creds: credsPath,
+        servers: this.servers,
+        configPath,
+        model: opts.model,
+        transcript: opts.transcript,
+        mcpServers,
+      });
+      const handle = this.runtime.spawn(name, spec, this.workspaceRoot);
       const managed: ManagedAgent = {
         name,
         role,
@@ -482,6 +505,10 @@ export class Manager {
       // (rate-floored) and reaps any children — keeps the ceiling from ratcheting shut with orphans.
       this.watchExit(managed);
       return { ok: true, data: { name, role, agent, id: identity.id, mode: handle.kind } };
+    } catch (e) {
+      // Failure after reserve (provision / launch threw): the slot was never live, so no cold-start
+      // was paid — the reserved rollback (finally) is enough, no cooling stamp.
+      return { ok: false, error: (e as Error).message };
     } finally {
       this.reserved.delete(name);
     }

--- a/implementations/manager/src/roster.ts
+++ b/implementations/manager/src/roster.ts
@@ -12,8 +12,9 @@ import type { StartAgentOpts } from "./manager.js";
  *
  * Each entry maps 1:1 to a {@link Manager.startAgent} call — the same spawn path the
  * control-plane `start` op uses. `agent` is required (the connector type; there is no
- * default connector). `role`/`config` are optional; persona/model come from the agent
- * file the manager discovers at `.cotal/agents/<name>.md`.
+ * default connector). `name` is the persona REF (the file `.cotal/agents/<name>.md`, which
+ * must exist); the booted peer presents under that file's own `name:`. `role`/`config` are
+ * optional; persona/model come from the same file.
  */
 export function loadRoster(path: string): StartAgentOpts[] {
   const doc: unknown = parse(readFileSync(path, "utf8"));

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "smoke:attach": "tsx implementations/manager/smoke/attach.smoke.ts",
     "smoke:env-isolate": "tsx implementations/manager/smoke/env-isolate.smoke.ts",
     "smoke:start-model": "tsx implementations/manager/smoke/start-model-preflight.smoke.ts",
+    "smoke:persona-acl": "tsx implementations/manager/smoke/persona-identity-acl.smoke.ts",
     "smoke:spawn-args": "tsx extensions/connector-core/smoke/spawn-args.smoke.ts",
     "smoke:install": "tsx implementations/cli/smoke/install.smoke.ts",
     "smoke:send": "tsx implementations/cli/smoke/send.smoke.ts",


### PR DESCRIPTION
## Problem

A manager spawn (control-plane `start` / `cotal_spawn` / roster boot) resolved the persona file by the spawn name, but on a miss it **silently minted default creds** (read `general` only, default-deny publish, no capabilities). So a persona spawned by its display name, a typo, or a renamed file became a **live agent with silently-wrong ACLs** — e.g. the `review-*` personas (whose `name:` differed from their filename) joined able to read only `#general`, unable to post to `#review`.

Root cause: the manager and `cotal spawn` disagreed. The CLI treats the argument as a persona *ref* (file picker) and takes identity from the file's `name:`, failing loud on a miss. The manager treated the argument as *both* the file key and the identity, and fell back silently.

## Fix — unify the manager onto the CLI model

- The spawn argument is a persona **ref**: a filename in `.cotal/agents` (the unique spawn key), or a path via `--config`. The file **must exist** — a miss fails loud (no default-ACL mint).
- The mesh **identity** comes from the file's `name:` (free-form), **auto-numbered** on collision (`socrates` → `socrates-2`) — no longer forced to equal the filename.
- Role + read/post ACL are provisioned from the loaded persona, never defaults.
- Persona load moved before the unique-name pick; all pre-reserve work stays synchronous, so the capacity→reserve gate remains atomic.
- Pre-spawn staggering + roster boot now wait on / log the **spawned identity** (`reply.data.name`), not the ref — a `filename != name:` persona no longer stalls the 30s presence wait.
- CLI help + the `cotal_spawn` schema now describe ref/identity semantics.

## Tests

- New `smoke:persona-acl` — for a `filename != name:` persona with a non-default ACL, **decodes the minted creds JWT** and asserts: identity = the file's `name:`, ACL = the persona's (not default), spawning by display-name fails loud, second spawn auto-numbers.
- `smoke:start-model` updated to the new contract (a manager spawn requires a discoverable persona).
- typecheck (all projects) + `smoke:persona-acl` + `smoke:start-model` green.

## Review

Designed + reviewed with `review-general` on the mesh — **signed off**, no remaining blocking findings (the pre-spawn wait/log bug was caught in review and fixed).

## Note

`--config X` no longer lets the `name` arg override the identity (identity always comes from the file) — this was undocumented/incidental behavior.