### PR TITLE
fix(manager): harden console asset serving

### DIFF
--- a/implementations/manager/package.json
+++ b/implementations/manager/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json && node -e \"const fs=require('node:fs'); fs.rmSync('dist/console', { recursive: true, force: true }); fs.cpSync('src/console', 'dist/console', { recursive: true })\"",
     "prepublishOnly": "pnpm run build"
   },
   "dependencies": {

--- a/implementations/manager/smoke/console-assets.smoke.ts
+++ b/implementations/manager/smoke/console-assets.smoke.ts
@@ -1,0 +1,65 @@
+import { existsSync } from "node:fs";
+import { createConnection } from "node:net";
+import { join } from "node:path";
+import { AttachEndpoint } from "../dist/attach-endpoint.js";
+
+let failures = 0;
+
+function check(label: string, cond: boolean): void {
+  console.log(`${cond ? "✓" : "✗"} ${label}`);
+  if (!cond) failures++;
+}
+
+function malformedUpgrade(url: string): Promise<string> {
+  const { hostname, port } = new URL(url);
+  return new Promise((resolve, reject) => {
+    const socket = createConnection(Number(port), hostname);
+    let data = "";
+
+    socket.setTimeout(2_000);
+    socket.on("connect", () => {
+      socket.write(
+        "GET /attach/% HTTP/1.1\r\n" +
+          `Host: ${hostname}\r\n` +
+          "Connection: Upgrade\r\n" +
+          "Upgrade: websocket\r\n" +
+          "Sec-WebSocket-Version: 13\r\n" +
+          "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n",
+      );
+    });
+    socket.on("data", (chunk) => (data += chunk.toString("utf8")));
+    socket.on("close", () => resolve(data));
+    socket.on("timeout", () => {
+      socket.destroy();
+      reject(new Error("malformed upgrade timed out"));
+    });
+    socket.on("error", reject);
+  });
+}
+
+const index = join(process.cwd(), "implementations/manager/dist/console/index.html");
+check("manager build emits dist/console/index.html", existsSync(index));
+
+const endpoint = new AttachEndpoint(
+  () => undefined,
+  () => [],
+  () => [],
+);
+
+await endpoint.start();
+try {
+  const base = endpoint.consoleUrl();
+  const res = await fetch(base);
+  check("built manager console GET / returns 200", res.status === 200);
+  check("built manager console serves HTML", (res.headers.get("content-type") ?? "").includes("text/html"));
+  await res.text();
+
+  const badUpgrade = await malformedUpgrade(base);
+  check("malformed attach upgrade returns 400", badUpgrade.includes("400 Bad Request"));
+  check("endpoint survives malformed attach upgrade", (await fetch(new URL("agents", base))).status === 200);
+} finally {
+  await endpoint.stop();
+}
+
+console.log(failures ? `\n${failures} check(s) failed` : "\nall checks passed");
+process.exit(failures ? 1 : 0);

--- a/implementations/manager/src/attach-endpoint.ts
+++ b/implementations/manager/src/attach-endpoint.ts
@@ -61,14 +61,19 @@ export class AttachEndpoint {
     this.#http = createServer((req, res) => this.#onRequest(req, res));
     this.#wss = new WebSocketServer({ noServer: true });
     this.#http.on("upgrade", (req, socket, head) => {
-      const path = req.url ?? "/";
+      const path = (req.url ?? "/").split("?")[0];
       if (!path.startsWith("/attach/")) {
         socket.destroy();
         return;
       }
-      this.#wss.handleUpgrade(req, socket, head, (ws) =>
-        this.#onConnection(ws, decodeURIComponent(path.slice("/attach/".length))),
-      );
+      let name: string;
+      try {
+        name = decodeURIComponent(path.slice("/attach/".length));
+      } catch {
+        socket.end("HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n");
+        return;
+      }
+      this.#wss.handleUpgrade(req, socket, head, (ws) => this.#onConnection(ws, name));
     });
   }
 
@@ -106,23 +111,49 @@ export class AttachEndpoint {
   }
 
   #onRequest(req: IncomingMessage, res: ServerResponse): void {
-    const path = (req.url ?? "/").split("?")[0];
-    if (path === "/agents") {
-      res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify(this.list()));
-      return;
+    try {
+      const path = (req.url ?? "/").split("?")[0];
+      if (path === "/agents") {
+        const body = JSON.stringify(this.list());
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(body);
+        return;
+      }
+      if (path === "/feed") {
+        this.#openFeed(res);
+        return;
+      }
+      const file = PAGE[path] ?? ASSETS[path];
+      if (file) {
+        this.#serveFile(res, file.path, file.type);
+        return;
+      }
+      res.writeHead(404).end("not found");
+    } catch {
+      // Last-resort guard: a stray/malformed request must never kill the manager.
+      try {
+        if (!res.headersSent) res.writeHead(500);
+        res.end("internal error");
+      } catch {
+        /* response already torn down */
+      }
     }
-    if (path === "/feed") {
-      this.#openFeed(res);
-      return;
+  }
+
+  #serveFile(res: ServerResponse, file: string, type: string): void {
+    try {
+      const body = readFileSync(file);
+      res.writeHead(200, { "content-type": type });
+      res.end(body);
+    } catch (e) {
+      const err = e as NodeJS.ErrnoException;
+      if (err.code === "ENOENT" || err.code === "ENOTDIR") {
+        res.writeHead(404).end("not found");
+        return;
+      }
+      console.error(`manager console failed to serve ${file}:`, err);
+      res.writeHead(500).end("internal error");
     }
-    const file = PAGE[path] ?? ASSETS[path];
-    if (file) {
-      res.writeHead(200, { "content-type": file.type });
-      res.end(readFileSync(file.path));
-      return;
-    }
-    res.writeHead(404).end("not found");
   }
 
   /** Open an SSE stream, replay the snapshot, and keep it on the broadcast set. */

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "smoke:opencode": "tsx extensions/connector-opencode/smoke/turn-wedge.smoke.ts",
     "smoke:opencode-coop": "tsx extensions/connector-opencode/smoke/cooperative-stop.smoke.ts",
     "smoke:attach": "tsx implementations/manager/smoke/attach.smoke.ts",
+    "smoke:manager-console": "pnpm --filter @cotal-ai/manager... build && tsx implementations/manager/smoke/console-assets.smoke.ts",
     "smoke:windows": "tsx implementations/manager/smoke/windows-launch.smoke.ts",
     "smoke:secret-fs": "tsx packages/core/smoke/secret-fs.smoke.ts",
     "smoke:env-isolate": "tsx implementations/manager/smoke/env-isolate.smoke.ts",


### PR DESCRIPTION
Summary
- Copy manager console assets into dist during package build.
- Harden the manager attach endpoint against missing/static asset failures and malformed WebSocket attach URLs.
- Add a manager-console smoke covering the built console and bad attach upgrades.

Tests
- pnpm smoke:manager-console
- pnpm --filter @cotal-ai/manager typecheck
- pnpm build
- pnpm smoke:attach