### PR TITLE
fix(connector-opencode): drive turns through serve API

### DIFF
--- a/.changeset/opencode-http-injection.md
+++ b/.changeset/opencode-http-injection.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/connector-opencode": patch
+---
+
+Drive OpenCode peer-message turns through the authenticated serve HTTP API for the exact attached session.

--- a/extensions/connector-opencode/smoke/cooperative-stop-probe.ts
+++ b/extensions/connector-opencode/smoke/cooperative-stop-probe.ts
@@ -1,23 +1,37 @@
 /**
  * Subprocess probe for the opencode cooperative-stop smoke (cooperative-stop.smoke.ts) — never run
- * standalone. Loads the REAL plugin with a fake opencode client plus the COTAL_* identity + control
- * env the parent set, so the plugin connects its mesh agent and starts its control server. The parent
- * then sends an authenticated {op:"shutdown"} to that endpoint; the plugin leaves the mesh (publishes
- * offline presence) and exits 0 — which the parent asserts. A separate process because the plugin's
- * cooperative shutdown ends in process.exit, which would otherwise tear down the test itself.
+ * standalone. Loads the REAL plugin with a tiny fake OpenCode HTTP server plus the COTAL_* identity +
+ * control env the parent set, so the plugin connects its mesh agent and starts its control server. The
+ * parent then sends an authenticated {op:"shutdown"} to that endpoint; the plugin leaves the mesh
+ * (publishes offline presence) and exits 0 — which the parent asserts. A separate process because the
+ * plugin's cooperative shutdown ends in process.exit, which would otherwise tear down the test itself.
  */
+import { once } from "node:events";
+import { createServer } from "node:http";
 import { cotal } from "../src/plugin.js";
 
-// The plugin only calls session.create at boot (to own a session) and session.promptAsync to drive a
-// turn; a shutdown test drives neither a model nor a turn, so a minimal fake satisfies it.
-const fakeClient = {
-  session: {
-    create: async () => ({ data: { id: "ses_coop" } }),
-    promptAsync: async () => ({ data: {} }),
-  },
-};
+// The plugin calls OpenCode's HTTP API at boot to own a session. A shutdown test drives no turn, so
+// only POST /session is needed.
+const auth = `Basic ${Buffer.from("opencode:test-secret").toString("base64")}`;
+const oc = createServer((req, res) => {
+  if (req.headers.authorization !== auth) {
+    res.writeHead(401).end();
+    return;
+  }
+  if (req.method === "POST" && req.url === "/session") {
+    res.writeHead(200, { "content-type": "application/json" }).end(JSON.stringify({ id: "ses_coop" }));
+    return;
+  }
+  res.writeHead(404).end();
+});
+oc.listen(0, "127.0.0.1");
+await once(oc, "listening");
+const port = (oc.address() as { port: number }).port;
+process.env.COTAL_OPENCODE_SERVER_URL = `http://127.0.0.1:${port}`;
+process.env.OPENCODE_SERVER_USERNAME = "opencode";
+process.env.OPENCODE_SERVER_PASSWORD = "test-secret";
 
-await cotal({ client: fakeClient } as never);
+await cotal({} as never);
 
 // The plugin's control server keeps the event loop alive; the authenticated shutdown op calls
 // process.exit(0). Backstop: never linger on CI if the parent dies before driving shutdown.

--- a/extensions/connector-opencode/smoke/cooperative-stop-probe.ts
+++ b/extensions/connector-opencode/smoke/cooperative-stop-probe.ts
@@ -31,7 +31,7 @@ process.env.COTAL_OPENCODE_SERVER_URL = `http://127.0.0.1:${port}`;
 process.env.OPENCODE_SERVER_USERNAME = "opencode";
 process.env.OPENCODE_SERVER_PASSWORD = "test-secret";
 
-await cotal({} as never);
+await cotal();
 
 // The plugin's control server keeps the event loop alive; the authenticated shutdown op calls
 // process.exit(0). Backstop: never linger on CI if the parent dies before driving shutdown.

--- a/extensions/connector-opencode/smoke/turn-wedge.smoke.ts
+++ b/extensions/connector-opencode/smoke/turn-wedge.smoke.ts
@@ -109,7 +109,7 @@ try {
   await pub.start();
 
   // Boot the plugin (it connects its mesh agent in the background and creates session SID).
-  hooks = await cotal({} as never);
+  hooks = await cotal();
   for (let i = 0; i < 50; i++) {
     if (pub.getRoster().some((p) => p.card.name === "Otto")) break;
     await sleep(100);

--- a/extensions/connector-opencode/smoke/turn-wedge.smoke.ts
+++ b/extensions/connector-opencode/smoke/turn-wedge.smoke.ts
@@ -6,21 +6,33 @@
  * first human turn left `busy` stuck true and every later channel/DM push was buffered forever.
  *
  * Flow (no model, no `opencode` binary — just the plugin closure + a real mesh):
- *   1. a live channel message drives a turn (promptAsync #1)  — baseline push works;
+ *   1. a live channel message drives a turn (prompt_async #1)  — baseline push works;
  *   2. that turn completes (session.idle);
  *   3. a HUMAN turn runs on the same session (session.status busy → session.idle) — the wedge trigger;
- *   4. a second channel message MUST still drive a turn (promptAsync #2) — pre-fix this never fires.
+ *   4. a second channel message MUST still drive a turn (prompt_async #2) — pre-fix this never fires.
  * Run: pnpm smoke:opencode
  */
 import { strict as assert } from "node:assert";
 import { spawn } from "node:child_process";
+import { createServer as createHttpServer } from "node:http";
+import { createServer as createNetServer } from "node:net";
 import { mkdtempSync, rmSync } from "node:fs";
+import { once } from "node:events";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CotalEndpoint, seedChannelRegistry, isReachable } from "@cotal-ai/core";
 import { cotal } from "../src/plugin.js";
 
-const PORT = 14238;
+async function freePort(): Promise<number> {
+  const srv = createNetServer();
+  srv.listen(0, "127.0.0.1");
+  await once(srv, "listening");
+  const port = (srv.address() as { port: number }).port;
+  await new Promise<void>((r) => srv.close(() => r()));
+  return port;
+}
+
+const PORT = await freePort();
 const servers = `nats://127.0.0.1:${PORT}`;
 const space = "ocwedge";
 const SID = "ses_test";
@@ -28,6 +40,7 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 const dir = mkdtempSync(join(tmpdir(), "cotal-ocwedge-"));
 const srv = spawn("nats-server", ["-js", "-p", String(PORT), "-sd", join(dir, "js")], { stdio: "ignore" });
+const auth = `Basic ${Buffer.from("opencode:test-secret").toString("base64")}`;
 let pass = 0;
 const check = (name: string, cond: boolean, extra?: unknown) => {
   assert.ok(cond, `${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
@@ -35,26 +48,46 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
   console.log(`  ✓ ${name}`);
 };
 
-// The plugin reads its identity from COTAL_* env (it runs inside the opencode process).
+// A fake OpenCode HTTP server: hand the plugin a session id and record every turn it drives.
+const prompts: { id: string; body: unknown }[] = [];
+const oc = createHttpServer((req, res) => {
+  if (req.headers.authorization !== auth) {
+    res.writeHead(401).end();
+    return;
+  }
+  let raw = "";
+  req.setEncoding("utf8");
+  req.on("data", (d) => (raw += d));
+  req.on("end", () => {
+    if (req.method === "POST" && req.url === "/session") {
+      res.writeHead(200, { "content-type": "application/json" }).end(JSON.stringify({ id: SID }));
+      return;
+    }
+    if (req.method === "POST" && req.url === `/session/${SID}/prompt_async`) {
+      prompts.push({ id: SID, body: raw ? JSON.parse(raw) : undefined });
+      res.writeHead(204).end();
+      return;
+    }
+    res.writeHead(404).end();
+  });
+});
+oc.listen(0, "127.0.0.1");
+await once(oc, "listening");
+const ocPort = (oc.address() as { port: number }).port;
+
+// The plugin reads its identity from COTAL_* env (it runs inside the opencode process). Scrub any
+// managed-agent env inherited by this smoke itself; stale creds/links would point at the wrong broker.
+for (const k of Object.keys(process.env)) if (k.startsWith("COTAL_")) delete process.env[k];
 Object.assign(process.env, {
   COTAL_NAME: "Otto",
   COTAL_SPACE: space,
   COTAL_SERVERS: servers,
   COTAL_SUBSCRIBE: "team",
   COTAL_ROLE: "generalist",
+  COTAL_OPENCODE_SERVER_URL: `http://127.0.0.1:${ocPort}`,
+  OPENCODE_SERVER_USERNAME: "opencode",
+  OPENCODE_SERVER_PASSWORD: "test-secret",
 });
-
-// A fake opencode client: hand the plugin a session id and record every turn it drives.
-const prompts: { id: string }[] = [];
-const fakeClient = {
-  session: {
-    create: async (_: unknown) => ({ data: { id: SID } }),
-    promptAsync: async ({ path }: { path: { id: string } }) => {
-      prompts.push({ id: path.id });
-      return { data: {} };
-    },
-  },
-};
 
 // Fire one opencode bus event at the plugin's `event` hook.
 type Hooks = Awaited<ReturnType<typeof cotal>>;
@@ -76,8 +109,12 @@ try {
   await pub.start();
 
   // Boot the plugin (it connects its mesh agent in the background and creates session SID).
-  hooks = await cotal({ client: fakeClient } as never);
-  await sleep(2000); // let the internal MeshAgent connect + subscribe to #team
+  hooks = await cotal({} as never);
+  for (let i = 0; i < 50; i++) {
+    if (pub.getRoster().some((p) => p.card.name === "Otto")) break;
+    await sleep(100);
+  }
+  check("the opencode plugin came online (Otto live in the publisher roster)", pub.getRoster().some((p) => p.card.name === "Otto"));
 
   // (1) a live channel message drives a turn — baseline push works.
   await pub.multicast("hello team", { channel: "team" });
@@ -102,6 +139,7 @@ try {
   await hooks?.dispose?.();
   await pub.stop();
   srv.kill("SIGKILL");
+  oc.close();
   await sleep(150);
   rmSync(dir, { recursive: true, force: true });
 }

--- a/extensions/connector-opencode/src/extension.ts
+++ b/extensions/connector-opencode/src/extension.ts
@@ -18,8 +18,8 @@ const SERVE_SHIM = fileURLToPath(new URL("./serve.js", import.meta.url));
  * OpenCode's client/server split (see serve.ts). The Cotal mesh bridge runs as an in-process plugin
  * inside a headless `opencode serve`: it holds the {@link MeshAgent}, registers the cotal_* tools
  * natively (from the shared specs, at parity with Claude Code), reports presence off the event bus,
- * and owns ONE session it drives — injecting each incoming peer batch as a turn via the prompt API
- * (`session.promptAsync`, server-side, so it can't race the TUI input box). The shim then attaches a
+ * and owns ONE session it drives — injecting each incoming peer batch through the authenticated
+ * OpenCode server API on the same serve process the TUI attaches to. The shim then attaches a
  * foreground TUI to that session, so a human watching sees the agent work and can type into it.
  *
  * Config rides in `OPENCODE_CONFIG_CONTENT` (inline JSON, the highest merge layer), so the

--- a/extensions/connector-opencode/src/plugin.ts
+++ b/extensions/connector-opencode/src/plugin.ts
@@ -8,9 +8,9 @@
  *  • registers the cotal_* tools natively, rendered from the SHARED {@link cotalToolSpecs}
  *    (`./tools.ts`) — same surface as Claude Code, incl. channels / join / leave / channel_info;
  *  • maps OpenCode bus events to presence (idle | working | waiting | offline);
- *  • owns ONE session (created at boot) and drives it: it injects each inbox batch as a turn via the
- *    prompt API (`session.promptAsync` — server-side, so it can't race the TUI input box; the
- *    attached TUI renders it live), acking ON TURN COMPLETION (so a crash/error redelivers).
+ *  • owns ONE session (created at boot) and drives it: it injects each inbox batch as a turn through
+ *    the authenticated OpenCode server HTTP API (the same server the TUI is attached to), acking ON
+ *    TURN COMPLETION (so a crash/error redelivers).
  *    Delivery is **attention-aware** (open/dnd/focus) and never interrupts a running turn — a
  *    message that arrives mid-turn waits for the turn to end (matching Claude's no-interrupt
  *    behavior), then drives.
@@ -42,7 +42,7 @@ function log(msg: string): void {
  *  one agent), whichever scope opencode ends up using. */
 const guard = globalThis as { __cotalOpencodeHooks?: Hooks };
 
-export const cotal: Plugin = async ({ client }) => {
+export const cotal: Plugin = async () => {
   // No identity → a plain `opencode`, not a launcher-spawned agent. Stay inert.
   if (!hasIdentity()) {
     log("no COTAL_NAME — not a managed session; staying off the mesh");
@@ -51,8 +51,29 @@ export const cotal: Plugin = async ({ client }) => {
   if (guard.__cotalOpencodeHooks) return guard.__cotalOpencodeHooks; // one agent; reuse the hooks
   const config = configFromEnv();
   config.connector = "opencode"; // advertise the host harness on our AgentCard (meta.connector)
+  const serverUrl = process.env.COTAL_OPENCODE_SERVER_URL?.trim();
+  const serverUsername = process.env.OPENCODE_SERVER_USERNAME?.trim() || "opencode";
+  const serverPassword = process.env.OPENCODE_SERVER_PASSWORD?.trim();
+  if (!serverUrl || !serverPassword) throw new Error("opencode connector: missing COTAL_OPENCODE_SERVER_URL/OPENCODE_SERVER_PASSWORD");
+  const serverAuth = `Basic ${Buffer.from(`${serverUsername}:${serverPassword}`).toString("base64")}`;
+
   const agent = new MeshAgent(config);
   agent.start(); // background connect with retry — never blocks startup
+
+  async function opencodeApi<T>(path: string, init?: RequestInit, timeoutMs = 10_000): Promise<T> {
+    const res = await fetch(`${serverUrl}${path}`, {
+      ...init,
+      signal: init?.signal ?? AbortSignal.timeout(timeoutMs),
+      headers: {
+        authorization: serverAuth,
+        "content-type": "application/json",
+        ...(init?.headers ?? {}),
+      },
+    });
+    if (!res.ok) throw new Error(`OpenCode HTTP ${res.status} ${res.statusText} for ${path}`);
+    if (res.status === 204) return undefined as T;
+    return (await res.json()) as T;
+  }
 
   const def = process.env.COTAL_AGENT_FILE?.trim() ? loadAgentFile(process.env.COTAL_AGENT_FILE.trim()) : undefined;
   // Face-hosted (`face:` in the agent file → the shim attaches the face viewer): teach the agent
@@ -81,7 +102,7 @@ export const cotal: Plugin = async ({ client }) => {
   let sessionID: string | undefined;
   let busy = false; // a turn is running (ours via drive(), OR the human's via session.status) → don't
   // prompt: opencode would COALESCE onto it (no reject). Released at EVERY turn end (completeTurn).
-  let driving = false; // re-entrancy guard around an in-flight promptAsync
+  let driving = false; // re-entrancy guard around an in-flight server prompt
   let primed = false; // persona is prepended to the first turn's text once
   let briefed = false; // the boot channel briefing is prepended once, on the first turn
   let surfaced: string[] = []; // ids surfaced into the current turn, acked on completion (by id, not count)
@@ -158,8 +179,11 @@ export const cotal: Plugin = async ({ client }) => {
    *  can't be picked. Awaited by ensureSession before the first drive. */
   const sessionReady: Promise<string | undefined> = (async () => {
     try {
-      const res = await client.session.create({ body: { title: `cotal:${config.space}:${config.name}` } });
-      const id = res.data?.id;
+      const res = await opencodeApi<{ id?: string }>("/session", {
+        method: "POST",
+        body: JSON.stringify({ title: `cotal:${config.space}:${config.name}` }),
+      }, 10_000);
+      const id = res.id;
       if (id) {
         adoptSession(id, "boot");
         process.stderr.write(`[cotal-session] ${id}\n`);
@@ -176,7 +200,7 @@ export const cotal: Plugin = async ({ client }) => {
   }
 
   /** Drive a turn carrying the current inbox batch (and the boot briefing once) into the visible
-   *  session via the prompt API — server-side, so it can't race like the TUI input box, and the TUI
+   *  session via the server API — server-side, so it can't race like the TUI input box, and the TUI
    *  renders it live (it subscribes to that session's events). Surfaces the items but does NOT ack
    *  them — ackSurfaced runs on turn completion, so a crash/error redelivers. `override` replaces
    *  the body (a bare nudge, e.g. a focus @mention pull) and surfaces nothing to ack. Self-guards
@@ -211,10 +235,10 @@ export const cotal: Plugin = async ({ client }) => {
       if (!primed && persona) body.system = `${persona}\n\n${ORIENTATION_BOOTSTRAP}`;
       busy = true;
       surfaced = ids;
-      // Arm BEFORE the await: a turn-end signal can land before promptAsync resolves, and
+      // Arm BEFORE the await: a turn-end signal can land before the server request resolves, and
       // completeTurn bails unless armed — arming after would drop it and wedge the agent.
       awaitingTurnEnd = true;
-      await client.session.promptAsync({ path: { id }, body });
+      await opencodeApi(`/session/${encodeURIComponent(id)}/prompt_async`, { method: "POST", body: JSON.stringify(body) }, 10_000);
       primed = true;
     } catch (e) {
       busy = false;

--- a/extensions/connector-opencode/src/serve.ts
+++ b/extensions/connector-opencode/src/serve.ts
@@ -6,7 +6,7 @@
  *   2. poke it once so the lazily-loaded plugin initializes (joins the mesh, creates ONE session);
  *   3. the plugin announces that session's id on stderr (`[cotal-session] <id>`);
  *   4. launch a foreground `opencode attach <url> --session <id>` — the TUI opens straight onto the
- *      agent's session, and every turn the plugin drives (via `session.promptAsync`) renders live.
+ *      agent's session, and every turn the plugin drives through this exact server renders live.
  *
  * The attach TUI is a pure viewer (it connects to the running server); its env strips the plugin
  * config + COTAL_* so it never loads a *second* mesh endpoint.
@@ -43,6 +43,7 @@ function resolveOpencodeBin(): string {
 }
 
 const BIN = resolveOpencodeBin();
+const USERNAME = "opencode";
 
 /** Per-launch secret gating the spawned server's HTTP API (see SECURITY above). */
 const SECRET = randomBytes(24).toString("hex");
@@ -103,7 +104,13 @@ async function main(): Promise<void> {
 
   mkdirSync(agentHome, { recursive: true });
   const serve = spawn(BIN, ["serve", "--hostname", "127.0.0.1", "--port", port], {
-    env: { ...process.env, OPENCODE_SERVER_PASSWORD: SECRET, OPENCODE_DB: dbPath },
+    env: {
+      ...process.env,
+      COTAL_OPENCODE_SERVER_URL: url,
+      OPENCODE_SERVER_USERNAME: USERNAME,
+      OPENCODE_SERVER_PASSWORD: SECRET,
+      OPENCODE_DB: dbPath,
+    },
     stdio: ["ignore", "pipe", "pipe"],
   });
   writeFileSync(pidFile, String(serve.pid));
@@ -136,7 +143,7 @@ async function main(): Promise<void> {
   // bootstrap that loads the plugin. Each poke carries its own abort timeout: a request that
   // lands in the early-boot window can hang with no response, and an un-timed fetch would pin
   // the loop on it forever (undici queues later requests behind it on the pooled connection).
-  const auth = `Basic ${Buffer.from(`opencode:${SECRET}`).toString("base64")}`;
+  const auth = `Basic ${Buffer.from(`${USERNAME}:${SECRET}`).toString("base64")}`;
   void (async () => {
     for (let i = 0; i < 300 && !sessionId; i++) {
       try {
@@ -164,6 +171,7 @@ async function main(): Promise<void> {
 
   const tuiEnv: NodeJS.ProcessEnv = {
     ...process.env,
+    OPENCODE_SERVER_USERNAME: USERNAME,
     OPENCODE_SERVER_PASSWORD: SECRET,
     OPENCODE_DB: dbPath,
   };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "gen:schema": "node scripts/generate-cotal-schema.mjs",
     "test": "pnpm -r --if-present test",
     "check": "pnpm typecheck && pnpm test && pnpm smoke:view && pnpm smoke:spawn-from-anywhere && pnpm smoke:spawn-from-anywhere:live && pnpm smoke:connect && pnpm smoke:core-boundary && pnpm smoke:preflight && pnpm smoke:ci",
-    "smoke:ci": "pnpm smoke:read-acl:auth && pnpm smoke:sub-acl:auth && pnpm smoke:self-serve-join:auth && pnpm smoke:control-auth && pnpm smoke:channels:auth && pnpm smoke:e2e:acl && pnpm smoke:plane3:auth && pnpm smoke:delivery-lease:auth && pnpm smoke:delivery-leave-tombstone:auth && pnpm smoke:delivery-reconnect:auth && pnpm smoke:delivery-cred:auth && pnpm smoke:delivery-reply-injection:auth && pnpm smoke:membership:auth && pnpm smoke:membership-feed-confinement:auth && pnpm smoke:wildcard-backfill",
+    "smoke:ci": "pnpm smoke:read-acl:auth && pnpm smoke:sub-acl:auth && pnpm smoke:self-serve-join:auth && pnpm smoke:control-auth && pnpm smoke:channels:auth && pnpm smoke:e2e:acl && pnpm smoke:plane3:auth && pnpm smoke:delivery-lease:auth && pnpm smoke:delivery-leave-tombstone:auth && pnpm smoke:delivery-reconnect:auth && pnpm smoke:delivery-cred:auth && pnpm smoke:delivery-reply-injection:auth && pnpm smoke:membership:auth && pnpm smoke:membership-feed-confinement:auth && pnpm smoke:wildcard-backfill && pnpm smoke:opencode && pnpm smoke:opencode-coop",
     "clean:dry": "git clean -ndX -- node_modules .pnpm-store packages extensions implementations examples remotion",
     "clean": "git clean -fdX -- node_modules .pnpm-store packages extensions implementations examples remotion",
     "cotal": "tsx bin/cotal.ts",


### PR DESCRIPTION
## Summary
- drive OpenCode Cotal turns through the authenticated opencode serve HTTP API for the exact attached session
- create the owned OpenCode session through the same server API instead of the plugin SDK client
- harden serve auth username/password handling and add bounded plugin HTTP requests
- cover the OpenCode connector smokes in smoke:ci
- add a patch changeset for @cotal-ai/connector-opencode

## Validation
- pnpm typecheck
- pnpm smoke:ci
- live fixed-connector E2E: fresh mesh + manager from this worktree spawned an OpenCode reviewer, received a Cotal assignment, acted, and replied with NO FINDINGS
