### PR TITLE
docs: scope authz docs to the least-privilege credential profiles

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -704,8 +704,25 @@ later).
     ACL-gated, so this is a deliberate opt-in: `cotal web --admin` with an admin cred.
     `CONSUMER.CREATE` on `DM_<space>` is the DM-confidentiality surface, granted here only for
     this profile.
-  - **manager:** privileged (broad), the provisioner host; pre-creates others' DM/TASK durables.
-    (Eventually it should be scoped too, see limitations.)
+  - **operator profiles (the manager + CLI side):** there is **no allow-all `manager` profile** —
+    the most-privileged identity is split into narrow, single-purpose creds (each a default-deny
+    allow-list), so no one connection can read every DM or delete every stream:
+    - **supervisor** — the always-on daemon: serves the three control tiers, opens the manager
+      lease, pub/watches presence. Enumerated `$JS`; **no** DM/DLV read, consumer-create,
+      `STREAM.CREATE/DELETE/PURGE`, or chat publish.
+    - **provisioner** — the *signer capability* (holds the account signing key), ephemeral and
+      **create-only**: pre-creates the per-agent DM/TASK/history durables at spawn.
+    - **teardown** — the **sole `STREAM.DELETE` holder** (`down -f`), scoped to the space's own
+      streams; **channel-purger** / **purger** hold only `STREAM.PURGE` (channel-delete /
+      history-clear).
+    - **control-caller-privileged** / **control-caller-admin** — per-command lifecycle callers
+      (`ps`/`start` vs `stop`/`attach`): each holds exactly its one `ctl.<tier>.<id>` request
+      subject plus that tier's bounded reply. **deployer** (`spawn -f`) reads live state
+      (presence/registry/membership/lease) and calls the admin tier; no `$JS.>`, `STREAM.DELETE`,
+      DM read, or self-post.
+    - **operator** — the read/publish CLI cred (`send`/`dm`/`console`): self-scoped publish +
+      presence-watch + channel read. **probe** — connect-only liveness. `cotal join` self-provisions
+      (mints an ephemeral provisioner, then connects as a plain **agent**).
 - **The control plane is split into three privilege tiers**, op↔tier routed **fail-closed** by
   the manager (a misrouted op is rejected before anything acts: the cred gates *who reaches* a
   subject, this gates *what each subject honors*):
@@ -720,11 +737,12 @@ later).
     actually invoke instead of failing at call time (`cotal_despawn` stays — its no-name
     self-despawn is on `ctl.self`, granted to all). The cred is still the boundary; in open mode
     (no creds minted) the gate is permissive, since nothing is enforced there anyway.
-  - `ctl.admin.<id>` (reached only by the manager's allow-all profile, **no agent ever gets
-    it**): the destructive / cross-agent operator ops: `purge`, and stop/despawn/attach/
-    `definePersona` of *any* agent. Admin is transport-proven (reaching the subject = holding
-    manager creds), so the handler never guesses it. `purge` lives here on purpose: on the
-    privileged tier any spawn-capable agent could wipe space history.
+  - `ctl.admin.<id>` (reached only by the operator's per-command **control-caller-admin** cred,
+    **no agent ever gets it**): the destructive / cross-agent operator ops: `purge`, and
+    stop/despawn/attach/`definePersona` of *any* agent. Admin is transport-proven (reaching the
+    subject = holding that scoped cred; the manager does not re-check the caller), so the handler
+    never guesses it. `purge` lives here on purpose: on the privileged tier any spawn-capable agent
+    could wipe space history.
 - **`definePersona` separates content from policy.** Its write path takes only content (`model`
   / `persona`); `role` / `publish` / `capabilities` / `owner` are policy and have no slot, so a
   peer cannot grant itself a capability or seize ownership by redefining. A fresh name records its
@@ -785,8 +803,6 @@ later).
   it no longer logs a broker auth-error on every check. Limitation: it returns false for a TLS-first
   (`handshake_first`) listener (that broker config isn't supported by the credless probe yet); the
   creds path stays a real authenticated connect and is unaffected.
-- The **manager profile is allow-all**, fine for Demo 1, but the most-privileged identity should
-  eventually be scoped for the full untrusted-peer claim.
 - **Callout stage (later, additive):** auth-callout (NATS 2.10+) mints creds *at connect* from a
   per-space/per-profile bootstrap token (the `token@` the join link already parses), moving the
   signing key into the callout service (true key-confinement) and removing the out-of-band mint.

--- a/docs/security.md
+++ b/docs/security.md
@@ -80,8 +80,13 @@ Each adversary, what it can attempt, and what stops it (or why it is out of scop
   nonce or idempotency key. It cannot replay as another agent (subject binding still holds).
 - **Credential revocation/TTL:** minted credentials are long-lived in v0 unless rotated out of
   band.
-- **Manager compromise:** the v0 manager profile is broad because it hosts provisioning; its
-  blast radius is the whole space. Scoping it is reserved for a later version.
+- **Manager compromise:** the operator side is split into narrow, single-purpose profiles (there
+  is **no allow-all cred**) — the long-lived **supervisor** serves control and touches
+  presence/its lease but cannot read a DM, create a consumer, or delete a stream; the destructive
+  verbs (`STREAM.DELETE`/`PURGE`, cross-agent stop, per-agent provisioning) ride ephemeral
+  per-command creds (teardown / control-caller-admin / deployer / provisioner). What stays hot is
+  the account **signing key** on the mint/manager box — a compromise there can still mint fresh
+  creds — and confining it is the auth-callout stage.
 
 ## Prompt-facing data
 

--- a/docs/transport.md
+++ b/docs/transport.md
@@ -52,7 +52,7 @@ NATS/JetStream satisfies all five capabilities:
 | Durability and history | JetStream streams `CHAT_/DM_/TASK_<space>`, per-instance chat/DM durables (`chat_`/`dm_`), per-role task durables (`svc_`), at-least-once ack-on-surface, `Nats-Msg-Id` publish dedup, Direct-Get chat backfill for late join. |
 | Presence and registry | KV buckets `cotal_presence_<space>` (TTL/stale/delete-derived liveness) and `cotal_channels_<space>` (durable channel config). |
 | Identity | The instance's **nkey public key** = `card.id` = subject sender token = JWT subject = the id token used in per-instance durable names ([`identity.ts`](../packages/core/src/identity.ts)). |
-| Authz and isolation | Operator-signed **account per space** plus per-profile JWT ACLs (agent/observer/admin/manager) built from the shared subject/stream builders ([`provision.ts`](../packages/core/src/provision.ts)). |
+| Authz and isolation | Operator-signed **account per space** plus per-profile JWT ACLs (agent/observer/admin plus the narrow operator-side profiles — supervisor/provisioner/teardown/control-caller/deployer/operator/probe/purger; **no allow-all profile**) built from the shared subject/stream builders ([`provision.ts`](../packages/core/src/provision.ts)). |
 
 Capabilities 2 and 3 are offloaded to JetStream and KV. Cotal does not implement history,
 presence, ack/redelivery, or publish dedup itself; it uses the native NATS mechanisms. Handlers


### PR DESCRIPTION
Follow-up to #161 (which deleted the allow-all `manager` NATS credential). The merged PR did not touch `docs/`, so the protocol docs still described the old broad-manager model. This aligns them with the code.

## Changes
- **architecture.md** — replace the `manager` profile bullet with the scoped operator profiles (supervisor / provisioner / teardown / channel-purger / purger / control-caller-{privileged,admin} / deployer / operator / probe); retarget the `ctl.admin` tier description to the `control-caller-admin` cred (subject-gated, manager doesn't re-check the caller); drop the now-resolved *"manager profile is allow-all"* known-limitation bullet.
- **security.md** — rewrite the *Manager compromise* threat entry: there is no allow-all cred anymore; the long-lived supervisor can't read a DM / create a consumer / delete a stream; the real residual is the still-hot account signing key (auth-callout stage).
- **transport.md** — fix the profile list in the Authz row.

Docs-only; no code change. Profile names verified against the `Profile` union in `packages/core/src/provision.ts`.