### PR TITLE
fix(manager): repaint full-screen agents on (re)attach over `cotal attach`

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -385,7 +385,10 @@ browser).
   `addon-attach`, `addon-serialize`, all MIT, zero-dep) for the terminal, in **our own
   lightweight UI** (no framework lock-in, no forked dashboard). The manager exposes a local
   **attach endpoint** (HTTP plus WebSocket) that bridges PTY ↔ browser; `addon-attach` wires a
-  pane straight to that socket, and `addon-serialize` replays scrollback on late attach.
+  pane straight to that socket. The manager mirrors each PTY into a **headless terminal**
+  (`@xterm/headless` + `addon-serialize`) and, on attach, replays a serialized snapshot of it —
+  including a full-screen TUI's alternate-screen buffer — so a late or concurrent attach repaints
+  the current screen in full rather than a partial frame.
 - **Topology:** the manager hosts the attach endpoint (it holds the PTYs); the **console** runs
   **in-process** today, so the manager serves the page itself (`GET /` console, `GET /agents`
   the managed roster, `/assets/*` the vendored xterm bundles, `WS /attach/<name>` the PTY

--- a/implementations/manager/package.json
+++ b/implementations/manager/package.json
@@ -29,6 +29,8 @@
     "@cotal-ai/workspace": "workspace:*",
     "@xterm/addon-attach": "^0.11.0",
     "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-serialize": "^0.13.0",
+    "@xterm/headless": "^5.5.0",
     "@xterm/xterm": "^5.5.0",
     "ws": "^8.21.0",
     "yaml": "^2.9.0",

--- a/implementations/manager/smoke/attach-repaint.smoke.ts
+++ b/implementations/manager/smoke/attach-repaint.smoke.ts
@@ -1,0 +1,122 @@
+/**
+ * Repaint-on-attach: a late or concurrent attach must paint the child's CURRENT screen, not a
+ * partial one. The manager mirrors each PTY into a headless terminal and, on attach, replays a
+ * serialized snapshot of it — the alternate-screen buffer of a full-screen TUI, or the scrollback
+ * of an inline one — so the client repaints deterministically without the child having to emit a
+ * SIGWINCH-driven redraw. (The old raw byte-ring replay couldn't reconstruct an alt-screen, so a
+ * same-size re/co-attach was left staring at a stale partial frame.)
+ *
+ * A) PtyRuntime: a real pty runs a tiny full-screen program; its backlog() reconstructs the current
+ *    alt-screen — twice over (a repeat/concurrent attach is deterministic), and it tracks the live
+ *    screen as the child redraws.
+ * B) AttachEndpoint: with an async backlog, the client gets the snapshot FIRST, then live output in
+ *    order and exactly once — output arriving mid-snapshot is buffered, not lost or raced ahead.
+ */
+import assert from "node:assert";
+import WebSocket from "ws";
+import { AttachEndpoint } from "../src/attach-endpoint.js";
+import { PtyRuntime } from "../src/runtime/pty.js";
+import type { AttachSession, LaunchSpec } from "@cotal-ai/core";
+import type { AgentHandle } from "../src/runtime/index.js";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const str = (b: Buffer | Promise<Buffer>) => Promise.resolve(b).then((x) => x.toString("utf8"));
+
+// A full-screen program: enter the alternate screen, draw PHASE-ONE, then after 400ms clear and
+// draw PHASE-TWO. `\x1b` is written as `\\x1b` so the node -e source contains the literal escape.
+const CHILD = [
+  "-e",
+  "const w=s=>process.stdout.write(s);" +
+    "w('\\x1b[?1049h\\x1b[2J\\x1b[H');" +
+    "w('PHASE-ONE-MARKER top line');" +
+    "setTimeout(()=>w('\\x1b[2J\\x1b[HPHASE-TWO-MARKER redrawn'),400);" +
+    "setTimeout(()=>{},4000);",
+];
+
+async function testPtyReconstruction(): Promise<void> {
+  const rt = new PtyRuntime();
+  const spec = { command: process.execPath, args: CHILD, env: { PATH: process.env.PATH ?? "" } } as LaunchSpec;
+  const handle = rt.spawn("probe", spec, process.cwd());
+  try {
+    await sleep(250); // let PHASE-ONE render into the mirror
+    const snap1 = await str(handle.attach().backlog());
+    assert.match(snap1, /\x1b\[\?1049h/, "A: snapshot re-enters the alternate screen");
+    assert.match(snap1, /PHASE-ONE-MARKER/, "A: snapshot reconstructs the current alt-screen content");
+    assert.doesNotMatch(snap1, /PHASE-TWO/, "A: PHASE-TWO not drawn yet");
+
+    // A second attach's snapshot is identical — reconstruction is deterministic, so a repeat or
+    // concurrent attach gets the full screen every time (the bug was the 2nd/3rd attach going partial).
+    const snap2 = await str(handle.attach().backlog());
+    assert.strictEqual(snap2, snap1, "A: repeat attach reconstructs the same full screen");
+
+    await sleep(300); // now past the 400ms redraw
+    const snap3 = await str(handle.attach().backlog());
+    assert.match(snap3, /PHASE-TWO-MARKER/, "A: snapshot tracks the live redraw");
+    assert.doesNotMatch(snap3, /PHASE-ONE/, "A: the cleared PHASE-ONE is gone");
+    console.log("  ✓ pty reconstructs the alt-screen on (repeat) attach and tracks redraws");
+  } finally {
+    handle.stop({ graceful: false });
+  }
+}
+
+async function testEndpointOrdering(): Promise<void> {
+  // Snapshot resolves after 50ms; live chunks are emitted at 20ms (mid-snapshot → must be buffered
+  // behind it) and 90ms (post-snapshot → straight through). Expect exactly "SNAP" then both, in order.
+  let dataFn: ((c: Buffer) => void) | undefined;
+  const session = {
+    cols: 80,
+    rows: 24,
+    backlog: () => new Promise<Buffer>((res) => setTimeout(() => res(Buffer.from("SNAP")), 50)),
+    onData: (fn: (c: Buffer) => void) => {
+      dataFn = fn;
+      return () => (dataFn = undefined);
+    },
+    onExit: () => () => {},
+    write: () => {},
+    resize: () => {},
+  } as unknown as AttachSession;
+  const handle = {
+    name: "a",
+    kind: "pty",
+    status: () => "running",
+    stop: () => {},
+    interrupt: () => {},
+    attach: () => session,
+  } as unknown as AgentHandle;
+
+  const ep = new AttachEndpoint((n) => (n === "a" ? handle : undefined), () => [], () => [], 0);
+  await ep.start();
+  try {
+    const got: string[] = [];
+    const ws = new WebSocket(ep.url("a"));
+    ws.on("message", (d: Buffer) => got.push(d.toString("utf8")));
+    await new Promise<void>((resolve, reject) => {
+      ws.on("open", () => resolve());
+      ws.on("error", reject);
+    });
+    setTimeout(() => dataFn?.(Buffer.from("LIVE")), 20); // mid-snapshot → buffered
+    setTimeout(() => dataFn?.(Buffer.from("AFTER")), 90); // post-snapshot → live
+    await sleep(220);
+    ws.close();
+    await sleep(20);
+
+    assert.strictEqual(got[0], "SNAP", "B: snapshot arrives first");
+    assert.strictEqual(got.join(""), "SNAPLIVEAFTER", "B: live output ordered after the snapshot, exactly once");
+    console.log("  ✓ endpoint sends the snapshot first, then buffered + live output in order");
+  } finally {
+    await ep.stop();
+  }
+}
+
+async function main(): Promise<void> {
+  await testPtyReconstruction();
+  await testEndpointOrdering();
+  console.log("\nATTACH REPAINT SMOKE OK ✅  (2 tests)");
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/implementations/manager/src/attach-endpoint.ts
+++ b/implementations/manager/src/attach-endpoint.ts
@@ -73,7 +73,9 @@ export class AttachEndpoint {
         socket.end("HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n");
         return;
       }
-      this.#wss.handleUpgrade(req, socket, head, (ws) => this.#onConnection(ws, name));
+      this.#wss.handleUpgrade(req, socket, head, (ws) => {
+        this.#onConnection(ws, name).catch(() => ws.close());
+      });
     });
   }
 
@@ -178,7 +180,7 @@ export class AttachEndpoint {
     res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
   }
 
-  #onConnection(ws: WebSocket, name: string): void {
+  async #onConnection(ws: WebSocket, name: string): Promise<void> {
     const handle = this.lookup(name);
     if (!handle || handle.status() !== "running") {
       ws.close();
@@ -194,14 +196,23 @@ export class AttachEndpoint {
       return;
     }
 
-    const backlog = session.backlog();
-    if (backlog.length) ws.send(backlog);
-
+    const send = (b: Buffer) => {
+      if (ws.readyState === ws.OPEN) ws.send(b);
+    };
+    // Subscribe to live output BEFORE requesting the snapshot, and buffer what arrives until the
+    // snapshot is sent. The snapshot (below) is a point-in-time screen image; anything the child
+    // emits after it must land after it, in order. Subscribing first (no await in between) means no
+    // chunk can slip through unobserved, and the buffer stops a mid-snapshot burst from racing ahead
+    // of — or being lost before — the image.
+    let live = false;
+    const buffered: Buffer[] = [];
     const offData = session.onData((chunk) => {
-      if (ws.readyState === ws.OPEN) ws.send(chunk);
+      if (live) send(chunk);
+      else buffered.push(chunk);
     });
     const offExit = session.onExit(() => ws.close());
-
+    // Wire input + cleanup now too, so the client's initial `r:cols,rows` (and any early keystrokes)
+    // during the snapshot await aren't dropped, and a disconnect mid-await still unsubscribes.
     ws.on("message", (data, isBinary) => {
       if (isBinary) {
         session.write((data as Buffer).toString("utf8"));
@@ -209,12 +220,31 @@ export class AttachEndpoint {
       }
       const text = data.toString();
       const m = /^r:(\d+),(\d+)$/.exec(text);
-      if (m) session.resize(Number(m[1]), Number(m[2]));
-      else session.write(text);
+      if (!m) {
+        session.write(text);
+        return;
+      }
+      session.resize(Number(m[1]), Number(m[2]));
     });
     ws.on("close", () => {
       offData();
       offExit();
     });
+
+    // Reconstructed screen image: the backend replays a byte-exact snapshot — including the
+    // alternate-screen buffer of a full-screen TUI (OpenCode/Claude) — so a late or concurrent attach
+    // paints correctly without depending on the child to repaint. (Raw scrollback replay couldn't
+    // rebuild an alt-screen, leaving same-size re/co-attaches a partial screen.) Then flush anything
+    // that arrived while we built it, and switch to sending live output straight through.
+    let snapshot: Buffer;
+    try {
+      snapshot = await session.backlog();
+    } catch {
+      ws.close(1011, "attach snapshot failed");
+      return;
+    }
+    if (snapshot.length) send(snapshot);
+    for (const chunk of buffered) send(chunk);
+    live = true; // snapshot delivered — stream subsequent output straight through
   }
 }

--- a/implementations/manager/src/runtime/pty.ts
+++ b/implementations/manager/src/runtime/pty.ts
@@ -1,11 +1,14 @@
 import * as pty from "@lydell/node-pty";
+import Headless from "@xterm/headless";
+import { SerializeAddon } from "@xterm/addon-serialize";
 import type { AgentHandle, AttachSession, LaunchSpec, Runtime } from "@cotal-ai/core";
 import { preparePtyLaunch } from "./windows-launch.js";
 
 const DEFAULT_COLS = 120;
 const DEFAULT_ROWS = 32;
-/** How much terminal output to retain for late-attach scrollback replay. */
-const SCROLLBACK_BYTES = 256 * 1024;
+/** How many rows of history the attach-time screen mirror retains (see spawn) so a late attach
+ *  still sees output that scrolled past. */
+const SCROLLBACK_ROWS = 1000;
 /** Spacing between auto-confirm Enter presses, and how many to send. Claude's startup gates
  *  (workspace-trust, then the dev-channels warning) each wait for Enter and neither has a headless
  *  override. The count is variable — a fresh folder shows both, a re-launch on a now-trusted folder
@@ -47,8 +50,18 @@ export class PtyRuntime implements Runtime {
 
     const dataSubs = new Set<(c: Buffer) => void>();
     const exitSubs = new Set<() => void>();
-    const ring: Buffer[] = [];
-    let ringBytes = 0;
+    // Mirror the child's PTY into a headless terminal, so on attach we hand the new client a
+    // reconstructed screen image — the alternate-screen buffer of a full-screen TUI, or the
+    // scrollback of an inline one — instead of a raw byte replay. A raw replay can't rebuild an
+    // alt-screen, which left a late or concurrent attach staring at a partial screen (see `backlog`).
+    const term = new Headless.Terminal({
+      cols: DEFAULT_COLS,
+      rows: DEFAULT_ROWS,
+      scrollback: SCROLLBACK_ROWS,
+      allowProposedApi: true, // the serialize addon reads buffer internals via proposed API
+    });
+    const serializer = new SerializeAddon();
+    term.loadAddon(serializer);
     let alive = true;
     let cols = DEFAULT_COLS;
     let rows = DEFAULT_ROWS;
@@ -70,12 +83,8 @@ export class PtyRuntime implements Runtime {
     }
 
     proc.onData((d) => {
+      term.write(d); // mirror into the screen model for attach-time reconstruction
       const b = Buffer.from(d, "utf8");
-      ring.push(b);
-      ringBytes += b.length;
-      while (ringBytes > SCROLLBACK_BYTES && ring.length > 1) {
-        ringBytes -= ring.shift()!.length;
-      }
       for (const fn of dataSubs) fn(b);
     });
     proc.onExit(() => {
@@ -133,7 +142,14 @@ export class PtyRuntime implements Runtime {
         get rows() {
           return rows;
         },
-        backlog: () => Buffer.concat(ring),
+        backlog: () =>
+          // Serialize the mirrored screen into bytes that repaint it exactly — the alt-screen buffer
+          // (and modes) of a full-screen TUI, or the scrollback of an inline one. The empty write
+          // drains the parser first (xterm writes are FIFO), so the snapshot reflects every byte the
+          // child has emitted so far, not a state that lags behind in-flight output.
+          new Promise<Buffer>((resolve) =>
+            term.write("", () => resolve(Buffer.from(serializer.serialize(), "utf8"))),
+          ),
         onData: (fn) => {
           dataSubs.add(fn);
           return () => dataSubs.delete(fn);
@@ -148,6 +164,7 @@ export class PtyRuntime implements Runtime {
         resize: (c, r) => {
           cols = c;
           rows = r;
+          if (c > 0 && r > 0) term.resize(c, r); // keep the mirror in step so snapshots reconstruct at size
           if (alive) proc.resize(c, r);
         },
       }),

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "smoke:opencode-coop": "tsx extensions/connector-opencode/smoke/cooperative-stop.smoke.ts",
     "smoke:opencode-transcript": "tsx extensions/connector-opencode/smoke/transcript-mirror.smoke.ts",
     "smoke:attach": "tsx implementations/manager/smoke/attach.smoke.ts",
+    "smoke:attach-repaint": "tsx implementations/manager/smoke/attach-repaint.smoke.ts",
     "smoke:manager-console": "pnpm --filter @cotal-ai/manager... build && tsx implementations/manager/smoke/console-assets.smoke.ts",
     "smoke:windows": "tsx implementations/manager/smoke/windows-launch.smoke.ts",
     "smoke:secret-fs": "tsx packages/core/smoke/secret-fs.smoke.ts",

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -11,8 +11,10 @@ export type RuntimeKind = string;
 export interface AttachSession {
   readonly cols: number;
   readonly rows: number;
-  /** Scrollback so a late attach sees output that already scrolled past. */
-  backlog(): Buffer;
+  /** A snapshot to bootstrap a late/concurrent attach: bytes that repaint the current screen.
+   *  May be async — a backend can reconstruct a full-screen (alternate-screen) TUI's buffer rather
+   *  than replay raw scrollback, so an attach paints correctly without the child having to repaint. */
+  backlog(): Buffer | Promise<Buffer>;
   /** Subscribe to live output; returns an unsubscribe fn. */
   onData(fn: (chunk: Buffer) => void): () => void;
   /** Fires when the underlying process exits; returns an unsubscribe fn. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,6 +288,12 @@ importers:
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
+      '@xterm/addon-serialize':
+        specifier: ^0.13.0
+        version: 0.13.0(@xterm/xterm@5.5.0)
+      '@xterm/headless':
+        specifier: ^5.5.0
+        version: 5.5.0
       '@xterm/xterm':
         specifier: ^5.5.0
         version: 5.5.0
@@ -934,6 +940,14 @@ packages:
     resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
     peerDependencies:
       '@xterm/xterm': ^5.0.0
+
+  '@xterm/addon-serialize@0.13.0':
+    resolution: {integrity: sha512-kGs8o6LWAmN1l2NpMp01/YkpxbmO4UrfWybeGu79Khw5K9+Krp7XhXbBTOTc3GJRRhd6EmILjpR8k5+odY39YQ==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
+
+  '@xterm/headless@5.5.0':
+    resolution: {integrity: sha512-5xXB7kdQlFBP82ViMJTwwEc3gKCLGKR/eoxQm4zge7GPBl86tCdI0IdPJjoKd8mUSFXz5V7i/25sfsEkP4j46g==}
 
   '@xterm/xterm@5.5.0':
     resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
@@ -2387,6 +2401,12 @@ snapshots:
   '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
     dependencies:
       '@xterm/xterm': 5.5.0
+
+  '@xterm/addon-serialize@0.13.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
+
+  '@xterm/headless@5.5.0': {}
 
   '@xterm/xterm@5.5.0': {}
 


### PR DESCRIPTION
## Problem

A late or concurrent `cotal attach` to a full-screen (alternate-screen) TUI — OpenCode, Claude — rendered a **partial screen**: content missing, only a fragment of the UI drawn.

The attach endpoint bootstrapped each new client by replaying the PTY's raw 256 KB byte ring. That replay can't reconstruct an alternate-screen buffer, so the client relied on the child process itself repainting — which only happens on a real `SIGWINCH`. A **first** attach worked by accident: the PTY starts at the spawn default (120×32), the client's real size differs, so the initial resize is a genuine dimension change → `SIGWINCH` → clean repaint. A **second, third, or concurrent** attach resizes to the size the PTY is already at → no change → no `SIGWINCH` → no repaint → partial screen.

## Fix

Reconstruct the screen **server-side**, the way terminal multiplexers (tmux, mosh) do, instead of replaying raw bytes and hoping the child repaints:

- `PtyRuntime` mirrors each PTY into a **headless xterm terminal** (`@xterm/headless`); every chunk of child output is fed into it as it streams.
- On attach, `backlog()` serializes that mirror (`@xterm/addon-serialize`) into bytes that repaint the current screen exactly — the alternate-screen buffer and terminal modes of a full-screen TUI, or the scrollback of an inline one.

The new client therefore receives a byte-exact snapshot of the live screen with no dependence on the child emitting a redraw, so every attach — repeat, concurrent, any size — paints in full. The raw byte ring is removed. This also realizes the `addon-serialize` late-attach design already documented in `docs/architecture.md`, which the ring implementation had drifted from.

**Endpoint ordering.** `#onConnection` subscribes to live output *before* requesting the snapshot (no `await` between the two, so no chunk can slip by unobserved), buffers anything that arrives while the snapshot is built, sends the snapshot first, then flushes the buffer in order and switches to live passthrough — output is never lost, reordered, or duplicated across the async boundary.

**Contract.** `AttachSession.backlog()` widens to `Buffer | Promise<Buffer>`; the pty backend drains the parser before serializing so the snapshot reflects every byte emitted so far. Other backends' synchronous implementations are unaffected.

This retires the earlier height-jog approach (transiently resize a row to force a `SIGWINCH`): `SIGWINCH` is a non-queued signal, so two back-to-back resizes can coalesce into a single delivery at the final, unchanged size — the repaint then fired only when process scheduling happened to cooperate, and it went partial on the 3rd/concurrent attach in practice.

## Testing

- New `smoke:attach-repaint` (2 tests): a **real PTY** running a full-screen program — `backlog()` reconstructs the alternate screen, returns an **identical snapshot on a repeat attach** (the exact 2nd/3rd-attach case), and tracks a live redraw; and the endpoint sends the snapshot first, then buffered and live output in order and exactly once.
- `smoke:attach` regression, `typecheck`, and a full `pnpm -r build` all green.
- Verified live: repeat and concurrent attach to a running OpenCode agent now paint the full screen every time.

## Notes

- No changeset (intentional).
- Follow-up to #156 (the OpenCode wheel-scroll fix). Detach remains `Ctrl-]`.