### PR TITLE
fix(manager): fail loud when the pty runtime runs under Bun

### DIFF
--- a/implementations/manager/src/commands.ts
+++ b/implementations/manager/src/commands.ts
@@ -325,7 +325,16 @@ async function runManager(argv: string[], defaultRuntime: RuntimeMode): Promise<
     process.exit(1);
   }
   const consolePort = v["console-port"] ? Number(v["console-port"]) : undefined;
-  const mgr = new Manager({ space, servers: server, runtime, consolePort });
+  // Construction resolves the runtime (createRuntime) — which fails loud on an unusable env, e.g. the
+  // pty runtime under Bun. Render that as one actionable line, not a raw stack (this also lands in
+  // `.cotal/manager.log` for a detached `cotal up` daemon).
+  let mgr: Manager;
+  try {
+    mgr = new Manager({ space, servers: server, runtime, consolePort });
+  } catch (e) {
+    console.error(c.red(`✗ ${(e as Error).message}`));
+    process.exit(1);
+  }
   await mgr.start();
   console.log(
     c.green("✓ manager up") +

--- a/implementations/manager/src/runtime/index.ts
+++ b/implementations/manager/src/runtime/index.ts
@@ -17,7 +17,18 @@ export type RuntimeMode = RuntimeKind | "auto";
  *  reachable — throws, never a silent fallback to pty. `session` names the tmux session (per space). */
 export function createRuntime(mode: RuntimeMode, session: string): Runtime {
   const kind: RuntimeKind = mode === "auto" ? "pty" : mode;
-  if (kind === "pty") return new PtyRuntime();
+  if (kind === "pty") {
+    // node-pty's native spawn-helper hangs before exec under Bun — it never becomes the child, so
+    // every agent wedges at "starting…" with no error. Fail loud rather than silently break the mesh:
+    // the pty runtime is Node-only. tmux/cmux drive their own CLIs (no node-pty), so they're fine.
+    if (process.versions.bun)
+      throw new Error(
+        `the pty runtime requires Node.js — the manager is running under Bun (v${process.versions.bun}), ` +
+          `where @lydell/node-pty's spawn-helper hangs before exec and every agent wedges at "starting…". ` +
+          `Run the manager under node, or use --runtime tmux / --runtime cmux (which don't use node-pty).`,
+      );
+    return new PtyRuntime();
+  }
   let provider: RuntimeProvider;
   try {
     provider = registry.resolve<RuntimeProvider>("runtime", kind);


### PR DESCRIPTION
Fixes #137.

## Problem
`@lydell/node-pty`'s native `spawn-helper` hangs *before* `exec` under Bun — it never becomes the child process, so every agent the manager spawns wedges at `starting…` with no error logged. The manager itself comes up fine (no pty yet), so the breakage is silent until the first spawn. The identical flow works under Node. Reproduced on macOS arm64 with bun 1.3.14 / node 26 / `@lydell/node-pty@1.2.0-beta.12`.

Both entry points are affected: `cotal supervise` directly, and `cotal up` — its detached supervisor re-execs via `process.execPath`, inheriting Bun.

## Fix
The pty runtime is Node-only. Guard at `createRuntime` (`implementations/manager/src/runtime/index.ts`) — the single chokepoint where `auto`/explicit `pty` resolves — and throw when `process.versions.bun` is set, before `new PtyRuntime()`. `runManager` renders the throw as one actionable line (`✗ …`) instead of a raw stack; the message also lands in the detached daemon's `manager.log`.

No silent re-exec under Node — that would mask the operator's chosen interpreter (a fallback the repo doctrine forbids). tmux/cmux drive their own CLIs (no node-pty) and are unaffected, so they're offered as the alternative.

```
✗ the pty runtime requires Node.js — the manager is running under Bun (v1.3.14),
  where @lydell/node-pty's spawn-helper hangs before exec and every agent wedges
  at "starting…". Run the manager under node, or use --runtime tmux / --runtime cmux
  (which don't use node-pty).
```

## Verification
- `pnpm typecheck` + `pnpm build` green.
- `createRuntime("auto")` against the built dist: **node** → returns `kind="pty"`; **bun** → throws the message. 
- `bun cotal supervise` against a live broker → prints the clean `✗` line and exits 1 before `manager up`; `node` path unaffected.

No test added: the guard only triggers under Bun, and there is no Bun lane in CI to verify it — an unrunnable test would be worse than none.