### PR TITLE
fix(cli): write defaults.deliveryClass at space creation (SPEC §4)

### DIFF
--- a/implementations/cli/src/commands/up.ts
+++ b/implementations/cli/src/commands/up.ts
@@ -21,6 +21,7 @@ import {
   newIdentity,
   setupSpaceStreams,
   seedChannelRegistry,
+  ensureDefaultDeliveryClass,
   type SpaceAuth,
   type ChannelRegistryFile,
 } from "@cotal-ai/core";
@@ -444,6 +445,16 @@ async function postStart(
   if (seedFile) {
     await seedChannelRegistry({ servers: server, space, creds: setup?.creds, file: seedFile });
   }
+  // SPEC §4: `defaults.deliveryClass` MUST be written at space creation so the effective default is
+  // discoverable on the wire, never inferred from the `?? "durable"` resolution fallback. Auth mode
+  // (`setup` present ⇒ the delivery daemon is up) is local/self-hosted ⇒ `durable`; open mode has no
+  // daemon and is live-only ⇒ `live`. Runs after the seed so an explicit `channels.json` default wins.
+  await ensureDefaultDeliveryClass({
+    servers: server,
+    space,
+    creds: setup?.creds,
+    deliveryClass: setup ? "durable" : "live",
+  });
 }
 
 /** Load the declarative channels-config file to seed the registry. An explicit `--channels`

--- a/packages/core/smoke/channels.smoke.ts
+++ b/packages/core/smoke/channels.smoke.ts
@@ -17,7 +17,8 @@ import { join } from "node:path";
 import { connect } from "@nats-io/transport-node";
 import { jetstream } from "@nats-io/jetstream";
 import {
-  CotalEndpoint, seedChannelRegistry, readChannelRegistry, effectiveReplay, validateChannelConfig,
+  CotalEndpoint, seedChannelRegistry, readChannelRegistry, effectiveReplay, effectiveDeliveryClass,
+  ensureDefaultDeliveryClass, validateChannelConfig,
   isReachable, chatSubject, type CotalMessage, type Delivery, type MessageMeta,
 } from "../src/index.js";
 
@@ -75,6 +76,15 @@ try {
   check("merge-on-write keeps other fields", reg2.channels?.review.description === "Critique v2" && reg2.channels?.review.instructions === "Be specific.");
   assert.throws(() => validateChannelConfig({ description: "x".repeat(1000) }), /too long/);
   check("validation rejects oversize", true);
+
+  // ---- default delivery class written at space creation (SPEC §4: on the wire, not inferred) ----
+  const dcSpace = `${space}-dc`;
+  check("writes default deliveryClass when unset", (await ensureDefaultDeliveryClass({ servers, space: dcSpace, deliveryClass: "durable" })) === true);
+  const dcReg = await readChannelRegistry({ servers, space: dcSpace });
+  check("default deliveryClass is discoverable on the wire", dcReg.defaults?.deliveryClass === "durable" && effectiveDeliveryClass(undefined, dcReg.defaults) === "durable");
+  check("idempotent re-write is a no-op", (await ensureDefaultDeliveryClass({ servers, space: dcSpace, deliveryClass: "durable" })) === false);
+  check("clobber-safe: an existing class wins over the profile default", (await ensureDefaultDeliveryClass({ servers, space: dcSpace, deliveryClass: "live" })) === false
+    && (await readChannelRegistry({ servers, space: dcSpace })).defaults?.deliveryClass === "durable");
 
   // ---- replay on join ----
   const A = new CotalEndpoint({ space, servers, card: { name: "A", kind: "agent", id: "A_pub" }, channels: ["log", "chat", "general", "incident"] });

--- a/packages/core/src/channels.ts
+++ b/packages/core/src/channels.ts
@@ -178,6 +178,34 @@ export async function seedChannelRegistry(opts: {
   }
 }
 
+/** Write the space-wide default delivery class at space creation IF it is not already set (SPEC §4:
+ *  `defaults.deliveryClass` MUST be on the wire so the effective default is discoverable, never
+ *  inferred from the `?? "durable"` resolution fallback). Clobber-safe and idempotent: an explicit
+ *  value already in the registry (e.g. seeded from a `channels.json` default) wins, so a re-up never
+ *  overrides an operator's choice. Returns true if it wrote. Called by `cotal up` with the profile
+ *  class — local/self-hosted (auth, daemon present) ⇒ `durable`, open/dev (no daemon) ⇒ `live`. */
+export async function ensureDefaultDeliveryClass(opts: {
+  servers: string;
+  space: string;
+  creds?: string;
+  deliveryClass: DeliveryClass;
+}): Promise<boolean> {
+  const nc = await connect({
+    servers: opts.servers,
+    ...(opts.creds
+      ? { authenticator: credsAuthenticator(new TextEncoder().encode(opts.creds)) }
+      : {}),
+  });
+  try {
+    const kv = await openChannelRegistry(nc, opts.space, { create: true });
+    if ((await readChannelDefaults(kv))?.deliveryClass !== undefined) return false;
+    await writeChannelDefaults(kv, { deliveryClass: opts.deliveryClass });
+    return true;
+  } finally {
+    await nc.drain();
+  }
+}
+
 /** Connect (privileged/open), delete the given channel-registry keys, disconnect. Used by
  *  `cotal down -f` to remove ONLY the cards a `spawn -f` run created (ownership-scoped); the caller is
  *  responsible for the members-present safety check. The bucket must already exist (no create on a


### PR DESCRIPTION
## What

`cotal up` never wrote the space-wide default delivery class, so the effective default was only ever inferred from the `?? "durable"` resolution constant in `effectiveDeliveryClass` — not discoverable on the wire. SPEC §4 requires the opposite:

> `defaults.deliveryClass` MUST be written at space creation from the deployment profile … so the effective default is always discoverable on the wire, never inferred from out-of-band context.

## Change

- **`channels.ts`** — new `ensureDefaultDeliveryClass()`: write-if-absent, idempotent, clobber-safe (an explicit `channels.json` default or a prior choice wins, so a re-up never overrides an operator's decision).
- **`up.ts` `postStart()`** — writes the default at creation for **both** `up` and `up -f`. Profile derived honestly from daemon presence: **auth (delivery daemon up) ⇒ `durable`; open (live-only, no daemon) ⇒ `live`** — so we never advertise `durable` where it can't be delivered.
- The reader fallback in `effectiveDeliveryClass` is **kept** — it is part of the spec's normative resolution formula (`channel ?? defaults ?? "durable"`, SPEC.md:288).

## Tests

- `pnpm typecheck` — clean.
- `pnpm smoke:channels` — 27/27 (4 new: writes-when-unset, discoverable-on-wire, idempotent, clobber-safe).

Note: only writes at **creation**, so pre-existing spaces stay inferred until re-created (harmless — covered by the reader fallback).