### PR TITLE
fix(connector-opencode): retry peer delivery after turn errors

### DIFF
--- a/extensions/connector-opencode/smoke/turn-wedge.smoke.ts
+++ b/extensions/connector-opencode/smoke/turn-wedge.smoke.ts
@@ -1,6 +1,6 @@
 /**
  * OpenCode turn-state regression test (no test runner) — spins up its OWN nats-server and drives the
- * plugin's turn state machine with a FAKE opencode `client` + real opencode bus events. It guards the
+ * plugin's turn state machine with a fake OpenCode HTTP server + real opencode bus events. It guards the
  * wedge fixed in plugin.ts: `busy` is set true by `session.status: busy` for ANY turn (incl. a human
  * typing into the attached TUI), but used to be cleared only on a connector-DRIVEN turn's end — so the
  * first human turn left `busy` stuck true and every later channel/DM push was buffered forever.
@@ -8,8 +8,11 @@
  * Flow (no model, no `opencode` binary — just the plugin closure + a real mesh):
  *   1. a live channel message drives a turn (prompt_async #1)  — baseline push works;
  *   2. that turn completes (session.idle);
- *   3. a HUMAN turn runs on the same session (session.status busy → session.idle) — the wedge trigger;
- *   4. a second channel message MUST still drive a turn (prompt_async #2) — pre-fix this never fires.
+ *   3. quiet channel traffic is buffered while idle and injected into the next native chat.message;
+ *   4. if that native turn errors, the injected batch is NOT acked and can be injected again;
+ *   5. a directed DM that auto-drives and errors is retried after a bounded delay;
+ *   6. a HUMAN turn still clears busy, then a second normal channel message MUST drive a turn
+ *      (prompt_async #2) — the original wedge fix still holds.
  * Run: pnpm smoke:opencode
  */
 import { strict as assert } from "node:assert";
@@ -80,9 +83,11 @@ const ocPort = (oc.address() as { port: number }).port;
 for (const k of Object.keys(process.env)) if (k.startsWith("COTAL_")) delete process.env[k];
 Object.assign(process.env, {
   COTAL_NAME: "Otto",
+  COTAL_ID: "otto",
   COTAL_SPACE: space,
   COTAL_SERVERS: servers,
-  COTAL_SUBSCRIBE: "team",
+  COTAL_SUBSCRIBE: "team,quiet",
+  COTAL_QUIET: "quiet",
   COTAL_ROLE: "generalist",
   COTAL_OPENCODE_SERVER_URL: `http://127.0.0.1:${ocPort}`,
   OPENCODE_SERVER_USERNAME: "opencode",
@@ -92,9 +97,13 @@ Object.assign(process.env, {
 // Fire one opencode bus event at the plugin's `event` hook.
 type Hooks = Awaited<ReturnType<typeof cotal>>;
 const fire = (hooks: Hooks, event: unknown) => hooks.event!({ event } as never);
+const chatMessage = (hooks: Hooks) =>
+  (hooks as Hooks & {
+    "chat.message"?: (input: { sessionID?: string }, output: { parts?: { type: string; text?: string }[] }) => Promise<void>;
+  })["chat.message"]!;
 
 // A plain peer that posts ambient channel traffic at the agent.
-const pub = new CotalEndpoint({ space, servers, card: { name: "Pubby", kind: "agent", id: "pubby" }, channels: ["team"] });
+const pub = new CotalEndpoint({ space, servers, card: { name: "Pubby", kind: "agent", id: "pubby" }, channels: ["team", "quiet"] });
 pub.on("error", () => {});
 
 // Poll until the plugin has driven `n` turns (push is event-driven + async).
@@ -102,10 +111,15 @@ const waitForPrompts = async (n: number, ms = 5000): Promise<void> => {
   for (let i = 0; i < ms / 100 && prompts.length < n; i++) await sleep(100);
 };
 
+function promptText(prompt: { body: unknown } | undefined): string {
+  const body = prompt?.body as { parts?: { text?: string }[] } | undefined;
+  return body?.parts?.map((p) => p.text ?? "").join("\n") ?? "";
+}
+
 let hooks: Hooks | undefined;
 try {
   for (let i = 0; i < 50; i++) { if (await isReachable(servers)) break; await sleep(200); }
-  await seedChannelRegistry({ servers, space, file: { defaults: { replay: false }, channels: { team: { replay: false } } } });
+  await seedChannelRegistry({ servers, space, file: { defaults: { replay: false }, channels: { team: { replay: false }, quiet: { replay: false } } } });
   await pub.start();
 
   // Boot the plugin (it connects its mesh agent in the background and creates session SID).
@@ -124,15 +138,49 @@ try {
   // (2) complete the connector's turn (acks it, returns the session to idle).
   await fire(hooks, { type: "session.idle", properties: { sessionID: SID } });
 
-  // (3) a HUMAN turn on the same session — the exact thing that used to wedge `busy`.
+  // (3) quiet channel traffic is buffered while idle. It should not drive prompt_async by itself,
+  //     but it should ride the next native prompt at OpenCode's real pre-model hook point.
+  await pub.multicast("quiet buffered", { channel: "quiet" });
+  await sleep(500);
+  check("quiet channel traffic does not drive prompt_async", prompts.length === 1, prompts);
+  const nativePrompt = { parts: [{ type: "text", text: "human native prompt" }] };
+  await chatMessage(hooks)({ sessionID: SID }, nativePrompt);
+  check("buffered peer traffic injects into the next native prompt", nativePrompt.parts[0]?.text?.includes("quiet buffered") === true, nativePrompt);
+
+  // (4) a failed native/model turn must not ack the injected Cotal batch. It should remain in the
+  //     inbox and be injectable again on a later native prompt, instead of being lost on error.
+  await fire(hooks, { type: "session.status", properties: { sessionID: SID, status: { type: "busy" } } });
+  await fire(hooks, { type: "session.error", properties: { sessionID: SID } });
+  check("failed native turn does not retry-drive prompt_async immediately", prompts.length === 1, prompts);
+  const retryPrompt = { parts: [{ type: "text", text: "retry native prompt" }] };
+  await chatMessage(hooks)({ sessionID: SID }, retryPrompt);
+  check("failed native turn leaves peer traffic available for retry", retryPrompt.parts[0]?.text?.includes("quiet buffered") === true, retryPrompt);
+
+  // (5) finish the retried native turn; the injected batch is acked on this successful boundary.
   await fire(hooks, { type: "session.status", properties: { sessionID: SID, status: { type: "busy" } } });
   await fire(hooks, { type: "session.idle", properties: { sessionID: SID } });
 
-  // (4) a second channel message MUST still drive a turn. Pre-fix: `busy` is stuck true, so the
-  //     incoming message is buffered and this never fires — waitForPrompts times out at length 1.
-  await pub.multicast("still there?", { channel: "team" });
+  // A directed DM auto-drives an unattended prompt_async. If that turn errors, the pending inbox id
+  // is deduped and would not emit another `incoming`; the connector must schedule a delayed retry.
+  await pub.unicast("otto", "retry dm");
   await waitForPrompts(2);
-  check("a channel message STILL drives after a human turn (no busy wedge)", prompts.length === 2, prompts);
+  check("a directed DM auto-drives prompt_async", prompts.length === 2 && promptText(prompts[1]).includes("retry dm"), prompts);
+  await fire(hooks, { type: "session.error", properties: { sessionID: SID } });
+  await sleep(200);
+  check("directed error retry is not immediate", prompts.length === 2, prompts);
+  await waitForPrompts(3);
+  check("directed DM retries after session.error", prompts.length === 3 && promptText(prompts[2]).includes("retry dm"), prompts);
+  await fire(hooks, { type: "session.idle", properties: { sessionID: SID } });
+
+  // A HUMAN turn with no Cotal batch still must clear busy (the original wedge trigger).
+  await fire(hooks, { type: "session.status", properties: { sessionID: SID, status: { type: "busy" } } });
+  await fire(hooks, { type: "session.idle", properties: { sessionID: SID } });
+
+  // (6) a second channel message MUST still drive a turn. Pre-fix: `busy` is stuck true, so the
+  //     incoming message is buffered and this never fires — waitForPrompts times out at length 3.
+  await pub.multicast("still there?", { channel: "team" });
+  await waitForPrompts(4);
+  check("a channel message STILL drives after a human turn (no busy wedge)", prompts.length === 4, prompts);
 
   console.log(`\nOPENCODE TURN-WEDGE TEST PASSED ✅  (${pass} checks)`);
 } finally {

--- a/extensions/connector-opencode/src/plugin.ts
+++ b/extensions/connector-opencode/src/plugin.ts
@@ -10,10 +10,9 @@
  *  • maps OpenCode bus events to presence (idle | working | waiting | offline);
  *  • owns ONE session (created at boot) and drives it: it injects each inbox batch as a turn through
  *    the authenticated OpenCode server HTTP API (the same server the TUI is attached to), acking ON
- *    TURN COMPLETION (so a crash/error redelivers).
- *    Delivery is **attention-aware** (open/dnd/focus) and never interrupts a running turn — a
- *    message that arrives mid-turn waits for the turn to end (matching Claude's no-interrupt
- *    behavior), then drives.
+ *    TURN COMPLETION (so a crash/error redelivers). Pending peer messages are also injected into
+ *    the next native prompt creation when a human/API prompt starts in the attached session.
+ *    Delivery is **attention-aware** (open/dnd/focus) and never interrupts a running turn.
  *
  * Identity comes from COTAL_* env (the plugin runs in the opencode process and inherits it).
  * No identity → inert, so an operator's own `opencode` never joins as a stray peer.
@@ -41,6 +40,8 @@ function log(msg: string): void {
  *  call wires up the agent, and every call returns the *same* hooks (the same tools, bound to that
  *  one agent), whichever scope opencode ends up using. */
 const guard = globalThis as { __cotalOpencodeHooks?: Hooks };
+const ERROR_RETRY_INITIAL_MS = 1_000;
+const ERROR_RETRY_MAX_MS = 30_000;
 
 export const cotal: Plugin = async () => {
   // No identity → a plain `opencode`, not a launcher-spawned agent. Stay inert.
@@ -107,6 +108,8 @@ export const cotal: Plugin = async () => {
   let briefed = false; // the boot channel briefing is prepended once, on the first turn
   let surfaced: string[] = []; // ids surfaced into the current turn, acked on completion (by id, not count)
   let awaitingTurnEnd = false; // a turn is in flight → ignore a duplicate idle that isn't its end
+  let errorRetryTimer: ReturnType<typeof setTimeout> | undefined;
+  let errorRetryMs = ERROR_RETRY_INITIAL_MS;
 
   const safeStatus = async (status: PresenceStatus, activity?: string): Promise<void> => {
     try {
@@ -156,6 +159,23 @@ export const cotal: Plugin = async () => {
     return agent.pendingWake(); // mode-and-channel-aware: excludes held dnd/quiet ambient
   }
 
+  function clearErrorRetry(resetDelay = false): void {
+    if (errorRetryTimer) clearTimeout(errorRetryTimer);
+    errorRetryTimer = undefined;
+    if (resetDelay) errorRetryMs = ERROR_RETRY_INITIAL_MS;
+  }
+
+  function scheduleErrorRetry(): void {
+    if (errorRetryTimer || pendingForWake() === 0) return;
+    const delay = errorRetryMs;
+    errorRetryMs = Math.min(errorRetryMs * 2, ERROR_RETRY_MAX_MS);
+    errorRetryTimer = setTimeout(() => {
+      errorRetryTimer = undefined;
+      if (!busy && pendingForWake() > 0) void drive();
+    }, delay);
+    errorRetryTimer.unref?.();
+  }
+
   function adoptSession(id: string, reason: string): void {
     if (sessionID === id) return;
     const previous = sessionID;
@@ -167,6 +187,7 @@ export const cotal: Plugin = async () => {
     briefed = false;
     surfaced = [];
     awaitingTurnEnd = false;
+    clearErrorRetry(true);
     if (previous) {
       log(`adopted opencode session ${id} after ${reason}; mesh identity unchanged`);
       if (pendingForWake() > 0) void drive();
@@ -245,6 +266,7 @@ export const cotal: Plugin = async () => {
       surfaced = [];
       awaitingTurnEnd = false;
       log(`drive failed: ${(e as Error).message}`);
+      scheduleErrorRetry();
     } finally {
       driving = false;
     }
@@ -264,6 +286,31 @@ export const cotal: Plugin = async () => {
     surfaced = [];
   }
 
+  function abandonSurfaced(): void {
+    surfaced = [];
+  }
+
+  /** Native TUI / API prompts enter through OpenCode's chat.message hook before the model loop
+   *  starts. This is the real "next turn" boundary for human-typed input: prepend the buffered Cotal
+   *  batch to the user's text, then ack it when the resulting turn ends. We only mutate an existing
+   *  text part so we don't need to manufacture OpenCode's internal part IDs. */
+  function injectIntoPrompt(output: { parts?: unknown[] }): void {
+    if (driving || awaitingTurnEnd) return; // drive() already injected, or one surfaced batch is open
+    const items = agent.peekInbox();
+    if (items.length === 0) return;
+    const inj = formatInjection(items);
+    if (!inj) return;
+    const textPart = output.parts?.find(
+      (p): p is { type: "text"; text: string } =>
+        typeof p === "object" && p !== null && (p as { type?: unknown }).type === "text" && typeof (p as { text?: unknown }).text === "string",
+    );
+    if (!textPart) return;
+    textPart.text = `${inj}\n\n${textPart.text}`;
+    surfaced = items.map((i) => i.id);
+    awaitingTurnEnd = true;
+    busy = true;
+  }
+
   /** A turn ended — ANY turn, ours (a driven inbox batch) OR the human's (typing into the attached
    *  TUI, a `/reconnect`, etc). Clear `busy` regardless of who drove it: it's the COALESCE guard, so
    *  a turn the connector didn't drive must still release it or every later push wedges behind a
@@ -278,6 +325,7 @@ export const cotal: Plugin = async () => {
       awaitingTurnEnd = false;
       ackSurfaced(); // our driven turn: ack the surfaced batch (the sole ack site)
     }
+    clearErrorRetry(true);
     if (pendingForWake() > 0) void drive();
   }
 
@@ -287,7 +335,7 @@ export const cotal: Plugin = async () => {
   // (read on the agent's terms; a `quiet` @mention still drives). `muted` ambient never reaches here
   // (ack-dropped at ingest); in `focus`, ambient/@mentions never reach "incoming" either.
   agent.on("incoming", (item: InboxItem) => {
-    if (busy) return; // buffer; completeTurn drives at turn end
+    if (busy) return; // buffer; chat.message or completeTurn drives at the next safe boundary
     const directed = item.kind !== "channel" || item.mentionsMe;
     const quiet = item.kind === "channel" && agent.channelMode(item.channel) === "quiet";
     if (directed || (!quiet && agent.attention === "open")) void drive();
@@ -310,6 +358,11 @@ export const cotal: Plugin = async () => {
 
   const hooks: Hooks = {
     tool: buildCotalTools(agent, config),
+
+    "chat.message": async (input, output) => {
+      if (!ours(input.sessionID)) return;
+      injectIntoPrompt(output);
+    },
 
     event: async ({ event }) => {
       // The server emits `permission.asked` (the SDK's `permission.updated` type ships but never
@@ -354,10 +407,10 @@ export const cotal: Plugin = async () => {
           busy = false;
           if (awaitingTurnEnd) {
             awaitingTurnEnd = false;
-            ackSurfaced(); // our turn surfaced the batch but failed — ack (don't retry-loop) and move on
+            abandonSurfaced(); // failed turn: leave inbox unacked so the batch can retry on a later safe turn
           }
           await safeStatus("idle");
-          if (pendingForWake() > 0) void drive();
+          scheduleErrorRetry();
           break;
         case "session.deleted":
           if (!ours(event.properties.info.id)) return;
@@ -379,6 +432,7 @@ export const cotal: Plugin = async () => {
         /* ignore */
       }
       await safeStatus("offline");
+      clearErrorRetry(true);
       await agent.stop();
     },
   };


### PR DESCRIPTION
## Summary
- inject pending peer messages into the next native OpenCode chat.message prompt when available
- avoid acking surfaced peer messages on session.error
- add bounded delayed retry for wake-eligible pending messages after turn errors

## Verification
- pnpm smoke:opencode
- pnpm --filter @cotal-ai/connector-opencode typecheck
- pnpm --filter @cotal-ai/connector-opencode build

## Notes
- Keeps the authenticated local OpenCode HTTP API path from main.
- chat.message injection intentionally only mutates an existing text part; non-text-only prompts leave peer messages buffered for later delivery.