### PR TITLE
ci(release): include changeset summaries in GitHub Release notes

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -95,8 +95,14 @@ jobs:
           fi
           notes=$(gh api "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
             -f tag_name="$tag" -f target_commitish="$GITHUB_SHA" --jq .body)
+          # The generated notes are merged-PR *titles* only. Prepend the changeset summaries (the actual
+          # per-change descriptions changesets wrote into the package CHANGELOGs) so a release reads as
+          # more than a list of one-liners. Best-effort: the package is already published, so a hiccup in
+          # this cosmetic step must never block cutting the Release (|| true).
+          detail=$(node scripts/release-notes-detail.mjs "$version" 2>/dev/null || true)
           {
             printf '🚀 **Cotal %s is out!**\n\nGrab it: `npm i cotal-ai@%s`\n\n' "$version" "$version"
+            if [ -n "$detail" ]; then printf '%s\n\n' "$detail"; fi
             printf '%s\n' "$notes"
           } > "$RUNNER_TEMP/release-notes.md"
           gh release create "$tag" \

--- a/scripts/release-notes-detail.mjs
+++ b/scripts/release-notes-detail.mjs
@@ -1,0 +1,55 @@
+/**
+ * Collect the human-written changeset summaries for a release version out of the workspace
+ * CHANGELOG.md files, deduped, as a markdown block. The GitHub Release notes are otherwise generated
+ * from merged PR *titles* only (`releases/generate-notes`); this surfaces the actual per-change
+ * descriptions that changesets writes into each package's changelog, so a release reads as more than a
+ * list of one-line PR titles.
+ *
+ * Usage: node scripts/release-notes-detail.mjs <version>   (prints nothing if there are no summaries)
+ *
+ * Reads the `## <version>` section of every package CHANGELOG (the basic `@changesets/cli/changelog`
+ * format: top-level `- <hash>: <summary>` bullets, plus `- Updated dependencies …` lines we skip).
+ * Because a single changeset is listed under several packages (fixed versioning), the same summary
+ * appears in many changelogs — we dedupe by text so each change shows once.
+ */
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const version = process.argv[2];
+if (!version) {
+  process.stderr.write("usage: release-notes-detail.mjs <version>\n");
+  process.exit(1);
+}
+
+const changelogs = [];
+if (existsSync("bin/CHANGELOG.md")) changelogs.push("bin/CHANGELOG.md");
+for (const root of ["packages", "extensions", "implementations"]) {
+  if (!existsSync(root)) continue;
+  for (const name of readdirSync(root)) {
+    const f = join(root, name, "CHANGELOG.md");
+    if (existsSync(f)) changelogs.push(f);
+  }
+}
+
+const summaries = new Set();
+for (const file of changelogs) {
+  let inSection = false;
+  for (const line of readFileSync(file, "utf8").split("\n")) {
+    if (line.startsWith("## ")) {
+      inSection = line.slice(3).trim() === version; // a `## <version>` header starts/ends a section
+      continue;
+    }
+    if (!inSection) continue;
+    const m = line.match(/^- (?:[0-9a-f]{7,40}: )?(.+)$/); // a top-level changeset bullet (optional hash)
+    if (!m) continue;
+    const summary = m[1].trim();
+    if (/^Updated dependencies\b/i.test(summary)) continue; // skip the dependency-bump bookkeeping
+    if (/^@?[\w./-]+@\d+\.\d+\.\d+/.test(summary)) continue; // skip bare `pkg@version` dep-bump lines
+    summaries.add(summary);
+  }
+}
+
+if (summaries.size) {
+  process.stdout.write("## Changes in this release\n\n");
+  for (const s of summaries) process.stdout.write(`- ${s}\n`);
+}


### PR DESCRIPTION
## What

GitHub Release notes were generated from merged-PR **titles** only (`releases/generate-notes`), so a release read as a flat list of one-line PR subjects — while the actual per-change descriptions that changesets writes into the package `CHANGELOG.md` files went unused.

This adds `scripts/release-notes-detail.mjs`, which collects the release version's changeset summaries (deduped across the fixed-version packages, dependency-bump bookkeeping filtered out) and the `changesets.yml` release step prepends them to the generated notes as a **'Changes in this release'** section.

So a release now shows both the detailed change descriptions *and* the 'What's Changed' PR list.

## Notes
- Workflow/script only — no package code, **no changeset** (nothing to publish).
- Best-effort (`|| true`): the package is already published when this runs, so a hiccup in this cosmetic step can never block cutting the Release/tag.
- Verified locally: extracts exactly the real summary for v0.8.2, and (simulated against the open version PR) the full summary for v0.8.3.