### PR TITLE
fix(manager): scroll the mouse wheel in full-screen agents over `cotal attach`

### DIFF
--- a/implementations/manager/src/attach-client.ts
+++ b/implementations/manager/src/attach-client.ts
@@ -11,14 +11,39 @@ const DETACH = 0x1d;
  * all mouse-report modes + focus reporting + bracketed paste, resets the keypad/cursor-key modes,
  * shows the cursor, and resets attributes. Deliberately does NOT toggle the alternate screen.
  */
+const MOUSE_OFF = "\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1005l\x1b[?1006l\x1b[?1015l"; // all mouse tracking off
 const RESTORE =
-  "\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1005l\x1b[?1006l\x1b[?1015l" + // mouse tracking off
+  MOUSE_OFF +
   "\x1b[?1004l" + // focus reporting off
   "\x1b[?2004l" + // bracketed paste off
   "\x1b[?1l" + // application cursor keys off (DECCKM): a full-screen TUI enables it; left on, arrows emit ESC O A not ESC [ A
   "\x1b>" + // keypad → numeric (DECKPNM)
   "\x1b[?25h" + // show cursor
   "\x1b[0m"; // reset attributes
+
+// Wheel-scroll for full-screen children. A full-screen TUI (e.g. OpenCode) runs in the alternate
+// screen — where the terminal's native scrollback is dead — and scrolls its content itself off mouse
+// reports. But it enables that mouse capture on ITS pty, and the enable doesn't reliably survive the
+// attach hop (backlog eviction / nested pty), so our terminal never reports the wheel and scrolling
+// dies. So while the child is in the alternate screen we enable SGR mouse reporting on OUR terminal
+// and translate each wheel tick into PageUp/PageDown — the keystrokes every full-screen TUI treats
+// as "scroll the view" (OpenCode: `messages_page_up`/`_down`). Inline children (Claude) never enter
+// the alt-screen, so this stays off and their native terminal-scrollback wheel is untouched.
+const MOUSE_ON = "\x1b[?1002h\x1b[?1006h"; // button+drag tracking, SGR encoding
+const PAGE_UP = "\x1b[5~";
+const PAGE_DOWN = "\x1b[6~";
+// Enter/leave the alternate screen: xterm `?1049`, plus the older `?1047`/`?47`.
+const ALT_ENTER = /\x1b\[\?(?:1049|1047|47)h/g;
+const ALT_LEAVE = /\x1b\[\?(?:1049|1047|47)l/g;
+// A complete SGR mouse report: `ESC [ < btn ; col ; row (M|m)`.
+const SGR_MOUSE = /^\x1b\[<(\d+);\d+;\d+[Mm]/;
+
+const lastIndexOfRe = (re: RegExp, s: string): number => {
+  re.lastIndex = 0;
+  let last = -1;
+  for (let m = re.exec(s); m; m = re.exec(s)) last = m.index;
+  return last;
+};
 
 /**
  * Drive a manager's attach endpoint from the terminal: raw-mode stdin streams to
@@ -37,6 +62,35 @@ export function attachClient(url: string): Promise<void> {
     // so it outlives the async error tick) to turn it into a handled no-op.
     process.stdout.on("error", () => {});
 
+    // Wheel-scroll state (see MOUSE_ON above): whether the child is in the alternate screen, and a
+    // buffer for an SGR mouse report split across stdin reads.
+    let altScreen = false;
+    let mouseBuf = "";
+    // Carry the tail of the previous output frame so an alt-screen escape split across ws frames
+    // (e.g. `ESC[?10` then `49h`) is still detected; 16 bytes covers these private-mode sequences.
+    // Acting only on state *change* below makes re-scanning the carried bytes idempotent.
+    let scanTail = "";
+
+    // Track the child's alt-screen transitions in its output so we can arm/disarm wheel translation.
+    const trackAltScreen = (data: Buffer): void => {
+      const s = scanTail + data.toString("latin1");
+      scanTail = s.slice(-16);
+      const enter = lastIndexOfRe(ALT_ENTER, s);
+      const leave = lastIndexOfRe(ALT_LEAVE, s);
+      if (enter === -1 && leave === -1) return;
+      const nowAlt = enter > leave;
+      if (nowAlt === altScreen) return;
+      altScreen = nowAlt;
+      if (altScreen) {
+        if (process.stdout.isTTY) process.stdout.write(MOUSE_ON);
+      } else {
+        // Leaving alt-screen mid-session: undo the mouse modes WE enabled so the terminal stops
+        // reporting the wheel/clicks and native scrollback works again — don't wait for detach.
+        mouseBuf = "";
+        if (process.stdout.isTTY) process.stdout.write(MOUSE_OFF);
+      }
+    };
+
     const sendResize = () =>
       ws.send(`r:${process.stdout.columns ?? 80},${process.stdout.rows ?? 24}`);
     const onInput = (d: Buffer) => {
@@ -44,7 +98,45 @@ export function attachClient(url: string): Promise<void> {
         ws.close();
         return;
       }
-      ws.send(d);
+      // Inline child: forward keystrokes raw (its wheel scrolls the local terminal, not the app).
+      if (!altScreen) {
+        ws.send(d);
+        return;
+      }
+      // Full-screen child: rewrite wheel reports to PageUp/PageDown, pass everything else through.
+      mouseBuf += d.toString("latin1");
+      let out = "";
+      for (;;) {
+        const i = mouseBuf.indexOf("\x1b[<");
+        if (i === -1) {
+          // A report split right before `<` (`ESC[` now, `<…M` next) would slip through untranslated:
+          // hold a trailing `ESC[` for the next read. Never hold a bare trailing `ESC` — that's the
+          // Escape key and must forward at once (e.g. OpenCode's interrupt); the rarer `ESC`|`[<…`
+          // split stays raw by design.
+          const keep = mouseBuf.endsWith("\x1b[") ? 2 : 0;
+          out += mouseBuf.slice(0, mouseBuf.length - keep);
+          mouseBuf = mouseBuf.slice(mouseBuf.length - keep);
+          break;
+        }
+        out += mouseBuf.slice(0, i);
+        const rest = mouseBuf.slice(i);
+        const m = SGR_MOUSE.exec(rest);
+        if (!m) {
+          // Hold only a still-valid partial report (`ESC[<` + digits/semicolons) for the next read;
+          // anything else can't become an SGR mouse report, so pass it straight through.
+          if (/^\x1b\[<[\d;]*$/.test(rest)) mouseBuf = rest;
+          else {
+            out += rest;
+            mouseBuf = "";
+          }
+          break;
+        }
+        const btn = Number(m[1]);
+        if (btn & 0x40) out += btn & 1 ? PAGE_DOWN : PAGE_UP; // wheel: 64=up, 65=down
+        else out += m[0]; // other mouse (click/drag): forward raw so the TUI still gets it
+        mouseBuf = rest.slice(m[0].length);
+      }
+      if (out) ws.send(Buffer.from(out, "latin1"));
     };
     const cleanup = () => {
       stdin.off("data", onInput);
@@ -62,7 +154,10 @@ export function attachClient(url: string): Promise<void> {
       process.stdout.on("resize", sendResize);
       stdin.on("data", onInput);
     });
-    ws.on("message", (data: Buffer) => process.stdout.write(data));
+    ws.on("message", (data: Buffer) => {
+      trackAltScreen(data);
+      process.stdout.write(data);
+    });
     ws.on("close", () => {
       cleanup();
       resolve();


### PR DESCRIPTION
## Problem

Attaching to an OpenCode agent with `cotal attach`, the mouse wheel doesn't scroll the conversation. OpenCode is a full-screen (alternate-screen) TUI that captures the mouse itself, but it runs nested under attach (terminal → manager PTY → `opencode attach`) and its mouse-enable escape doesn't reach the local terminal, so the wheel is never reported to it. Claude renders inline and rides the terminal's native scrollback, so it was unaffected.

## Fix

While the child is in the alternate screen, the attach client (`implementations/manager/src/attach-client.ts`):

- enables SGR mouse reporting on the local terminal so it captures the wheel;
- rewrites each wheel tick into PageUp/PageDown — the keys a full-screen TUI treats as "scroll the view";
- passes non-wheel mouse events (clicks/drags) through raw.

It's gated on the alternate screen, so inline agents (Claude) keep their native terminal-scrollback wheel untouched.

Robustness:
- alt-screen detection carries a 16-byte tail across output frames, so a `ESC[?1049h` split across WebSocket frames is still caught;
- the SGR parser buffers reports split across stdin reads — holding a trailing `ESC[` but never a bare `ESC`, so the Escape key (OpenCode's interrupt) is never delayed;
- the local mouse modes are disabled again on alt-screen leave, not only on detach.

## Testing

- `pnpm --filter @cotal-ai/manager typecheck` and build clean.
- `pnpm smoke:attach`, `smoke:opencode`, `smoke:opencode-coop`, `smoke:opencode-transcript` all green.
- Wheel scroll confirmed by hand against a live OpenCode attach; Claude scroll unchanged.

## Notes

- No changeset (intentional — not versioning this yet).
- Separate, pre-existing issue out of scope here: attaching twice to a full-screen agent can render a partial screen, because the raw scrollback ring can't reconstruct the alternate screen and a same-size resize doesn't force a repaint. Tracked for a follow-up PR.
