### PR TITLE
fix(manager): ps/start/stop/attach resolve the broker from the registry

### DIFF
--- a/.changeset/manager-command-server-resolution.md
+++ b/.changeset/manager-command-server-resolution.md
@@ -1,0 +1,12 @@
+---
+"@cotal-ai/manager": patch
+---
+
+Fix: `cotal ps` / `start` / `stop` / `attach` now resolve their broker from the mesh registry — the
+same way `send` / `channels` / `console` / `web` and the manifest verbs already do — instead of
+silently defaulting to `nats://127.0.0.1:4222`. Managing a manifest mesh on a non-default port no
+longer needs an explicit `--server`: `--space <name>` finds the recorded broker, and `--server`
+stays an override only. Each command also mints its privileged "manager" cred from the **resolved**
+mesh's own recorded root, so `--space <other>` loads that mesh's trust material instead of failing
+against the current folder's. `--creds` remains a raw off-registry escape hatch; the `supervise`
+daemon is unchanged.

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -90,9 +90,9 @@ the whole space). An additive deploy from `spawn -f` is torn down with **`cotal 
 `up -f` and `spawn -f` accept `--dry-run` (preview the plan, change nothing). `up -f` also takes
 `--server` / `--host` / `--space` / `--runtime` / `--open` to override the file for one run.
 
-> The manager commands `cotal ps` / `start` / `stop` / `attach` default to
-> `nats://127.0.0.1:4222`. They work as-is for a default-port mesh; for a manifest mesh on
-> another port, pass `--server` (see [Operating a manifest mesh](#operating-a-manifest-mesh)).
+> The manager commands `cotal ps` / `start` / `stop` / `attach` resolve the broker from the mesh
+> registry too, so `--space <name>` reaches a manifest mesh on any port; `--server` is an override
+> (see [Operating a manifest mesh](#operating-a-manifest-mesh)).
 
 ## Fields
 
@@ -225,18 +225,16 @@ it before deleting anything:
 
 ## Operating a manifest mesh
 
-The mesh-level commands (`send`, `channels`, `console`, `web`, plus `up -f` / `spawn -f` /
-`down -f` themselves) resolve the broker from the mesh registry, so `--space <name>` is enough.
-
-**Known limitation:** the manager control commands — `cotal ps` / `start` / `stop` / `attach` —
-do **not** yet registry-resolve the broker, and default to `nats://127.0.0.1:4222`. For a
-manifest mesh on a non-default port, pass an explicit `--server`:
+Every mesh-touching command resolves the broker from the mesh registry, so `--space <name>` is
+enough — `send`, `channels`, `console`, `web`, the manifest verbs (`up -f` / `spawn -f` /
+`down -f`), and the manager control commands (`cotal ps` / `start` / `stop` / `attach`) all reach
+a manifest mesh on any port without a `--server` flag:
 
 ```bash
-cotal ps --space research-team --server nats://127.0.0.1:14999
+cotal ps --space research-team        # finds research-team's broker via the registry
 ```
 
-A follow-up will route these through the same resolution as the rest of the CLI.
+`--server` remains an explicit override for an off-registry broker.
 
 ## Today / not yet
 
@@ -244,7 +242,7 @@ A follow-up will route these through the same resolution as the rest of the CLI.
 |---|---|
 | Single space per file (`space:` scalar) | ✅ today |
 | `up -f` / `spawn -f` / `down -f` / `topology view -f` | ✅ today |
-| `--server` resolution for `ps`/`start`/`stop`/`attach` | follow-up |
+| Registry server-resolution for `ps`/`start`/`stop`/`attach` | ✅ today |
 | Multiple spaces per manifest (`spaces:`) | not in v1 |
 
 ---

--- a/implementations/manager/smoke/server-resolution.smoke.ts
+++ b/implementations/manager/smoke/server-resolution.smoke.ts
@@ -1,0 +1,56 @@
+/**
+ * Manager control-command server-resolution smoke — proves `cotal ps` / `start` / `stop` / `attach`
+ * resolve their broker from the mesh registry (the same way the rest of the CLI does), instead of
+ * silently assuming `DEFAULT_SERVER` (:4222). That silent default was the bug: `ps --space <mesh>`
+ * for a mesh on another port hit :4222 and got an auth violation.
+ *
+ * No broker, no manager: it drives the pure `resolveManagerTarget` against a SANDBOXED registry
+ * (`COTAL_HOME` → a tmpdir) and a cwd with no `.cotal` ancestor, so the result is environment-
+ * independent. Run: pnpm smoke:server-resolution
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_SERVER, recordMesh } from "@cotal-ai/core";
+import { resolveManagerTarget } from "../src/commands.js";
+
+let failures = 0;
+function check(label: string, cond: boolean, extra?: unknown): void {
+  console.log(`${cond ? "✓" : "✗"} ${label}${cond ? "" : ` — got ${JSON.stringify(extra)}`}`);
+  if (!cond) failures++;
+}
+
+// Sandbox the registry so we never touch the real ~/.cotal, and run from a dir with no `.cotal`
+// up-tree so the bare (no-flags) case falls through to the registry rather than a local project.
+const home = mkdtempSync(join(tmpdir(), "cotal-ps-resolve-home-"));
+const cwd = mkdtempSync(join(tmpdir(), "cotal-ps-resolve-cwd-"));
+const projectRoot = mkdtempSync(join(tmpdir(), "cotal-ps-resolve-root-"));
+process.env.COTAL_HOME = home;
+process.chdir(cwd);
+
+const OTHER = "nats://127.0.0.1:14999";
+const OVERRIDE = "nats://127.0.0.1:7777";
+
+// An OPEN mesh registered on a NON-default port (open ⇒ no creds to mint — keeps the smoke broker-free).
+recordMesh({ space: "team-alpha", server: OTHER, root: projectRoot, mode: "open", ts: new Date(0).toISOString() });
+
+// 1. The fix: `--space` resolves the registry-recorded broker, NOT DEFAULT_SERVER.
+const bySpace = await resolveManagerTarget({ space: "team-alpha" });
+check("--space resolves the registry-recorded broker", bySpace.server === OTHER, bySpace.server);
+check("did NOT fall back to DEFAULT_SERVER (:4222)", bySpace.server !== DEFAULT_SERVER, bySpace.server);
+check("open mesh ⇒ no creds minted", bySpace.creds === undefined, bySpace.creds);
+check("resolved space is preserved", bySpace.space === "team-alpha", bySpace.space);
+
+// 2. Bare (no flags) with a single registered mesh → still resolves that mesh's broker.
+const bare = await resolveManagerTarget({});
+check("bare resolves the single registered mesh", bare.server === OTHER, bare.server);
+
+// 3. `--server` stays an explicit override, even when `--space` is registered elsewhere.
+const override = await resolveManagerTarget({ space: "team-alpha", server: OVERRIDE });
+check("--server overrides the registry", override.server === OVERRIDE, override.server);
+
+rmSync(home, { recursive: true, force: true });
+rmSync(cwd, { recursive: true, force: true });
+rmSync(projectRoot, { recursive: true, force: true });
+console.log(failures ? `\n✗ ${failures} check(s) failed` : "\n✓ all checks passed");
+process.exit(failures ? 1 : 0);

--- a/implementations/manager/smoke/server-resolution.smoke.ts
+++ b/implementations/manager/smoke/server-resolution.smoke.ts
@@ -49,6 +49,15 @@ check("bare resolves the single registered mesh", bare.server === OTHER, bare.se
 const override = await resolveManagerTarget({ space: "team-alpha", server: OVERRIDE });
 check("--server overrides the registry", override.server === OVERRIDE, override.server);
 
+// 4. Raw OPEN off-registry escape hatch (parity with connectOrExit): `--server` + an UNregistered
+//    `--space` → a bare connection, no registry lookup, no creds.
+const rawOpen = await resolveManagerTarget({ server: OTHER, space: "not-registered" });
+check(
+  "--server + unregistered --space → raw open (no creds, no registry)",
+  rawOpen.server === OTHER && rawOpen.space === "not-registered" && rawOpen.creds === undefined,
+  rawOpen,
+);
+
 rmSync(home, { recursive: true, force: true });
 rmSync(cwd, { recursive: true, force: true });
 rmSync(projectRoot, { recursive: true, force: true });

--- a/implementations/manager/smoke/server-resolution.smoke.ts
+++ b/implementations/manager/smoke/server-resolution.smoke.ts
@@ -8,10 +8,10 @@
  * (`COTAL_HOME` → a tmpdir) and a cwd with no `.cotal` ancestor, so the result is environment-
  * independent. Run: pnpm smoke:server-resolution
  */
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { DEFAULT_SERVER, recordMesh } from "@cotal-ai/core";
+import { DEFAULT_SERVER, DEFAULT_SPACE, recordMesh } from "@cotal-ai/core";
 import { resolveManagerTarget } from "../src/commands.js";
 
 let failures = 0;
@@ -56,6 +56,18 @@ check(
   "--server + unregistered --space → raw open (no creds, no registry)",
   rawOpen.server === OTHER && rawOpen.space === "not-registered" && rawOpen.creds === undefined,
   rawOpen,
+);
+
+// 5. Explicit --creds → a raw off-registry connection: the file's creds verbatim, `--server`
+//    honored, and (no `--space`) space defaults to this folder's auth-space via spaceFor — here the
+//    clean cwd has no auth, so DEFAULT_SPACE. (Deliberate manager-command default, not connectOrExit's.)
+const credsFile = join(home, "dummy.creds");
+writeFileSync(credsFile, "DUMMY-CREDS\n");
+const withCreds = await resolveManagerTarget({ creds: credsFile, server: OVERRIDE });
+check(
+  "--creds → raw connection (file creds, honored --server, spaceFor default)",
+  withCreds.creds === "DUMMY-CREDS\n" && withCreds.server === OVERRIDE && withCreds.space === DEFAULT_SPACE,
+  withCreds,
 );
 
 rmSync(home, { recursive: true, force: true });

--- a/implementations/manager/src/commands.ts
+++ b/implementations/manager/src/commands.ts
@@ -36,14 +36,21 @@ function spaceFor(v: Values): string {
   return v.space ?? loadSpaceAuth(authDir(findCotalRoot()))?.space ?? DEFAULT_SPACE;
 }
 
-/** Resolve which running mesh a control command (`ps`/`start`/`stop`/`attach`) targets — the SAME
- *  registry/`current` resolution the rest of the CLI uses ({@link resolveMeshTarget}), so
- *  `cotal ps --space <name>` reaches that mesh's RECORDED broker instead of silently assuming
- *  `DEFAULT_SERVER` (:4222). `--server` is an override only. An explicit `--creds` is a raw
- *  off-registry connection (honor `--server`/`--space` verbatim, no registry lookup), mirroring the
- *  CLI's `connectOrExit`. Mints a privileged "manager" cred from the RESOLVED mesh's trust material
- *  (its own recorded root — so `--space other` loads other's auth, not this folder's), or none for
- *  an open mesh. */
+/** Resolve which running mesh a control command (`ps`/`start`/`stop`/`attach`) targets, with the
+ *  same precedence as the rest of the CLI ({@link resolveMeshTarget} / `connectOrExit`):
+ *    1. explicit `--creds` → a raw off-registry connection. Space defaults to this folder's
+ *       auth-space via {@link spaceFor} (a deliberate manager-command choice — more correct than
+ *       `DEFAULT_SPACE` for a non-default-space project, and what these commands did before — NOT
+ *       `connectOrExit`'s `DEFAULT_SPACE`).
+ *    2. `--server` + an UNregistered `--space` → a raw OPEN off-registry connection, no creds (the
+ *       same escape hatch `connectOrExit` has).
+ *    3. otherwise the registry/`current` resolver — so `cotal ps --space <name>` reaches that mesh's
+ *       RECORDED broker instead of silently assuming `DEFAULT_SERVER` (:4222); `--server` overrides.
+ *  In case 3 the privileged "manager" cred is minted from the RESOLVED mesh's own recorded root (so
+ *  `--space other` loads other's auth, guarded by `targetFromEntry`'s `auth.space === m.space`
+ *  check), or none for an open mesh. Unlike `connectOrExit` it doesn't prune stale entries or
+ *  preflight here (those helpers are CLI-only) — a dead `--space` fails in `ask()`'s reachability
+ *  check rather than being pruned with a "stale registry entry" message. */
 export async function resolveManagerTarget(v: Values): Promise<{ space: string; server: string; creds?: string }> {
   if (v.creds) {
     return { space: spaceFor(v), server: v.server ?? DEFAULT_SERVER, creds: readFileSync(v.creds, "utf8") };

--- a/implementations/manager/src/commands.ts
+++ b/implementations/manager/src/commands.ts
@@ -12,11 +12,13 @@ import {
   mintCreds,
   newIdentity,
   registry,
+  resolveMeshTarget,
   CONTROL_PRIVILEGED,
   CONTROL_ADMIN,
   type Command,
   type ControlReply,
   type ControlTier,
+  type MeshTarget,
 } from "@cotal-ai/core";
 import { Manager } from "./manager.js";
 import { loadRoster } from "./roster.js";
@@ -31,6 +33,29 @@ type Values = Record<string, string | undefined>;
  *  default — so a manually-run manager matches the folder's mesh instead of assuming the default. */
 function spaceFor(v: Values): string {
   return v.space ?? loadSpaceAuth(authDir(findCotalRoot()))?.space ?? DEFAULT_SPACE;
+}
+
+/** Resolve which running mesh a control command (`ps`/`start`/`stop`/`attach`) targets — the SAME
+ *  registry/`current` resolution the rest of the CLI uses ({@link resolveMeshTarget}), so
+ *  `cotal ps --space <name>` reaches that mesh's RECORDED broker instead of silently assuming
+ *  `DEFAULT_SERVER` (:4222). `--server` is an override only. An explicit `--creds` is a raw
+ *  off-registry connection (honor `--server`/`--space` verbatim, no registry lookup), mirroring the
+ *  CLI's `connectOrExit`. Mints a privileged "manager" cred from the RESOLVED mesh's trust material
+ *  (its own recorded root — so `--space other` loads other's auth, not this folder's), or none for
+ *  an open mesh. */
+export async function resolveManagerTarget(v: Values): Promise<{ space: string; server: string; creds?: string }> {
+  if (v.creds) {
+    return { space: spaceFor(v), server: v.server ?? DEFAULT_SERVER, creds: readFileSync(v.creds, "utf8") };
+  }
+  let target: MeshTarget;
+  try {
+    target = resolveMeshTarget(process.cwd(), { server: v.server, space: v.space });
+  } catch (e) {
+    console.error(c.red(`✗ ${(e as Error).message}`));
+    process.exit(1);
+  }
+  const creds = target.auth ? await mintCreds(target.auth, newIdentity(), "manager") : undefined;
+  return { space: target.space, server: target.server, creds };
 }
 
 function parse(argv: string[]): Values {
@@ -67,35 +92,19 @@ function parse(argv: string[]): Values {
   return values as Values;
 }
 
-/** Connect a short-lived client, send one control request to the manager, disconnect. `tier` picks
- *  the control subject: privileged for spawn/ps; admin for the operator's cross-agent ops
- *  (stop/attach/purge), which the manager refuses on the privileged subject for a non-owner. The
- *  CLI mints a "manager" cred (allow-all), so it can reach either subject. */
+/** Connect a short-lived client with the resolved creds, send one control request to the manager,
+ *  disconnect. `tier` picks the control subject: privileged for spawn/ps; admin for the operator's
+ *  cross-agent ops (stop/attach/purge), which the manager refuses on the privileged subject for a
+ *  non-owner. `creds` is the privileged "manager" cred resolved by {@link resolveManagerTarget}
+ *  (allow-all, so it reaches either subject), or undefined on an open mesh. */
 async function ask(
   space: string,
   server: string,
   op: string,
   args?: Record<string, unknown>,
-  credsPath?: string,
+  creds?: string,
   tier: ControlTier = CONTROL_PRIVILEGED,
 ): Promise<ControlReply> {
-  // An explicit --creds wins; else self-mint a privileged "manager" cred from .cotal/auth so the
-  // operator's start/stop/ps reach the privileged control subject (P5: only spawn-capable/admin/
-  // manager creds may publish there — an agent cred no longer works); else connect bare on an open
-  // mesh. Mirrors `cotal send`/`spawn`/`history`.
-  let creds = credsPath ? readFileSync(credsPath, "utf8") : undefined;
-  if (!creds) {
-    const auth = loadSpaceAuth(authDir(findCotalRoot()));
-    if (auth) {
-      if (space && space !== auth.space) {
-        console.error(
-          c.red(`Auth here is for space "${auth.space}", not "${space}". Use --space ${auth.space} (or pass --creds).`),
-        );
-        process.exit(1);
-      }
-      creds = await mintCreds(auth, newIdentity(), "manager");
-    }
-  }
   if (!(await isReachable(server, { creds }))) {
     console.error(c.red(`Can't reach NATS at ${server}. Run: cotal up`));
     process.exit(1);
@@ -134,7 +143,8 @@ async function start(argv: string[]): Promise<void> {
     console.error(c.red("--name is required"));
     process.exit(1);
   }
-  const reply = await ask(spaceFor(v), v.server ?? DEFAULT_SERVER, "start", {
+  const t = await resolveManagerTarget(v);
+  const reply = await ask(t.space, t.server, "start", {
     name: v.name,
     role: v.role,
     agent: v.agent,
@@ -142,7 +152,7 @@ async function start(argv: string[]): Promise<void> {
     model: v.model,
     // Opt-in: only sent when `--transcript` is given; absent => the daemon's default (mirror off).
     transcript: v.transcript ? true : undefined,
-  }, v.creds);
+  }, t.creds);
   failIfNotOk(reply);
   const d = reply.data as { name: string; role?: string; agent: string; mode: string };
   console.log(
@@ -159,16 +169,18 @@ async function stop(argv: string[]): Promise<void> {
   }
   // Operator stop is a cross-agent (admin) op — the CLI operator isn't the agent's spawner, so the
   // privileged subject would reject it; admin (its allow-all "manager" cred reaches it) is correct.
-  const reply = await ask(spaceFor(v), v.server ?? DEFAULT_SERVER, "stop", {
+  const t = await resolveManagerTarget(v);
+  const reply = await ask(t.space, t.server, "stop", {
     name: v.name,
-  }, v.creds, CONTROL_ADMIN);
+  }, t.creds, CONTROL_ADMIN);
   failIfNotOk(reply);
   console.log(c.dim(`✓ stopped ${v.name}`));
 }
 
 async function ps(argv: string[]): Promise<void> {
   const v = parse(argv);
-  const reply = await ask(spaceFor(v), v.server ?? DEFAULT_SERVER, "ps", undefined, v.creds);
+  const t = await resolveManagerTarget(v);
+  const reply = await ask(t.space, t.server, "ps", undefined, t.creds);
   failIfNotOk(reply);
   const rows =
     (reply.data as Array<{
@@ -209,9 +221,10 @@ async function attach(argv: string[]): Promise<void> {
   }
   // Operator attach is a cross-agent (admin) op — same reasoning as stop (the operator isn't the
   // spawner; admin reaches any agent).
-  const reply = await ask(spaceFor(v), v.server ?? DEFAULT_SERVER, "attach", {
+  const t = await resolveManagerTarget(v);
+  const reply = await ask(t.space, t.server, "attach", {
     name: v.name,
-  }, v.creds, CONTROL_ADMIN);
+  }, t.creds, CONTROL_ADMIN);
   failIfNotOk(reply);
   const { ws } = reply.data as { ws: string };
   console.error(c.dim(`attached to ${v.name} — Ctrl-] to detach`));

--- a/implementations/manager/src/commands.ts
+++ b/implementations/manager/src/commands.ts
@@ -12,6 +12,7 @@ import {
   mintCreds,
   newIdentity,
   registry,
+  findMesh,
   resolveMeshTarget,
   CONTROL_PRIVILEGED,
   CONTROL_ADMIN,
@@ -46,6 +47,13 @@ function spaceFor(v: Values): string {
 export async function resolveManagerTarget(v: Values): Promise<{ space: string; server: string; creds?: string }> {
   if (v.creds) {
     return { space: spaceFor(v), server: v.server ?? DEFAULT_SERVER, creds: readFileSync(v.creds, "utf8") };
+  }
+  // A raw OPEN off-registry mesh: explicit `--server` + a `--space` that isn't registered. Naming
+  // both is as deliberate as `--creds`, but an open broker has no creds to pass — connect bare,
+  // off-registry (no registry lookup). Mirrors `connectOrExit`'s same-shaped escape hatch; a
+  // registered `--space` still goes through the resolver below (which honors `--server` as override).
+  if (v.server && v.space && !findMesh(v.space)) {
+    return { space: v.space, server: v.server, creds: undefined };
   }
   let target: MeshTarget;
   try {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "pnpm -r build",
     "gen:schema": "node scripts/generate-cotal-schema.mjs",
     "test": "pnpm -r --if-present test",
-    "check": "pnpm typecheck && pnpm test && pnpm smoke:view && pnpm smoke:spawn-from-anywhere && pnpm smoke:connect && pnpm smoke:ci",
+    "check": "pnpm typecheck && pnpm test && pnpm smoke:view && pnpm smoke:spawn-from-anywhere && pnpm smoke:connect && pnpm smoke:server-resolution && pnpm smoke:ci",
     "smoke:ci": "pnpm smoke:read-acl:auth && pnpm smoke:sub-acl:auth && pnpm smoke:self-serve-join:auth && pnpm smoke:control-auth && pnpm smoke:channels:auth && pnpm smoke:e2e:acl && pnpm smoke:plane3:auth && pnpm smoke:delivery-lease:auth && pnpm smoke:delivery-leave-tombstone:auth && pnpm smoke:delivery-reconnect:auth && pnpm smoke:delivery-cred:auth && pnpm smoke:delivery-reply-injection:auth && pnpm smoke:membership:auth && pnpm smoke:membership-feed-confinement:auth && pnpm smoke:wildcard-backfill",
     "clean:dry": "git clean -ndX -- node_modules .pnpm-store packages extensions implementations examples remotion",
     "clean": "git clean -fdX -- node_modules .pnpm-store packages extensions implementations examples remotion",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "smoke:start-model": "tsx implementations/manager/smoke/start-model-preflight.smoke.ts",
     "smoke:persona-acl": "tsx implementations/manager/smoke/persona-identity-acl.smoke.ts",
     "smoke:manifest-launch": "tsx implementations/manager/smoke/manifest-launch.smoke.ts",
+    "smoke:server-resolution": "tsx implementations/manager/smoke/server-resolution.smoke.ts",
     "smoke:spawn-args": "tsx extensions/connector-core/smoke/spawn-args.smoke.ts",
     "smoke:install": "tsx implementations/cli/smoke/install.smoke.ts",
     "smoke:send": "tsx implementations/cli/smoke/send.smoke.ts",


### PR DESCRIPTION
Closes the known limitation from the mesh-manifest work (#108 / #110, documented in `docs/manifest.md`): the four manager control commands — `cotal ps` / `start` / `stop` / `attach` — resolved `--server` as `v.server ?? DEFAULT_SERVER` and never consulted the mesh registry, so `cotal ps --space <mesh-on-another-port>` hit `:4222` and got a raw auth violation.

## Fix
Route the four commands through core's `resolveMeshTarget` (the exact resolution `connectOrExit` uses), via a small shared `resolveManagerTarget`:
- `--space <name>` → the mesh's **recorded** broker (the fix).
- `--server` → an explicit override only.
- the privileged "manager" cred is minted from the **resolved** mesh's own recorded root, so `--space <other>` loads that mesh's trust material instead of failing against the current folder's auth.
- `--creds` stays a raw off-registry escape hatch; `supervise` (the daemon) is unchanged.

`resolveMeshTarget` lives in `@cotal-ai/core`, so the manager uses it without importing the CLI (implementations don't cross-import).

## Tests
- New broker-free regression smoke `smoke:server-resolution` (6 checks): `--space` resolves the recorded broker (not `:4222`), bare resolves the single registered mesh, `--server` overrides, open mesh mints no creds.
- Typecheck clean; existing manager smokes (`start-model`, `persona-acl`, `manifest-launch`) pass — no regression.

## Docs
`docs/manifest.md` updated in the same change — the "Known limitation" section and the Today/not-yet row now state these commands registry-resolve.

Plan: `.internal/plans/manager-command-server-resolution.md`.