### PR TITLE
refactor(cli): make all mesh commands work from any directory

### DIFF
--- a/implementations/cli/smoke/connect.smoke.ts
+++ b/implementations/cli/smoke/connect.smoke.ts
@@ -1,0 +1,71 @@
+/**
+ * The preflight decision tree — `classifyPreflightFailure` (lib/connect.ts). This is the riskiest
+ * new logic in the command migration: a wrong branch PRUNES A LIVE registry entry. Pure + offline,
+ * so every (source × reason × has-auth) combination is exercised here without a broker. The
+ * load-bearing invariant: a NON-registry source (flag-server / local-space, or a raw `--creds`
+ * connection) is never pruned — only the registry owns its entries. Run: pnpm smoke:connect
+ */
+import { strict as assert } from "node:assert";
+import { classifyPreflightFailure } from "../src/lib/connect.js";
+
+let pass = 0;
+const check = (name: string, cond: boolean, extra?: unknown) => {
+  assert.ok(cond, `${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
+  pass++;
+  console.log(`  ✓ ${name}`);
+};
+
+const REGISTRY = ["registry", "current", "flag-space", "local-recorded"] as const;
+const NON_REGISTRY = ["flag-server", "local-space"] as const;
+
+// unreachable: a registry-owned target prunes (broker gone); a non-registry one never does.
+for (const s of REGISTRY)
+  check(
+    `unreachable + ${s} → prune + 'unreachable'`,
+    (() => {
+      const r = classifyPreflightFailure(s, "unreachable", true);
+      return r.prune === true && r.kind === "unreachable";
+    })(),
+  );
+for (const s of NON_REGISTRY)
+  check(
+    `unreachable + ${s} → NO prune + 'unreachable'`,
+    (() => {
+      const r = classifyPreflightFailure(s, "unreachable", false);
+      return r.prune === false && r.kind === "unreachable";
+    })(),
+  );
+
+// auth-required, registry-owned WITH auth: minted creds rejected → stale entry, prune.
+check("auth-required + registry + has-auth → prune + 'registry-creds-rejected'", (() => {
+  const r = classifyPreflightFailure("flag-space", "auth-required", true);
+  return r.prune === true && r.kind === "registry-creds-rejected";
+})());
+// auth-required, registry-owned OPEN: probed credless, broker now wants auth → stale, prune.
+check("auth-required + registry + open → prune + 'registry-open-now-auth'", (() => {
+  const r = classifyPreflightFailure("registry", "auth-required", false);
+  return r.prune === true && r.kind === "registry-open-now-auth";
+})());
+// auth-required, NON-registry WITH auth: caller's creds rejected → user owns it, NO prune.
+check("auth-required + local + has-auth → NO prune + 'creds-rejected'", (() => {
+  const r = classifyPreflightFailure("local-space", "auth-required", true);
+  return r.prune === false && r.kind === "creds-rejected";
+})());
+// auth-required, NON-registry open: broker wants auth, we hold none → NO prune.
+check("auth-required + local + open → NO prune + 'open-wants-auth'", (() => {
+  const r = classifyPreflightFailure("flag-server", "auth-required", false);
+  return r.prune === false && r.kind === "open-wants-auth";
+})());
+
+// The invariant, exhaustively: a non-registry source is NEVER pruned — whatever the reason/auth.
+// (This is the guard behind the escape hatch: a bad `--creds` can't delete a good registry entry.)
+for (const s of NON_REGISTRY)
+  for (const reason of ["unreachable", "auth-required"] as const)
+    for (const hasAuth of [true, false])
+      check(
+        `non-registry ${s} / ${reason} / auth=${hasAuth} never prunes`,
+        classifyPreflightFailure(s, reason, hasAuth).prune === false,
+      );
+
+console.log(`\nconnect (preflight classifier) smoke: ${pass} checks passed`);
+process.exit(0);

--- a/implementations/cli/smoke/spawn-from-anywhere-live.smoke.ts
+++ b/implementations/cli/smoke/spawn-from-anywhere-live.smoke.ts
@@ -27,6 +27,7 @@ const { resolveMeshTarget, recordMesh, loadMeshes, probeConnect, meshesDir } = a
   "@cotal-ai/core"
 );
 const { pruneStaleMeshes } = await import("../src/lib/meshes.js");
+const { reachableOrExit } = await import("../src/lib/connect.js");
 
 let pass = 0;
 const kids: ChildProcess[] = [];
@@ -88,6 +89,12 @@ try {
   // Preflight's core against the LIVE broker (open → no creds): must connect.
   const live = await probeConnect(t.server, {});
   ok("B: probeConnect to the LIVE recorded broker → ok", live.ok === true, live);
+
+  // reachableOrExit — the raw-path reachability used by the `--creds` escape hatch and join's
+  // explicit path — RETURNS on a live open broker (it would process.exit() on failure, which would
+  // kill this run before the assertion; reaching it proves success).
+  await reachableOrExit(SRV_OPEN, {});
+  ok("B: reachableOrExit returns on a live open broker (raw-path reachability)", true);
 
   // B(auth-required): the unreachable-vs-auth split against a REAL auth broker.
   startBroker(4456, true);

--- a/implementations/cli/smoke/spawn-from-anywhere-live.smoke.ts
+++ b/implementations/cli/smoke/spawn-from-anywhere-live.smoke.ts
@@ -27,7 +27,7 @@ const { resolveMeshTarget, recordMesh, loadMeshes, probeConnect, meshesDir } = a
   "@cotal-ai/core"
 );
 const { pruneStaleMeshes } = await import("../src/lib/meshes.js");
-const { reachableOrExit } = await import("../src/lib/connect.js");
+const { connectOrExit, reachableOrExit } = await import("../src/lib/connect.js");
 
 let pass = 0;
 const kids: ChildProcess[] = [];
@@ -95,6 +95,16 @@ try {
   // kill this run before the assertion; reaching it proves success).
   await reachableOrExit(SRV_OPEN, {});
   ok("B: reachableOrExit returns on a live open broker (raw-path reachability)", true);
+
+  // Escape hatch: `--server` + an UNREGISTERED `--space` (open remote mesh, no creds) bypasses the
+  // registry and connects bare, returning the flag values — no "no mesh named X" throw. ("rawopen"
+  // is not in the registry; only "alpha" is.)
+  const raw = await connectOrExit({ server: SRV_OPEN, space: "rawopen" }, "manager");
+  ok(
+    "B: connectOrExit(--server + unregistered --space) → raw open connect (escape hatch)",
+    raw.server === SRV_OPEN && raw.space === "rawopen" && raw.creds === undefined,
+    raw,
+  );
 
   // B(auth-required): the unreachable-vs-auth split against a REAL auth broker.
   startBroker(4456, true);

--- a/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
+++ b/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
@@ -125,10 +125,15 @@ try {
   writeFileSync(join(projA, ".cotal", "auth", "auth.json"), JSON.stringify({ space: "alpha" }));
   recordMesh(entry("openmesh", projA, SERVER)); // entry() is mode:"open"
   check("open mesh resolves with NO auth despite auth files in its root", resolveMeshTarget(neutral, { space: "openmesh" }).auth === undefined);
-  recordMesh({ ...entry("authmesh", projA, SERVER), mode: "auth" });
-  check("auth mesh resolves WITH auth from its root", Boolean(resolveMeshTarget(neutral, { space: "authmesh" }).auth));
+  recordMesh({ ...entry("alpha", projA, SERVER), mode: "auth" }); // space matches projA's auth.json
+  check("auth mesh resolves WITH auth from its root", Boolean(resolveMeshTarget(neutral, { space: "alpha" }).auth));
+  // Defense in depth (mitnick): an AUTH entry whose recorded space ≠ the root's on-disk auth.space is
+  // stale — resolving it throws AND prunes the entry, rather than minting space-Y creds for space X.
+  recordMesh({ ...entry("mismatch", projA, SERVER), mode: "auth" }); // projA's auth.json says "alpha"
+  assert.throws(() => resolveMeshTarget(neutral, { space: "mismatch" }), /stale entry removed/);
+  check("auth entry whose space ≠ root's auth.space throws + prunes", !loadMeshes().some((m) => m.space === "mismatch"));
   removeMesh("openmesh");
-  removeMesh("authmesh");
+  removeMesh("alpha");
 
   // Fix A (HIGH): a local project whose mesh is in the registry resolves to the RECORDED server +
   // mode, not the hardcoded DEFAULT_SERVER — so `cotal up --server …:4333` then an in-project spawn

--- a/implementations/cli/src/commands/channels.ts
+++ b/implementations/cli/src/commands/channels.ts
@@ -1,10 +1,5 @@
 import { parseArgs } from "node:util";
 import {
-  authDir,
-  loadSpaceAuth,
-  mintCreds,
-  newIdentity,
-  DEFAULT_SERVER,
   seedChannelRegistry,
   readChannelRegistry,
   effectiveReplay,
@@ -12,14 +7,15 @@ import {
   type ChannelDefaults,
   type ChannelRegistryFile,
 } from "@cotal-ai/core";
-import { cotalRoot } from "../lib/paths.js";
-import { resolveSpace } from "../lib/status.js";
+import { connectOrExit } from "../lib/connect.js";
 import { c } from "../ui.js";
 
 /**
  * `cotal channels` — inspect and mutate the per-space channel registry (replay policy,
- * description, instructions) while the mesh is up. Writes are privileged: in auth mode the
- * command mints ephemeral manager creds from `.cotal/auth`; in open mode it connects plainly.
+ * description, instructions) while the mesh is up. Writes are privileged: on an auth mesh the
+ * command mints ephemeral manager creds from the resolved mesh's `.cotal/auth`; on an open mesh it
+ * connects plainly. Works from any directory (resolves the running mesh); `--creds` is a raw
+ * off-registry connection.
  *
  *   cotal channels list
  *   cotal channels set <name> [--replay|--no-replay] [--desc <s>] [--instructions <s>]
@@ -32,6 +28,7 @@ export async function channels(argv: string[]): Promise<void> {
     options: {
       server: { type: "string" },
       space: { type: "string" },
+      creds: { type: "string" },
       replay: { type: "boolean" },
       "no-replay": { type: "boolean" },
       window: { type: "string" }, // backfill window, e.g. 24h / 30m / 7d
@@ -39,11 +36,9 @@ export async function channels(argv: string[]): Promise<void> {
       instructions: { type: "string" },
     },
   });
-  const server = values.server ?? DEFAULT_SERVER;
-  const space = values.space ?? resolveSpace(process.cwd());
+  const { server, space, creds } = await connectOrExit(values, "manager"); // creds undefined ⇒ open mode
   // Tri-state replay: --replay → true, --no-replay → false, neither → leave unchanged.
   const replay = values["no-replay"] ? false : values.replay ? true : undefined;
-  const creds = await managerCreds(); // undefined ⇒ open mode
 
   switch (positionals[0]) {
     case "list": {
@@ -83,14 +78,6 @@ export async function channels(argv: string[]): Promise<void> {
   }
 }
 
-/** Privileged creds for a registry write: mint ephemeral manager creds from the space auth
- *  (auth mode), or undefined to connect open. Throws nothing — open mode is the no-auth dev mesh. */
-async function managerCreds(): Promise<string | undefined> {
-  const auth = loadSpaceAuth(authDir(cotalRoot()));
-  if (!auth) return undefined;
-  return mintCreds(auth, newIdentity(), "manager");
-}
-
 function printRegistry(reg: ChannelRegistryFile): void {
   const def = reg.defaults?.replay;
   const dw = reg.defaults?.replayWindow;
@@ -113,7 +100,7 @@ function printRegistry(reg: ChannelRegistryFile): void {
 function usage(): void {
   console.error(
     c.red(
-      "usage: cotal channels <list | set <name> [--replay|--no-replay] [--window <dur>] [--desc <s>] [--instructions <s>] | default [--replay|--no-replay] [--window <dur>]> [--space <s>] [--server <url>]",
+      "usage: cotal channels <list | set <name> [--replay|--no-replay] [--window <dur>] [--desc <s>] [--instructions <s>] | default [--replay|--no-replay] [--window <dur>]> [--space <s>] [--server <url>] [--creds <path>]",
     ),
   );
   process.exit(1);

--- a/implementations/cli/src/commands/channels.ts
+++ b/implementations/cli/src/commands/channels.ts
@@ -36,11 +36,16 @@ export async function channels(argv: string[]): Promise<void> {
       instructions: { type: "string" },
     },
   });
-  const { server, space, creds } = await connectOrExit(values, "manager"); // creds undefined ⇒ open mode
+  // Validate the subcommand BEFORE connecting, so a typo (or a bare `cotal channels`) prints usage,
+  // not "no mesh running" — the same validate-first order as `history`.
+  const sub = positionals[0];
+  if (sub !== "list" && sub !== "set" && sub !== "default") return usage();
+  if (sub === "set" && !positionals[1]) return usage(); // need a channel name before touching the mesh
   // Tri-state replay: --replay → true, --no-replay → false, neither → leave unchanged.
   const replay = values["no-replay"] ? false : values.replay ? true : undefined;
+  const { server, space, creds } = await connectOrExit(values, "manager"); // creds undefined ⇒ open mode
 
-  switch (positionals[0]) {
+  switch (sub) {
     case "list": {
       printRegistry(await readChannelRegistry({ servers: server, space, creds }));
       return;

--- a/implementations/cli/src/commands/console.ts
+++ b/implementations/cli/src/commands/console.ts
@@ -3,17 +3,9 @@ import { readFileSync, writeSync } from "node:fs";
 import { userInfo } from "node:os";
 import { createElement } from "react";
 import { render } from "ink";
-import {
-  isReachable,
-  DEFAULT_SERVER,
-  chatWildcard,
-  authDir,
-  loadSpaceAuth,
-  mintCreds,
-  newIdentity,
-} from "@cotal-ai/core";
-import { cotalRoot } from "../lib/paths.js";
+import { chatWildcard, mintCreds, newIdentity } from "@cotal-ai/core";
 import { resolveSpace } from "../lib/status.js";
+import { preflightOrExit, resolveTargetOrExit } from "../lib/connect.js";
 import { c } from "../ui.js";
 import { runLog } from "../render.js";
 import { Root, makeObserver } from "../console/root.js";
@@ -35,33 +27,21 @@ export async function console_(argv: string[]): Promise<void> {
       creds: { type: "string" },
     },
   });
-  const server = values.server ?? DEFAULT_SERVER;
-  let creds = values.creds ? readFileSync(values.creds, "utf8") : undefined;
-  let space = values.space;
-
-  // Auth mode (.cotal/auth present): self-mint an admin cred for the local space so the console
-  // works without --creds — same god-view as `cotal web` (the console shows DMs/anycast, which the
-  // narrower `observer` profile denies → NATS Authorization Violation). An authed server hosts
-  // exactly one space, so there's no overview — we enter it directly. Open mode (no auth): connect
-  // bare; with no --space, the TTY shows the space overview.
-  if (!creds) {
-    const auth = loadSpaceAuth(authDir(cotalRoot()));
-    if (auth) {
-      if (space && space !== auth.space) {
-        console.error(
-          c.red(`Auth here is for space "${auth.space}", not "${space}". Use --space ${auth.space} (or pass --creds).`),
-        );
-        process.exit(1);
-      }
-      space = auth.space;
-      creds = await mintCreds(auth, newIdentity(), "admin");
-    }
-  }
-
-  if (!(await isReachable(server, { creds }))) {
-    console.error(c.red(`Can't reach NATS at ${server}. Run: pnpm cotal up`));
-    process.exit(1);
-  }
+  // Resolve WHICH running mesh (server + trust material) from any directory — same as `spawn`/`web`.
+  // Auth mode self-mints an admin god-view cred (the console shows DMs/anycast, which the narrower
+  // `observer` profile denies → NATS Authorization Violation); an authed server hosts exactly one
+  // space, so we enter it directly. Open mode connects bare; with no --space, the TTY shows the
+  // space overview. An explicit --creds wins.
+  const target = await resolveTargetOrExit({ server: values.server, space: values.space });
+  const server = target.server;
+  const creds = values.creds
+    ? readFileSync(values.creds, "utf8")
+    : target.auth
+      ? await mintCreds(target.auth, newIdentity(), "admin")
+      : undefined;
+  await preflightOrExit(target, creds);
+  // Auth pins its one space; open mode keeps --space (undefined → the overview picker).
+  const space = target.auth ? target.space : values.space;
 
   // Operator identity for sent messages (still off the roster). Open mode or an explicit --creds can
   // write; the self-minted observer cred (auth default) is read-only, so the palette/`D` are inert.

--- a/implementations/cli/src/commands/console.ts
+++ b/implementations/cli/src/commands/console.ts
@@ -1,11 +1,10 @@
 import { parseArgs } from "node:util";
-import { readFileSync, writeSync } from "node:fs";
+import { writeSync } from "node:fs";
 import { userInfo } from "node:os";
 import { createElement } from "react";
 import { render } from "ink";
-import { chatWildcard, mintCreds, newIdentity } from "@cotal-ai/core";
-import { resolveSpace } from "../lib/status.js";
-import { preflightOrExit, resolveTargetOrExit } from "../lib/connect.js";
+import { chatWildcard } from "@cotal-ai/core";
+import { connectOrExit } from "../lib/connect.js";
 import { c } from "../ui.js";
 import { runLog } from "../render.js";
 import { Root, makeObserver } from "../console/root.js";
@@ -32,16 +31,9 @@ export async function console_(argv: string[]): Promise<void> {
   // `observer` profile denies → NATS Authorization Violation); an authed server hosts exactly one
   // space, so we enter it directly. Open mode connects bare; with no --space, the TTY shows the
   // space overview. An explicit --creds wins.
-  const target = await resolveTargetOrExit({ server: values.server, space: values.space });
-  const server = target.server;
-  const creds = values.creds
-    ? readFileSync(values.creds, "utf8")
-    : target.auth
-      ? await mintCreds(target.auth, newIdentity(), "admin")
-      : undefined;
-  await preflightOrExit(target, creds);
+  const { server, space: resolvedSpace, creds, auth } = await connectOrExit(values, "admin");
   // Auth pins its one space; open mode keeps --space (undefined → the overview picker).
-  const space = target.auth ? target.space : values.space;
+  const space = auth ? resolvedSpace : values.space;
 
   // Operator identity for sent messages (still off the roster). Open mode or an explicit --creds can
   // write; the self-minted observer cred (auth default) is read-only, so the palette/`D` are inert.
@@ -55,9 +47,9 @@ export async function console_(argv: string[]): Promise<void> {
   const canWrite = !creds || !!values.creds;
 
   // No TTY (piped/headless) or --plain → the passive line stream; Ink needs a real terminal, and a
-  // stream can't host the picker, so it falls back to the default space.
+  // stream can't host the picker, so it falls back to the RESOLVED mesh's space (not the cwd's).
   if (values.plain || process.stdout.isTTY !== true) {
-    const s = space ?? resolveSpace(process.cwd());
+    const s = space ?? resolvedSpace;
     await runLog(makeObserver(s, server, creds, operator), s, creds ? chatWildcard(s) : undefined);
     return;
   }

--- a/implementations/cli/src/commands/history.ts
+++ b/implementations/cli/src/commands/history.ts
@@ -1,15 +1,6 @@
-import { readFileSync } from "node:fs";
 import { parseArgs } from "node:util";
-import {
-  authDir,
-  clearSpaceHistory,
-  DEFAULT_SERVER,
-  loadSpaceAuth,
-  mintCreds,
-  newIdentity,
-} from "@cotal-ai/core";
-import { cotalRoot } from "../lib/paths.js";
-import { resolveSpace } from "../lib/status.js";
+import { clearSpaceHistory } from "@cotal-ai/core";
+import { connectOrExit } from "../lib/connect.js";
 import { c } from "../ui.js";
 
 /** Administrative history operations. Purges JetStream backlog only; live in-process
@@ -34,9 +25,10 @@ export async function history(argv: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const space = values.space ?? resolveSpace(process.cwd());
-  const server = values.server ?? DEFAULT_SERVER;
-  const creds = values.creds ? readFileSync(values.creds, "utf8") : await managerCreds();
+  // Resolve the running mesh (from any dir) + manager creds — `--creds` is a raw off-registry connect.
+  // `history clear` is destructive, so targeting the RIGHT mesh matters: this no longer blindly hits
+  // DEFAULT_SERVER + the cwd space.
+  const { server, space, creds } = await connectOrExit(values, "manager");
   const result = await clearSpaceHistory({
     servers: server,
     space,
@@ -46,12 +38,6 @@ export async function history(argv: string[]): Promise<void> {
 
   const dm = result.dm === undefined ? "" : `, ${result.dm} DM message${result.dm === 1 ? "" : "s"}`;
   console.log(c.green(`✓ cleared ${result.chat} channel message${result.chat === 1 ? "" : "s"}${dm} from "${space}"`));
-}
-
-async function managerCreds(): Promise<string | undefined> {
-  const auth = loadSpaceAuth(authDir(cotalRoot()));
-  if (!auth) return undefined;
-  return mintCreds(auth, newIdentity(), "manager");
 }
 
 function usage(): void {

--- a/implementations/cli/src/commands/join.ts
+++ b/implementations/cli/src/commands/join.ts
@@ -5,6 +5,8 @@ import * as readline from "node:readline";
 import {
   CotalEndpoint,
   isReachable,
+  mintCreds,
+  newIdentity,
   parseJoinLink,
   resolvePeer,
   AmbiguousPeerError,
@@ -15,6 +17,7 @@ import {
   type CotalMessage,
 } from "@cotal-ai/core";
 import { resolveSpace } from "../lib/status.js";
+import { preflightOrExit, resolveTargetOrExit } from "../lib/connect.js";
 import { c, statusBadge } from "../ui.js";
 
 export async function join(argv: string[]): Promise<void> {
@@ -37,9 +40,7 @@ export async function join(argv: string[]): Promise<void> {
 
   // A join link carries server + auth + space; explicit flags still override it.
   const link = values.link ? parseJoinLink(values.link) : undefined;
-  const space = values.space ?? link?.space ?? resolveSpace(process.cwd());
   const name = values.name ?? userInfo().username;
-  const server = values.server ?? link?.servers ?? DEFAULT_SERVER;
   const channel = values.channel ?? link?.channels?.[0] ?? "general";
   const auth = {
     token: values.token ?? link?.token,
@@ -49,12 +50,27 @@ export async function join(argv: string[]): Promise<void> {
     tls: values.tls ?? link?.tls ?? false,
   };
 
-  if (!(await isReachable(server, auth))) {
-    console.error(c.red(`Can't reach NATS at ${server}.`));
-    console.error(
-      c.dim(link ? "Check the join link and that the host is up." : "Start it in another terminal:  pnpm cotal up"),
-    );
-    process.exit(1);
+  let space: string;
+  let server: string;
+  // An explicit connection (a join link, --token, or --creds) is taken at face value — that's the
+  // escape hatch. Otherwise resolve the running mesh from any directory (server + trust material)
+  // and self-mint, so a bare `cotal join` works outside the project instead of crashing credless.
+  if (link || values.token || values.creds) {
+    space = values.space ?? link?.space ?? resolveSpace(process.cwd());
+    server = values.server ?? link?.servers ?? DEFAULT_SERVER;
+    if (!(await isReachable(server, auth))) {
+      console.error(c.red(`Can't reach NATS at ${server}.`));
+      console.error(
+        c.dim(link ? "Check the join link and that the host is up." : "Start it in another terminal:  pnpm cotal up"),
+      );
+      process.exit(1);
+    }
+  } else {
+    const target = await resolveTargetOrExit({ server: values.server, space: values.space });
+    space = target.space;
+    server = target.server;
+    if (target.auth) auth.creds = await mintCreds(target.auth, newIdentity(), "manager");
+    await preflightOrExit(target, auth.creds);
   }
 
   const ep = new CotalEndpoint({

--- a/implementations/cli/src/commands/join.ts
+++ b/implementations/cli/src/commands/join.ts
@@ -4,9 +4,6 @@ import { readFileSync } from "node:fs";
 import * as readline from "node:readline";
 import {
   CotalEndpoint,
-  isReachable,
-  mintCreds,
-  newIdentity,
   parseJoinLink,
   resolvePeer,
   AmbiguousPeerError,
@@ -17,7 +14,7 @@ import {
   type CotalMessage,
 } from "@cotal-ai/core";
 import { resolveSpace } from "../lib/status.js";
-import { preflightOrExit, resolveTargetOrExit } from "../lib/connect.js";
+import { connectOrExit, reachableOrExit } from "../lib/connect.js";
 import { c, statusBadge } from "../ui.js";
 
 export async function join(argv: string[]): Promise<void> {
@@ -58,19 +55,15 @@ export async function join(argv: string[]): Promise<void> {
   if (link || values.token || values.creds) {
     space = values.space ?? link?.space ?? resolveSpace(process.cwd());
     server = values.server ?? link?.servers ?? DEFAULT_SERVER;
-    if (!(await isReachable(server, auth))) {
-      console.error(c.red(`Can't reach NATS at ${server}.`));
-      console.error(
-        c.dim(link ? "Check the join link and that the host is up." : "Start it in another terminal:  pnpm cotal up"),
-      );
-      process.exit(1);
-    }
+    // Preflight with the ACTUAL auth (probeConnect, not isReachable — which returns true on an auth
+    // REJECT, so a bad --creds/token/link would skip the check and crash raw at ep.start()). One
+    // sentence on unreachable vs credentials-rejected, then we connect with the same auth.
+    await reachableOrExit(server, auth);
   } else {
-    const target = await resolveTargetOrExit({ server: values.server, space: values.space });
-    space = target.space;
-    server = target.server;
-    if (target.auth) auth.creds = await mintCreds(target.auth, newIdentity(), "manager");
-    await preflightOrExit(target, auth.creds);
+    const conn = await connectOrExit(values, "manager");
+    space = conn.space;
+    server = conn.server;
+    auth.creds = conn.creds;
   }
 
   const ep = new CotalEndpoint({

--- a/implementations/cli/src/commands/meshes.ts
+++ b/implementations/cli/src/commands/meshes.ts
@@ -18,4 +18,8 @@ export async function meshes(): Promise<void> {
     const marker = m.space === current ? c.green("*") : " ";
     console.log(`${marker} ${m.space.padEnd(pad)}  ${c.dim(`${m.server}  ${m.mode}  ${m.root}`)}`);
   }
+  // A `current` that no longer matches any running mesh (its broker went down) shows no `*` — say
+  // why, so a bare `cotal spawn` still reporting "multiple meshes" isn't a mystery.
+  if (current && !all.some((m) => m.space === current))
+    console.log(c.dim(`\nnote: default "${current}" is not running — \`cotal use <name>\` to set a live one`));
 }

--- a/implementations/cli/src/commands/spawn.ts
+++ b/implementations/cli/src/commands/spawn.ts
@@ -14,20 +14,17 @@ import {
   mintCreds,
   newIdentity,
   parseShareSelection,
-  probeConnect,
   provisionAgent,
   registry,
-  removeMesh,
   resolveMeshTarget,
   CotalEndpoint,
   type AgentDef,
   type CompletionResult,
   type Connector,
-  type MeshTarget,
   type SpaceAuth,
 } from "@cotal-ai/core";
 import { c } from "../ui.js";
-import { pruneStaleMeshes } from "../lib/meshes.js";
+import { preflightOrExit, resolveTargetOrExit } from "../lib/connect.js";
 import { listPersonas } from "../lib/personas.js";
 
 /** Completion for `cotal spawn` — `--space <TAB>` lists the running meshes, and the first positional
@@ -115,78 +112,6 @@ async function uniqueMeshName(
   }
 }
 
-/** Resolve the mesh this spawn targets, exiting with one human sentence on an unresolved/ambiguous
- *  registry rather than a stack trace. Prunes dead registry entries first so a crashed mesh doesn't
- *  block a bare spawn or get offered by `--space`. */
-async function resolveTargetOrExit(flags: { server?: string; space?: string }): Promise<MeshTarget> {
-  await pruneStaleMeshes();
-  try {
-    return resolveMeshTarget(process.cwd(), flags);
-  } catch (e) {
-    console.error(c.red(`✗ ${(e as Error).message}`));
-    process.exit(1);
-  }
-}
-
-/** Confirm the resolved mesh is actually up and accepts our creds — replaces the raw NATS
- *  "Authorization Violation" trace with one sentence, and prunes the entry if the broker is gone. */
-async function preflightOrExit(target: MeshTarget): Promise<void> {
-  const creds = target.auth ? await mintCreds(target.auth, newIdentity(), "manager") : undefined;
-  const probe = await probeConnect(target.server, creds ? { creds } : {});
-  if (probe.ok) return;
-  // A target whose server + mode came from a registry record owns that record, so a definitive
-  // failure prunes the stale entry. `local-recorded` (a local project matched to an entry by root)
-  // is registry-owned for pruning even though the success line treats it as a quiet local target.
-  const fromRegistry =
-    target.source === "registry" ||
-    target.source === "current" ||
-    target.source === "flag-space" ||
-    target.source === "local-recorded";
-  if (probe.reason === "unreachable") {
-    if (fromRegistry) removeMesh(target.space); // the broker is gone — drop the stale entry
-    console.error(
-      c.red(
-        `✗ no mesh running at ${target.server}${fromRegistry ? " (stale registry entry — removed)" : ""} — run \`cotal up\``,
-      ),
-    );
-  } else if (fromRegistry && target.auth) {
-    // We DID present creds minted from the registry's own trust material and the broker rejected
-    // them — so the entry now points at a DIFFERENT broker on that port. The fix isn't "spawn from
-    // the root" (we just used it); it's that the registry entry is stale. Drop it and say so.
-    removeMesh(target.space);
-    console.error(
-      c.red(
-        `✗ mesh "${target.space}" at ${target.server} no longer matches its registry entry (credentials rejected — port reused?) — re-run \`cotal up\` from ${target.root}, or \`cotal meshes\` to see what's live`,
-      ),
-    );
-  } else if (fromRegistry) {
-    // An OPEN-mode registry target probed credlessly, but the broker now wants auth — the recorded
-    // open mesh is gone (its port was reused by an auth broker). Same stale class; drop the entry.
-    removeMesh(target.space);
-    console.error(
-      c.red(
-        `✗ open mesh "${target.space}" at ${target.server} no longer matches its registry entry (broker now requires auth — port reused?) — re-run \`cotal up\` from ${target.root}, or \`cotal meshes\` to see what's live`,
-      ),
-    );
-  } else if (target.auth) {
-    // Creds were presented and rejected, but the target is a local project / --server we don't own
-    // in the registry. A different mesh is likely on that port — the user owns the diagnosis, so we
-    // don't prune; we point at the likely cause. "Can't provide" would be wrong: the folder DID.
-    console.error(
-      c.red(
-        `✗ credentials for "${target.space}" were rejected at ${target.server} — a different mesh may be running there. Run \`cotal meshes\` to check, or \`cotal up\` here to start yours`,
-      ),
-    );
-  } else {
-    // No creds to present (open, non-registry) and the broker wants auth.
-    console.error(
-      c.red(
-        `✗ broker at ${target.server} requires auth, but this mesh is open (no trust material) — use \`--space <name>\` for an auth mesh, or run \`cotal up\` here without \`--open\``,
-      ),
-    );
-  }
-  process.exit(1);
-}
 
 export async function spawn(argv: string[]): Promise<void> {
   const { values, positionals } = parseArgs({

--- a/implementations/cli/src/commands/web.ts
+++ b/implementations/cli/src/commands/web.ts
@@ -7,19 +7,16 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import {
   CotalEndpoint,
-  isReachable,
-  DEFAULT_SERVER,
   deliveryOf,
   parseSubject,
   spaceWildcard,
-  authDir,
-  loadSpaceAuth,
   mintCreds,
   newIdentity,
   clearChannel,
 } from "@cotal-ai/core";
+import { cotalPath } from "../lib/paths.js";
 import { resolveSpace } from "../lib/status.js";
-import { cotalPath, cotalRoot } from "../lib/paths.js";
+import { preflightOrExit, resolveTargetOrExit } from "../lib/connect.js";
 import { c } from "../ui.js";
 import { selfArgv } from "../lib/self-exec.js";
 
@@ -54,30 +51,22 @@ export async function web(argv: string[]): Promise<void> {
       creds: { type: "string" },
     },
   });
-  const space = values.space ?? resolveSpace(process.cwd());
-  const server = values.server ?? DEFAULT_SERVER;
+  // Resolve WHICH running mesh (from any directory) + its trust material, the same way `spawn` does.
+  const target = await resolveTargetOrExit({ server: values.server, space: values.space });
+  const space = target.space;
+  const server = target.server;
   const port = values.port ? Number(values.port) : WEB_PORT;
-  // The dashboard is always an admin god-view (no read-only viewer mode) so it can show DMs
-  // and anycast. Auth mode (`.cotal/auth` present): self-mint an `admin` cred so it joins the
-  // authed mesh with no manual --creds — like `cotal spawn`, it holds the space signing key.
-  // An explicit --creds still wins. Open mode (no auth): connect bare.
-  // Loaded once at function scope: the observer connects with a read-only `admin` cred, but
-  // the channel-delete write path mints an ephemeral `manager` cred from this same material.
-  const auth = loadSpaceAuth(authDir(cotalRoot()));
-  let creds = values.creds ? readFileSync(values.creds, "utf8") : undefined;
-  if (!creds && auth) {
-    if (auth.space !== space) {
-      console.error(
-        c.red(`Auth here is for space "${auth.space}", not "${space}". Use --space ${auth.space} (or pass --creds).`),
-      );
-      process.exit(1);
-    }
-    creds = await mintCreds(auth, newIdentity(), "admin");
-  }
-  if (!(await isReachable(server, { creds }))) {
-    console.error(c.red(`Can't reach NATS at ${server}. Run: pnpm cotal up`));
-    process.exit(1);
-  }
+  // The dashboard is always an admin god-view (no read-only viewer mode) so it can show DMs and
+  // anycast. Auth mode: self-mint an `admin` cred from the resolved mesh's trust material so it joins
+  // with no manual --creds (an explicit --creds still wins). Open mode: connect bare. `auth` is kept
+  // at function scope: the channel-delete write path mints an ephemeral `manager` cred from it.
+  const auth = target.auth;
+  const creds = values.creds
+    ? readFileSync(values.creds, "utf8")
+    : auth
+      ? await mintCreds(auth, newIdentity(), "admin")
+      : undefined;
+  await preflightOrExit(target, creds);
 
   // Observer: never registers presence, never consumes an inbox — invisible to peers.
   const ep = new CotalEndpoint({

--- a/implementations/cli/src/commands/web.ts
+++ b/implementations/cli/src/commands/web.ts
@@ -16,7 +16,7 @@ import {
 } from "@cotal-ai/core";
 import { cotalPath } from "../lib/paths.js";
 import { resolveSpace } from "../lib/status.js";
-import { preflightOrExit, resolveTargetOrExit } from "../lib/connect.js";
+import { connectOrExit } from "../lib/connect.js";
 import { c } from "../ui.js";
 import { selfArgv } from "../lib/self-exec.js";
 
@@ -52,21 +52,12 @@ export async function web(argv: string[]): Promise<void> {
     },
   });
   // Resolve WHICH running mesh (from any directory) + its trust material, the same way `spawn` does.
-  const target = await resolveTargetOrExit({ server: values.server, space: values.space });
-  const space = target.space;
-  const server = target.server;
-  const port = values.port ? Number(values.port) : WEB_PORT;
   // The dashboard is always an admin god-view (no read-only viewer mode) so it can show DMs and
-  // anycast. Auth mode: self-mint an `admin` cred from the resolved mesh's trust material so it joins
-  // with no manual --creds (an explicit --creds still wins). Open mode: connect bare. `auth` is kept
-  // at function scope: the channel-delete write path mints an ephemeral `manager` cred from it.
-  const auth = target.auth;
-  const creds = values.creds
-    ? readFileSync(values.creds, "utf8")
-    : auth
-      ? await mintCreds(auth, newIdentity(), "admin")
-      : undefined;
-  await preflightOrExit(target, creds);
+  // anycast — `connectOrExit("admin")` self-mints that cred on an auth mesh, connects bare on an
+  // open one, or takes `--creds` as a raw off-registry connection. `auth` is kept at function scope:
+  // the channel-delete write path mints an ephemeral `manager` cred from it (registry path only).
+  const { server, space, creds, auth } = await connectOrExit(values, "admin");
+  const port = values.port ? Number(values.port) : WEB_PORT;
 
   // Observer: never registers presence, never consumes an inbox — invisible to peers.
   const ep = new CotalEndpoint({

--- a/implementations/cli/src/index.ts
+++ b/implementations/cli/src/index.ts
@@ -47,7 +47,7 @@ const baseCommands: Command[] = [
     kind: "command",
     name: "down",
     group: "Mesh",
-    summary: "stop a background mesh started with `up --detach`",
+    summary: "stop a background mesh started with `up --detach` (run from its project — local only)",
     run: down,
   },
   {

--- a/implementations/cli/src/lib/connect.ts
+++ b/implementations/cli/src/lib/connect.ts
@@ -67,6 +67,14 @@ export async function connectOrExit(flags: ConnectFlags, role: Profile): Promise
     await reachableOrExit(server, { creds });
     return { server, space, creds };
   }
+  // A raw OPEN remote mesh: explicit `--server` + a `--space` that isn't locally registered. Naming
+  // both is as deliberate as `--creds`, but an open broker has no creds to pass — connect bare,
+  // off-registry (no registry lookup, no prune). A registered `--space` still goes through the
+  // resolver below (which honors `--server` as an override); `--server` alone resolves there too.
+  if (flags.server && flags.space && !findMesh(flags.space)) {
+    await reachableOrExit(flags.server, {});
+    return { server: flags.server, space: flags.space };
+  }
   const target = await resolveTargetOrExit({ server: flags.server, space: flags.space });
   const creds = target.auth ? await mintCreds(target.auth, newIdentity(), role) : undefined;
   await preflightOrExit(target, creds);

--- a/implementations/cli/src/lib/connect.ts
+++ b/implementations/cli/src/lib/connect.ts
@@ -1,4 +1,6 @@
 import {
+  findMesh,
+  getCurrent,
   mintCreds,
   newIdentity,
   probeConnect,
@@ -24,12 +26,20 @@ export async function resolveTargetOrExit(flags: {
   space?: string;
 }): Promise<MeshTarget> {
   await pruneStaleMeshes();
+  let target: MeshTarget;
   try {
-    return resolveMeshTarget(process.cwd(), flags);
+    target = resolveMeshTarget(process.cwd(), flags);
   } catch (e) {
     console.error(c.red(`✗ ${(e as Error).message}`));
     process.exit(1);
   }
+  // If a dangling `current` was silently bypassed — it named a mesh that's since gone and we fell
+  // back to the only live one — say so. The N>1 case errors loudly; this is the one spot that would
+  // otherwise quietly redirect a stale default.
+  const cur = getCurrent();
+  if (cur && !findMesh(cur) && target.source === "registry")
+    console.error(c.dim(`note: default mesh "${cur}" is down — using "${target.space}"`));
+  return target;
 }
 
 /** Confirm the resolved mesh is up and accepts these creds — replaces the raw NATS "Authorization

--- a/implementations/cli/src/lib/connect.ts
+++ b/implementations/cli/src/lib/connect.ts
@@ -21,8 +21,9 @@ import { pruneStaleMeshes } from "./meshes.js";
  * and confirms it's actually up — so `spawn`, `send`/`dm`/`msg`/`ask`, `console`, `join`, `web`,
  * `channels`, `history`, and `personas --running` all behave identically from any directory instead
  * of each re-deriving it from a cwd walk-up (which mistook `$HOME/.cotal` for a space and crashed
- * with a raw NATS auth violation). An explicit `--creds` is the escape hatch: a RAW off-registry
- * connection to `--server`, no registry lookup and no stale-prune.
+ * with a raw NATS auth violation). Two escape hatches take a RAW off-registry connection (no
+ * registry lookup, no stale-prune): explicit `--creds`, and `--server` + an unregistered `--space`
+ * (an open remote mesh that has no creds to pass).
  */
 
 export interface ConnectFlags {
@@ -47,7 +48,8 @@ export interface Connection {
   space: string;
   creds?: string;
   /** The mesh's trust material when resolved from the registry on an auth mesh — undefined for an
-   *  open mesh or a raw `--creds` connection. (web keeps it for its per-delete manager mint.) */
+   *  open mesh or a raw off-registry connection (`--creds` or `--server`+unregistered `--space`).
+   *  (web keeps it for its per-delete manager mint.) */
   auth?: SpaceAuth;
 }
 

--- a/implementations/cli/src/lib/connect.ts
+++ b/implementations/cli/src/lib/connect.ts
@@ -1,0 +1,94 @@
+import {
+  mintCreds,
+  newIdentity,
+  probeConnect,
+  removeMesh,
+  resolveMeshTarget,
+  type MeshTarget,
+} from "@cotal-ai/core";
+import { c } from "../ui.js";
+import { pruneStaleMeshes } from "./meshes.js";
+
+/**
+ * The one way every command that touches a running mesh figures out WHICH mesh + with what creds,
+ * and confirms it's actually up — so `spawn`, `send`, `console`, `join`, `web`, `channels`, and
+ * `history` all behave identically from any directory instead of each re-deriving it from a cwd
+ * walk-up (which mistook `$HOME/.cotal` for a space and crashed with a raw NATS auth violation).
+ */
+
+/** Resolve the mesh a command targets, exiting with one human sentence on an unresolved/ambiguous
+ *  registry rather than a stack trace. Prunes dead registry entries first so a crashed mesh doesn't
+ *  block a bare command or get offered by `--space`. */
+export async function resolveTargetOrExit(flags: {
+  server?: string;
+  space?: string;
+}): Promise<MeshTarget> {
+  await pruneStaleMeshes();
+  try {
+    return resolveMeshTarget(process.cwd(), flags);
+  } catch (e) {
+    console.error(c.red(`✗ ${(e as Error).message}`));
+    process.exit(1);
+  }
+}
+
+/** Confirm the resolved mesh is up and accepts these creds — replaces the raw NATS "Authorization
+ *  Violation" trace with one sentence, and prunes the entry if the broker is gone. Probes with
+ *  `probeCreds` when given (the caller's `--creds`/minted creds); otherwise mints a throwaway
+ *  identity from the target's own trust material. */
+export async function preflightOrExit(target: MeshTarget, probeCreds?: string): Promise<void> {
+  const creds =
+    probeCreds ?? (target.auth ? await mintCreds(target.auth, newIdentity(), "manager") : undefined);
+  const probe = await probeConnect(target.server, creds ? { creds } : {});
+  if (probe.ok) return;
+  // A target whose server + mode came from a registry record owns that record, so a definitive
+  // failure prunes the stale entry. `local-recorded` (a local project matched to an entry by root)
+  // is registry-owned for pruning even though the success line treats it as a quiet local target.
+  const fromRegistry =
+    target.source === "registry" ||
+    target.source === "current" ||
+    target.source === "flag-space" ||
+    target.source === "local-recorded";
+  if (probe.reason === "unreachable") {
+    if (fromRegistry) removeMesh(target.space); // the broker is gone — drop the stale entry
+    console.error(
+      c.red(
+        `✗ no mesh running at ${target.server}${fromRegistry ? " (stale registry entry — removed)" : ""} — run \`cotal up\``,
+      ),
+    );
+  } else if (fromRegistry && target.auth) {
+    // Creds minted from the registry's own trust material were rejected — the entry now points at a
+    // DIFFERENT broker on that port. Not "spawn from the root" (we just used it); the entry is stale.
+    removeMesh(target.space);
+    console.error(
+      c.red(
+        `✗ mesh "${target.space}" at ${target.server} no longer matches its registry entry (credentials rejected — port reused?) — re-run \`cotal up\` from ${target.root}, or \`cotal meshes\` to see what's live`,
+      ),
+    );
+  } else if (fromRegistry) {
+    // An OPEN-mode registry target probed credlessly, but the broker now wants auth — the recorded
+    // open mesh is gone (port reused by an auth broker). Same stale class; drop the entry.
+    removeMesh(target.space);
+    console.error(
+      c.red(
+        `✗ open mesh "${target.space}" at ${target.server} no longer matches its registry entry (broker now requires auth — port reused?) — re-run \`cotal up\` from ${target.root}, or \`cotal meshes\` to see what's live`,
+      ),
+    );
+  } else if (target.auth) {
+    // Creds were presented and rejected, but the target is a local project / --server we don't own
+    // in the registry. A different mesh is likely on that port — the user owns the diagnosis.
+    console.error(
+      c.red(
+        `✗ credentials for "${target.space}" were rejected at ${target.server} — a different mesh may be running there. Run \`cotal meshes\` to check, or \`cotal up\` here to start yours`,
+      ),
+    );
+  } else {
+    // No creds to present (open, non-registry) and the broker wants auth.
+    console.error(
+      c.red(
+        `✗ broker at ${target.server} requires auth, but this mesh is open (no trust material) — use \`--space <name>\` for an auth mesh, or run \`cotal up\` here without \`--open\``,
+      ),
+    );
+  }
+  process.exit(1);
+}

--- a/implementations/cli/src/lib/connect.ts
+++ b/implementations/cli/src/lib/connect.ts
@@ -1,4 +1,7 @@
+import { readFileSync } from "node:fs";
 import {
+  DEFAULT_SERVER,
+  DEFAULT_SPACE,
   findMesh,
   getCurrent,
   mintCreds,
@@ -7,16 +10,84 @@ import {
   removeMesh,
   resolveMeshTarget,
   type MeshTarget,
+  type Profile,
+  type SpaceAuth,
 } from "@cotal-ai/core";
 import { c } from "../ui.js";
 import { pruneStaleMeshes } from "./meshes.js";
 
 /**
  * The one way every command that touches a running mesh figures out WHICH mesh + with what creds,
- * and confirms it's actually up — so `spawn`, `send`, `console`, `join`, `web`, `channels`, and
- * `history` all behave identically from any directory instead of each re-deriving it from a cwd
- * walk-up (which mistook `$HOME/.cotal` for a space and crashed with a raw NATS auth violation).
+ * and confirms it's actually up — so `spawn`, `send`/`dm`/`msg`/`ask`, `console`, `join`, `web`,
+ * `channels`, `history`, and `personas --running` all behave identically from any directory instead
+ * of each re-deriving it from a cwd walk-up (which mistook `$HOME/.cotal` for a space and crashed
+ * with a raw NATS auth violation). An explicit `--creds` is the escape hatch: a RAW off-registry
+ * connection to `--server`, no registry lookup and no stale-prune.
  */
+
+export interface ConnectFlags {
+  server?: string;
+  space?: string;
+  /** Explicit creds file — triggers a raw off-registry connection (see {@link connectOrExit}). */
+  creds?: string;
+}
+
+/** Raw NATS auth for an off-registry connection — a join link / --token / --user+--pass / --creds.
+ *  Structurally matches what `probeConnect` accepts. */
+export interface RawAuth {
+  token?: string;
+  user?: string;
+  pass?: string;
+  creds?: string;
+  tls?: boolean;
+}
+
+export interface Connection {
+  server: string;
+  space: string;
+  creds?: string;
+  /** The mesh's trust material when resolved from the registry on an auth mesh — undefined for an
+   *  open mesh or a raw `--creds` connection. (web keeps it for its per-delete manager mint.) */
+  auth?: SpaceAuth;
+}
+
+/**
+ * Resolve where a mesh-touching command connects + with what creds.
+ *  • Explicit `--creds` → a RAW off-registry connection: straight to `--server` (default loopback)
+ *    as `--space`, with those creds. No registry lookup, no stale-prune, plain reachability message
+ *    (the user is deliberately off-registry — e.g. a remote mesh that isn't locally recorded).
+ *  • Otherwise → resolve the running mesh from the registry (works from any dir), mint `role` creds
+ *    on an auth mesh, and preflight with the registry's stale-prune.
+ */
+export async function connectOrExit(flags: ConnectFlags, role: Profile): Promise<Connection> {
+  if (flags.creds) {
+    const server = flags.server ?? DEFAULT_SERVER;
+    const space = flags.space ?? DEFAULT_SPACE;
+    const creds = readFileSync(flags.creds, "utf8");
+    await reachableOrExit(server, { creds });
+    return { server, space, creds };
+  }
+  const target = await resolveTargetOrExit({ server: flags.server, space: flags.space });
+  const creds = target.auth ? await mintCreds(target.auth, newIdentity(), role) : undefined;
+  await preflightOrExit(target, creds);
+  return { server: target.server, space: target.space, creds, auth: target.auth };
+}
+
+/** Reachability check for a RAW (off-registry) connection — one plain sentence, never a registry/
+ *  stale-entry message and never a prune. Used by the `--creds` escape hatch and `join`'s explicit
+ *  (link/token/creds) path, both of which connect to a broker the user named, not the registry. */
+export async function reachableOrExit(server: string, auth: RawAuth = {}): Promise<void> {
+  const probe = await probeConnect(server, auth);
+  if (probe.ok) return;
+  console.error(
+    c.red(
+      probe.reason === "auth-required"
+        ? `✗ credentials rejected at ${server} — check your creds, or the broker wants different auth`
+        : `✗ can't reach a broker at ${server} — is it running? (\`cotal up\`)`,
+    ),
+  );
+  process.exit(1);
+}
 
 /** Resolve the mesh a command targets, exiting with one human sentence on an unresolved/ambiguous
  *  registry rather than a stack trace. Prunes dead registry entries first so a crashed mesh doesn't
@@ -42,63 +113,63 @@ export async function resolveTargetOrExit(flags: {
   return target;
 }
 
+/** The five distinct ways a preflight fails. Each also says whether the target OWNS its registry
+ *  entry (→ prune): `fromRegistry` means the server+mode came from a registry record (incl. a
+ *  `local-recorded` project matched by root), so a definitive failure is a stale-entry signal. */
+export type PreflightFailure =
+  | "unreachable"
+  | "registry-creds-rejected"
+  | "registry-open-now-auth"
+  | "creds-rejected"
+  | "open-wants-auth";
+
+/** Pure decision for {@link preflightOrExit} — separated from I/O so the whole branch tree is
+ *  unit-testable (it's the riskiest new logic: a wrong branch prunes a LIVE registry entry). A
+ *  non-registry source (`flag-server`/`local-space`, or a raw `--creds` connection) is NEVER pruned;
+ *  the user owns that diagnosis. */
+export function classifyPreflightFailure(
+  source: MeshTarget["source"],
+  reason: "auth-required" | "unreachable",
+  hasAuth: boolean,
+): { prune: boolean; kind: PreflightFailure } {
+  const fromRegistry =
+    source === "registry" ||
+    source === "current" ||
+    source === "flag-space" ||
+    source === "local-recorded";
+  if (reason === "unreachable") return { prune: fromRegistry, kind: "unreachable" };
+  if (fromRegistry && hasAuth) return { prune: true, kind: "registry-creds-rejected" };
+  if (fromRegistry) return { prune: true, kind: "registry-open-now-auth" };
+  if (hasAuth) return { prune: false, kind: "creds-rejected" };
+  return { prune: false, kind: "open-wants-auth" };
+}
+
+function preflightMessage(kind: PreflightFailure, t: MeshTarget, pruned: boolean): string {
+  switch (kind) {
+    case "unreachable":
+      return `✗ no mesh running at ${t.server}${pruned ? " (stale registry entry — removed)" : ""} — run \`cotal up\``;
+    case "registry-creds-rejected":
+      return `✗ mesh "${t.space}" at ${t.server} no longer matches its registry entry (credentials rejected — port reused?) — re-run \`cotal up\` from ${t.root}, or \`cotal meshes\` to see what's live`;
+    case "registry-open-now-auth":
+      return `✗ open mesh "${t.space}" at ${t.server} no longer matches its registry entry (broker now requires auth — port reused?) — re-run \`cotal up\` from ${t.root}, or \`cotal meshes\` to see what's live`;
+    case "creds-rejected":
+      return `✗ credentials for "${t.space}" were rejected at ${t.server} — a different mesh may be running there. Run \`cotal meshes\` to check, or \`cotal up\` here to start yours`;
+    case "open-wants-auth":
+      return `✗ broker at ${t.server} requires auth, but this mesh is open (no trust material) — use \`--space <name>\` for an auth mesh, or run \`cotal up\` here without \`--open\``;
+  }
+}
+
 /** Confirm the resolved mesh is up and accepts these creds — replaces the raw NATS "Authorization
- *  Violation" trace with one sentence, and prunes the entry if the broker is gone. Probes with
- *  `probeCreds` when given (the caller's `--creds`/minted creds); otherwise mints a throwaway
- *  identity from the target's own trust material. */
+ *  Violation" trace with one sentence, and prunes the entry if the broker is gone / mismatched.
+ *  Probes with `probeCreds` when given (the caller's `--creds`/minted creds); otherwise mints a
+ *  throwaway identity from the target's own trust material. */
 export async function preflightOrExit(target: MeshTarget, probeCreds?: string): Promise<void> {
   const creds =
     probeCreds ?? (target.auth ? await mintCreds(target.auth, newIdentity(), "manager") : undefined);
   const probe = await probeConnect(target.server, creds ? { creds } : {});
   if (probe.ok) return;
-  // A target whose server + mode came from a registry record owns that record, so a definitive
-  // failure prunes the stale entry. `local-recorded` (a local project matched to an entry by root)
-  // is registry-owned for pruning even though the success line treats it as a quiet local target.
-  const fromRegistry =
-    target.source === "registry" ||
-    target.source === "current" ||
-    target.source === "flag-space" ||
-    target.source === "local-recorded";
-  if (probe.reason === "unreachable") {
-    if (fromRegistry) removeMesh(target.space); // the broker is gone — drop the stale entry
-    console.error(
-      c.red(
-        `✗ no mesh running at ${target.server}${fromRegistry ? " (stale registry entry — removed)" : ""} — run \`cotal up\``,
-      ),
-    );
-  } else if (fromRegistry && target.auth) {
-    // Creds minted from the registry's own trust material were rejected — the entry now points at a
-    // DIFFERENT broker on that port. Not "spawn from the root" (we just used it); the entry is stale.
-    removeMesh(target.space);
-    console.error(
-      c.red(
-        `✗ mesh "${target.space}" at ${target.server} no longer matches its registry entry (credentials rejected — port reused?) — re-run \`cotal up\` from ${target.root}, or \`cotal meshes\` to see what's live`,
-      ),
-    );
-  } else if (fromRegistry) {
-    // An OPEN-mode registry target probed credlessly, but the broker now wants auth — the recorded
-    // open mesh is gone (port reused by an auth broker). Same stale class; drop the entry.
-    removeMesh(target.space);
-    console.error(
-      c.red(
-        `✗ open mesh "${target.space}" at ${target.server} no longer matches its registry entry (broker now requires auth — port reused?) — re-run \`cotal up\` from ${target.root}, or \`cotal meshes\` to see what's live`,
-      ),
-    );
-  } else if (target.auth) {
-    // Creds were presented and rejected, but the target is a local project / --server we don't own
-    // in the registry. A different mesh is likely on that port — the user owns the diagnosis.
-    console.error(
-      c.red(
-        `✗ credentials for "${target.space}" were rejected at ${target.server} — a different mesh may be running there. Run \`cotal meshes\` to check, or \`cotal up\` here to start yours`,
-      ),
-    );
-  } else {
-    // No creds to present (open, non-registry) and the broker wants auth.
-    console.error(
-      c.red(
-        `✗ broker at ${target.server} requires auth, but this mesh is open (no trust material) — use \`--space <name>\` for an auth mesh, or run \`cotal up\` here without \`--open\``,
-      ),
-    );
-  }
+  const { prune, kind } = classifyPreflightFailure(target.source, probe.reason, Boolean(target.auth));
+  if (prune) removeMesh(target.space);
+  console.error(c.red(preflightMessage(kind, target, prune)));
   process.exit(1);
 }

--- a/implementations/cli/src/lib/transient.ts
+++ b/implementations/cli/src/lib/transient.ts
@@ -1,14 +1,13 @@
-import { readFileSync } from "node:fs";
-import { CotalEndpoint, mintCreds, newIdentity } from "@cotal-ai/core";
+import { CotalEndpoint } from "@cotal-ai/core";
 import { c } from "../ui.js";
-import { preflightOrExit, resolveTargetOrExit } from "./connect.js";
+import { connectOrExit } from "./connect.js";
 
 /**
  * A one-shot, write-capable connection for the headless commands that touch the live mesh
- * (`dm`/`msg`/`ask`, and `personas list --running`). Resolves WHICH mesh + creds via the shared
- * `resolveMeshTarget` (so these work from any directory, not just inside the project), opens a
- * transient endpoint that never joins the roster, does the one thing, stops. Fail-loud throughout —
- * an unresolved/ambiguous registry or an unreachable/auth-mismatched broker exits, never degrades.
+ * (`dm`/`msg`/`ask`, and `personas list --running`). Resolution + creds + reachability all go through
+ * the shared `connectOrExit` (so these work from any directory, and an explicit `--creds` is a raw
+ * off-registry connection). Opens a transient endpoint that never joins the roster, does the one
+ * thing, stops.
  */
 
 export interface ConnectValues {
@@ -17,20 +16,14 @@ export interface ConnectValues {
   creds?: string;
 }
 
-/** Resolve where to connect and with what credentials: an explicit `--creds` wins; else self-mint
- *  from the resolved mesh's `.cotal/auth` so an AUTH-mode mesh admits us; else connect bare on an
- *  open mesh. Preflights the broker (one-sentence exit on unreachable / auth mismatch). */
+/** Resolve where to connect + with what credentials (`--creds` → raw off-registry; else the running
+ *  mesh's minted manager creds). Fail-loud — an unresolved registry or an unreachable/auth-mismatched
+ *  broker exits with one sentence, never degrades. */
 export async function resolveConnect(
   values: ConnectValues,
 ): Promise<{ server: string; space: string; creds?: string }> {
-  const target = await resolveTargetOrExit({ server: values.server, space: values.space });
-  const creds = values.creds
-    ? readFileSync(values.creds, "utf8")
-    : target.auth
-      ? await mintCreds(target.auth, newIdentity(), "manager")
-      : undefined;
-  await preflightOrExit(target, creds);
-  return { server: target.server, space: target.space, creds };
+  const { server, space, creds } = await connectOrExit(values, "manager");
+  return { server, space, creds };
 }
 
 /** Open a transient endpoint: it watches presence (so name→id resolution and the live roster work)

--- a/implementations/cli/src/lib/transient.ts
+++ b/implementations/cli/src/lib/transient.ts
@@ -1,22 +1,14 @@
 import { readFileSync } from "node:fs";
-import {
-  CotalEndpoint,
-  isReachable,
-  DEFAULT_SERVER,
-  DEFAULT_SPACE,
-  authDir,
-  loadSpaceAuth,
-  mintCreds,
-  newIdentity,
-} from "@cotal-ai/core";
+import { CotalEndpoint, mintCreds, newIdentity } from "@cotal-ai/core";
 import { c } from "../ui.js";
-import { cotalRoot } from "./paths.js";
+import { preflightOrExit, resolveTargetOrExit } from "./connect.js";
 
 /**
  * A one-shot, write-capable connection for the headless commands that touch the live mesh
- * (`dm`/`msg`/`ask`, and `personas list --running`). Resolve space/server/creds the same way
- * everywhere, open a transient endpoint that never joins the roster, do the one thing, stop.
- * Fail-loud throughout — an unreachable server or a space mismatch exits, never degrades.
+ * (`dm`/`msg`/`ask`, and `personas list --running`). Resolves WHICH mesh + creds via the shared
+ * `resolveMeshTarget` (so these work from any directory, not just inside the project), opens a
+ * transient endpoint that never joins the roster, does the one thing, stops. Fail-loud throughout —
+ * an unresolved/ambiguous registry or an unreachable/auth-mismatched broker exits, never degrades.
  */
 
 export interface ConnectValues {
@@ -26,33 +18,19 @@ export interface ConnectValues {
 }
 
 /** Resolve where to connect and with what credentials: an explicit `--creds` wins; else self-mint
- *  from `.cotal/auth` so an AUTH-mode mesh admits us; else connect bare on an open mesh. Exits with
- *  a clear message on a `--space` that contradicts the local auth, or an unreachable server. */
+ *  from the resolved mesh's `.cotal/auth` so an AUTH-mode mesh admits us; else connect bare on an
+ *  open mesh. Preflights the broker (one-sentence exit on unreachable / auth mismatch). */
 export async function resolveConnect(
   values: ConnectValues,
 ): Promise<{ server: string; space: string; creds?: string }> {
-  const server = values.server ?? DEFAULT_SERVER;
-  let creds = values.creds ? readFileSync(values.creds, "utf8") : undefined;
-  let space = values.space;
-  if (!creds) {
-    const auth = loadSpaceAuth(authDir(cotalRoot()));
-    if (auth) {
-      if (space && space !== auth.space) {
-        console.error(
-          c.red(`Auth here is for space "${auth.space}", not "${space}". Use --space ${auth.space} (or pass --creds).`),
-        );
-        process.exit(1);
-      }
-      space = auth.space;
-      creds = await mintCreds(auth, newIdentity(), "manager");
-    }
-  }
-  space = space ?? DEFAULT_SPACE;
-  if (!(await isReachable(server, { creds }))) {
-    console.error(c.red(`Can't reach NATS at ${server}. Run: cotal up`));
-    process.exit(1);
-  }
-  return { server, space, creds };
+  const target = await resolveTargetOrExit({ server: values.server, space: values.space });
+  const creds = values.creds
+    ? readFileSync(values.creds, "utf8")
+    : target.auth
+      ? await mintCreds(target.auth, newIdentity(), "manager")
+      : undefined;
+  await preflightOrExit(target, creds);
+  return { server: target.server, space: target.space, creds };
 }
 
 /** Open a transient endpoint: it watches presence (so name→id resolution and the live roster work)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "pnpm -r build",
     "gen:schema": "node scripts/generate-cotal-schema.mjs",
     "test": "pnpm -r --if-present test",
-    "check": "pnpm typecheck && pnpm test && pnpm smoke:view",
+    "check": "pnpm typecheck && pnpm test && pnpm smoke:view && pnpm smoke:spawn-from-anywhere && pnpm smoke:connect",
     "clean:dry": "git clean -ndX -- node_modules .pnpm-store packages extensions implementations examples remotion",
     "clean": "git clean -fdX -- node_modules .pnpm-store packages extensions implementations examples remotion",
     "cotal": "tsx bin/cotal.ts",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "smoke:send": "tsx implementations/cli/smoke/send.smoke.ts",
     "smoke:spawn-from-anywhere": "tsx implementations/cli/smoke/spawn-from-anywhere.smoke.ts",
     "smoke:spawn-from-anywhere:live": "tsx implementations/cli/smoke/spawn-from-anywhere-live.smoke.ts",
+    "smoke:connect": "tsx implementations/cli/smoke/connect.smoke.ts",
     "smoke:delivery-cred:auth": "tsx packages/core/smoke/delivery-cred-confinement.smoke.ts",
     "smoke:delivery-reply-injection:auth": "tsx packages/core/smoke/delivery-reply-injection.smoke.ts",
     "smoke:delivery-shards-reject": "tsx implementations/delivery/smoke/delivery-shards-reject.smoke.ts",

--- a/packages/core/src/mesh-target.ts
+++ b/packages/core/src/mesh-target.ts
@@ -7,6 +7,7 @@ import {
   getCurrent,
   homeCotalDir,
   loadMeshes,
+  removeMesh,
   type MeshEntry,
 } from "./mesh-registry.js";
 
@@ -54,14 +55,27 @@ function personaRoot(root: string): string {
 }
 
 function targetFromEntry(m: MeshEntry, server: string, source: MeshTarget["source"]): MeshTarget {
+  // Honor the recorded mode: an OPEN mesh connects credlessly even if its root still has auth
+  // material on disk (e.g. a root that once ran auth mode). Loading it would make `spawn` mint
+  // creds against a broker that takes none.
+  let auth: SpaceAuth | undefined;
+  if (m.mode === "auth") {
+    auth = loadSpaceAuth(authDir(m.root));
+    // Defense in depth: the root's on-disk auth must still be for THIS space. A divergence (the root
+    // was re-`up`ed as a different space without re-recording) would otherwise mint mesh-A creds
+    // against the entry for space B. Prune the stale entry and fail loud rather than connect wrong.
+    if (auth && auth.space !== m.space) {
+      removeMesh(m.space);
+      throw new Error(
+        `registry entry "${m.space}" points at ${m.root}, whose auth is now for "${auth.space}" — stale entry removed; re-run \`cotal up\` or check \`cotal meshes\``,
+      );
+    }
+  }
   return {
     root: m.root,
     server,
     space: m.space,
-    // Honor the recorded mode: an OPEN mesh connects credlessly even if its root still has auth
-    // material on disk (e.g. a root that once ran auth mode). Loading it would make `spawn` mint
-    // creds against a broker that takes none.
-    auth: m.mode === "auth" ? loadSpaceAuth(authDir(m.root)) : undefined,
+    auth,
     personaRoot: personaRoot(m.root),
     source,
   };


### PR DESCRIPTION
## What

**Stacked on #98.** Migrates the remaining CLI commands that connect to a running mesh off the old cwd-walk resolution onto the shared `resolveMeshTarget` + preflight — so `send`/`dm`/`msg`/`ask`, `console`, `join`, `web`, `channels`, `history`, and `personas --running` all work from **any** directory, not just inside the project that ran `cotal up`.

Before, each re-derived creds from `loadSpaceAuth(authDir(cotalRoot()))` + `DEFAULT_SERVER`; from outside the project that walk-up lands on `$HOME/.cotal` and the command crashes with a raw NATS Authorization Violation — the exact bug `cotal spawn` fixed in #98, still live in every other connecting command ("spawn works, watch doesn't").

## How

- **New `lib/connect.ts`** — `resolveTargetOrExit` + `preflightOrExit`, extracted from `spawn.ts` so every mesh-touching command resolves the same way and emits the same one-sentence preflight instead of a raw trace. `preflightOrExit` takes optional probe creds (for the `--creds` escape hatch).
- **`lib/transient.ts`** (`resolveConnect`/`openTransient`) now uses the shared helper → migrates `send`, `history`, `channels`, `personas --running` in one move.
- **`web` / `console` / `join`** migrated, each keeping its escape hatches: `web`/`console` keep `--creds` and `console`'s open-mode space overview (space stays undefined with no `--space`); `join` keeps the join-link / `--token` / `--creds` paths and only the bare case resolves + self-mints.
- **`spawn.ts`** now imports the shared helper (de-duplicated; the local copies are gone).

`up` / `down` / `setup` / `mint` / `demo` stay on `cotalRoot()` — they operate on the local project by design.

## Hygiene (deferred review notes, folded in)

- **`targetFromEntry`** (mitnick): prune + fail loud when an AUTH entry's recorded space no longer matches its root's on-disk `auth.space` — never mint space-Y creds against the entry for space X.
- **`resolveTargetOrExit`** (fowler): a dim `default "X" is down — using "Y"` note when a dangling `current` is silently bypassed (the N>1 case already errors loudly; this was the one quiet redirect).
- **`cotal meshes` / `cotal down`** (norman): a dangling-`current` note in the listing; `down` summary clarified as local-only.
- **Not folded:** "`removeMesh` self-clears `current`" (fowler) — socrates showed it would *widen* the exit-handler clobber guarded in #98 (round 8 `f4de2fa`), so `clearCurrent` stays at identity-aware call sites.

## Tests

- Hermetic smoke now **24 checks** (+ the space-mismatch prune); live-broker e2e still **9/9**; `pnpm typecheck` green across all 16 projects.

## Note

Targets `feat/spawn-from-anywhere` (#98) since it builds on that PR's resolver + the round-8 exit-handler guard. Rebase onto `main` once #98 merges.
