### PR TITLE
fix(attach): reset cursor-key mode (DECCKM) on detach

### DIFF
--- a/implementations/manager/src/attach-client.ts
+++ b/implementations/manager/src/attach-client.ts
@@ -8,13 +8,15 @@ const DETACH = 0x1d;
  * locally on detach/exit: the agent keeps running after Ctrl-], so it never restores OUR terminal.
  * Without this, detaching from a mouse-tracking TUI leaves the terminal reporting every cursor move
  * as input (a stream of `ESC[<…M` escape codes), or its focus in/out as `ESC[I`/`ESC[O`. Disables
- * all mouse-report modes + focus reporting + bracketed paste, shows the cursor, and resets
- * attributes. Deliberately does NOT toggle the alternate screen.
+ * all mouse-report modes + focus reporting + bracketed paste, resets the keypad/cursor-key modes,
+ * shows the cursor, and resets attributes. Deliberately does NOT toggle the alternate screen.
  */
 const RESTORE =
   "\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1005l\x1b[?1006l\x1b[?1015l" + // mouse tracking off
   "\x1b[?1004l" + // focus reporting off
   "\x1b[?2004l" + // bracketed paste off
+  "\x1b[?1l" + // application cursor keys off (DECCKM): a full-screen TUI enables it; left on, arrows emit ESC O A not ESC [ A
+  "\x1b>" + // keypad → numeric (DECKPNM)
   "\x1b[?25h" + // show cursor
   "\x1b[0m"; // reset attributes
 


### PR DESCRIPTION
`RESTORE` reset mouse/focus/paste/cursor/attrs but not DECCKM. A full-screen child TUI enables application cursor keys (`ESC[?1h`); that escape reaches the real terminal via the PTY, and on `Ctrl-]` detach the client never sent `ESC[?1l`, so the shell was left emitting SS3 arrows (`ESC O A`) instead of `ESC [ A`. `setRawMode(false)` doesn't help — DECCKM is in-band, not termios.

Append `ESC[?1l` + `ESC>` (keypad numeric) to `RESTORE`. One file, +4/−2. Same class as the earlier focus-reporting reset.

Closes #129