### PR TITLE
fix(cli): web — pre-mint a scoped manager cred, drop the account signing seed

### DIFF
--- a/implementations/cli/smoke/web-seed-live.smoke.ts
+++ b/implementations/cli/smoke/web-seed-live.smoke.ts
@@ -1,0 +1,116 @@
+/**
+ * LIVE-broker e2e for the `cotal web` account-seed hardening (#102/#103). After dropping the
+ * account signing seed, the dashboard connects with an ADMIN cred and purges channels with a
+ * SEPARATELY pre-minted MANAGER cred (minted once at startup), instead of re-minting from the seed
+ * per delete. This proves the behavioral guarantee that change must keep — against a real JWT-auth
+ * broker:
+ *   • the pre-minted manager cred purges a channel (web's delete path still works), and
+ *   • the admin connection cred CANNOT purge (which is *why* web pre-mints a manager cred — if admin
+ *     could, the separate mint would be pointless).
+ *
+ * Needs `nats-server` on PATH (like the other auth smokes). Kills only the broker it spawns.
+ * Run: pnpm smoke:web-seed:live
+ */
+import { mkdtempSync, writeFileSync, openSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn, type ChildProcess } from "node:child_process";
+import {
+  CotalEndpoint,
+  clearChannel,
+  createSpaceAuth,
+  isReachable,
+  mintCreds,
+  newIdentity,
+  seedChannelRegistry,
+  serverConfig,
+  setupSpaceStreams,
+} from "@cotal-ai/core";
+
+const port = 4461;
+const server = `nats://127.0.0.1:${port}`;
+const space = "webseed";
+const dir = mkdtempSync(join(tmpdir(), "cotal-webseed-"));
+const storeDir = join(dir, "nats");
+const conf = join(dir, "s.conf");
+const log = join(dir, "s.log");
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+let pass = 0;
+const kids: ChildProcess[] = [];
+const ok = (name: string, cond: boolean, extra?: unknown) => {
+  if (!cond) throw new Error(`FAIL: ${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
+  pass++;
+  console.log(`  ✓ ${name}`);
+};
+
+try {
+  const auth = await createSpaceAuth(space); // the account signing SEED
+  writeFileSync(conf, serverConfig(auth, { port, storeDir }));
+  const fd = openSync(log, "w");
+  kids.push(spawn("nats-server", ["-c", conf], { stdio: ["ignore", fd, fd] }));
+
+  const mgrCreds = await mintCreds(auth, newIdentity(), "manager");
+  let up = false;
+  for (let i = 0; i < 50; i++) {
+    if (await isReachable(server, { creds: mgrCreds })) {
+      up = true;
+      break;
+    }
+    await sleep(200);
+  }
+  ok("JWT-auth broker up", up, up ? undefined : readFileSync(log, "utf8").slice(-400));
+
+  await setupSpaceStreams({ servers: server, space, creds: mgrCreds });
+  await seedChannelRegistry({ servers: server, space, creds: mgrCreds, file: { channels: { ops: { replay: true } } } });
+
+  // web's NEW model: connect as ADMIN, pre-mint ONE MANAGER cred for the purge, drop the seed.
+  const adminCreds = await mintCreds(auth, newIdentity(), "admin");
+  const purgeCreds = await mintCreds(auth, newIdentity(), "manager"); // pre-minted once, like web
+
+  // Seed #ops with history (via a manager endpoint — a plain publisher).
+  const pub = new CotalEndpoint({
+    space,
+    servers: server,
+    creds: mgrCreds,
+    card: { name: "seed", kind: "endpoint" },
+    consume: false,
+    registerPresence: false,
+    watchPresence: false,
+  });
+  await pub.start();
+  for (let i = 0; i < 3; i++) await pub.multicast(`m${i}`, { channel: "ops" });
+  await sleep(300);
+  await pub.stop();
+
+  // The ADMIN connection cred (what web connects with) must NOT be able to purge — that's the whole
+  // reason web mints a manager cred separately.
+  let adminBlocked = false;
+  try {
+    await clearChannel({ servers: server, space, channel: "ops", creds: adminCreds });
+  } catch {
+    adminBlocked = true;
+  }
+  ok("admin connection cred CANNOT purge (why web pre-mints a manager cred)", adminBlocked);
+
+  // The pre-minted MANAGER cred purges the channel — web's delete path works after the seed-drop.
+  const result = await clearChannel({ servers: server, space, channel: "ops", creds: purgeCreds });
+  ok(
+    "pre-minted manager cred purges the channel (web delete works post-seed-drop)",
+    result !== undefined && (result.purged ?? 0) >= 1,
+    result,
+  );
+
+  console.log(`\nweb account-seed live e2e: ${pass} checks passed`);
+} finally {
+  for (const k of kids) {
+    try {
+      k.kill("SIGKILL");
+    } catch {
+      /* already gone */
+    }
+  }
+  await sleep(300);
+  rmSync(dir, { recursive: true, force: true });
+}
+process.exit(0);

--- a/implementations/cli/src/commands/web.ts
+++ b/implementations/cli/src/commands/web.ts
@@ -51,12 +51,17 @@ export async function web(argv: string[]): Promise<void> {
       creds: { type: "string" },
     },
   });
-  // Resolve WHICH running mesh (from any directory) + its trust material, the same way `spawn` does.
-  // The dashboard is always an admin god-view (no read-only viewer mode) so it can show DMs and
-  // anycast — `connectOrExit("admin")` self-mints that cred on an auth mesh, connects bare on an
-  // open one, or takes `--creds` as a raw off-registry connection. `auth` is kept at function scope:
-  // the channel-delete write path mints an ephemeral `manager` cred from it (registry path only).
-  const { server, space, creds, auth } = await connectOrExit(values, "admin");
+  // Resolve WHICH running mesh + creds (admin god-view: shows DMs + anycast), then DROP the account
+  // seed. The dashboard is a loopback HTTP process; holding the space signing seed (`auth` — it can
+  // mint ANY identity/role) for the whole session would make a dashboard compromise = full account
+  // control. Instead pre-mint ONE scoped `manager` cred for the only write path (channel delete) and
+  // let the seed fall out of scope here, so it isn't reachable from the request handlers. `--creds`
+  // / open mode have no seed → the connection creds carry the purge rights.
+  const { server, space, creds, purgeCreds } = await (async () => {
+    const conn = await connectOrExit(values, "admin");
+    const purge = conn.auth ? await mintCreds(conn.auth, newIdentity(), "manager") : conn.creds;
+    return { server: conn.server, space: conn.space, creds: conn.creds, purgeCreds: purge };
+  })();
   const port = values.port ? Number(values.port) : WEB_PORT;
 
   // Observer: never registers presence, never consumes an inbox — invisible to peers.
@@ -161,9 +166,9 @@ export async function web(argv: string[]): Promise<void> {
       return json(res, await ep.channelHistory(name, { limit }));
     }
     // Delete a channel and its content. The only write path on this otherwise read-only
-    // dashboard, so it's POST-gated and guarded by a confirm in the UI. The observer's admin
-    // cred can't purge; mint an ephemeral manager cred (auth mode) for the op, else connect
-    // bare (open mode has full rights). A wildcard / missing channel is a 400.
+    // dashboard, so it's POST-gated and guarded by a confirm in the UI. Uses the manager cred
+    // pre-minted at startup (auth mode) or the connection creds (open / --creds), NOT the account
+    // seed (which we dropped). A wildcard / missing channel is a 400.
     if (path === "/api/channel/delete" && req.method === "POST") {
       const body = await readBody(req).catch(() => ({}) as { channel?: string });
       const channel = typeof body.channel === "string" ? body.channel : "";
@@ -173,7 +178,6 @@ export async function web(argv: string[]): Promise<void> {
         return;
       }
       try {
-        const purgeCreds = auth ? await mintCreds(auth, newIdentity(), "manager") : creds;
         const result = await clearChannel({ servers: server, space, channel, creds: purgeCreds });
         return json(res, { ok: true, ...result });
       } catch (e) {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "smoke:spawn-from-anywhere": "tsx implementations/cli/smoke/spawn-from-anywhere.smoke.ts",
     "smoke:spawn-from-anywhere:live": "tsx implementations/cli/smoke/spawn-from-anywhere-live.smoke.ts",
     "smoke:connect": "tsx implementations/cli/smoke/connect.smoke.ts",
+    "smoke:web-seed:live": "tsx implementations/cli/smoke/web-seed-live.smoke.ts",
     "smoke:delivery-cred:auth": "tsx packages/core/smoke/delivery-cred-confinement.smoke.ts",
     "smoke:delivery-reply-injection:auth": "tsx packages/core/smoke/delivery-reply-injection.smoke.ts",
     "smoke:delivery-shards-reject": "tsx implementations/delivery/smoke/delivery-shards-reject.smoke.ts",


### PR DESCRIPTION
Closes #102.

## Problem
`cotal web` retained the space `SpaceAuth` — the **account signing seed**, which can mint *any* identity/role — at function scope for the whole session, re-minting a `manager` cred from it on every channel delete. The dashboard is a loopback HTTP server that parses request bodies, so a compromise of that process exposed full account-minting capability.

## Fix (socrates' recommendation)
Pre-mint **one** scoped `manager` cred at startup (for the only write path — channel delete) inside an IIFE, and let the seed fall out of scope so the long-lived request handlers can't reach it. Blast radius shrinks from "mint anything for the account" → "purge channels as one manager". Open / `--creds` modes have no seed and use the connection creds (unchanged).

## Notes
- Behavior of channel-delete is unchanged (still a manager-cred purge); only the seed's lifetime/reachability changes.
- typecheck green (16 projects). No new automated test — the change is a memory-reachability property, not a behavioral one; delete is covered by existing flows.
- Pre-existing issue (not introduced by the spawn-from-anywhere work); surfaced in the #101 review and scoped out to here.