### PR TITLE
feat(examples): frontier-faces — ten-panel cast, topic channels, showcase recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ cotal down         # stop everything
 <td width="50%" valign="middle"><b><a href="examples/02-self-improving-console">A swarm rebuilds Cotal's console</a></b><br><br>Four real Claude Code agents join one mesh and coordinate as lateral peers; an orchestrator spawns the workers in cmux tabs and they ship a polished Ink/React TUI for the live console.<br><br><sub>four coding agents · <a href="https://cmux.com">cmux</a> tabs</sub></td>
 <td width="50%"><img src="assets/example-02.gif" alt="Four Claude Code agents (orchestrator, backend, tui-designer, manager) coordinating on the Cotal mesh, with the live cotal console on the left and the agents in cmux tabs on the right"></td>
 </tr>
+<tr>
+<td width="50%"><img src="assets/example-04-frontier.gif" alt="Ten panelist personas as animated pixel-art OpenCode agents on the Cotal mesh, each lip-syncing its streamed reply and steering its own expression"></td>
+<td width="50%" valign="middle"><b><a href="examples/04-frontier-faces">Frontier Tower faces</a></b><br><br>Ten panelist personas as animated pixel-art OpenCode agents: each thinks, lip-syncs its streamed reply, and steers its own 32×32 expression, and on the mesh they coordinate as lateral peers in one space.<br><br><sub>ten OpenCode faces · <a href="https://opencode.ai">OpenCode</a> · browser + tmux wall</sub></td>
+</tr>
 </table>
 
 Full index: [docs/examples.md](docs/examples.md).

--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ cotal down         # stop everything
 <td width="50%"><img src="assets/example-02.gif" alt="Four Claude Code agents (orchestrator, backend, tui-designer, manager) coordinating on the Cotal mesh, with the live cotal console on the left and the agents in cmux tabs on the right"></td>
 </tr>
 <tr>
-<td width="50%"><img src="assets/example-04-frontier.gif" alt="Ten panelist personas as animated pixel-art OpenCode agents on the Cotal mesh, each lip-syncing its streamed reply and steering its own expression"></td>
-<td width="50%" valign="middle"><b><a href="examples/04-frontier-faces">Frontier Tower faces</a></b><br><br>Ten panelist personas as animated pixel-art OpenCode agents: each thinks, lip-syncs its streamed reply, and steers its own 32×32 expression, and on the mesh they coordinate as lateral peers in one space.<br><br><sub>ten OpenCode faces · <a href="https://opencode.ai">OpenCode</a> · browser + tmux wall</sub></td>
+<td width="50%"><img src="assets/example-04-frontier.webp" alt="The Frontier Tower faces demo on the tmux wall: pixel-art OpenCode agents on the Cotal mesh lip-syncing their streamed replies, with the live cotal console beside them"></td>
+<td width="50%" valign="middle"><b><a href="examples/04-frontier-faces">Frontier Tower faces</a></b><br><br>Ten panelist personas as animated pixel-art OpenCode agents: each thinks, lip-syncs its streamed reply, and steers its own 32×32 expression, and on the mesh they coordinate as lateral peers in one space.<br><br><sub>ten OpenCode faces · <a href="https://opencode.ai">OpenCode</a> · tmux wall + browser</sub></td>
 </tr>
 </table>
 

--- a/examples/04-frontier-faces/README.md
+++ b/examples/04-frontier-faces/README.md
@@ -1,19 +1,20 @@
-# Example 04 — Frontier Tower faces
+# Example 04: Frontier Tower faces
 
 Animated pixel-art avatars for agents, built for the Frontier Tower demo: each persona is
 an OpenCode-hosted agent with a 32×32 truecolor face that thinks, lip-syncs its streamed
-reply, and steers its own expression as it talks. Run as a mesh, the
-faces coordinate as lateral peers in one Cotal space — you watch them talk to each other.
+reply, and steers its own expression as it talks. Run as a mesh, the faces coordinate as
+lateral peers in one Cotal space: you watch them talk to each other. The demo runs on a
+live display on Frontier Tower's 10th floor, the Immersive Commons floor.
 
 There are two front-ends onto the *same* live mesh: a **browser studio** (`tools/studio.mjs`)
 and a **tmux wall** (`mesh-wall.sh`). Both spawn real agents; nothing here is scripted.
 
 ## Live studio (browser)
 
-One command brings up the whole thing — the mesh, the agents, and the web UI:
+One command brings up the whole thing (the mesh, the agents, and the web UI):
 
 ```sh
-node tools/studio.mjs                 # the full panel — cast from cotal.yaml
+node tools/studio.mjs                 # the full panel, cast from cotal.yaml
 node tools/studio.mjs -f my-panel.yaml # a smaller cast (your own manifest)
 SPACE=demo PORT=4097 node tools/studio.mjs
 # then open http://127.0.0.1:4097/
@@ -22,14 +23,14 @@ SPACE=demo PORT=4097 node tools/studio.mjs
 What happens end to end, all real:
 
 1. it ensures a Cotal mesh is up (starts `cotal up --open` if one isn't);
-2. it joins as an operator endpoint — **"you"**, the human seat in the room;
+2. it joins as an operator endpoint: **"you"**, the human seat in the room;
 3. it spawns each roster member as a real headless mesh agent (OpenCode + the cotal plugin);
 4. the page renders each agent's animated face driven by that agent's **live** OpenCode stream,
    the authoritative **mesh transcript** (what the operator endpoint actually receives on
    `#general`), and a prompt box.
 
 The bottom box **broadcasts to `#general`** (the whole panel); each face also has its own input to
-**DM that one agent privately** — only it wakes, and it replies straight back to you. Type → the
+**DM that one agent privately**: only it wakes, and it replies straight back to you. Type → the
 operator posts → every (or one) agent's connector turns it into an OpenCode turn → they reply and
 coordinate over the mesh → you watch their faces talk. A face's status dot tracks its real activity
 (thinking / working / speaking); a tile flashes when that agent sends on the mesh. The studio
@@ -38,7 +39,7 @@ fresh-boots the space's history on start, so each run begins clean. Ctrl-C tears
 Requires `opencode` (`opencode auth login`) and a built repo (`pnpm build` at the repo root).
 
 The studio needs an **`--open`** mesh (it joins bare, as the operator). If something is already on
-the default port that rejects it — e.g. an existing **auth** mesh on `:4222` — it stops with a clear
+the default port that rejects it (e.g. an existing **auth** mesh on `:4222`), it stops with a clear
 message; run it on its own free port + space instead:
 
 ```sh
@@ -47,12 +48,12 @@ SPACE=frontier COTAL_SERVERS=nats://127.0.0.1:4299 node tools/studio.mjs sven da
 
 ## Quick start (tmux)
 
-Requirements: Node ≥ 20, [OpenCode](https://opencode.ai) (run `opencode auth login` once —
+Requirements: Node ≥ 20, [OpenCode](https://opencode.ai) (run `opencode auth login` once;
 the personas default to `opencode-go/glm-5.1`), and `tmux`. The mesh's `nats-server` is
 bundled by the CLI, so there's nothing else to install.
 
 ```sh
-# the whole demo: start the mesh, a grid of mesh faces, and the console — one command
+# the whole demo in one command: start the mesh, a grid of mesh faces, and the console
 ./mesh-wall.sh                 # curated roster + console
 ./mesh-wall.sh sven david      # pick agents (agent-file basenames)
 ./mesh-wall.sh all             # every agent (capped at 9 panes)
@@ -61,20 +62,21 @@ bundled by the CLI, so there's nothing else to install.
 ```
 
 Standard layout: the face grid is on the **left**, the `console` (live mesh traffic) is the
-pane on the **right** — one tmux window. Each face is a real Cotal mesh peer; type into one and
+pane on the **right**, in one tmux window. Each face is a real Cotal mesh peer; type into one and
 the others can see and answer it on the shared space. Switch focus with the mouse or `Ctrl-b
 ←/→`. Override the model, space, or console width with `MODEL=opencode/<free-model>`,
 `SPACE=demo`, or `CONSOLE_WIDTH=40% ./mesh-wall.sh`.
 
 ## Live event / signage
 
-Built to run on a public monitor where people walk up and try it. The mesh wall shows a Cotal
-signage strip across the top — wordmark + tagline + a **QR to [cotal.ai](https://cotal.ai)** so
-passers-by can open the site on their phone — plus a persistent `Cotal · cotal.ai` status bar along
-the bottom. The browser wall (`tools/serve-wall.mjs`) carries the same QR in its header and footer.
+Built to run on a public monitor where people walk up and try it, like the demo's live display
+on Frontier Tower's 10th floor, the Immersive Commons floor. The mesh wall shows a Cotal signage strip
+across the top (wordmark + tagline + a **QR to [cotal.ai](https://cotal.ai)** so passers-by can
+open the site on their phone), plus a persistent `Cotal · cotal.ai` status bar along the bottom.
+The browser wall (`tools/serve-wall.mjs`) carries the same QR in its header and footer.
 
 The terminal QR is an inverted **glow** (bright pixels on the dark theme, no white card). It's a
-mildly non-standard inverted code — modern phones (iOS Camera, Google Lens) scan it, and the
+mildly non-standard inverted code: modern phones (iOS Camera, Google Lens) scan it, and the
 **browser wall renders a dark-on-light QR that scans on everything**, so that's the reliable path.
 
 ```sh
@@ -86,19 +88,19 @@ BANNER_VARIANT=3 BANNER_HEIGHT=24 ./mesh-wall.sh  # Hero strip (taller; the QR n
 ```
 
 The QR is pre-generated, not encoded at runtime: `qr-cotal.mjs` holds the static matrix (rendered by
-both walls — terminal half-blocks and a browser canvas) and `tools/brand-banner.mjs` /
+both walls: terminal half-blocks and a browser canvas) and `tools/brand-banner.mjs` /
 `tools/tmux-brand.sh` draw the strip and status bar. To point it at a different URL, regenerate the
 matrix per the note in `qr-cotal.mjs`.
 
 ## Unattended signage
 
-For a public monitor, run the live studio (above) full-screen — it self-recovers and keeps the
+For a public monitor, run the live studio (above) full-screen; it self-recovers and keeps the
 panel talking. Nudge it occasionally (a question in the prompt box) to keep the conversation moving.
 The studio carries the same Cotal branding as the tmux wall's signage strip.
 
 ## Without the mesh (standalone faces)
 
-Each face is its own OpenCode chat — no mesh, no shared space:
+Each face is its own OpenCode chat, with no mesh and no shared space:
 
 ```sh
 # one face, one live agent
@@ -122,42 +124,42 @@ node tools/serve-wall.mjs      # then open the printed URL
 
 ## What's here
 
-- **`tools/studio.mjs`** — the browser studio: ensures the mesh, joins it as the operator
+- **`tools/studio.mjs`**: the browser studio; it ensures the mesh, joins it as the operator
   endpoint, spawns the roster as headless mesh agents (the connector's `COTAL_SERVE_HEADLESS`
   mode), proxies each agent's live OpenCode stream, and serves `web/studio.html`.
-- **`web/studio.html`** — the studio UI: a grid of live `<cotal-face>` tiles + the mesh
+- **`web/studio.html`**: the studio UI, a grid of live `<cotal-face>` tiles + the mesh
   transcript + a prompt box. Drives each face from its agent's real OpenCode SSE (via
   `cotal-opencode.js`) and the transcript from the operator endpoint's feed.
-- **`mesh-wall.sh`** — the tmux one-command launcher: starts the mesh, a tmux grid of mesh faces
+- **`mesh-wall.sh`**: the tmux one-command launcher; starts the mesh, a tmux grid of mesh faces
   (one `mesh-face.sh` per agent), and the console.
-- **`mesh-face.sh`** + **`mesh-face.mjs`** — one mesh agent: the `.mjs` launcher starts an
+- **`mesh-face.sh`** + **`mesh-face.mjs`**: one mesh agent. The `.mjs` launcher starts an
   `opencode serve` with the `@cotal-ai/connector-opencode` plugin + an agent file (so it joins the
   mesh and creates a session), reads that session's id (the plugin prints `[cotal-session] <id>`),
-  and attaches the face. The OpenCode connector is face-agnostic — this launcher owns the viewer
+  and attaches the face. The OpenCode connector is face-agnostic; this launcher owns the viewer
   attach, so face rendering never leaks into shared code.
-- **`face-plugin.mjs`** — example-local OpenCode plugin registering the `face_<mood>` expression
+- **`face-plugin.mjs`**: example-local OpenCode plugin registering the `face_<mood>` expression
   tools. A mesh face calls them to drive its avatar, keeping its `cotal_*` messages clean on the wire.
-- **`face-term.mjs`** — the terminal face (half-block renderer, zero deps). Connects to an OpenCode
+- **`face-term.mjs`**: the terminal face (half-block renderer, zero deps). Connects to an OpenCode
   server, maps its SSE events to the face: assistant text drives the lip-sync, while `face_<mood>`
   tool calls (mesh) and inline `[[face:X]]` tags (standalone direct chat) drive the expression.
-- **`personas.mjs`** — the pixel data, one entry per persona (single source for the terminal face).
-- **`face-wall.sh`** — tmux grid of standalone faces, one direct chat session per pane.
-- **`agents/`** — the persona definitions (OpenCode agent files): digital twins of ten
+- **`personas.mjs`**: the pixel data, one entry per persona (single source for the terminal face).
+- **`face-wall.sh`**: tmux grid of standalone faces, one direct chat session per pane.
+- **`agents/`**: the persona definitions (OpenCode agent files): digital twins of ten
   Frontier Tower panelists, each tuned to coordinate as a lateral peer on a Cotal mesh. The `face:`
   frontmatter maps an agent to its persona key where the names differ (steve→jobs, elon→musk,
   rayan→ray).
-- **`research/`** — the public-record research the agent files are distilled from.
-- **`web/`** — the same engine as a `<cotal-face>` custom element (`cotal-face.js`, drawing
+- **`research/`**: the public-record research the agent files are distilled from.
+- **`web/`**: the same engine as a `<cotal-face>` custom element (`cotal-face.js`, drawing
   its personas straight from `personas.mjs`), a live `wall.html` (a browser twin of the tmux
   wall), and a userscript that overlays a face on OpenCode's web UI (its CSP blocks plain
   script injection).
-- **`tools/`** — persona authoring: `img2rows.mjs` roughs a reference image into rows+palette,
+- **`tools/`**: persona authoring; `img2rows.mjs` roughs a reference image into rows+palette,
   `render-png.mjs` renders a contact sheet for review, `face-template.mjs` is the copy-me
   reference face. `preview.html` shows every persona straight from `personas.mjs`.
 
 ## Adding a persona
 
-Append an entry to `personas.mjs` (rows, colors, glow, mouths, expr, eyes, lines) — it's
+Append an entry to `personas.mjs` (rows, colors, glow, mouths, expr, eyes, lines) and it's
 immediately available everywhere: `--persona`, `--list`, the walls, and the browser
 (`web/cotal-face.js` imports `personas.mjs`, so no manual sync). Copy `tools/face-template.mjs`
 to start from a known-good face; **[FACE-DESIGN.md](FACE-DESIGN.md)** documents the grid zones,

--- a/examples/04-frontier-faces/README.md
+++ b/examples/04-frontier-faces/README.md
@@ -13,8 +13,8 @@ and a **tmux wall** (`mesh-wall.sh`). Both spawn real agents; nothing here is sc
 One command brings up the whole thing — the mesh, the agents, and the web UI:
 
 ```sh
-node tools/studio.mjs                 # curated roster (sven, david, garry)
-node tools/studio.mjs sven david elon # explicit agents (agent-file basenames)
+node tools/studio.mjs                 # the full panel — cast from cotal.yaml
+node tools/studio.mjs -f my-panel.yaml # a smaller cast (your own manifest)
 SPACE=demo PORT=4097 node tools/studio.mjs
 # then open http://127.0.0.1:4097/
 ```

--- a/examples/04-frontier-faces/cotal.yaml
+++ b/examples/04-frontier-faces/cotal.yaml
@@ -43,14 +43,26 @@ channels:
     subscribe: [david, sven]
     allowPublish: [david, sven]
 
-  # Spicy provocations — no consensus required.
-  hot-takes:
-    description: Spicy provocations — no consensus required.
-    subscribe: [sven, garry, elon, steve, bernie, mira]
-    allowPublish: [sven, garry, elon, steve, bernie, mira]
+  # Control vs. emergence — a human at the gate, or environments that self-correct?
+  gates-vs-gardens:
+    description: Control vs. emergence — a human at the gate, or environments that self-correct?
+    subscribe: [sven, david, rayan, michelle, mira]
+    allowPublish: [sven, david, rayan, michelle, mira]
 
-  # Getting it right — safety, ethics, and the long game.
-  stewardship:
-    description: Getting it right — safety, ethics, and the long game.
-    subscribe: [michelle, mira, dario, bernie, rayan]
-    allowPublish: [michelle, mira, dario, bernie, rayan]
+  # How fast, how dangerous, and can we steer it?
+  the-curve:
+    description: How fast, how dangerous, and can we steer it?
+    subscribe: [dario, elon, garry, mira, sven]
+    allowPublish: [dario, elon, garry, mira, sven]
+
+  # The human ledger of automation — jobs, access, and power.
+  who-pays:
+    description: The human ledger of automation — jobs, access, and power.
+    subscribe: [bernie, elon, garry, dario, michelle, mira]
+    allowPublish: [bernie, elon, garry, dario, michelle, mira]
+
+  # Craft, and the last moat when agents generate everything.
+  taste-and-slop:
+    description: Craft, and the last moat when agents generate everything.
+    subscribe: [steve, rayan, sven, garry, david, michelle]
+    allowPublish: [steve, rayan, sven, garry, david, michelle]

--- a/examples/04-frontier-faces/cotal.yaml
+++ b/examples/04-frontier-faces/cotal.yaml
@@ -1,6 +1,6 @@
 # Frontier Tower faces — declarative mesh.
 #
-#   cotal up -f cotal.yaml            # fresh broker + channels + the four agents
+#   cotal up -f cotal.yaml            # fresh broker + channels + the full panel
 #   cotal up -f cotal.yaml --dry-run  # validate + print the plan, change nothing
 #
 # Channel membership lives here, not in a launcher script: `subscribe` is who reads a
@@ -25,13 +25,17 @@ agents:
   elon: agents/elon.md
   michelle: agents/michelle.md
   mira: agents/mira.md
+  bernie: agents/bernie.md
+  dario: agents/dario.md
+  steve: agents/steve.md
+  rayan: agents/rayan.md
 
 channels:
   # Everyone — the open broadcast panel.
   general:
     description: The whole panel — open broadcast to every agent.
-    subscribe: [sven, david, garry, elon, michelle, mira]
-    allowPublish: [sven, david, garry, elon, michelle, mira]
+    subscribe: [sven, david, garry, elon, michelle, mira, bernie, dario, steve, rayan]
+    allowPublish: [sven, david, garry, elon, michelle, mira, bernie, dario, steve, rayan]
 
   # The two founders building Cotal.
   cotal:
@@ -39,14 +43,14 @@ channels:
     subscribe: [david, sven]
     allowPublish: [david, sven]
 
-  # Spicy provocations — the optimist, accelerationist, contrarian, and perfectionist go at it.
+  # Spicy provocations — no consensus required.
   hot-takes:
     description: Spicy provocations — no consensus required.
-    subscribe: [sven, garry, elon, david]
-    allowPublish: [sven, garry, elon, david]
+    subscribe: [sven, garry, elon, steve, bernie, mira]
+    allowPublish: [sven, garry, elon, steve, bernie, mira]
 
-  # The women's room: the conscience and the diplomat on stewardship and getting it right.
-  salon:
-    description: Stewardship and getting it right — the conscience and the diplomat.
-    subscribe: [michelle, mira]
-    allowPublish: [michelle, mira]
+  # Getting it right — safety, ethics, and the long game.
+  stewardship:
+    description: Getting it right — safety, ethics, and the long game.
+    subscribe: [michelle, mira, dario, bernie, rayan]
+    allowPublish: [michelle, mira, dario, bernie, rayan]

--- a/examples/04-frontier-faces/face-term.mjs
+++ b/examples/04-frontier-faces/face-term.mjs
@@ -178,10 +178,16 @@ function tick() {
   // blink
   if (state.blink && t > blinkOffAt) { state.blink = false; nextBlinkAt = t + 2200 + Math.random() * 2800; }
   else if (!state.blink && t > nextBlinkAt) { state.blink = true; blinkOffAt = t + 140; }
-  // lip-sync: consume one queued char per frame; status follows the mouth, not just the events.
-  // Expression markers ride the same queue, so a mid-message [[face:X]] lands exactly when the
-  // mouth reaches that sentence.
+  // lip-sync: consume one queued char per frame, but follow the LATEST output — agents write far
+  // faster than one char per frame, and playing the whole backlog kept the mouth flapping for
+  // minutes after the agent went quiet. Skip everything beyond ~2s of backlog (like the browser
+  // engine's pushTokens), applying skipped expression markers so a fast-forwarded [[face:X]] still
+  // lands the right mood; within the window a marker still fires when the mouth reaches its spot.
   if (speakBuf.length) {
+    while (speakBuf.length > 25) {
+      const skipped = speakBuf.shift();
+      if (skipped && typeof skipped === 'object') applyExpr(skipped.expr);
+    }
     let head = speakBuf.shift();
     while (head && typeof head === 'object') { applyExpr(head.expr); head = speakBuf.shift(); }
     if (head !== undefined) { state.viseme = vis(head); state.speaking = true; state.status = 'speaking'; }
@@ -276,6 +282,14 @@ async function streamEvents(sid) {
       }
     }
   }
+}
+
+/** The event stream is gone (serve exited, or the connection failed): the agent cannot speak
+ *  anymore, so stop the mouth NOW — drop the un-played backlog instead of talking on as if alive. */
+function streamDead() {
+  speakBuf.length = 0;
+  state.speaking = false; state.viseme = null; turnDone = true;
+  state.status = 'error';
 }
 
 // A mesh agent speaks through the cotal send tools — its words are tool-call ARGUMENTS, not
@@ -417,7 +431,7 @@ async function main() {
         ? `watching ${p.label} · session ${SESSION.slice(0, 16)}… type + Enter to talk to it.`
         : `connected to ${SERVER} · model ${MODEL.providerID}/${MODEL.modelID}. ask me something + Enter.`,
     });
-    try { sid = await getSession(); streamEvents(sid).catch(() => { state.status = 'error'; }); }
+    try { sid = await getSession(); streamEvents(sid).then(streamDead, streamDead); }
     catch (e) { convo.push({ who: p.label, text: '[no server at ' + SERVER + ' — run `opencode serve --port 4096`, or use --demo]' }); }
   }
 }

--- a/examples/04-frontier-faces/mesh-wall.sh
+++ b/examples/04-frontier-faces/mesh-wall.sh
@@ -25,7 +25,7 @@ SESSION="${SESSION:-mesh-faces}"
 PLUGIN="$ROOT/extensions/connector-opencode/dist/plugin.bundle.js"
 PIDFILE="/tmp/cotal-mesh-wall.pids"
 MESHLOG="/tmp/cotal-mesh-wall.log"
-MAX=9
+MAX=10
 # default to a clean 2x2 (faces render at a fixed 32x16, so 4 leaves each pane big enough).
 # names are agent-file basenames; their faces come from `face:` (elon->musk, steve->jobs, rayan->ray).
 DEFAULT_ROSTER=(sven david elon garry)

--- a/examples/04-frontier-faces/tools/studio.mjs
+++ b/examples/04-frontier-faces/tools/studio.mjs
@@ -40,7 +40,7 @@ const PLUGIN = join(CONN, "plugin.bundle.js");
 const PORT = Number(process.env.PORT || 4097);
 const MODEL = process.env.MODEL || ""; // overrides each agent file's model
 const EFFORT = process.env.REASONING_EFFORT || "medium"; // reasoning effort for models that support it
-const MAX = 9;
+const MAX = 10;
 
 // The roster and per-channel membership come from a Cotal mesh manifest (cotal.yaml): a channel's
 // `subscribe` is who reads it, `allowPublish` who may post. `-f <path>` overrides ./cotal.yaml.


### PR DESCRIPTION
Completes the 04-frontier-faces example and its README showcase:

- cast all ten panelists (add bernie, dario, steve, rayan) and replace the gendered salon/hot-takes split with mixed topic channels (gates-vs-gardens, the-curve, who-pays, taste-and-slop)
- add the showcase recording of the tmux wall (animated webp, 4.9 MB) — the README row previously referenced a missing image
- face-term: stop the talk animation when the agent goes quiet or its event stream dies (cap the lip-sync backlog at ~2s following the latest output; drop it and flip to error on stream death)