### PR TITLE
fix(manager): leave the alternate screen on detach from a full-screen agent

### DIFF
--- a/implementations/manager/smoke/attach-repaint.smoke.ts
+++ b/implementations/manager/smoke/attach-repaint.smoke.ts
@@ -11,10 +11,16 @@
  *    screen as the child redraws.
  * B) AttachEndpoint: with an async backlog, the client gets the snapshot FIRST, then live output in
  *    order and exactly once — output arriving mid-snapshot is buffered, not lost or raced ahead.
+ * C) attachClient teardown: the snapshot re-enters the child's alternate screen on OUR terminal, so
+ *    on detach the client must leave it again — but ONLY when the child was full-screen. An inline
+ *    child keeps its native scrollback untouched. (Regression: leaving the terminal in the alt buffer
+ *    stranded it with no scrollback, and the wheel walked shell history via xterm alt-scroll.)
  */
 import assert from "node:assert";
-import WebSocket from "ws";
+import type { AddressInfo } from "node:net";
+import WebSocket, { WebSocketServer } from "ws";
 import { AttachEndpoint } from "../src/attach-endpoint.js";
+import { attachClient } from "../src/attach-client.js";
 import { PtyRuntime } from "../src/runtime/pty.js";
 import type { AttachSession, LaunchSpec } from "@cotal-ai/core";
 import type { AgentHandle } from "../src/runtime/index.js";
@@ -108,10 +114,55 @@ async function testEndpointOrdering(): Promise<void> {
   }
 }
 
+// Drive the real attachClient through one attach→detach and return the bytes it wrote to the
+// (faked-TTY) terminal. The server hands back `snapshot` on connect; Ctrl-] (0x1d) on stdin detaches.
+async function driveDetach(snapshot: string, marker: string): Promise<string> {
+  const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+  await new Promise<void>((r) => wss.on("listening", () => r()));
+  const { port } = wss.address() as AddressInfo;
+  wss.on("connection", (sock) => sock.send(Buffer.from(snapshot, "latin1")));
+
+  let captured = "";
+  const realWrite = process.stdout.write;
+  const realTTY = process.stdout.isTTY;
+  Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+  process.stdout.write = ((chunk: string | Buffer): boolean => {
+    captured += Buffer.isBuffer(chunk) ? chunk.toString("latin1") : String(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    const done = attachClient(`ws://127.0.0.1:${port}/attach/x`);
+    // Detach only once the snapshot has actually been painted to our terminal (poll, don't guess a
+    // fixed sleep — a late snapshot on a loaded runner would fail the alt case / pass inline vacuously).
+    for (let i = 0; i < 200 && !captured.includes(marker); i++) await sleep(10);
+    assert.ok(captured.includes(marker), "C: snapshot painted before detach");
+    process.stdin.emit("data", Buffer.from([0x1d])); // Ctrl-] → detach → cleanup()
+    await done;
+  } finally {
+    process.stdout.write = realWrite;
+    Object.defineProperty(process.stdout, "isTTY", { value: realTTY, configurable: true });
+    await new Promise<void>((res) => wss.close(() => res()));
+  }
+  return captured;
+}
+
+async function testDetachLeavesAltScreen(): Promise<void> {
+  const alt = await driveDetach("\x1b[?1049h\x1b[H\x1b[?1002hFULLSCREEN-VIEW", "FULLSCREEN-VIEW");
+  assert.match(alt, /\x1b\[\?1049l/, "C: detach from a full-screen child leaves the alternate screen");
+  // Must NOT touch `?1007` — attach never enabled alt-scroll, so disabling it would clobber the
+  // operator's own preference for later apps. Leaving the alt buffer already makes alt-scroll inert.
+  assert.doesNotMatch(alt, /\x1b\[\?1007/, "C: detach does not touch the operator's alt-scroll mode");
+
+  const inline = await driveDetach("inline conversation line\r\n$ ", "inline conversation line");
+  assert.doesNotMatch(inline, /\x1b\[\?1049l/, "C: detach from an inline child keeps native scrollback (no alt-screen toggle)");
+  console.log("  ✓ attach client leaves the alt-screen on detach only when the child entered it");
+}
+
 async function main(): Promise<void> {
   await testPtyReconstruction();
   await testEndpointOrdering();
-  console.log("\nATTACH REPAINT SMOKE OK ✅  (2 tests)");
+  await testDetachLeavesAltScreen();
+  console.log("\nATTACH REPAINT SMOKE OK ✅  (3 tests)");
 }
 
 main()

--- a/implementations/manager/src/attach-client.ts
+++ b/implementations/manager/src/attach-client.ts
@@ -4,12 +4,14 @@ import WebSocket from "ws";
 const DETACH = 0x1d;
 
 /**
- * Terminal modes a full-screen child (e.g. Claude's TUI) commonly turns on but that we must undo
- * locally on detach/exit: the agent keeps running after Ctrl-], so it never restores OUR terminal.
- * Without this, detaching from a mouse-tracking TUI leaves the terminal reporting every cursor move
- * as input (a stream of `ESC[<…M` escape codes), or its focus in/out as `ESC[I`/`ESC[O`. Disables
- * all mouse-report modes + focus reporting + bracketed paste, resets the keypad/cursor-key modes,
- * shows the cursor, and resets attributes. Deliberately does NOT toggle the alternate screen.
+ * Terminal modes a full-screen child (a fullscreen TUI: OpenCode, or Claude under `/tui fullscreen`)
+ * commonly turns on but that we must undo locally on detach/exit: the agent keeps running after
+ * Ctrl-], so it never restores OUR terminal. Without this, detaching from a mouse-tracking TUI leaves
+ * the terminal reporting every cursor move as input (a stream of `ESC[<…M` escape codes), or its
+ * focus in/out as `ESC[I`/`ESC[O`. Disables all mouse-report modes + focus reporting + bracketed
+ * paste, resets the keypad/cursor-key modes, shows the cursor, and resets attributes. Leaving the
+ * alternate screen is handled separately (ALT_LEAVE_SEQ), only when we actually entered it — see
+ * cleanup().
  */
 const MOUSE_OFF = "\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1005l\x1b[?1006l\x1b[?1015l"; // all mouse tracking off
 const RESTORE =
@@ -21,14 +23,24 @@ const RESTORE =
   "\x1b[?25h" + // show cursor
   "\x1b[0m"; // reset attributes
 
-// Wheel-scroll for full-screen children. A full-screen TUI (e.g. OpenCode) runs in the alternate
-// screen — where the terminal's native scrollback is dead — and scrolls its content itself off mouse
-// reports. But it enables that mouse capture on ITS pty, and the enable doesn't reliably survive the
-// attach hop (backlog eviction / nested pty), so our terminal never reports the wheel and scrolling
-// dies. So while the child is in the alternate screen we enable SGR mouse reporting on OUR terminal
-// and translate each wheel tick into PageUp/PageDown — the keystrokes every full-screen TUI treats
-// as "scroll the view" (OpenCode: `messages_page_up`/`_down`). Inline children (Claude) never enter
-// the alt-screen, so this stays off and their native terminal-scrollback wheel is untouched.
+// Leave the alternate screen on detach, but ONLY if the child put us there (altScreen). The attach
+// snapshot faithfully re-enters the child's alt-screen (`?1049h`) on our terminal; without a matching
+// leave we strand it in the alt buffer, which has no scrollback and — with xterm alt-scroll — turns
+// the wheel into ↑/↓ that walk shell history. Leaving the alt buffer IS the whole fix: alt-scroll
+// (`?1007`) only acts inside the alt buffer, so `?1049l` alone makes it inert. We deliberately don't
+// send `?1007l` — nothing on this path ever enabled it (unlike console.ts, which sets `?1007h` on
+// entry), so disabling it would clobber the operator's own alternate-scroll preference for later apps.
+const ALT_LEAVE_SEQ = "\x1b[?1049l"; // leave alt-screen — alt-scroll is inert once back in the main buffer
+
+// Wheel-scroll for full-screen children. A fullscreen TUI (OpenCode, or Claude under `/tui
+// fullscreen`) runs in the alternate screen — where the terminal's native scrollback is dead — and
+// scrolls its content itself off mouse reports. But it enables that mouse capture on ITS pty, and the
+// enable doesn't reliably survive the attach hop (backlog eviction / nested pty), so our terminal
+// never reports the wheel and scrolling dies. So while the child is in the alternate screen we enable
+// SGR mouse reporting on OUR terminal and translate each wheel tick into PageUp/PageDown — the
+// keystrokes a fullscreen TUI treats as "scroll the view" (OpenCode: `messages_page_up`/`_down`;
+// Claude's fullscreen binds PageUp/PageDown too). A child in the normal screen (inline Claude) keeps
+// altScreen=false, so this stays off and its native terminal-scrollback wheel is untouched.
 const MOUSE_ON = "\x1b[?1002h\x1b[?1006h"; // button+drag tracking, SGR encoding
 const PAGE_UP = "\x1b[5~";
 const PAGE_DOWN = "\x1b[6~";
@@ -142,7 +154,9 @@ export function attachClient(url: string): Promise<void> {
       stdin.off("data", onInput);
       process.stdout.off("resize", sendResize);
       // Undo terminal modes the (still-running) agent's TUI enabled — it won't restore us on detach.
-      if (process.stdout.isTTY) process.stdout.write(RESTORE);
+      // If the child put us in its alternate screen (altScreen), leave it too so the terminal isn't
+      // stranded in the alt buffer; an inline child (altScreen=false) keeps its scrollback.
+      if (process.stdout.isTTY) process.stdout.write(RESTORE + (altScreen ? ALT_LEAVE_SEQ : ""));
       if (stdin.isTTY) stdin.setRawMode(wasRaw);
       stdin.pause();
     };


### PR DESCRIPTION
## What

On detach from a full-screen agent, the operator's terminal was left stranded in the alternate screen buffer — no scrollback to scroll up through, and (with xterm alternate-scroll) the mouse wheel emitted arrow keys that walked shell history.

The attach snapshot faithfully re-enters the child's alternate screen (`?1049h`) on the local terminal, but `cleanup()` only reset the mouse/keypad modes and never emitted `?1049l`. This fix leaves the alt-screen on detach — but **only when the child put us there** (`altScreen`). Leaving the alt buffer is the whole fix: alt-scroll (`?1007`) only acts inside it, so `?1049l` alone makes it inert. We deliberately do **not** send `?1007l` — nothing on this path enables it (unlike `console.ts`, which sets `?1007h` on entry), so disabling it would clobber the operator's own alternate-scroll preference for later apps.

The behavior is driven by the alt-screen state, not the agent type, so it covers both a full-screen TUI (OpenCode, or Claude under `/tui fullscreen`) and an inline child — inline keeps its native scrollback untouched. Stale comments that assumed Claude is always inline are refreshed.

## Why

Claude Code gained a fullscreen (alternate-screen) rendering mode (`/tui fullscreen` / `CLAUDE_CODE_NO_FLICKER`), so "Claude renders inline" no longer holds. The attach/scroll plumbing was already mode-driven; the missing piece was symmetric teardown on detach, which is the same gap for any full-screen agent.

## Tests

- New regression smoke (`attach-repaint.smoke.ts`, test C) drives the real `attachClient` through attach→detach for both cases: asserts the full-screen path writes `?1049l` and does not touch `?1007`, and the inline path writes neither. Waits on the painted snapshot rather than a fixed sleep.
- `pnpm typecheck` clean across all packages; `pnpm smoke:attach-repaint` green (3/3).
- Independently reviewed on the mesh (APPROVE) after one round that caught and removed a `?1007l` overreach.