### PR TITLE
fix(manager): forward resolved channel ACL to spawned connectors

### DIFF
--- a/extensions/connector-claude-code/src/extension.ts
+++ b/extensions/connector-claude-code/src/extension.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { loadAgentFile, registry, type Connector, type LaunchOpts, type LaunchSpec } from "@cotal-ai/core";
-import { launchEnv, mcpServerEnvKeys } from "@cotal-ai/connector-core";
+import { aclEnv, launchEnv, mcpServerEnvKeys } from "@cotal-ai/connector-core";
 
 /** Name the cotal MCP server is registered under via --mcp-config (see buildLaunch). */
 const MCP_SERVER_NAME = "cotal";
@@ -42,6 +42,7 @@ export const claudeConnector: Connector = {
     // by name). The operator's unrelated secrets don't reach the child (P3).
     const env: Record<string, string> = {
       ...launchEnv({ mcpKeys: mcpServerEnvKeys(shared) }),
+      ...aclEnv(opts),
       COTAL_SPACE: opts.space,
       COTAL_NAME: opts.name,
       // Force the connector to emit channel wake-nudges: Claude doesn't advertise the

--- a/extensions/connector-core/src/launch.ts
+++ b/extensions/connector-core/src/launch.ts
@@ -85,6 +85,24 @@ export function launchEnv(
   return env;
 }
 
+/** The agent's resolved access policy as `COTAL_*` env, when present. Forwarded by each connector
+ *  so the spawned session's runtime read/post set matches the creds the manager minted from the
+ *  same policy. Without it a manifest-spawned agent — whose materialized persona carries no access
+ *  frontmatter — falls back to `["general"]`, which its scoped creds deny, so it joins nothing.
+ *  Empty/absent lists are omitted: the connector then defers to the persona file or the `general`
+ *  baseline (the no-channel case), preserving the persona-spawn path unchanged. */
+export function aclEnv(opts: {
+  subscribe?: string[];
+  allowSubscribe?: string[];
+  allowPublish?: string[];
+}): Record<string, string> {
+  const env: Record<string, string> = {};
+  if (opts.subscribe?.length) env.COTAL_SUBSCRIBE = opts.subscribe.join(",");
+  if (opts.allowSubscribe?.length) env.COTAL_ALLOW_SUBSCRIBE = opts.allowSubscribe.join(",");
+  if (opts.allowPublish?.length) env.COTAL_ALLOW_PUBLISH = opts.allowPublish.join(",");
+  return env;
+}
+
 /** The environment-variable NAMES a set of shared MCP server specs reference via `${VAR}` /
  *  `${VAR:-default}` (in command/args/env/url/headers). The single source of which operator vars
  *  a shared server needs: forwarded BY NAME through {@link launchEnv} (`mcpKeys`), never

--- a/extensions/connector-hermes/src/extension.ts
+++ b/extensions/connector-hermes/src/extension.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { loadAgentFile, registry, type Connector, type LaunchOpts, type LaunchSpec } from "@cotal-ai/core";
-import { launchEnv, MODEL_PROVIDER_KEYS } from "@cotal-ai/connector-core";
+import { aclEnv, launchEnv, MODEL_PROVIDER_KEYS } from "@cotal-ai/connector-core";
 
 /** The launcher (run via tsx, which loads both) owns the mesh endpoint and supervises the Hermes
  *  gateway as a child — see launch.ts. Resolve `.ts` when this module loads from source (dev) and
@@ -30,6 +30,7 @@ export const hermesConnector: Connector = {
     // don't reach the gateway child (P3).
     const env: Record<string, string> = {
       ...launchEnv({ providerKeys: MODEL_PROVIDER_KEYS }),
+      ...aclEnv(opts),
       COTAL_SPACE: opts.space,
       COTAL_NAME: opts.name,
     };

--- a/extensions/connector-opencode/src/extension.ts
+++ b/extensions/connector-opencode/src/extension.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from "node:url";
 import { resolve } from "node:path";
 import { loadAgentFile, registry, type Connector, type LaunchOpts, type LaunchSpec } from "@cotal-ai/core";
-import { launchEnv, MODEL_PROVIDER_KEYS } from "@cotal-ai/connector-core";
+import { aclEnv, launchEnv, MODEL_PROVIDER_KEYS } from "@cotal-ai/connector-core";
 
 /** The bundled in-process plugin (esbuild → `dist/plugin.bundle.js`). `opencode serve` loads it by
  *  absolute path from the inline config, so it runs *inside* the server and shares its SDK client.
@@ -50,6 +50,7 @@ export const opencodeConnector: Connector = {
     // unrelated secrets don't reach the child (P3).
     const env: Record<string, string> = {
       ...launchEnv({ providerKeys: MODEL_PROVIDER_KEYS }),
+      ...aclEnv(opts),
       COTAL_SPACE: opts.space,
       COTAL_NAME: opts.name,
     };

--- a/implementations/cli/src/commands/spawn.ts
+++ b/implementations/cli/src/commands/spawn.ts
@@ -212,6 +212,13 @@ export async function spawn(argv: string[]): Promise<void> {
   // Open mode (no `.cotal/auth`): unchanged — the session connects without creds.
   let id: string | undefined;
   let credsPath: string | undefined;
+  // The agent's access policy (flags > persona file) — minted into the creds AND forwarded to the
+  // connector (COTAL_SUBSCRIBE / COTAL_ALLOW_*) so the session's runtime read/post set matches its
+  // credentials. One source, so a `--subscribe` override can't land in the creds yet be lost at
+  // runtime (the connector would otherwise read only the persona file / fall back to `general`).
+  const subscribe = splitFlag(values.subscribe) ?? def.subscribe;
+  const allowSubscribe = splitFlag(values["allow-subscribe"]) ?? def.allowSubscribe ?? subscribe;
+  const allowPublish = splitFlag(values["allow-publish"]) ?? def.allowPublish;
   if (auth) {
     const identity = newIdentity();
     const prov = new CotalEndpoint({
@@ -226,7 +233,6 @@ export async function spawn(argv: string[]): Promise<void> {
     });
     prov.on("error", (e: Error) => console.error(`! provisioner: ${e.message}`));
     await prov.start();
-    const subscribe = splitFlag(values.subscribe) ?? def.subscribe;
     // Direct foreground spawn is LIVE-ONLY: this short-lived provisioner is not a managing Plane-3 host,
     // and no long-lived manager knows this agent (it's in no manager's `agents` ledger), so a durable
     // boot membership could be neither authorized for reader delivery nor leaved via self-service. Skip
@@ -234,8 +240,8 @@ export async function spawn(argv: string[]): Promise<void> {
     // (`cotal start` / `cotal up`).
     const creds = await provisionAgent(prov, auth, identity, {
       subscribe,
-      allowSubscribe: splitFlag(values["allow-subscribe"]) ?? def.allowSubscribe ?? subscribe,
-      allowPublish: splitFlag(values["allow-publish"]) ?? def.allowPublish,
+      allowSubscribe,
+      allowPublish,
       role,
       capabilities: def.capabilities,
       durableMembership: false,
@@ -267,6 +273,9 @@ export async function spawn(argv: string[]): Promise<void> {
     creds: credsPath,
     servers: server,
     configPath: path,
+    subscribe,
+    allowSubscribe,
+    allowPublish,
     prompt: values.prompt,
     transcript,
     mcpServers,

--- a/implementations/manager/smoke/start-model-preflight.smoke.ts
+++ b/implementations/manager/smoke/start-model-preflight.smoke.ts
@@ -10,6 +10,10 @@
  *   2. Model THREADING — `--model` rides StartAgentOpts → buildLaunch's LaunchOpts verbatim.
  *   3. Model PRECEDENCE — across the three real connectors: flag > agent-file `model:`, the flag
  *      applies with no agent file, and the file is the fallback (the actual bug the fix closes).
+ *   4. ACL THREADING — the resolved read/post set rides StartAgentOpts → LaunchOpts and each
+ *      connector forwards it as COTAL_SUBSCRIBE / COTAL_ALLOW_*. Guards the bug where creds were
+ *      minted from the policy but it never reached the connector, so a manifest-spawned agent (whose
+ *      materialized persona has no access frontmatter) fell back to ["general"] and joined nothing.
  */
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -34,6 +38,8 @@ const workspaceRoot = mkdtempSync(join(tmpdir(), "cotal-start-ws-"));
 const agentsDir = join(workspaceRoot, ".cotal", "agents");
 mkdirSync(agentsDir, { recursive: true });
 for (const n of ["reject1", "rec1", "rec2"]) writeFileSync(join(agentsDir, `${n}.md`), `---\nname: ${n}\n---\n`);
+// rec3 carries an explicit access policy — its frontmatter ACL must thread through to LaunchOpts.
+writeFileSync(join(agentsDir, "rec3.md"), `---\nname: rec3\nsubscribe: [team]\nallowSubscribe: [team, team.>]\nallowPublish: [team]\n---\n`);
 const mgr = new Manager({ space: "smoke", servers: undefined, runtime: "pty", workspaceRoot });
 
 // Inert handle/runtime: the success branch records the built spec but launches nothing; the `ep`
@@ -90,6 +96,14 @@ registry.register(recCon);
   lastOpts = undefined;
   await mgr.startAgent({ name: "rec2", agent: "smoke-rec" });
   check("no --model → LaunchOpts.model undefined", lastOpts?.model === undefined, lastOpts?.model);
+
+  // ACL threading: the resolved read/post set must reach the connector via LaunchOpts (the bug —
+  // it was minted into creds but never handed to buildLaunch, so the connector fell back to general).
+  lastOpts = undefined;
+  await mgr.startAgent({ name: "rec3", agent: "smoke-rec" });
+  check("persona subscribe threads into LaunchOpts.subscribe", JSON.stringify(lastOpts?.subscribe) === '["team"]', lastOpts?.subscribe);
+  check("persona allowSubscribe threads into LaunchOpts", JSON.stringify(lastOpts?.allowSubscribe) === '["team","team.>"]', lastOpts?.allowSubscribe);
+  check("persona allowPublish threads into LaunchOpts", JSON.stringify(lastOpts?.allowPublish) === '["team"]', lastOpts?.allowPublish);
 }
 
 // 3 — Model PRECEDENCE across the three real connectors (direct buildLaunch; no PATH/broker need).
@@ -125,6 +139,19 @@ registry.register(recCon);
   check("claude: nothing → no --model", claudeModel(claudeConnector.buildLaunch({ ...base })) === undefined);
   check("opencode: nothing → no config.model", ocModel(opencodeConnector.buildLaunch({ ...base })) === undefined);
   check("hermes: nothing → no HERMES_MODEL", hermesModel(hermesConnector.buildLaunch({ ...base })) === undefined);
+
+  // 4 — ACL ENV emission: each connector forwards the resolved policy so the spawned session's
+  // runtime read/post set matches its minted creds. Wildcard allowSubscribe (team.>) must survive.
+  const acl = { subscribe: ["team"], allowSubscribe: ["team", "team.>"], allowPublish: ["team"] };
+  for (const con of [claudeConnector, opencodeConnector, hermesConnector]) {
+    const env = con.buildLaunch({ ...base, ...acl }).env!;
+    check(`${con.name}: COTAL_SUBSCRIBE forwarded`, env.COTAL_SUBSCRIBE === "team", env.COTAL_SUBSCRIBE);
+    check(`${con.name}: COTAL_ALLOW_SUBSCRIBE forwarded (wildcard kept)`, env.COTAL_ALLOW_SUBSCRIBE === "team,team.>", env.COTAL_ALLOW_SUBSCRIBE);
+    check(`${con.name}: COTAL_ALLOW_PUBLISH forwarded`, env.COTAL_ALLOW_PUBLISH === "team", env.COTAL_ALLOW_PUBLISH);
+    // No policy → no env (persona-spawn / no-channel path unchanged: connector reads the file or
+    // falls back to the general baseline — never silently overridden to empty).
+    check(`${con.name}: no policy → COTAL_SUBSCRIBE absent`, con.buildLaunch({ ...base }).env!.COTAL_SUBSCRIBE === undefined);
+  }
 }
 
 console.log(`\nSTART-MODEL/PREFLIGHT SMOKE ${failures === 0 ? "OK ✅" : "FAILED ❌"}`);

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -556,6 +556,13 @@ export class Manager {
         servers: this.servers,
         configPath,
         model,
+        // The SAME access set the creds were minted from (above) — forwarded so the session's
+        // runtime read/post set matches its credentials. Without this a manifest-spawned agent
+        // (materialized persona has no access frontmatter) falls back to `["general"]`, which its
+        // scoped creds deny, and it joins nothing.
+        subscribe,
+        allowSubscribe,
+        allowPublish,
         transcript: opts.transcript,
         mcpServers,
       });

--- a/packages/core/src/connector.ts
+++ b/packages/core/src/connector.ts
@@ -14,6 +14,16 @@ export interface LaunchOpts {
    *  as `id`; absent when the mesh runs open. */
   creds?: string;
   servers?: string;
+  /** The agent's resolved access policy — the SAME read/post set the manager mints the agent's
+   *  creds from. The connector forwards it (`COTAL_SUBSCRIBE` / `COTAL_ALLOW_SUBSCRIBE` /
+   *  `COTAL_ALLOW_PUBLISH`) so the session's runtime read set matches its credentials. Essential
+   *  for manifest spawns, whose materialized persona carries NO access frontmatter: without it the
+   *  connector falls back to `["general"]`, which the scoped creds deny — so the agent joins
+   *  nothing. Empty/absent lists are omitted (the connector then defers to the persona file or the
+   *  `general` baseline — the no-channel case). */
+  subscribe?: string[];
+  allowSubscribe?: string[];
+  allowPublish?: string[];
   /** Path to an agent definition file (`.cotal/agents/<name>.md`). The connector
    *  passes it through (`COTAL_AGENT_FILE`) so the joined session reads its own
    *  card from it, and applies the file's persona/model at launch. */


### PR DESCRIPTION
## Problem

A manifest-spawned agent mints scoped creds from its launch-spec policy but never received that policy **at runtime**: `buildLaunch` was called without the read/post set, and a materialized persona carries no access frontmatter, so `configFromEnv` fell back to `["general"]` — which the scoped creds deny. The agent joined nothing.

Tell: an agent left out of *every* channel was the only one that landed on a channel — its empty policy makes its creds default to `general`, so both halves happened to agree.

## Fix

Thread `subscribe` / `allowSubscribe` / `allowPublish` from the manager and `cotal spawn` into `LaunchOpts`, and emit them as `COTAL_SUBSCRIBE` / `COTAL_ALLOW_SUBSCRIBE` / `COTAL_ALLOW_PUBLISH` from every connector via a shared `aclEnv` helper, so the runtime read/post set matches the minted creds. Empty/absent lists are omitted, leaving the persona-spawn path (reads its own file) and the no-channel/`general` baseline unchanged.

Extends the start-model/preflight smoke to guard both halves across all three connectors, including wildcard `allowSubscribe`.