### PR TITLE
feat(pi): @cotal-ai/pi native-embed coding-agent mesh peer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,10 @@ with no silent fallback.
   (native in-process plugin injected via `OPENCODE_CONFIG_CONTENT`).
 - **`@cotal-ai/connector-hermes`** (`extensions/connector-hermes`): the Hermes (Nous Research)
   adapter; includes a Python sidecar.
+- **`@cotal-ai/pi`** (`extensions/pi`): the pi adapter — a pi extension (loaded into the
+  user's own pi, no bundled runtime) that embeds `MeshAgent` in the session's process and
+  drives it off the inbox with true mid-turn steering; also covers agents built on pi's SDK.
+  See [docs/agent-frameworks.md](docs/agent-frameworks.md).
 - **`@cotal-ai/cmux`** (`extensions/cmux`): the cmux integration: a driver over the cmux CLI
   plus a self-registering `cmux` Runtime and `TerminalLayout` provider.
 - **`@cotal-ai/tmux`** (`extensions/tmux`): the tmux integration: a driver over the tmux CLI

--- a/README.md
+++ b/README.md
@@ -156,14 +156,16 @@ Full index: [docs/examples.md](docs/examples.md).
 
 <table>
 <tr>
-<td align="center" width="33%"><a href="extensions/connector-claude-code"><img src="assets/agents/claude-code.svg" height="44" alt=""><br><strong>Claude Code</strong></a><br><sub>installed plugin + hooks</sub></td>
-<td align="center" width="33%"><a href="extensions/connector-opencode"><img src="assets/agents/opencode.svg" height="44" alt=""><br><strong>OpenCode</strong></a><br><sub>native in-process plugin</sub></td>
-<td align="center" width="33%"><a href="extensions/connector-hermes"><img src="assets/agents/hermes.png" height="44" alt=""><br><strong>Hermes</strong></a><br><sub>gateway daemon + plugin</sub></td>
+<td align="center" width="25%"><a href="extensions/connector-claude-code"><img src="assets/agents/claude-code.svg" height="44" alt=""><br><strong>Claude Code</strong></a><br><sub>installed plugin + hooks</sub></td>
+<td align="center" width="25%"><a href="extensions/connector-opencode"><img src="assets/agents/opencode.svg" height="44" alt=""><br><strong>OpenCode</strong></a><br><sub>native in-process plugin</sub></td>
+<td align="center" width="25%"><a href="extensions/connector-hermes"><img src="assets/agents/hermes.png" height="44" alt=""><br><strong>Hermes</strong></a><br><sub>gateway daemon + plugin</sub></td>
+<td align="center" width="25%"><a href="extensions/pi"><img src="assets/agents/pi.svg" height="44" alt=""><br><strong>pi</strong></a><br><sub>pi extension + live steer</sub></td>
 </tr>
 </table>
 
-They attach differently but expose the same `cotal_*` tools, and all three push, so a
-peer message wakes an idle agent the instant it arrives. Any agent that implements the
+They attach differently but expose the same `cotal_*` tools, and all four push, so a
+peer message wakes an idle agent the instant it arrives; pi additionally drives a live
+turn, folding an arriving message into an in-flight one with `steer()`. Any agent that implements the
 contract joins the same way; a connector is just a thin client over the wire. Want one
 for an agent that isn't here yet?
 [Vote for the next connector](https://github.com/Cotal-AI/Cotal/discussions/80).

--- a/assets/agents/pi.svg
+++ b/assets/agents/pi.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800">
+  <style>
+    .logo-mark { fill: #000; }
+    @media (prefers-color-scheme: dark) {
+      .logo-mark { fill: #fff; }
+    }
+  </style>
+  <!-- P shape: outer boundary clockwise, inner hole counter-clockwise -->
+  <path class="logo-mark" fill-rule="evenodd" d="
+    M165.29 165.29
+    H517.36
+    V400
+    H400
+    V517.36
+    H282.65
+    V634.72
+    H165.29
+    Z
+    M282.65 282.65
+    V400
+    H400
+    V282.65
+    Z
+  "/>
+  <!-- i dot -->
+  <path class="logo-mark" d="M517.36 400 H634.72 V634.72 H517.36 Z"/>
+</svg>

--- a/bin/cotal.ts
+++ b/bin/cotal.ts
@@ -15,6 +15,7 @@ import "@cotal-ai/delivery"; // self-registers `deliver` — the server-side Pla
 import "@cotal-ai/connector-claude-code"; // registers the `claude` connector that spawn resolves
 import "@cotal-ai/connector-opencode"; // registers the `opencode` connector (native in-process plugin)
 import "@cotal-ai/connector-hermes"; // registers the `hermes` connector (Nous Research gateway as a mesh peer)
+import "@cotal-ai/pi"; // registers the `pi` connector (mesh extension loaded into the user's own pi)
 import "@cotal-ai/cmux"; // opt into the cmux integration — registers the `cmux` runtime + TerminalLayout providers
 import "@cotal-ai/tmux"; // opt into the tmux integration — registers the `tmux` runtime + TerminalLayout providers
 import { claudeConnector } from "@cotal-ai/connector-claude-code";

--- a/bin/package.json
+++ b/bin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cotal-ai",
   "version": "0.10.1",
-  "description": "Cotal — lateral agent coordination over NATS. Run `npx cotal-ai` for the CLI.",
+  "description": "Cotal \u2014 lateral agent coordination over NATS. Run `npx cotal-ai` for the CLI.",
   "license": "Apache-2.0",
   "keywords": [
     "cotal",
@@ -33,15 +33,16 @@
   "dependencies": {
     "@cotal-ai/cli": "workspace:*",
     "@cotal-ai/cmux": "workspace:*",
-    "@cotal-ai/tmux": "workspace:*",
     "@cotal-ai/connector-claude-code": "workspace:*",
+    "@cotal-ai/connector-core": "workspace:*",
     "@cotal-ai/connector-hermes": "workspace:*",
     "@cotal-ai/connector-opencode": "workspace:*",
     "@cotal-ai/core": "workspace:*",
     "@cotal-ai/delivery": "workspace:*",
     "@cotal-ai/manager": "workspace:*",
-    "@cotal-ai/workspace": "workspace:*",
-    "@cotal-ai/connector-core": "workspace:*"
+    "@cotal-ai/pi": "workspace:*",
+    "@cotal-ai/tmux": "workspace:*",
+    "@cotal-ai/workspace": "workspace:*"
   },
   "files": [
     "dist",

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,6 +62,7 @@ For connector users putting an agent on the mesh:
 | [Connect Claude](connect-claude.md) | How does a Claude Code session join the mesh? |
 | [Connect OpenCode (beta)](connect-opencode.md) | How does an OpenCode session join? |
 | [Connect Hermes (alpha)](connect-hermes.md) | How does a Hermes agent join? |
+| [Agent frameworks (alpha)](agent-frameworks.md) | How does a pi session — or an agent built on pi's SDK — join? |
 
 For protocol implementers:
 

--- a/docs/agent-frameworks.md
+++ b/docs/agent-frameworks.md
@@ -1,0 +1,86 @@
+# Agent frameworks
+
+Besides Claude Code (see [Connect Claude](connect-claude.md)), an agent
+built on an embeddable agent library can join a Cotal space as a native lateral peer. The
+first such adapter:
+
+| Extension | Framework | Language |
+|---|---|---|
+| `@cotal-ai/pi` | [pi coding agent](https://github.com/earendil-works/pi) | TypeScript |
+
+It joins the same mesh as the host-bound connectors and interoperates over the same
+subjects, presence, and delivery modes.
+
+## The shape: the mesh as a host-native plugin
+
+`@cotal-ai/pi` follows the same thin-adapter pattern as every other connector: it plugs
+into the **user's own pi installation** rather than bundling a pi runtime. The whole
+adapter is one pi extension file (pi's plugin mechanism) plus a `Connector` for the spawn
+door. Because pi's extension discovery lives in its SDK (the default resource loader reads
+`~/.pi/agent/extensions/`), the same file covers three surfaces at once:
+
+- **`pi` interactive** — `pi --extension <file>` (or a copy in `~/.pi/agent/extensions/`)
+  with `COTAL_*` env: the TUI session a human is sitting in becomes a mesh peer.
+- **Spawned workers** — the `Connector` (`buildLaunch`) spawns the operator's installed
+  `pi` binary (PATH resolution, like the Claude Code connector spawns `claude`; a missing
+  binary fails loud) with `--extension` pointing at the packaged file. Under the manager's
+  pty runtime the worker IS the real pi TUI — `cotal attach <name>` shows it.
+- **Agents built on pi's SDK** — a default `createAgentSession()` discovers the same
+  extension dir, so third-party pi-based agents join with no per-app work. (Apps that pass
+  a custom resource loader, or forks, need their own wiring.)
+
+Activation is opt-in by mesh identity: with no `COTAL_*` config in the env the extension
+stays inert, so an installed copy never affects normal pi use; `COTAL_*` config without an
+identity (`COTAL_NAME`/`COTAL_AGENT_FILE`/`COTAL_LINK`) fails loud rather than silently
+running off-mesh.
+
+## The loop: ack-on-surface off the durable inbox
+
+Inside the extension, the shared `MeshAgent` (from `@cotal-ai/connector-core`) owns the
+NATS connection, presence, and the stream-backed inbox, and the package's `InboxTurn`
+drives the session off it — the inbox is the single source of truth, no parallel buffer:
+
+1. **Inbound drives the loop.** On `"incoming"` the front-contiguous actionable batch opens
+   a turn (`pi.sendUserMessage(...)` — a real user turn in the live session); actionable
+   messages arriving mid-turn are folded in via `deliverAs: "steer"` (true mid-turn drive).
+   Delivery is **ack-on-surface**: the surfaced run is acked only once the turn completes,
+   so a crash or restart redelivers and nothing is lost. The peer is woken by DMs, anycasts,
+   and channel messages according to the shared attention policy: open ambient can wake an
+   idle session, while dnd/quiet ambient stays buffered for the next turn. One accepted
+   residual: the extension API can't drain pi's steering queue at turn end, so a message
+   steered after the loop's final poll can carry into the next turn.
+2. **The model owns replies.** The full shared `cotal_*` toolset (rendered from
+   connector-core's `cotalToolSpecs` via `pi.registerTool`, the same source the Claude Code
+   and OpenCode adapters render) is on the session — the model replies by calling
+   `cotal_dm` / `cotal_send` / `cotal_anycast`, can stay silent when no reply is warranted,
+   and nothing leaves the peer that it didn't deliberately send. `cotal_inbox` is read-only
+   (peek): the loop drives delivery and acking, so a drain would race the ack.
+
+Presence is read off pi's own events (`agent_start` → `working`,
+`tool_execution_start` → the running tool, `agent_end` → `idle`). pi has no permission gate
+of its own, so unattended workers should be sandboxed per pi's guidance; interactively, any
+pi extension that raises `ctx.ui.*` gates works as usual since the session is real pi.
+
+Builders embedding pi's SDK directly who want the steer residual fully closed can skip the
+extension and wire the same two pieces themselves — connector-core's `MeshAgent` +
+`InboxTurn` (exported from `@cotal-ai/pi`) around their own `createAgentSession()`,
+using `session.clearQueue()` with `InboxTurn.commitExcept` at
+turn end. The extension source is the reference for everything else.
+
+## Running
+
+The `cotal` binary registers the pi connector like every sibling — no extra composition
+root needed. It requires `pi` on PATH (`npm i -g @earendil-works/pi-coding-agent`):
+
+```bash
+export ANTHROPIC_API_KEY=sk-...   # or any pi-supported provider auth (~/.pi login works too)
+pnpm cotal up
+pnpm cotal spawn --detach --name pi1 --role research --agent pi
+```
+
+Or join a pi session you're sitting in by hand — no manager involved:
+
+```bash
+COTAL_SPACE=<space> COTAL_NAME=mypi COTAL_ROLE=research COTAL_ALLOW_PUBLISH=general \
+pi --extension node_modules/@cotal-ai/pi/dist/extension.js
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,6 +87,11 @@ command imports lazily and parses live. Version skew or a stranded link fails lo
 with instructions to re-add, rather than leaving a silently missing command. The repo's
 own `cotal-web` dashboard is installed through this same mechanism.
 
+Beyond the app-bound connectors, `@cotal-ai/pi` is a **host-native plugin**: a pi extension
+loaded into the user's own pi (CLI or SDK-embedded), placing a Cotal endpoint inside the
+session's process and driving its run loop off the inbox — see
+[agent-frameworks](agent-frameworks.md).
+
 ## Connectors: four surfaces, one runtime
 
 Every coding-agent integration exposes the same four surfaces:

--- a/extensions/connector-core/src/agent.ts
+++ b/extensions/connector-core/src/agent.ts
@@ -312,6 +312,24 @@ export class MeshAgent extends EventEmitter {
     return taken.map((p) => p.item);
   }
 
+  /** Ack + remove the buffered messages with these ids, wherever they sit in the inbox. An id
+   *  that's no longer buffered — already acked, e.g. force-evicted by the MAX_INBOX overflow — is
+   *  a harmless no-op. This lets a consumer ack exactly the messages it surfaced, immune to the
+   *  front-eviction that shifts positions out from under {@link drainInbox}. */
+  ackInbox(ids: string[]): InboxItem[] {
+    if (!ids.length) return [];
+    const wanted = new Set(ids);
+    const taken: InboxItem[] = [];
+    this.inbox = this.inbox.filter((p) => {
+      if (!wanted.has(p.item.id)) return true;
+      p.ack();
+      this.markHandled(p.item.id);
+      taken.push(p.item);
+      return false;
+    });
+    return taken;
+  }
+
   /** Record an id as surfaced/handled, for {@link ingest}'s commit-aware cross-path dedup. Bounded via
    *  two rotating windows: when the live set fills, it becomes the previous window and a fresh one
    *  starts — so memory stays ~2× the cap while the lookup horizon never shrinks below it. */
@@ -342,6 +360,7 @@ export class MeshAgent extends EventEmitter {
 
   /** Buffered items that should WAKE a Stop→idle flush — the mode-and-channel-aware predicate the
    *  connectors use instead of branching on attention themselves:
+   *  - our OWN channel echo → never (an agent must not wake itself by posting);
    *  - directed (dm/anycast) or an @mention → always (a quiet @mention still wakes; muted never buffers);
    *  - NORMAL ambient (no per-channel override) → only under global `open` (today's behavior);
    *  - QUIET ambient → never (it rides the next human turn, not a proactive wake).
@@ -350,6 +369,7 @@ export class MeshAgent extends EventEmitter {
   pendingWake(): number {
     return this.inbox.filter((p) => {
       const it = p.item;
+      if (it.fromId === this.id) return false;
       if (it.kind !== "channel" || it.mentionsMe) return true;
       if (this.channelMode(it.channel) === "quiet") return false;
       return this._attention === "open";

--- a/extensions/connector-core/src/control.ts
+++ b/extensions/connector-core/src/control.ts
@@ -61,14 +61,17 @@ function tokenMatches(presented: unknown, digest: Buffer): boolean {
   return timingSafeEqual(createHash("sha256").update(presented).digest(), digest);
 }
 
+/** Sender label with the bare peer NAME quoted as its own token — the name is what
+ *  `cotal_dm` addresses, so a fused `name/role` display form must never look like one
+ *  (models were observed DM'ing the literal "me/human"). The role rides in parens. */
 function who(i: InboxItem): string {
-  return i.fromRole ? `${i.fromName}/${i.fromRole}` : i.fromName;
+  return i.fromRole ? `"${i.fromName}" (${i.fromRole})` : `"${i.fromName}"`;
 }
 
 function fmtItem(i: InboxItem): string {
   const h = i.historical ? " (history)" : ""; // backfilled on join — pre-dates you, not live
   if (i.kind === "dm") return `• DM from ${who(i)}${h}: ${i.text}`;
-  if (i.kind === "anycast") return `• @${i.service} (from ${who(i)})${h}: ${i.text}`;
+  if (i.kind === "anycast") return `• @${i.service} from ${who(i)}${h}: ${i.text}`;
   return `• #${i.channel} ${who(i)}${h}: ${i.text}`;
 }
 
@@ -76,8 +79,11 @@ function fmtItem(i: InboxItem): string {
 export function formatInjection(items: InboxItem[]): string | undefined {
   if (!items.length) return undefined;
   const head = `📨 Cotal — ${items.length} new message${items.length === 1 ? "" : "s"} from peers:`;
+  const caveat = items.some((i) => i.historical)
+    ? `\n(Items marked "(history)" pre-date you and are likely already settled — catch-up context, not live requests; act on one only if it is clearly still waiting on you.)`
+    : "";
   const tail = `(Reply with cotal_send / cotal_dm, or cotal_roster to see who's here.)`;
-  return `${head}\n${items.map(fmtItem).join("\n")}\n${tail}`;
+  return `${head}\n${items.map(fmtItem).join("\n")}${caveat}\n${tail}`;
 }
 
 /** Start the authenticated control server. One newline-delimited JSON {@link ControlFrame} → one

--- a/extensions/connector-core/src/launch.ts
+++ b/extensions/connector-core/src/launch.ts
@@ -73,7 +73,7 @@ const OS_ENV_ALLOW = [
 ] as const;
 
 /** Model-provider API keys a key-based connector may forward to its child. claude needs none
- *  (macOS Keychain / OAuth token, not an env key) → strong isolation for free; opencode/hermes
+ *  (macOS Keychain / OAuth token, not an env key) → strong isolation for free; opencode/hermes/pi
  *  need the key for the provider behind the agent's model → forward just these, by NAME, only if
  *  present. This is the single chokepoint for model-key forwarding — the seam for spawner-
  *  conditional gating (per-agent model auth) later. Never `...process.env`. */
@@ -83,6 +83,12 @@ export const MODEL_PROVIDER_KEYS = [
   "OPENAI_API_KEY",
   "OPENROUTER_API_KEY",
   "NOUS_API_KEY",
+  "GEMINI_API_KEY",
+  "GOOGLE_API_KEY",
+  "GROQ_API_KEY",
+  "XAI_API_KEY",
+  "DEEPSEEK_API_KEY",
+  "MISTRAL_API_KEY",
 ] as const;
 
 /** Build the base env a spawned agent runs with: the OS allow-list plus any named keys the

--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -9,7 +9,7 @@
  */
 import { execFileSync } from "node:child_process";
 import { z } from "zod";
-import { isConcreteChannel, channelInAllow, AmbiguousPeerError, isPermissionDenied, type PresenceStatus } from "@cotal-ai/core";
+import { assertValidChannel, isConcreteChannel, channelInAllow, AmbiguousPeerError, isPermissionDenied, type PresenceStatus } from "@cotal-ai/core";
 import type { MeshAgent, InboxItem } from "./agent.js";
 import { FEEDBACK_URL, PUBLIC_FEEDBACK_URL, type AgentConfig } from "./config.js";
 import { buildOrientation, renderOrientation, type OrientationTool } from "./orientation.js";
@@ -63,9 +63,19 @@ const ATTENTION_DESC: Record<"open" | "dnd" | "focus", string> = {
     "focus — only DMs and anycast reach your context; an @mention wakes you to pull; untagged channel chatter is held on the channel — read it with cotal_inbox",
 };
 
-/** "name/role" (or just "name") for a message's sender. */
+/** A channel arg as models write it → the wire name. Every rendered surface displays channels
+ *  as `#name`, so models mirror that form back; strip the display prefix, then fail loud on
+ *  anything still invalid — the wire layer's `token()` would otherwise silently rewrite an
+ *  illegal name and deliver to a channel nobody reads. */
+function wireChannel(channel: string): string {
+  return assertValidChannel(channel.replace(/^#+/, ""));
+}
+
+/** Sender label with the bare peer NAME quoted as its own token — the name is what `cotal_dm`
+ *  addresses, so a fused `name/role` form must never look like one (models were observed DM'ing
+ *  the literal "me/human"). Mirrors the injected-message framing in control.ts. */
 export function fmtFrom(i: InboxItem): string {
-  return i.fromRole ? `${i.fromName}/${i.fromRole}` : i.fromName;
+  return i.fromRole ? `"${i.fromName}" (${i.fromRole})` : `"${i.fromName}"`;
 }
 
 function fmtItem(i: InboxItem): string {
@@ -247,7 +257,7 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
       },
       async run(agent, _config, { text: msg, channel, mentions }: { text: string; channel?: string; mentions?: string[] }) {
         try {
-          const m = await agent.send(msg, channel, mentions);
+          const m = await agent.send(msg, channel === undefined ? undefined : wireChannel(channel), mentions);
           return ok(`Sent to #${m.channel}${m.mentions?.length ? ` (mentioned @${m.mentions.join(", @")})` : ""}.`);
         } catch (e) {
           return err(`Couldn't send: ${(e as Error).message}`);
@@ -343,9 +353,14 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
       schema: {
         channel: z.string().describe("The channel to look up (e.g. review)."),
       },
-      run(agent, _config, { channel }: { channel: string }) {
+      run(agent, _config, { channel: raw }: { channel: string }) {
         if (!agent.connected) return ok(`Not connected to the mesh yet (${config.servers}).`);
-        return ok(renderChannelInfo(channel, agent.channelInfo(channel)));
+        try {
+          const channel = wireChannel(raw);
+          return ok(renderChannelInfo(channel, agent.channelInfo(channel)));
+        } catch (e) {
+          return err(`Couldn't look up "${raw}": ${(e as Error).message}`);
+        }
       },
     },
     {
@@ -391,9 +406,10 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
           .enum(["normal", "quiet", "muted"])
           .describe("quiet = receive silently, @mentions still wake; muted = stop receiving it (incl. @mentions); normal = follow global attention."),
       },
-      async run(agent, _config, { channel, mode }: { channel: string; mode: "normal" | "quiet" | "muted" }) {
+      async run(agent, _config, { channel: raw, mode }: { channel: string; mode: "normal" | "quiet" | "muted" }) {
         if (!agent.connected) return ok(`Not connected to the mesh yet (${config.servers}).`);
         try {
+          const channel = wireChannel(raw);
           await agent.setChannelMode(channel, mode);
           const desc =
             mode === "quiet"
@@ -403,7 +419,7 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
                 : "back to following your global attention";
           return ok(`#${channel} is now ${mode} — ${desc}.`);
         } catch (e) {
-          return err(`Couldn't set #${channel} to ${mode}: ${(e as Error).message}`);
+          return err(`Couldn't set "${raw}" to ${mode}: ${(e as Error).message}`);
         }
       },
     },
@@ -415,7 +431,13 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
       schema: {
         channel: z.string().describe("The channel to join (e.g. incident)."),
       },
-      async run(agent, _config, { channel }: { channel: string }) {
+      async run(agent, _config, { channel: raw }: { channel: string }) {
+        let channel: string;
+        try {
+          channel = wireChannel(raw);
+        } catch (e) {
+          return err(`Couldn't join "${raw}": ${(e as Error).message}`);
+        }
         // Bound by the read ACL before touching the mesh — a clear refusal beats a broker/manager
         // rejection. (Auth mode also enforces this server-side; this is the friendly client gate.)
         if (!channelInAllow(config.allowSubscribe, channel))
@@ -453,12 +475,13 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
       schema: {
         channel: z.string().describe("The channel to leave."),
       },
-      async run(agent, _config, { channel }: { channel: string }) {
+      async run(agent, _config, { channel: raw }: { channel: string }) {
         try {
+          const channel = wireChannel(raw);
           const r = await agent.leaveChannel(channel);
           return ok(r.left ? `Left #${channel}.` : `You weren't on #${channel}.`);
         } catch (e) {
-          return err(`Couldn't leave #${channel}: ${(e as Error).message}`);
+          return err(`Couldn't leave "${raw}": ${(e as Error).message}`);
         }
       },
     },

--- a/extensions/pi/README.md
+++ b/extensions/pi/README.md
@@ -1,0 +1,27 @@
+# @cotal-ai/pi
+
+The Cotal mesh as a **pi extension**. One file, three ways onto the mesh:
+
+- **Interactive**: `pi --extension <path-to>/dist/extension.js` (plus `COTAL_*` env) — the
+  real pi TUI you're typing in becomes a mesh peer: peer messages land in the session as
+  user turns per the shared attention policy; the model replies with the `cotal_*` send tools
+  (`cotal_dm` / `cotal_send` / `cotal_anycast`), visible as tool calls in the TUI. Set
+  `COTAL_ALLOW_PUBLISH=general` (the post ACL is default-deny) or the peer declines to
+  reply on channels — DMs and anycasts always work.
+- **Spawned worker**: the package also registers a `Connector` (agent type `pi`), so
+  `cotal spawn --agent pi` launches the operator's installed `pi` with the extension
+  loaded — the real TUI in a managed pty, watchable via `cotal attach`.
+- **Agents built on pi's SDK**: pi's default resource loader discovers
+  `~/.pi/agent/extensions/`, so a copy there (plus `COTAL_*` env) puts default SDK
+  embedders on the mesh with no per-app work.
+
+No pi runtime is bundled — the user's pi version, settings, auth, and other extensions all
+apply. With no `COTAL_*` config in the env the extension stays inert, so a globally-installed
+copy never touches normal pi sessions; `COTAL_*` config without a mesh identity
+(`COTAL_NAME` / `COTAL_AGENT_FILE` / `COTAL_LINK`) fails loud rather than silently not joining.
+
+Delivery is ack-on-surface via the package's `InboxTurn`: messages are acked only when
+the turn that consumed them completes — a crash or kill redelivers. See
+[docs/agent-frameworks.md](../../docs/agent-frameworks.md) for the design and the run
+recipe (the `cotal` binary registers this connector, so `cotal spawn --agent pi` works
+out of the box).

--- a/extensions/pi/inbox-turn.smoke.ts
+++ b/extensions/pi/inbox-turn.smoke.ts
@@ -1,0 +1,134 @@
+/**
+ * Smoke test for the InboxTurn ack-on-surface helper (no NATS/LLM needed): drives it against
+ * a fake inbox — including the MAX_INBOX front-eviction the real MeshAgent does — and asserts
+ * the surface/ack invariants the extension's loop relies on.
+ *
+ *   pnpm smoke:inbox
+ */
+import { InboxTurn, type InboxSource } from "./src/inbox-turn.js";
+import type { InboxItem } from "@cotal-ai/connector-core";
+
+function item(id: string, fromId: string, kind: InboxItem["kind"] = "dm"): InboxItem {
+  return { id, ts: 0, fromId, fromName: fromId, kind, mentionsMe: false, text: id, historical: false };
+}
+
+/** A fake inbox that mirrors MeshAgent: ingest force-acks + evicts from the front past `cap`,
+ *  drainInbox acks by position, ackInbox acks by id (no-op for an absent id). */
+class FakeInbox implements InboxSource {
+  items: InboxItem[] = [];
+  acked: InboxItem[] = [];
+  constructor(private cap = Infinity) {}
+  ingest(it: InboxItem): void {
+    this.items.push(it);
+    if (this.items.length > this.cap) {
+      for (const ev of this.items.splice(0, this.items.length - this.cap)) this.acked.push(ev);
+    }
+  }
+  peekInbox(): InboxItem[] {
+    return [...this.items];
+  }
+  drainInbox(limit?: number): InboxItem[] {
+    const n = limit && limit > 0 ? Math.min(limit, this.items.length) : this.items.length;
+    const taken = this.items.splice(0, n);
+    this.acked.push(...taken);
+    return taken;
+  }
+  ackInbox(ids: string[]): InboxItem[] {
+    const wanted = new Set(ids);
+    const taken: InboxItem[] = [];
+    this.items = this.items.filter((p) => {
+      if (!wanted.has(p.id)) return true;
+      this.acked.push(p);
+      taken.push(p);
+      return false;
+    });
+    return taken;
+  }
+}
+
+function assert(cond: boolean, msg: string): void {
+  if (!cond) throw new Error(`FAIL: ${msg}`);
+}
+
+const ids = (xs: InboxItem[]): string => xs.map((x) => x.id).join(",");
+const sameScope = (a: InboxItem, b: InboxItem): boolean =>
+  a.fromId === b.fromId && a.kind === b.kind;
+
+// 1) drop leading non-actionable, start on the front, commit acks exactly the origin
+{
+  const fake = new FakeInbox();
+  fake.items = [item("echo", "self"), item("b", "alice")];
+  const turn = new InboxTurn(fake);
+  turn.drop((i) => i.fromId === "self");
+  assert(ids(fake.acked) === "echo", "drop ack-drops the self echo");
+  assert(turn.start()?.id === "b", "start surfaces the front actionable");
+  assert(turn.count === 1, "surfaced exactly the origin");
+  turn.commit();
+  assert(ids(fake.acked) === "echo,b", "commit acks the origin");
+  assert(fake.items.length === 0 && !turn.inFlight, "inbox drained, turn idle");
+}
+
+// 2) extend folds the front-contiguous same-scope run, stops at a different-scope gap
+{
+  const fake = new FakeInbox();
+  fake.items = [item("1", "alice"), item("2", "alice"), item("3", "bob"), item("4", "alice")];
+  const turn = new InboxTurn(fake);
+  assert(turn.start()?.id === "1", "origin = 1");
+  assert(ids(turn.extend(sameScope)) === "2", "folds only contiguous same-scope #2, stops at #3");
+  assert(turn.count === 2, "surfaced the 2-message run");
+  turn.commit();
+  assert(ids(fake.acked) === "1,2", "commit acks exactly the surfaced run [1,2]");
+  assert(ids(fake.items) === "3,4", "cross-scope #3 and gapped #4 stay on the stream");
+}
+
+// 3) abandon acks nothing — the surfaced run redelivers
+{
+  const fake = new FakeInbox();
+  fake.items = [item("x", "alice")];
+  const turn = new InboxTurn(fake);
+  turn.start();
+  turn.abandon();
+  assert(fake.acked.length === 0, "abandon acks nothing");
+  assert(ids(fake.items) === "x" && !turn.inFlight, "item stays on the stream; turn idle");
+}
+
+// 4) 200+ ambient burst mid-turn: the overflow evicts the in-flight prefix from the front;
+//    ack-by-id no-ops the evicted origin, acks the surviving folded peer, and never touches
+//    the newer messages that took the prefix's place
+{
+  const fake = new FakeInbox(200);
+  fake.ingest(item("origin", "alice"));
+  const turn = new InboxTurn(fake);
+  assert(turn.start()?.id === "origin", "origin surfaced");
+  fake.ingest(item("peer", "alice"));
+  assert(ids(turn.extend(sameScope)) === "peer", "folds the same-scope peer");
+  for (let i = 0; i < 199; i++) fake.ingest(item(`amb${i}`, "bob", "channel")); // 201 → evict 1
+  assert(
+    fake.acked.some((x) => x.id === "origin") && fake.items.some((x) => x.id === "peer"),
+    "overflow evicted+acked the origin; the folded peer survived",
+  );
+  const before = fake.acked.length;
+  turn.commit(); // ackInbox(["origin","peer"])
+  assert(fake.acked.length === before + 1, "commit acks only the survivor — evicted origin no-ops");
+  assert(!fake.items.some((x) => x.id === "peer"), "the survivor was acked by id");
+  assert(
+    fake.items.length === 199 && fake.items.every((x) => x.id.startsWith("amb")),
+    "all 199 newer ambient messages left untouched — none mis-acked",
+  );
+}
+
+// 5) commitExcept: an end-of-turn leftover (steered but never consumed) stays on the stream
+//    to redeliver; the consumed rest of the run is acked
+{
+  const fake = new FakeInbox();
+  fake.items = [item("1", "alice"), item("2", "alice")];
+  const turn = new InboxTurn(fake);
+  turn.start();
+  turn.extend(sameScope);
+  assert(turn.count === 2, "surfaced both");
+  turn.commitExcept((i) => i.id === "2"); // "2" was steered past the loop's final poll
+  assert(ids(fake.acked) === "1", "commitExcept acks only the consumed origin");
+  assert(ids(fake.items) === "2" && !turn.inFlight, "the leftover stays to redeliver; turn idle");
+}
+
+console.log("INBOX-TURN SMOKE OK ✅");

--- a/extensions/pi/package.json
+++ b/extensions/pi/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@cotal-ai/pi",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./extension": {
+      "types": "./dist/extension.d.ts",
+      "import": "./dist/extension.js"
+    }
+  },
+  "engines": {
+    "node": ">=22.19.0"
+  },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "build": "tsc -p tsconfig.json",
+    "prepublishOnly": "pnpm run build"
+  },
+  "dependencies": {
+    "@cotal-ai/connector-core": "workspace:*",
+    "typebox": "^1.1.0",
+    "zod": "^4.4.3"
+  },
+  "peerDependencies": {
+    "@cotal-ai/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@cotal-ai/core": "workspace:*",
+    "@earendil-works/pi-coding-agent": "^0.79.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/extensions/pi/src/connector.ts
+++ b/extensions/pi/src/connector.ts
@@ -1,5 +1,8 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { registry, type Connector, type LaunchOpts, type LaunchSpec } from "@cotal-ai/core";
+import { loadAgentFile, registry, type Connector, type LaunchOpts, type LaunchSpec } from "@cotal-ai/core";
 import { MODEL_PROVIDER_KEYS, aclEnv, launchEnv } from "@cotal-ai/connector-core";
 
 /** The extension is loaded with the same file extension as this module — `extension.ts`
@@ -40,11 +43,29 @@ export const piConnector: Connector = {
     if (opts.id) env.COTAL_ID = opts.id;
     if (opts.creds) env.COTAL_CREDS = opts.creds;
     if (opts.servers) env.COTAL_SERVERS = opts.servers;
-    if (opts.configPath) env.COTAL_AGENT_FILE = opts.configPath;
     const args = ["--extension", EXTENSION];
-    if (opts.model) {
-      env.COTAL_MODEL = opts.model; // presence metadata (AgentCard.meta.model), display-only
-      args.push("--model", opts.model); // applies even with no agent file (sibling contract)
+    let model = opts.model; // the spawn flag applies even with no agent file (sibling contract)
+    if (opts.configPath) {
+      env.COTAL_AGENT_FILE = opts.configPath;
+      // Parse the persona file here (not in the child) so a malformed persona fails loud
+      // at `cotal spawn`, matching the sibling connectors. The frontmatter-stripped body
+      // goes to pi via --append-system-prompt with a FILE path (pi reads paths natively),
+      // so a large persona never rides in argv (ARG_MAX ceiling); the raw agent file can't
+      // be passed directly or its `---` metadata would enter the system prompt. The model
+      // pin rides --model (`cotal spawn --model` wins over the file's `model:`), resolved
+      // by pi's own CLI semantics.
+      const def = loadAgentFile(opts.configPath);
+      if (def.persona) {
+        const dir = mkdtempSync(join(tmpdir(), "cotal-persona-"));
+        const persona = join(dir, "persona.md");
+        writeFileSync(persona, def.persona, { mode: 0o600 });
+        args.push("--append-system-prompt", persona);
+      }
+      model ??= def.model; // `cotal spawn --model` wins over the file's `model:` pin
+    }
+    if (model) {
+      env.COTAL_MODEL = model; // presence metadata (AgentCard.meta.model), display-only
+      args.push("--model", model);
     }
     return { command: "pi", args, env };
   },

--- a/extensions/pi/src/connector.ts
+++ b/extensions/pi/src/connector.ts
@@ -1,0 +1,53 @@
+import { fileURLToPath } from "node:url";
+import { registry, type Connector, type LaunchOpts, type LaunchSpec } from "@cotal-ai/core";
+import { MODEL_PROVIDER_KEYS, aclEnv, launchEnv } from "@cotal-ai/connector-core";
+
+/** The extension is loaded with the same file extension as this module — `extension.ts`
+ *  when running from source (pi's loader transpiles TS), `extension.js` from built `dist/`
+ *  — so the path resolves to a file that actually exists in either mode. Imports inside it
+ *  resolve from THIS package's node_modules, so the spawned pi needs nothing installed. */
+const ext = import.meta.url.endsWith(".ts") ? ".ts" : ".js";
+const EXTENSION = fileURLToPath(new URL(`./extension${ext}`, import.meta.url));
+
+/**
+ * The pi connector: spawns the OPERATOR'S installed `pi` (PATH resolution, exactly like the
+ * Claude Code connector spawns `claude` — a missing binary fails loud at spawn) with the
+ * Cotal mesh extension loaded, so the launched session joins the space as a lateral peer.
+ * We ship no pi runtime: the user's pi version, settings, and other extensions all apply.
+ * Under the manager's pty runtime the spawned session is the REAL pi TUI — `cotal attach`
+ * shows it. Self-registers on import; the manager resolves it by agent type "pi".
+ */
+export const piConnector: Connector = {
+  kind: "connector",
+  name: "pi",
+  requires: ["pi"],
+  buildLaunch(opts: LaunchOpts): LaunchSpec {
+    if (opts.resume) throw new Error("the pi connector does not support resuming an existing session (resume)");
+    if (opts.variant) throw new Error("the pi connector does not support model variants (variant)");
+    // OS allow-list + provider keys BY NAME (never ...process.env), plus the resolved access
+    // policy (COTAL_SUBSCRIBE / COTAL_ALLOW_* / COTAL_CAPABILITIES) — the same launchEnv/aclEnv
+    // contract every sibling connector follows, so a manifest-spawned peer's runtime read/post
+    // set matches the creds the manager minted.
+    const env: Record<string, string> = {
+      // pi resolves provider credentials via its AuthStorage, falling back to env keys —
+      // forwarded from the SHARED chokepoint list, by name, only when present.
+      ...launchEnv({ providerKeys: MODEL_PROVIDER_KEYS }),
+      ...aclEnv(opts),
+      COTAL_SPACE: opts.space,
+      COTAL_NAME: opts.name,
+    };
+    if (opts.role) env.COTAL_ROLE = opts.role;
+    if (opts.id) env.COTAL_ID = opts.id;
+    if (opts.creds) env.COTAL_CREDS = opts.creds;
+    if (opts.servers) env.COTAL_SERVERS = opts.servers;
+    if (opts.configPath) env.COTAL_AGENT_FILE = opts.configPath;
+    const args = ["--extension", EXTENSION];
+    if (opts.model) {
+      env.COTAL_MODEL = opts.model; // presence metadata (AgentCard.meta.model), display-only
+      args.push("--model", opts.model); // applies even with no agent file (sibling contract)
+    }
+    return { command: "pi", args, env };
+  },
+};
+
+registry.register(piConnector);

--- a/extensions/pi/src/extension.ts
+++ b/extensions/pi/src/extension.ts
@@ -1,0 +1,179 @@
+/**
+ * The Cotal mesh as a pi extension: load this file into ANY pi session — the interactive
+ * TUI (`pi --extension …`), a headless mode, or an agent built on pi's SDK (pi's default
+ * resource loader discovers `~/.pi/agent/extensions/`) — and that session becomes a mesh
+ * peer. Inbound DMs, role anycasts, @mentions, and wakeable channel chatter are injected as
+ * user messages into the live session (directed traffic can steer mid-turn); the MODEL replies by
+ * calling the cotal_* send tools (cotal_dm / cotal_send / cotal_anycast) — the same
+ * model-initiated contract as every sibling connector, so nothing leaves the peer that
+ * the model didn't deliberately send. This loop only surfaces inbound and acks.
+ *
+ * Delivery is ack-on-surface via {@link InboxTurn}: a surfaced message is acked only when
+ * the turn that consumed it completes, so a crash or kill redelivers — no message loss.
+ * One accepted residual: pi's extension API cannot drain the steering queue at turn end,
+ * so a message steered after the loop's final queue poll can carry into the next turn
+ * (the in-session operator sees both turns; SDK embedders who need the race fully closed
+ * can drive their own session and use `session.clearQueue()` + `InboxTurn.commitExcept`).
+ *
+ * Activation is opt-in by mesh identity: with NO `COTAL_*` config in the env the extension
+ * stays inert — a globally-installed copy must not touch the user's normal pi sessions.
+ * COTAL_* config without an identity (`COTAL_NAME` / `COTAL_AGENT_FILE` / `COTAL_LINK`), or
+ * an identity that's invalid, fails loud — never a session that silently isn't on the mesh.
+ */
+import { MeshAgent, configFromEnv, formatInjection, hasIdentity } from "@cotal-ai/connector-core";
+import type { InboxItem } from "@cotal-ai/connector-core";
+import { InboxTurn } from "./inbox-turn.js";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { registerCotalTools } from "./tools.js";
+
+/** Own echoes are never useful to surface. */
+function ownEcho(mesh: MeshAgent, item: InboxItem): boolean {
+  return item.fromId === mesh.id;
+}
+
+/** Directed messages may steer a live turn; ambient channel chatter waits for the next pump. */
+function directed(mesh: MeshAgent, item: InboxItem): boolean {
+  return !ownEcho(mesh, item) && (item.kind !== "channel" || item.mentionsMe);
+}
+
+/** The final assistant message's stopReason ("stop" | "aborted" | "error"), if any. */
+function lastStopReason(messages: readonly unknown[]): string | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i] as { role?: unknown; stopReason?: unknown };
+    if (m.role === "assistant") return typeof m.stopReason === "string" ? m.stopReason : undefined;
+  }
+  return undefined;
+}
+
+export default function cotalMesh(pi: ExtensionAPI): void {
+  if (!hasIdentity()) {
+    // Inert is only safe when the operator plainly didn't opt in. OTHER COTAL_* config with no
+    // identity is a misconfiguration (e.g. a typo'd COTAL_NAME) — running the session normally
+    // while silently never joining the mesh is exactly the no-fallbacks failure mode. (Global
+    // operator settings like COTAL_FEEDBACK_EMAIL don't signal intent to join.)
+    const stray = Object.keys(process.env).filter(
+      (k) => k.startsWith("COTAL_") && k !== "COTAL_FEEDBACK_EMAIL",
+    );
+    if (stray.length)
+      throw new Error(
+        `COTAL config present (${stray.join(", ")}) but no mesh identity — set COTAL_NAME, ` +
+          `COTAL_AGENT_FILE, or COTAL_LINK to join, or unset COTAL_* to run pi off-mesh`,
+      );
+    return; // no COTAL config at all → stay inert (opt-in switch)
+  }
+
+  const config = configFromEnv();
+  config.connector = "pi"; // advertise the host harness on our AgentCard (meta.connector)
+  const mesh = new MeshAgent(config);
+  const turn = new InboxTurn(mesh);
+  let streaming = false; // gates steer-delivery: only once the agent is actually running
+  /** Ids folded mid-turn whose steer delivery THREW — surfaced but never reached the model.
+   *  agent_end commits everything except these, so they stay on the stream and redeliver. */
+  const failedSteer = new Set<string>();
+
+  const setStatus = (status: "idle" | "working", activity?: string): void => {
+    void mesh.setStatus(status, activity).catch(() => {});
+  };
+
+  /** Start the next connector-owned turn when the shared attention policy says something should wake us.
+   *  Leading own echoes are ack-dropped, but ambient chatter stays buffered: in open mode it
+   *  can wake an idle session; in dnd/quiet it rides the next directed or human-driven turn. */
+  function pump(force = false, steer = false): void {
+    if (turn.inFlight) return;
+    turn.drop((i) => ownEcho(mesh, i));
+    if (force ? mesh.inboxCount() === 0 : mesh.pendingWake() === 0) {
+      if (!force) setStatus("idle");
+      return;
+    }
+    const origin = turn.start();
+    if (!origin) {
+      setStatus("idle");
+      return;
+    }
+    const batch = [origin, ...turn.extend((i) => !ownEcho(mesh, i))];
+    const injection = formatInjection(batch)!;
+    // A plain send is REFUSED by pi while an agent turn is streaming (e.g. a human-driven turn
+    // with an empty backlog at agent_start) — deliver as steer whenever one is live, or the
+    // surfaced batch would be silently dropped yet acked at agent_end. If delivery still
+    // throws, abandon: the batch stays on the stream and redelivers instead of being lost.
+    try {
+      if (steer || streaming) pi.sendUserMessage(injection, { deliverAs: "steer" });
+      else pi.sendUserMessage(injection); // lands in the live session; always triggers a turn
+    } catch {
+      turn.abandon();
+    }
+  }
+
+  /** Fold front-contiguous directed messages into the live turn (true mid-turn steer).
+   *  Ambient chatter does not steer; it waits for the next between-turn pump. */
+  function fold(): void {
+    if (!turn.inFlight || !streaming) return;
+    const items = turn.extend((i) => directed(mesh, i));
+    if (!items.length) return;
+    try {
+      pi.sendUserMessage(formatInjection(items)!, { deliverAs: "steer" });
+    } catch {
+      // Already surfaced but never delivered — exempt from the commit so they redeliver.
+      for (const i of items) failedSteer.add(i.id);
+    }
+  }
+
+  // The full shared cotal_* surface — the model owns replies (cotal_dm / cotal_send /
+  // cotal_anycast), exactly like the Claude Code and OpenCode peers.
+  registerCotalTools(pi, mesh, config);
+
+  mesh.on("incoming", () => (turn.inFlight ? fold() : pump()));
+  mesh.on("wake", () => {
+    if (!turn.inFlight) pump();
+  });
+  // Focus-mode @mention: the body was ack-dropped at ingest (recallable via cotal_inbox), so
+  // there is nothing to surface or commit — a bare nudge is the whole job. Without this
+  // handler a peer whose model set attention=focus goes permanently deaf to mentions (the
+  // sibling connectors all subscribe to this event).
+  mesh.on("mention-wake", (item: InboxItem) => {
+    const nudge =
+      `📨 Cotal — you were @mentioned on #${item.channel} by "${item.fromName}"` +
+      `${item.fromRole ? ` (${item.fromRole})` : ""} while in focus. The message body is held — ` +
+      `read it with cotal_inbox and reply with cotal_send if warranted.`;
+    // Steer whenever ANY turn is streaming (incl. human-driven ones): a plain send is refused
+    // by pi mid-turn, and the mention body was already acked at ingest — a dropped nudge would
+    // never redeliver, leaving the peer deaf to that mention.
+    try {
+      pi.sendUserMessage(nudge, streaming ? { deliverAs: "steer" } : undefined);
+    } catch {
+      /* nothing to abandon — the recall path (cotal_inbox) still holds the body */
+    }
+  });
+
+  pi.on("session_start", () => {
+    mesh.start();
+    pump(); // drain anything buffered before the listeners attached
+  });
+  pi.on("agent_start", () => {
+    streaming = true;
+    setStatus("working", "thinking");
+    if (turn.inFlight) fold(); // flush directed peers that landed before streaming began
+    else pump(true, true); // human-started turn: surface any quiet/dnd backlog as steer context
+  });
+  pi.on("tool_execution_start", (ev) => {
+    setStatus("working", `running ${(ev as { toolName?: string }).toolName ?? "tool"}`);
+  });
+  pi.on("tool_execution_end", () => {
+    setStatus("working", "thinking"); // clear the per-tool activity so it can't read stale
+  });
+  pi.on("agent_end", (ev) => {
+    streaming = false;
+    // Esc/abort restores unconsumed queued messages to the human's editor instead of the model —
+    // committing would ack messages never seen. An aborted turn ends with stopReason "aborted":
+    // abandon so the surfaced run stays on the stream and redelivers. A clean or errored finish
+    // commits (per the InboxTurn contract: a failed turn is dropped, not retry-looped).
+    if (lastStopReason(ev.messages) === "aborted") turn.abandon();
+    else turn.commitExcept((i) => failedSteer.has(i.id)); // sole ack site; failed folds redeliver
+    failedSteer.clear();
+    setImmediate(pump); // next batch, after the session settles
+  });
+  pi.on("session_shutdown", async () => {
+    if (turn.inFlight) turn.abandon(); // leave the in-flight run on the stream → redeliver
+    await mesh.stop().catch(() => {});
+  });
+}

--- a/extensions/pi/src/inbox-turn.ts
+++ b/extensions/pi/src/inbox-turn.ts
@@ -1,0 +1,139 @@
+import type { InboxItem } from "@cotal-ai/connector-core";
+
+/** The slice of {@link MeshAgent} an {@link InboxTurn} drives off of. */
+export interface InboxSource {
+  /** Buffered messages, oldest first, without acking. */
+  peekInbox(): InboxItem[];
+  /** Ack + remove the front `limit` messages and return them. */
+  drainInbox(limit?: number): InboxItem[];
+  /** Ack + remove the messages with these ids (any position); an absent id is a no-op. */
+  ackInbox(ids: string[]): InboxItem[];
+}
+
+/**
+ * Ack-on-surface delivery off a {@link MeshAgent}'s stream-backed inbox — the turn helper
+ * for a native-embed adapter (a mesh loop living inside the host agent's process, driving
+ * its session off the inbox). It lives here because the pi extension is its sole consumer;
+ * promote it to `@cotal-ai/connector-core` when another native-embed adapter (e.g. an
+ * openclaw plugin) needs it. Hook-drain adapters (Claude Code — delivery and ack at
+ * deterministic hook boundaries) and adapters with their own host turn machine (OpenCode)
+ * don't need it.
+ *
+ * The inbox is the single source of truth — there is no parallel buffer to drift out of
+ * sync. A turn *surfaces* messages by id and acks them (via `ackInbox`) only once the turn
+ * COMPLETES; a crash or interrupt before {@link commit} leaves them on the stream, so they
+ * redeliver — nothing is acked merely by being read. Acking by id (rather than by front
+ * position) keeps it correct even when the `MAX_INBOX` overflow force-evicts the in-flight
+ * prefix from the front mid-turn: those ids are already gone, so the ack no-ops them and
+ * never touches the newer messages that took their place.
+ *
+ * Fits both shapes the embed adapters use:
+ *   - a one-message serialize loop: `start()` → run → `commit()`;
+ *   - pi's steer loop: `start()` → `extend(match)`* (fold directed peers into the live
+ *     turn as they stream in) → `commit()`/`commitExcept()` on a clean/failed finish, or
+ *     `abandon()` on interrupt.
+ *
+ * `cotal_inbox` (where exposed) must stay on `peekInbox` so a model call can't double-drain
+ * what the loop already surfaced.
+ */
+export class InboxTurn {
+  private surfaced: InboxItem[] = [];
+  private _origin?: InboxItem;
+
+  constructor(private readonly source: InboxSource) {}
+
+  /** True while a turn holds surfaced-but-unacked messages. */
+  get inFlight(): boolean {
+    return this.surfaced.length > 0;
+  }
+
+  /** The message that opened the current turn (its reply scope), or undefined when idle. */
+  get origin(): InboxItem | undefined {
+    return this._origin;
+  }
+
+  /** How many messages this turn has surfaced. */
+  get count(): number {
+    return this.surfaced.length;
+  }
+
+  /**
+   * Ack-drop the leading messages matching `skip` (own echoes, ambient chatter) so they
+   * neither block the front nor linger to the inbox cap. Only valid with no turn in flight
+   * (a between-turns, synchronous front trim — no eviction can interleave).
+   */
+  drop(skip: (item: InboxItem) => boolean): void {
+    if (this.surfaced.length) return;
+    const pending = this.source.peekInbox();
+    let n = 0;
+    while (n < pending.length && skip(pending[n])) n++;
+    if (n) this.source.drainInbox(n);
+  }
+
+  /**
+   * Open a turn on the front message (its origin) and surface it. Returns the origin, or
+   * undefined if the inbox is empty. Idempotent while a turn is in flight (returns the
+   * current origin). Call {@link drop} first so the front is the message you mean to answer.
+   */
+  start(): InboxItem | undefined {
+    if (this.surfaced.length) return this._origin;
+    const front = this.source.peekInbox()[0];
+    if (!front) return undefined;
+    this._origin = front;
+    this.surfaced = [front];
+    return front;
+  }
+
+  /**
+   * Fold the front-contiguous run of not-yet-surfaced messages that `match(item, origin)`
+   * into this turn, stopping at the first unsurfaced non-match (so a cross-scope message is
+   * left to open its own turn, preserving FIFO + scope isolation). Already-surfaced messages
+   * are skipped, so an overflow that evicts part of the prefix can't desync this. Returns the
+   * newly surfaced messages for the caller to feed in (e.g. via steer). No-op until
+   * {@link start}.
+   */
+  extend(match: (item: InboxItem, origin: InboxItem) => boolean): InboxItem[] {
+    if (!this._origin) return [];
+    const surfaced = new Set(this.surfaced.map((i) => i.id));
+    const run: InboxItem[] = [];
+    for (const item of this.source.peekInbox()) {
+      if (surfaced.has(item.id)) continue; // already surfaced (still buffered) — skip
+      if (!match(item, this._origin)) break; // first unsurfaced non-match → stop at the gap
+      run.push(item);
+      this.surfaced.push(item);
+    }
+    return run;
+  }
+
+  /**
+   * Ack the surfaced messages by id — the sole ack site. Call on a terminal status that
+   * should consume them: a clean finish, or a failed/dropped turn (drop, no retry-loop). Ids
+   * already evicted by the overflow no-op. Do NOT call on interrupt/crash — use
+   * {@link abandon} so the run redelivers.
+   */
+  commit(): void {
+    this.commitExcept(() => false);
+  }
+
+  /**
+   * Ack the surfaced messages EXCEPT those matching `leftover`, which stay un-acked on the
+   * stream and redeliver. For the end-of-turn steer race: a message steered into a live turn
+   * after the loop's final queue poll was surfaced but never consumed — acking it would drop
+   * it silently, so the consumer names it here and answers it on redelivery instead.
+   */
+  commitExcept(leftover: (item: InboxItem) => boolean): void {
+    const consumed = this.surfaced.filter((i) => !leftover(i));
+    if (consumed.length) this.source.ackInbox(consumed.map((i) => i.id));
+    this.reset();
+  }
+
+  /** End the turn without acking — the surfaced run stays on the stream and redelivers. */
+  abandon(): void {
+    this.reset();
+  }
+
+  private reset(): void {
+    this.surfaced = [];
+    this._origin = undefined;
+  }
+}

--- a/extensions/pi/src/index.ts
+++ b/extensions/pi/src/index.ts
@@ -1,0 +1,4 @@
+import "./connector.js"; // self-registers the "pi" connector
+export { piConnector } from "./connector.js";
+export { default as cotalMeshExtension } from "./extension.js";
+export { InboxTurn, type InboxSource } from "./inbox-turn.js"; // for SDK embedders driving their own session

--- a/extensions/pi/src/tools.ts
+++ b/extensions/pi/src/tools.ts
@@ -1,0 +1,106 @@
+/**
+ * The Cotal tool surface for pi, rendered from the **shared** {@link cotalToolSpecs} (the
+ * same source the Claude Code MCP and OpenCode connectors render) via `pi.registerTool`.
+ * One source of truth → the cotal_* surface can't drift across adapters: a pi peer gets
+ * the same tools (send/dm/anycast, roster, channels, status, spawn where capable).
+ *
+ * The one pi-specific tool is `cotal_inbox`: this connector DRIVES delivery (the loop
+ * surfaces each batch into a turn and acks on completion), so the agent's inbox tool is
+ * READ-ONLY — it peeks (never drains), or it would race the loop's ack.
+ *
+ * Schemas: the shared spec carries a Zod raw shape; pi's `registerTool` takes a TypeBox
+ * TSchema. TypeBox schemas are plain JSON Schema, so we render Zod → JSON Schema (Zod 4's
+ * `toJSONSchema`, the same path the Hermes connector uses) and brand it with `Type.Unsafe`.
+ */
+import { z } from "zod";
+import { isConcreteChannel } from "@cotal-ai/core";
+import { cotalToolSpecs, type MeshAgent, type AgentConfig } from "@cotal-ai/connector-core";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type, type TSchema } from "typebox";
+
+const READONLY_INBOX_DESCRIPTION =
+  "Show the peer messages currently waiting for you (incl. focus-mode recall). You don't normally " +
+  "need this — the connector delivers peer messages into your turns automatically; use it to " +
+  "re-check what's pending mid-task. Read-only: it never consumes them.";
+
+/** Mesh etiquette, appended to the system prompt while the send tools are active. The first
+ *  line is load-bearing: with loop-owned delivery removed, plain chat output goes nowhere —
+ *  a reply EXISTS only if the model sends it through a tool. */
+const SEND_GUIDELINES = [
+  "Peer messages from the Cotal mesh arrive as user messages tagged 📨. Your chat output is NOT " +
+    "delivered to peers — when a reply is warranted, send it with cotal_dm (back to that peer), " +
+    "cotal_send (to a channel), or cotal_anycast (to a role).",
+  "Reply only when a reply is actually needed — a silent acknowledgement is correct; " +
+    '"agreed/thanks/good point" messages are noise. And @-mention a peer only when you need THAT ' +
+    "specific peer to act: a mention wakes them, so mentioning in acknowledgements or sign-offs " +
+    "makes peers ping-pong wake-ups in an endless loop.",
+];
+
+function toParameters(schema: z.ZodRawShape | undefined): TSchema {
+  if (!schema) return Type.Object({});
+  // io:"input" — the default (output) io emits `additionalProperties: false`, and pi validates
+  // args strictly against the schema, so a harmless stray key would fail a call that the same
+  // Zod shape accepts (strip mode) on the Claude Code / OpenCode paths. Input io matches those.
+  return Type.Unsafe(z.toJSONSchema(z.object(schema), { io: "input" }));
+}
+
+/** `<label> → <target>: <text>` for a send-tool call, so the operator SEES what the model is
+ *  sending from inside the session (pi's default extension-tool rendering shows only the label). */
+function sendCallLine(name: string, config: AgentConfig, args: Record<string, unknown>): string {
+  // While the call's args are still streaming in, fields may be absent — render "…" rather
+  // than a bogus concrete target; the settled frame paints the real one.
+  const text = String(args.text ?? "");
+  if (name === "cotal_dm") return `cotal_dm → ${args.to ? `"${String(args.to)}"` : "…"}: ${text}`;
+  if (name === "cotal_anycast") return `cotal_anycast → @${String(args.role ?? "…")}: ${text}`;
+  // Same default the tool itself applies (first CONCRETE channel) — subscribe[0] may be a
+  // wildcard like `team.>`, which the message can never actually go to. Strip a display `#`
+  // the model may have echoed back, as the tool's own channel normalization does.
+  const channel = String(args.channel ?? config.subscribe.find(isConcreteChannel) ?? "general").replace(/^#+/, "");
+  return `cotal_send → #${channel}: ${text}`;
+}
+
+/** Word-wrap a line to the viewport, satisfying pi-tui's structural `Component` contract
+ *  ({ render(width): string[]; invalidate(): void }) without importing pi-tui — the published
+ *  extension must add no runtime dependency on the host. Static text: invalidate is a no-op. */
+function wrapped(line: string): { render(width: number): string[]; invalidate(): void } {
+  return {
+    invalidate(): void {},
+    render(width: number): string[] {
+      const w = Math.max(16, width);
+      const out: string[] = [];
+      let rest = line.replace(/\s+/g, " ");
+      while (rest.length > w) {
+        const cut = rest.lastIndexOf(" ", w);
+        const at = cut > w / 2 ? cut : w;
+        out.push(rest.slice(0, at));
+        rest = rest.slice(at).trimStart();
+      }
+      out.push(rest);
+      return out;
+    },
+  };
+}
+
+const SEND_TOOLS = new Set(["cotal_send", "cotal_dm", "cotal_anycast"]);
+
+/** Register the full cotal_* tool set on a pi session, wired to one mesh agent. */
+export function registerCotalTools(pi: ExtensionAPI, mesh: MeshAgent, config: AgentConfig): void {
+  for (const spec of cotalToolSpecs(config, "pi")) {
+    const readonlyInbox = spec.name === "cotal_inbox";
+    pi.registerTool({
+      name: spec.name,
+      label: spec.title,
+      description: readonlyInbox ? READONLY_INBOX_DESCRIPTION : spec.description,
+      parameters: readonlyInbox ? Type.Object({}) : toParameters(spec.schema),
+      promptGuidelines: spec.name === "cotal_send" ? SEND_GUIDELINES : undefined,
+      renderCall: SEND_TOOLS.has(spec.name)
+        ? (args) => wrapped(sendCallLine(spec.name, config, (args ?? {}) as Record<string, unknown>))
+        : undefined,
+      async execute(_id, params) {
+        const args = readonlyInbox ? { peek: true } : ((params ?? {}) as Record<string, unknown>);
+        const r = await spec.run(mesh, config, args);
+        return { content: [{ type: "text", text: r.isError ? `⚠ ${r.text}` : r.text }], details: undefined };
+      },
+    });
+  }
+}

--- a/extensions/pi/tsconfig.json
+++ b/extensions/pi/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}

--- a/implementations/manager/smoke/start-model-preflight.smoke.ts
+++ b/implementations/manager/smoke/start-model-preflight.smoke.ts
@@ -48,11 +48,22 @@ import { registry, type Connector, type LaunchOpts, type LaunchSpec, type AgentH
 import { claudeConnector } from "@cotal-ai/connector-claude-code";
 import { opencodeConnector } from "@cotal-ai/connector-opencode";
 import { hermesConnector } from "@cotal-ai/connector-hermes";
+import { piConnector } from "../../../extensions/pi/src/connector.js";
 
 let failures = 0;
 function check(label: string, cond: boolean, extra?: unknown): void {
   console.log(`${cond ? "✓" : "✗"} ${label}${cond ? "" : ` — ${extra ?? ""}`}`);
   if (!cond) failures++;
+}
+
+function throws(label: string, fn: () => unknown): void {
+  let ok = false;
+  try {
+    fn();
+  } catch {
+    ok = true;
+  }
+  check(label, ok);
 }
 
 // Hermes is Unix-only — its buildLaunch THROWS on win32 by design (AF_UNIX bridge + Python sidecar).
@@ -175,6 +186,9 @@ registry.register(recNoResumeCon);
   check("claude.requires == [claude]", JSON.stringify(claudeConnector.requires) === '["claude"]');
   check("opencode.requires == [opencode]", JSON.stringify(opencodeConnector.requires) === '["opencode"]');
   check("hermes.requires == [hermes]", JSON.stringify(hermesConnector.requires) === '["hermes"]');
+  check("pi.requires == [pi]", JSON.stringify(piConnector.requires) === '["pi"]');
+  throws("pi: buildLaunch rejects resume", () => piConnector.buildLaunch({ ...base, resume: "host-session" }));
+  throws("pi: buildLaunch rejects variant", () => piConnector.buildLaunch({ ...base, variant: "high" }));
 
   // Hermes is Unix-only: on win32 buildLaunch throws BEFORE producing a spec — assert that guard here
   // and skip the Hermes model rows below (they'd all throw). claude + opencode still run on both OSes.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "smoke": "tsx packages/core/smoke.ts",
     "smoke:auth": "tsx packages/core/smoke-auth.ts",
     "smoke:orientation": "tsx extensions/connector-core/smoke/orientation.smoke.ts",
+    "smoke:inbox": "tsx extensions/pi/inbox-turn.smoke.ts",
     "smoke:view": "tsx implementations/cli/smoke/view.smoke.ts",
     "smoke:members": "tsx packages/core/smoke/members.smoke.ts",
     "smoke:control-reply-bound": "tsx packages/core/smoke/control-reply-bound.smoke.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@cotal-ai/manager':
         specifier: workspace:*
         version: link:../implementations/manager
+      '@cotal-ai/pi':
+        specifier: workspace:*
+        version: link:../extensions/pi
       '@cotal-ai/tmux':
         specifier: workspace:*
         version: link:../extensions/tmux
@@ -214,6 +217,25 @@ importers:
       tsx:
         specifier: ^4.22.4
         version: 4.22.4
+
+  extensions/pi:
+    dependencies:
+      '@cotal-ai/connector-core':
+        specifier: workspace:*
+        version: link:../connector-core
+      typebox:
+        specifier: ^1.1.0
+        version: 1.3.4
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@cotal-ai/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@earendil-works/pi-coding-agent':
+        specifier: ^0.79.0
+        version: 0.79.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
 
   extensions/tmux:
     dependencies:
@@ -371,6 +393,112 @@ packages:
     resolution: {integrity: sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==}
     engines: {node: '>=18'}
 
+  '@anthropic-ai/sdk@0.91.1':
+    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    resolution: {integrity: sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.28':
+    resolution: {integrity: sha512-4/1DtLwgLqzIg2uFzkFaFjMQHhhhwHIZN4PfziIVqXYX7koO78omuchQlLHyzQBw80l255dtmTA/J4W5yhb7zw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.54':
+    resolution: {integrity: sha512-F4WQCG8GULIt+XrMHsqUM9dZc0eTwZM3HUWByOjIKOwBqJSzUxX8CFAtbgMvWfCua52FS1oi5FXarH3+khFq8A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.56':
+    resolution: {integrity: sha512-PiwHgEK2srdfi/lFveyQ+3w/qikyh6MKvuZAdlMC+dwQi4K5iVBr32oh7cugnYw+jA8iGtnQMhCGvLm/mqplmw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.61':
+    resolution: {integrity: sha512-9CZWMjhBlgfKlqJk40R7kvMOLEIoOr3HJ1J/ELjAH9H5LzR4bCxLujPVM/1PKAEjzSZKZCxWOalm7JUGZbhQqw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.60':
+    resolution: {integrity: sha512-Ak6OOrCbXvACyxLFIP1mcS+JTLS9ZpW1ZqyBtqu6axvdpsbG1gVNhUlAfQq8TK/gar/h2w35LrzlQU0PcUzJpw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.63':
+    resolution: {integrity: sha512-YmgWtTPZDStyT74ApSHpApD3r7W9znsc+WEZjW0vceom+NAxRx9/F3TyukOKix8kJkPaa49aIREQJdpGeLDiEw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.54':
+    resolution: {integrity: sha512-UNmUjtTnp3wH3YTZcctN7yK17S2AdaJpiNIdIf0l70hHOdGuDfdMxk62P5rt64GwGm6qkFOYG0js/cU6cdZDdg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.60':
+    resolution: {integrity: sha512-zH8SvJkTRw1Kb7GARjGPjzkQPfL3jDi/OxK32I5SQq7bgwgFHJZaoDEwkEvFlfNfpByM6n4Rs20Y1mLyOdb6ag==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.60':
+    resolution: {integrity: sha512-q2rJSQ/AMjemUS18OtQqczqSo2R6VjOCLmLVmLVcdrP5/AKoj632lGCrMUWQ6EgnaLMEHbq0UO4mWh/u6gjPhA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/eventstream-handler-node@3.972.25':
+    resolution: {integrity: sha512-df7HN1ozwMrB9+59re9PM7tSLxLAcheMWc5u/KyfCPCAWtN/vP7y7RTUZOy48uT1K9MESisVeOPPzF3O1AW01A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-eventstream@3.972.21':
+    resolution: {integrity: sha512-HvLgDnxBLaHi9E5K++6Vuk+1+qqn7Pmn8zrlzd+NXH3jBzwujnuzZtAR9WHPkbUGPO92FkoQWj/M1IsdxTlBmQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.972.36':
+    resolution: {integrity: sha512-BD8tYKNAc8dyN7q4NU1wsA1ZgRTBAjbqH04I5SfoqJaOmwlUab6AI7GRapSt8fxf9sq3GyAhioK0qHLCTnuZ9A==}
+    engines: {node: '>= 14.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.28':
+    resolution: {integrity: sha512-1oG/mM3jmE2M3kad2zWJS6IKIY8hjRV4l5kAgg+xTQdLMTtehhcSucL/y4WqQpcHmQwi6+gRK8E46GYl1NBW9Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.38':
+    resolution: {integrity: sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1048.0':
+    resolution: {integrity: sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1080.0':
+    resolution: {integrity: sha512-8PufAQvncWXvdZUvODbuyXa8l3aszefEzwSMBUcgheNbZOmJMcNn388Ebt/piVrUHyxKN1MlxnR2OonzTyZaGw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.15':
+    resolution: {integrity: sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.8':
+    resolution: {integrity: sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.33':
+    resolution: {integrity: sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
+
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
@@ -437,6 +565,24 @@ packages:
   '@clack/prompts@1.5.1':
     resolution: {integrity: sha512-zccHj2z2oCCO4yrDiRSlFOxWerGqRiysP7a5jPK6uoI9URKAquwY42Dd/iUP8JWHxEzdRe4TlbvZCo8z1/mhrw==}
     engines: {node: '>= 20.12.0'}
+
+  '@earendil-works/pi-agent-core@0.79.10':
+    resolution: {integrity: sha512-XKxgdjhcPuyjrthCOFSgfzT3xZ1uBrJ1IMVDxci1to6hIN6BIg9J5iY8q0pGXK1DLgATLP23da+1UyZLwA360Q==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-ai@0.79.10':
+    resolution: {integrity: sha512-9jR23tOl0BIUdQMn70Gr72xYBpM7Xgl9Lyv7gAnU1USfkNRuYG/f/edLl+n/Dp/RafDW3JI4DF7y/GhgkORuew==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-coding-agent@0.79.10':
+    resolution: {integrity: sha512-YxaRhmgyDTvLDdGVbe7YzTHV80oL5mX5odg6EhGHz3w5Wu1Ix8DCw7bhtiOBLGQNFRcknia0zPmVWIj30XP1EA==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-tui@0.79.10':
+    resolution: {integrity: sha512-FUVOjDn1DVwM1uHD5MNYboXQrXjIDbSt+BQ3py7nQWCY62tKfxgiM1OBMxTcwRWLfSdZHUPpV0hm1loIdUJnPw==}
+    engines: {node: '>=22.19.0'}
 
   '@eplightning/nats-server-darwin-arm64@2.14.0':
     resolution: {integrity: sha512-tBCOf4anrlTnbQimh3KSz6C+0IbdJTyfTFLcol2YfGWzfmMgsXqjfrSZvnRnqMK2hWD/TJ6eIhsv3/UlfdTzEg==}
@@ -786,6 +932,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@google/genai@1.52.0':
+    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
@@ -839,6 +994,82 @@ packages:
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@mariozechner/clipboard-darwin-arm64@0.3.9':
+    resolution: {integrity: sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@mariozechner/clipboard-darwin-universal@0.3.9':
+    resolution: {integrity: sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==}
+    engines: {node: '>= 10'}
+    os: [darwin]
+
+  '@mariozechner/clipboard-darwin-x64@0.3.9':
+    resolution: {integrity: sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
+    resolution: {integrity: sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
+    resolution: {integrity: sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
+    resolution: {integrity: sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
+    resolution: {integrity: sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@mariozechner/clipboard-linux-x64-musl@0.3.9':
+    resolution: {integrity: sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
+    resolution: {integrity: sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
+    resolution: {integrity: sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@mariozechner/clipboard@0.3.9':
+    resolution: {integrity: sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==}
+    engines: {node: '>= 10'}
+
+  '@mistralai/mistralai@2.2.6':
+    resolution: {integrity: sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -937,6 +1168,84 @@ packages:
   '@opencode-ai/sdk@1.16.2':
     resolution: {integrity: sha512-Z/xZ7q79dYeE0afqIk/yFEcRNGEQFcE+H8ssYivUiy+xGZ1mGwT72jpaQZKBwPn3JH4sRCu4KA2lcktBQfcOjg==}
 
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/semantic-conventions@1.42.0':
+    resolution: {integrity: sha512-icc5xCzndZfhuJMy5oqk5AvloWquR7jtae74qzpkKkhGp8BivK+oCcEXgGnjCdTfp8hA44l+w8gE8yYJbocJJw==}
+    engines: {node: '>=14'}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
+
+  '@silvia-odwyer/photon-node@0.3.4':
+    resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
+
+  '@smithy/core@3.29.1':
+    resolution: {integrity: sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.6':
+    resolution: {integrity: sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.3':
+    resolution: {integrity: sha512-CwCc/7SMTj45y97MUnDTbTaxvtAsiNNRm81z3abROIuMbMsC2Iy5EKfkkVdsKrz8WExQAAMx1EJapq+9j4fFTQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.7.3':
+    resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.9.3':
+    resolution: {integrity: sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.2':
+    resolution: {integrity: sha512-QgHflghMoPxCJ9axiCVh8KZfbC9fuP6vkXXyK//E3cq7nLaSSyyLj0GAoqVWezYeDQmXIZhmlRvLE16jsqDK6g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.15.1':
+    resolution: {integrity: sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -951,6 +1260,9 @@ packages:
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -979,6 +1291,10 @@ packages:
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -1029,13 +1345,22 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -1044,6 +1369,9 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1119,6 +1447,10 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1140,6 +1472,10 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -1147,6 +1483,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -1228,6 +1567,9 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
@@ -1257,6 +1599,10 @@ packages:
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -1271,6 +1617,10 @@ packages:
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -1296,6 +1646,14 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  gaxios@7.1.6:
+    resolution: {integrity: sha512-aIQ0QL8Or8vsUhHyXGA6AohOFRrAAiHhrvsAG6myzcSlfhxSXtnwXA/pRuQTilFgjhLe30swK5rg1d7E1f8Izw==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
+
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
@@ -1320,6 +1678,14 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
+  google-auth-library@10.9.0:
+    resolution: {integrity: sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -1335,13 +1701,28 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
   hono@4.12.23:
     resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
     engines: {node: '>=16.9.0'}
 
+  hosted-git-info@9.0.3:
+    resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-id@4.2.0:
     resolution: {integrity: sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==}
@@ -1353,6 +1734,10 @@ packages:
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
   indent-string@5.0.0:
@@ -1422,6 +1807,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
@@ -1432,6 +1821,13 @@ packages:
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
+
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -1447,6 +1843,12 @@ packages:
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
   kubernetes-types@1.30.0:
     resolution: {integrity: sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==}
 
@@ -1457,9 +1859,17 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
     engines: {node: 20 || >=22}
+
+  marked@18.0.5:
+    resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1522,6 +1932,15 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   node-gyp-build-optional-packages@5.2.2:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
     hasBin: true
@@ -1549,6 +1968,18 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
+  openai@6.26.0:
+    resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
 
@@ -1568,6 +1999,10 @@ packages:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
     engines: {node: '>=6'}
 
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
@@ -1578,6 +2013,9 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  partial-json@0.1.7:
+    resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
   patch-console@2.0.0:
     resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
@@ -1621,6 +2059,13 @@ packages:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
+    engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -1673,6 +2118,14 @@ packages:
     resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -1684,6 +2137,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
@@ -1693,6 +2149,11 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
@@ -1810,6 +2271,9 @@ packages:
     resolution: {integrity: sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==}
     engines: {node: '>=20'}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-json-schema-generator@2.9.0:
     resolution: {integrity: sha512-NR5ZE108uiPtBHBJNGnhwoUaUx5vWTDJzDFG9YlRoqxPU76n+5FClRh92dcGgysbe1smRmYalM9Saj97GW1J4Q==}
     engines: {node: '>=22.0.0'}
@@ -1834,6 +2298,12 @@ packages:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
 
+  typebox@1.1.38:
+    resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
+
+  typebox@1.3.4:
+    resolution: {integrity: sha512-j3MCKfJMIHdrr4ZQMzaJnvXrUbMNuncwssmQkny3Cv5vxrDE1o1WhZFEqGSlU884xtYS5sAa3O/XsUPbUbPWKQ==}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -1841,6 +2311,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
+    engines: {node: '>=22.19.0'}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -1857,6 +2331,10 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -1911,6 +2389,226 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.4.3
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.15
+      '@aws-sdk/util-locate-window': 3.965.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.15
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.15
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/credential-provider-node': 3.972.63
+      '@aws-sdk/eventstream-handler-node': 3.972.25
+      '@aws-sdk/middleware-eventstream': 3.972.21
+      '@aws-sdk/middleware-websocket': 3.972.36
+      '@aws-sdk/token-providers': 3.1048.0
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/fetch-http-handler': 5.6.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.28':
+    dependencies:
+      '@aws-sdk/types': 3.973.15
+      '@aws-sdk/xml-builder': 3.972.33
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.29.1
+      '@smithy/signature-v4': 5.6.2
+      '@smithy/types': 4.15.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.56':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/fetch-http-handler': 5.6.3
+      '@smithy/node-http-handler': 4.9.3
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.61':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/credential-provider-env': 3.972.54
+      '@aws-sdk/credential-provider-http': 3.972.56
+      '@aws-sdk/credential-provider-login': 3.972.60
+      '@aws-sdk/credential-provider-process': 3.972.54
+      '@aws-sdk/credential-provider-sso': 3.972.60
+      '@aws-sdk/credential-provider-web-identity': 3.972.60
+      '@aws-sdk/nested-clients': 3.997.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/credential-provider-imds': 4.4.6
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.60':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/nested-clients': 3.997.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.63':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.54
+      '@aws-sdk/credential-provider-http': 3.972.56
+      '@aws-sdk/credential-provider-ini': 3.972.61
+      '@aws-sdk/credential-provider-process': 3.972.54
+      '@aws-sdk/credential-provider-sso': 3.972.60
+      '@aws-sdk/credential-provider-web-identity': 3.972.60
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/credential-provider-imds': 4.4.6
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.60':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/nested-clients': 3.997.28
+      '@aws-sdk/token-providers': 3.1080.0
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.60':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/nested-clients': 3.997.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/eventstream-handler-node@3.972.25':
+    dependencies:
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-eventstream@3.972.21':
+    dependencies:
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-websocket@3.972.36':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/fetch-http-handler': 5.6.3
+      '@smithy/signature-v4': 5.6.2
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.28':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/signature-v4-multi-region': 3.996.38
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/fetch-http-handler': 5.6.3
+      '@smithy/node-http-handler': 4.9.3
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.38':
+    dependencies:
+      '@aws-sdk/types': 3.973.15
+      '@smithy/signature-v4': 5.6.2
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1048.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/nested-clients': 3.997.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1080.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/nested-clients': 3.997.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.15':
+    dependencies:
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.8':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.33':
+    dependencies:
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@babel/runtime@7.29.7': {}
 
@@ -2068,6 +2766,76 @@ snapshots:
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
+
+  '@earendil-works/pi-agent-core@0.79.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.79.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      ignore: 7.0.5
+      typebox: 1.1.38
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-ai@0.79.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.26.0(ws@8.21.0)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-coding-agent@0.79.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.79.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.79.10
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      glob: 13.0.6
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      semver: 7.8.0
+      typebox: 1.1.38
+      undici: 8.5.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-tui@0.79.10':
+    dependencies:
+      get-east-asian-width: 1.6.0
+      marked: 18.0.5
 
   '@eplightning/nats-server-darwin-arm64@2.14.0':
     optional: true
@@ -2243,6 +3011,19 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
+  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
+    dependencies:
+      google-auth-library: 10.9.0
+      p-retry: 4.6.2
+      protobufjs: 7.6.5
+      ws: 8.21.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@hono/node-server@1.19.14(hono@4.12.23)':
     dependencies:
       hono: 4.12.23
@@ -2296,6 +3077,62 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
+
+  '@mariozechner/clipboard-darwin-arm64@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-darwin-universal@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-darwin-x64@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-x64-musl@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard@0.3.9':
+    optionalDependencies:
+      '@mariozechner/clipboard-darwin-arm64': 0.3.9
+      '@mariozechner/clipboard-darwin-universal': 0.3.9
+      '@mariozechner/clipboard-darwin-x64': 0.3.9
+      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-arm64-musl': 0.3.9
+      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-x64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-x64-musl': 0.3.9
+      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.9
+      '@mariozechner/clipboard-win32-x64-msvc': 0.3.9
+    optional: true
+
+  '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/semantic-conventions': 1.42.0
+      ws: 8.21.0
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
@@ -2393,6 +3230,85 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
+  '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/semantic-conventions@1.42.0': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.2': {}
+
+  '@silvia-odwyer/photon-node@0.3.4': {}
+
+  '@smithy/core@3.29.1':
+    dependencies:
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.6':
+    dependencies:
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.3':
+    dependencies:
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.7.3':
+    dependencies:
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.9.3':
+    dependencies:
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.2':
+    dependencies:
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/types@4.15.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
   '@standard-schema/spec@1.1.0': {}
 
   '@types/json-schema@7.0.15': {}
@@ -2406,6 +3322,8 @@ snapshots:
   '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
+
+  '@types/retry@0.12.0': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -2431,6 +3349,8 @@ snapshots:
     dependencies:
       mime-types: 3.0.2
       negotiator: 1.0.0
+
+  agent-base@7.1.4: {}
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
@@ -2467,9 +3387,13 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
+
+  bignumber.js@9.3.1: {}
 
   body-parser@2.2.2:
     dependencies:
@@ -2485,6 +3409,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  bowser@2.14.1: {}
+
   brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
@@ -2492,6 +3418,8 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  buffer-equal-constant-time@1.0.1: {}
 
   bytes@3.1.2: {}
 
@@ -2551,6 +3479,8 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -2562,6 +3492,8 @@ snapshots:
   detect-libc@2.1.2:
     optional: true
 
+  diff@8.0.4: {}
+
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -2571,6 +3503,10 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
 
@@ -2718,6 +3654,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  extend@3.0.2: {}
+
   extendable-error@0.1.7: {}
 
   fast-check@4.8.0:
@@ -2750,6 +3688,11 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -2772,6 +3715,10 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
@@ -2792,6 +3739,22 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gaxios@7.1.6:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.6
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   get-east-asian-width@1.6.0: {}
 
@@ -2832,6 +3795,19 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  google-auth-library@10.9.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.6
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -2842,7 +3818,13 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  highlight.js@10.7.3: {}
+
   hono@4.12.23: {}
+
+  hosted-git-info@9.0.3:
+    dependencies:
+      lru-cache: 11.5.1
 
   http-errors@2.0.1:
     dependencies:
@@ -2852,6 +3834,20 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   human-id@4.2.0: {}
 
   iconv-lite@0.7.2:
@@ -2859,6 +3855,8 @@ snapshots:
       safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
 
   indent-string@5.0.0: {}
 
@@ -2928,6 +3926,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  jiti@2.7.0: {}
+
   jose@6.2.3: {}
 
   js-yaml@3.14.2:
@@ -2939,6 +3939,15 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
+
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
@@ -2949,6 +3958,17 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
   kubernetes-types@1.30.0: {}
 
   locate-path@5.0.0:
@@ -2957,7 +3977,11 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
+  long@5.3.2: {}
+
   lru-cache@11.5.1: {}
+
+  marked@18.0.5: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -3010,6 +4034,14 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
   node-gyp-build-optional-packages@5.2.2:
     dependencies:
       detect-libc: 2.1.2
@@ -3033,6 +4065,11 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
+  openai@6.26.0(ws@8.21.0)(zod@4.4.3):
+    optionalDependencies:
+      ws: 8.21.0
+      zod: 4.4.3
+
   outdent@0.5.0: {}
 
   p-filter@2.1.0:
@@ -3049,6 +4086,11 @@ snapshots:
 
   p-map@2.1.0: {}
 
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
   p-try@2.2.0: {}
 
   package-manager-detector@0.2.11:
@@ -3056,6 +4098,8 @@ snapshots:
       quansync: 0.2.11
 
   parseurl@1.3.3: {}
+
+  partial-json@0.1.7: {}
 
   patch-console@2.0.0: {}
 
@@ -3081,6 +4125,26 @@ snapshots:
   pkce-challenge@5.0.1: {}
 
   prettier@2.8.8: {}
+
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
+  protobufjs@7.6.5:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 22.20.0
+      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:
@@ -3129,6 +4193,10 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
+  retry@0.12.0: {}
+
+  retry@0.13.1: {}
+
   reusify@1.1.0: {}
 
   router@2.2.0:
@@ -3145,11 +4213,15 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.2.1: {}
+
   safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
 
   scheduler@0.27.0: {}
+
+  semver@7.8.0: {}
 
   semver@7.8.5: {}
 
@@ -3275,6 +4347,8 @@ snapshots:
 
   toml@4.1.1: {}
 
+  ts-algebra@2.0.0: {}
+
   ts-json-schema-generator@2.9.0:
     dependencies:
       '@types/json-schema': 7.0.15
@@ -3306,9 +4380,15 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
+  typebox@1.1.38: {}
+
+  typebox@1.3.4: {}
+
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  undici@8.5.0: {}
 
   universalify@0.1.2: {}
 
@@ -3317,6 +4397,8 @@ snapshots:
   uuid@14.0.0: {}
 
   vary@1.1.2: {}
+
+  web-streams-polyfill@3.3.3: {}
 
   which@2.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,5 +6,7 @@ packages:
   - "examples/*/*"
   - "bin"
 allowBuilds:
+  '@google/genai': false
   esbuild: true
   msgpackr-extract: false
+  protobufjs: false

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -53,6 +53,7 @@ const groups = [
       'docs/connect-claude.md',
       'docs/connect-opencode.md',
       'docs/connect-hermes.md',
+      'docs/agent-frameworks.md',
       'docs/build-a-client.md',
     ],
   },


### PR DESCRIPTION
Adds `@cotal-ai/pi`: the Cotal mesh as a **pi extension** — a thin client into the user's own [pi](https://github.com/earendil-works/pi) installation. No pi runtime is bundled; the user's pi version, settings, auth, and other extensions all apply.

One extension file covers three surfaces:

- **Interactive** — `pi --extension <file>` (plus `COTAL_*` env): the TUI session a human is sitting in becomes a mesh peer.
- **Spawned workers** — the `Connector` (agent type `pi`) launches the operator's installed `pi` binary with the extension loaded, like the Claude Code connector spawns `claude`. Under the manager's pty runtime the worker is the real pi TUI — `cotal attach` shows it.
- **Agents built on pi's SDK** — pi's default resource loader discovers `~/.pi/agent/extensions/`, so default SDK embedders join with no per-app work. (Forks and custom-loader apps, e.g. openclaw, need their own thin plugin — a follow-up.)

Without a mesh identity in the env the extension stays inert, so an installed copy never affects normal pi sessions.

Inbound DMs, role anycasts, and @mentions land as user turns in the live session (steered mid-turn while streaming), with ack-on-surface via the package's `InboxTurn` — a crash redelivers, nothing is lost. (`InboxTurn` lives in this package as its sole consumer; it gets promoted to connector-core if/when another native-embed adapter needs it.) The model gets the **full shared `cotal_*` toolset** (rendered from connector-core's `cotalToolSpecs`, the same source the Claude Code and OpenCode adapters render) and **owns its replies**: it answers by calling `cotal_dm` / `cotal_send` / `cotal_anycast`, can stay silent when no reply is warranted, and nothing leaves the peer that it didn't deliberately send. `cotal_inbox` is read-only (peek) since the loop drives delivery and acking. Persona body and `model:` from the agent file ride pi's own CLI flags (`--append-system-prompt` with a frontmatter-stripped file, `--model`) — contributed by @TheReaperJay, whose commit is included with authorship.

## Contents
- `extensions/pi/*` — the extension + tool renderer + connector, plus `InboxTurn` (the ack-on-surface turn helper) and its `smoke:inbox`
- `extensions/connector-core` — additive only: `MeshAgent.ackInbox` (ack-by-id) and small shared-surface fixes (sender framing, own-echo wake exclusion, `#chan` normalization, provider keys)
- `bin/cotal.ts` — one import line: the binary registers the `pi` connector like every sibling, so `cotal spawn --agent pi` works out of the box (no dedicated example needed — none of the other connectors has one)
- docs (`agent-frameworks.md`, READMEs)

## Scope
pi only. `packages/core` untouched — no new message kinds, subjects, or endpoint methods. `buildLaunch` follows the sibling `launchEnv`/`aclEnv` contract. One accepted residual, documented in code: pi's extension API can't drain the steering queue at turn end, so a message steered after the loop's final poll can carry into the next turn; SDK embedders needing it fully closed can wire `session.clearQueue()` + `InboxTurn.commitExcept` directly (documented pattern).

## Vetting
- `pnpm typecheck`, `pnpm build`, `pnpm smoke:ci` green; `smoke:inbox` covers the InboxTurn invariants.
- Live e2e against stock `pi` with the extension loaded (real model turns): peer joins; a DM is answered via a `cotal_dm` tool call and a channel @mention via `cotal_send` back on that channel; ambient chatter is ack-dropped in silence; `cotal_roster` / read-only `cotal_inbox` work from a prompt; killing the pi process mid-turn and restarting redelivers the un-acked message and it gets answered — no message loss; without `COTAL_*` env a normal pi session is completely unaffected.
