### PR TITLE
fix(connector): remove the face viewer that leaked into shared connector code

### DIFF
--- a/.changeset/deleak-face-viewer.md
+++ b/.changeset/deleak-face-viewer.md
@@ -1,0 +1,13 @@
+---
+"@cotal-ai/connector-opencode": patch
+"@cotal-ai/connector-core": patch
+---
+
+Remove the `face:` viewer activation that leaked from the frontier-faces example into shared connector code.
+
+`@cotal-ai/connector-opencode` no longer reads an agent file's `face:` key, injects a face-steering
+prompt, or swaps the attached TUI for a face viewer — so an OpenCode persona with a `face:` field boots
+normally instead of crashing when no face runtime is present. `@cotal-ai/connector-core` no longer strips
+`[[face:X]]` tags from `cotal_send`/`cotal_dm`/`cotal_anycast`; the platform-neutral tool surface sends
+text verbatim. Face rendering now lives entirely in `examples/04-frontier-faces`, which owns its own
+launcher (`mesh-face.mjs`) and expression steering.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -227,13 +227,7 @@ holds the mesh connection in-process. It does run the same authenticated control
 manager's cooperative `{op:"shutdown"}` (its hooks are in-process, so there is no hook relay): on a
 graceful stop where the runtime can't deliver a signal (Windows ConPTY), the plugin leaves the mesh
 cleanly — publishing offline presence — instead of lingering until its presence TTL expires. It also
-leaves on OpenCode's own `dispose`. Spawned agents run autonomously (`permission: "allow"`). The foreground viewer is swappable: an agent file's
-optional `face:` id makes the launcher attach an animated avatar viewer to the session instead
-of the chat TUI (`COTAL_FACE_BIN` must point at a face-term-compatible script; it watches the
-same event stream and can still send prompts into the session). A face-hosted agent is also told
-to embed `[[face:X]]` emotion tags in its send text. The viewer reads them from the tool-call
-input to animate the avatar, and the send tools strip them before publishing, so they never
-reach the wire.
+leaves on OpenCode's own `dispose`. Spawned agents run autonomously (`permission: "allow"`).
 
 **Connection recovery.** The endpoint self-heals. When nats.js exhausts its own reconnect and
 the connection closes terminally, a supervisor rebuilds it (`connectAndBind` is re-runnable;

--- a/examples/04-frontier-faces/README.md
+++ b/examples/04-frontier-faces/README.md
@@ -2,7 +2,7 @@
 
 Animated pixel-art avatars for agents, built for the Frontier Tower demo: each persona is
 an OpenCode-hosted agent with a 32×32 truecolor face that thinks, lip-syncs its streamed
-reply, and steers its own expression with hidden `[[face:X]]` tags. Run as a mesh, the
+reply, and steers its own expression as it talks. Run as a mesh, the
 faces coordinate as lateral peers in one Cotal space — you watch them talk to each other.
 
 There are two front-ends onto the *same* live mesh: a **browser studio** (`tools/studio.mjs`)
@@ -130,18 +130,22 @@ node tools/serve-wall.mjs      # then open the printed URL
   `cotal-opencode.js`) and the transcript from the operator endpoint's feed.
 - **`mesh-wall.sh`** — the tmux one-command launcher: starts the mesh, a tmux grid of mesh faces
   (one `mesh-face.sh` per agent), and the console.
-- **`mesh-face.sh`** — one mesh agent: starts an `opencode serve` with the
-  `@cotal-ai/connector-opencode` plugin + an agent file, so it joins the mesh and creates a
-  session; the script reads that session's id (the plugin prints `[cotal-session] <id>`)
-  and attaches the face, so the face renders the agent's real mesh turns.
-- **`face-term.mjs`** — the terminal face (half-block renderer, zero deps). Connects to an
-  OpenCode server, maps its SSE events to the face, strips `[[face:X]]` tags into expressions.
+- **`mesh-face.sh`** + **`mesh-face.mjs`** — one mesh agent: the `.mjs` launcher starts an
+  `opencode serve` with the `@cotal-ai/connector-opencode` plugin + an agent file (so it joins the
+  mesh and creates a session), reads that session's id (the plugin prints `[cotal-session] <id>`),
+  and attaches the face. The OpenCode connector is face-agnostic — this launcher owns the viewer
+  attach, so face rendering never leaks into shared code.
+- **`face-plugin.mjs`** — example-local OpenCode plugin registering the `face_<mood>` expression
+  tools. A mesh face calls them to drive its avatar, keeping its `cotal_*` messages clean on the wire.
+- **`face-term.mjs`** — the terminal face (half-block renderer, zero deps). Connects to an OpenCode
+  server, maps its SSE events to the face: assistant text drives the lip-sync, while `face_<mood>`
+  tool calls (mesh) and inline `[[face:X]]` tags (standalone direct chat) drive the expression.
 - **`personas.mjs`** — the pixel data, one entry per persona (single source for the terminal face).
 - **`face-wall.sh`** — tmux grid of standalone faces, one direct chat session per pane.
 - **`agents/`** — the persona definitions (OpenCode agent files): digital twins of ten
-  Frontier Tower panelists, each tuned to coordinate as a lateral peer on a Cotal mesh and
-  to emit face tags. The `face:` frontmatter maps an agent to its persona key where the
-  names differ (steve→jobs, elon→musk, rayan→ray).
+  Frontier Tower panelists, each tuned to coordinate as a lateral peer on a Cotal mesh. The `face:`
+  frontmatter maps an agent to its persona key where the names differ (steve→jobs, elon→musk,
+  rayan→ray).
 - **`research/`** — the public-record research the agent files are distilled from.
 - **`web/`** — the same engine as a `<cotal-face>` custom element (`cotal-face.js`, drawing
   its personas straight from `personas.mjs`), a live `wall.html` (a browser twin of the tmux

--- a/examples/04-frontier-faces/face-plugin.mjs
+++ b/examples/04-frontier-faces/face-plugin.mjs
@@ -1,0 +1,34 @@
+// face-plugin.mjs — example-local OpenCode plugin: a clean way for a mesh face to drive its
+// expression. Each `face_<mood>` is a no-op tool the agent calls when its mood shifts; face-term
+// reads the tool call off the session event stream and animates the avatar.
+//
+// Why a tool and not an inline [[face:X]] tag: the personas answer ONLY through tools ("plain text
+// vanishes"), and the de-leak removed the connector's wire-side tag stripping. A tool call is
+// therefore the one mechanism that (a) obeys that rule with no contradiction and (b) keeps the
+// agent's cotal_send / cotal_dm text clean on the wire AND in the on-screen console — the
+// expression never appears as message text anywhere on the mesh.
+//
+// This is the example's own protocol; shared connector code knows nothing about faces. The tools
+// are plain ToolDefinition objects — OpenCode's `tool()` helper is an identity wrapper, so no
+// import is needed (and no zod: the mood rides the tool NAME, so each tool takes no arguments).
+
+const FACE = (mood) => ({
+  description:
+    `Set your animated face to "${mood}". Call this the moment your mood becomes ${mood}. It only ` +
+    `drives your avatar — it is NOT a message and no peer ever sees it, so your cotal_send / ` +
+    `cotal_dm / cotal_anycast text stays clean.`,
+  args: {},
+  async execute() {
+    return `face → ${mood}`;
+  },
+});
+
+export const facePlugin = async () => ({
+  tool: {
+    face_neutral: FACE("neutral"),
+    face_happy: FACE("happy"),
+    face_sad: FACE("sad"),
+    face_angry: FACE("angry"),
+    face_surprised: FACE("surprised"),
+  },
+});

--- a/examples/04-frontier-faces/face-term.mjs
+++ b/examples/04-frontier-faces/face-term.mjs
@@ -319,7 +319,14 @@ function handleEvent(sid, ev) {
       const part = pr.part;
       if (!part) break;
       if (part.type === 'tool') {
-        if (MESH_SEND_TOOLS.has(part.tool) && part.state?.status === 'completed') feedMeshSend(part);
+        if (part.tool?.startsWith('face_')) {
+          // Expression tool (mesh mode): the mood rides the tool name (face_happy → happy). It
+          // never animates the mouth (it isn't speech) and never shows status — just set the face.
+          if (part.state?.status === 'completed') {
+            const e = part.tool.slice(5);
+            if (EXPRS.includes(e)) state.expr = e;
+          }
+        } else if (MESH_SEND_TOOLS.has(part.tool) && part.state?.status === 'completed') feedMeshSend(part);
         else if (state.status !== 'speaking') state.status = 'working';
       } else if (part.type === 'text' && msgRole.get(part.messageID) === 'assistant') {
         // Snapshot: full text so far — feed only what the delta path hasn't already. Key the

--- a/examples/04-frontier-faces/mesh-face.mjs
+++ b/examples/04-frontier-faces/mesh-face.mjs
@@ -1,0 +1,191 @@
+// mesh-face.mjs — example-local launcher: a mesh OpenCode peer rendered as its animated face.
+//
+// The OpenCode connector's own serve shim (extensions/connector-opencode/dist/serve.js) starts a
+// headless `opencode serve` with the Cotal plugin and then attaches the STANDARD `opencode attach`
+// TUI — it is deliberately face-agnostic (face rendering is this example's concern, not the
+// connector's). So this example owns the viewer attach itself: same serve orchestration, but the
+// foreground process is `face-term.mjs` instead of the chat TUI.
+//
+// It mirrors serve.js's lifecycle (free port, per-launch server password, per-agent SQLite DB,
+// `[cotal-session]` handshake, teardown) and adds two example-only steps:
+//   • composes the agent's persona with a face-steering block (so the agent drives its expression by
+//     calling the face_<mood> tools from face-plugin.mjs — which face-term reads off the session
+//     event stream — while its cotal_send/cotal_dm messages stay clean on the wire and console);
+//   • attaches `node face-term.mjs --persona … --server … --session … --password …`.
+//
+// Env (set by mesh-face.sh): COTAL_OPENCODE_HOME (data root, required), COTAL_NAME, COTAL_AGENT_FILE,
+// FACE_PERSONA (face-term persona key), FACE_BIN (path to face-term.mjs), OPENCODE_CONFIG_CONTENT
+// (the inline opencode config with the Cotal plugin). COTAL_OPENCODE_BIN overrides the opencode bin.
+import { spawn } from "node:child_process";
+import { createServer } from "node:net";
+import { once } from "node:events";
+import { randomBytes } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
+
+const BIN = process.env.COTAL_OPENCODE_BIN?.trim() || "opencode";
+const USERNAME = "opencode";
+const SECRET = randomBytes(24).toString("hex"); // per-launch HTTP basic-auth secret for the serve API
+
+// The face-steering block appended to the agent's persona. Expression rides the `face_<mood>` tools
+// (from face-plugin.mjs), NOT the message text — so it obeys the personas' "answer only through
+// tools" rule with no contradiction, and the de-leak's clean wire/console is preserved (face-term
+// reads the tool call off the session event stream; peers and the console never see any markup).
+const FACE_STEER = [
+  "## Expressing emotion (face viewer)",
+  "You are rendered as an animated pixel-art face. Drive its expression with your face tools: call",
+  "face_happy / face_sad / face_angry / face_surprised / face_neutral the moment your mood shifts to",
+  "match. These only animate your avatar — they are not messages and no peer sees them, so they fit",
+  "'answer only through tools' perfectly while keeping your cotal_send / cotal_dm / cotal_anycast",
+  "text clean. Never describe your expression inside the messages themselves.",
+].join("\n");
+
+/** Ask the OS for a free port (bind :0, read it, release) so co-located faces don't collide. */
+async function freePort() {
+  const srv = createServer();
+  srv.listen(0, "127.0.0.1");
+  await once(srv, "listening");
+  const port = srv.address().port;
+  await new Promise((r) => srv.close(() => r()));
+  return port;
+}
+
+/** SIGTERM the serve, then SIGKILL if it's still alive 3s later — a lingering serve keeps the agent's
+ *  SQLite dir open and wedges the next same-name launch. Resolves once it's dead. */
+async function killServe(serve) {
+  if (serve.exitCode !== null || serve.signalCode !== null) return;
+  serve.kill("SIGTERM");
+  const dead = await Promise.race([
+    once(serve, "exit").then(() => true),
+    new Promise((r) => setTimeout(() => r(false), 3000)),
+  ]);
+  if (!dead) {
+    serve.kill("SIGKILL");
+    await once(serve, "exit");
+  }
+}
+
+async function main() {
+  const name = process.env.COTAL_NAME?.trim() || "agent";
+  const persona = process.env.FACE_PERSONA?.trim() || name;
+  const faceBin = process.env.FACE_BIN?.trim();
+  if (!faceBin) throw new Error("FACE_BIN is not set — point it at face-term.mjs");
+  const agentFile = process.env.COTAL_AGENT_FILE?.trim();
+  if (!agentFile) throw new Error("COTAL_AGENT_FILE is not set — the launcher must pass the persona file");
+
+  // Data root pinned by the launcher (mirrors the connector: own SQLite DB per agent so concurrent
+  // faces don't fight the global write lock); fail loud rather than scatter it into the launch cwd.
+  const dataRoot = process.env.COTAL_OPENCODE_HOME?.trim();
+  if (!dataRoot) throw new Error("COTAL_OPENCODE_HOME is not set — the launcher must pin the agent's data root");
+  const agentHome = join(dataRoot, ".cotal", "opencode", name);
+  const dbPath = join(agentHome, "opencode.db");
+
+  // Refuse a second serve on the same agent DB (they share the SQLite file and stall each other).
+  const pidFile = join(agentHome, "serve.pid");
+  if (existsSync(pidFile)) {
+    const pid = Number(readFileSync(pidFile, "utf8"));
+    let alive = false;
+    try {
+      process.kill(pid, 0);
+      alive = true;
+    } catch {
+      /* stale pidfile */
+    }
+    if (alive) throw new Error(`agent "${name}" is already running (opencode serve pid ${pid}) — kill it first`);
+    rmSync(pidFile);
+  }
+
+  mkdirSync(agentHome, { recursive: true });
+
+  // Compose persona + face-steering into a launch-local agent file the plugin loads (the connector
+  // no longer injects any face prompt). Same frontmatter ⇒ identity/ACLs are unchanged.
+  const composedFile = join(agentHome, basename(agentFile));
+  writeFileSync(composedFile, `${readFileSync(agentFile, "utf8").trimEnd()}\n\n${FACE_STEER}\n`);
+
+  const port = process.env.COTAL_OPENCODE_PORT?.trim() || String(await freePort());
+  const url = `http://127.0.0.1:${port}`;
+  const serve = spawn(BIN, ["serve", "--hostname", "127.0.0.1", "--port", port], {
+    env: {
+      ...process.env,
+      COTAL_AGENT_FILE: composedFile, // the plugin injects the composed persona
+      COTAL_OPENCODE_SERVER_URL: url,
+      OPENCODE_SERVER_USERNAME: USERNAME,
+      OPENCODE_SERVER_PASSWORD: SECRET,
+      OPENCODE_DB: dbPath,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  writeFileSync(pidFile, String(serve.pid));
+  serve.on("exit", () => rmSync(pidFile, { force: true }));
+
+  // Scan the server's output for the plugin's session handshake; forward boot logs to our stderr
+  // until the face viewer takes over the terminal.
+  let sessionId;
+  let attached = false;
+  let onSession;
+  const scan = (d) => {
+    if (!attached) process.stderr.write(d);
+    if (!sessionId) {
+      const m = d.toString().match(/\[cotal-session\] (\S+)/);
+      if (m) {
+        sessionId = m[1];
+        onSession?.(sessionId);
+      }
+    }
+  };
+  serve.stdout?.on("data", scan);
+  serve.stderr?.on("data", scan);
+  serve.on("exit", (code, signal) => {
+    if (!attached) process.exit(code ?? (signal ? 1 : 0)); // died before the face came up
+  });
+
+  // Poke the server until the lazily-loaded plugin joins the mesh and creates its session. Don't
+  // stop at the first 2xx: early in boot /session can answer before the plugin has bootstrapped.
+  const auth = `Basic ${Buffer.from(`${USERNAME}:${SECRET}`).toString("base64")}`;
+  void (async () => {
+    for (let i = 0; i < 300 && !sessionId; i++) {
+      try {
+        await fetch(`${url}/session`, { headers: { authorization: auth }, signal: AbortSignal.timeout(1500) });
+      } catch {
+        /* not up yet (or a hung early request, aborted) — retry on a fresh connection */
+      }
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  })();
+
+  const id = await new Promise((resolve) => {
+    if (sessionId) return resolve(sessionId);
+    onSession = resolve;
+    setTimeout(() => resolve(sessionId), 60_000);
+  });
+  if (!id) {
+    process.stderr.write(
+      `[mesh-face] serve: agent session never came up (~60s) — aborting. Check the boot log above (OPENCODE_DB=${dbPath})\n`,
+    );
+    await killServe(serve);
+    process.exit(1);
+  }
+
+  // Attach the animated face to the agent's session. A viewer, not a peer: strip the plugin config +
+  // COTAL_* so it can't load a second mesh endpoint.
+  const faceEnv = { ...process.env };
+  delete faceEnv.OPENCODE_CONFIG_CONTENT;
+  for (const k of Object.keys(faceEnv)) if (k.startsWith("COTAL_")) delete faceEnv[k];
+  attached = true;
+  const face = spawn(
+    process.execPath,
+    [faceBin, "--persona", persona, "--server", url, "--session", id, "--password", SECRET],
+    { env: faceEnv, stdio: "inherit" },
+  );
+
+  for (const sig of ["SIGINT", "SIGTERM"])
+    process.on(sig, () => {
+      face.kill(sig);
+      serve.kill(sig);
+    });
+  face.on("exit", (code, signal) => {
+    void killServe(serve).then(() => process.exit(code ?? (signal ? 1 : 0)));
+  });
+}
+
+void main();

--- a/examples/04-frontier-faces/mesh-face.sh
+++ b/examples/04-frontier-faces/mesh-face.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # mesh-face.sh <agent-name> [agent-file] — launch ONE mesh agent rendered as its pixel face.
 #
-# Thin wrapper over the connector's serve shim (extensions/connector-opencode/dist/serve.js):
-# the shim starts a headless `opencode serve` with the Cotal plugin (which joins the mesh and
-# creates the agent's session), then attaches the animated face (face-term.mjs) to that session.
+# Thin wrapper over the example-local launcher (mesh-face.mjs): it starts a headless `opencode serve`
+# with the Cotal plugin (which joins the mesh and creates the agent's session), then attaches the
+# animated face (face-term.mjs) to that session. The OpenCode connector itself is face-agnostic — face
+# rendering is this example's concern, so the example owns the viewer attach.
 # Persona + model come from the agent file's `face:` / `model:` frontmatter.
 #
 #   env: COTAL_SPACE (demo) · COTAL_SERVERS (nats://127.0.0.1:4222) · MODEL (overrides agent file)
@@ -14,25 +15,25 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$DIR/../.." && pwd)"
 NAME="$1"
 AGENT="${2:-$DIR/agents/$NAME.md}"
-CONN="$ROOT/extensions/connector-opencode/dist"
-SERVE="$CONN/serve.js"
-PLUGIN="$CONN/plugin.bundle.js"
+PLUGIN="$ROOT/extensions/connector-opencode/dist/plugin.bundle.js"
+FACE_PLUGIN="$DIR/face-plugin.mjs"   # example-local: registers the face_<mood> expression tools
+SHIM="$DIR/mesh-face.mjs"
 [ -f "$AGENT" ] || { echo "mesh-face: no agent file: $AGENT" >&2; exit 1; }
-{ [ -f "$SERVE" ] && [ -f "$PLUGIN" ]; } || { echo "mesh-face: connector not built — run: pnpm build" >&2; exit 1; }
+[ -f "$PLUGIN" ] || { echo "mesh-face: connector plugin not built — run: pnpm build" >&2; exit 1; }
 
 PERSONA="$(grep -m1 '^face:'  "$AGENT" | sed 's/face:[[:space:]]*//' || true)"; PERSONA="${PERSONA:-$NAME}"
 MODEL="${MODEL:-$(grep -m1 '^model:' "$AGENT" | sed 's/model:[[:space:]]*//' || true)}"
 
-# serve.js reads COTAL_FACE_PERSONA + COTAL_FACE_BIN to swap its chat TUI for the face viewer;
-# the plugin reads COTAL_AGENT_FILE for the persona and joins COTAL_SERVERS in COTAL_SPACE.
-# COTAL_OPENCODE_HOME pins the agent's data root (serve.js requires it) — its SQLite DB and
-# pidfile live under "$ROOT/.cotal/opencode/<name>".
+# mesh-face.mjs reads FACE_PERSONA + FACE_BIN to attach the face viewer to the agent's session; the
+# Cotal plugin (in OPENCODE_CONFIG_CONTENT) reads COTAL_AGENT_FILE for the persona and joins
+# COTAL_SERVERS in COTAL_SPACE. COTAL_OPENCODE_HOME pins the agent's data root (the shim requires it)
+# — its SQLite DB and pidfile live under "$ROOT/.cotal/opencode/<name>".
 export COTAL_SPACE="${COTAL_SPACE:-demo}" COTAL_NAME="$NAME" \
   COTAL_SERVERS="${COTAL_SERVERS:-nats://127.0.0.1:4222}" \
   COTAL_AGENT_FILE="$AGENT" COTAL_OPENCODE_HOME="$ROOT" \
-  COTAL_FACE_PERSONA="$PERSONA" COTAL_FACE_BIN="$DIR/face-term.mjs" \
-  OPENCODE_CONFIG_CONTENT="{\"\$schema\":\"https://opencode.ai/config.json\",\"permission\":\"allow\",\"plugin\":[\"$PLUGIN\"]${MODEL:+,\"model\":\"$MODEL\"}}"
+  FACE_PERSONA="$PERSONA" FACE_BIN="$DIR/face-term.mjs" \
+  OPENCODE_CONFIG_CONTENT="{\"\$schema\":\"https://opencode.ai/config.json\",\"permission\":\"allow\",\"plugin\":[\"$PLUGIN\",\"$FACE_PLUGIN\"]${MODEL:+,\"model\":\"$MODEL\"}}"
 
 echo "mesh-face: $NAME (face=$PERSONA, model=${MODEL:-default}) → joining space $COTAL_SPACE" >&2
-cd "$ROOT" # serve.js keeps the agent's data dir under ./.cotal/opencode/<name>
-exec node "$SERVE"
+cd "$ROOT" # the shim keeps the agent's data dir under ./.cotal/opencode/<name>
+exec node "$SHIM"

--- a/examples/04-frontier-faces/mesh-wall.sh
+++ b/examples/04-frontier-faces/mesh-wall.sh
@@ -111,7 +111,7 @@ if [ -n "$FRESH" ]; then
 fi
 
 # --- build the tmux grid: one mesh-face.sh per agent --------------------------
-cmd_for() {  # <index> — serve.js picks a free port; mesh-face derives the persona from `face:`
+cmd_for() {  # <index> — mesh-face.mjs picks a free port; mesh-face derives the persona from `face:`
   local i="$1" pre
   pre="COTAL_SPACE=$(printf %q "$SPACE")"
   [ -n "${MODEL:-}" ] && pre="$pre MODEL=$(printf %q "$MODEL")"

--- a/extensions/connector-core/src/config.ts
+++ b/extensions/connector-core/src/config.ts
@@ -24,7 +24,7 @@ export interface AgentConfig {
   role?: string;
   description?: string;
   tags?: string[];
-  /** Display-only metadata from unmodelled agent-file frontmatter keys (for example `face`).
+  /** Display-only metadata from unmodelled agent-file frontmatter keys (for example `theme`).
    *  Connector-owned keys such as `connector` and `model` are overlaid later and cannot be spoofed here. */
   meta?: Record<string, string>;
   /** Control-plane capabilities this session declares (from the agent file's `capabilities:`); today

--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -54,12 +54,6 @@ function statusGlyph(s: PresenceStatus): string {
   return s === "working" ? "●" : s === "waiting" ? "◐" : s === "idle" ? "○" : "·";
 }
 
-/** Viewer-only `[[face:X]]` emotion tags — a face-hosted agent embeds them in its send text and
- *  the face viewer reads them from the tool-call input (the event stream); the wire gets clean
- *  text, so peers and the console never see them. */
-const FACE_TAG_RE = /\[\[\s*face\s*:\s*[\w-]+\s*\]\]\s?/gi;
-const stripFaceTags = (text: string): string => text.replace(FACE_TAG_RE, "");
-
 /** One-line meaning of each attention mode, echoed back on set/read so the agent always sees the
  *  effect of a mode it may have set turns ago (self-visibility is the escape hatch for `focus`). */
 const ATTENTION_DESC: Record<"open" | "dnd" | "focus", string> = {
@@ -253,7 +247,7 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
       },
       async run(agent, _config, { text: msg, channel, mentions }: { text: string; channel?: string; mentions?: string[] }) {
         try {
-          const m = await agent.send(stripFaceTags(msg), channel, mentions);
+          const m = await agent.send(msg, channel, mentions);
           return ok(`Sent to #${m.channel}${m.mentions?.length ? ` (mentioned @${m.mentions.join(", @")})` : ""}.`);
         } catch (e) {
           return err(`Couldn't send: ${(e as Error).message}`);
@@ -270,7 +264,7 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
       },
       async run(agent, _config, { to, text: msg }: { to: string; text: string }) {
         try {
-          const { peer } = await agent.dm(to, stripFaceTags(msg));
+          const { peer } = await agent.dm(to, msg);
           return ok(`DM sent to ${peer.card.name}.`);
         } catch (e) {
           if (e instanceof AmbiguousPeerError) {
@@ -297,7 +291,7 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
       },
       async run(agent, _config, { role, text: msg }: { role: string; text: string }) {
         try {
-          await agent.anycast(role, stripFaceTags(msg));
+          await agent.anycast(role, msg);
           return ok(`Sent to one @${role}.`);
         } catch (e) {
           return err(`Couldn't send: ${(e as Error).message}`);

--- a/extensions/connector-opencode/src/extension.ts
+++ b/extensions/connector-opencode/src/extension.ts
@@ -94,8 +94,6 @@ export const opencodeConnector: Connector = {
       env.COTAL_AGENT_FILE = path; // plugin reads persona from it
       const def = loadAgentFile(path);
       model ??= def.model;
-      const face = def.meta?.face;
-      if (face) env.COTAL_FACE_PERSONA = face; // shim swaps the TUI for the face viewer
     }
     // The `--model` flag wins over the agent file, and applies even with no agent file. Pin it to a
     // dedicated primary agent made the default, so an operator's own `default_agent` in

--- a/extensions/connector-opencode/src/plugin.ts
+++ b/extensions/connector-opencode/src/plugin.ts
@@ -79,24 +79,7 @@ export const cotal: Plugin = async () => {
   }
 
   const def = process.env.COTAL_AGENT_FILE?.trim() ? loadAgentFile(process.env.COTAL_AGENT_FILE.trim()) : undefined;
-  // Face-hosted (`face:` in the agent file → the shim attaches the face viewer): teach the agent
-  // to steer its avatar's expression with inline [[face:X]] tags in the text it passes to the
-  // cotal send tools. The viewer reads them from the tool-call input; the tool layer strips them
-  // before the wire, so peers never see them.
-  const facePrompt = process.env.COTAL_FACE_PERSONA?.trim()
-    ? "You speak through an animated pixel-art avatar of yourself. Hard formatting rule: the text " +
-      "you pass to the cotal send tools (cotal_send / cotal_dm) must START with an emotion tag " +
-      "[[face:X]], where X is one of: neutral, happy, sad, angry, surprised — pick the one matching " +
-      "your mood, and insert another tag mid-text whenever your mood shifts. Example: " +
-      '"[[face:angry]] That race condition cost me three days. [[face:happy]] But watch it run now." ' +
-      "Never mention or explain the tags — they are stripped before peers see your message."
-    : undefined;
-  const persona = [def?.persona, facePrompt].filter(Boolean).join("\n\n") || undefined;
-  // System-position rules get ignored by some models — repeat the format rule in every injected
-  // turn (a fresh user-turn instruction is followed far more reliably).
-  const faceReminder = facePrompt
-    ? "(avatar: begin your cotal_send/cotal_dm text with [[face:X]] — neutral|happy|sad|angry|surprised — and add another tag when your mood shifts)"
-    : undefined;
+  const persona = def?.persona || undefined;
 
   // This agent OWNS one top-level OpenCode session at a time. The serve shim attaches the foreground
   // TUI to the boot session; if the human runs `/new` in that same TUI/process, OpenCode creates a
@@ -260,7 +243,6 @@ export const cotal: Plugin = async () => {
         if (brief) parts.unshift({ type: "text", text: brief });
       }
       if (parts.length === 0) return;
-      if (faceReminder) parts.push({ type: "text", text: faceReminder });
       const body: { parts: typeof parts; system?: string } = { parts };
       // persona once, as system (no --append-system-prompt). Append the orientation bootstrap so the
       // agent is told to orient first — gated on persona so we never replace OpenCode's default system.

--- a/extensions/connector-opencode/src/serve.ts
+++ b/extensions/connector-opencode/src/serve.ts
@@ -190,21 +190,7 @@ async function main(): Promise<void> {
   delete tuiEnv.OPENCODE_CONFIG_CONTENT; // a viewer, not a peer — must NOT load the plugin again
   for (const k of Object.keys(tuiEnv)) if (k.startsWith("COTAL_")) delete tuiEnv[k];
   attached = true;
-  // COTAL_FACE_PERSONA (from the agent file's `face:`) swaps the chat TUI for the animated
-  // face viewer (face-term). COTAL_FACE_BIN must point at face-term.mjs — no fallback.
-  const facePersona = process.env.COTAL_FACE_PERSONA?.trim();
-  const faceBin = process.env.COTAL_FACE_BIN?.trim();
-  if (facePersona && !faceBin) {
-    await killServe(serve); // don't orphan the server — it holds the agent's data dir
-    throw new Error("COTAL_FACE_PERSONA is set but COTAL_FACE_BIN is not — point it at face-term.mjs");
-  }
-  const [cmd, args] = facePersona
-    ? [
-        process.execPath,
-        [faceBin!, "--persona", facePersona, "--server", url, "--session", id, "--password", SECRET],
-      ]
-    : [BIN, ["attach", url, "--session", id, "--password", SECRET]];
-  const tui = spawn(cmd, args, {
+  const tui = spawn(BIN, ["attach", url, "--session", id, "--password", SECRET], {
     env: tuiEnv,
     stdio: "inherit",
   });

--- a/extensions/connector-opencode/src/transcript.ts
+++ b/extensions/connector-opencode/src/transcript.ts
@@ -5,8 +5,8 @@
  * the work channels (the Claude connector has had this; OpenCode did not).
  *
  * EVENT-DRIVEN, not poll-based. The connector plugin already receives OpenCode's bus events
- * in-process, so the mirror taps them (the same live stream the frontier-faces studio proxies to its
- * browser, instead of re-reading the session each frame):
+ * in-process, so the mirror taps them (the same live stream a UI can proxy to a browser, instead of
+ * re-reading the session each frame):
  *   • record(msg)   ← message.updated:      learn which messageIDs are ASSISTANT (mirror the agent's
  *                                           own output, never the injected user/peer turns).
  *   • observe(part) ← message.part.updated: condense the part NOW and buffer its lines (tool results

--- a/packages/core/src/agent-file.ts
+++ b/packages/core/src/agent-file.ts
@@ -12,8 +12,8 @@
  *   allowPublish: [general]    # post ACL — channels it may publish to; omit ⇒ DENY (default-deny)
  *   model: opus                # optional CLI/model override
  *   capabilities: [spawn]  # control-plane capabilities (spawn → may start/despawn others)
- *   face: sven             # any unmodelled key is kept verbatim in AgentDef.meta — e.g. the
- *                          #   OpenCode connector reads meta.face for its avatar viewer
+ *   theme: dark            # any unmodelled key is kept verbatim in AgentDef.meta, so a
+ *                          #   connector can read its own launcher hints without core knowing them
  *   ---
  *   <the Markdown body is the persona — an appended system prompt>
  *
@@ -68,7 +68,7 @@ export interface AgentDef {
    *  existing file. Set once at creation (owner = creator), preserved on every later redefine. */
   owner?: string;
   /** Frontmatter keys not modelled above, kept verbatim so a connector can read its own launcher
-   *  hints without core knowing about each one (e.g. the OpenCode face viewer's `face:` avatar id). */
+   *  hints without core knowing about each one. */
   meta?: Record<string, string>;
   /** Markdown body — the agent's persona / appended system prompt. */
   persona?: string;
@@ -184,8 +184,8 @@ export function loadAgentFile(path: string): AgentDef {
         throw new Error(`agent file ${path}: ${field} channel "${ch}" is not within your read ACL / allowSubscribe [${effAllow.join(", ")}]`);
     }
 
-  // Sweep every scalar frontmatter key we don't model into meta, verbatim — connector hints
-  // (face, etc.) ride here so core stays ignorant of surface-specific keys.
+  // Sweep every scalar frontmatter key we don't model into meta, verbatim — connector launcher
+  // hints ride here so core stays ignorant of surface-specific keys.
   const known = new Set(["name", "role", "kind", "description", "tags", "subscribe", "allowSubscribe", "allowPublish", "quiet", "muted", "model", "capabilities", "owner"]);
   const meta: Record<string, string> = {};
   for (const [k, v] of Object.entries(fm)) if (!known.has(k) && typeof v === "string") meta[k] = v;


### PR DESCRIPTION
## What & why

The frontier-faces showcase's face viewer had been activated from **shared connector code**, so an OpenCode persona carrying a `face:` frontmatter key crashed on launch anywhere no face runtime was configured (`COTAL_FACE_PERSONA is set but COTAL_FACE_BIN is not`).

Per AGENTS.md, examples only configure/orchestrate — they never add behavior to shared layers. This removes all face logic from the shared layers and re-homes the showcase in the example that owns it.

## Shared-layer de-leak

- **`connector-opencode`**: stop reading `def.meta.face` (`extension.ts`); drop the face viewer swap + the no-bin throw (`serve.ts`); drop the face-steering prompt/reminder (`plugin.ts`).
- **`connector-core`**: delete `stripFaceTags` from the platform-neutral send/dm/anycast tools (`tool-specs.ts`) — no more hidden wire-text mutation for one example's private markup.
- **Docs/comments**: drop the face paragraph from `architecture.md`; neutralize the illustrative `face` mentions in `core/agent-file.ts` and `connector-core/config.ts`.
- Result: `face:` is now inert connector metadata; a `face:` persona boots normally.

## Example re-home (`examples/04-frontier-faces`)

- **`mesh-face.mjs`** — example-local serve shim that owns the opencode-serve orchestration + viewer attach; the connector stays face-agnostic (no shared viewer hook added).
- **`face-plugin.mjs`** — registers `face_<mood>` expression tools. Expression is now a *tool call*, which satisfies the personas' "answer only through tools" rule with no contradiction and keeps `cotal_*` text clean on the wire and in the on-screen console.
- **`face-term`** reads the tool calls off the session event stream (still supports inline `[[face:X]]` for standalone direct-chat).

## Verification

- `pnpm typecheck` + `pnpm smoke:ci` green (incl. the OpenCode turn-wedge / cooperative-stop / transcript-mirror suites — no protocol regression from removing `stripFaceTags`).
- Live: a `face:` OpenCode persona boots + joins a fresh mesh with no crash; opencode loads `face-plugin.mjs` and the model calls `face_happy`; `buildLaunch` sets no `COTAL_FACE_*` env for a `face:` file.
- Reviewed by two OpenCode reviewers (architecture + adversarial lenses) across all phases + the tool-based revision.

Includes a changeset (patch: `@cotal-ai/connector-opencode`, `@cotal-ai/connector-core`).
