### PR TITLE
feat: resume an existing session into the mesh (#23)

### DIFF
--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -170,21 +170,20 @@ whose `~/.claude` holds that transcript.
   (the forked context runs under the current mesh persona). Because it launches in your own terminal
   (inherited stdio), a bad id / missing session / old-`claude` error is Claude's own stderr right in
   front of you and the command exits non-zero — never flattened into a generic "spawn failed".
-- `cotal start --resume <id>` (and MCP `cotal_spawn(resume:)`) work too, but the manager is detached,
-  so two things differ. **Locality:** the id resolves against the **manager host's** `~/.claude`, and
-  you practically need `--cwd` to point at the original project directory. **Async failure (less
-  obvious):** the manager reports `✓ started` the moment the process launches — *before* Claude runs —
-  so a missing id or an old CLI rejecting `--fork-session` makes Claude exit inside its PTY and the
-  error is **not** reported at the call site. The symptom is a peer that "started" but never appears in
-  `cotal ps` / the roster; diagnose with `cotal attach`. Prefer foreground `spawn` unless you know the
-  manager shares your session state. (The *unsupported-connector* case is still inline — `cotal start
-  --agent opencode --resume …` fails with `✗ …` before launching; only the claude-exits-after-launch
-  case is async.)
-- MCP `cotal_spawn(resume:)` carries a trust note for the **operator**, not only the calling peer: a
-  spawn-capable mesh peer can name a host-local session id and fork that `~/.claude` transcript into a
-  live agent — a bounded read of your local session context. It's gated by the privileged spawn
-  capability and high-entropy ids make guessing impractical, but you, the host operator, bear that
-  exposure. (`cotal_spawn` deliberately can't request transcript mirroring, so there's no auto-leak.)
+- `cotal start --resume <id>` works too, but the manager is detached, so two things differ.
+  **Locality:** the id resolves against the **manager host's** `~/.claude`, and you practically need
+  `--cwd` to point at the original project directory. **Async failure (less obvious):** the manager
+  reports `✓ started` the moment the process launches — *before* Claude runs — so a missing id or an
+  old CLI rejecting `--fork-session` makes Claude exit inside its PTY and the error is **not** reported
+  at the call site. The symptom is a peer that "started" but never appears in `cotal ps` / the roster;
+  diagnose with `cotal attach`. Prefer foreground `spawn` unless you know the manager shares your
+  session state. (The *unsupported-connector* case is still inline — `cotal start --agent opencode
+  --resume …` fails with `✗ …` before launching; only the claude-exits-after-launch case is async.)
+- Resume is an **operator surface only** — it is deliberately **not** exposed on MCP `cotal_spawn`.
+  Forking a host-local `~/.claude` transcript is operator-local intent; letting a spawn-capable mesh
+  *peer* name a host session id would widen the `spawn` capability into host-transcript disclosure with
+  no broker-enforced boundary. A peer-facing, capability-gated resume is deferred
+  ([#159](https://github.com/Cotal-AI/Cotal/issues/159)).
 - Only the **claude** connector supports resume today; **opencode** and **hermes** fail loud rather
   than silently spawning fresh (opencode: *"resuming an existing session … is not implemented"*,
   tracked in [#154](https://github.com/Cotal-AI/Cotal/issues/154); hermes: *"does not support resuming

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -177,6 +177,9 @@ whose `~/.claude` holds that transcript.
   `claude` that doesn't know `--fork-session`) surfaces Claude's own stderr — it is never flattened
   into a generic "spawn failed". opencode resume is tracked in
   [#154](https://github.com/Cotal-AI/Cotal/issues/154).
+- Needs a `claude` new enough to know `--resume ... --fork-session` (verified on **2.1.197**). Cotal
+  only co-emits the flags; it can't force an old binary to honor them — an old `claude` rejects
+  `--fork-session` with its own error, which the surfaced stderr above makes obvious.
 
 **Manage the catalog from the CLI.** `cotal personas` is the operator-side counterpart to the
 runtime `cotal_persona` tool. It reads and writes the same `.cotal/agents/*.md` files

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -167,19 +167,32 @@ whose `~/.claude` holds that transcript.
 
 - `cotal spawn --resume <id>` is the primary, least-surprising surface — it runs as *you*, in *your*
   cwd, on *your* machine, so the transcript is right there. Combines with `--prompt` and a persona
-  (the forked context runs under the current mesh persona).
-- `cotal start --resume <id>` (and MCP `cotal_spawn(resume:)`) work too, but the manager is detached:
-  the id is resolved against the **manager host's** `~/.claude`, and you practically need `--cwd` to
-  point at the original project directory. Prefer foreground `spawn` unless you know the manager
-  shares your session state.
-- Only the **claude** connector supports resume today; **opencode** and **hermes** fail loud
-  (`resume not supported`) rather than silently spawning fresh. A bad id (missing session, or an old
-  `claude` that doesn't know `--fork-session`) surfaces Claude's own stderr — it is never flattened
-  into a generic "spawn failed". opencode resume is tracked in
-  [#154](https://github.com/Cotal-AI/Cotal/issues/154).
+  (the forked context runs under the current mesh persona). Because it launches in your own terminal
+  (inherited stdio), a bad id / missing session / old-`claude` error is Claude's own stderr right in
+  front of you and the command exits non-zero — never flattened into a generic "spawn failed".
+- `cotal start --resume <id>` (and MCP `cotal_spawn(resume:)`) work too, but the manager is detached,
+  so two things differ. **Locality:** the id resolves against the **manager host's** `~/.claude`, and
+  you practically need `--cwd` to point at the original project directory. **Async failure (less
+  obvious):** the manager reports `✓ started` the moment the process launches — *before* Claude runs —
+  so a missing id or an old CLI rejecting `--fork-session` makes Claude exit inside its PTY and the
+  error is **not** reported at the call site. The symptom is a peer that "started" but never appears in
+  `cotal ps` / the roster; diagnose with `cotal attach`. Prefer foreground `spawn` unless you know the
+  manager shares your session state. (The *unsupported-connector* case is still inline — `cotal start
+  --agent opencode --resume …` fails with `✗ …` before launching; only the claude-exits-after-launch
+  case is async.)
+- MCP `cotal_spawn(resume:)` carries a trust note for the **operator**, not only the calling peer: a
+  spawn-capable mesh peer can name a host-local session id and fork that `~/.claude` transcript into a
+  live agent — a bounded read of your local session context. It's gated by the privileged spawn
+  capability and high-entropy ids make guessing impractical, but you, the host operator, bear that
+  exposure. (`cotal_spawn` deliberately can't request transcript mirroring, so there's no auto-leak.)
+- Only the **claude** connector supports resume today; **opencode** and **hermes** fail loud rather
+  than silently spawning fresh (opencode: *"resuming an existing session … is not implemented"*,
+  tracked in [#154](https://github.com/Cotal-AI/Cotal/issues/154); hermes: *"does not support resuming
+  an existing session"*).
 - Needs a `claude` new enough to know `--resume ... --fork-session` (verified on **2.1.197**). Cotal
   only co-emits the flags; it can't force an old binary to honor them — an old `claude` rejects
-  `--fork-session` with its own error, which the surfaced stderr above makes obvious.
+  `--fork-session` with its own error (surfaced inline on foreground `spawn`, async on detached
+  `start`, per above).
 
 **Manage the catalog from the CLI.** `cotal personas` is the operator-side counterpart to the
 runtime `cotal_persona` tool. It reads and writes the same `.cotal/agents/*.md` files

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -157,6 +157,27 @@ agent spawn door carries the same knobs as the operator's `cotal start` — `rol
 and `model` (overrides the persona file's `model:`) — set at spawn because they are policy, not
 persona content.
 
+**Resume an existing session (fork, never hijack).** `--resume <session-id>` pulls an existing
+Claude session — its deep context and long transcript — into the mesh instead of starting fresh
+([issue #23](https://github.com/Cotal-AI/Cotal/issues/23)). It **forks**: Claude mints a *new*
+session id from that transcript (`claude --resume <id> --fork-session`) so the meshed agent gets its
+own session and the original is left untouched — resuming never takes over the source session. The
+session id is **machine-local state**, not a portable value: it only means something on the host
+whose `~/.claude` holds that transcript.
+
+- `cotal spawn --resume <id>` is the primary, least-surprising surface — it runs as *you*, in *your*
+  cwd, on *your* machine, so the transcript is right there. Combines with `--prompt` and a persona
+  (the forked context runs under the current mesh persona).
+- `cotal start --resume <id>` (and MCP `cotal_spawn(resume:)`) work too, but the manager is detached:
+  the id is resolved against the **manager host's** `~/.claude`, and you practically need `--cwd` to
+  point at the original project directory. Prefer foreground `spawn` unless you know the manager
+  shares your session state.
+- Only the **claude** connector supports resume today; **opencode** and **hermes** fail loud
+  (`resume not supported`) rather than silently spawning fresh. A bad id (missing session, or an old
+  `claude` that doesn't know `--fork-session`) surfaces Claude's own stderr — it is never flattened
+  into a generic "spawn failed". opencode resume is tracked in
+  [#154](https://github.com/Cotal-AI/Cotal/issues/154).
+
 **Manage the catalog from the CLI.** `cotal personas` is the operator-side counterpart to the
 runtime `cotal_persona` tool. It reads and writes the same `.cotal/agents/*.md` files
 **directly** — instant, offline, no mesh — where the tool path goes over the wire with the

--- a/extensions/connector-claude-code/src/extension.ts
+++ b/extensions/connector-claude-code/src/extension.ts
@@ -124,6 +124,13 @@ export const claudeConnector: Connector = {
     // The `--model` flag wins over the agent file, and applies even with no agent file.
     if (model) args.push("--model", model);
 
+    // Fork an existing session INTO the mesh (opts.resume, an opaque host-local id). `--fork-session`
+    // is pushed in the SAME branch — resume here is fork-only, never a hijack: claude mints a NEW
+    // session id from that transcript and leaves the original untouched. The id is a single argv
+    // token (no shell), so a hostile-looking id can't inject. The persona `--append-system-prompt`
+    // above still applies, so the forked context runs under the current mesh persona.
+    if (opts.resume) args.push("--resume", opts.resume, "--fork-session");
+
     return {
       command: "claude",
       args,

--- a/extensions/connector-core/src/agent.ts
+++ b/extensions/connector-core/src/agent.ts
@@ -490,15 +490,16 @@ export class MeshAgent extends EventEmitter {
    *  How it lands — a detached PTY, a tmux window, a cmux tab — is the manager's
    *  runtime; from here it just joins the mesh as a lateral peer. `opts.agent` picks
    *  the harness (default the manager's `cotal`/Claude), `opts.model` overrides the
-   *  persona file's `model:`, `opts.cwd` roots the new peer at a different folder/repo
-   *  than the manager's workspace, and `opts.resume` forks an existing (host-local) session id
-   *  into the mesh — the same knobs the operator's `cotal start` carries, so
-   *  the agent and operator spawn doors share one control-op contract. */
-  async spawn(name: string, role?: string, opts?: { agent?: string; model?: string; cwd?: string; resume?: string }): Promise<ControlReply> {
+   *  persona file's `model:`, and `opts.cwd` roots the new peer at a different folder/repo
+   *  than the manager's workspace — the same knobs the operator's `cotal start` carries, so
+   *  the agent and operator spawn doors share one control-op contract. (Session `resume` is
+   *  intentionally NOT forwarded here: forking a host-local `~/.claude` transcript is an
+   *  operator-local intent, kept off the peer-facing spawn door — see #159.) */
+  async spawn(name: string, role?: string, opts?: { agent?: string; model?: string; cwd?: string }): Promise<ControlReply> {
     this.assertConnected();
     return this.ep.requestControl(CONTROL_PRIVILEGED, {
       op: "start",
-      args: { name, role, agent: opts?.agent, model: opts?.model, cwd: opts?.cwd, resume: opts?.resume },
+      args: { name, role, agent: opts?.agent, model: opts?.model, cwd: opts?.cwd },
     });
   }
 

--- a/extensions/connector-core/src/agent.ts
+++ b/extensions/connector-core/src/agent.ts
@@ -490,14 +490,15 @@ export class MeshAgent extends EventEmitter {
    *  How it lands — a detached PTY, a tmux window, a cmux tab — is the manager's
    *  runtime; from here it just joins the mesh as a lateral peer. `opts.agent` picks
    *  the harness (default the manager's `cotal`/Claude), `opts.model` overrides the
-   *  persona file's `model:`, and `opts.cwd` roots the new peer at a different folder/repo
-   *  than the manager's workspace — the same knobs the operator's `cotal start` carries, so
+   *  persona file's `model:`, `opts.cwd` roots the new peer at a different folder/repo
+   *  than the manager's workspace, and `opts.resume` forks an existing (host-local) session id
+   *  into the mesh — the same knobs the operator's `cotal start` carries, so
    *  the agent and operator spawn doors share one control-op contract. */
-  async spawn(name: string, role?: string, opts?: { agent?: string; model?: string; cwd?: string }): Promise<ControlReply> {
+  async spawn(name: string, role?: string, opts?: { agent?: string; model?: string; cwd?: string; resume?: string }): Promise<ControlReply> {
     this.assertConnected();
     return this.ep.requestControl(CONTROL_PRIVILEGED, {
       op: "start",
-      args: { name, role, agent: opts?.agent, model: opts?.model, cwd: opts?.cwd },
+      args: { name, role, agent: opts?.agent, model: opts?.model, cwd: opts?.cwd, resume: opts?.resume },
     });
   }
 

--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -489,6 +489,7 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
           ),
         resume: z
           .string()
+          .min(1)
           .optional()
           .describe(
             "Optional: fork an existing session id into the mesh instead of starting fresh (claude only; the new peer gets a NEW session forked from that transcript, the original is untouched). The id is a HOST-LOCAL pointer into the manager host's `~/.claude` — it means nothing on another machine, and forking it reads that host's transcript. Only meaningful for a session on the manager's own host.",

--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -487,17 +487,15 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
           .describe(
             "Optional working directory to root the new peer at (e.g. a different repo). A relative path resolves against the manager's workspace; omitted → it shares the manager's workspace.",
           ),
-        resume: z
-          .string()
-          .min(1)
-          .optional()
-          .describe(
-            "Optional: fork an existing session id into the mesh instead of starting fresh (claude only; the new peer gets a NEW session forked from that transcript, the original is untouched). The id is a HOST-LOCAL pointer into the manager host's `~/.claude` — it means nothing on another machine, and forking it reads that host's transcript. Only meaningful for a session on the manager's own host.",
-          ),
+        // NOTE: session `resume` is deliberately NOT exposed here. Forking a host-local `~/.claude`
+        // transcript is an operator-local intent; letting a spawn-capable mesh PEER name a host
+        // session id would expand `spawn` into host-transcript disclosure with no broker-enforced
+        // boundary. Resume lives only on the operator CLI (`cotal spawn --resume` / `cotal start
+        // --resume`); a peer-facing, capability-gated resume is deferred (see #159).
       },
-      async run(agent, _config, { name, role, agent: agentType, model, cwd, resume }: { name: string; role?: string; agent?: string; model?: string; cwd?: string; resume?: string }) {
+      async run(agent, _config, { name, role, agent: agentType, model, cwd }: { name: string; role?: string; agent?: string; model?: string; cwd?: string }) {
         try {
-          const reply = await agent.spawn(name, role, { agent: agentType, model, cwd, resume });
+          const reply = await agent.spawn(name, role, { agent: agentType, model, cwd });
           if (!reply.ok) return err(`Couldn't spawn ${name}: ${reply.error ?? "manager refused"}`);
           const d = reply.data as { name?: string; mode?: string } | undefined;
           const actual = d?.name ?? name; // the manager auto-numbers on a collision — report what it spawned

--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -487,10 +487,16 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
           .describe(
             "Optional working directory to root the new peer at (e.g. a different repo). A relative path resolves against the manager's workspace; omitted → it shares the manager's workspace.",
           ),
+        resume: z
+          .string()
+          .optional()
+          .describe(
+            "Optional: fork an existing session id into the mesh instead of starting fresh (claude only; the new peer gets a NEW session forked from that transcript, the original is untouched). The id is a HOST-LOCAL pointer into the manager host's `~/.claude` — it means nothing on another machine, and forking it reads that host's transcript. Only meaningful for a session on the manager's own host.",
+          ),
       },
-      async run(agent, _config, { name, role, agent: agentType, model, cwd }: { name: string; role?: string; agent?: string; model?: string; cwd?: string }) {
+      async run(agent, _config, { name, role, agent: agentType, model, cwd, resume }: { name: string; role?: string; agent?: string; model?: string; cwd?: string; resume?: string }) {
         try {
-          const reply = await agent.spawn(name, role, { agent: agentType, model, cwd });
+          const reply = await agent.spawn(name, role, { agent: agentType, model, cwd, resume });
           if (!reply.ok) return err(`Couldn't spawn ${name}: ${reply.error ?? "manager refused"}`);
           const d = reply.data as { name?: string; mode?: string } | undefined;
           const actual = d?.name ?? name; // the manager auto-numbers on a collision — report what it spawned

--- a/extensions/connector-hermes/src/extension.ts
+++ b/extensions/connector-hermes/src/extension.ts
@@ -30,6 +30,11 @@ export const hermesConnector: Connector = {
     // the manager can't drive (no Windows named-pipe bridge, no cooperative shutdown). No fallback.
     if (process.platform === "win32")
       throw new Error("the Hermes connector is Unix-only (AF_UNIX bridge + Python sidecar) — not supported on Windows");
+    // Resuming an existing session isn't supported by Hermes (no fork-from-transcript primitive in
+    // the gateway launcher). Throw rather than spawn fresh silently — this connector otherwise
+    // ignores opts it doesn't render, so without this guard `resume` would be dropped without a word.
+    if (opts.resume)
+      throw new Error("the Hermes connector does not support resuming an existing session (resume)");
     // OS allow-list + the named model-provider key (Hermes is model-agnostic; any one unlocks a
     // provider), forwarded BY NAME — never `...process.env` — so the operator's unrelated secrets
     // don't reach the gateway child (P3).

--- a/extensions/connector-opencode/src/extension.ts
+++ b/extensions/connector-opencode/src/extension.ts
@@ -33,6 +33,15 @@ export const opencodeConnector: Connector = {
   transcriptChannel, // the shared `tr-<name>` convention (connector-core), exposed via the contract
   requires: ["opencode"],
   buildLaunch(opts: LaunchOpts): LaunchSpec {
+    // Resuming an existing session isn't wired for opencode: the connector runs `opencode serve` +
+    // a plugin that CREATES its own session then attaches a TUI, so a fork must plumb into
+    // session-creation (SDK fork / the serve attach), not argv. Throw rather than spawn fresh
+    // silently (no fallbacks). Tracked as a follow-up (issue #154).
+    if (opts.resume)
+      throw new Error(
+        "opencode connector: resuming an existing session (resume) is not implemented — it needs " +
+          "session-creation plumbing (SDK fork), not an argv flag. Tracked in issue #154.",
+      );
     // Tool-sharing isn't wired for opencode: its OPENCODE_CONFIG_CONTENT is a merge layer, so an
     // opencode agent already INHERITS the operator's MCP servers (the opposite default to Claude's
     // strict isolation). A `connectors.opencode.mcpServers` entry would need inverse (opt-OUT)

--- a/implementations/cli/smoke/manifest.smoke.ts
+++ b/implementations/cli/smoke/manifest.smoke.ts
@@ -172,6 +172,14 @@ agents: { a: { persona: ./a.md, bogus: 1 } }
 channels: { general: { subscribe: [a] } }
 `, "Unrecognized key");
 
+// `resume:` is an IMPERATIVE-only knob (cotal spawn/start/cotal_spawn) — a manifest must reject it,
+// not silently forward it. Pins the strictObject lock so a future loosen-to-passthrough breaks CI
+// (issue #23: session resume is excluded from the declarative path by construction).
+fails(`${HEAD}
+agents: { a: { persona: ./a.md, resume: sess-123 } }
+channels: { general: { subscribe: [a] } }
+`, "Unrecognized key");
+
 // undeclared name inside allowPublish specifically
 fails(`${HEAD}
 agents: { a: ./a.md }

--- a/implementations/cli/src/commands/spawn.ts
+++ b/implementations/cli/src/commands/spawn.ts
@@ -126,6 +126,7 @@ export async function spawn(argv: string[]): Promise<void> {
       agent: { type: "string" },
       role: { type: "string" },
       prompt: { type: "string" },
+      resume: { type: "string" }, // fork an existing session id into the mesh (host-local; claude only)
       transcript: { type: "boolean" },
       "no-transcript": { type: "boolean" },
       "share-tools": { type: "string" },
@@ -278,6 +279,9 @@ export async function spawn(argv: string[]): Promise<void> {
     allowSubscribe,
     allowPublish,
     prompt: values.prompt,
+    // Fork an existing session into the mesh. `prompt + resume` is a supported combo (claude accepts
+    // the positional prompt alongside `--resume … --fork-session`); an unsupported connector throws.
+    resume: values.resume,
     transcript,
     mcpServers,
   });

--- a/implementations/cli/src/commands/spawn.ts
+++ b/implementations/cli/src/commands/spawn.ts
@@ -153,6 +153,12 @@ export async function spawn(argv: string[]): Promise<void> {
     });
     return;
   }
+  // `--resume ""` / `--resume=` means the operator asked to resume but named no session — fail loud
+  // rather than silently spawn a fresh one (no fallbacks). An absent flag (undefined) is fine.
+  if (values.resume !== undefined && !values.resume.trim()) {
+    console.error("--resume needs a session id (got an empty value)");
+    process.exit(1);
+  }
   // Transcript mirroring to `tr-<name>` is OFF by default; `--transcript` opts in
   // (`--no-transcript` is accepted too, to be explicit about the default).
   const transcript = values.transcript ? true : values["no-transcript"] ? false : false;

--- a/implementations/cli/src/index.ts
+++ b/implementations/cli/src/index.ts
@@ -111,7 +111,7 @@ const baseCommands: Command[] = [
     name: "spawn",
     group: "Agents",
     summary:
-      "launch an agent in this terminal from a file — spawn [<name-or-path>] (defaults to the `default` persona) | --name <n> --config <path> [--agent <a>] [--role <r>]",
+      "launch an agent in this terminal from a file — spawn [<name-or-path>] (defaults to the `default` persona) | --name <n> --config <path> [--agent <a>] [--role <r>] [--resume <id>]",
     run: spawn,
     complete: spawnComplete,
   },

--- a/implementations/manager/package.json
+++ b/implementations/manager/package.json
@@ -18,6 +18,7 @@
     }
   },
   "scripts": {
+    "test": "tsx smoke/start-model-preflight.smoke.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "tsc -p tsconfig.json && node -e \"const fs=require('node:fs'); fs.rmSync('dist/console', { recursive: true, force: true }); fs.cpSync('src/console', 'dist/console', { recursive: true })\"",
     "prepublishOnly": "pnpm run build"

--- a/implementations/manager/smoke/start-model-preflight.smoke.ts
+++ b/implementations/manager/smoke/start-model-preflight.smoke.ts
@@ -200,6 +200,15 @@ registry.register(recCon);
     check("claude: resume + persona → --resume kept", a.includes("--resume"), a);
     check("claude: resume + persona → --fork-session kept", a.includes("--fork-session"), a);
   }
+  // prompt + resume: the ONE combo that only foreground spawn can produce (the recommended primary
+  // surface). The leading positional prompt AND the resume/fork pair must coexist — auto-submit into
+  // the forked session, not a special resume-only launch shape.
+  {
+    const a = cArgs({ ...base, prompt: "hello mesh", resume: "sess-p" });
+    check("claude: prompt+resume → prompt is the leading positional", a[0] === "hello mesh", a[0]);
+    check("claude: prompt+resume → --resume still emitted", a.includes("--resume"), a);
+    check("claude: prompt+resume → --fork-session still emitted", a.includes("--fork-session"), a);
+  }
   // opencode + hermes THROW on resume and produce NO command (fail loud, never spawn fresh silently).
   for (const con of [opencodeConnector, hermesConnector]) {
     let threw = false;

--- a/implementations/manager/smoke/start-model-preflight.smoke.ts
+++ b/implementations/manager/smoke/start-model-preflight.smoke.ts
@@ -34,6 +34,13 @@ function check(label: string, cond: boolean, extra?: unknown): void {
   if (!cond) failures++;
 }
 
+// Hermes is Unix-only — its buildLaunch THROWS on win32 by design (AF_UNIX bridge + Python sidecar).
+// This smoke is CI-gated on both OSes (`pnpm test`), so on Windows we skip the Hermes buildLaunch rows
+// (claude + opencode still run) and instead assert the Unix-only guard fires. `connectors` is the set
+// whose buildLaunch is exercised per-platform.
+const onWin = process.platform === "win32";
+const connectors = onWin ? [claudeConnector, opencodeConnector] : [claudeConnector, opencodeConnector, hermesConnector];
+
 // A workspace with no cotal *config*. A manager spawn now REQUIRES a discoverable persona (no
 // silent default-ACL fallback), so seed a minimal `.cotal/agents/<name>.md` per spawned name —
 // this test's subject is harness preflight + model threading, not persona/ACL resolution.
@@ -123,30 +130,38 @@ registry.register(recCon);
   check("opencode.requires == [opencode]", JSON.stringify(opencodeConnector.requires) === '["opencode"]');
   check("hermes.requires == [hermes]", JSON.stringify(hermesConnector.requires) === '["hermes"]');
 
+  // Hermes is Unix-only: on win32 buildLaunch throws BEFORE producing a spec — assert that guard here
+  // and skip the Hermes model rows below (they'd all throw). claude + opencode still run on both OSes.
+  if (onWin) {
+    let threw = false;
+    try { hermesConnector.buildLaunch({ ...base }); } catch { threw = true; }
+    check("hermes: buildLaunch throws (Unix-only) on win32", threw);
+  }
+
   // flag wins over the agent file's `model:`
   check("claude: flag beats frontmatter", claudeModel(claudeConnector.buildLaunch({ ...base, configPath: af, model: "sonnet" })) === "sonnet");
   check("opencode: flag beats frontmatter", ocModel(opencodeConnector.buildLaunch({ ...base, configPath: af, model: "sonnet" })) === "sonnet");
-  check("hermes: flag beats frontmatter", hermesModel(hermesConnector.buildLaunch({ ...base, configPath: af, model: "sonnet" })) === "sonnet");
+  if (!onWin) check("hermes: flag beats frontmatter", hermesModel(hermesConnector.buildLaunch({ ...base, configPath: af, model: "sonnet" })) === "sonnet");
 
   // flag applies with NO agent file (the gap the fix closes)
   check("claude: flag with no agent file", claudeModel(claudeConnector.buildLaunch({ ...base, model: "sonnet" })) === "sonnet");
   check("opencode: flag with no agent file", ocModel(opencodeConnector.buildLaunch({ ...base, model: "sonnet" })) === "sonnet");
-  check("hermes: flag with no agent file", hermesModel(hermesConnector.buildLaunch({ ...base, model: "sonnet" })) === "sonnet");
+  if (!onWin) check("hermes: flag with no agent file", hermesModel(hermesConnector.buildLaunch({ ...base, model: "sonnet" })) === "sonnet");
 
   // no flag → agent-file model is the fallback (incl. Hermes, whose launcher previously ignored it)
   check("claude: no flag → frontmatter opus", claudeModel(claudeConnector.buildLaunch({ ...base, configPath: af })) === "opus");
   check("opencode: no flag → frontmatter opus", ocModel(opencodeConnector.buildLaunch({ ...base, configPath: af })) === "opus");
-  check("hermes: no flag → frontmatter opus", hermesModel(hermesConnector.buildLaunch({ ...base, configPath: af })) === "opus");
+  if (!onWin) check("hermes: no flag → frontmatter opus", hermesModel(hermesConnector.buildLaunch({ ...base, configPath: af })) === "opus");
 
   // nothing set → no model applied
   check("claude: nothing → no --model", claudeModel(claudeConnector.buildLaunch({ ...base })) === undefined);
   check("opencode: nothing → no config.model", ocModel(opencodeConnector.buildLaunch({ ...base })) === undefined);
-  check("hermes: nothing → no HERMES_MODEL", hermesModel(hermesConnector.buildLaunch({ ...base })) === undefined);
+  if (!onWin) check("hermes: nothing → no HERMES_MODEL", hermesModel(hermesConnector.buildLaunch({ ...base })) === undefined);
 
   // 4 — ACL ENV emission: each connector forwards the resolved policy so the spawned session's
   // runtime read/post set matches its minted creds. Wildcard allowSubscribe (team.>) must survive.
   const acl = { subscribe: ["team"], allowSubscribe: ["team", "team.>"], allowPublish: ["team"] };
-  for (const con of [claudeConnector, opencodeConnector, hermesConnector]) {
+  for (const con of connectors) {
     const env = con.buildLaunch({ ...base, ...acl }).env!;
     check(`${con.name}: COTAL_SUBSCRIBE forwarded`, env.COTAL_SUBSCRIBE === "team", env.COTAL_SUBSCRIBE);
     check(`${con.name}: COTAL_ALLOW_SUBSCRIBE forwarded (wildcard kept)`, env.COTAL_ALLOW_SUBSCRIBE === "team,team.>", env.COTAL_ALLOW_SUBSCRIBE);
@@ -210,14 +225,16 @@ registry.register(recCon);
     check("claude: prompt+resume → --fork-session still emitted", a.includes("--fork-session"), a);
   }
   // opencode + hermes THROW on resume and produce NO command (fail loud, never spawn fresh silently).
-  for (const con of [opencodeConnector, hermesConnector]) {
+  // Hermes is excluded on win32 (its buildLaunch throws Unix-only regardless — asserted in §3).
+  const unsupportedResume = onWin ? [opencodeConnector] : [opencodeConnector, hermesConnector];
+  for (const con of unsupportedResume) {
     let threw = false;
     let spec: LaunchSpec | undefined;
     try { spec = con.buildLaunch({ ...base, resume: "sess-1" }); } catch { threw = true; }
     check(`${con.name}: buildLaunch({resume}) throws`, threw, spec);
   }
   // …but the common no-resume path still builds normally (the guard doesn't over-fire).
-  for (const con of [opencodeConnector, hermesConnector]) {
+  for (const con of unsupportedResume) {
     let built = false;
     try { con.buildLaunch({ ...base }); built = true; } catch { /* unexpected */ }
     check(`${con.name}: no resume → builds normally`, built);

--- a/implementations/manager/smoke/start-model-preflight.smoke.ts
+++ b/implementations/manager/smoke/start-model-preflight.smoke.ts
@@ -14,6 +14,9 @@
  *      connector forwards it as COTAL_SUBSCRIBE / COTAL_ALLOW_*. Guards the bug where creds were
  *      minted from the policy but it never reached the connector, so a manifest-spawned agent (whose
  *      materialized persona has no access frontmatter) fell back to ["general"] and joined nothing.
+ *   5. RESUME (issue #23) — claude buildLaunch emits `--resume <id> --fork-session` (never one
+ *      without the other, hostile id stays one argv token, coexists with the persona append);
+ *      opencode + hermes THROW; and `resume` threads StartAgentOpts → LaunchOpts verbatim.
  */
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -37,7 +40,7 @@ function check(label: string, cond: boolean, extra?: unknown): void {
 const workspaceRoot = mkdtempSync(join(tmpdir(), "cotal-start-ws-"));
 const agentsDir = join(workspaceRoot, ".cotal", "agents");
 mkdirSync(agentsDir, { recursive: true });
-for (const n of ["reject1", "rec1", "rec2"]) writeFileSync(join(agentsDir, `${n}.md`), `---\nname: ${n}\n---\n`);
+for (const n of ["reject1", "rec1", "rec2", "rrec1", "rrec2"]) writeFileSync(join(agentsDir, `${n}.md`), `---\nname: ${n}\n---\n`);
 // rec3 carries an explicit access policy — its frontmatter ACL must thread through to LaunchOpts.
 writeFileSync(join(agentsDir, "rec3.md"), `---\nname: rec3\nsubscribe: [team]\nallowSubscribe: [team, team.>]\nallowPublish: [team]\n---\n`);
 const mgr = new Manager({ space: "smoke", servers: undefined, runtime: "pty", workspaceRoot });
@@ -152,6 +155,71 @@ registry.register(recCon);
     // falls back to the general baseline — never silently overridden to empty).
     check(`${con.name}: no policy → COTAL_SUBSCRIBE absent`, con.buildLaunch({ ...base }).env!.COTAL_SUBSCRIBE === undefined);
   }
+}
+
+// 5 — RESUME: fork an existing session into the mesh (issue #23). claude renders
+// `--resume <id> --fork-session`; opencode + hermes THROW (no silent fresh-spawn fallback); the id
+// threads through the manager verbatim and stays a single argv token (no shell). The manifest path
+// carries no resume by construction (see the cotal.yaml reject in cli manifest.smoke.ts).
+{
+  const base = { space: "smoke", name: "tester" };
+  const cArgs = (o: LaunchOpts) => claudeConnector.buildLaunch(o).args;
+
+  // claude, resume SET → BOTH --resume <id> and --fork-session, id is the token right after --resume.
+  {
+    const a = cArgs({ ...base, resume: "sess-123" });
+    const ri = a.indexOf("--resume");
+    check("claude: --resume emitted when resume set", ri >= 0, a);
+    check("claude: id is the single token after --resume", a[ri + 1] === "sess-123", a[ri + 1]);
+    check("claude: --fork-session emitted when resume set", a.includes("--fork-session"), a);
+  }
+  // claude, resume UNSET → neither flag.
+  {
+    const a = cArgs({ ...base });
+    check("claude: no --resume when unset", !a.includes("--resume"), a);
+    check("claude: no --fork-session when unset", !a.includes("--fork-session"), a);
+  }
+  // INVARIANT — claude NEVER emits --resume without --fork-session (argv-level hijack guard).
+  {
+    const a = cArgs({ ...base, resume: "x" });
+    check("claude: --resume never without --fork-session", !a.includes("--resume") || a.includes("--fork-session"), a);
+  }
+  // A hostile-looking id stays ONE argv element — args is an array, so no shell/interpolation/split.
+  {
+    const weird = "abc def;$(nope) `id` && rm -rf /";
+    const a = cArgs({ ...base, resume: weird });
+    check("claude: hostile id stays one argv element", a[a.indexOf("--resume") + 1] === weird, a[a.indexOf("--resume") + 1]);
+  }
+  // resume + persona: the forked context runs under the CURRENT mesh persona (both flags coexist).
+  {
+    const dir = mkdtempSync(join(tmpdir(), "cotal-resume-af-"));
+    const af = join(dir, "p.md");
+    writeFileSync(af, "---\nname: p\n---\nMESH PERSONA BODY\n");
+    const a = cArgs({ ...base, configPath: af, resume: "sess-9" });
+    check("claude: resume + persona → --append-system-prompt kept", a.includes("--append-system-prompt"), a);
+    check("claude: resume + persona → --resume kept", a.includes("--resume"), a);
+    check("claude: resume + persona → --fork-session kept", a.includes("--fork-session"), a);
+  }
+  // opencode + hermes THROW on resume and produce NO command (fail loud, never spawn fresh silently).
+  for (const con of [opencodeConnector, hermesConnector]) {
+    let threw = false;
+    let spec: LaunchSpec | undefined;
+    try { spec = con.buildLaunch({ ...base, resume: "sess-1" }); } catch { threw = true; }
+    check(`${con.name}: buildLaunch({resume}) throws`, threw, spec);
+  }
+  // …but the common no-resume path still builds normally (the guard doesn't over-fire).
+  for (const con of [opencodeConnector, hermesConnector]) {
+    let built = false;
+    try { con.buildLaunch({ ...base }); built = true; } catch { /* unexpected */ }
+    check(`${con.name}: no resume → builds normally`, built);
+  }
+  // MANAGER THREADING: startAgent({resume}) → LaunchOpts.resume verbatim, and absent → undefined.
+  lastOpts = undefined;
+  await mgr.startAgent({ name: "rrec1", agent: "smoke-rec", resume: "sess-thread" });
+  check("startAgent resume threads into LaunchOpts.resume", lastOpts?.resume === "sess-thread", lastOpts?.resume);
+  lastOpts = undefined;
+  await mgr.startAgent({ name: "rrec2", agent: "smoke-rec" });
+  check("no resume → LaunchOpts.resume undefined", lastOpts?.resume === undefined, lastOpts?.resume);
 }
 
 console.log(`\nSTART-MODEL/PREFLIGHT SMOKE ${failures === 0 ? "OK ✅" : "FAILED ❌"}`);

--- a/implementations/manager/src/commands.ts
+++ b/implementations/manager/src/commands.ts
@@ -133,6 +133,7 @@ function parse(argv: string[]): Values {
       agent: { type: "string" },
       config: { type: "string" },
       model: { type: "string" }, // start: model override, wins over the agent file's `model:`
+      resume: { type: "string" }, // start: fork an existing session id into the mesh (host-local; claude only)
       roster: { type: "string" },
       creds: { type: "string" },
       runtime: { type: "string" }, // supervise: force pty | tmux | cmux (default pty)
@@ -212,6 +213,7 @@ async function start(argv: string[]): Promise<void> {
     agent: v.agent,
     config: v.config,
     model: v.model,
+    resume: v.resume, // fork an existing session into the mesh (host-local id; caveated for detached start — see docs)
     // Opt-in: only sent when `--transcript` is given; absent => the daemon's default (mirror off).
     transcript: v.transcript ? true : undefined,
     cwd: v.cwd,

--- a/implementations/manager/src/commands.ts
+++ b/implementations/manager/src/commands.ts
@@ -206,6 +206,11 @@ async function start(argv: string[]): Promise<void> {
     console.error(c.red("--name is required"));
     process.exit(1);
   }
+  // `--resume ""` asked to resume but named no session — fail loud, don't silently start fresh.
+  if (v.resume !== undefined && !v.resume.trim()) {
+    console.error(c.red("--resume needs a session id (got an empty value)"));
+    process.exit(1);
+  }
   const t = await resolveManagerTarget(v);
   const reply = await ask(t.space, t.server, "start", {
     name: v.name,
@@ -429,7 +434,7 @@ const managerCommands: Command[] = [
     name: "start",
     group: "Control plane",
     summary:
-      "ask the manager to spawn a persona — --name <persona> [--role <r>] [--agent <a>] [--config <file>] [--model <m>] [--cwd <dir>] (loads .cotal/agents/<persona>.md; the peer joins under its name:)",
+      "ask the manager to spawn a persona — --name <persona> [--role <r>] [--agent <a>] [--config <file>] [--model <m>] [--cwd <dir>] [--resume <id> (pair with --cwd)] (loads .cotal/agents/<persona>.md; the peer joins under its name:)",
     run: start,
   },
   {

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -428,6 +428,11 @@ export class Manager {
 
   /** Parse an untyped control-plane `start` request into {@link StartAgentOpts}. */
   private opStart(args: Record<string, unknown>, caller: string): Promise<ControlReply> {
+    // `resume`, when present, must be a non-empty session id. An empty/whitespace value is a
+    // malformed request, not an implicit "spawn fresh" (no fallbacks). The CLI surfaces reject it,
+    // but a raw control message could otherwise slip an empty value through and silently start fresh.
+    if (args.resume !== undefined && !String(args.resume).trim())
+      return Promise.resolve({ ok: false, error: "resume: session id must not be empty" });
     return this.startAgent(
       {
         name: String(args.name ?? "").trim(),

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -68,6 +68,10 @@ export interface StartAgentOpts {
   config?: string;
   /** Model override (the `--model` flag). Takes precedence over the agent file's `model:`. */
   model?: string;
+  /** Opaque host-local session id to FORK into the mesh (the `--resume` flag), forwarded verbatim to
+   *  the connector. Only ever set from imperative control args (`opStart`), NEVER from `resolved` —
+   *  the manifest path stays resume-free by construction. Unsupported connectors throw at buildLaunch. */
+  resume?: string;
   /** Mirror the session's transcript to `tr-<name>`. Defaults to off; `true` (the
    *  `--transcript` flag) opts in. */
   transcript?: boolean;
@@ -431,6 +435,7 @@ export class Manager {
         role: args.role ? String(args.role) : undefined,
         config: args.config ? String(args.config) : undefined,
         model: args.model ? String(args.model) : undefined,
+        resume: args.resume ? String(args.resume) : undefined,
         transcript: typeof args.transcript === "boolean" ? args.transcript : undefined,
         cwd: args.cwd ? String(args.cwd) : undefined,
       },
@@ -628,6 +633,10 @@ export class Manager {
         servers: this.servers,
         configPath,
         model,
+        // Fork an existing session into the mesh. Taken straight from `opts.resume` (the imperative
+        // control arg), never from `opts.resolved` — so the manifest launch path carries no resume by
+        // construction. An unsupported connector throws here before any process is spawned.
+        resume: opts.resume,
         // The SAME access set the creds were minted from (above) — forwarded so the session's
         // runtime read/post set matches its credentials. Without this a manifest-spawned agent
         // (materialized persona has no access frontmatter) falls back to `["general"]`, which its

--- a/packages/core/src/connector.ts
+++ b/packages/core/src/connector.ts
@@ -42,6 +42,14 @@ export interface LaunchOpts {
    *  that support an auto-submitted first prompt (Claude Code) deliver it; others
    *  ignore it. Used to make a driving session greet the operator on launch. */
   prompt?: string;
+  /** An OPAQUE prior-session handle to FORK FROM when launching — never reused, never resolved by
+   *  core. Like `creds` / `configPath`, this is a HOST-LOCAL pointer (into e.g. `~/.claude`), NOT a
+   *  portable value like `model`: it only means something on the machine that produced it. A
+   *  connector that honors it MUST fork a new session id from that transcript (Claude
+   *  `--resume <id> --fork-session`), so the meshed agent gets a fresh session and the original is
+   *  left untouched — resuming MUST NOT hijack the source session. A connector that can't fork
+   *  THROWS at {@link Connector.buildLaunch} rather than silently spawning fresh. */
+  resume?: string;
   /** Mirror this session's transcript to the connector's per-agent transcript channel (see
    *  {@link Connector.transcriptChannel}) so peers/observers can read what the agent actually did
    *  (sets `COTAL_TRANSCRIPT`). Defaults to OFF; set `true` to opt in — surfaced as the `--transcript`


### PR DESCRIPTION
Closes #23.

Every `cotal spawn` / `cotal start` launches a **fresh** `claude`. This lets an operator pull an
existing session — deep context, long transcript — **into** the mesh instead. A running process
can't be retrofitted (MCP is fixed at launch + we isolate with `--strict-mcp-config`), so "resume"
replays the conversation into a fresh, cotal-equipped process via `claude --resume <id> --fork-session`
(verified on 2.1.197).

**Fork, never hijack.** The original session id is never reused — the meshed agent gets a NEW session
forked from that transcript; the source is left untouched. This is pinned at the type: the core
doc-comment on `resume?` says fork-from, so a future connector author can't write hijack-resume and
still be conformant.

### What changed (7 edits, one PR — no cross-PR silent-fresh-launch window)
- **`core/connector.ts`** — `resume?: string` on `LaunchOpts`: an opaque, **host-local** pointer
  (like `creds`/`configPath`, *not* a portable value like `model`) that core forwards but never resolves.
- **claude connector** — renders `--resume <id> --fork-session` in one branch; the persona
  `--append-system-prompt` still applies (forked context under the current mesh persona).
- **opencode + hermes connectors** — **throw** at `buildLaunch` rather than silently spawning fresh
  (no fallbacks). The hermes throw is net-new guard code — it otherwise ignores unrendered opts.
- **3 imperative paths threaded** — foreground `cotal spawn --resume`, `cotal start --resume`
  (→ `op:start`), MCP `cotal_spawn(resume:)`. The manager takes resume **only** from the imperative
  control arg, never from a resolved manifest.
- **declarative manifest stays resume-free by construction** — `MeshManifestSchema`/`AgentEntry` are
  `z.strictObject`, so a `resume:` key fails validation (regression-tested).

### Tests
- Extended the `start-model-preflight` buildLaunch matrix (+33 assertions): claude emits **both**
  flags / never `--resume` without `--fork-session` / hostile id stays one argv token / coexists with
  the persona append; opencode+hermes **throw**; `resume` threads `StartAgentOpts → LaunchOpts`. This
  smoke is now **gated** via a manager `test` script (runs under `pnpm test` in CI).
- Added a `cotal.yaml` `resume:`-key reject case to the (already gated) cli manifest smoke.
- `pnpm typecheck` clean across all packages.

### Docs
`docs/claude-code-integration.md` gains a resume section: foreground `spawn` is the primary surface
(same user/cwd/machine); `start` is caveated (detached — resolves against the manager host's
`~/.claude`, practically needs `--cwd`); a bad id surfaces claude's own stderr, never a generic
"spawn failed".

### Deferred / notes
- **opencode real resume** — it has `--session <id> --fork`, but the connector runs `opencode serve`
  + a plugin that owns session-creation, so it needs SDK/attach plumbing, not argv. Throws until then;
  tracked in #154. The generic `resume?` already accommodates it (connector-internal change only).
- **Manual/live smoke** (CI can't reach a real claude): a real `cotal spawn --resume <id>` forking a
  live session, confirming the original is untouched — a runtime verification, not a code-branch decider.
- Not in this PR: a pre-existing failure in the **ungated** `manifest-launch` smoke (fails identically
  on `main` — unrelated to resume; left as-is to avoid scope creep).
- No changeset included — leaving the version-bump decision to the maintainer.