### PR TITLE
feat(cli): re-export lifecycle helpers for external composition roots

### DIFF
--- a/implementations/cli/src/index.ts
+++ b/implementations/cli/src/index.ts
@@ -175,3 +175,9 @@ registry.register(...baseCommands);
 
 export { runCli } from "./command.js";
 export { c, statusBadge } from "./ui.js";
+
+// Lifecycle helpers for an external composition root (e.g. paw) — this package's exports are
+// restricted to ".", so subpath imports are blocked; re-export from the index instead.
+// `isReachable` (core) is already exported from @cotal-ai/core.
+export { startMeshDetached } from "./commands/up.js";
+export { ensureManager, managerUp } from "./lib/manager-proc.js";


### PR DESCRIPTION
## Why
`@cotal-ai/cli` restricts its package `exports` to `.`, so a downstream composition root (e.g. one that wants cotal to own its mesh + manager lifecycle) can't import the detached-daemon helpers via a subpath like `@cotal-ai/cli/commands/up.js` — the import is blocked.

## Change
Re-export the lifecycle helpers from the package index (additive only):
- `startMeshDetached` (from `./commands/up`)
- `ensureManager`, `managerUp` (from `./lib/manager-proc`)

`isReachable` (core) is already exported from `@cotal-ai/core`. No behavior change.