### PR TITLE
feat(windows): secrets-at-rest ACL hardening + path/home portability (Stage 3)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -82,10 +82,16 @@ jobs:
         run: pnpm smoke:view && pnpm smoke:core-boundary && pnpm smoke:preflight && pnpm smoke:env-isolate
 
       # The `.cmd`/`.bat` launch matrix (PATHEXT resolution + cmd-arg byte-for-byte quoting + orphan
-      # reap). Deterministic, broker-free, validated green-in-logs on windows-latest → an ENFORCED
-      # required gate (no continue-on-error: a future regression fails the gate, never masked).
-      - name: Windows launch matrix (smoke:windows)
+      # reap) + the authenticated control-plane seams (first-frame token auth, shutdown routing,
+      # fatal-bind-on-squat, pre-auth DoS bound). Deterministic, broker-free, validated green-in-logs
+      # on windows-latest → an ENFORCED required gate (no continue-on-error: a regression fails it).
+      - name: Windows launch + control-plane matrix (smoke:windows)
         run: pnpm smoke:windows
+
+      # Secrets at rest: 0o600/0o700 is a no-op on Windows, so secret files/dirs are locked down via
+      # an NTFS ACL (icacls). This asserts the broad inherited access is actually stripped.
+      - name: Secrets-at-rest ACL hardening (smoke:secret-fs)
+        run: pnpm smoke:secret-fs
 
       - name: Protocol & security smoke tests
         run: pnpm smoke:ci

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -293,10 +293,13 @@ Hermes has no MCP), so it lives in connector settings, not the
 - **Secrets stay references.** Write keys as `${VAR}` / `${VAR:-default}`, never literals — the
   config file is safe to keep in `~/.config` or a gitignored `.cotal/`. At launch the connector
   forwards *only* the named vars the chosen servers declare (from the operator's env, by name —
-  never the whole environment, preserving the P3 env allow-list) and passes the merged config as a
-  `0600` file (in a private `0700` temp dir); Claude expands the references from that env at launch,
-  so the secret never lands on disk or the command line. `--strict-mcp-config` stays on, so only
-  cotal + the explicitly-shared servers ever load.
+  never the whole environment, preserving the P3 env allow-list) and passes the merged config as an
+  owner-only file in a private temp dir (`0600`/`0700` on POSIX; on Windows — where those modes are a
+  no-op — the file and dir are ACL-hardened via `icacls` to the current user + SYSTEM + Admins);
+  Claude expands the references from that env at launch, so the secret never lands on disk or the
+  command line. `--strict-mcp-config` stays on, so only cotal + the explicitly-shared servers ever
+  load. (Operator config lives at `$XDG_CONFIG_HOME/cotal/config.json`, else `~/.config/cotal/` on
+  POSIX / `%APPDATA%\Cotal\` on Windows; machine state under `~/.cotal` / `%LOCALAPPDATA%\Cotal`.)
 - **Sharing a server grants its credential to the agent.** The forwarded var lives in the *Claude
   process's* environment (that's how Claude expands the `${VAR}` and the server reads it), so an
   agent with shell/tool access can read it directly — not only through the server's tools. Keeping
@@ -448,10 +451,16 @@ falls back to `Notification.message`. The pending tool is cleared on turn start 
 idle-input wait never inherits a stale command.
 
 Wired in [`hooks.json`](../extensions/connector-claude-code/hooks/hooks.json), relayed over
-the connector's control socket
+the connector's **authenticated** control endpoint
 ([`connector-core/src/control.ts`](../extensions/connector-core/src/control.ts)), and mapped
 to presence by the Claude handle in
-[`mcp.ts`](../extensions/connector-claude-code/src/mcp.ts).
+[`mcp.ts`](../extensions/connector-claude-code/src/mcp.ts). The endpoint is a per-user socket on
+POSIX and a named pipe on Windows; its path + a random per-launch token ride the child env
+(`COTAL_CONTROL_SOCKET`/`COTAL_CONTROL_TOKEN`), and every frame's token is checked (constant-time)
+before any handler runs — so a local process that finds the path still can't drive presence, inject
+messages, or stop the agent. The manager also uses it to send a cooperative `{op:"shutdown"}` on a
+graceful stop where the runtime can't deliver a signal (Windows ConPTY), so the agent leaves the
+mesh cleanly instead of being hard-killed.
 
 ## Transcript mirror
 

--- a/extensions/connector-claude-code/src/extension.ts
+++ b/extensions/connector-claude-code/src/extension.ts
@@ -1,8 +1,8 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { loadAgentFile, registry, type Connector, type LaunchOpts, type LaunchSpec } from "@cotal-ai/core";
+import { hardenPrivate, loadAgentFile, registry, writeSecretFile, type Connector, type LaunchOpts, type LaunchSpec } from "@cotal-ai/core";
 import { aclEnv, controlEndpoint, launchEnv, mcpServerEnvKeys } from "@cotal-ai/connector-core";
 
 /** Name the cotal MCP server is registered under via --mcp-config (see buildLaunch). */
@@ -104,8 +104,9 @@ export const claudeConnector: Connector = {
       // overwrite). Left for the OS to reap: the file must outlive this call (Claude reads it at
       // startup and on /mcp reconnect), and buildLaunch doesn't own the child's lifecycle.
       const dir = mkdtempSync(join(tmpdir(), "cotal-mcp-"));
+      hardenPrivate(dir, "dir"); // win32: mkdtemp's 0700 is a no-op — harden the ACL before the config lands
       mcpConfig = join(dir, "mcp.json");
-      writeFileSync(mcpConfig, JSON.stringify({ mcpServers }, null, 2), { mode: 0o600 });
+      writeSecretFile(mcpConfig, JSON.stringify({ mcpServers }, null, 2));
     }
     args.push("--strict-mcp-config", "--mcp-config", mcpConfig);
 

--- a/extensions/connector-hermes/src/extension.ts
+++ b/extensions/connector-hermes/src/extension.ts
@@ -25,6 +25,11 @@ export const hermesConnector: Connector = {
   name: "hermes",
   requires: ["hermes"],
   buildLaunch(opts: LaunchOpts): LaunchSpec {
+    // Hermes is Unix-only: its sidecar bridge + hook relay use AF_UNIX `.sock` paths and a Python
+    // sidecar, none of which are ported to Windows. Fail loud rather than launch a half-wired agent
+    // the manager can't drive (no Windows named-pipe bridge, no cooperative shutdown). No fallback.
+    if (process.platform === "win32")
+      throw new Error("the Hermes connector is Unix-only (AF_UNIX bridge + Python sidecar) — not supported on Windows");
     // OS allow-list + the named model-provider key (Hermes is model-agnostic; any one unlocks a
     // provider), forwarded BY NAME — never `...process.env` — so the operator's unrelated secrets
     // don't reach the gateway child (P3).

--- a/implementations/cli/src/commands/mint.ts
+++ b/implementations/cli/src/commands/mint.ts
@@ -1,12 +1,14 @@
-import { mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { resolve, join, dirname } from "node:path";
 import { parseArgs } from "node:util";
 import {
   agentFilePath,
   loadAgentFile,
   mintCreds,
+  mkSecretDir,
   newIdentity,
   stripSpaceAuth,
+  writeSecretFile,
   type Profile,
 } from "@cotal-ai/core";
 import { authDir, loadSpaceAuth } from "@cotal-ai/workspace";
@@ -45,7 +47,7 @@ export async function mint(argv: string[]): Promise<void> {
       console.error(c.red(`${out} already exists — pass --force to overwrite`));
       process.exit(1);
     }
-    writeFileSync(out, JSON.stringify(stripSpaceAuth(auth), null, 2), { mode: 0o600 });
+    writeSecretFile(out, JSON.stringify(stripSpaceAuth(auth), null, 2));
     console.log(c.green(`✓ wrote signer for space "${auth.space}"`));
     console.log(c.dim(`  ${out}`));
     console.log(c.dim("  mount read-only at /workspace/.cotal/auth/auth.json in the container"));
@@ -86,8 +88,8 @@ export async function mint(argv: string[]): Promise<void> {
   const identity = newIdentity();
   const creds = await mintCreds(auth, identity, profile, { allowSubscribe, allowPublish, role });
   const out = resolve(values.out ?? join(dir, "creds", `${name}.creds`));
-  mkdirSync(dirname(out), { recursive: true });
-  writeFileSync(out, creds, { mode: 0o600 });
+  mkSecretDir(dirname(out));
+  writeSecretFile(out, creds);
   console.log(c.green(`✓ minted ${profile} creds for "${name}"`));
   console.log(c.dim(`  id:    ${identity.id}`));
   console.log(c.dim(`  creds: ${out}`));

--- a/implementations/cli/src/commands/setup.ts
+++ b/implementations/cli/src/commands/setup.ts
@@ -1,6 +1,5 @@
 import { spawnSync } from "node:child_process";
 import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 import * as p from "@clack/prompts";
@@ -12,7 +11,7 @@ import {
   type Pane,
   type TerminalLayout,
 } from "@cotal-ai/core";
-import { authDir, loadSpaceAuth } from "@cotal-ai/workspace";
+import { authDir, homeCotalDir, loadSpaceAuth } from "@cotal-ai/workspace";
 import { brand, brandBold, dim, ok, note, splash } from "../lib/theme.js";
 import { LivePane } from "../lib/live-window.js";
 import { runSteps, type Step } from "../lib/steps.js";
@@ -283,7 +282,7 @@ function claudePluginStep(): Step {
     name: "claude-plugin",
     title: "Install the Claude Code plugin",
     explain: "Lets a Claude Code session join the web and wake on peer messages.",
-    context: [join(homedir(), ".cotal/claude-plugin"), CC_DOCS_URL],
+    context: [join(homeCotalDir(), "claude-plugin"), CC_DOCS_URL],
     async run() {
       installClaudePlugin();
       return "cotal@cotal-mesh (local scope)";
@@ -567,7 +566,7 @@ function installClaudePlugin(): void {
     }
   }
 
-  const marketDir = join(homedir(), ".cotal", "claude-plugin");
+  const marketDir = join(homeCotalDir(), "claude-plugin");
   const pluginDir = join(marketDir, "cotal");
   for (const f of [".claude-plugin", ".mcp.json", "hooks", "dist/mcp.cjs", "dist/hook.cjs"]) {
     cpSync(join(pluginRoot, f), join(pluginDir, f), { recursive: true });

--- a/implementations/cli/src/commands/spawn.ts
+++ b/implementations/cli/src/commands/spawn.ts
@@ -1,5 +1,4 @@
 import { spawn as spawnProcess } from "node:child_process";
-import { mkdirSync, writeFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { parseArgs } from "node:util";
 import {
@@ -10,10 +9,12 @@ import {
   loadAgentFile,
   loadCotalConfig,
   mintCreds,
+  mkSecretDir,
   newIdentity,
   parseShareSelection,
   provisionAgent,
   registry,
+  writeSecretFile,
   CotalEndpoint,
   type AgentDef,
   type CompletionResult,
@@ -246,8 +247,8 @@ export async function spawn(argv: string[]): Promise<void> {
     });
     await prov.stop();
     credsPath = join(authDir(target.root), "creds", `${name}.creds`);
-    mkdirSync(dirname(credsPath), { recursive: true });
-    writeFileSync(credsPath, creds, { mode: 0o600 });
+    mkSecretDir(dirname(credsPath)); // harden the creds dir before the cred lands
+    writeSecretFile(credsPath, creds);
     id = identity.id;
     console.error(`minted creds for ${name} (auth mode) → ${credsPath}`);
   }

--- a/implementations/cli/src/commands/up.ts
+++ b/implementations/cli/src/commands/up.ts
@@ -22,6 +22,7 @@ import {
   setupSpaceStreams,
   seedChannelRegistry,
   ensureDefaultDeliveryClass,
+  mkSecretDir,
   writeSecretFile,
   type SpaceAuth,
   type ChannelRegistryFile,
@@ -512,6 +513,7 @@ async function provisionMembershipCreds(auth: SpaceAuth): Promise<void> {
   try {
     const observer = await mintMembershipObserverCreds(auth, newIdentity());
     const rw = await mintCreds(auth, newIdentity(), "membership-rw");
+    mkSecretDir(cotalPath()); // harden .cotal/ before the creds land (born under a private ACL, no race)
     writeSecretFile(cotalPath("membership-observer.creds"), observer);
     writeSecretFile(cotalPath("membership-rw.creds"), rw);
     writeSecretFile(cotalPath("membership.json"), JSON.stringify({ accountId: auth.account.pub }));

--- a/implementations/cli/src/commands/up.ts
+++ b/implementations/cli/src/commands/up.ts
@@ -22,6 +22,7 @@ import {
   setupSpaceStreams,
   seedChannelRegistry,
   ensureDefaultDeliveryClass,
+  writeSecretFile,
   type SpaceAuth,
   type ChannelRegistryFile,
 } from "@cotal-ai/core";
@@ -511,9 +512,9 @@ async function provisionMembershipCreds(auth: SpaceAuth): Promise<void> {
   try {
     const observer = await mintMembershipObserverCreds(auth, newIdentity());
     const rw = await mintCreds(auth, newIdentity(), "membership-rw");
-    writeFileSync(cotalPath("membership-observer.creds"), observer, { mode: 0o600 });
-    writeFileSync(cotalPath("membership-rw.creds"), rw, { mode: 0o600 });
-    writeFileSync(cotalPath("membership.json"), JSON.stringify({ accountId: auth.account.pub }), { mode: 0o600 });
+    writeSecretFile(cotalPath("membership-observer.creds"), observer);
+    writeSecretFile(cotalPath("membership-rw.creds"), rw);
+    writeSecretFile(cotalPath("membership.json"), JSON.stringify({ accountId: auth.account.pub }));
   } catch (e) {
     console.error(c.dim(`• broker-sourced membership not provisioned: ${(e as Error).message}`));
   }

--- a/implementations/cli/src/lib/delivery-proc.ts
+++ b/implementations/cli/src/lib/delivery-proc.ts
@@ -5,6 +5,7 @@ import {
   mintCreds,
   newIdentity,
   waitForDeliveryLease,
+  writeSecretFile,
 } from "@cotal-ai/core";
 import { authDir, findCotalRoot, loadSpaceAuth } from "@cotal-ai/workspace";
 import { selfArgv } from "./self-exec.js";
@@ -101,7 +102,7 @@ export async function ensureDelivery(o: Opts = {}): Promise<{ running: boolean }
   const space = o.space ?? resolveSpace(process.cwd());
   const server = o.server ?? DEFAULT_SERVER;
   if (!deliveryUp()) {
-    writeFileSync(CREDS_PATH(), creds, { mode: 0o600 });
+    writeSecretFile(CREDS_PATH(), creds);
     startDeliveryDetached({ ...o, space, server });
   }
   // ALWAYS wait for the daemon to be READY (lease flipped ready AFTER it bound ctl.delivery) before

--- a/implementations/cli/src/lib/delivery-proc.ts
+++ b/implementations/cli/src/lib/delivery-proc.ts
@@ -3,6 +3,7 @@ import { existsSync, openSync, closeSync, writeFileSync, readFileSync, rmSync } 
 import {
   DEFAULT_SERVER,
   mintCreds,
+  mkSecretDir,
   newIdentity,
   waitForDeliveryLease,
   writeSecretFile,
@@ -102,6 +103,7 @@ export async function ensureDelivery(o: Opts = {}): Promise<{ running: boolean }
   const space = o.space ?? resolveSpace(process.cwd());
   const server = o.server ?? DEFAULT_SERVER;
   if (!deliveryUp()) {
+    mkSecretDir(cotalPath()); // harden .cotal/ before the cred lands (born under a private ACL, no race)
     writeSecretFile(CREDS_PATH(), creds);
     startDeliveryDetached({ ...o, space, server });
   }

--- a/implementations/cli/src/lib/onboard.ts
+++ b/implementations/cli/src/lib/onboard.ts
@@ -1,5 +1,6 @@
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { mkSecretDir } from "@cotal-ai/core";
 import { homeCotalDir } from "@cotal-ai/workspace";
 
 /** Machine-level "I've onboarded before" marker. Its presence flips `cotal` from the
@@ -12,6 +13,6 @@ export function isOnboarded(): boolean {
 }
 
 export function markOnboarded(version: string): void {
-  mkdirSync(homeCotalDir(), { recursive: true, mode: 0o700 });
+  mkSecretDir(homeCotalDir()); // the home dir holds secrets — keep it owner-only (0700 / hardened ACL)
   writeFileSync(MARKER(), JSON.stringify({ version, ts: new Date().toISOString() }, null, 2));
 }

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { join, dirname, resolve } from "node:path";
 import {
   CotalEndpoint,
@@ -11,10 +11,12 @@ import {
   loadAgentFile,
   loadCotalConfig,
   mintCreds,
+  mkSecretDir,
   newIdentity,
   provisionAgent,
   registry,
   saveAgentFile,
+  writeSecretFile,
   subjectMatches,
   CONTROL_PRIVILEGED,
   CONTROL_SELF_SERVICE,
@@ -579,8 +581,8 @@ export class Manager {
           capabilities,
         });
         credsPath = join(authDir(this.workspaceRoot), "creds", `${name}.creds`);
-        mkdirSync(dirname(credsPath), { recursive: true });
-        writeFileSync(credsPath, creds, { mode: 0o600 });
+        mkSecretDir(dirname(credsPath)); // harden the creds dir before the cred lands
+        writeSecretFile(credsPath, creds);
       }
       // Personal MCP servers the operator opted to share with manager-spawned agents of this type
       // (cotal config; default none → isolated, the memory-safe default this guards).

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "smoke:opencode": "tsx extensions/connector-opencode/smoke/turn-wedge.smoke.ts",
     "smoke:attach": "tsx implementations/manager/smoke/attach.smoke.ts",
     "smoke:windows": "tsx implementations/manager/smoke/windows-launch.smoke.ts",
+    "smoke:secret-fs": "tsx packages/core/smoke/secret-fs.smoke.ts",
     "smoke:env-isolate": "tsx implementations/manager/smoke/env-isolate.smoke.ts",
     "smoke:tmux": "tsx extensions/tmux/smoke.ts",
     "smoke:runtime": "pnpm smoke:tmux && pnpm smoke:env-isolate && pnpm smoke:attach",

--- a/packages/core/smoke/secret-fs.smoke.ts
+++ b/packages/core/smoke/secret-fs.smoke.ts
@@ -1,0 +1,65 @@
+/**
+ * Private-secret filesystem smoke (no NATS, no test runner) — run with: pnpm smoke:secret-fs
+ *
+ * Guards the WS5 secrets-at-rest seam a POSIX-only build breaks on Windows: `0o600`/`0o700` are a
+ * no-op there, so secrets must be locked down via an NTFS ACL instead. POSIX checks run EVERYWHERE
+ * (the local regression guard — mode bits after write/harden). The win32 `icacls` readback (the real
+ * point — broad inherited access is actually stripped) is win32-only; Windows CI is the oracle.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { hardenPrivate, mkSecretDir, writeSecretFile } from "../src/secret-fs.js";
+
+const isWin = process.platform === "win32";
+let failures = 0;
+function check(label: string, cond: boolean): void {
+  console.log(`${cond ? "✓" : "✗"} ${label}`);
+  if (!cond) failures++;
+}
+
+const dir = mkdtempSync(join(tmpdir(), "cotal-secret-"));
+
+// writeSecretFile creates the file with the secret content.
+const file = join(dir, "creds.secret");
+writeSecretFile(file, "super-secret-token\n");
+check("writeSecretFile wrote the file", statSync(file).isFile());
+
+// mkSecretDir creates a private dir.
+const sub = join(dir, "auth");
+mkSecretDir(sub);
+check("mkSecretDir created the dir", statSync(sub).isDirectory());
+
+if (!isWin) {
+  // POSIX: the mode bits are the security boundary — assert them exactly.
+  check("file is 0600 (owner rw, no group/other)", (statSync(file).mode & 0o777) === 0o600);
+  check("dir is 0700 (owner rwx, no group/other)", (statSync(sub).mode & 0o777) === 0o700);
+  // hardenPrivate re-asserts on an existing path (idempotent).
+  hardenPrivate(file, "file");
+  check("hardenPrivate keeps the file 0600", (statSync(file).mode & 0o777) === 0o600);
+  console.log("· icacls ACL stripping is win32-only — skipped (CI is the oracle)");
+} else {
+  // win32: the Unix mode is a no-op — the NTFS ACL is the boundary. Read it back with icacls and
+  // assert the broad inherited principals are GONE and only owner + SYSTEM + Administrators remain.
+  const acl = (p: string): string => execFileSync("icacls", [p], { encoding: "utf8" });
+  const broadGone = (out: string): boolean =>
+    !/\bEveryone\b/i.test(out) &&
+    !/\bAuthenticated Users\b/i.test(out) &&
+    !/\\Users:/i.test(out); // BUILTIN\Users
+  const hasSafe = (out: string): boolean =>
+    /\\SYSTEM:/i.test(out) && /\\Administrators:/i.test(out);
+
+  const fileAcl = acl(file);
+  check("file ACL strips Everyone / Authenticated Users / Users", broadGone(fileAcl));
+  check("file ACL grants SYSTEM + Administrators (+ owner)", hasSafe(fileAcl));
+  check("file ACL dropped inheritance (no inherited ACEs)", !/\(I\)/.test(fileAcl));
+
+  const dirAcl = acl(sub);
+  check("dir ACL strips Everyone / Authenticated Users / Users", broadGone(dirAcl));
+  check("dir ACL grants SYSTEM + Administrators (+ owner)", hasSafe(dirAcl));
+}
+
+rmSync(dir, { recursive: true, force: true, maxRetries: 10 });
+console.log(failures ? `\n${failures} check(s) failed` : "\nall checks passed");
+process.exit(failures ? 1 : 0);

--- a/packages/core/smoke/secret-fs.smoke.ts
+++ b/packages/core/smoke/secret-fs.smoke.ts
@@ -43,21 +43,24 @@ if (!isWin) {
   // win32: the Unix mode is a no-op — the NTFS ACL is the boundary. Read it back with icacls and
   // assert the broad inherited principals are GONE and only owner + SYSTEM + Administrators remain.
   const acl = (p: string): string => execFileSync("icacls", [p], { encoding: "utf8" });
+  // The current account name (icacls shows resolved NAMES, not SIDs) — its ACE must survive so we
+  // never lock ourselves out of our own secret.
+  const user = execFileSync("whoami", { encoding: "utf8" }).trim(); // e.g. machine\user
   const broadGone = (out: string): boolean =>
     !/\bEveryone\b/i.test(out) &&
     !/\bAuthenticated Users\b/i.test(out) &&
     !/\\Users:/i.test(out); // BUILTIN\Users
   const hasSafe = (out: string): boolean =>
-    /\\SYSTEM:/i.test(out) && /\\Administrators:/i.test(out);
+    /\\SYSTEM:/i.test(out) && /\\Administrators:/i.test(out) && out.toLowerCase().includes(user.toLowerCase());
 
   const fileAcl = acl(file);
   check("file ACL strips Everyone / Authenticated Users / Users", broadGone(fileAcl));
-  check("file ACL grants SYSTEM + Administrators (+ owner)", hasSafe(fileAcl));
+  check("file ACL grants owner SID + SYSTEM + Administrators", hasSafe(fileAcl));
   check("file ACL dropped inheritance (no inherited ACEs)", !/\(I\)/.test(fileAcl));
 
   const dirAcl = acl(sub);
   check("dir ACL strips Everyone / Authenticated Users / Users", broadGone(dirAcl));
-  check("dir ACL grants SYSTEM + Administrators (+ owner)", hasSafe(dirAcl));
+  check("dir ACL grants owner SID + SYSTEM + Administrators", hasSafe(dirAcl));
 }
 
 rmSync(dir, { recursive: true, force: true, maxRetries: 10 });

--- a/packages/core/src/agent-file.ts
+++ b/packages/core/src/agent-file.ts
@@ -253,12 +253,13 @@ function fmItem(value: string): string {
   return fmScalar(value);
 }
 
-/** Resolve a name-or-path to an agent file. A path (absolute, contains a slash,
- *  or ends in `.md`) is used as given; a bare name maps to the directory
+/** Resolve a name-or-path to an agent file. A path (absolute, contains a slash — `/` or, on
+ *  Windows, `\` — or ends in `.md`) is used as given; a bare name maps to the directory
  *  convention `<root>/.cotal/agents/<name>.md`. */
 export function agentFilePath(root: string, nameOrPath: string): string {
   if (isAbsolute(nameOrPath)) return nameOrPath;
-  if (nameOrPath.includes("/") || nameOrPath.endsWith(".md")) return resolve(root, nameOrPath);
+  if (nameOrPath.includes("/") || nameOrPath.includes("\\") || nameOrPath.endsWith(".md"))
+    return resolve(root, nameOrPath);
   return join(root, ".cotal", "agents", `${nameOrPath}.md`);
 }
 

--- a/packages/core/src/connector-config.ts
+++ b/packages/core/src/connector-config.ts
@@ -54,10 +54,14 @@ export interface CotalConfig {
   connectors?: Record<string, ConnectorConfig>;
 }
 
-/** Operator-level config path: `$XDG_CONFIG_HOME/cotal/config.json`, else `~/.config/cotal/config.json`. */
+/** Operator-level config path: `$XDG_CONFIG_HOME/cotal/config.json`; else `%APPDATA%\Cotal\config.json`
+ *  on Windows (the platform's per-user roaming config dir) or `~/.config/cotal/config.json` on POSIX. */
 export function globalConfigPath(): string {
-  const base = process.env.XDG_CONFIG_HOME?.trim() || join(homedir(), ".config");
-  return join(base, "cotal", "config.json");
+  const xdg = process.env.XDG_CONFIG_HOME?.trim();
+  if (xdg) return join(xdg, "cotal", "config.json");
+  if (process.platform === "win32" && process.env.APPDATA?.trim())
+    return join(process.env.APPDATA.trim(), "Cotal", "config.json");
+  return join(homedir(), ".config", "cotal", "config.json");
 }
 
 /** Space-local config path: `<root>/.cotal/config.json`. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export * from "./lease.js";
 export * from "./agent-file.js";
 export * from "./launch.js";
 export * from "./fs-safe.js";
+export * from "./secret-fs.js";
 export * from "./connector-config.js";
 export * from "./endpoint.js";
 export * from "./spaces.js";

--- a/packages/core/src/resolve.ts
+++ b/packages/core/src/resolve.ts
@@ -89,4 +89,6 @@ export function assertValidName(name: string): void {
     throw new Error(`invalid name ${JSON.stringify(name)}: must be a single line`);
   if (name.includes("/"))
     throw new Error(`invalid name ${JSON.stringify(name)}: "/" is reserved (the owner/name separator)`);
+  if (name.includes("\\"))
+    throw new Error(`invalid name ${JSON.stringify(name)}: "\\" is reserved (a Windows path separator)`);
 }

--- a/packages/core/src/secret-fs.ts
+++ b/packages/core/src/secret-fs.ts
@@ -1,0 +1,87 @@
+/**
+ * Private-by-owner file/dir helpers — the one place secret material (creds, signing keys, the
+ * transient MCP config) is written so it is readable ONLY by the current user.
+ *
+ * On POSIX `writeFileSync(…, { mode: 0o600 })` does this. On Windows the Unix mode is a NO-OP — Node
+ * honors only the write bit — so a secret written that way inherits its parent's ACL and can be
+ * world-readable (e.g. a `.cotal/auth` under a project on a permissive path). The fix is to harden
+ * the NTFS ACL explicitly with the built-in `icacls` (no new dependency). See {@link hardenPrivate}.
+ */
+import { chmodSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const isWin = process.platform === "win32";
+
+/** The current user's SID, for an `icacls` grant — parsed from `whoami /user /fo csv /nh`
+ *  (`"machine\user","S-1-5-…"`). Cached: it never changes within a process. win32-only. */
+let cachedSid: string | undefined;
+function ownerSid(): string {
+  if (cachedSid) return cachedSid;
+  const out = execFileSync("whoami", ["/user", "/fo", "csv", "/nh"], { encoding: "utf8" });
+  const sid = out.trim().split(",").pop()?.replace(/^"|"$/g, "").trim();
+  if (!sid || !/^S-1-/.test(sid))
+    throw new Error(`could not determine the current user's SID from \`whoami\` (got: ${out.trim()})`);
+  cachedSid = sid;
+  return sid;
+}
+
+/**
+ * Lock a file or directory down to the current user (+ SYSTEM + Administrators) only.
+ *
+ * POSIX: `chmod` (0o600 file / 0o700 dir) — a belt-and-braces reassert of the create-time mode.
+ * win32: harden the NTFS ACL with `icacls` — `/inheritance:r` drops every inherited (broad) ACE and
+ * `/grant:r` REPLACES the ACL with grants for ONLY the owner SID (`whoami /user`), SYSTEM
+ * (`S-1-5-18`), and Administrators (`S-1-5-32-544`). Removing broad grants this way — rather than
+ * adding deny ACEs, which can catch the owner through group membership — is the documented-safe
+ * pattern. Numeric SIDs are `*`-prefixed; invoked shell-free (arg arrays). A directory grants
+ * `(OI)(CI)` so children inherit the private ACE. FAIL-CLOSED: any `whoami`/`icacls` failure throws.
+ */
+export function hardenPrivate(path: string, kind: "file" | "dir"): void {
+  if (!isWin) {
+    chmodSync(path, kind === "dir" ? 0o700 : 0o600);
+    return;
+  }
+  const perm = kind === "dir" ? "(OI)(CI)(F)" : "(F)";
+  const grant = (sid: string): string[] => ["/grant:r", `*${sid}:${perm}`];
+  try {
+    execFileSync(
+      "icacls",
+      [path, "/inheritance:r", ...grant(ownerSid()), ...grant("S-1-5-18"), ...grant("S-1-5-32-544")],
+      { stdio: ["ignore", "ignore", "pipe"] },
+    );
+  } catch (e) {
+    throw new Error(
+      `failed to harden ${kind} "${path}" to private via icacls: ${(e as Error).message.trim()}. ` +
+        `Cotal will not leave a secret with a permissive ACL — ensure \`icacls\`/\`whoami\` are on PATH and the path is on an NTFS volume.`,
+    );
+  }
+}
+
+/**
+ * Write a private secret file: the bytes (mode 0o600 at create on POSIX), then {@link hardenPrivate}
+ * for the win32 ACL. FAIL-CLOSED — if hardening throws, the just-written file is deleted before the
+ * error propagates, so a secret is never left behind with a permissive ACL. `flag` (e.g. `"wx"` for
+ * exclusive create) is honored.
+ */
+export function writeSecretFile(path: string, data: string | Buffer, opts: { flag?: string } = {}): void {
+  writeFileSync(path, data, opts.flag ? { mode: 0o600, flag: opts.flag } : { mode: 0o600 });
+  if (!isWin) return; // POSIX mode set at create — nothing more to do
+  try {
+    hardenPrivate(path, "file");
+  } catch (e) {
+    try {
+      unlinkSync(path);
+    } catch {
+      /* ignore */
+    }
+    throw e;
+  }
+}
+
+/** Create a private directory chain (recursive) and harden it — call BEFORE writing secrets into it
+ *  so a child file is born under a private ACL (no creation-race window). POSIX sets 0o700 at create;
+ *  win32 hardens the leaf's ACL (children then inherit it). Idempotent. */
+export function mkSecretDir(path: string): void {
+  mkdirSync(path, { recursive: true, mode: 0o700 });
+  hardenPrivate(path, "dir");
+}

--- a/packages/core/src/secret-fs.ts
+++ b/packages/core/src/secret-fs.ts
@@ -9,15 +9,23 @@
  */
 import { chmodSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { join } from "node:path";
 
 const isWin = process.platform === "win32";
+
+/** Absolute path to a System32 tool — `icacls`/`whoami` are resolved from `%SystemRoot%` (not PATH)
+ *  so a hijacked PATH can't substitute a malicious binary during the secret-hardening window. */
+function sys32(exe: string): string {
+  const root = process.env.SystemRoot || process.env.windir || "C:\\Windows";
+  return join(root, "System32", exe);
+}
 
 /** The current user's SID, for an `icacls` grant — parsed from `whoami /user /fo csv /nh`
  *  (`"machine\user","S-1-5-…"`). Cached: it never changes within a process. win32-only. */
 let cachedSid: string | undefined;
 function ownerSid(): string {
   if (cachedSid) return cachedSid;
-  const out = execFileSync("whoami", ["/user", "/fo", "csv", "/nh"], { encoding: "utf8" });
+  const out = execFileSync(sys32("whoami.exe"), ["/user", "/fo", "csv", "/nh"], { encoding: "utf8" });
   const sid = out.trim().split(",").pop()?.replace(/^"|"$/g, "").trim();
   if (!sid || !/^S-1-/.test(sid))
     throw new Error(`could not determine the current user's SID from \`whoami\` (got: ${out.trim()})`);
@@ -25,16 +33,21 @@ function ownerSid(): string {
   return sid;
 }
 
+/** Broad principals an ACL must never grant a secret: Everyone, Authenticated Users, Users. */
+const BROAD_SIDS = ["S-1-1-0", "S-1-5-11", "S-1-5-32-545"] as const;
+
 /**
  * Lock a file or directory down to the current user (+ SYSTEM + Administrators) only.
  *
  * POSIX: `chmod` (0o600 file / 0o700 dir) — a belt-and-braces reassert of the create-time mode.
- * win32: harden the NTFS ACL with `icacls` — `/inheritance:r` drops every inherited (broad) ACE and
- * `/grant:r` REPLACES the ACL with grants for ONLY the owner SID (`whoami /user`), SYSTEM
- * (`S-1-5-18`), and Administrators (`S-1-5-32-544`). Removing broad grants this way — rather than
- * adding deny ACEs, which can catch the owner through group membership — is the documented-safe
- * pattern. Numeric SIDs are `*`-prefixed; invoked shell-free (arg arrays). A directory grants
- * `(OI)(CI)` so children inherit the private ACE. FAIL-CLOSED: any `whoami`/`icacls` failure throws.
+ * win32: harden the NTFS ACL with `icacls`: `/inheritance:r` drops inherited ACEs; `/remove:g` drops
+ * any pre-existing EXPLICIT broad grant (Everyone / Authenticated Users / Users) that `/grant:r`
+ * alone would leave intact (e.g. on a pre-planted or pre-existing target); `/grant:r` then sets ONLY
+ * the owner SID (`whoami /user`), SYSTEM (`S-1-5-18`), and Administrators (`S-1-5-32-544`). Removing
+ * broad grants this way — rather than adding deny ACEs, which can catch the owner through group
+ * membership — is the documented-safe pattern. Numeric SIDs are `*`-prefixed; the tools resolve from
+ * `%SystemRoot%` and run shell-free. A directory grants `(OI)(CI)` so children inherit the private
+ * ACE. FAIL-CLOSED: any `whoami`/`icacls` failure throws.
  */
 export function hardenPrivate(path: string, kind: "file" | "dir"): void {
   if (!isWin) {
@@ -42,17 +55,25 @@ export function hardenPrivate(path: string, kind: "file" | "dir"): void {
     return;
   }
   const perm = kind === "dir" ? "(OI)(CI)(F)" : "(F)";
+  const removeBroad = BROAD_SIDS.flatMap((sid) => ["/remove:g", `*${sid}`]);
   const grant = (sid: string): string[] => ["/grant:r", `*${sid}:${perm}`];
   try {
     execFileSync(
-      "icacls",
-      [path, "/inheritance:r", ...grant(ownerSid()), ...grant("S-1-5-18"), ...grant("S-1-5-32-544")],
+      sys32("icacls.exe"),
+      [
+        path,
+        "/inheritance:r",
+        ...removeBroad,
+        ...grant(ownerSid()),
+        ...grant("S-1-5-18"),
+        ...grant("S-1-5-32-544"),
+      ],
       { stdio: ["ignore", "ignore", "pipe"] },
     );
   } catch (e) {
     throw new Error(
       `failed to harden ${kind} "${path}" to private via icacls: ${(e as Error).message.trim()}. ` +
-        `Cotal will not leave a secret with a permissive ACL — ensure \`icacls\`/\`whoami\` are on PATH and the path is on an NTFS volume.`,
+        `Cotal will not leave a secret with a permissive ACL — ensure the path is on an NTFS volume and %SystemRoot%\\System32\\icacls.exe is available.`,
     );
   }
 }
@@ -61,10 +82,10 @@ export function hardenPrivate(path: string, kind: "file" | "dir"): void {
  * Write a private secret file: the bytes (mode 0o600 at create on POSIX), then {@link hardenPrivate}
  * for the win32 ACL. FAIL-CLOSED — if hardening throws, the hardening error propagates (the caller
  * never proceeds as if the secret were safe) and the just-written file is best-effort deleted so it
- * isn't left readable. `flag` (e.g. `"wx"` for exclusive create) is honored.
+ * isn't left readable.
  */
-export function writeSecretFile(path: string, data: string | Buffer, opts: { flag?: string } = {}): void {
-  writeFileSync(path, data, opts.flag ? { mode: 0o600, flag: opts.flag } : { mode: 0o600 });
+export function writeSecretFile(path: string, data: string | Buffer): void {
+  writeFileSync(path, data, { mode: 0o600 });
   if (!isWin) return; // POSIX mode set at create — nothing more to do
   try {
     hardenPrivate(path, "file");

--- a/packages/core/src/secret-fs.ts
+++ b/packages/core/src/secret-fs.ts
@@ -59,9 +59,9 @@ export function hardenPrivate(path: string, kind: "file" | "dir"): void {
 
 /**
  * Write a private secret file: the bytes (mode 0o600 at create on POSIX), then {@link hardenPrivate}
- * for the win32 ACL. FAIL-CLOSED — if hardening throws, the just-written file is deleted before the
- * error propagates, so a secret is never left behind with a permissive ACL. `flag` (e.g. `"wx"` for
- * exclusive create) is honored.
+ * for the win32 ACL. FAIL-CLOSED — if hardening throws, the hardening error propagates (the caller
+ * never proceeds as if the secret were safe) and the just-written file is best-effort deleted so it
+ * isn't left readable. `flag` (e.g. `"wx"` for exclusive create) is honored.
  */
 export function writeSecretFile(path: string, data: string | Buffer, opts: { flag?: string } = {}): void {
   writeFileSync(path, data, opts.flag ? { mode: 0o600, flag: opts.flag } : { mode: 0o600 });
@@ -70,9 +70,9 @@ export function writeSecretFile(path: string, data: string | Buffer, opts: { fla
     hardenPrivate(path, "file");
   } catch (e) {
     try {
-      unlinkSync(path);
+      unlinkSync(path); // best-effort cleanup; the hardening error below is what the caller sees
     } catch {
-      /* ignore */
+      /* ignore — surface the original hardening failure, not a secondary unlink error */
     }
     throw e;
   }

--- a/packages/workspace/src/auth-paths.ts
+++ b/packages/workspace/src/auth-paths.ts
@@ -1,6 +1,6 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join, dirname, resolve } from "node:path";
-import type { SpaceAuth } from "@cotal-ai/core";
+import { mkSecretDir, writeSecretFile, type SpaceAuth } from "@cotal-ai/core";
 
 /**
  * On-disk auth-material I/O for a local checkout's `.cotal/` — machine-local path resolution plus
@@ -36,9 +36,9 @@ export function findCotalRoot(start: string = process.cwd()): string {
  *  The system-account `sys.signingSeed` is STRIPPED before writing: it is broker-admin minting capability,
  *  so it never lands on disk (it lives only in the in-memory {@link createSpaceAuth} result). */
 export function saveSpaceAuth(dir: string, auth: SpaceAuth): void {
-  mkdirSync(dir, { recursive: true });
+  mkSecretDir(dir); // harden the auth dir BEFORE the secret lands (private ACL on win32, 0700 POSIX)
   const onDisk: SpaceAuth = { ...auth, sys: { pub: auth.sys.pub, jwt: auth.sys.jwt } };
-  writeFileSync(join(dir, AUTH_FILE), JSON.stringify(onDisk, null, 2), { mode: 0o600 });
+  writeSecretFile(join(dir, AUTH_FILE), JSON.stringify(onDisk, null, 2));
 }
 
 /** Load the space trust material, or undefined if auth was never set up here. */

--- a/packages/workspace/src/mesh-registry.ts
+++ b/packages/workspace/src/mesh-registry.ts
@@ -1,13 +1,7 @@
-import {
-  mkdirSync,
-  readFileSync,
-  readdirSync,
-  renameSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { readFileSync, readdirSync, renameSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { mkSecretDir, writeSecretFile } from "@cotal-ai/core";
 
 /**
  * The registry of running meshes: one record per broker `cotal up` started on this machine, so a
@@ -34,11 +28,16 @@ export interface MeshEntry {
   ts: string;
 }
 
-/** The cotal machine-home dir (`~/.cotal`), overridable via `COTAL_HOME` so tests sandbox it and
- *  never touch the real one. The single source of that path for the registry, the current pointer,
- *  and the onboard marker. */
+/** The cotal machine-home dir, overridable via `COTAL_HOME` so tests sandbox it and never touch the
+ *  real one. POSIX: `~/.cotal`. Windows: `%LOCALAPPDATA%\Cotal` — the platform's place for per-user
+ *  app state (a dotdir in the profile root is a Unix idiom; `%LOCALAPPDATA%` is already a per-user
+ *  private dir, so secrets under it start owner-only). The single source of that path for the
+ *  registry, the current pointer, and the onboard marker. */
 export function homeCotalDir(): string {
-  return process.env.COTAL_HOME ?? join(homedir(), ".cotal");
+  if (process.env.COTAL_HOME) return process.env.COTAL_HOME;
+  if (process.platform === "win32" && process.env.LOCALAPPDATA)
+    return join(process.env.LOCALAPPDATA, "Cotal");
+  return join(homedir(), ".cotal");
 }
 
 /** Directory holding the per-mesh registry files (`~/.cotal/meshes`). */
@@ -56,14 +55,15 @@ function currentFile(): string {
 
 /** Record (or refresh) a running mesh — atomic write, 0600 (the file points at a secrets dir). */
 export function recordMesh(m: MeshEntry): void {
-  // 0700: the filenames in here ARE the space names, so a world-traversable dir would leak them to
-  // other local users even though the file contents are 0600. Keep the dir readable only by us.
-  mkdirSync(meshesDir(), { recursive: true, mode: 0o700 });
+  // The filenames in here ARE the space names, so a world-traversable dir would leak them to other
+  // local users even though the file contents are private. Keep the dir readable only by us
+  // (0700 POSIX / hardened ACL win32).
+  mkSecretDir(meshesDir());
   const file = meshFile(m.space);
   // Per-process temp name so two concurrent `up`s for the same space can't stomp each other's
   // half-written file before the rename.
   const tmp = `${file}.${process.pid}.tmp`;
-  writeFileSync(tmp, JSON.stringify(m, null, 2), { mode: 0o600 });
+  writeSecretFile(tmp, JSON.stringify(m, null, 2)); // hardened before rename; rename preserves the ACL/mode
   renameSync(tmp, file); // atomic replace — a reader never sees a half-written record
 }
 
@@ -108,8 +108,8 @@ export function getCurrent(): string | undefined {
 }
 
 export function setCurrent(space: string): void {
-  mkdirSync(homeCotalDir(), { recursive: true, mode: 0o700 });
-  writeFileSync(currentFile(), space, { mode: 0o600 });
+  mkSecretDir(homeCotalDir());
+  writeSecretFile(currentFile(), space);
 }
 
 export function clearCurrent(): void {


### PR DESCRIPTION
Stage 3 (final) of native Windows support: **secrets-at-rest hardening** + **path/home portability** (WS5). Stacked on Stage 2 (#135) — review the diff against `feat/windows-control-plane`.

## Why
`writeFileSync(…, { mode: 0o600 })` and `mkdirSync(…, { mode: 0o700 })` are a **no-op on Windows** — Node honors only the write bit — so a credential written that way inherits its parent's ACL and can be readable by other local users (e.g. a `.cotal/auth` under a project on a permissive path). Cotal's whole trust model rests on those creds staying private.

## What this does

### Secrets at rest — one no-dep helper, fail-closed
New `packages/core/src/secret-fs.ts` (beside `fs-safe`):
- **`hardenPrivate(path, kind)`** — POSIX: `chmod` (0o600 file / 0o700 dir). win32: harden the NTFS ACL with the built-in **`icacls`** — `/inheritance:r` drops every inherited (broad) ACE, `/grant:r` replaces it with grants for ONLY the owner SID (`whoami /user`), SYSTEM (`S-1-5-18`), and Administrators (`S-1-5-32-544`). Removes broad grants rather than adding deny ACEs (which can catch the owner via group membership); numeric SIDs `*`-prefixed; invoked **shell-free** (arg arrays). **Fail-closed** — any `whoami`/`icacls` failure throws.
- **`writeSecretFile(path, data, {flag?})`** — write (0o600 at create on POSIX) then harden; if hardening throws, the file is **deleted before rethrowing** so a secret is never left readable.
- **`mkSecretDir(path)`** — recursive mkdir + harden; called BEFORE writing secrets into a dir so a child is born under a private ACL (no creation-race).

Wired every credential/auth secret write: space auth (`saveSpaceAuth`), manager + CLI minted creds (`manager.ts`, `spawn`, `mint`, delivery, membership), the mesh registry, and the transient shared-MCP config (claude `extension.ts`). Non-secret writes (manifest ledger, nats pidfile, persona files) are left as-is.

### Paths / home
- `homeCotalDir()` → `%LOCALAPPDATA%\Cotal` on win32 (POSIX `~/.cotal` unchanged; `COTAL_HOME` still wins).
- `globalConfigPath()` → `%APPDATA%\Cotal\config.json` on win32 (`XDG_CONFIG_HOME` still wins).
- `assertValidName` now also rejects `\` (a Windows path separator → traversal); `agentFilePath` treats a `\`-containing arg as a path.

## Tests
New `smoke:secret-fs` (wired into the Windows required CI lane): POSIX asserts the mode bits after write/harden (local regression guard); win32 reads the ACL back with `icacls` and asserts the broad principals (Everyone / Authenticated Users / Users) are **gone** and only owner + SYSTEM + Administrators remain. Local: `typecheck` + `build` clean, `smoke:secret-fs` + full `smoke:ci` green. Windows CI is the oracle for the `icacls` path.

This completes native Windows support: launch (Stage 1) → authenticated control plane + cooperative stop (Stage 2) → secrets/paths (this).
