### PR TITLE
fix(manager,core): reject unsupported-connector resume before provisioning (#159 Part A)

### DIFF
--- a/extensions/connector-claude-code/src/extension.ts
+++ b/extensions/connector-claude-code/src/extension.ts
@@ -34,6 +34,8 @@ export const claudeConnector: Connector = {
   transcriptChannel, // the shared `tr-<name>` convention (connector-core), exposed via the contract
   pluginRoot: PLUGIN_ROOT,
   requires: ["claude"],
+  supportsResume: true, // renders `--resume <id> --fork-session` (fork-from, never hijack) — see buildLaunch
+
   buildLaunch(opts: LaunchOpts): LaunchSpec {
     // Operator MCP servers shared with this agent (default none — see the --mcp-config block).
     const shared = opts.mcpServers ?? {};

--- a/implementations/manager/smoke/start-model-preflight.smoke.ts
+++ b/implementations/manager/smoke/start-model-preflight.smoke.ts
@@ -17,6 +17,9 @@
  *   5. RESUME (issue #23) — claude buildLaunch emits `--resume <id> --fork-session` (never one
  *      without the other, hostile id stays one argv token, coexists with the persona append);
  *      opencode + hermes THROW; and `resume` threads StartAgentOpts → LaunchOpts verbatim.
+ *   6. RESUME CAPABILITY PREFLIGHT (issue #159 Part A) — a resume request for a connector that doesn't
+ *      declare `supportsResume` is rejected BEFORE any provisioning side effect (no mint, no
+ *      buildLaunch), mirroring the harness preflight; `supportsResume` matrix across the connectors.
  */
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -47,7 +50,7 @@ const connectors = onWin ? [claudeConnector, opencodeConnector] : [claudeConnect
 const workspaceRoot = mkdtempSync(join(tmpdir(), "cotal-start-ws-"));
 const agentsDir = join(workspaceRoot, ".cotal", "agents");
 mkdirSync(agentsDir, { recursive: true });
-for (const n of ["reject1", "rec1", "rec2", "rrec1", "rrec2"]) writeFileSync(join(agentsDir, `${n}.md`), `---\nname: ${n}\n---\n`);
+for (const n of ["reject1", "rec1", "rec2", "rrec1", "rrec2", "norsm1", "norsm2"]) writeFileSync(join(agentsDir, `${n}.md`), `---\nname: ${n}\n---\n`);
 // rec3 carries an explicit access policy — its frontmatter ACL must thread through to LaunchOpts.
 writeFileSync(join(agentsDir, "rec3.md"), `---\nname: rec3\nsubscribe: [team]\nallowSubscribe: [team, team.>]\nallowPublish: [team]\n---\n`);
 const mgr = new Manager({ space: "smoke", servers: undefined, runtime: "pty", workspaceRoot });
@@ -70,15 +73,28 @@ let lastSpec: LaunchSpec | undefined;
 const agentCount = () => (mgr as unknown as { agents: Map<string, unknown> }).agents.size;
 
 // A recording connector that requires `node` (present whenever this smoke runs) — captures the
-// LaunchOpts the manager hands it, so we can assert the model threads through verbatim.
+// LaunchOpts the manager hands it, so we can assert the model threads through verbatim. Declares
+// `supportsResume` so a resume request passes the pre-mint preflight and reaches buildLaunch.
 let lastOpts: LaunchOpts | undefined;
 const recCon: Connector = {
   kind: "connector",
   name: "smoke-rec",
   requires: ["node"],
+  supportsResume: true,
   buildLaunch: (o) => { lastOpts = o; return { command: "true", args: [], env: {} }; },
 };
 registry.register(recCon);
+
+// A twin that passes the harness preflight (node present) but does NOT support resume — used to prove
+// the pre-mint resume preflight rejects BEFORE reaching buildLaunch (its buildLaunch must never run).
+let noResumeBuilt = false;
+const recNoResumeCon: Connector = {
+  kind: "connector",
+  name: "smoke-norsm",
+  requires: ["node"],
+  buildLaunch: (o) => { noResumeBuilt = true; lastOpts = o; return { command: "true", args: [], env: {} }; },
+};
+registry.register(recNoResumeCon);
 
 // 1 — Preflight REJECT: hide PATH so `claude` can't be found; the real claude connector requires it.
 {
@@ -246,6 +262,30 @@ registry.register(recCon);
   lastOpts = undefined;
   await mgr.startAgent({ name: "rrec2", agent: "smoke-rec" });
   check("no resume → LaunchOpts.resume undefined", lastOpts?.resume === undefined, lastOpts?.resume);
+}
+
+// 6 — RESUME CAPABILITY PREFLIGHT (#159 Part A): resume is a connector capability. A resume request for
+// a connector that doesn't declare `supportsResume` is REJECTED before any side effect (no reserve, no
+// mint, no buildLaunch) — mirrors the harness preflight; the buildLaunch throw stays the backstop.
+{
+  check("claude supportsResume === true", claudeConnector.supportsResume === true);
+  check("opencode supportsResume falsy", !opencodeConnector.supportsResume, opencodeConnector.supportsResume);
+  check("hermes supportsResume falsy", !hermesConnector.supportsResume, hermesConnector.supportsResume);
+
+  // REJECT: smoke-norsm passes the node PATH check but declares no resume support.
+  noResumeBuilt = false;
+  const before = agentCount();
+  const reply = await mgr.startAgent({ name: "norsm1", agent: "smoke-norsm", resume: "sess-x" });
+  check("unsupported-connector resume rejected", reply.ok === false, reply);
+  check("reject names 'does not support resuming'", /does not support resuming/.test(reply.error ?? ""), reply.error);
+  check("reject BEFORE buildLaunch (no spec built)", noResumeBuilt === false);
+  check("reject BEFORE side effect (no agent recorded)", agentCount() === before);
+
+  // …but no resume → the same connector spawns normally (the preflight doesn't over-fire).
+  noResumeBuilt = false;
+  const ok = await mgr.startAgent({ name: "norsm2", agent: "smoke-norsm" });
+  check("no resume → unsupported-resume connector still spawns", ok.ok === true, ok);
+  check("no resume → buildLaunch reached", noResumeBuilt === true);
 }
 
 console.log(`\nSTART-MODEL/PREFLIGHT SMOKE ${failures === 0 ? "OK ✅" : "FAILED ❌"}`);

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -538,6 +538,11 @@ export class Manager {
     const missing = (connector.requires ?? []).filter((bin) => !resolveOnPath(bin));
     if (missing.length)
       return { ok: false, error: `${agent} harness needs ${missing.join(", ")} on PATH — not found` };
+    // Resume is a connector capability: reject an unsupported resume HERE, before the reserve/mint, so
+    // it can never provision creds + durables and then throw at buildLaunch (mint-then-orphan). Same
+    // reject-before-side-effects window as the harness preflight above; buildLaunch stays the backstop.
+    if (opts.resume && !connector.supportsResume)
+      return { ok: false, error: `${agent} connector does not support resuming an existing session (resume)` };
 
     // Resolve the launch profile: IDENTITY (free-form `name:`) + role + read/post ACL + capabilities
     // + model. Either from a fully-resolved manifest launch object (`opts.resolved`, whose `config`

--- a/packages/core/src/connector.ts
+++ b/packages/core/src/connector.ts
@@ -119,4 +119,12 @@ export interface Connector extends Extension {
    *  plugin install. Consumers (like `cotal setup`) resolve it via the registry
    *  so they never import the extension package directly. */
   readonly pluginRoot?: string;
+  /** Whether this connector can honor {@link LaunchOpts.resume} (fork an existing session into the
+   *  mesh). The manager reads this as a PRE-MINT preflight: when `resume` is requested for a connector
+   *  that doesn't declare support, it fails loud BEFORE any provisioning side effect (mirrors the
+   *  {@link requires} PATH preflight) — so an unsupported resume can never mint-then-orphan creds +
+   *  durables. Default-deny: absent/false → not supported, and `buildLaunch` throwing on `resume`
+   *  stays as the backstop. Only a connector that forks-from a prior session (never hijacks it) sets
+   *  this `true`. */
+  readonly supportsResume?: boolean;
 }


### PR DESCRIPTION
**Part A of #159** (harden detached launch-failure handling). Small, self-contained; B (early-exit surfacing + deprovision) and C (capability-gated peer resume) follow, coordinated with the per-user-auth 1.5 owner.

### Problem
A `resume` request for a connector that can't fork (opencode/hermes, or any future connector) went through the whole spawn setup — `newIdentity()` → `provisionAgent` (creds + `dm_`/`dlv_` durables + ACL row) → `writeSecretFile` — and **only then** threw at `connector.buildLaunch`. The `catch` returns `{ok:false}` but the `finally` rolls back only the reserved name, so the minted creds + broker durables are **orphaned**.

### Fix
- Add `readonly supportsResume?: boolean` to the **Connector SPI** (`packages/core/src/connector.ts`); the claude connector declares `supportsResume: true` (opencode/hermes omit it).
- A **pre-mint preflight** in `startAgent` (`manager.ts`, right after the `requires` PATH check): if `resume` is set and the connector isn't resume-capable, return `{ok:false}` **before** the reserve / mint / buildLaunch — so an unsupported resume never provisions anything.
- **Fail-loud is now the default:** any future connector that neither declares `supportsResume` nor handles resume is rejected up front (closes the fallback-by-omission hole). The `buildLaunch` throw stays as the backstop.

### Tests
`start-model-preflight` smoke §6: the `supportsResume` matrix (claude ✓, opencode/hermes ✗) + a connector that passes the harness preflight but declares no resume support is rejected **before buildLaunch** and **before any agent is recorded**; no-resume still spawns normally. Windows-safe (no Hermes buildLaunch on this path). `pnpm typecheck` + `pnpm test` green.

No changeset (maintainer's call).