### PR TITLE
fix(runtime): keep agent secrets off tmux argv + out of a world-readable cmux script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,14 @@ jobs:
       - name: Runtime smoke tests (tmux)
         # Exercises the tmux Runtime + TerminalLayout end to end (driver, lifecycle by stable
         # @window_id/%pane_id, P3 env -i isolation, attach hints). dist is built by Typecheck above.
+        # Includes the privateLaunch no-leak guard: a live pane's command carries no env secret.
         run: pnpm smoke:runtime
+
+      - name: cmux launcher secret-hygiene smoke
+        # The cmux pane launcher writes the agent's env (creds + control token) to a 0o600 file in a
+        # 0o700 dir, never a world-readable /tmp script or the returned command line. Exercises
+        # paneCommand directly (no cmux CLI needed), so it runs here.
+        run: pnpm smoke:cmux
 
       - name: OpenCode cooperative-stop smoke test
         # The opencode plugin's control-plane cooperative shutdown: a {op:"shutdown"} makes the plugin

--- a/extensions/cmux/smoke.ts
+++ b/extensions/cmux/smoke.ts
@@ -1,0 +1,45 @@
+/**
+ * Security smoke for @cotal-ai/cmux — proves the pane launcher never exposes the agent's env secrets:
+ * the script is written 0o600 inside a fresh 0o700 dir (not a world-readable /tmp file at a
+ * predictable path), and the secret env VALUES live only in that owner-only file, never in the
+ * returned `bash <path>` command. Exercises paneCommand directly, so it needs no cmux CLI and runs in
+ * CI. Run: pnpm smoke:cmux
+ */
+import { rmSync, readFileSync, statSync } from "node:fs";
+import { dirname } from "node:path";
+import { paneCommand } from "./src/runtime.js";
+
+let passed = 0;
+let failed = 0;
+function ok(label: string, val: unknown): void {
+  if (val) {
+    console.log(`  ✓ ${label}`);
+    passed++;
+  } else {
+    console.error(`  ✗ FAIL: ${label}`);
+    failed++;
+  }
+}
+
+const SECRET = "leak-canary-cmux-DO-NOT-LEAK";
+const cmd = paneCommand(
+  { command: "/bin/echo", args: ["hi"], env: { COTAL_CONTROL_TOKEN: SECRET }, cwd: "/tmp" },
+  false,
+  true, // isolate (P3): the agent gets ONLY the connector-declared env
+);
+
+ok("paneCommand returns a `bash <path>` invocation", /^bash '\/.*\/launch\.sh'$/.test(cmd));
+const scriptPath = cmd.replace(/^bash\s+(?:-l\s+)?'|'$/g, "");
+ok("launcher script is 0o600 (owner-only, never world-readable)", (statSync(scriptPath).mode & 0o777) === 0o600);
+ok("launcher dir is 0o700 (owner-only)", (statSync(dirname(scriptPath)).mode & 0o777) === 0o700);
+ok("returned command does NOT contain the secret (no argv leak)", !cmd.includes(SECRET));
+ok("secret lives in the launcher script (read from the file, not the command line)", readFileSync(scriptPath, "utf8").includes(SECRET));
+
+try {
+  rmSync(dirname(scriptPath), { recursive: true, force: true });
+} catch {
+  /* best-effort cleanup */
+}
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+if (failed > 0) process.exit(1);

--- a/extensions/cmux/src/runtime.ts
+++ b/extensions/cmux/src/runtime.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -34,15 +34,19 @@ function shellQuote(s: string): string {
  *  assignments, so `env` applies them and then execs the command. `isolate` (agent-spawn panes)
  *  adds `-i` so the pane inherits ONLY the connector-declared env, not the cmux server's (P3 — the
  *  operator's unrelated secrets don't reach a spawned agent); setup panes keep the inherited env. */
-function paneCommand(pane: Pane, key: string, login: boolean, isolate = false): string {
+function paneCommand(pane: Pane, login: boolean, isolate = false): string {
   const env = Object.entries(pane.env ?? {}).map(([k, v]) => `${k}=${shellQuote(v)}`);
   const cmd = [...env, shellQuote(pane.command), ...(pane.args ?? []).map(shellQuote)].join(" ");
   const cd = pane.cwd ? `cd ${shellQuote(pane.cwd)}\n` : "";
   const confirm = pane.confirm ? `${ENTER_LOOP}\n` : "";
   const script = `#!/usr/bin/env bash\n${cd}${confirm}exec env ${isolate ? "-i " : ""}${cmd}\n`;
-  const scriptPath = join(tmpdir(), `cotal-pane-${key.replace(/[^A-Za-z0-9_.-]/g, "_")}.sh`);
-  writeFileSync(scriptPath, script, { mode: 0o755 });
-  return `bash ${login ? "-l " : ""}${scriptPath}`;
+  // The script holds the pane's env inline (the agent's creds + control token, and any provider key).
+  // Write it into a fresh 0o700 temp dir as a 0o600 file: never a world-readable script, and never a
+  // predictable, symlink-attackable /tmp path. cmux runs it as the same user via `bash <path>`.
+  const dir = mkdtempSync(join(tmpdir(), "cotal-pane-"));
+  const scriptPath = join(dir, "launch.sh");
+  writeFileSync(scriptPath, script, { mode: 0o600 });
+  return `bash ${login ? "-l " : ""}${shellQuote(scriptPath)}`;
 }
 
 /** A single-terminal pane node in cmux's layout JSON. */
@@ -54,7 +58,7 @@ function surface(command: string): unknown {
  *  knows cmux's layout shape. One pane → a bare terminal; several → a split (`direction` + `split`
  *  ratio). These panes run under a login shell. */
 function cmuxLayout(label: string, tab: Tab): string {
-  const nodes = tab.panes.map((p, i) => surface(paneCommand(p, `${label}-${i}`, true)));
+  const nodes = tab.panes.map((p) => surface(paneCommand(p, true)));
   if (nodes.length === 1 && !tab.split) return JSON.stringify(nodes[0]);
   if (!tab.split)
     throw new Error(`cmux layout "${label}": ${nodes.length} panes need a split (direction + ratio)`);
@@ -86,7 +90,6 @@ export class CmuxRuntime implements Runtime {
     // tab's own surface — so a spawned teammate joins the mesh without anyone switching to its tab.
     const command = paneCommand(
       { command: spec.command, args: spec.args, env: spec.env, cwd, confirm: Boolean(spec.confirm) },
-      `spawn-${name}`,
       false,
       true, // isolate: spawned agent gets ONLY the connector-declared env (P3)
     );

--- a/extensions/cmux/src/runtime.ts
+++ b/extensions/cmux/src/runtime.ts
@@ -34,7 +34,7 @@ function shellQuote(s: string): string {
  *  assignments, so `env` applies them and then execs the command. `isolate` (agent-spawn panes)
  *  adds `-i` so the pane inherits ONLY the connector-declared env, not the cmux server's (P3 — the
  *  operator's unrelated secrets don't reach a spawned agent); setup panes keep the inherited env. */
-function paneCommand(pane: Pane, login: boolean, isolate = false): string {
+export function paneCommand(pane: Pane, login: boolean, isolate = false): string {
   const env = Object.entries(pane.env ?? {}).map(([k, v]) => `${k}=${shellQuote(v)}`);
   const cmd = [...env, shellQuote(pane.command), ...(pane.args ?? []).map(shellQuote)].join(" ");
   const cd = pane.cwd ? `cd ${shellQuote(pane.cwd)}\n` : "";

--- a/extensions/tmux/smoke.ts
+++ b/extensions/tmux/smoke.ts
@@ -125,15 +125,27 @@ ok("layout window closes by stable id", !tmux.windowAliveRef(lay.windowId));
 console.log("\n── runtime ─────────────────────────────────────");
 
 const runtime = new TmuxRuntime(SESSION);
+const SECRET_CANARY = "leak-canary-tmux-DO-NOT-LEAK";
 const handle = runtime.spawn("smoke-agent", {
   command: "sleep",
   args: ["30"],
-  env: { TEST_VAR: "hello" },
+  env: { TEST_VAR: "hello", COTAL_CONTROL_TOKEN: SECRET_CANARY },
 }, "/tmp");
 ok(`handle.name = "smoke-agent"`, handle.name === "smoke-agent");
 ok(`handle.kind = "tmux"`, handle.kind === "tmux");
 ok("handle.status() = running", handle.status() === "running");
 ok("window alive after spawn", tmux.windowAlive(SESSION, "smoke-agent"));
+
+// E2E no-leak: the LIVE pane's start command must NOT contain the secret env VALUE — it rides the
+// 0o600 launcher script (privateLaunch), so tmux only ever sees `bash <path>`. This fails on the old
+// inline-`env -i KEY='value'` path (the canary would appear in pane_start_command).
+const paneStartCmd = execFileSync(
+  "tmux",
+  ["list-panes", "-t", `${SESSION}:smoke-agent`, "-F", "#{pane_start_command}"],
+  { encoding: "utf8" },
+);
+ok("live tmux pane command is `bash <script>` (not inline env)", paneStartCmd.includes("bash "));
+ok("live tmux pane command does NOT leak the env secret", !paneStartCmd.includes(SECRET_CANARY));
 
 handle.interrupt();
 ok("interrupt() doesn't throw", true);

--- a/extensions/tmux/smoke.ts
+++ b/extensions/tmux/smoke.ts
@@ -7,6 +7,7 @@ import * as tmux from "./src/driver.js";
 import { TmuxRuntime, tmuxRuntimeProvider, tmuxTerminalProvider } from "./src/runtime.js";
 import { registry } from "@cotal-ai/core";
 import { execFileSync } from "node:child_process";
+import { readFileSync, statSync } from "node:fs";
 
 const SESSION = "cotal-tmux-smoke";
 let passed = 0;
@@ -167,6 +168,16 @@ ok("isolatedCommand contains quoted command", isolated.includes("'/usr/bin/env'"
 const merged = tmux.mergedCommand({ FOO: "bar" }, "echo", ["hello"]);
 ok("mergedCommand starts with 'env'", merged.startsWith("env"));
 ok("mergedCommand does NOT contain '-i'", !merged.includes("env -i"));
+
+// privateLaunch keeps secret env VALUES off tmux's command line: the rendered body (with the secret)
+// goes into an owner-only (0o600) launcher script, and tmux only ever sees `bash <path>`.
+const secretBody = tmux.isolatedCommand({ COTAL_CONTROL_TOKEN: "s3cr3t-token" }, "/bin/echo", ["hi"]);
+const launch = tmux.privateLaunch(secretBody);
+const launchPath = launch.replace(/^bash\s+'?|'?$/g, ""); // strip `bash '` … `'`
+ok("privateLaunch returns a `bash <path>` invocation", launch.startsWith("bash ") && launchPath.endsWith(".sh"));
+ok("privateLaunch does NOT leak the secret into the returned command", !launch.includes("s3cr3t-token"));
+ok("privateLaunch script is 0o600 (owner-only)", (statSync(launchPath).mode & 0o777) === 0o600);
+ok("privateLaunch script contains the secret body (read from the file, not argv)", readFileSync(launchPath, "utf8").includes("s3cr3t-token"));
 
 console.log("\n────────────────────────────────────────────────");
 console.log(`\n${passed} passed, ${failed} failed\n`);

--- a/extensions/tmux/src/driver.ts
+++ b/extensions/tmux/src/driver.ts
@@ -1,4 +1,7 @@
 import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 /** True if tmux is installed and reachable on PATH. */
 export function available(): boolean {
@@ -210,6 +213,19 @@ export function mergedCommand(
   args: string[],
 ): string {
   return ["env", ...envPairs(env), shellQuote(command), ...args.map(shellQuote)].join(" ");
+}
+
+/** Wrap a secret-bearing command body (e.g. an {@link isolatedCommand} `env -i KEY='val' … cmd`) in a
+ *  private launcher script and return a `bash` invocation of it. tmux runs the command we hand it as a
+ *  process argument — visible to any local `ps`/`tmux list-panes` — so passing the rendered `env`
+ *  inline would leak the agent's creds + control token (and any model-provider key). Instead the body
+ *  lives in a fresh 0o700 temp dir as a 0o600 (owner-only) script; tmux only ever sees `bash <path>`,
+ *  and the secrets are read from the file, never the command line. */
+export function privateLaunch(commandBody: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "cotal-tmux-"));
+  const scriptPath = join(dir, "launch.sh");
+  writeFileSync(scriptPath, `#!/usr/bin/env bash\nexec ${commandBody}\n`, { mode: 0o600 });
+  return `bash ${shellQuote(scriptPath)}`;
 }
 
 /** Type literal text into a tmux target.

--- a/extensions/tmux/src/runtime.ts
+++ b/extensions/tmux/src/runtime.ts
@@ -48,8 +48,9 @@ export class TmuxRuntime implements Runtime {
 
     tmux.ensureSession(this.session, cwd);
     // P3: env -i strips the tmux server's inherited environment; only the connector-declared
-    // env reaches the spawned agent (identity, model key, OS allow-list).
-    const command = tmux.isolatedCommand(spec.env ?? {}, spec.command, spec.args);
+    // env reaches the spawned agent (identity, model key, OS allow-list). privateLaunch keeps those
+    // values out of tmux's command line (ps-visible) — they ride a 0o600 launcher script instead.
+    const command = tmux.privateLaunch(tmux.isolatedCommand(spec.env ?? {}, spec.command, spec.args));
     // Key the whole lifecycle off the STABLE window ID (@N), not `session:name`. tmux can rename
     // a window (automatic-rename / a title escape), which would desync a name-based status/stop.
     const { windowId } = tmux.openWindow(this.session, name, command, cwd, { focus: false });
@@ -112,7 +113,7 @@ function tmuxLayout(session: string, label: string, tab: Tab): string {
   const [first, ...rest] = tab.panes;
   if (!first) throw new Error(`tmux layout "${label}": tab has no panes`);
 
-  const firstCmd = tmux.mergedCommand(first.env ?? {}, first.command, first.args ?? []);
+  const firstCmd = tmux.privateLaunch(tmux.mergedCommand(first.env ?? {}, first.command, first.args ?? []));
   // Drive splits/focus/confirm off the STABLE window/pane IDs returned here — never `session:label`
   // (labels can collide or be renamed) or pane indexes `.0`/`.1` (shift under `pane-base-index`).
   const { windowId, paneId: firstPane } = tmux.openWindow(session, label, firstCmd, first.cwd ?? ".", {
@@ -127,7 +128,7 @@ function tmuxLayout(session: string, label: string, tab: Tab): string {
   if (first.confirm) scheduleConfirm(firstPane);
 
   rest.forEach((pane) => {
-    const cmd = tmux.mergedCommand(pane.env ?? {}, pane.command, pane.args ?? []);
+    const cmd = tmux.privateLaunch(tmux.mergedCommand(pane.env ?? {}, pane.command, pane.args ?? []));
     const newPane = tmux.splitWindow(windowId, cmd, pane.cwd ?? ".", tab.split!.direction, tab.split!.ratio);
     if (pane.confirm) scheduleConfirm(newPane);
   });

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "smoke:secret-fs": "tsx packages/core/smoke/secret-fs.smoke.ts",
     "smoke:env-isolate": "tsx implementations/manager/smoke/env-isolate.smoke.ts",
     "smoke:tmux": "tsx extensions/tmux/smoke.ts",
+    "smoke:cmux": "tsx extensions/cmux/smoke.ts",
     "smoke:runtime": "pnpm smoke:tmux && pnpm smoke:env-isolate && pnpm smoke:attach",
     "smoke:start-model": "tsx implementations/manager/smoke/start-model-preflight.smoke.ts",
     "smoke:persona-acl": "tsx implementations/manager/smoke/persona-identity-acl.smoke.ts",


### PR DESCRIPTION
Fixes a secret-hygiene gap surfaced by the [#138](https://github.com/Cotal-AI/Cotal/pull/138) cross-model review.

## The leak
The authenticated control plane (Stage 2) puts `COTAL_CONTROL_TOKEN` into the child `env`, and the **tmux** and **cmux** runtimes serialize `env` into a shell command line / temp script — so the token, the agent's creds, and any model-provider key could leak:

- **tmux** rendered `env -i KEY='value' …` directly into the `new-window`/`split-window` command, which is a process argument → visible to any local `ps` / `tmux list-panes`.
- **cmux** wrote the pane launcher to a **world-readable `0o755`** script at a **predictable `/tmp` path** → any local user could `cat` the secrets, and the predictable path is symlink-attackable.

`pty` passes `env` structurally (no leak), so this only affected the Unix-only tmux/cmux runtimes. The control token is never used on those (the manager only fires `controlShutdown` on Windows/pty), but the **provider API keys and creds** leak regardless of platform — so this is worth fixing on its own.

## The fix
- **tmux**: new `privateLaunch()` writes the rendered (secret-bearing) command body to a `0o600` launcher script inside a fresh `0o700` `mkdtemp` dir, and returns `bash <path>`. tmux only ever sees `bash <path>` — the env values are read from the owner-only file, never the command line. The pure `isolatedCommand`/`mergedCommand` builders are unchanged (still unit-tested); the runtime wraps their output at the three spawn sites before handing it to tmux.
- **cmux**: the pane launcher moves from a predictable `0o755` `/tmp` path to a `0o600` file in a fresh `0o700` `mkdtemp` dir — fixing both the world-readable perms and the predictable/symlink-attackable path. Drops the now-unused `key` param.

## Validation
- tmux smoke adds `privateLaunch` coverage: returns `bash <path>`, the secret is **not** in the returned command, the script is `0o600`, and the secret lives in the file. The existing real-tmux spawn/stop/status e2e exercises the wrapper end-to-end. **41/41 green** locally.
- cmux has no local CLI, so it's validated by typecheck; the change mirrors cmux's existing script pattern (it already wrote + `bash`'d a script).
