### PR TITLE
test(core): de-flake self-serve-join boot-membership checks on slow CI

### DIFF
--- a/packages/core/smoke/self-serve-join-auth.smoke.ts
+++ b/packages/core/smoke/self-serve-join-auth.smoke.ts
@@ -260,7 +260,15 @@ try {
   //    by her self-join via the daemon. Below we force its mirror entry to a pending/missing state, so
   //    leaving "ops" must STILL tombstone — leaveChannel re-resolves the generation from the delivery
   //    service on demand (fail-closed), so a missing mirror entry is not a silent §7 fail-open.
-  const aliceOpsBefore = await pub.channelMembers("ops");
+  // alice self-joined "ops" in Phase 1 (no daemon yet); the daemon reconciles that boot membership
+  // only after it comes up in Phase 2, so POLL for it rather than assume the elapsed review.db steps
+  // were enough — a slow round-trip (CI/Windows) lagged it and flaked this check (cf. the `until`
+  // wait the durable-delivery check above uses for the same eventual-consistency reason).
+  let aliceOpsBefore = await pub.channelMembers("ops");
+  for (let i = 0; i < 160 && !aliceOpsBefore.some((m) => m.id === aId.id); i++) {
+    await wait(50);
+    aliceOpsBefore = await pub.channelMembers("ops");
+  }
   check("alice's boot 'ops' membership is present (self-joined at connect)", aliceOpsBefore.some((m) => m.id === aId.id), aliceOpsBefore);
 
   // Force alice's "ops" record to a crash-stuck PENDING activation (activated:false). It still routes
@@ -302,9 +310,14 @@ try {
   b.on("error", () => {});
   b.on("message", (m, d: Delivery) => { gotB.push(`#${m.channel}:${m.parts.map((p) => (p.kind === "text" ? p.text : "")).join("")}`); d.ack(); });
   await b.start();
-  await wait(400); // connect + boot-membership hydration round-trip
 
-  const bootMembers = await pub.channelMembers("ops");
+  // Poll for bob's boot self-join to hydrate (connect + daemon round-trip) rather than assume a fixed
+  // delay — same eventual-consistency flake class as alice's check above; a fixed wait can lag on CI/Windows.
+  let bootMembers = await pub.channelMembers("ops");
+  for (let i = 0; i < 160 && !bootMembers.some((m) => m.id === bId.id); i++) {
+    await wait(50);
+    bootMembers = await pub.channelMembers("ops");
+  }
   check("bob's BOOT durable membership is listed (activated, hydrated)", bootMembers.some((m) => m.id === bId.id), bootMembers);
 
   const bootLeave = await b.leaveChannel("ops");


### PR DESCRIPTION
Fixes the intermittent Windows `required` failure on `self-serve-join:auth` (seen on the #139 merge commit; green on #135/#136/#138 and #139's own PR — i.e. a timing flake, not a regression).

## Symptom
```
✗ alice's boot 'ops' membership is present (self-joined at connect) []
✗ scenario threw: Cannot read properties of undefined (reading 'record')
```

## Root cause
alice self-joins `ops` in **Phase 1 — before the delivery daemon exists**. Her boot membership is reconciled only **after the daemon comes up in Phase 2**. The assertion checked it with **no wait** for that reconciliation (unlike the durable-delivery check, which already polls via `until`). On a slow runner the reconciliation lagged the check → empty members → the next line deref'd the missing record (`!.record`).

## Fix (test-only)
Poll for the membership (eventual-consistency) instead of assuming elapsed steps were enough:
- **alice** — had no wait at all → poll up to ~8s (matching `until`'s timeout).
- **bob** — had a fixed `wait(400)` (same flake class) → same poll.

No behavioral change on a fast box. Verified locally: old code 6/6 pass (doesn't repro on macOS — Windows-slow-specific), fixed code 23/23 × 6 runs. `@cotal-ai/core` typecheck clean.