### PR TITLE
fix(core): silent TCP+INFO liveness probe (no broker auth-error log)

### DIFF
--- a/.changeset/silent-liveness-probe.md
+++ b/.changeset/silent-liveness-probe.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/core": patch
+---
+
+Make credential-less `isReachable` a silent plaintext TCP+`INFO` liveness probe so it no longer logs a broker `authentication error` on every check (e.g. every `cotal supervise` start and registry prune sweep against an auth broker). It reads the server's unprompted pre-auth `INFO` greeting over a plain socket and closes before authenticating, so a live broker (open or auth) reports reachable with no auth-error/auth-timeout log line. The boolean result is unchanged for every caller; only the mechanism changes. `pruneStaleMeshes` uses the same silent probe; `probeConnect` and the with-creds `auth-required` classification are untouched. Limitation: the credless probe is plaintext-only — it returns false for a TLS-first (`handshake_first`) listener; the creds path stays a real authenticated connect.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -782,7 +782,11 @@ later).
   signing key is **rotated** (which re-mints *everyone*, the only per-cred revocation today) or it
   is cut at the network. Despawn is the immediate lever, not full containment of a compromised
   identity; per-cred TTL/rotation is the deferred fix (auth-callout, below).
-- `isReachable` conflates auth-failure with server-down (a misleading "run cotal up").
+- **Credless liveness** (`isReachable`/`pruneStaleMeshes` with no creds) is a silent plaintext
+  TCP+`INFO` probe — it reads the server's pre-auth greeting and closes without authenticating, so
+  it no longer logs a broker auth-error on every check. Limitation: it returns false for a TLS-first
+  (`handshake_first`) listener (that broker config isn't supported by the credless probe yet); the
+  creds path stays a real authenticated connect and is unaffected.
 - The **manager profile is allow-all**, fine for Demo 1, but the most-privileged identity should
   eventually be scoped for the full untrusted-peer claim.
 - **Callout stage (later, additive):** auth-callout (NATS 2.10+) mints creds *at connect* from a

--- a/implementations/cli/smoke/spawn-from-anywhere-live.smoke.ts
+++ b/implementations/cli/smoke/spawn-from-anywhere-live.smoke.ts
@@ -14,6 +14,7 @@
  * never pkill, so a co-running broker on :4222 is untouched. Run: pnpm smoke:spawn-from-anywhere:live
  */
 import { spawn, type ChildProcess } from "node:child_process";
+import { createServer, type Server } from "node:net";
 import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -23,13 +24,14 @@ import { join } from "node:path";
 const home = mkdtempSync(join(tmpdir(), "cotal-live-home-"));
 process.env.COTAL_HOME = home;
 
-const { probeConnect } = await import("@cotal-ai/core");
+const { probeConnect, isReachable } = await import("@cotal-ai/core");
 const { resolveMeshTarget, recordMesh, loadMeshes, meshesDir } = await import("@cotal-ai/workspace");
 const { pruneStaleMeshes } = await import("../src/lib/meshes.js");
 const { connectOrExit, reachableOrExit } = await import("../src/lib/connect.js");
 
 let pass = 0;
 const kids: ChildProcess[] = [];
+let notNats: Server | undefined;
 const ok = (name: string, cond: boolean, extra?: unknown) => {
   if (!cond) throw new Error(`FAIL: ${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
   pass++;
@@ -115,12 +117,22 @@ try {
     credless,
   );
 
+  // E: isReachable — the silent TCP+INFO liveness primitive (the fix). A live broker is reachable
+  // WITHOUT a credless connect, so an AUTH broker reports up with no broker-side auth-error log; a
+  // non-NATS listener is NOT reachable (we require a real `INFO {` greeting, not "any open port").
+  ok("E: isReachable(live open broker) → true", (await isReachable(SRV_OPEN)) === true);
+  ok("E: isReachable(live AUTH broker) → true (credless, no auth-error log)", (await isReachable(SRV_AUTH)) === true);
+  notNats = createServer((s) => s.end("hello, not nats\r\n"));
+  await new Promise<void>((res) => notNats!.listen(4457, "127.0.0.1", res));
+  ok("E: isReachable(non-NATS listener) → false (not 'any open port')", (await isReachable("nats://127.0.0.1:4457")) === false);
+
   // C: prune-on-real-death. Kill ONLY our 4455 child, then the entry must prune.
   const opener = kids[0]!;
   opener.kill("SIGTERM");
   for (let i = 0; i < 50 && opener.exitCode === null && opener.signalCode === null; i++) await sleep(100);
   const dead = await probeConnect(SRV_OPEN, { timeoutMs: 800 });
   ok("C: probeConnect to the killed broker → unreachable", !dead.ok && dead.reason === "unreachable", dead);
+  ok("E: isReachable(killed broker) → false", (await isReachable(SRV_OPEN)) === false);
   ok("C: registry still holds alpha before prune", loadMeshes().some((m) => m.space === "alpha"));
   await pruneStaleMeshes();
   ok("C: pruneStaleMeshes drops the dead entry", !loadMeshes().some((m) => m.space === "alpha"), loadMeshes());
@@ -134,6 +146,7 @@ try {
       /* already gone */
     }
   }
+  try { notNats?.close(); } catch { /* already closed */ }
   await sleep(300);
   for (const d of [home, projA]) rmSync(d, { recursive: true, force: true });
 }

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import { randomUUID } from "node:crypto";
+import { createConnection } from "node:net";
 import {
   connect,
   credsAuthenticator,
@@ -2639,15 +2640,70 @@ export function isPermissionDenied(e: unknown): boolean {
   return /permissions?\s+violation/i.test(String((e as { message?: unknown } | null)?.message ?? ""));
 }
 
-/** Whether a NATS server is *running* at `servers`. True on a successful connect AND on an
- *  auth rejection — an auth error means a server is there, just refusing these creds (so the
- *  caller should surface the real auth failure, not a misleading "server down", and `up`
- *  must not try to start a duplicate on the bound port). Only a genuine connection failure
- *  (refused / timeout / no server) returns false. */
+/** Parse a NATS server URL (`nats://host:port`, `host:port`, a bare host, or a comma list — the
+ *  first entry wins) into a host+port for {@link tcpInfoProbe}. Defaults the port to 4222. */
+function hostPort(server: string): { host: string; port: number } {
+  const first = (server.split(",")[0] ?? "").trim().replace(/^[a-z][a-z0-9+.-]*:\/\//i, ""); // strip scheme
+  const u = new URL(`http://${first}`); // http:// so .hostname/.port resolve (incl. bracketed IPv6)
+  return { host: u.hostname, port: u.port ? Number(u.port) : 4222 };
+}
+
+/** Silent credless liveness probe. Opens a plain TCP connection and confirms a NATS server is there
+ *  by reading its UNPROMPTED `INFO {…}` greeting — which the server sends on accept, BEFORE the
+ *  client's CONNECT/auth (per the NATS client protocol) — then closes immediately without
+ *  authenticating. Since it never sends CONNECT, an auth broker has nothing to reject, so this emits
+ *  NO broker-side auth-error/auth-timeout log line (unlike a credless `connect()`, which an auth
+ *  broker rejects and logs). It is a *plaintext NATS* liveness check only:
+ *    • a TLS-first (`handshake_first`, NATS ≥ 2.10.4) listener sends its TLS handshake before INFO,
+ *      so the read won't match → returns false (a documented false-negative for that broker config);
+ *    • a non-NATS / silent listener never sends a valid `INFO {` → also false (we require the real
+ *      greeting, never "any open port is reachable").
+ *  Closes well within the server's ~1s authorization timeout, so it cannot trip a timeout log. */
+function tcpInfoProbe(server: string, timeoutMs: number): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    let socket: ReturnType<typeof createConnection> | undefined;
+    let done = false;
+    const finish = (live: boolean) => {
+      if (done) return;
+      done = true;
+      try { socket?.destroy(); } catch { /* already gone */ }
+      resolve(live);
+    };
+    let host: string, port: number;
+    try { ({ host, port } = hostPort(server)); } catch { return resolve(false); }
+    socket = createConnection({ host, port });
+    socket.setTimeout(timeoutMs);
+    let buf = "";
+    socket.on("data", (chunk: Buffer) => {
+      buf += chunk.toString("utf8");
+      const nl = buf.indexOf("\r\n");
+      if (nl === -1) { if (buf.length > 4096) finish(false); return; } // no real INFO line is 4KB+
+      const line = buf.slice(0, nl);
+      const brace = line.indexOf("{"); // greeting is `INFO {json}` (the server appends a trailing space)
+      if (!/^INFO\b/.test(line) || brace === -1) return finish(false); // not NATS (incl. a TLS-first handshake)
+      try { JSON.parse(line.slice(brace)); finish(true); } // require a real INFO greeting, not arbitrary bytes
+      catch { finish(false); }
+    });
+    socket.on("timeout", () => finish(false));
+    socket.on("error", () => finish(false)); // refused / reset / DNS failure
+    socket.on("close", () => finish(false)); // closed before a full INFO line arrived
+  });
+}
+
+/** Whether a NATS server is *running* at `servers`. With NO creds this is a SILENT plaintext
+ *  liveness check ({@link tcpInfoProbe}): it reads the server's pre-auth `INFO` greeting and closes
+ *  WITHOUT authenticating, so a live broker (open OR auth — INFO precedes auth) returns true while
+ *  emitting no broker auth-error log. It may return false for a TLS-first listener — the credless
+ *  probe is plaintext-only. With creds/token/tls supplied it is instead the AUTHORITATIVE identity
+ *  check: a real authenticated connect, true on success AND on an auth rejection (a server that
+ *  refuses these creds is still up — so the caller surfaces the real auth failure, and `up` won't
+ *  start a duplicate on the bound port). Only a genuine connection failure (refused/timeout) is false. */
 export async function isReachable(
   servers: string = DEFAULT_SERVER,
   opts: AuthOpts & { timeoutMs?: number } = {},
 ): Promise<boolean> {
+  if (!opts.creds && !opts.token && !opts.user && !opts.pass && !opts.tls)
+    return tcpInfoProbe(servers, opts.timeoutMs ?? 1000);
   try {
     const nc = await connect({
       servers,

--- a/packages/workspace/src/preflight.ts
+++ b/packages/workspace/src/preflight.ts
@@ -1,4 +1,4 @@
-import { mintCreds, newIdentity, probeConnect } from "@cotal-ai/core";
+import { mintCreds, newIdentity, probeConnect, isReachable } from "@cotal-ai/core";
 import { loadMeshes, removeMesh } from "./mesh-registry.js";
 import type { MeshTarget } from "./mesh-target.js";
 
@@ -67,16 +67,18 @@ export async function preflightTarget(
 
 /**
  * Drop registry entries whose broker is gone — a `cotal up` that crashed or was `kill -9`'d without
- * `cotal down` leaves a record behind. Probe each in parallel; only `unreachable` (refused/timeout)
- * is stale, an auth broker answering `auth-required` is alive. An EXPLICIT call (never wired into
- * resolution itself), so registry mutation stays opt-in: callers that act on the registry
- * (`spawn`/`use`/`meshes`, the manager control commands) invoke it; `<TAB>` completion must not.
+ * `cotal down` leaves a record behind. This is liveness-only and we hold NO creds for these meshes,
+ * so it uses the silent TCP+INFO {@link isReachable} probe — NOT a credless `probeConnect`, whose
+ * auth-rejection-as-liveness would log a broker auth error on every live AUTH mesh it sweeps.
+ * `isReachable` is true for any live broker (open or auth, since INFO precedes auth); only a truly
+ * dead one (refused/timeout) prunes. An EXPLICIT call (never wired into resolution itself), so
+ * registry mutation stays opt-in: callers that act on the registry (`spawn`/`use`/`meshes`, the
+ * manager control commands) invoke it; `<TAB>` completion must not.
  */
 export async function pruneStaleMeshes(): Promise<void> {
   await Promise.all(
     loadMeshes().map(async (m) => {
-      const r = await probeConnect(m.server);
-      if (!r.ok && r.reason === "unreachable") removeMesh(m.space);
+      if (!(await isReachable(m.server))) removeMesh(m.space);
     }),
   );
 }


### PR DESCRIPTION
## Problem

Credential-less liveness checks open a real NATS `connect()` and read the broker's auth rejection as proof-of-life (`isReachable` returns true on `AuthorizationError`). Against an auth broker, every such probe is a failed login the broker logs as `[ERR] … authentication error` — on **every** `cotal supervise` start (`runManager`'s reachability gate) and **every** registry prune sweep (`pruneStaleMeshes`). It conflates "is a broker listening" with "did auth reject me", and poisons the broker's auth-failure log.

## Fix

Credential-less liveness becomes a **silent plaintext TCP+`INFO` probe**: open a plain TCP socket, read the server's unprompted `INFO {…}` greeting (sent on accept, before `CONNECT`/auth — per the NATS client protocol), validate it, and close before authenticating. No auth path is entered, so no auth-error/auth-timeout log line is produced.

- **Minimal blast radius:** only `isReachable`'s *mechanism* changes — its boolean result is identical for every caller (true for any live broker, open or auth; false for dead/non-NATS). `pruneStaleMeshes` switches to `isReachable` (it only ever branched on `unreachable`, never on `auth-required`, so no classification signal is lost). `probeConnect` + `classifyPreflightFailure` are **untouched** — the with-creds `auth-required` classification is fully preserved.
- **Matcher note:** real `nats-server` appends a trailing space after the `INFO` JSON, so the matcher is an `INFO` prefix check + `JSON.parse` from the first `{` (tolerant of the trailing space, still rejects non-NATS/garbage).
- **Limitation (documented):** the credless probe is plaintext-only — it returns false for a TLS-first (`handshake_first`, NATS ≥ 2.10.4) listener. Cotal brokers are plaintext today; the creds path stays a real authenticated connect and is unaffected.

## Verification

- `typecheck` (15 projects) + `build` clean.
- `smoke:spawn-from-anywhere:live` 15 — incl. 4 new asserts: live open → true, live **auth** → true (credless, no auth log), non-NATS listener → false, killed → false.
- `smoke:preflight` 43, `smoke:server-resolution:live` 15, full `smoke:ci` auth gate — all green.
- **Empirical broker-log check** (throwaway auth broker + logfile): the old credless connect adds exactly one `[ERR] … authentication error`; three new `isReachable` probes add **zero** while returning reachable.

Resolves the `docs/architecture.md` "isReachable conflates auth-failure with server-down" rough-edge (replaced with the new behaviour + the TLS-first limitation).
