### PR TITLE
feat(windows): authenticated control plane + cooperative graceful stop (Stage 2)

### DIFF
--- a/extensions/connector-claude-code/src/extension.ts
+++ b/extensions/connector-claude-code/src/extension.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { loadAgentFile, registry, type Connector, type LaunchOpts, type LaunchSpec } from "@cotal-ai/core";
-import { aclEnv, launchEnv, mcpServerEnvKeys } from "@cotal-ai/connector-core";
+import { aclEnv, controlEndpoint, launchEnv, mcpServerEnvKeys } from "@cotal-ai/connector-core";
 
 /** Name the cotal MCP server is registered under via --mcp-config (see buildLaunch). */
 const MCP_SERVER_NAME = "cotal";
@@ -40,6 +40,11 @@ export const claudeConnector: Connector = {
     // The OS allow-list (PATH/HOME/TERM/…) is the only thing inherited from the manager env, plus
     // — only when a shared server declares them via `${VAR}` — the named secrets it needs (mcpKeys,
     // by name). The operator's unrelated secrets don't reach the child (P3).
+    // The session's local control endpoint: the in-process MCP server LISTENS on it (auth), and the
+    // lifecycle hooks (child processes of `claude`, which inherit this env) CONNECT to it. Both read
+    // path+token from the env — never recomputed from public identity — and the manager keeps the
+    // pair (returned as `control` below) to drive a cooperative shutdown on Windows.
+    const control = controlEndpoint(opts.space, opts.name);
     const env: Record<string, string> = {
       ...launchEnv({ mcpKeys: mcpServerEnvKeys(shared) }),
       ...aclEnv(opts),
@@ -48,6 +53,8 @@ export const claudeConnector: Connector = {
       // Force the connector to emit channel wake-nudges: Claude doesn't advertise the
       // `claude/channel` capability back over MCP, so auto-detection would see it "off".
       COTAL_CHANNEL: "1",
+      COTAL_CONTROL_SOCKET: control.path,
+      COTAL_CONTROL_TOKEN: control.token, // env only — never argv/logs/persisted (token hygiene)
     };
     // A session can mirror its own transcript to `tr-<name>` so peers can read what the
     // agent actually did — OFF by default (transcripts are verbose and may carry sensitive
@@ -122,6 +129,7 @@ export const claudeConnector: Connector = {
       // The dev-channels flag shows a one-time "Enter to confirm" prompt; the
       // manager auto-clears it so a supervised launch needs no human keypress.
       confirm: "Enter to confirm",
+      control,
     };
   },
 };

--- a/extensions/connector-claude-code/src/mcp.ts
+++ b/extensions/connector-claude-code/src/mcp.ts
@@ -14,7 +14,6 @@ import {
   configFromEnv,
   hasIdentity,
   MeshAgent,
-  controlSocketPath,
   startControlServer,
   registerCotalTools,
   feedbackLine,
@@ -136,9 +135,39 @@ async function main(): Promise<void> {
   if (/^(1|true|yes|on)$/i.test(process.env.COTAL_TRANSCRIPT ?? ""))
     mirror = new TranscriptMirror(agent, transcriptChannel(config.name));
 
-  // Local control plane for the lifecycle hooks (presence + message injection).
-  const socketPath = controlSocketPath(config.space, config.name);
-  const controlServer = startControlServer(agent, socketPath, claudeHandle);
+  // Local control plane for the lifecycle hooks (presence + message injection) and the manager's
+  // cooperative shutdown. Path + token come from the launch env (buildLaunch set them, and the hooks
+  // inherit this process's env) — a managed session without them is misconfigured, so fail loud
+  // rather than serve an unauthenticated/no control plane.
+  const controlPath = process.env.COTAL_CONTROL_SOCKET;
+  const controlToken = process.env.COTAL_CONTROL_TOKEN;
+  if (!controlPath || !controlToken) {
+    process.stderr.write(
+      "[cotal-connector] managed session missing COTAL_CONTROL_SOCKET/COTAL_CONTROL_TOKEN — cannot serve the control plane\n",
+    );
+    process.exit(1);
+  }
+  // Defined before the server so it can be the cooperative-shutdown handler; only ever CALLED after
+  // `controlServer` is assigned (on a signal or an authed `{op:"shutdown"}`), so the forward ref is safe.
+  let controlServer: ReturnType<typeof startControlServer> | undefined;
+  const shutdown = async () => {
+    try {
+      controlServer?.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      await agent.stop();
+    } finally {
+      process.exit(0);
+    }
+  };
+  controlServer = startControlServer(
+    agent,
+    { path: controlPath, token: controlToken },
+    claudeHandle,
+    { fatalBind: true, onShutdown: () => void shutdown() },
+  );
 
   const server = new McpServer(
     { name: "cotal", version: "0.0.0" },
@@ -216,18 +245,6 @@ async function main(): Promise<void> {
   );
   agent.on("wake", () => nudge());
 
-  const shutdown = async () => {
-    try {
-      controlServer.close();
-    } catch {
-      /* ignore */
-    }
-    try {
-      await agent.stop();
-    } finally {
-      process.exit(0);
-    }
-  };
   process.on("SIGINT", () => void shutdown());
   process.on("SIGTERM", () => void shutdown());
 

--- a/extensions/connector-core/src/control.ts
+++ b/extensions/connector-core/src/control.ts
@@ -10,6 +10,7 @@
  */
 import { createServer, type Server } from "node:net";
 import { existsSync, unlinkSync } from "node:fs";
+import { createHash, timingSafeEqual } from "node:crypto";
 import type { MeshAgent, InboxItem } from "./agent.js";
 
 /** One lifecycle event, as the agent runtime delivers it on stdin. */
@@ -20,6 +21,35 @@ export interface HookEvent {
 
 /** Maps one hook event to the JSON reply the runtime applies. */
 export type HookHandle = (agent: MeshAgent, ev: HookEvent) => Promise<Record<string, unknown>>;
+
+/** The authenticated control-plane wire frame (one newline-delimited JSON object per connection):
+ *  a hook event the runtime delivered, or the manager's cooperative shutdown — both carry the
+ *  endpoint `token` as their first field, validated before anything else runs. Shutdown is an
+ *  explicit op, NOT a disguised hook event. */
+type ControlFrame =
+  | { token?: unknown; event?: unknown; op?: undefined }
+  | { token?: unknown; op?: "shutdown" };
+
+export interface ControlServerOpts {
+  /** Fail loud on a bind we can't hold. A managed listener (the in-agent MCP server, the Hermes
+   *  sidecar) MUST own its endpoint: if `listen` errors (e.g. a squatter already holds the win32
+   *  pipe → `EADDRINUSE`; libuv binds with `FILE_FLAG_FIRST_PIPE_INSTANCE`), the process exits
+   *  rather than running on with a hijacked or no-op control plane. Default off (an ad-hoc/test
+   *  server logs and stays up). */
+  fatalBind?: boolean;
+  /** Cooperative shutdown: invoked on an AUTHENTICATED `{op:"shutdown"}` frame. The connector runs
+   *  its own clean teardown (close the server, `agent.stop()` to leave the mesh, then exit) — the
+   *  server never owns `process.exit`. Absent → shutdown frames are accepted + acked but inert. */
+  onShutdown?: () => void;
+}
+
+/** Constant-time match of a presented token against the endpoint's. Both sides are SHA-256'd first
+ *  so the compare is fixed-length (and length-independent) regardless of the presented value — a
+ *  non-string or wrong-length token can never throw `timingSafeEqual` or leak length via timing. */
+function tokenMatches(presented: unknown, digest: Buffer): boolean {
+  if (typeof presented !== "string") return false;
+  return timingSafeEqual(createHash("sha256").update(presented).digest(), digest);
+}
 
 function who(i: InboxItem): string {
   return i.fromRole ? `${i.fromName}/${i.fromRole}` : i.fromName;
@@ -40,15 +70,26 @@ export function formatInjection(items: InboxItem[]): string | undefined {
   return `${head}\n${items.map(fmtItem).join("\n")}\n${tail}`;
 }
 
-/** Start the control socket. One newline-delimited JSON request → one reply per connection. */
+/** Start the authenticated control server. One newline-delimited JSON {@link ControlFrame} → one
+ *  reply per connection. The first thing every connection does is validate its `token` against the
+ *  endpoint's (constant-time) — a mismatch is dropped before `handle` (or `onShutdown`) ever runs,
+ *  so an unauthenticated local process that finds/guesses the path still can't drive presence,
+ *  inject peer messages, or shut the agent down. */
 export function startControlServer(
   agent: MeshAgent,
-  socketPath: string,
+  endpoint: { path: string; token: string },
   handle: HookHandle,
+  opts: ControlServerOpts = {},
 ): Server {
-  if (existsSync(socketPath)) {
+  const { path } = endpoint;
+  const digest = createHash("sha256").update(endpoint.token).digest();
+  // Stale-socket cleanup is POSIX-only: a win32 named pipe is not a filesystem entry to unlink, and
+  // a live one there is a SQUATTER the fatal `EADDRINUSE` is meant to catch — never clear it. (With
+  // a token-random path a stale POSIX socket from a dead predecessor is itself near-impossible, but
+  // the unlink stays as cheap insurance against an exact-path leftover.)
+  if (process.platform !== "win32" && existsSync(path)) {
     try {
-      unlinkSync(socketPath); // clear a stale socket from a dead predecessor
+      unlinkSync(path);
     } catch {
       /* ignore */
     }
@@ -60,12 +101,26 @@ export function startControlServer(
       buf += d;
       const nl = buf.indexOf("\n");
       if (nl < 0) return; // wait for the full line
-      let ev: HookEvent = {};
+      let frame: ControlFrame = {};
       try {
-        ev = JSON.parse(buf.slice(0, nl) || "{}") as HookEvent;
+        frame = JSON.parse(buf.slice(0, nl) || "{}") as ControlFrame;
       } catch {
-        /* malformed — treat as empty */
+        /* malformed — fails the auth check below and is dropped */
       }
+      if (!tokenMatches(frame.token, digest)) {
+        sock.end(); // unauthenticated — drop before handle/onShutdown
+        return;
+      }
+      if ((frame as { op?: unknown }).op === "shutdown") {
+        try {
+          sock.end(JSON.stringify({ ok: true }) + "\n");
+        } catch {
+          /* client gone */
+        }
+        opts.onShutdown?.();
+        return;
+      }
+      const ev = ((frame as { event?: unknown }).event ?? {}) as HookEvent;
       const reply = await handle(agent, ev);
       try {
         sock.end(JSON.stringify(reply) + "\n");
@@ -77,11 +132,17 @@ export function startControlServer(
       /* ignore client errors */
     });
   });
-  server.on("error", (e) =>
-    process.stderr.write(`[cotal-connector] control server error: ${(e as Error).message}\n`),
-  );
-  server.listen(socketPath, () =>
-    process.stderr.write(`[cotal-connector] control socket: ${socketPath}\n`),
-  );
+  let bound = false;
+  server.on("error", (e) => {
+    process.stderr.write(`[cotal-connector] control server error: ${(e as Error).message}\n`);
+    // A bind we never held (listen errored before "listening", e.g. EADDRINUSE from a squatter) is
+    // fatal for a managed listener — better to die than serve a hijacked/no-op control plane. A
+    // post-bind error is just logged.
+    if (opts.fatalBind && !bound) process.exit(1);
+  });
+  server.listen(path, () => {
+    bound = true;
+    process.stderr.write(`[cotal-connector] control socket: ${path}\n`); // path is leakage-safe; the token never logs
+  });
   return server;
 }

--- a/extensions/connector-core/src/control.ts
+++ b/extensions/connector-core/src/control.ts
@@ -43,6 +43,14 @@ export interface ControlServerOpts {
   onShutdown?: () => void;
 }
 
+/** Hard cap on the first (only) frame: a control request is a token + one small lifecycle event —
+ *  kilobytes at most. Generous headroom for a legit event, tiny next to the ~512MB string limit an
+ *  unauthenticated spewer would otherwise drive `buf` toward to crash the process. */
+const MAX_FRAME_BYTES = 1 << 20; // 1 MiB
+/** Idle window for a connection that hasn't sent its newline-terminated frame yet — reaps a silent
+ *  client camping on a finite pipe instance. Cleared once the full frame is in hand. */
+const CONN_IDLE_MS = 5_000;
+
 /** Constant-time match of a presented token against the endpoint's. Both sides are SHA-256'd first
  *  so the compare is fixed-length (and length-independent) regardless of the presented value — a
  *  non-string or wrong-length token can never throw `timingSafeEqual` or leak length via timing. */
@@ -96,11 +104,25 @@ export function startControlServer(
   }
   const server = createServer((sock) => {
     let buf = "";
+    let handled = false; // one frame per connection — ignore anything after the first line
     sock.setEncoding("utf8");
+    // Bound an UNAUTHENTICATED peer: on Windows the named pipe's default DACL lets any local process
+    // connect, so a client that streams bytes with no newline (would grow `buf` until it throws
+    // `Invalid string length` → crashes this long-lived process) or that connects and sends nothing
+    // (camps on a finite pipe instance) must be cut off BEFORE auth. The idle timeout reaps a silent
+    // client; MAX_FRAME_BYTES caps a spewing one. A legit client sends one small line immediately.
+    sock.setTimeout(CONN_IDLE_MS, () => sock.destroy());
     sock.on("data", async (d) => {
+      if (handled) return;
       buf += d;
+      if (buf.length > MAX_FRAME_BYTES) {
+        sock.destroy(); // oversized pre-newline — drop hard, never half-close (it keeps spewing)
+        return;
+      }
       const nl = buf.indexOf("\n");
       if (nl < 0) return; // wait for the full line
+      handled = true;
+      sock.setTimeout(0); // full frame in hand — don't let the idle timeout reap a slow handler
       let frame: ControlFrame = {};
       try {
         frame = JSON.parse(buf.slice(0, nl) || "{}") as ControlFrame;
@@ -108,7 +130,7 @@ export function startControlServer(
         /* malformed — fails the auth check below and is dropped */
       }
       if (!tokenMatches(frame.token, digest)) {
-        sock.end(); // unauthenticated — drop before handle/onShutdown
+        sock.destroy(); // unauthenticated — drop hard before handle/onShutdown (no half-open)
         return;
       }
       if ((frame as { op?: unknown }).op === "shutdown") {

--- a/extensions/connector-core/src/control.ts
+++ b/extensions/connector-core/src/control.ts
@@ -47,9 +47,11 @@ export interface ControlServerOpts {
  *  kilobytes at most. Generous headroom for a legit event, tiny next to the ~512MB string limit an
  *  unauthenticated spewer would otherwise drive `buf` toward to crash the process. */
 const MAX_FRAME_BYTES = 1 << 20; // 1 MiB
-/** Idle window for a connection that hasn't sent its newline-terminated frame yet — reaps a silent
- *  client camping on a finite pipe instance. Cleared once the full frame is in hand. */
-const CONN_IDLE_MS = 5_000;
+/** ABSOLUTE deadline (not an idle timeout — a slow-loris dribbling one byte at a time would keep
+ *  resetting an idle timer) for a connection to deliver its complete auth frame. Past it, an
+ *  unauthenticated connection is dropped so a local process can't camp on a finite pipe instance.
+ *  Cleared the instant a full frame is in hand (the token-bearing client then owns the connection). */
+const AUTH_DEADLINE_MS = 5_000;
 
 /** Constant-time match of a presented token against the endpoint's. Both sides are SHA-256'd first
  *  so the compare is fixed-length (and length-independent) regardless of the presented value — a
@@ -107,11 +109,14 @@ export function startControlServer(
     let handled = false; // one frame per connection — ignore anything after the first line
     sock.setEncoding("utf8");
     // Bound an UNAUTHENTICATED peer: on Windows the named pipe's default DACL lets any local process
-    // connect, so a client that streams bytes with no newline (would grow `buf` until it throws
-    // `Invalid string length` → crashes this long-lived process) or that connects and sends nothing
-    // (camps on a finite pipe instance) must be cut off BEFORE auth. The idle timeout reaps a silent
-    // client; MAX_FRAME_BYTES caps a spewing one. A legit client sends one small line immediately.
-    sock.setTimeout(CONN_IDLE_MS, () => sock.destroy());
+    // connect, so a client that streams bytes with no newline (would grow `buf` toward the ~512MB
+    // string limit → crashes this long-lived process), that connects and sends nothing, OR that
+    // dribbles a byte at a time (a slow-loris) to camp on a finite pipe instance must be cut off
+    // BEFORE auth. MAX_FRAME_BYTES caps a spewing one; an ABSOLUTE deadline (reset-proof, unlike an
+    // idle timeout) reaps a silent/slow one. A legit client sends one small line immediately.
+    const deadline = setTimeout(() => sock.destroy(), AUTH_DEADLINE_MS);
+    deadline.unref?.(); // never hold the process open on an unauthenticated connection
+    sock.on("close", () => clearTimeout(deadline));
     sock.on("data", async (d) => {
       if (handled) return;
       buf += d;
@@ -122,7 +127,7 @@ export function startControlServer(
       const nl = buf.indexOf("\n");
       if (nl < 0) return; // wait for the full line
       handled = true;
-      sock.setTimeout(0); // full frame in hand — don't let the idle timeout reap a slow handler
+      clearTimeout(deadline); // full frame in hand — the token-bearing client now owns the connection
       let frame: ControlFrame = {};
       try {
         frame = JSON.parse(buf.slice(0, nl) || "{}") as ControlFrame;

--- a/extensions/connector-core/src/relay.ts
+++ b/extensions/connector-core/src/relay.ts
@@ -8,8 +8,7 @@
  * entry points are one-liners over {@link runHookRelay}.
  */
 import { connect } from "node:net";
-import { configFromEnv, hasIdentity } from "./config.js";
-import { controlSocketPath } from "./runtime.js";
+import { hasIdentity } from "./config.js";
 
 const TIMEOUT_MS = 2000;
 
@@ -36,9 +35,20 @@ function done(out: string): void {
 /** Relay one hook event from stdin to the connector's control socket and print the reply. */
 export async function runHookRelay(): Promise<void> {
   if (!hasIdentity()) return done(""); // plain session, not a managed one — no-op
+  // Path + token come from the launch env (shared with the in-agent server, which we inherited from);
+  // never recomputed from public identity. Absent → not an authenticated control session: no-op (fail
+  // open, so a hook never blocks the user's session).
+  const path = process.env.COTAL_CONTROL_SOCKET;
+  const token = process.env.COTAL_CONTROL_TOKEN;
+  if (!path || !token) return done("");
   const raw = (await readStdin()).trim() || "{}";
-  const cfg = configFromEnv();
-  const sock = connect(controlSocketPath(cfg.space, cfg.name));
+  let event: unknown = {};
+  try {
+    event = JSON.parse(raw); // the hook event the runtime piped in
+  } catch {
+    /* malformed — relay an empty event under a valid token */
+  }
+  const sock = connect(path);
 
   let reply = "";
   let settled = false;
@@ -55,7 +65,7 @@ export async function runHookRelay(): Promise<void> {
   const timer = setTimeout(() => finish(""), TIMEOUT_MS);
 
   sock.setEncoding("utf8");
-  sock.on("connect", () => sock.write(raw + "\n"));
+  sock.on("connect", () => sock.write(JSON.stringify({ token, event }) + "\n"));
   sock.on("data", (d) => {
     reply += d;
     const nl = reply.indexOf("\n");

--- a/extensions/connector-core/src/runtime.ts
+++ b/extensions/connector-core/src/runtime.ts
@@ -1,24 +1,36 @@
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-
-const ILLEGAL = /[^A-Za-z0-9_-]/g;
-
-function tok(s: string): string {
-  const t = s.trim().replace(ILLEGAL, "_");
-  return t.length ? t.slice(0, 40) : "_";
-}
+import { createHash, randomBytes } from "node:crypto";
 
 /**
- * Deterministic path to a connector's local control socket. Both the long-lived
- * MCP server (which listens) and its short-lived hooks (which connect) compute
- * this from the SAME identity, so they always agree without a discovery step.
+ * A connector's local control endpoint: the OS path its lifecycle hooks (and the manager's
+ * cooperative-shutdown call) connect to, plus the shared secret that authenticates the first frame.
  *
- * NOTE: the Windows control plane (a `\\.\pipe\` named pipe — Node has no filesystem
- * AF_UNIX socket there) is deferred to the control-plane stage, where it lands WITH
- * the authenticated endpoint (random token, hashed id, first-frame auth, fatal bind).
- * A deterministic identity-only pipe name is a guessable, squattable, unauthenticated
- * endpoint, so it must not ship ahead of that auth. This stays POSIX-shaped for now.
+ * The path id is `sha256(space\0name\0pid\0token)` (base64url, ≤32) — unguessable and
+ * collision-free without leaking identity; the 256-bit `token` is the actual auth boundary (the
+ * server validates it with a constant-time compare before doing anything — see `control.ts`).
+ *
+ * Transport is per-platform but the same `node:net` path string drives both: win32 has no
+ * filesystem AF_UNIX socket Node can bind, so the path is a named pipe (`\\.\pipe\…`) whose default
+ * DACL lets ANY local process connect — which is exactly why the token, not the path, is the
+ * security boundary there. POSIX uses a per-user `tmpdir` socket.
+ *
+ * Minted ONCE at launch (in the manager's process, via the connector's `buildLaunch`). Both ends —
+ * the in-agent server that LISTENS and the short-lived hooks that CONNECT — then read `path`+`token`
+ * from the child env (`COTAL_CONTROL_SOCKET`/`COTAL_CONTROL_TOKEN`), never recompute them from
+ * public identity; the manager keeps them in memory for the cooperative shutdown. (`process.pid` is
+ * just generation-time entropy — the value flows by env, so it never has to match across processes.)
  */
-export function controlSocketPath(space: string, name: string): string {
-  return join(tmpdir(), `cotal-${tok(space)}-${tok(name)}.sock`);
+export function controlEndpoint(
+  space: string,
+  name: string,
+  token: string = randomBytes(32).toString("base64url"),
+): { path: string; token: string } {
+  const id = createHash("sha256")
+    .update(`${space}\0${name}\0${process.pid}\0${token}`)
+    .digest("base64url")
+    .slice(0, 32);
+  const path =
+    process.platform === "win32" ? `\\\\.\\pipe\\cotal-${id}` : join(tmpdir(), `cotal-${id}.sock`);
+  return { path, token };
 }

--- a/extensions/connector-hermes/plugin/cotal/__init__.py
+++ b/extensions/connector-hermes/plugin/cotal/__init__.py
@@ -16,6 +16,7 @@ in the environment. Two run modes:
 from __future__ import annotations
 
 import os
+import secrets
 import shutil
 import subprocess
 import tempfile
@@ -99,6 +100,10 @@ def _bootstrap_standalone_sidecar() -> None:
     space = os.environ.get("COTAL_SPACE") or "(from COTAL_LINK)"
     os.environ.setdefault("COTAL_BRIDGE_SOCKET", str(run_dir / "bridge.sock"))
     os.environ.setdefault("COTAL_CONTROL_SOCKET", str(run_dir / "control.sock"))
+    # The sidecar (listener) and the lifecycle hooks (this process) authenticate the control plane
+    # with a shared first-frame token. Managed mode gets it from the launcher; standalone mints one
+    # here so both sides — they share this env — agree on it.
+    os.environ.setdefault("COTAL_CONTROL_TOKEN", secrets.token_urlsafe(32))
     os.environ.setdefault("COTAL_TOOLS_FILE", str(run_dir / "cotal-tools.json"))
 
     sidecar = _resolve_sidecar_js()

--- a/extensions/connector-hermes/plugin/cotal/hooks.py
+++ b/extensions/connector-hermes/plugin/cotal/hooks.py
@@ -1,9 +1,11 @@
 """Hermes lifecycle hooks → Cotal presence (the relay.ts pattern, in Python).
 
 Each hook makes a one-shot connection to connector-core's control socket
-(``COTAL_CONTROL_SOCKET``), sends ``{"hook_event_name": ...}``, and ignores the reply — the TS
-``hermesHookHandle`` turns it into a presence change. Hooks must never block the gateway, so the
-connection has a short timeout and every error is swallowed.
+(``COTAL_CONTROL_SOCKET``), sends ``{"token": ..., "event": {"hook_event_name": ...}}``, and
+ignores the reply — the TS ``hermesHookHandle`` turns it into a presence change. The control server
+validates ``token`` (constant-time) before doing anything, so a frame without it is dropped. Both
+the path and token come from the launch env (shared with the sidecar). Hooks must never block the
+gateway, so the connection has a short timeout and every error is swallowed.
 
 Hermes hook callback signatures vary by version; these take ``*args, **kwargs`` and best-effort
 extract what they need, so a signature change degrades to "no detail" rather than an exception.
@@ -21,9 +23,10 @@ _TIMEOUT_S = 2.0
 def relay(event_name: str, **fields: Any) -> None:
     """Forward one lifecycle event to the connector's control socket; fire-and-forget."""
     path = os.environ.get("COTAL_CONTROL_SOCKET")
-    if not path:
+    token = os.environ.get("COTAL_CONTROL_TOKEN")
+    if not path or not token:
         return
-    payload = {"hook_event_name": event_name, **fields}
+    payload = {"token": token, "event": {"hook_event_name": event_name, **fields}}
     try:
         s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         s.settimeout(_TIMEOUT_S)

--- a/extensions/connector-hermes/src/launch.ts
+++ b/extensions/connector-hermes/src/launch.ts
@@ -19,7 +19,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { loadAgentFile } from "@cotal-ai/core";
-import { hasIdentity, configFromEnv, controlSocketPath, ORIENTATION_BOOTSTRAP } from "@cotal-ai/connector-core";
+import { hasIdentity, configFromEnv, controlEndpoint, ORIENTATION_BOOTSTRAP } from "@cotal-ai/connector-core";
 import { startSidecar } from "./sidecar.js";
 
 /** Hermes API line this connector is written + pinned against (see pyproject.toml). A different
@@ -111,10 +111,11 @@ async function main(): Promise<void> {
 
   // Paths shared by the sidecar and the gateway child — set in our env so startSidecar reads
   // them, and forwarded verbatim to the child so the plugin connects to the same sockets/file.
-  const controlSock = controlSocketPath(config.space, config.name);
+  const control = controlEndpoint(config.space, config.name);
   const bridgeSock = bridgeSocketPath(config.space, config.name);
   const toolsFile = join(home, "cotal-tools.json");
-  process.env.COTAL_CONTROL_SOCKET = controlSock;
+  process.env.COTAL_CONTROL_SOCKET = control.path;
+  process.env.COTAL_CONTROL_TOKEN = control.token; // first-frame auth, shared sidecar↔plugin via env
   process.env.COTAL_BRIDGE_SOCKET = bridgeSock;
   process.env.COTAL_TOOLS_FILE = toolsFile;
 
@@ -126,7 +127,8 @@ async function main(): Promise<void> {
   const childEnv: NodeJS.ProcessEnv = {
     ...process.env,
     HERMES_HOME: home,
-    COTAL_CONTROL_SOCKET: controlSock,
+    COTAL_CONTROL_SOCKET: control.path,
+    COTAL_CONTROL_TOKEN: control.token,
     COTAL_BRIDGE_SOCKET: bridgeSock,
     COTAL_TOOLS_FILE: toolsFile,
   };

--- a/extensions/connector-hermes/src/sidecar.ts
+++ b/extensions/connector-hermes/src/sidecar.ts
@@ -45,10 +45,17 @@ export function startSidecar(): Sidecar {
   agent.start(); // background connect with retry
 
   const controlSock = need("COTAL_CONTROL_SOCKET");
+  const controlToken = need("COTAL_CONTROL_TOKEN");
   const bridgeSock = need("COTAL_BRIDGE_SOCKET");
   const toolsFile = need("COTAL_TOOLS_FILE");
 
-  const controlServer = startControlServer(agent, controlSock, hermesHookHandle);
+  // Managed listener: own the endpoint (fatal bind) and authenticate every frame against the token.
+  const controlServer = startControlServer(
+    agent,
+    { path: controlSock, token: controlToken },
+    hermesHookHandle,
+    { fatalBind: true },
+  );
   const bridge = startBridgeServer(agent, config, bridgeSock);
 
   // The plugin reads this at register(ctx) time to declare the cotal_* tools (full shared parity).

--- a/implementations/manager/smoke/fatal-bind-probe.ts
+++ b/implementations/manager/smoke/fatal-bind-probe.ts
@@ -1,0 +1,11 @@
+/**
+ * Subprocess probe for the smoke's fatal-bind-on-squat check (section G, win32-only). Tries to start
+ * a managed control server (fatalBind) on a pipe a squatter already holds; the bind must fail
+ * EADDRINUSE and the process must exit(1). If it somehow binds (regression), we exit(0) after a beat
+ * so the parent test sees the wrong code and fails. Argv: <path> <token>.
+ */
+import { startControlServer, type MeshAgent } from "@cotal-ai/connector-core";
+
+const [path, token] = process.argv.slice(2);
+startControlServer({} as unknown as MeshAgent, { path, token }, async () => ({}), { fatalBind: true });
+setTimeout(() => process.exit(0), 3000);

--- a/implementations/manager/smoke/fatal-bind-probe.ts
+++ b/implementations/manager/smoke/fatal-bind-probe.ts
@@ -6,6 +6,9 @@
  */
 import { startControlServer, type MeshAgent } from "@cotal-ai/connector-core";
 
+// NB: the token rides argv here only because this is a throwaway TEST probe (a fresh per-run token
+// the parent squats around). Real launches pass the token via env ONLY, never argv — see the
+// connectors' buildLaunch. Don't copy this argv pattern into a production launch path.
 const [path, token] = process.argv.slice(2);
 startControlServer({} as unknown as MeshAgent, { path, token }, async () => ({}), { fatalBind: true });
 setTimeout(() => process.exit(0), 3000);

--- a/implementations/manager/smoke/windows-launch.smoke.ts
+++ b/implementations/manager/smoke/windows-launch.smoke.ts
@@ -491,6 +491,38 @@ if (isWin) {
   const r = await sendFrame(ep.path, { token: ep.token, event: { hook_event_name: "Ping" } });
   eq("DoS: server still serves a valid frame after the flood", r.trim(), JSON.stringify({ ok: true }));
   eq("DoS: the post-flood valid frame reached the handler", hits, 1);
+
+  // Slow-loris: dribble bytes (no newline) PAST the auth deadline. An ABSOLUTE deadline must drop it
+  // even though traffic keeps arriving — an idle timeout would reset on each byte and never fire.
+  const loris = await new Promise<string>((resolve) => {
+    const sock = connect(ep.path);
+    let done = false;
+    const finish = (s: string): void => {
+      if (done) return;
+      done = true;
+      try {
+        sock.destroy();
+      } catch {
+        /* ignore */
+      }
+      resolve(s);
+    };
+    sock.on("connect", () => {
+      let n = 0;
+      const t = setInterval(() => {
+        if (n++ > 9 || sock.destroyed) return clearInterval(t);
+        try {
+          sock.write("x"); // one byte, never a newline — past the 5s deadline (~8s of dribble)
+        } catch {
+          clearInterval(t);
+        }
+      }, 800);
+    });
+    sock.on("close", () => finish("closed"));
+    sock.on("error", () => finish("closed"));
+    setTimeout(() => finish("timeout"), 11000);
+  });
+  check("DoS: a slow-loris (dribbled bytes, no newline) is dropped at the absolute auth deadline", loris === "closed");
   server.close();
 }
 

--- a/implementations/manager/smoke/windows-launch.smoke.ts
+++ b/implementations/manager/smoke/windows-launch.smoke.ts
@@ -1,10 +1,13 @@
 /**
- * Stage-1 Windows launch smoke (no NATS, no test runner) — run with: pnpm smoke:windows
+ * Windows seam smoke (Stage 1 launch + Stage 2 control plane; no NATS, no test runner) — run with:
+ * pnpm smoke:windows
  *
- * Guards the resolver + `.cmd`/`.bat` launch adapter + child-env seams a POSIX-only build breaks on
- * Windows. Most of it runs EVERYWHERE — the pure resolver/quoting checks are the regression guard for
- * the local (macOS/Linux) validate loop. The end-to-end ConPTY round-trip is inherently win32 and is
- * logged-and-skipped off Windows; Windows CI is the oracle for those (this box can't run cmd.exe).
+ * Guards the resolver + `.cmd`/`.bat` launch adapter + child-env + authenticated control-plane seams
+ * a POSIX-only build breaks on Windows. Most of it runs EVERYWHERE — the pure resolver/quoting and
+ * the control-auth checks are the regression guard for the local (macOS/Linux) validate loop
+ * (`node:net` abstracts AF_UNIX ↔ named pipe, so the auth logic exercises identically). The pieces
+ * that are inherently win32 (the ConPTY argv round-trip, orphan reap, named-pipe squat) are
+ * logged-and-skipped off Windows; Windows CI is the oracle for those.
  *
  *   A. resolveOnPath resolves against the PASSED env (not global process.env), and on win32 prefers a
  *      real `.exe` over a `.cmd` shim. [WS1 / security: executable selection stays in P3 isolation]
@@ -16,13 +19,22 @@
  *      `Path`/`ComSpec`/`windir`) with no case-duplicate. [WS5(env)]
  *   E. a hard stop of a `.cmd`-wrapped agent reaps the WHOLE conpty→cmd.exe→node tree (no orphaned
  *      grandchild). [WS2 orphan-on-kill, win32-only]
+ *   F. the control endpoint authenticates the first frame: a wrong/absent token is dropped before the
+ *      handler or shutdown ever runs; the cooperative `{op:"shutdown"}` routes to onShutdown, not the
+ *      hook handler; controlShutdown (manager → server) round-trips. [WS3/WS4: the auth boundary]
+ *   G. a managed listener whose endpoint is squatted exits(1) — fatal bind, no degraded plane. [WS3,
+ *      win32-only: a named pipe is the only transport where a live squatter yields EADDRINUSE]
  */
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, delimiter } from "node:path";
+import { connect, createServer } from "node:net";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { resolveOnPath } from "@cotal-ai/workspace";
-import { launchEnv } from "@cotal-ai/connector-core";
+import { launchEnv, controlEndpoint, startControlServer, type MeshAgent } from "@cotal-ai/connector-core";
 import { quoteCmdArg, buildCmdCommandLine, resolveComspec, preparePtyLaunch } from "../src/runtime/windows-launch.js";
+import { controlShutdown } from "../src/control-shutdown.js";
 import { createRuntime } from "../src/index.js";
 
 const isWin = process.platform === "win32";
@@ -323,6 +335,117 @@ if (isWin) {
   rmSync(dir, { recursive: true, force: true, maxRetries: 10 });
 } else {
   console.log("· orphan-on-kill is win32-only (the cmd.exe grandchild layer) — skipped (CI is the oracle)");
+}
+
+// =================================================================================================
+// F. authenticated control plane — first-frame auth + shutdown routing. Runs EVERYWHERE (node:net
+//    abstracts the AF_UNIX socket / named pipe, so the auth + routing logic exercises identically).
+// =================================================================================================
+function sendFrame(path: string, frame: unknown): Promise<string> {
+  return new Promise((resolve) => {
+    const sock = connect(path);
+    let reply = "";
+    let settled = false;
+    const finish = (): void => {
+      if (settled) return;
+      settled = true;
+      try {
+        sock.destroy();
+      } catch {
+        /* ignore */
+      }
+      resolve(reply);
+    };
+    sock.setEncoding("utf8");
+    sock.on("connect", () => sock.write(JSON.stringify(frame) + "\n"));
+    sock.on("data", (d) => (reply += d));
+    sock.on("end", finish);
+    sock.on("close", finish);
+    sock.on("error", finish);
+    setTimeout(finish, 2000);
+  });
+}
+function waitListening(server: ReturnType<typeof startControlServer>): Promise<void> {
+  return new Promise((resolve) => {
+    server.on("listening", () => resolve());
+    setTimeout(resolve, 500); // backstop — listen is async (next tick), we attach before it fires
+  });
+}
+{
+  const stubAgent = {} as unknown as MeshAgent;
+  const ep = controlEndpoint("smoke", "ctl");
+
+  // F1: endpoint shape — a named pipe on win32 / a tmpdir .sock on POSIX, a 256-bit base64url token,
+  // and a token-derived (so unguessable) path.
+  check(
+    "controlEndpoint path is a named pipe on win32 / a tmpdir .sock on POSIX",
+    isWin ? ep.path.startsWith("\\\\.\\pipe\\cotal-") : ep.path.startsWith(join(tmpdir(), "cotal-")) && ep.path.endsWith(".sock"),
+  );
+  check("controlEndpoint token is a 43-char base64url string (32 random bytes)", /^[A-Za-z0-9_-]{43}$/.test(ep.token));
+  check("controlEndpoint path is token-derived (different token → different path)", controlEndpoint("smoke", "ctl").path !== ep.path);
+
+  const events: unknown[] = [];
+  let shutdowns = 0;
+  const handle = async (_a: MeshAgent, ev: unknown): Promise<Record<string, unknown>> => {
+    events.push(ev);
+    return { handled: true };
+  };
+  const server = startControlServer(stubAgent, ep, handle, { onShutdown: () => shutdowns++ });
+  await waitListening(server);
+
+  // F2: a WRONG token is dropped before the handler — no reply, the event never reaches it.
+  const before = events.length;
+  const r2 = await sendFrame(ep.path, { token: "not-the-token", event: { hook_event_name: "X" } });
+  await sleep(50);
+  eq("auth: wrong token → no reply (connection dropped)", r2, "");
+  eq("auth: wrong token → handler NOT invoked", events.length, before);
+
+  // F3: the RIGHT token + an event → handler runs and its reply comes back, with the event intact.
+  const r3 = await sendFrame(ep.path, { token: ep.token, event: { hook_event_name: "SessionStart", k: 1 } });
+  eq("auth: right token → handler reply returned", r3.trim(), JSON.stringify({ handled: true }));
+  eq("auth: right token → handler saw the event", events.at(-1), { hook_event_name: "SessionStart", k: 1 });
+
+  // F4: a valid {op:"shutdown"} routes to onShutdown, NOT the hook handler.
+  const evBefore = events.length;
+  const r4 = await sendFrame(ep.path, { token: ep.token, op: "shutdown" });
+  await sleep(50);
+  eq("shutdown: acked", r4.trim(), JSON.stringify({ ok: true }));
+  eq("shutdown: onShutdown fired", shutdowns, 1);
+  eq("shutdown: NOT routed through the hook handler", events.length, evBefore);
+
+  // F5: a {op:"shutdown"} with a WRONG token shuts nothing down.
+  await sendFrame(ep.path, { token: "nope", op: "shutdown" });
+  await sleep(50);
+  eq("shutdown: wrong token → onShutdown NOT fired", shutdowns, 1);
+
+  // F6: the manager's controlShutdown client round-trips to a server's onShutdown (the WS4 wire path).
+  const ep2 = controlEndpoint("smoke", "ws4");
+  let ws4 = false;
+  const server2 = startControlServer(stubAgent, ep2, handle, { onShutdown: () => (ws4 = true) });
+  await waitListening(server2);
+  controlShutdown(ep2);
+  for (let i = 0; i < 40 && !ws4; i++) await sleep(25);
+  check("WS4: controlShutdown(endpoint) reaches the server's onShutdown", ws4);
+
+  server.close();
+  server2.close();
+}
+
+// =================================================================================================
+// G. fatal bind on a squatted endpoint — win32-only. A named pipe is the only transport where a LIVE
+//    squatter yields EADDRINUSE (libuv binds with FILE_FLAG_FIRST_PIPE_INSTANCE; POSIX unlinks a
+//    stale socket first). A managed listener must then exit(1), never serve a hijacked/no-op plane.
+// =================================================================================================
+if (isWin) {
+  const ep = controlEndpoint("squat", "test");
+  const squatter = createServer(() => {});
+  await new Promise<void>((resolve) => squatter.listen(ep.path, () => resolve()));
+  const probe = fileURLToPath(new URL("./fatal-bind-probe.ts", import.meta.url));
+  const res = spawnSync(process.execPath, ["--import", "tsx", probe, ep.path, ep.token], { timeout: 15000 });
+  check(`fatal bind: a squatted managed listener exits(1) (got status ${res.status})`, res.status === 1);
+  squatter.close();
+} else {
+  console.log("· fatal-bind-on-squat needs a live named-pipe squatter (EADDRINUSE) — win32-only, skipped (CI is the oracle)");
 }
 
 console.log(failures ? `\n${failures} check(s) failed` : "\nall checks passed");

--- a/implementations/manager/smoke/windows-launch.smoke.ts
+++ b/implementations/manager/smoke/windows-launch.smoke.ts
@@ -448,5 +448,51 @@ if (isWin) {
   console.log("· fatal-bind-on-squat needs a live named-pipe squatter (EADDRINUSE) — win32-only, skipped (CI is the oracle)");
 }
 
+// =================================================================================================
+// H. pre-auth DoS hardening — on the win32 pipe ANY local process can connect, so an UNauthenticated
+//    client streaming bytes with no newline must NOT grow `buf` toward the ~512MB string limit and
+//    crash the long-lived server. The connection is dropped (oversized) and the server keeps serving.
+//    Runs everywhere (the bound is platform-agnostic).
+// =================================================================================================
+{
+  const stubAgent = {} as unknown as MeshAgent;
+  const ep = controlEndpoint("smoke", "dos");
+  let hits = 0;
+  const handle = async (): Promise<Record<string, unknown>> => {
+    hits++;
+    return { ok: true };
+  };
+  const server = startControlServer(stubAgent, ep, handle);
+  await waitListening(server);
+
+  // Stream >1 MiB with NO newline — must be dropped without ever reaching the handler or crashing.
+  const flood = await new Promise<string>((resolve) => {
+    const sock = connect(ep.path);
+    let done = false;
+    const finish = (r: string): void => {
+      if (done) return;
+      done = true;
+      try {
+        sock.destroy();
+      } catch {
+        /* ignore */
+      }
+      resolve(r);
+    };
+    sock.on("connect", () => sock.write("x".repeat((1 << 20) + 1024)));
+    sock.on("close", () => finish("closed"));
+    sock.on("error", () => finish("closed"));
+    setTimeout(() => finish("timeout"), 4000);
+  });
+  check("DoS: oversized newline-less frame is dropped (connection closed)", flood === "closed");
+  eq("DoS: oversized frame never reached the handler", hits, 0);
+
+  // The server SURVIVED the flood and still serves a valid frame on a fresh connection.
+  const r = await sendFrame(ep.path, { token: ep.token, event: { hook_event_name: "Ping" } });
+  eq("DoS: server still serves a valid frame after the flood", r.trim(), JSON.stringify({ ok: true }));
+  eq("DoS: the post-flood valid frame reached the handler", hits, 1);
+  server.close();
+}
+
 console.log(failures ? `\n${failures} check(s) failed` : "\nall checks passed");
 process.exit(failures ? 1 : 0);

--- a/implementations/manager/src/control-shutdown.ts
+++ b/implementations/manager/src/control-shutdown.ts
@@ -1,0 +1,50 @@
+import { connect } from "node:net";
+
+/** Window to deliver the cooperative shutdown frame before we give up and let the runtime's own
+ *  grace timer hard-kill. Short — the frame is one small write; this only guards a hung connect. */
+const TIMEOUT_MS = 2_000;
+
+/**
+ * Ask a managed agent to shut down cleanly over its authenticated control endpoint.
+ *
+ * On a runtime that can't deliver a clean exit signal (ConPTY/Windows: node-pty `kill(SIGTERM)`
+ * throws, a pseudoconsole can't carry a signal), a hard kill denies the agent its exit handlers —
+ * so it never leaves the mesh / publishes offline presence. This sends `{token, op:"shutdown"}`;
+ * the agent's control server (which validated the token) runs `agent.stop()` then exits on its own.
+ *
+ * Best-effort and fire-and-forget: the runtime hard-kills as a fallback after its own grace window,
+ * so a failed, refused, or slow send never blocks the stop — it just falls through to the kill. The
+ * token authenticates the frame; it is held in memory only (never logged or persisted).
+ */
+export function controlShutdown(endpoint: { path: string; token: string }): void {
+  let sock: ReturnType<typeof connect>;
+  let done = false;
+  const finish = (): void => {
+    if (done) return;
+    done = true;
+    clearTimeout(timer);
+    try {
+      sock.destroy();
+    } catch {
+      /* ignore */
+    }
+  };
+  const timer = setTimeout(finish, TIMEOUT_MS);
+  try {
+    sock = connect(endpoint.path);
+  } catch {
+    clearTimeout(timer);
+    return; // not reachable — the fallback hard-kill covers it
+  }
+  sock.setEncoding("utf8");
+  sock.on("connect", () => {
+    try {
+      sock.write(JSON.stringify({ token: endpoint.token, op: "shutdown" }) + "\n");
+    } catch {
+      /* ignore — fallback kill covers it */
+    }
+  });
+  sock.on("data", finish); // ack received — the agent is tearing down
+  sock.on("end", finish);
+  sock.on("error", finish); // not running / refused — fallback kill covers it
+}

--- a/implementations/manager/src/control-shutdown.ts
+++ b/implementations/manager/src/control-shutdown.ts
@@ -30,6 +30,7 @@ export function controlShutdown(endpoint: { path: string; token: string }): void
     }
   };
   const timer = setTimeout(finish, TIMEOUT_MS);
+  timer.unref?.(); // best-effort + fire-and-forget — never hold the manager's event loop open at exit
   try {
     sock = connect(endpoint.path);
   } catch {

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -30,6 +30,7 @@ import {
 } from "./runtime/index.js";
 import { AttachEndpoint } from "./attach-endpoint.js";
 import { launchSpecForRun, materializePersona, launchAgentToStartOpts } from "./launch.js";
+import { controlShutdown } from "./control-shutdown.js";
 
 /** Concurrency ceiling — the manager refuses to hold more than this many live + in-flight +
  *  cooling slots at once (P4a). Bounds a fork-bomb: spawn is a full agent process per call. */
@@ -93,6 +94,11 @@ interface ManagedAgent {
   spawner: string;
   startedAt: number;
   handle: AgentHandle;
+  /** This agent's local control endpoint (path + first-frame auth token), when its connector runs
+   *  one. Kept in memory only (never persisted — token hygiene) so a graceful stop on a signal-less
+   *  runtime (ConPTY/Windows) can send a cooperative `{op:"shutdown"}` over it instead of a hard
+   *  kill that would deny the agent its clean mesh-leave. */
+  control?: { path: string; token: string };
 }
 
 /**
@@ -316,7 +322,7 @@ export class Manager {
     const target = [...this.agents.values()].find((a) => a.id === callerId);
     if (!target) return { ok: false, error: `self-stop: caller ${callerId} is not a managed agent` };
     const graceful = args.graceful !== false;
-    target.handle.stop({ graceful });
+    this.stopHandle(target, graceful);
     this.freeSlot(target, true); // self-despawn is rate-floored (recycle churn)
     return { ok: true, data: { name: target.name, stopped: true, graceful } };
   }
@@ -325,6 +331,17 @@ export class Manager {
   // `ctl.delivery` control service (endpoint.startPlane3 → handleDeliveryControl). The manager is
   // lifecycle-only; it records each agent's read ACL at spawn (commitAcl) so the daemon can validate
   // those ops against the durable ACL registry — the single source of truth, no in-memory ledger.
+
+  /** Tear an agent down — the single chokepoint for every stop path (despawn, self-stop, reap). On
+   *  Windows a graceful stop can't ride a signal (ConPTY delivers none, so the agent never runs its
+   *  exit handlers / leaves the mesh), so first send a cooperative `{op:"shutdown"}` over its authed
+   *  control endpoint; the agent exits cleanly and the runtime hard-kills as a fallback after its
+   *  grace window. POSIX delivers SIGTERM→SIGKILL natively, so it keeps the signal path. A hard stop
+   *  (`graceful:false`, e.g. emergency reap) skips the cooperative step on every platform. */
+  private stopHandle(a: ManagedAgent, graceful: boolean): void {
+    if (graceful && process.platform === "win32" && a.control) controlShutdown(a.control);
+    a.handle.stop({ graceful });
+  }
 
   /** Drop a live agent's slot. When `floor` is set and the agent died young (lived less than
    *  MIN_LIFETIME), push a cooling stamp so the freed slot still counts toward the ceiling until it
@@ -343,7 +360,7 @@ export class Manager {
   private reapChildrenOf(parentId: string): void {
     for (const child of [...this.agents.values()]) {
       if (child.spawner !== parentId) continue;
-      child.handle.stop({ graceful: false });
+      this.stopHandle(child, false);
       this.freeSlot(child, true);
       this.reapChildrenOf(child.id);
     }
@@ -604,6 +621,7 @@ export class Manager {
         spawner: spawner ?? this.ep.ref().id,
         startedAt: Date.now(),
         handle,
+        control: spec.control,
       };
       this.agents.set(name, managed);
       // Wire the runtime exit signal so a natural exit (crash / /exit / finished) frees the slot
@@ -648,7 +666,7 @@ export class Manager {
     const denied = this.authorizeNamed(a, caller, admin);
     if (denied) return { ok: false, error: denied };
     const graceful = args.graceful !== false;
-    a.handle.stop({ graceful });
+    this.stopHandle(a, graceful);
     this.freeSlot(a, !admin); // own-child despawn is rate-floored; admin emergency-kill is not
     return { ok: true, data: { name, stopped: true, graceful } };
   }

--- a/implementations/manager/src/runtime/pty.ts
+++ b/implementations/manager/src/runtime/pty.ts
@@ -92,10 +92,17 @@ export class PtyRuntime implements Runtime {
       stop: (opts) => {
         if (!alive) return;
         // node-pty's ConPTY backend has no signals: kill(<signal>) throws on Windows, and a
-        // pseudoconsole can't deliver SIGTERM for a graceful mesh-leave. So a stop here is a hard
-        // terminate — the agent's presence then expires via NATS rather than leaving cleanly.
+        // pseudoconsole can't deliver SIGTERM for a graceful mesh-leave. The manager instead sends a
+        // cooperative `{op:"shutdown"}` over the agent's control endpoint BEFORE a graceful stop, so
+        // here we just give the agent a window to run its exit handlers (leave the mesh, publish
+        // offline) and exit on its own, then hard-kill (ConPTY close) as a fallback. A hard stop
+        // (graceful:false — emergency reap) skips the window and kills immediately.
         if (process.platform === "win32") {
-          proc.kill();
+          if (opts?.graceful === false) {
+            proc.kill();
+            return;
+          }
+          setTimeout(() => alive && proc.kill(), GRACE_MS);
           return;
         }
         if (opts?.graceful === false) {

--- a/implementations/manager/src/runtime/pty.ts
+++ b/implementations/manager/src/runtime/pty.ts
@@ -102,7 +102,16 @@ export class PtyRuntime implements Runtime {
             proc.kill();
             return;
           }
-          setTimeout(() => alive && proc.kill(), GRACE_MS);
+          // `alive` guards the already-exited case; the try/catch covers the narrow race where the
+          // ConPTY tears down between the check and the kill (node-pty throws on a dead handle).
+          setTimeout(() => {
+            if (!alive) return;
+            try {
+              proc.kill();
+            } catch {
+              /* already gone */
+            }
+          }, GRACE_MS);
           return;
         }
         if (opts?.graceful === false) {

--- a/packages/core/src/connector.ts
+++ b/packages/core/src/connector.ts
@@ -63,6 +63,13 @@ export interface LaunchSpec {
    *  non-interactive. Matched after stripping ANSI + whitespace (TUIs position
    *  text with cursor moves, not spaces). */
   confirm?: string;
+  /** This agent's local control endpoint — the OS path its lifecycle hooks connect to (passed in
+   *  the child env as `COTAL_CONTROL_SOCKET`/`COTAL_CONTROL_TOKEN`), plus the first-frame `token`
+   *  that authenticates it. The connector mints it in `buildLaunch`; the manager keeps it IN MEMORY
+   *  (never persisted — token hygiene) to send a cooperative `{op:"shutdown"}` on a runtime that
+   *  can't deliver a clean exit signal (ConPTY/Windows). Absent for connectors with no control
+   *  plane (OpenCode is in-process). */
+  control?: { path: string; token: string };
 }
 
 /**


### PR DESCRIPTION
Stage 2 of native Windows support: the **authenticated control plane** (WS3) + **cooperative graceful stop** (WS4). Builds on the Stage 1 launch adapter (#134).

## What this does

### WS3 — authenticated control plane
The connector's local control plane (lifecycle hooks → presence + message injection) gains real authentication, and the Windows named pipe — deliberately deferred out of Stage 1 — returns here **with** auth.

- **`controlEndpoint(space, name, token?)`** mints a per-launch endpoint: a `sha256(space\0name\0pid\0token)` path id (base64url, ≤32 — unguessable and identity-free) over a win32 named pipe (`\\.\pipe\…`) / POSIX `tmpdir` socket, plus a 256-bit random token. A Windows named pipe's default DACL lets **any** local process connect, so the **token, not the path**, is the security boundary.
- **`startControlServer`** validates the first frame's token (constant-time: `sha256` both sides → `timingSafeEqual`, so length- and type-independent) **before** the hook handler or shutdown ever runs. A managed listener (the in-agent MCP server, the Hermes sidecar) **fails the bind loud** — `process.exit` on `EADDRINUSE`, i.e. a squatter already holds the pipe (libuv binds with `FILE_FLAG_FIRST_PIPE_INSTANCE`) — rather than serve a hijacked or no-op plane.
- Path + token flow via the child env (`COTAL_CONTROL_SOCKET` / `COTAL_CONTROL_TOKEN`), **never recomputed from public identity**; the token is env-only (never argv/logs/persisted — token hygiene). Carried to the manager via `LaunchSpec.control` (in memory only).
- The claude TS hook relay + the Hermes Python hook now send `{token, event}`; the hook relay stays **fail-open** on connect/auth so a hook never blocks the user's session.

### WS4 — cooperative graceful stop
ConPTY has no signals, so a Windows `kill()` denies the agent its exit handlers — it never leaves the mesh / publishes offline presence. The manager now sends `{token, op:"shutdown"}` over the authed endpoint before a graceful stop (one chokepoint for despawn / self-stop / reap); the agent runs `agent.stop()` then exits, and the `PtyRuntime` hard-kills as a fallback after the grace window. **POSIX keeps signal-based SIGTERM→SIGKILL** unchanged.

## Scope notes
- **OpenCode is in-process** (bus events → presence, no control socket) — untouched.
- **Hermes** is Unix-only for the broker/sidecar, but its shared control plane gets the same auth (Python hook + sidecar updated) so it keeps working.

## Tests
Seam tests added to `smoke:windows` (most run **everywhere** — `node:net` abstracts AF_UNIX ↔ named pipe):
- first-frame auth: wrong/absent token dropped **before** the handler;
- shutdown-op routing → `onShutdown`, **not** the hook handler;
- `controlShutdown` (manager → server) round-trip;
- fatal-bind-on-squat → `exit(1)` (win32-only: a live named-pipe squatter is the only EADDRINUSE path).

Local: `typecheck` clean, `build` clean, `smoke:windows` green (control sections pass on macOS), full `smoke:ci` green (14/14). Windows CI is the oracle for the win32-only paths.

Follow-up: **Stage 3** — secrets `icacls` hardening + `%LOCALAPPDATA%` paths.
