### PR TITLE
fix(attach): restore terminal modes on detach

### DIFF
--- a/implementations/manager/src/attach-client.ts
+++ b/implementations/manager/src/attach-client.ts
@@ -7,11 +7,13 @@ const DETACH = 0x1d;
  * Terminal modes a full-screen child (e.g. Claude's TUI) commonly turns on but that we must undo
  * locally on detach/exit: the agent keeps running after Ctrl-], so it never restores OUR terminal.
  * Without this, detaching from a mouse-tracking TUI leaves the terminal reporting every cursor move
- * as input (a stream of `ESC[<…M` escape codes). Disables all mouse-report modes + bracketed paste,
- * shows the cursor, and resets attributes. Deliberately does NOT toggle the alternate screen.
+ * as input (a stream of `ESC[<…M` escape codes), or its focus in/out as `ESC[I`/`ESC[O`. Disables
+ * all mouse-report modes + focus reporting + bracketed paste, shows the cursor, and resets
+ * attributes. Deliberately does NOT toggle the alternate screen.
  */
 const RESTORE =
   "\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1005l\x1b[?1006l\x1b[?1015l" + // mouse tracking off
+  "\x1b[?1004l" + // focus reporting off
   "\x1b[?2004l" + // bracketed paste off
   "\x1b[?25h" + // show cursor
   "\x1b[0m"; // reset attributes
@@ -26,6 +28,12 @@ export function attachClient(url: string): Promise<void> {
     const ws = new WebSocket(url);
     const stdin = process.stdin;
     const wasRaw = stdin.isRaw ?? false;
+
+    // A broken local pipe (terminal closed / SIGHUP) makes stdout writes async-error on a later
+    // tick; with no listener that EPIPE/EIO becomes an uncaughtException — crashing on the per-frame
+    // PTY write or the on-detach restore write. Register a no-op listener once here (not in cleanup,
+    // so it outlives the async error tick) to turn it into a handled no-op.
+    process.stdout.on("error", () => {});
 
     const sendResize = () =>
       ws.send(`r:${process.stdout.columns ?? 80},${process.stdout.rows ?? 24}`);

--- a/implementations/manager/src/attach-client.ts
+++ b/implementations/manager/src/attach-client.ts
@@ -4,6 +4,19 @@ import WebSocket from "ws";
 const DETACH = 0x1d;
 
 /**
+ * Terminal modes a full-screen child (e.g. Claude's TUI) commonly turns on but that we must undo
+ * locally on detach/exit: the agent keeps running after Ctrl-], so it never restores OUR terminal.
+ * Without this, detaching from a mouse-tracking TUI leaves the terminal reporting every cursor move
+ * as input (a stream of `ESC[<…M` escape codes). Disables all mouse-report modes + bracketed paste,
+ * shows the cursor, and resets attributes. Deliberately does NOT toggle the alternate screen.
+ */
+const RESTORE =
+  "\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1005l\x1b[?1006l\x1b[?1015l" + // mouse tracking off
+  "\x1b[?2004l" + // bracketed paste off
+  "\x1b[?25h" + // show cursor
+  "\x1b[0m"; // reset attributes
+
+/**
  * Drive a manager's attach endpoint from the terminal: raw-mode stdin streams to
  * the PTY, PTY output streams to stdout, and SIGWINCH-style resizes are forwarded.
  * Ctrl-] detaches without killing the agent.
@@ -26,6 +39,8 @@ export function attachClient(url: string): Promise<void> {
     const cleanup = () => {
       stdin.off("data", onInput);
       process.stdout.off("resize", sendResize);
+      // Undo terminal modes the (still-running) agent's TUI enabled — it won't restore us on detach.
+      if (process.stdout.isTTY) process.stdout.write(RESTORE);
       if (stdin.isTTY) stdin.setRawMode(wasRaw);
       stdin.pause();
     };


### PR DESCRIPTION
## Problem
`attachClient` puts stdin in raw mode but never restores the terminal modes the attached agent's TUI enables (mouse tracking, bracketed paste, hidden cursor). Because `Ctrl-]` detaches **without** killing the agent, the agent keeps running and never restores the *local* terminal — so after detaching from a mouse-tracking TUI (e.g. Claude Code), the terminal is left reporting every cursor move as input: a stream of `ESC[<…M` codes spewed into whatever you run next.

## Fix
`cleanup()` now emits a restore sequence on every disconnect path (detach, agent-exit, ws error): disable all mouse-report modes (1000/1002/1003/1005/1006/1015) + bracketed paste (2004), show the cursor (25h), reset attributes (0m). It deliberately does **not** toggle the alternate screen.

## Test
Attach to a mouse-tracking TUI, move the mouse (reporting on), `Ctrl-]` to detach. Before: the shell receives `ESC[<…M` on every mouse move. After: clean.