### PR TITLE
fix(cli): web graph mode filters gate persistent edges + no-cache dashboard assets

### DIFF
--- a/implementations/cli/src/commands/web.ts
+++ b/implementations/cli/src/commands/web.ts
@@ -189,7 +189,9 @@ export async function web(argv: string[]): Promise<void> {
 
     const file = PAGE[path];
     if (file) {
-      res.writeHead(200, { "content-type": file.type });
+      // no-cache: always revalidate so a `cotal` upgrade's new dashboard code is picked up on
+      // reload — a stale cached graph.js silently runs old behavior (e.g. pre-fix filters).
+      res.writeHead(200, { "content-type": file.type, "cache-control": "no-cache" });
       res.end(readFileSync(file.path));
       return;
     }

--- a/implementations/cli/src/web/graph.js
+++ b/implementations/cli/src/web/graph.js
@@ -299,10 +299,11 @@
     ctx.setLineDash([]);
     // activity layer: traffic glow on top (members + transient non-member posts)
     ctx.globalCompositeOperation = "lighter";
-    for (const e of edges.values()) { const h = hubs.get(e.chan); if (!h || isHidden(h) || e.heat <= 0.02 || isHiddenMember(e)) continue; const lit = inFan(e, f); ctx.beginPath(); ctx.moveTo(e.a.x, e.a.y); ctx.lineTo(h.x, h.y); ctx.strokeStyle = rgba(MODE.chat, Math.min(0.55, e.heat * 0.55) * (lit ? 1 : 0.35)); ctx.lineWidth = 1 + e.heat * 1.6; ctx.stroke(); }
+    for (const e of edges.values()) { const h = hubs.get(e.chan); if (!filter.chat || !h || isHidden(h) || e.heat <= 0.02 || isHiddenMember(e)) continue; const lit = inFan(e, f); ctx.beginPath(); ctx.moveTo(e.a.x, e.a.y); ctx.lineTo(h.x, h.y); ctx.strokeStyle = rgba(MODE.chat, Math.min(0.55, e.heat * 0.55) * (lit ? 1 : 0.35)); ctx.lineWidth = 1 + e.heat * 1.6; ctx.stroke(); }
     ctx.globalCompositeOperation = "source-over"; ctx.globalAlpha = 1;
   }
   function drawDmEdges() {
+    if (!filter.unicast) return; // the `direct` chip filters DM traffic — including the persistent DM curves
     ctx.setLineDash([3, 4]);
     for (const d of dms.values()) {
       if (isHidden(d.a) || isHidden(d.b)) continue;


### PR DESCRIPTION
## What

Two fixes for the `/graph` mesh dashboard.

### Mode chips now filter the geometry, not just the animation
The `channel` / `direct` / `anycast` chips only gated whether a *new traffic comet* animated when a message arrived. The persistent edges were never gated, so:

- toggling **direct** off left every orange DM curve on screen, and
- toggling **channel** off left the blue spoke glow.

Now `drawDmEdges` returns early when `filter.unicast` is off (the DM curves *are* the direct-traffic representation), and the channel-traffic glow layer in `drawSpokes` is gated on `filter.chat`. Membership spokes stay put — those are the membership layer, governed by hide-offline / hide-empty. Verified in a browser: with **direct** off, all DM curves vanish while the grey membership spokes correctly remain.

> `channel` / `anycast` are traffic filters — on a quiet mesh they still look inert because there's no traffic of that type to suppress. **direct** is the only chip with a persistent element, which is why it stood out as "broken".

### Dashboard assets sent with `cache-control: no-cache`
The static assets (`graph.js`, `graph.html`, `app.js`, `index.html`) were served with no cache headers and no validators, so a browser could keep running a stale `graph.js` after a `cotal` upgrade — silently shadowing dashboard fixes. They now always revalidate.

## Test
- Browser: confirmed **direct** off hides DM curves, membership spokes unaffected.
- Confirmed `/graph.js` responds with `cache-control: no-cache`.