### PR TITLE
feat(windows): opencode cooperative shutdown + WS4 live-broker cooperative-stop smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,5 +66,14 @@ jobs:
         # @window_id/%pane_id, P3 env -i isolation, attach hints). dist is built by Typecheck above.
         run: pnpm smoke:runtime
 
+      - name: OpenCode cooperative-stop smoke test
+        # The opencode plugin's control-plane cooperative shutdown: a {op:"shutdown"} makes the plugin
+        # leave the mesh (publish offline presence) instead of waiting out the presence TTL. Drives the
+        # real plugin closure (in a subprocess) under Node against a real broker; the real opencode
+        # (Bun) runtime — incl. Bun-on-Windows named pipes — is not in CI yet (no opencode binary here).
+        # (smoke:opencode / turn-wedge is intentionally not wired here — it depends on open-mode stream
+        # auto-setup that is currently broken independent of this change; tracked separately.)
+        run: pnpm smoke:opencode-coop
+
       - name: Verify Claude connector package
         run: pnpm --filter @cotal-ai/connector-claude-code pack --dry-run

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,9 +8,9 @@ name: Windows
 #     env-isolation / view / core-boundary / preflight), the `.cmd` launch matrix (`smoke:windows`,
 #     validated green-in-logs on windows-latest), and the protocol/security suite. Gating: a red here
 #     is a real Windows regression.
-#   • `smoke`    — the live-broker soak (`continue-on-error`): server-resolution + spawn-manifest, each
-#     its own step so one cleanup failure can't mask the next. Genuinely green now, but broker-timing-
-#     dependent — promote into `required` once proven stable across runs.
+#   • `smoke`    — the live-broker soak (`continue-on-error`): server-resolution + spawn-manifest +
+#     cooperative-stop (WS4), each its own step so one cleanup failure can't mask the next. Genuinely
+#     green now, but broker-timing-dependent — promote into `required` once proven stable across runs.
 #     See .internal/plans/windows-native-support.md.
 
 on:
@@ -149,3 +149,10 @@ jobs:
       - name: Live — spawn manifest
         continue-on-error: true
         run: pnpm smoke:spawn-manifest:live
+
+      # WS4: a cooperative graceful stop publishes OFFLINE presence over the named-pipe control plane
+      # (not TTL expiry). node:net abstracts the AF_UNIX socket ↔ Windows named pipe, so the real wire
+      # is exercised here against a live broker.
+      - name: Live — cooperative stop (WS4 offline presence)
+        continue-on-error: true
+        run: pnpm smoke:cooperative-stop:live

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -221,9 +221,13 @@ Code launches `claude`), and the plugin:
   box and the TUI renders it live), acking on `session.idle`. A human watching the TUI sees the
   agent work and can type into the same session.
 
-So it is push-capable, and unlike Claude Code it needs no separate hooks or control socket. The
-plugin holds the mesh connection for the session and closes it in `dispose`. Spawned agents run
-autonomously (`permission: "allow"`). The foreground viewer is swappable: an agent file's
+So it is push-capable, and unlike Claude Code it needs no separate hooks *process* — the plugin
+holds the mesh connection in-process. It does run the same authenticated control endpoint
+([`connector-core/src/control.ts`](../extensions/connector-core/src/control.ts)), but only for the
+manager's cooperative `{op:"shutdown"}` (its hooks are in-process, so there is no hook relay): on a
+graceful stop where the runtime can't deliver a signal (Windows ConPTY), the plugin leaves the mesh
+cleanly — publishing offline presence — instead of lingering until its presence TTL expires. It also
+leaves on OpenCode's own `dispose`. Spawned agents run autonomously (`permission: "allow"`). The foreground viewer is swappable: an agent file's
 optional `face:` id makes the launcher attach an animated avatar viewer to the session instead
 of the chat TUI (`COTAL_FACE_BIN` must point at a face-term-compatible script; it watches the
 same event stream and can still send prompts into the session). A face-hosted agent is also told

--- a/extensions/connector-opencode/smoke/cooperative-stop-probe.ts
+++ b/extensions/connector-opencode/smoke/cooperative-stop-probe.ts
@@ -1,0 +1,24 @@
+/**
+ * Subprocess probe for the opencode cooperative-stop smoke (cooperative-stop.smoke.ts) — never run
+ * standalone. Loads the REAL plugin with a fake opencode client plus the COTAL_* identity + control
+ * env the parent set, so the plugin connects its mesh agent and starts its control server. The parent
+ * then sends an authenticated {op:"shutdown"} to that endpoint; the plugin leaves the mesh (publishes
+ * offline presence) and exits 0 — which the parent asserts. A separate process because the plugin's
+ * cooperative shutdown ends in process.exit, which would otherwise tear down the test itself.
+ */
+import { cotal } from "../src/plugin.js";
+
+// The plugin only calls session.create at boot (to own a session) and session.promptAsync to drive a
+// turn; a shutdown test drives neither a model nor a turn, so a minimal fake satisfies it.
+const fakeClient = {
+  session: {
+    create: async () => ({ data: { id: "ses_coop" } }),
+    promptAsync: async () => ({ data: {} }),
+  },
+};
+
+await cotal({ client: fakeClient } as never);
+
+// The plugin's control server keeps the event loop alive; the authenticated shutdown op calls
+// process.exit(0). Backstop: never linger on CI if the parent dies before driving shutdown.
+setTimeout(() => process.exit(3), 30_000);

--- a/extensions/connector-opencode/smoke/cooperative-stop.smoke.ts
+++ b/extensions/connector-opencode/smoke/cooperative-stop.smoke.ts
@@ -32,7 +32,7 @@ import {
   newIdentity,
   setupSpaceStreams,
 } from "@cotal-ai/core";
-import { controlEndpoint } from "@cotal-ai/connector-core";
+import { opencodeConnector } from "../src/extension.js";
 
 // Fresh random port BELOW the Windows dynamic/ephemeral range (49152–65535) — see WS4 smoke.
 const PORT = 20000 + Math.floor(Math.random() * 20000); // 20000–39999
@@ -137,28 +137,33 @@ try {
   watcher.on("error", (e: Error) => console.error("  ! watcher:", e.message));
   await watcher.start();
 
-  // Mint Otto's control endpoint and write Otto's creds to a file (COTAL_CREDS is a path).
-  const ep = controlEndpoint(space, "Otto");
+  // Write Otto's creds to a file (COTAL_CREDS is a path), then build the launch THROUGH the connector
+  // — so this also guards that buildLaunch attaches the control endpoint to the LaunchSpec + child env
+  // (a regression dropping that wiring fails here instead of passing green on a hand-built env).
   const credsFile = join(dir, "otto.creds");
   writeFileSync(credsFile, ottoCreds);
+  const spec = opencodeConnector.buildLaunch({
+    space,
+    name: "Otto",
+    role: "worker",
+    id: ottoId.id,
+    creds: credsFile,
+    servers: SERVERS,
+    subscribe: ["general"],
+    allowSubscribe: ["general"],
+    allowPublish: ["general"],
+  });
+  check(
+    "buildLaunch attaches the control endpoint to the LaunchSpec + child env",
+    !!spec.control && spec.env?.COTAL_CONTROL_SOCKET === spec.control.path && spec.env?.COTAL_CONTROL_TOKEN === spec.control.token,
+    spec.control,
+  );
+  const ep = spec.control!;
 
-  // Boot the REAL plugin in a subprocess with Otto's identity + the control endpoint.
+  // Boot the REAL plugin in a subprocess with the connector-built env (Otto's identity + control).
   const PROBE = fileURLToPath(new URL("./cooperative-stop-probe.ts", import.meta.url));
   probe = spawn(process.execPath, ["--import", "tsx", PROBE], {
-    env: {
-      ...process.env,
-      COTAL_NAME: "Otto",
-      COTAL_ID: ottoId.id,
-      COTAL_ROLE: "worker",
-      COTAL_SPACE: space,
-      COTAL_SERVERS: SERVERS,
-      COTAL_CREDS: credsFile,
-      COTAL_SUBSCRIBE: "general",
-      COTAL_ALLOW_SUBSCRIBE: "general",
-      COTAL_ALLOW_PUBLISH: "general",
-      COTAL_CONTROL_SOCKET: ep.path,
-      COTAL_CONTROL_TOKEN: ep.token,
-    },
+    env: { ...process.env, ...spec.env },
     stdio: ["ignore", "inherit", "inherit"],
   });
   let probeExit: number | null = null;

--- a/extensions/connector-opencode/smoke/cooperative-stop.smoke.ts
+++ b/extensions/connector-opencode/smoke/cooperative-stop.smoke.ts
@@ -1,0 +1,212 @@
+/**
+ * OpenCode cooperative-stop smoke (no test runner) — run with: pnpm smoke:opencode-coop
+ *
+ * Proves the opencode connector's control plane (extension.ts mints the endpoint + the plugin starts
+ * the control server) leaves the mesh CLEANLY on a cooperative shutdown — the same {op:"shutdown"}
+ * the manager sends on a signal-less runtime (ConPTY/Windows), instead of leaving the agent online
+ * until its presence TTL expires. The real path, end to end:
+ *
+ *   parent sends {token,op:"shutdown"}  →  the plugin's startControlServer first-frame auth
+ *     →  onShutdown  →  agent.stop()  →  offline presence published  →  the plugin process exits 0.
+ *
+ * The plugin runs in a SUBPROCESS (cooperative-stop-probe.ts) because its cooperative shutdown ends in
+ * process.exit; the parent provisions a real JWT-auth broker + scoped creds, watches presence, drives
+ * the shutdown, and asserts both the offline flip AND a clean exit(0). Bun-on-Windows named pipes for
+ * the real opencode runtime are the one piece this can't reach (no opencode-in-Windows-CI yet); this
+ * runs under Node where node:net abstracts the socket, so it guards the wiring + the agent.stop path.
+ */
+import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
+import { connect } from "node:net";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  CotalEndpoint,
+  isReachable,
+  createSpaceAuth,
+  mintCreds,
+  provisionAgent,
+  serverConfig,
+  newIdentity,
+  setupSpaceStreams,
+} from "@cotal-ai/core";
+import { controlEndpoint } from "@cotal-ai/connector-core";
+
+// Fresh random port BELOW the Windows dynamic/ephemeral range (49152–65535) — see WS4 smoke.
+const PORT = 20000 + Math.floor(Math.random() * 20000); // 20000–39999
+const SERVERS = `nats://127.0.0.1:${PORT}`;
+const wait = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+const awaitExit = (proc: ReturnType<typeof spawn>, timeoutMs = 3000): Promise<void> =>
+  new Promise((resolve) => {
+    if (proc.exitCode !== null || proc.signalCode !== null) return resolve();
+    proc.once("exit", () => resolve());
+    setTimeout(resolve, timeoutMs);
+  });
+let pass = 0;
+let fail = 0;
+const check = (name: string, cond: boolean, extra?: unknown): void => {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    fail++;
+    console.log(`  ✗ FAIL: ${name}`, extra ?? "");
+  }
+};
+
+// Send the manager's cooperative-shutdown frame to a control endpoint and return its reply.
+function sendShutdown(path: string, token: string): Promise<string> {
+  return new Promise((resolve) => {
+    const sock = connect(path);
+    let reply = "";
+    let done = false;
+    const finish = (): void => {
+      if (done) return;
+      done = true;
+      try {
+        sock.destroy();
+      } catch {
+        /* ignore */
+      }
+      resolve(reply);
+    };
+    sock.setEncoding("utf8");
+    sock.on("connect", () => sock.write(JSON.stringify({ token, op: "shutdown" }) + "\n"));
+    sock.on("data", (d) => (reply += d));
+    sock.on("end", finish);
+    sock.on("close", finish);
+    sock.on("error", finish);
+    setTimeout(finish, 2000);
+  });
+}
+
+const space = `oc-coop-${randomUUID().slice(0, 8)}`;
+const auth = await createSpaceAuth(space);
+const dir = mkdtempSync(join(tmpdir(), "cotal-oc-coop-"));
+writeFileSync(join(dir, "server.conf"), serverConfig(auth, { port: PORT, storeDir: join(dir, "js") }));
+const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+
+let mgr: CotalEndpoint | undefined;
+let watcher: CotalEndpoint | undefined;
+let probe: ReturnType<typeof spawn> | undefined;
+
+try {
+  let up = false;
+  for (let i = 0; i < 50; i++) {
+    if (await isReachable(SERVERS)) {
+      up = true;
+      break;
+    }
+    await wait(200);
+  }
+  if (!up) throw new Error(`auth nats-server did not come up on ${PORT}`);
+
+  const mgrCreds = await mintCreds(auth, newIdentity(), "manager");
+  await setupSpaceStreams({ servers: SERVERS, space, creds: mgrCreds });
+  mgr = new CotalEndpoint({
+    space,
+    servers: SERVERS,
+    creds: mgrCreds,
+    card: { name: "mgr", kind: "endpoint" },
+    consume: false,
+    registerPresence: false,
+    watchPresence: false,
+    heartbeatMs: 300,
+    ttlMs: 1500,
+  });
+  await mgr.start();
+
+  const acl = { subscribe: ["general"], allowSubscribe: ["general"], allowPublish: ["general"] };
+  const ottoId = newIdentity();
+  const watchId = newIdentity();
+  const ottoCreds = await provisionAgent(mgr, auth, ottoId, { ...acl, role: "worker" });
+  const watchCreds = await provisionAgent(mgr, auth, watchId, { ...acl, role: "watcher" });
+
+  // The watcher endpoint observes Otto's presence (the proof of a clean leave).
+  watcher = new CotalEndpoint({
+    space,
+    servers: SERVERS,
+    creds: watchCreds,
+    card: { id: watchId.id, name: "watch", role: "watcher", kind: "agent" },
+    channels: ["general"],
+    heartbeatMs: 500,
+    ttlMs: 30_000,
+  });
+  watcher.on("error", (e: Error) => console.error("  ! watcher:", e.message));
+  await watcher.start();
+
+  // Mint Otto's control endpoint and write Otto's creds to a file (COTAL_CREDS is a path).
+  const ep = controlEndpoint(space, "Otto");
+  const credsFile = join(dir, "otto.creds");
+  writeFileSync(credsFile, ottoCreds);
+
+  // Boot the REAL plugin in a subprocess with Otto's identity + the control endpoint.
+  const PROBE = fileURLToPath(new URL("./cooperative-stop-probe.ts", import.meta.url));
+  probe = spawn(process.execPath, ["--import", "tsx", PROBE], {
+    env: {
+      ...process.env,
+      COTAL_NAME: "Otto",
+      COTAL_ID: ottoId.id,
+      COTAL_ROLE: "worker",
+      COTAL_SPACE: space,
+      COTAL_SERVERS: SERVERS,
+      COTAL_CREDS: credsFile,
+      COTAL_SUBSCRIBE: "general",
+      COTAL_ALLOW_SUBSCRIBE: "general",
+      COTAL_ALLOW_PUBLISH: "general",
+      COTAL_CONTROL_SOCKET: ep.path,
+      COTAL_CONTROL_TOKEN: ep.token,
+    },
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+  let probeExit: number | null = null;
+  probe.on("exit", (code) => (probeExit = code ?? -1));
+
+  // Wait for the plugin's mesh agent to come online (Otto live in the watcher's roster).
+  let ottoLive = false;
+  for (let i = 0; i < 100 && !ottoLive; i++) {
+    await wait(100);
+    const otto = watcher.getRoster().find((p) => p.card.name === "Otto");
+    ottoLive = otto !== undefined && otto.status !== "offline";
+  }
+  check("the opencode plugin came online (Otto live in the watcher roster)", ottoLive);
+
+  // Drive the cooperative shutdown — exactly what the manager sends on a win32 graceful stop.
+  const reply = await sendShutdown(ep.path, ep.token);
+  check("control server acked the shutdown", reply.trim() === JSON.stringify({ ok: true }), reply);
+
+  // The plugin leaves the mesh cleanly: Otto flips offline, and the probe exits 0.
+  let ottoOffline = false;
+  for (let i = 0; i < 60 && !ottoOffline; i++) {
+    await wait(100);
+    ottoOffline = watcher.getRoster().find((p) => p.card.name === "Otto")?.status === "offline";
+  }
+  check("cooperative stop leaves the mesh (watcher sees Otto offline)", ottoOffline, watcher.getRoster().find((p) => p.card.name === "Otto")?.status);
+
+  await awaitExit(probe, 5000);
+  check("the plugin process exited cleanly (0) on cooperative shutdown", probeExit === 0, probeExit);
+} catch (e) {
+  fail++;
+  console.error("  ✗ scenario threw:", (e as Error).message);
+} finally {
+  try {
+    if (probe && probe.exitCode === null) probe.kill("SIGKILL");
+  } catch {
+    /* ignore */
+  }
+  for (const ep of [watcher, mgr]) {
+    try {
+      await ep?.stop();
+    } catch {
+      /* already down */
+    }
+  }
+  srv.kill("SIGKILL");
+  await awaitExit(srv);
+  rmSync(dir, { recursive: true, force: true });
+}
+
+console.log(`\n${fail === 0 ? "OPENCODE COOPERATIVE-STOP SMOKE OK ✅" : "OPENCODE COOPERATIVE-STOP SMOKE FAILED ❌"}  (${pass} passed, ${fail} failed)`);
+process.exit(fail === 0 ? 0 : 1);

--- a/extensions/connector-opencode/src/extension.ts
+++ b/extensions/connector-opencode/src/extension.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from "node:url";
 import { resolve } from "node:path";
 import { loadAgentFile, registry, type Connector, type LaunchOpts, type LaunchSpec } from "@cotal-ai/core";
-import { aclEnv, launchEnv, MODEL_PROVIDER_KEYS } from "@cotal-ai/connector-core";
+import { aclEnv, launchEnv, controlEndpoint, MODEL_PROVIDER_KEYS } from "@cotal-ai/connector-core";
 
 /** The bundled in-process plugin (esbuild → `dist/plugin.bundle.js`). `opencode serve` loads it by
  *  absolute path from the inline config, so it runs *inside* the server and shares its SDK client.
@@ -108,11 +108,22 @@ export const opencodeConnector: Connector = {
 
     env.OPENCODE_CONFIG_CONTENT = JSON.stringify(config);
 
+    // Local control endpoint: the manager sends a cooperative {op:"shutdown"} here on a signal-less
+    // runtime (ConPTY/Windows), where a hard kill skips cleanup and the agent lingers until its
+    // presence TTL expires. The plugin (in the opencode server process) starts the control server and
+    // leaves the mesh cleanly on shutdown. Minted here; passed to the plugin in the child env (the
+    // token never on argv/logs) — opencode serve inherits this process env, the attached TUI strips
+    // COTAL_*. Returned in the LaunchSpec so the manager holds it in memory to drive the stop.
+    const control = controlEndpoint(opts.space, opts.name);
+    env.COTAL_CONTROL_SOCKET = control.path;
+    env.COTAL_CONTROL_TOKEN = control.token;
+
     // Run the shim (node dist/serve.js): `opencode serve` + an attached foreground TUI.
     return {
       command: process.execPath,
       args: [SERVE_SHIM],
       env,
+      control,
     };
   },
 };

--- a/extensions/connector-opencode/src/plugin.ts
+++ b/extensions/connector-opencode/src/plugin.ts
@@ -23,6 +23,7 @@ import {
   configFromEnv,
   hasIdentity,
   MeshAgent,
+  startControlServer,
   formatInjection,
   fmtFrom,
   ORIENTATION_BOOTSTRAP,
@@ -93,6 +94,42 @@ export const cotal: Plugin = async ({ client }) => {
       /* presence is best-effort — never throw into opencode */
     }
   };
+
+  // Cooperative shutdown. The manager sends an authenticated {op:"shutdown"} to this agent's local
+  // control endpoint on a signal-less runtime (ConPTY/Windows), where a hard kill would skip cleanup
+  // and leave the agent online until its presence TTL expires. We leave the mesh cleanly instead, then
+  // exit (the runtime hard-kills as a backstop). The endpoint (path + token) is minted by the
+  // connector's buildLaunch and arrives in the child env; the plugin runs inside the opencode server
+  // process, so it reads it there. Hooks are in-process (no external relay connects), so only the
+  // shutdown op is used — the handle path is inert. fatalBind: a managed agent MUST own its control
+  // endpoint, so a squatter (or a runtime that can't host the pipe) fails loud rather than running a
+  // hijacked or absent control plane.
+  let controlServer: ReturnType<typeof startControlServer> | undefined;
+  const shutdown = async (): Promise<void> => {
+    try {
+      controlServer?.close();
+    } catch {
+      /* ignore */
+    }
+    try {
+      await safeStatus("offline");
+      await agent.stop();
+    } finally {
+      process.exit(0);
+    }
+  };
+  const controlPath = process.env.COTAL_CONTROL_SOCKET?.trim();
+  const controlToken = process.env.COTAL_CONTROL_TOKEN?.trim();
+  if (controlPath && controlToken) {
+    const handle = async (): Promise<Record<string, unknown>> => ({
+      ok: false,
+      error: "opencode runs cotal hooks in-process; only the shutdown control op is supported",
+    });
+    controlServer = startControlServer(agent, { path: controlPath, token: controlToken }, handle, {
+      fatalBind: true,
+      onShutdown: () => void shutdown(),
+    });
+  }
 
   function pendingForWake(): number {
     return agent.pendingWake(); // mode-and-channel-aware: excludes held dnd/quiet ambient
@@ -312,6 +349,11 @@ export const cotal: Plugin = async ({ client }) => {
     },
 
     dispose: async () => {
+      try {
+        controlServer?.close();
+      } catch {
+        /* ignore */
+      }
       await safeStatus("offline");
       await agent.stop();
     },

--- a/implementations/manager/smoke/cooperative-stop-live.smoke.ts
+++ b/implementations/manager/smoke/cooperative-stop-live.smoke.ts
@@ -1,0 +1,188 @@
+/**
+ * Cooperative-stop live-broker smoke (no test runner) — run with: pnpm smoke:cooperative-stop:live
+ *
+ * WS4 end-to-end: proves the manager's cooperative shutdown actually publishes OFFLINE presence — the
+ * clean mesh-leave a signal-less runtime (ConPTY/Windows) would otherwise miss, leaving peers to wait
+ * out the presence TTL. The Windows seam smoke (windows-launch.smoke.ts §F6) only round-trips the
+ * shutdown FRAME against a stub; this drives the REAL path against a REAL JWT-auth broker:
+ *
+ *   manager controlShutdown(endpoint)  →  startControlServer first-frame auth  →  onShutdown
+ *     →  agent.stop()  →  endpoint publishes status:"offline" to the presence KV  →  a watcher sees it.
+ *
+ * The stopped agent carries a LONG presence TTL (30s) and we assert the watcher sees it offline within
+ * ~1.5s — far under that TTL — so the flip can only be the cooperative leave, never TTL expiry (the
+ * whole point of WS4). `node:net` abstracts the AF_UNIX socket ↔ Windows named pipe, so the control
+ * wire exercises identically here; this runs everywhere a broker is on PATH (CI's soak lane is the
+ * Windows oracle). The `agent` arg to startControlServer is a stub: the shutdown op never touches it
+ * (it routes straight to onShutdown), exactly as §F6 does.
+ */
+import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CotalEndpoint,
+  isReachable,
+  createSpaceAuth,
+  mintCreds,
+  provisionAgent,
+  serverConfig,
+  newIdentity,
+  setupSpaceStreams,
+} from "@cotal-ai/core";
+import { controlEndpoint, startControlServer, type MeshAgent } from "@cotal-ai/connector-core";
+import { controlShutdown } from "../src/control-shutdown.js";
+
+// A fresh random port BELOW the Windows dynamic/ephemeral range (49152–65535): a port the OS may have
+// already reserved makes nats-server fail to bind and the wait below time out as a phantom flake.
+const PORT = 20000 + Math.floor(Math.random() * 20000); // 20000–39999
+const SERVERS = `nats://127.0.0.1:${PORT}`;
+const wait = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+const awaitExit = (proc: ReturnType<typeof spawn>, timeoutMs = 3000): Promise<void> =>
+  new Promise((resolve) => {
+    if (proc.exitCode !== null || proc.signalCode !== null) return resolve();
+    proc.once("exit", () => resolve());
+    setTimeout(resolve, timeoutMs);
+  });
+let pass = 0;
+let fail = 0;
+const check = (name: string, cond: boolean, extra?: unknown): void => {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    fail++;
+    console.log(`  ✗ FAIL: ${name}`, extra ?? "");
+  }
+};
+
+const space = `coopstop-${randomUUID().slice(0, 8)}`;
+const auth = await createSpaceAuth(space);
+const dir = mkdtempSync(join(tmpdir(), "cotal-coopstop-"));
+writeFileSync(join(dir, "server.conf"), serverConfig(auth, { port: PORT, storeDir: join(dir, "js") }));
+const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+
+// Built outside try so finally can tear them down even if a mid-scenario assertion throws.
+let alice: CotalEndpoint | undefined;
+let bob: CotalEndpoint | undefined;
+let mgr: CotalEndpoint | undefined;
+let server: ReturnType<typeof startControlServer> | undefined;
+
+try {
+  let up = false;
+  for (let i = 0; i < 50; i++) {
+    if (await isReachable(SERVERS)) {
+      up = true;
+      break;
+    }
+    await wait(200);
+  }
+  if (!up) throw new Error(`auth nats-server did not come up on ${PORT}`);
+
+  // Privileged setup (manager profile: allow-all) — provisions the peers, exactly as a launcher would.
+  const mgrCreds = await mintCreds(auth, newIdentity(), "manager");
+  await setupSpaceStreams({ servers: SERVERS, space, creds: mgrCreds });
+  mgr = new CotalEndpoint({
+    space,
+    servers: SERVERS,
+    creds: mgrCreds,
+    card: { name: "mgr", kind: "endpoint" },
+    consume: false,
+    registerPresence: false,
+    watchPresence: false,
+    heartbeatMs: 300,
+    ttlMs: 1500,
+  });
+  await mgr.start();
+
+  const aliceId = newIdentity();
+  const bobId = newIdentity();
+  const acl = { subscribe: ["general"], allowSubscribe: ["general"], allowPublish: ["general"] };
+  const aliceCreds = await provisionAgent(mgr, auth, aliceId, { ...acl, role: "worker" });
+  const bobCreds = await provisionAgent(mgr, auth, bobId, { ...acl, role: "watcher" });
+
+  // alice is the agent we cooperatively stop. A LONG ttl (30s) so an offline flip within the assert
+  // window can ONLY be the cooperative leave, never TTL expiry.
+  alice = new CotalEndpoint({
+    space,
+    servers: SERVERS,
+    creds: aliceCreds,
+    card: { id: aliceId.id, name: "alice", role: "worker", kind: "agent" },
+    channels: ["general"],
+    heartbeatMs: 500,
+    ttlMs: 30_000,
+  });
+  // bob watches alice's presence.
+  bob = new CotalEndpoint({
+    space,
+    servers: SERVERS,
+    creds: bobCreds,
+    card: { id: bobId.id, name: "bob", role: "watcher", kind: "agent" },
+    channels: ["general"],
+    heartbeatMs: 500,
+    ttlMs: 30_000,
+  });
+  alice.on("error", (e: Error) => console.error("  ! alice:", e.message));
+  bob.on("error", (e: Error) => console.error("  ! bob:", e.message));
+  await alice.start();
+  await bob.start();
+  await wait(800);
+
+  // bob sees alice as a live peer (not offline) before the stop — the baseline.
+  const aliceLive = bob.getRoster().find((p) => p.card.name === "alice");
+  check("baseline: bob sees alice live", aliceLive !== undefined && aliceLive.status !== "offline", aliceLive?.status);
+
+  // Stand up alice's REAL control server. onShutdown does what the Claude Code connector's shutdown
+  // closure does — close the server, then agent.stop() (the offline-presence publish) — minus the
+  // process.exit (this test process lives on to observe the result).
+  const ep = controlEndpoint(space, "alice");
+  let onShutdownFired = false;
+  const stubAgent = {} as unknown as MeshAgent;
+  const handle = async (): Promise<Record<string, unknown>> => ({ ok: true });
+  server = startControlServer(stubAgent, ep, handle, {
+    onShutdown: () => {
+      onShutdownFired = true;
+      void alice!.stop(); // the real clean-leave: status:"offline" → presence KV
+    },
+  });
+  await new Promise<void>((resolve) => {
+    server!.on("listening", () => resolve());
+    setTimeout(resolve, 500); // backstop — listen fires next tick; we attach before it
+  });
+
+  // Fire the manager's REAL cooperative-shutdown client (the win32 graceful-stop path).
+  controlShutdown(ep);
+
+  // Wait for bob to observe alice offline — polled, well under alice's 30s TTL.
+  let aliceOffline = false;
+  for (let i = 0; i < 30 && !aliceOffline; i++) {
+    await wait(50);
+    aliceOffline = bob.getRoster().find((p) => p.card.name === "alice")?.status === "offline";
+  }
+
+  check("controlShutdown reached the control server's onShutdown", onShutdownFired);
+  check("cooperative stop publishes OFFLINE presence (bob sees alice offline, ≪ TTL)", aliceOffline, bob.getRoster().find((p) => p.card.name === "alice")?.status);
+} catch (e) {
+  fail++;
+  console.error("  ✗ scenario threw:", (e as Error).message);
+} finally {
+  try {
+    server?.close();
+  } catch {
+    /* ignore */
+  }
+  for (const ep of [alice, bob, mgr]) {
+    try {
+      await ep?.stop();
+    } catch {
+      /* already down */
+    }
+  }
+  srv.kill("SIGKILL");
+  await awaitExit(srv); // await actual exit so a failed run never leaks the broker onto its port
+  rmSync(dir, { recursive: true, force: true });
+}
+
+console.log(`\n${fail === 0 ? "COOPERATIVE-STOP SMOKE OK ✅" : "COOPERATIVE-STOP SMOKE FAILED ❌"}  (${pass} passed, ${fail} failed)`);
+process.exit(fail === 0 ? 0 : 1);

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "smoke:cross-path-dedup": "tsx extensions/connector-core/smoke/cross-path-dedup.smoke.ts",
     "smoke:feedback": "tsx extensions/connector-core/smoke/feedback.smoke.ts",
     "smoke:opencode": "tsx extensions/connector-opencode/smoke/turn-wedge.smoke.ts",
+    "smoke:opencode-coop": "tsx extensions/connector-opencode/smoke/cooperative-stop.smoke.ts",
     "smoke:attach": "tsx implementations/manager/smoke/attach.smoke.ts",
     "smoke:windows": "tsx implementations/manager/smoke/windows-launch.smoke.ts",
     "smoke:secret-fs": "tsx packages/core/smoke/secret-fs.smoke.ts",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "smoke:core-boundary": "tsx packages/core/smoke/core-boundary.smoke.ts",
     "smoke:preflight": "tsx packages/workspace/smoke/preflight.smoke.ts",
     "smoke:server-resolution:live": "tsx implementations/manager/smoke/server-resolution-live.smoke.ts",
+    "smoke:cooperative-stop:live": "tsx implementations/manager/smoke/cooperative-stop-live.smoke.ts",
     "smoke:spawn-args": "tsx extensions/connector-core/smoke/spawn-args.smoke.ts",
     "smoke:install": "tsx implementations/cli/smoke/install.smoke.ts",
     "smoke:send": "tsx implementations/cli/smoke/send.smoke.ts",

--- a/packages/core/src/connector.ts
+++ b/packages/core/src/connector.ts
@@ -67,8 +67,9 @@ export interface LaunchSpec {
    *  the child env as `COTAL_CONTROL_SOCKET`/`COTAL_CONTROL_TOKEN`), plus the first-frame `token`
    *  that authenticates it. The connector mints it in `buildLaunch`; the manager keeps it IN MEMORY
    *  (never persisted — token hygiene) to send a cooperative `{op:"shutdown"}` on a runtime that
-   *  can't deliver a clean exit signal (ConPTY/Windows). Absent for connectors with no control
-   *  plane (OpenCode is in-process). */
+   *  can't deliver a clean exit signal (ConPTY/Windows). Both the Claude Code (MCP server) and
+   *  OpenCode (in-process plugin) connectors mint one; absent only for a connector with no control
+   *  plane at all. */
   control?: { path: string; token: string };
 }
 


### PR DESCRIPTION
Two Windows control-plane follow-ups deferred from the native-Windows work (Stages 2–3, #135/#136, now merged).

## 1. `feat(opencode)`: cooperative shutdown via an authenticated control endpoint

OpenCode had no control plane (its hooks run in-process), so a graceful stop on a signal-less runtime (ConPTY/Windows) left the agent online until its presence TTL expired instead of leaving the mesh cleanly. It now gets the **same authenticated control endpoint Claude Code uses**:

- `buildLaunch` mints the endpoint and passes it in the child env (token never on argv/logs).
- The plugin (inside `opencode serve`) starts the control server and, on the manager's cooperative `{op:"shutdown"}`, publishes offline presence + leaves the mesh, then exits (the runtime hard-kills as a backstop).
- The manager **auto-wires** it — it already sends `controlShutdown` on a win32 graceful stop for any agent whose `LaunchSpec` carries a control endpoint. No manager change.
- **`fatalBind: true`** (chosen posture): a managed agent must own its control endpoint, so a squatter — or a runtime that can't host the pipe — fails loud rather than running a hijacked/absent plane. Only the shutdown op is used (hooks are in-process → no hook relay).

### Why this design (evidence-based)
opencode's own `dispose` teardown is unreliable — it runs plugins in a worker torn down with `worker.terminate()` ([sst/opencode#31301](https://github.com/sst/opencode/issues/31301)) — so the clean-leave is driven **explicitly**, not through opencode's lifecycle. Bun's `node:net` named-pipe support (server **and** client) has shipped since **v1.1.28** (Sept 2024), and the Node-side control plane is already win32-CI-proven (`windows-launch.smoke` §F/G).

### Validation
- New `smoke:opencode-coop`: a subprocess-hosted **closure smoke** — the real plugin connects to a live broker, the control server acks `{op:"shutdown"}`, the agent flips **offline**, and the process exits 0. Wired into **ubuntu CI**.
- Verified locally against the **real Bun runtime** (bun 1.3.14, the production runtime — unix socket on macOS): plugin online → control server acks → mesh leave → exit 0. ✅
- **Residual (flagged):** the real opencode **binary on Windows** isn't a project dependency and isn't in CI, so Bun-on-Windows named pipes inside opencode's plugin worker have no CI oracle yet. With `fatalBind`, if that ever fails it fails loud (per the chosen strict posture).

## 2. `test(windows)`: WS4 live-broker cooperative-stop offline-presence smoke

The Windows seam smoke (`windows-launch.smoke` §F6) only round-trips the shutdown **frame** against a stub — it never proves the agent actually leaves the mesh. New `smoke:cooperative-stop:live` drives the real path against a real JWT-auth broker:

`manager controlShutdown → first-frame auth → onShutdown → agent.stop() → offline presence published → a watching endpoint observes it`

The stopped agent carries a **30 s** presence TTL and the watcher must see it offline within ~1.5 s — so the flip can only be the cooperative leave, never TTL expiry (the point of WS4). Added to the Windows **soak** lane (`continue-on-error`) alongside the other live smokes.

## Notes
- Ports in the new live smokes are picked **below the Windows ephemeral range (49152–65535)** to avoid the bind-collision phantom flake.
- **Pre-existing, unrelated:** `smoke:opencode` (turn-wedge) fails locally on Node 26 / nats 2.14 (its open-mode stream auto-setup, independent of this change) — so it is **not** wired into CI here; only the auth-mode cooperative-stop smoke is. Worth tracking separately.

Both commits typecheck + build clean.
