### PR TITLE
feat: declarative command kernel — stage 1 of the CLI rework

### DIFF
--- a/bin/smoke/flag-inventory.smoke.ts
+++ b/bin/smoke/flag-inventory.smoke.ts
@@ -1,0 +1,116 @@
+/**
+ * Flag-inventory parity smoke: the GOLDEN inventory of every command's accepted flags,
+ * captured from main at the kernel migration (2026-07), asserted against the declared specs.
+ * Any future flag add/remove/retype must edit this file consciously — the silent-change
+ * vector (parseArgs strictness drift across hand-rolled parsers) is gone.
+ *
+ * Deliberate deltas from main, reviewed with the migration (see PR):
+ *  - commands whose positionals were accepted-but-ignored now reject them
+ *    (setup/go/up/down/join/console/demo/web);
+ *  - manager commands accepted the UNION of all manager flags; each now accepts exactly its own
+ *    (e.g. `stop --model` was accepted-and-ignored, now a usage error); the dead `--drive` flag
+ *    is gone;
+ *  - `feedback` keeps its own dual-mode parsing (rawArgs) until the intake server splits out.
+ *
+ * Run: pnpm smoke:flag-inventory
+ */
+import assert from "node:assert/strict";
+import { registry, type Command } from "@cotal-ai/core";
+import "@cotal-ai/cli"; // registers the base CLI commands
+import "@cotal-ai/manager"; // registers supervise/start/stop/ps/attach
+import "@cotal-ai/delivery"; // registers deliver
+
+/** flag spec inventory as "name:type" (+ ":short" when aliased), sorted. */
+const TARGET = ["creds:string", "server:string", "space:string"];
+const GOLDEN: Record<string, { flags: string[]; positionals: boolean; rawArgs?: boolean }> = {
+  setup: { flags: ["auth:boolean", "full:boolean", "open:boolean", "yes:boolean:y"], positionals: false },
+  go: { flags: ["auth:boolean", "full:boolean", "open:boolean", "yes:boolean:y"], positionals: false },
+  up: {
+    flags: [
+      "channels:string", "detach:boolean", "dry-run:boolean", "file:string:f", "host:string",
+      "open:boolean", "runtime:string", "server:string", "space:string", "store-dir:string",
+    ],
+    positionals: false,
+  },
+  down: { flags: ["dry-run:boolean", "file:string:f", "run:string"], positionals: false },
+  meshes: { flags: [], positionals: false },
+  use: { flags: [], positionals: true },
+  join: {
+    flags: [
+      ...TARGET, "channel:string", "kind:string", "link:string", "name:string", "role:string",
+      "tls:boolean", "token:string",
+    ],
+    positionals: false,
+  },
+  send: { flags: [...TARGET], positionals: true },
+  console: { flags: [...TARGET, "plain:boolean"], positionals: false },
+  demo: { flags: [...TARGET, "interval:string", "once:boolean"], positionals: false },
+  web: { flags: [...TARGET, "no-open:boolean", "port:string"], positionals: false },
+  spawn: {
+    flags: [
+      "agent:string", "allow-publish:string", "allow-stale:string", "allow-subscribe:string",
+      "config:string", "dry-run:boolean", "file:string:f", "name:string", "no-transcript:boolean",
+      "prompt:string", "resume:string", "role:string", "runtime:string", "server:string",
+      "share-tools:string", "space:string", "subscribe:string", "transcript:boolean",
+    ],
+    positionals: true,
+  },
+  personas: {
+    flags: [
+      ...TARGET, "force:boolean", "from:string", "model:string", "prompt:string", "role:string",
+      "running:boolean", "verbose:boolean:v",
+    ],
+    positionals: true,
+  },
+  completion: { flags: [], positionals: true },
+  __complete: { flags: [], positionals: true, rawArgs: true },
+  mint: {
+    flags: ["allow-publish:string", "allow-subscribe:string", "force:boolean", "out:string", "profile:string", "signer:boolean"],
+    positionals: true,
+  },
+  topology: { flags: ["file:string:f"], positionals: true },
+  channels: {
+    flags: [...TARGET, "desc:string", "instructions:string", "no-replay:boolean", "replay:boolean", "window:string"],
+    positionals: true,
+  },
+  history: { flags: [...TARGET, "dms:boolean", "force:boolean"], positionals: true },
+  feedback: { flags: [], positionals: true, rawArgs: true },
+  supervise: {
+    flags: ["console-port:string", "launch:string", "roster:string", "runtime:string", "server:string", "space:string", "spawn:string"],
+    positionals: false,
+  },
+  start: {
+    flags: [
+      ...TARGET, "agent:string", "config:string", "cwd:string", "model:string", "name:string",
+      "no-transcript:boolean", "resume:string", "role:string", "transcript:boolean",
+    ],
+    positionals: false,
+  },
+  stop: { flags: [...TARGET, "name:string"], positionals: false },
+  ps: { flags: [...TARGET], positionals: false },
+  attach: { flags: [...TARGET, "name:string"], positionals: false },
+  deliver: {
+    flags: ["creds:string", "dev-mint:boolean", "server:string", "shard:string", "shards:string", "space:string"],
+    positionals: false,
+  },
+};
+
+const commands = registry.all<Command>("command");
+const names = commands.map((c) => c.name).sort();
+assert.deepEqual(names, Object.keys(GOLDEN).sort(), "command set matches the golden inventory");
+
+for (const cmd of commands) {
+  const golden = GOLDEN[cmd.name];
+  const declared = (cmd.flags ?? [])
+    .map((f) => `${f.name}:${f.type}${f.short ? `:${f.short}` : ""}`)
+    .sort();
+  assert.deepEqual(declared, [...golden.flags].sort(), `flags of \`${cmd.name}\` match golden`);
+  assert.equal(cmd.positionals !== undefined, golden.positionals, `positionals gate of \`${cmd.name}\``);
+  assert.equal(Boolean(cmd.rawArgs), Boolean(golden.rawArgs), `rawArgs of \`${cmd.name}\``);
+  // Every declared flag is parseable metadata: string flags carry a metavar or default help.
+  for (const f of cmd.flags ?? []) {
+    assert.ok(f.name && (f.type === "string" || f.type === "boolean"), `flag spec sane on ${cmd.name} --${f.name}`);
+  }
+}
+
+console.log(`✓ flag-inventory smoke passed (${commands.length} commands)`);

--- a/implementations/cli/smoke/command-kernel.smoke.ts
+++ b/implementations/cli/smoke/command-kernel.smoke.ts
@@ -76,6 +76,21 @@ const noop = async (): Promise<void> => {};
   assert.equal(commandUsage(over), "custom usage");
 }
 
+// --- --help reaches rawArgs commands too (feedback), only __-internal is exempt -----------------
+{
+  const { runCli } = await import("../src/command.js");
+  let out = "";
+  const realLog = console.log;
+  console.log = (s?: unknown) => void (out += `${s}\n`);
+  try {
+    await runCli(registry, ["feedback", "--help"]);
+  } finally {
+    console.log = realLog;
+  }
+  assert.ok(out.includes("usage:"), "feedback --help prints its usage");
+  assert.ok(!out.includes("Unknown option"), "no usage error above the help");
+}
+
 // --- __complete offers declared flag names on a `-` prefix --------------------------------------
 {
   const spawnCmd = registry.all<Command>("command").find((c) => c.name === "spawn");

--- a/implementations/cli/smoke/command-kernel.smoke.ts
+++ b/implementations/cli/smoke/command-kernel.smoke.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure smoke for the command kernel (no NATS, no fs): parseCommandArgs semantics —
+ * strict flags, shorts, positional gating, rawArgs passthrough — plus commandUsage
+ * generation and the dispatcher's flag-name completion. Run: pnpm smoke:cli-kernel
+ */
+import assert from "node:assert/strict";
+import { commandUsage, parseCommandArgs, registry, type Command } from "@cotal-ai/core";
+import "../src/index.js"; // self-register the CLI commands (for the completion check)
+import { complete } from "../src/commands/completion.js";
+
+const noop = async (): Promise<void> => {};
+
+// --- flags parse strictly: strings, booleans, shorts -------------------------------------------
+{
+  const cmd: Command = {
+    kind: "command",
+    name: "t",
+    summary: "t",
+    positionals: "<x>",
+    flags: [
+      { name: "space", type: "string" },
+      { name: "dry-run", type: "boolean" },
+      { name: "file", type: "string", short: "f" },
+    ],
+    run: noop,
+  };
+  const a = parseCommandArgs(cmd, ["pos1", "--space", "demo", "--dry-run", "-f", "m.yaml", "pos2"]);
+  assert.equal(a.values.space, "demo");
+  assert.equal(a.values["dry-run"], true);
+  assert.equal(a.values.file, "m.yaml");
+  assert.deepEqual(a.positionals, ["pos1", "pos2"]);
+  assert.deepEqual(a.raw, ["pos1", "--space", "demo", "--dry-run", "-f", "m.yaml", "pos2"]);
+
+  // Unknown flag → ERR_PARSE_ARGS (the dispatcher renders it as a usage error).
+  assert.throws(
+    () => parseCommandArgs(cmd, ["--nope"]),
+    (e: unknown) => String((e as { code?: string }).code).startsWith("ERR_PARSE_ARGS"),
+  );
+}
+
+// --- a command with no declared positionals rejects strays --------------------------------------
+{
+  const cmd: Command = { kind: "command", name: "t2", summary: "t", flags: [{ name: "space", type: "string" }], run: noop };
+  assert.throws(
+    () => parseCommandArgs(cmd, ["stray"]),
+    (e: unknown) => String((e as { code?: string }).code).startsWith("ERR_PARSE_ARGS"),
+  );
+  const a = parseCommandArgs(cmd, ["--space", "demo"]);
+  assert.deepEqual(a.positionals, []);
+}
+
+// --- rawArgs: verbatim passthrough, flags of OTHER commands never throw -------------------------
+{
+  const cmd: Command = { kind: "command", name: "t3", summary: "t", rawArgs: true, positionals: "<w…>", run: noop };
+  const a = parseCommandArgs(cmd, ["spawn", "--space", ""]);
+  assert.deepEqual(a.positionals, ["spawn", "--space", ""]);
+  assert.deepEqual(a.values, {});
+}
+
+// --- commandUsage: generated line + explicit override -------------------------------------------
+{
+  const gen: Command = {
+    kind: "command",
+    name: "t4",
+    summary: "t",
+    positionals: "<name>",
+    flags: [
+      { name: "out", type: "string", value: "<path>" },
+      { name: "force", type: "boolean" },
+      { name: "file", type: "string", short: "f" },
+    ],
+    run: noop,
+  };
+  assert.equal(commandUsage(gen), "cotal t4 <name> [--out <path>] [--force] [-f|--file <value>]");
+  const over: Command = { ...gen, usage: "custom usage" };
+  assert.equal(commandUsage(over), "custom usage");
+}
+
+// --- __complete offers declared flag names on a `-` prefix --------------------------------------
+{
+  const spawnCmd = registry.all<Command>("command").find((c) => c.name === "spawn");
+  assert.ok(spawnCmd?.flags?.length, "spawn declares flags");
+  let out = "";
+  const realWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((s: string) => ((out += s), true)) as typeof process.stdout.write;
+  try {
+    await complete({ values: {}, positionals: ["spawn", "--"], raw: ["spawn", "--"] });
+  } finally {
+    process.stdout.write = realWrite;
+  }
+  assert.ok(out.includes("--space"), "flag completion lists --space");
+  assert.ok(out.includes("--config"), "flag completion lists --config");
+  assert.ok(out.trimEnd().endsWith(":nofiles"), "directive is nofiles");
+}
+
+console.log("✓ command-kernel smoke passed");

--- a/implementations/cli/src/command.ts
+++ b/implementations/cli/src/command.ts
@@ -57,8 +57,10 @@ export async function runCli(registry: Registry, argv: string[]): Promise<void> 
     help(commands);
     process.exit(1);
   }
-  // `cotal <cmd> --help` / `-h` → that command's help, never run it.
-  if (!cmd.rawArgs && (rest.includes("--help") || rest.includes("-h"))) {
+  // `cotal <cmd> --help` / `-h` → that command's help, never run it. This intercept also covers
+  // rawArgs commands (feedback) — only `__`-internal ones are exempt, because __complete's argv
+  // is ANOTHER command's half-typed line, where `--help` is a word being completed, not a request.
+  if (!cmd.name.startsWith("__") && (rest.includes("--help") || rest.includes("-h"))) {
     commandHelp(cmd);
     return;
   }

--- a/implementations/cli/src/command.ts
+++ b/implementations/cli/src/command.ts
@@ -1,4 +1,4 @@
-import type { Command, Registry } from "@cotal-ai/core";
+import { commandUsage, parseCommandArgs, type Command, type Registry } from "@cotal-ai/core";
 import { c } from "./ui.js";
 
 function help(commands: Command[]): void {
@@ -19,10 +19,20 @@ function help(commands: Command[]): void {
   console.log(out);
 }
 
-/** One-line help for a single command: its usage (or summary as fallback). */
+/** Full help for one command, generated from its declared specs: summary, usage line, and a
+ *  flag table (short, long, metavar, description). */
 function commandHelp(cmd: Command): void {
   console.log(`${c.bold(`cotal ${cmd.name}`)} — ${cmd.summary}`);
-  if (cmd.usage) console.log(c.dim(cmd.usage));
+  console.log(c.dim(`usage: ${commandUsage(cmd)}`));
+  const flags = cmd.flags ?? [];
+  if (!flags.length) return;
+  const left = flags.map((f) => {
+    const metavar = f.type === "string" ? ` ${f.value ?? "<value>"}` : "";
+    return `${f.short ? `-${f.short}, ` : "    "}--${f.name}${metavar}`;
+  });
+  const pad = Math.max(...left.map((s) => s.length));
+  console.log(c.bold("flags:"));
+  flags.forEach((f, i) => console.log(`  ${left[i].padEnd(pad)}  ${c.dim(f.description ?? "")}`));
 }
 
 /** node's parseArgs throws these for unknown/malformed flags; treat as a usage error. */
@@ -32,7 +42,8 @@ function isArgError(e: unknown): boolean {
 }
 
 /** Dispatch `argv` against the commands self-registered in a {@link Registry}.
- *  The single entry point a composition root calls — no hardcoded command list. */
+ *  The single entry point a composition root calls — no hardcoded command list.
+ *  Parsing happens HERE, from the command's declared specs; `run` gets parsed args. */
 export async function runCli(registry: Registry, argv: string[]): Promise<void> {
   const commands = registry.all<Command>("command");
   const [name, ...rest] = argv;
@@ -47,12 +58,12 @@ export async function runCli(registry: Registry, argv: string[]): Promise<void> 
     process.exit(1);
   }
   // `cotal <cmd> --help` / `-h` → that command's help, never run it.
-  if (rest.includes("--help") || rest.includes("-h")) {
+  if (!cmd.rawArgs && (rest.includes("--help") || rest.includes("-h"))) {
     commandHelp(cmd);
     return;
   }
   try {
-    await cmd.run(rest);
+    await cmd.run(parseCommandArgs(cmd, rest));
   } catch (e) {
     // A bad flag/arg prints the command's help, not a stack trace. Trim node's verbose
     // "To specify a positional argument starting with a '-' …" tail to the first sentence.

--- a/implementations/cli/src/commands/channels.ts
+++ b/implementations/cli/src/commands/channels.ts
@@ -1,4 +1,3 @@
-import { parseArgs } from "node:util";
 import {
   seedChannelRegistry,
   readChannelRegistry,
@@ -6,6 +5,7 @@ import {
   type ChannelConfig,
   type ChannelDefaults,
   type ChannelRegistryFile,
+  type ParsedArgs,
 } from "@cotal-ai/core";
 import { connectOrExit } from "../lib/connect.js";
 import { c } from "../ui.js";
@@ -21,21 +21,9 @@ import { c } from "../ui.js";
  *   cotal channels set <name> [--replay|--no-replay] [--desc <s>] [--instructions <s>]
  *   cotal channels default --replay|--no-replay
  */
-export async function channels(argv: string[]): Promise<void> {
-  const { values, positionals } = parseArgs({
-    args: argv,
-    allowPositionals: true,
-    options: {
-      server: { type: "string" },
-      space: { type: "string" },
-      creds: { type: "string" },
-      replay: { type: "boolean" },
-      "no-replay": { type: "boolean" },
-      window: { type: "string" }, // backfill window, e.g. 24h / 30m / 7d
-      desc: { type: "string" },
-      instructions: { type: "string" },
-    },
-  });
+export async function channels(args: ParsedArgs): Promise<void> {
+  const positionals = args.positionals;
+  const values = args.values as { server?: string; space?: string; creds?: string; replay?: boolean; "no-replay"?: boolean; window?: string; desc?: string; instructions?: string };
   // Validate the subcommand BEFORE connecting, so a typo (or a bare `cotal channels`) prints usage,
   // not "no mesh running" — the same validate-first order as `history`.
   const sub = positionals[0];

--- a/implementations/cli/src/commands/completion.ts
+++ b/implementations/cli/src/commands/completion.ts
@@ -6,6 +6,7 @@ import {
   type Command,
   type CompletionItem,
   type CompletionResult,
+  type ParsedArgs,
 } from "@cotal-ai/core";
 import { c } from "../ui.js";
 
@@ -37,9 +38,11 @@ function emit(items: CompletionItem[], directive: NonNullable<CompletionResult["
   process.stdout.write(`${lines.join("\n")}\n`);
 }
 
-/** The hidden dispatcher the shell stubs call. `argv` is the words after `cotal`, up to and
- *  including the (possibly empty) word being completed. */
-export async function complete(argv: string[]): Promise<void> {
+/** The hidden dispatcher the shell stubs call (`rawArgs`: its argv is another command's
+ *  half-typed line, never parsed). The words after `cotal`, up to and including the (possibly
+ *  empty) word being completed, arrive as `args.positionals` verbatim. */
+export async function complete(args: ParsedArgs): Promise<void> {
+  const argv = args.positionals;
   // Mirror help()'s visibility: drop `__`-internal and `hidden` commands (e.g. `demo`) so the
   // completion surface matches the listed one.
   const commands = registry
@@ -51,6 +54,15 @@ export async function complete(argv: string[]): Promise<void> {
     return;
   }
   const cmd = commands.find((cmd) => cmd.name === argv[0]);
+  // A word starting with `-` completes against the command's DECLARED flags — generated from
+  // the specs, so it can never drift from what parsing accepts. Value/positional completion
+  // stays with the command's own `complete` hook below.
+  const word = argv[argv.length - 1];
+  if (cmd && word.startsWith("-")) {
+    const items = (cmd.flags ?? []).map((f) => ({ value: `--${f.name}`, description: f.description }));
+    emit(items, "nofiles");
+    return;
+  }
   if (!cmd?.complete) {
     emit([], "default"); // unknown command, or one with no completer → defer to the shell
     return;
@@ -133,7 +145,8 @@ const SCRIPTS: Record<string, string> = {
   ),
 };
 
-export async function completion(argv: string[]): Promise<void> {
+export async function completion(args: ParsedArgs): Promise<void> {
+  const argv = args.positionals;
   if (argv[0] === "install") return install(argv[1]);
   const script = argv[0] ? SCRIPTS[argv[0]] : undefined;
   if (!script) {

--- a/implementations/cli/src/commands/console.ts
+++ b/implementations/cli/src/commands/console.ts
@@ -1,9 +1,8 @@
-import { parseArgs } from "node:util";
 import { writeSync } from "node:fs";
 import { userInfo } from "node:os";
 import { createElement } from "react";
 import { render } from "ink";
-import { chatWildcard } from "@cotal-ai/core";
+import { chatWildcard, type ParsedArgs } from "@cotal-ai/core";
 import { connectOrExit } from "../lib/connect.js";
 import { c } from "../ui.js";
 import { runLog } from "../render.js";
@@ -15,17 +14,8 @@ import { Root, makeObserver } from "../console/root.js";
  * overview of every space first (pick one to drill in, `b` to come back); `--space X` goes straight
  * in. Renders over a read-only observer whose lifecycle `useMesh` owns. See docs/protocol-view.md.
  */
-export async function console_(argv: string[]): Promise<void> {
-  const { values } = parseArgs({
-    args: argv,
-    allowPositionals: true,
-    options: {
-      space: { type: "string" },
-      server: { type: "string" },
-      plain: { type: "boolean" },
-      creds: { type: "string" },
-    },
-  });
+export async function console_(args: ParsedArgs): Promise<void> {
+  const values = args.values as { space?: string; server?: string; plain?: boolean; creds?: string };
   // Resolve WHICH running mesh (server + trust material) from any directory — same as `spawn`/`web`.
   // Auth mode self-mints an admin god-view cred (the console shows DMs/anycast, which the narrower
   // `observer` profile denies → NATS Authorization Violation); an authed server hosts exactly one

--- a/implementations/cli/src/commands/demo.ts
+++ b/implementations/cli/src/commands/demo.ts
@@ -1,9 +1,9 @@
-import { parseArgs } from "node:util";
 import { readFileSync } from "node:fs";
 import {
   CotalEndpoint,
   isReachable,
   DEFAULT_SERVER,
+  type ParsedArgs,
   type PresenceStatus,
 } from "@cotal-ai/core";
 import { resolveSpace } from "../lib/status.js";
@@ -66,18 +66,8 @@ const SCRIPT: Act[] = [
   { t: "chat", who: "linus", channel: "team.frontend", text: "frontend review queue is clear ✓" },
 ];
 
-export async function demo(argv: string[]): Promise<void> {
-  const { values } = parseArgs({
-    args: argv,
-    allowPositionals: true,
-    options: {
-      space: { type: "string" },
-      server: { type: "string" },
-      interval: { type: "string" },
-      once: { type: "boolean" },
-      creds: { type: "string" },
-    },
-  });
+export async function demo(args: ParsedArgs): Promise<void> {
+  const values = args.values as { space?: string; server?: string; interval?: string; once?: boolean; creds?: string };
   const space = values.space ?? resolveSpace(process.cwd());
   const server = values.server ?? DEFAULT_SERVER;
   const interval = values.interval ? Number(values.interval) : 1200;

--- a/implementations/cli/src/commands/down.ts
+++ b/implementations/cli/src/commands/down.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, rmSync } from "node:fs";
-import { parseArgs } from "node:util";
+import { type ParsedArgs } from "@cotal-ai/core";
 import { clearCurrent, getCurrent, removeMesh } from "@cotal-ai/workspace";
 import { c } from "../ui.js";
 import { cotalPath } from "../lib/paths.js";
@@ -10,16 +10,8 @@ import { downManifest } from "./down-manifest.js";
  *  delivery daemon, the web dashboard, and the mesh. With `-f <cotal.yaml>` (or `--run <id>`) it does
  *  an ownership-scoped teardown of a `spawn -f` deploy instead — removing ONLY what that run created
  *  (its agents + the channels it added), from the ledger, never the whole shared mesh. */
-export async function down(argv: string[] = []): Promise<void> {
-  const { values } = parseArgs({
-    args: argv,
-    allowPositionals: true,
-    options: {
-      file: { type: "string", short: "f" }, // ownership-scoped teardown of a spawn -f deploy
-      run: { type: "string" }, // tear down by run id (when the manifest was edited since spawn -f)
-      "dry-run": { type: "boolean" }, // print what would be removed, change nothing
-    },
-  });
+export async function down(args: ParsedArgs): Promise<void> {
+  const values = args.values as { file?: string; run?: string; "dry-run"?: boolean };
   if (values.file || values.run) {
     await downManifest(values.file ?? "<run>", { run: values.run, dryRun: Boolean(values["dry-run"]) });
     return;

--- a/implementations/cli/src/commands/feedback.ts
+++ b/implementations/cli/src/commands/feedback.ts
@@ -4,7 +4,7 @@ import { randomUUID, timingSafeEqual } from "node:crypto";
 import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { parseArgs } from "node:util";
-import { CotalEndpoint, DEFAULT_SERVER, isReachable } from "@cotal-ai/core";
+import { CotalEndpoint, DEFAULT_SERVER, isReachable, type ParsedArgs } from "@cotal-ai/core";
 import { c } from "../ui.js";
 
 type FeedbackType = "bug" | "idea" | "friction" | "praise" | "other";
@@ -55,8 +55,11 @@ class HttpError extends Error {
 const FEEDBACK_URL = "https://broker.cotal.ai/v1/feedback";
 const PUBLIC_FEEDBACK_URL = "https://cotal.ai/v1/feedback";
 
-/** Dual-mode: `--keys` runs the self-hosted intake server; otherwise sends feedback. */
-export async function feedback(argv: string[]): Promise<void> {
+/** Dual-mode: `--keys` runs the self-hosted intake server; otherwise sends feedback. The two
+ *  modes parse DIFFERENT flag sets, so this command keeps its own parsing (`rawArgs` — the
+ *  dispatcher passes argv through verbatim) until the intake server is split out of the CLI. */
+export async function feedback(args: ParsedArgs): Promise<void> {
+  const argv = args.positionals;
   if (argv.includes("--keys")) return serve(argv);
   return send(argv);
 }

--- a/implementations/cli/src/commands/history.ts
+++ b/implementations/cli/src/commands/history.ts
@@ -1,22 +1,12 @@
-import { parseArgs } from "node:util";
-import { clearSpaceHistory } from "@cotal-ai/core";
+import { clearSpaceHistory, type ParsedArgs } from "@cotal-ai/core";
 import { connectOrExit } from "../lib/connect.js";
 import { c } from "../ui.js";
 
 /** Administrative history operations. Purges JetStream backlog only; live in-process
  *  agent buffers may still contain messages already delivered before the purge. */
-export async function history(argv: string[]): Promise<void> {
-  const { values, positionals } = parseArgs({
-    args: argv,
-    allowPositionals: true,
-    options: {
-      server: { type: "string" },
-      space: { type: "string" },
-      creds: { type: "string" },
-      dms: { type: "boolean" },
-      force: { type: "boolean" },
-    },
-  });
+export async function history(args: ParsedArgs): Promise<void> {
+  const positionals = args.positionals;
+  const values = args.values as { server?: string; space?: string; creds?: string; dms?: boolean; force?: boolean };
 
   if (positionals[0] !== "clear") return usage();
   if (!values.force) {

--- a/implementations/cli/src/commands/join.ts
+++ b/implementations/cli/src/commands/join.ts
@@ -1,4 +1,3 @@
-import { parseArgs } from "node:util";
 import { userInfo } from "node:os";
 import { readFileSync } from "node:fs";
 import * as readline from "node:readline";
@@ -15,6 +14,7 @@ import {
   type EndpointKind,
   type PresenceStatus,
   type CotalMessage,
+  type ParsedArgs,
 } from "@cotal-ai/core";
 import { resolveSpace } from "../lib/status.js";
 import { reachableOrExit, resolveTargetOrExit, preflightOrExit } from "../lib/connect.js";
@@ -43,23 +43,8 @@ function renderJoinAuthError(e: unknown, space: string): boolean {
   return false;
 }
 
-export async function join(argv: string[]): Promise<void> {
-  const { values } = parseArgs({
-    args: argv,
-    allowPositionals: true,
-    options: {
-      space: { type: "string" },
-      name: { type: "string" },
-      role: { type: "string" },
-      channel: { type: "string" },
-      server: { type: "string" },
-      kind: { type: "string" },
-      link: { type: "string" },
-      token: { type: "string" },
-      creds: { type: "string" },
-      tls: { type: "boolean" },
-    },
-  });
+export async function join(args: ParsedArgs): Promise<void> {
+  const values = args.values as { space?: string; name?: string; role?: string; channel?: string; server?: string; kind?: string; link?: string; token?: string; creds?: string; tls?: boolean };
 
   // A join link carries server + auth + space; explicit flags still override it.
   const link = values.link ? parseJoinLink(values.link) : undefined;

--- a/implementations/cli/src/commands/meshes.ts
+++ b/implementations/cli/src/commands/meshes.ts
@@ -1,3 +1,4 @@
+import type { ParsedArgs } from "@cotal-ai/core";
 import { getCurrent, loadMeshes } from "@cotal-ai/workspace";
 import { c } from "../ui.js";
 import { pruneStaleMeshes } from "../lib/meshes.js";
@@ -5,7 +6,7 @@ import { pruneStaleMeshes } from "../lib/meshes.js";
 /** `cotal meshes` — list the running meshes (one `cotal up` each), with a `*` on the `current`
  *  default. The kubectl `get-contexts` analogue: how you see what a bare `cotal spawn` would join,
  *  and which `--space` names are available. Prunes dead entries first. */
-export async function meshes(): Promise<void> {
+export async function meshes(args: ParsedArgs): Promise<void> {
   await pruneStaleMeshes();
   const all = loadMeshes();
   if (all.length === 0) {

--- a/implementations/cli/src/commands/mint.ts
+++ b/implementations/cli/src/commands/mint.ts
@@ -1,6 +1,5 @@
 import { existsSync } from "node:fs";
 import { resolve, join, dirname } from "node:path";
-import { parseArgs } from "node:util";
 import {
   agentFilePath,
   loadAgentFile,
@@ -9,6 +8,7 @@ import {
   newIdentity,
   stripSpaceAuth,
   writeSecretFile,
+  type ParsedArgs,
   type Profile,
 } from "@cotal-ai/core";
 import { authDir, loadSpaceAuth } from "@cotal-ai/workspace";
@@ -20,19 +20,9 @@ import { c } from "../ui.js";
  *  `--signer` instead emits a stripped signer file — only the account signing material
  *  (`space` + `account.pub` + `account.signingSeed`), no operator root-of-trust — to mount into a
  *  containerized manager so it can mint per-agent creds without holding the account-minting key. */
-export async function mint(argv: string[]): Promise<void> {
-  const { values, positionals } = parseArgs({
-    args: argv,
-    allowPositionals: true,
-    options: {
-      profile: { type: "string" },
-      out: { type: "string" },
-      signer: { type: "boolean" }, // emit a stripped signer file instead of agent/observer creds
-      force: { type: "boolean" }, // (--signer) overwrite an existing signer file
-      "allow-subscribe": { type: "string" }, // read ACL override (comma-separated)
-      "allow-publish": { type: "string" }, // post ACL override (comma-separated)
-    },
-  });
+export async function mint(args: ParsedArgs): Promise<void> {
+  const positionals = args.positionals;
+  const values = args.values as { profile?: string; out?: string; signer?: boolean; force?: boolean; "allow-subscribe"?: string; "allow-publish"?: string };
   const dir = authDir(cotalRoot());
 
   // `--signer`: no identity, no name — strip this space's auth.json to its account signing material.

--- a/implementations/cli/src/commands/personas.ts
+++ b/implementations/cli/src/commands/personas.ts
@@ -1,7 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, renameSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { parseArgs } from "node:util";
 import {
   agentFilePath,
   assertValidName,
@@ -9,6 +8,7 @@ import {
   saveAgentFile,
   type AgentDef,
   type CompletionResult,
+  type ParsedArgs,
 } from "@cotal-ai/core";
 import { cotalRoot } from "../lib/paths.js";
 import { listPersonas, listPersonaNames, personasDir } from "../lib/personas.js";
@@ -31,23 +31,9 @@ import { c } from "../ui.js";
 /** Persona names are also filenames and spawn names — mirror the `cotal_persona` tool's pattern. */
 const NAME_RE = /^[A-Za-z0-9_-]+$/;
 
-export async function personas(argv: string[]): Promise<void> {
-  const { values, positionals } = parseArgs({
-    args: argv,
-    allowPositionals: true,
-    options: {
-      role: { type: "string" },
-      model: { type: "string" },
-      prompt: { type: "string" },
-      from: { type: "string" },
-      verbose: { type: "boolean", short: "v" },
-      force: { type: "boolean" },
-      running: { type: "boolean" },
-      space: { type: "string" },
-      server: { type: "string" },
-      creds: { type: "string" },
-    },
-  });
+export async function personas(args: ParsedArgs): Promise<void> {
+  const positionals = args.positionals;
+  const values = args.values as { role?: string; model?: string; prompt?: string; from?: string; verbose?: boolean; force?: boolean; running?: boolean; space?: string; server?: string; creds?: string };
 
   switch (positionals[0] ?? "list") {
     case "list":

--- a/implementations/cli/src/commands/send.ts
+++ b/implementations/cli/src/commands/send.ts
@@ -1,9 +1,9 @@
-import { parseArgs } from "node:util";
 import {
   resolvePeer,
   AmbiguousPeerError,
   type Presence,
   type CompletionResult,
+  type ParsedArgs,
 } from "@cotal-ai/core";
 import { c } from "../ui.js";
 import { openTransient } from "../lib/transient.js";
@@ -16,12 +16,6 @@ import { mentionsIn } from "../lib/mentions.js";
  * `anycast`); each connects, sends one message, and exits. Fire-and-forget: no reply waiting.
  */
 
-const SEND_OPTS = {
-  space: { type: "string" },
-  server: { type: "string" },
-  creds: { type: "string" },
-} as const;
-
 type SendValues = { space?: string; server?: string; creds?: string };
 
 /** Split `<target> <text…>` positionals, stripping a leading `@`/`#` from the target. */
@@ -30,11 +24,12 @@ function targetAndText(positionals: string[], strip: RegExp): { target?: string;
 }
 
 /** `cotal send <dm|msg|ask> …` — dispatch one-shot send by delivery mode, then exit. */
-export async function send(argv: string[]): Promise<void> {
-  const [mode, ...rest] = argv;
-  if (mode === "dm") return dm(rest);
-  if (mode === "msg") return msg(rest);
-  if (mode === "ask") return ask(rest);
+export async function send(args: ParsedArgs): Promise<void> {
+  const { values, positionals } = args;
+  const [mode, ...rest] = positionals;
+  if (mode === "dm") return dm(values, rest);
+  if (mode === "msg") return msg(values, rest);
+  if (mode === "ask") return ask(values, rest);
   console.error(
     'usage: cotal send <dm <agent> | msg <channel> | ask <role>> "<text>"  [--space <s>] [--server <url>] [--creds <path>]',
   );
@@ -42,8 +37,7 @@ export async function send(argv: string[]): Promise<void> {
 }
 
 /** `cotal send dm <agent> "<text>"` — one unicast to a peer by name, then exit. */
-async function dm(argv: string[]): Promise<void> {
-  const { values, positionals } = parseArgs({ args: argv, allowPositionals: true, options: SEND_OPTS });
+async function dm(values: ParsedArgs["values"], positionals: string[]): Promise<void> {
   const { target, text } = targetAndText(positionals, /^@/);
   if (!target || !text) {
     console.error('usage: cotal send dm <agent> "<text>"  [--space <s>] [--server <url>] [--creds <path>]');
@@ -77,8 +71,7 @@ async function dm(argv: string[]): Promise<void> {
 }
 
 /** `cotal send msg <channel> "<text>"` — one broadcast to a channel, then exit. */
-async function msg(argv: string[]): Promise<void> {
-  const { values, positionals } = parseArgs({ args: argv, allowPositionals: true, options: SEND_OPTS });
+async function msg(values: ParsedArgs["values"], positionals: string[]): Promise<void> {
   const { target: channel, text } = targetAndText(positionals, /^#/);
   if (!channel || !text) {
     console.error('usage: cotal send msg <channel> "<text>"  [--space <s>] [--server <url>] [--creds <path>]');
@@ -91,8 +84,7 @@ async function msg(argv: string[]): Promise<void> {
 }
 
 /** `cotal send ask <role> "<text>"` — one anycast to a role/service (exactly one instance), exit. */
-async function ask(argv: string[]): Promise<void> {
-  const { values, positionals } = parseArgs({ args: argv, allowPositionals: true, options: SEND_OPTS });
+async function ask(values: ParsedArgs["values"], positionals: string[]): Promise<void> {
   const { target: role, text } = targetAndText(positionals, /^@/);
   if (!role || !text) {
     console.error('usage: cotal send ask <role> "<text>"  [--space <s>] [--server <url>] [--creds <path>]');

--- a/implementations/cli/src/commands/setup.ts
+++ b/implementations/cli/src/commands/setup.ts
@@ -1,7 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { parseArgs } from "node:util";
 import * as p from "@clack/prompts";
 import {
   DEFAULT_SERVER,
@@ -9,6 +8,7 @@ import {
   registry,
   type Connector,
   type Pane,
+  type ParsedArgs,
   type TerminalLayout,
 } from "@cotal-ai/core";
 import { authDir, homeCotalDir, loadSpaceAuth } from "@cotal-ai/workspace";
@@ -39,17 +39,8 @@ const NATS_RELEASES_URL = "https://github.com/nats-io/nats-server/releases";
 /** `cotal setup`: guided setup. First run (no `~/.cotal/onboarded.json`) gets the full
  *  narrated flow; later runs get a compact ensure+status. `--full` forces the full flow.
  *  Each failed step offers an interactive Claude handoff (COTAL_SKIP_ASSIST=1 disables). */
-export async function setup(argv: string[]): Promise<void> {
-  const { values } = parseArgs({
-    args: argv,
-    allowPositionals: true,
-    options: {
-      full: { type: "boolean" },
-      yes: { type: "boolean", short: "y" },
-      auth: { type: "boolean" }, // (now the DEFAULT; kept for back-compat / explicitness)
-      open: { type: "boolean" }, // opt OUT of auth — a frictionless loopback-only open mesh (no JWT/ACLs, no durable backstop)
-    },
-  });
+export async function setup(args: ParsedArgs): Promise<void> {
+  const values = args.values as { full?: boolean; yes?: boolean; auth?: boolean; open?: boolean };
   // `--yes` (agents/CI) always runs the full flow non-interactively. The mesh is AUTHED by default
   // (JWT/ACLs — the trust-first default, and what the server-side delivery daemon needs to run); `--open`
   // opts out to a frictionless loopback-only open mesh with no auth (and so no durable backstop).
@@ -60,8 +51,8 @@ export async function setup(argv: string[]): Promise<void> {
 /** `cotal go` — open or resume your session. A friendlier-named alias of `cotal setup`: the first
  *  run installs (full guided flow), later runs fast-forward to the ensure path and reopen your
  *  cmux session. `cotal setup` stays the explicit install/update name. */
-export async function go(argv: string[]): Promise<void> {
-  return setup(argv);
+export async function go(args: ParsedArgs): Promise<void> {
+  return setup(args);
 }
 
 /** The full, narrated first-run experience. `yes` = non-interactive accept-all; `open` = run the mesh
@@ -342,7 +333,7 @@ async function offerDemo(haveClaude: boolean): Promise<void> {
         // terminal to the driving session. (auth → delivery daemon first, then the manager.)
         await ensureControlPlane({ space: resolveSpace(process.cwd()), server: DEFAULT_SERVER, spawn: [...DEMO_TEAM] });
         p.outro(brand("Launching your session... david and sven are warming up in the background."));
-        await spawn(["me", "--prompt", ME_GREETING]);
+        await spawn({ values: { prompt: ME_GREETING }, positionals: ["me"], raw: [] });
         process.exit(0);
       }
     }
@@ -503,7 +494,8 @@ async function runEnsure(): Promise<void> {
       // Match how the mesh last ran: open when this folder has no space auth (the frictionless
       // default), authed when it does — so restarting a downed open mesh doesn't come back JWT-authed.
       const authed = Boolean(loadSpaceAuth(authDir(cotalRoot())));
-      await up(authed ? ["--detach"] : ["--detach", "--open"]);
+      const upArgs = authed ? ["--detach"] : ["--detach", "--open"];
+      await up({ values: { detach: true, open: authed ? undefined : true }, positionals: [], raw: upArgs });
       s.stop("Web for agents started");
     } catch (e) {
       s.stop(`Couldn't start it: ${(e as Error).message}`);

--- a/implementations/cli/src/commands/spawn.ts
+++ b/implementations/cli/src/commands/spawn.ts
@@ -1,6 +1,5 @@
 import { spawn as spawnProcess } from "node:child_process";
 import { join, dirname } from "node:path";
-import { parseArgs } from "node:util";
 import {
   agentFilePath,
   connectorServers,
@@ -19,9 +18,10 @@ import {
   type AgentDef,
   type CompletionResult,
   type Connector,
+  type ParsedArgs,
   type SpaceAuth,
 } from "@cotal-ai/core";
-import { authDir, loadMeshes, resolveMeshTarget } from "@cotal-ai/workspace";
+import { authDir, loadMeshes, provenance, resolveMeshTarget } from "@cotal-ai/workspace";
 import { c } from "../ui.js";
 import { preflightOrExit, resolveTargetOrExit } from "../lib/connect.js";
 import { listPersonas } from "../lib/personas.js";
@@ -114,31 +114,9 @@ async function uniqueMeshName(
 }
 
 
-export async function spawn(argv: string[]): Promise<void> {
-  const { values, positionals } = parseArgs({
-    args: argv,
-    allowPositionals: true,
-    options: {
-      name: { type: "string" },
-      config: { type: "string" },
-      space: { type: "string" },
-      server: { type: "string" },
-      agent: { type: "string" },
-      role: { type: "string" },
-      prompt: { type: "string" },
-      resume: { type: "string" }, // fork an existing session id into the mesh (host-local; claude only)
-      transcript: { type: "boolean" },
-      "no-transcript": { type: "boolean" },
-      "share-tools": { type: "string" },
-      subscribe: { type: "string" }, // read set override (comma-separated)
-      "allow-subscribe": { type: "string" }, // read ACL override
-      "allow-publish": { type: "string" }, // post ACL override
-      file: { type: "string", short: "f" }, // a mesh manifest (cotal.yaml) — deploy onto the running mesh
-      "dry-run": { type: "boolean" }, // with -f: print the plan, mutate nothing
-      "allow-stale": { type: "string" }, // with -f: waive named stale agents (apply-only)
-      runtime: { type: "string" }, // with -f: override the manifest's runtime (pty | tmux | cmux)
-    },
-  });
+export async function spawn(args: ParsedArgs): Promise<void> {
+  const positionals = args.positionals;
+  const values = args.values as { name?: string; config?: string; space?: string; server?: string; agent?: string; role?: string; prompt?: string; resume?: string; transcript?: boolean; "no-transcript"?: boolean; "share-tools"?: string; subscribe?: string; "allow-subscribe"?: string; "allow-publish"?: string; file?: string; "dry-run"?: boolean; "allow-stale"?: string; runtime?: string };
   const splitFlag = (v?: string) => (v ? v.split(",").map((s) => s.trim()).filter(Boolean) : undefined);
 
   // `spawn -f cotal.yaml` is a distinct path: deploy a manifest onto a RUNNING mesh (additive,
@@ -191,6 +169,10 @@ export async function spawn(argv: string[]): Promise<void> {
     }
     process.exit(1);
   }
+
+  // Provenance: say which persona file WON resolution (--config > positional > --name > default)
+  // — the user must never wonder which directory their agent's definition came from.
+  provenance.read("persona", path);
 
   // --name / --role override the file (name defaults from the file's frontmatter).
   const requested = values.name ?? def.name;
@@ -259,7 +241,7 @@ export async function spawn(argv: string[]): Promise<void> {
     mkSecretDir(dirname(credsPath)); // harden the creds dir before the cred lands
     writeSecretFile(credsPath, creds);
     id = identity.id;
-    console.error(`minted creds for ${name} (auth mode) → ${credsPath}`);
+    provenance.wrote(`creds for ${name} (auth mode)`, credsPath);
   }
 
   // Which of the operator's personal MCP servers to share with this agent: declared in the cotal

--- a/implementations/cli/src/commands/topology.ts
+++ b/implementations/cli/src/commands/topology.ts
@@ -1,5 +1,5 @@
-import { parseArgs } from "node:util";
 import { resolve } from "node:path";
+import { type ParsedArgs } from "@cotal-ai/core";
 import { loadManifest, renderTopology, ManifestError } from "../lib/manifest/index.js";
 import { c } from "../ui.js";
 
@@ -9,18 +9,14 @@ import { c } from "../ui.js";
  * unmanaged scopes, and warnings. Read-only — it mutates nothing and needs no running broker, so
  * it's the safe way to see what `up -f` / `spawn -f` WOULD launch.
  */
-export async function topology(argv: string[]): Promise<void> {
-  const [sub, ...rest] = argv;
+export async function topology(args: ParsedArgs): Promise<void> {
+  const values = args.values as { file?: string };
+  const [sub, ...positionals] = args.positionals;
   if (sub !== "view") {
     console.error(c.red(`✗ unknown topology subcommand "${sub ?? ""}" — expected: view`));
     console.error(c.dim("cotal topology view -f <cotal.yaml>"));
     process.exit(1);
   }
-  const { values, positionals } = parseArgs({
-    args: rest,
-    allowPositionals: true,
-    options: { file: { type: "string", short: "f" } },
-  });
   const file = values.file ?? positionals[0];
   if (!file) {
     console.error(c.red("✗ a manifest file is required — `cotal topology view -f <cotal.yaml>`"));

--- a/implementations/cli/src/commands/up.ts
+++ b/implementations/cli/src/commands/up.ts
@@ -10,7 +10,6 @@ import {
   closeSync,
 } from "node:fs";
 import { resolve } from "node:path";
-import { parseArgs } from "node:util";
 import {
   isReachable,
   DEFAULT_SERVER,
@@ -26,6 +25,7 @@ import {
   writeSecretFile,
   type SpaceAuth,
   type ChannelRegistryFile,
+  type ParsedArgs,
 } from "@cotal-ai/core";
 import {
   authDir,
@@ -51,23 +51,8 @@ import { buildLaunchSpec, genRunId, manifestToChannels, preflightConnectors, wri
 import { renderUpPlan, renderInherited, renderWarnings } from "../lib/manifest/render.js";
 import { failManifest } from "./topology.js";
 
-export async function up(argv: string[]): Promise<void> {
-  const { values } = parseArgs({
-    args: argv,
-    allowPositionals: true,
-    options: {
-      server: { type: "string" },
-      "store-dir": { type: "string" },
-      space: { type: "string" },
-      open: { type: "boolean" }, // disable auth — run an open dev mesh
-      channels: { type: "string" }, // seed the channel registry from this JSON file
-      detach: { type: "boolean" }, // run the server in the background (pid in .cotal/nats.pid)
-      host: { type: "string" }, // bind address (default 127.0.0.1 — loopback; 0.0.0.0 to expose with auth)
-      runtime: { type: "string" }, // with -f: override the manifest's runtime (pty | tmux | cmux)
-      file: { type: "string", short: "f" }, // a mesh manifest (cotal.yaml) — fresh broker + channels + agents
-      "dry-run": { type: "boolean" }, // with -f: print the plan, mutate nothing
-    },
-  });
+export async function up(args: ParsedArgs): Promise<void> {
+  const values = args.values as { server?: string; "store-dir"?: string; space?: string; open?: boolean; channels?: string; detach?: boolean; host?: string; runtime?: string; file?: string; "dry-run"?: boolean };
   // `up -f cotal.yaml` is a distinct path: bring up a FRESH mesh described by a manifest (broker +
   // channels + booted agents). It owns the whole space; deploying onto a RUNNING mesh is `spawn -f`.
   // CLI flags override the manifest (flag > manifest > default) so the same file runs at a different
@@ -134,7 +119,7 @@ export async function up(argv: string[]): Promise<void> {
   const seedFile = loadChannelsFile(values.channels);
   const setup = useAuth ? await authSetup(storeDir, server, space, host) : undefined;
   const port = Number(new URL(server).port) || 4222;
-  const args = setup ? ["-c", setup.confPath] : ["-js", "-sd", storeDir, "-p", String(port), "-a", host];
+  const natsArgs = setup ? ["-c", setup.confPath] : ["-js", "-sd", storeDir, "-p", String(port), "-a", host];
   const { bin, source } = await resolveNatsServer();
 
   console.log(
@@ -143,7 +128,7 @@ export async function up(argv: string[]): Promise<void> {
     ),
   );
   console.log(c.dim("Press Ctrl-C to stop.\n"));
-  const child = spawn(bin, args, { stdio: "inherit" });
+  const child = spawn(bin, natsArgs, { stdio: "inherit" });
   child.on("error", (err) => {
     console.error(c.red(`Failed to start nats-server: ${err.message}`));
     process.exit(1);

--- a/implementations/cli/src/commands/use.ts
+++ b/implementations/cli/src/commands/use.ts
@@ -1,4 +1,4 @@
-import type { CompletionResult } from "@cotal-ai/core";
+import type { CompletionResult, ParsedArgs } from "@cotal-ai/core";
 import { findMesh, loadMeshes, setCurrent } from "@cotal-ai/workspace";
 import { c } from "../ui.js";
 import { pruneStaleMeshes } from "../lib/meshes.js";
@@ -6,8 +6,8 @@ import { pruneStaleMeshes } from "../lib/meshes.js";
 /** `cotal use <space>` — set the default mesh a bare `cotal spawn` (and friends) targets when more
  *  than one is running. The kubectl `use-context` analogue. Validated against the live registry, so
  *  you can't point `current` at a mesh that isn't up. */
-export async function use(argv: string[]): Promise<void> {
-  const space = argv[0];
+export async function use(args: ParsedArgs): Promise<void> {
+  const space = args.positionals[0];
   if (!space) {
     console.error(c.red("usage: cotal use <space>"));
     process.exit(1);

--- a/implementations/cli/src/commands/web.ts
+++ b/implementations/cli/src/commands/web.ts
@@ -1,4 +1,3 @@
-import { parseArgs } from "node:util";
 import { spawn } from "node:child_process";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { connect } from "node:net";
@@ -13,6 +12,7 @@ import {
   mintCreds,
   newIdentity,
   clearChannel,
+  type ParsedArgs,
 } from "@cotal-ai/core";
 import { cotalPath } from "../lib/paths.js";
 import { resolveSpace } from "../lib/status.js";
@@ -39,18 +39,8 @@ const PAGE: Record<string, { path: string; type: string }> = {
 /** A live observability dashboard for a space, served over HTTP + SSE. A read-only
  *  observer endpoint (invisible to peers) feeds the page presence, channel history,
  *  and a live message stream — no manager required. Bound to loopback. */
-export async function web(argv: string[]): Promise<void> {
-  const { values } = parseArgs({
-    args: argv,
-    allowPositionals: true,
-    options: {
-      space: { type: "string" },
-      server: { type: "string" },
-      port: { type: "string" },
-      "no-open": { type: "boolean" },
-      creds: { type: "string" },
-    },
-  });
+export async function web(args: ParsedArgs): Promise<void> {
+  const values = args.values as { space?: string; server?: string; port?: string; "no-open"?: boolean; creds?: string };
   // Resolve WHICH running mesh + creds (admin god-view: shows DMs + anycast), then DROP the account
   // seed. The dashboard is a loopback HTTP process; holding the space signing seed (`auth` — it can
   // mint ANY identity/role) for the whole session would make a dashboard compromise = full account

--- a/implementations/cli/src/index.ts
+++ b/implementations/cli/src/index.ts
@@ -1,4 +1,5 @@
 import { registry, type Command } from "@cotal-ai/core";
+import { targetFlags } from "@cotal-ai/workspace";
 import { up } from "./commands/up.js";
 import { down } from "./commands/down.js";
 import { use, useComplete } from "./commands/use.js";
@@ -21,13 +22,20 @@ import { topology } from "./commands/topology.js";
 /** The minimal mesh CLI: thin NATS clients (up/join/console), plus `spawn` — a
  *  foreground agent launch that reuses the connector's launch recipe. Self-registers
  *  on import; heavier surfaces (the manager's control plane) register the same way
- *  and are composed at a root. */
+ *  and are composed at a root. Flags are DECLARED here — the dispatcher parses them,
+ *  generates each command's help/usage/completion, and hands `run` the parsed args. */
 const baseCommands: Command[] = [
   {
     kind: "command",
     name: "setup",
     group: "Setup",
     summary: "guided setup — first run walks you through it; --yes for non-interactive (agents/CI), --full to redo",
+    flags: [
+      { name: "full", type: "boolean", description: "redo the full guided flow" },
+      { name: "yes", type: "boolean", short: "y", description: "non-interactive accept-all (agents/CI)" },
+      { name: "auth", type: "boolean", description: "JWT/ACL mesh (the default; kept for explicitness)" },
+      { name: "open", type: "boolean", description: "opt OUT of auth — loopback-only open mesh, no durable backstop" },
+    ],
     run: setup,
   },
   {
@@ -35,20 +43,45 @@ const baseCommands: Command[] = [
     name: "go",
     group: "Setup",
     summary: "open or resume your session (mesh + web + manager + your cmux tabs); first run installs",
+    flags: [
+      { name: "full", type: "boolean", description: "redo the full guided flow" },
+      { name: "yes", type: "boolean", short: "y", description: "non-interactive accept-all (agents/CI)" },
+      { name: "auth", type: "boolean", description: "JWT/ACL mesh (the default; kept for explicitness)" },
+      { name: "open", type: "boolean", description: "opt OUT of auth — loopback-only open mesh, no durable backstop" },
+    ],
     run: go,
   },
   {
     kind: "command",
     name: "up",
     group: "Mesh",
-    summary: "start a local nats-server (JetStream, JWT auth by default; --open for an unauthenticated dev mesh) — or `-f <cotal.yaml>` to launch a whole mesh from a manifest [--dry-run; --server/--host/--space/--runtime/--open override the file]",
+    summary:
+      "start a local nats-server (JetStream, JWT auth by default; --open for an unauthenticated dev mesh) — or `-f <cotal.yaml>` to launch a whole mesh from a manifest [--dry-run; --server/--host/--space/--runtime/--open override the file]",
+    flags: [
+      { name: "server", type: "string", value: "<url>", description: "listen URL override" },
+      { name: "host", type: "string", value: "<host>", description: "bind host override" },
+      { name: "space", type: "string", value: "<s>", description: "space name (default: the folder's)" },
+      { name: "store-dir", type: "string", value: "<dir>", description: "JetStream store directory" },
+      { name: "channels", type: "string", value: "<a,b>", description: "channels to pre-create" },
+      { name: "open", type: "boolean", description: "unauthenticated dev mesh (no JWT/ACLs)" },
+      { name: "detach", type: "boolean", description: "run in the background (stop with `cotal down`)" },
+      { name: "runtime", type: "string", value: "<pty|tmux|cmux>", description: "with -f: override the manifest's runtime" },
+      { name: "file", type: "string", short: "f", value: "<cotal.yaml>", description: "launch a whole mesh from a manifest" },
+      { name: "dry-run", type: "boolean", description: "with -f: print the plan, mutate nothing" },
+    ],
     run: up,
   },
   {
     kind: "command",
     name: "down",
     group: "Mesh",
-    summary: "stop a background mesh started with `up --detach` — or `-f <cotal.yaml>` / `--run <id>` for an ownership-scoped teardown of a `spawn -f` deploy [--dry-run] (run from its project — local only)",
+    summary:
+      "stop a background mesh started with `up --detach` — or `-f <cotal.yaml>` / `--run <id>` for an ownership-scoped teardown of a `spawn -f` deploy [--dry-run] (run from its project — local only)",
+    flags: [
+      { name: "file", type: "string", short: "f", value: "<cotal.yaml>", description: "tear down this manifest's deploy" },
+      { name: "run", type: "string", value: "<id>", description: "tear down one `spawn -f` run by id" },
+      { name: "dry-run", type: "boolean", description: "print the plan, mutate nothing" },
+    ],
     run: down,
   },
   {
@@ -63,6 +96,7 @@ const baseCommands: Command[] = [
     name: "use",
     group: "Mesh",
     summary: "set the default mesh for a bare `cotal spawn` when several are running — use <space>",
+    positionals: "<space>",
     run: use,
     complete: useComplete,
   },
@@ -71,6 +105,16 @@ const baseCommands: Command[] = [
     name: "join",
     group: "Mesh",
     summary: "join a space (interactive) — --space <s> --name <n> [--role <r>]",
+    flags: [
+      ...targetFlags,
+      { name: "name", type: "string", value: "<n>", description: "your presence name" },
+      { name: "role", type: "string", value: "<r>", description: "your role" },
+      { name: "channel", type: "string", value: "<c>", description: "channel to join" },
+      { name: "kind", type: "string", value: "<k>", description: "endpoint kind" },
+      { name: "link", type: "string", value: "<url>", description: "join link" },
+      { name: "token", type: "string", value: "<t>", description: "join token" },
+      { name: "tls", type: "boolean", description: "connect over TLS" },
+    ],
     run: join,
   },
   {
@@ -79,6 +123,8 @@ const baseCommands: Command[] = [
     group: "Mesh",
     summary: "send one message, then exit — send <dm <agent> | msg <channel> | ask <role>> \"<text>\"",
     usage: 'send <dm <agent> | msg <channel> | ask <role>> "<text>"  [--space <s>] [--server <url>] [--creds <path>]',
+    positionals: '<dm <agent> | msg <channel> | ask <role>> "<text>"',
+    flags: [...targetFlags],
     run: send,
     complete: sendComplete,
   },
@@ -87,6 +133,7 @@ const baseCommands: Command[] = [
     name: "console",
     group: "Mesh",
     summary: "live protocol view for a space — lazygit-style TUI, or a line stream on --plain — --space <s> [--plain]",
+    flags: [...targetFlags, { name: "plain", type: "boolean", description: "line stream instead of the TUI" }],
     run: console_,
   },
   {
@@ -97,6 +144,11 @@ const baseCommands: Command[] = [
     // top-level help so it doesn't clutter the user-facing surface.
     hidden: true,
     summary: "replay a scripted multi-agent trace (all message types) to exercise the console/web — --space <s> [--interval <ms>] [--once]",
+    flags: [
+      ...targetFlags,
+      { name: "interval", type: "string", value: "<ms>", description: "delay between messages" },
+      { name: "once", type: "boolean", description: "one pass, then exit" },
+    ],
     run: demo,
   },
   {
@@ -104,6 +156,11 @@ const baseCommands: Command[] = [
     name: "web",
     group: "Mesh",
     summary: "browser observability dashboard — presence, channels, live feed — --space <s> [--port <n>] [--no-open]",
+    flags: [
+      ...targetFlags,
+      { name: "port", type: "string", value: "<n>", description: "HTTP port (default 7799)" },
+      { name: "no-open", type: "boolean", description: "don't open the browser" },
+    ],
     run: web,
   },
   {
@@ -112,6 +169,27 @@ const baseCommands: Command[] = [
     group: "Agents",
     summary:
       "launch an agent in this terminal from a file — spawn [<name-or-path>] (defaults to the `default` persona) | --name <n> --config <path> [--agent <a>] [--role <r>] [--resume <id>]",
+    positionals: "[<name-or-path>]",
+    flags: [
+      { name: "space", type: "string", value: "<s>", description: "target space (default: the resolved mesh)" },
+      { name: "server", type: "string", value: "<url>", description: "broker URL (overrides the mesh registry entry)" },
+      { name: "name", type: "string", value: "<n>", description: "presence name (defaults from the persona file)" },
+      { name: "config", type: "string", value: "<path>", description: "agent file path (for a file outside .cotal/agents)" },
+      { name: "agent", type: "string", value: "<a>", description: "connector type (claude, opencode, hermes …)" },
+      { name: "role", type: "string", value: "<r>", description: "role override (wins over the agent file's role:)" },
+      { name: "prompt", type: "string", value: "<text>", description: "initial prompt auto-submitted at start" },
+      { name: "resume", type: "string", value: "<id>", description: "fork an existing session id into the mesh (claude only)" },
+      { name: "transcript", type: "boolean", description: "mirror the session transcript to tr-<name>" },
+      { name: "no-transcript", type: "boolean", description: "explicit default: no transcript mirror" },
+      { name: "share-tools", type: "string", value: "<sel>", description: "share named operator MCP servers with the agent" },
+      { name: "subscribe", type: "string", value: "<a,b>", description: "channel read set override" },
+      { name: "allow-subscribe", type: "string", value: "<a,b>", description: "read ACL override" },
+      { name: "allow-publish", type: "string", value: "<a,b>", description: "post ACL override" },
+      { name: "file", type: "string", short: "f", value: "<cotal.yaml>", description: "deploy a manifest onto the running mesh" },
+      { name: "dry-run", type: "boolean", description: "with -f: print the plan, mutate nothing" },
+      { name: "allow-stale", type: "string", value: "<a,b>", description: "with -f: waive named stale agents (apply-only)" },
+      { name: "runtime", type: "string", value: "<pty|tmux|cmux>", description: "with -f: override the manifest's runtime" },
+    ],
     run: spawn,
     complete: spawnComplete,
   },
@@ -121,6 +199,19 @@ const baseCommands: Command[] = [
     group: "Agents",
     summary:
       "list/manage local personas (.cotal/agents) — personas <list [-v] [--running] | show <name> | edit <name> | new <name> (--prompt <t>|--from <f>) [--role <r>] [--model <m>] | rm <name> --force>",
+    usage:
+      "personas <list [-v] [--running] | show <name> | edit <name> | new <name> (--prompt <t>|--from <f>) [--role <r>] [--model <m>] | rm <name> --force>",
+    positionals: "<list | show <name> | edit <name> | new <name> | rm <name>>",
+    flags: [
+      ...targetFlags,
+      { name: "role", type: "string", value: "<r>", description: "new: the persona's role" },
+      { name: "model", type: "string", value: "<m>", description: "new: the persona's model" },
+      { name: "prompt", type: "string", value: "<t>", description: "new: the persona's prompt text" },
+      { name: "from", type: "string", value: "<f>", description: "new: seed the prompt from a file" },
+      { name: "verbose", type: "boolean", short: "v", description: "list: include role/model/description" },
+      { name: "running", type: "boolean", description: "list: mark personas live on the mesh" },
+      { name: "force", type: "boolean", description: "rm: required — delete without prompting" },
+    ],
     run: personas,
     complete: personasComplete,
   },
@@ -129,6 +220,7 @@ const baseCommands: Command[] = [
     name: "completion",
     group: "Agents",
     summary: "shell completion — completion <bash|zsh|fish|powershell | install [shell]>",
+    positionals: "<bash|zsh|fish|powershell | install [shell]>",
     run: completion,
     complete: completionComplete,
   },
@@ -137,6 +229,8 @@ const baseCommands: Command[] = [
     name: "__complete",
     group: "Agents",
     summary: "(internal) emit completion candidates for the current command line",
+    rawArgs: true,
+    positionals: "<words…>",
     run: complete,
   },
   {
@@ -145,6 +239,15 @@ const baseCommands: Command[] = [
     group: "Mesh",
     summary:
       "mint a creds file for a space (auth mode) — mint <name> --profile <agent|observer> [--out <path>]; --signer emits a stripped account-signing file (no operator key) for a containerized manager",
+    positionals: "<name>",
+    flags: [
+      { name: "profile", type: "string", value: "<agent|observer|admin>", description: "cred profile (default agent)" },
+      { name: "out", type: "string", value: "<path>", description: "output path (default .cotal/auth/creds/<name>.creds)" },
+      { name: "signer", type: "boolean", description: "emit a stripped account-signing file instead" },
+      { name: "force", type: "boolean", description: "with --signer: overwrite an existing file" },
+      { name: "allow-subscribe", type: "string", value: "<a,b>", description: "read ACL override (comma-separated)" },
+      { name: "allow-publish", type: "string", value: "<a,b>", description: "post ACL override (comma-separated)" },
+    ],
     run: mint,
   },
   {
@@ -152,6 +255,8 @@ const baseCommands: Command[] = [
     name: "topology",
     group: "Mesh",
     summary: "validate + view a mesh manifest's access graph — topology view -f <cotal.yaml> (read-only; mutates nothing)",
+    positionals: "<view>",
+    flags: [{ name: "file", type: "string", short: "f", value: "<cotal.yaml>", description: "the manifest to inspect" }],
     run: topology,
   },
   {
@@ -160,6 +265,17 @@ const baseCommands: Command[] = [
     group: "Mesh",
     summary:
       "inspect/set channel registry — channels <list | set <name> [--replay|--no-replay] [--desc <s>] [--instructions <s>] | default --replay|--no-replay>",
+    usage:
+      "channels <list | set <name> [--replay|--no-replay] [--desc <s>] [--instructions <s>] | default --replay|--no-replay>",
+    positionals: "<list | set <name> | default>",
+    flags: [
+      ...targetFlags,
+      { name: "replay", type: "boolean", description: "set/default: replay history to new joiners" },
+      { name: "no-replay", type: "boolean", description: "set/default: don't replay history" },
+      { name: "window", type: "string", value: "<n>", description: "set: replay window size" },
+      { name: "desc", type: "string", value: "<s>", description: "set: one-line channel description" },
+      { name: "instructions", type: "string", value: "<s>", description: "set: instructions shown to joiners" },
+    ],
     run: channels,
   },
   {
@@ -167,6 +283,12 @@ const baseCommands: Command[] = [
     name: "history",
     group: "Mesh",
     summary: "clear retained message history — history clear --force [--dms] [--space <s>]",
+    positionals: "<clear>",
+    flags: [
+      ...targetFlags,
+      { name: "dms", type: "boolean", description: "also clear DM history" },
+      { name: "force", type: "boolean", description: "required — clear without prompting" },
+    ],
     run: history,
   },
   {
@@ -175,6 +297,12 @@ const baseCommands: Command[] = [
     group: "Mesh",
     summary:
       'send feedback — feedback "<summary>" [--type <t>] [--email <e>] — or run the intake server: feedback --keys <keys.json> --creds <creds> [--port <n>]',
+    usage:
+      'feedback "<summary>" [--type bug|idea|friction|praise|other] [--details …] [--severity low|medium|high] [--area …] [--email …] [--name …] [--url …] [--key …]  |  feedback --keys <keys.json> --creds <creds> [--port <n>]',
+    // Dual-mode (client vs intake server) with two different flag sets — keeps its own parsing
+    // until the intake server is split out of the CLI (stage 2b of the rework).
+    rawArgs: true,
+    positionals: '"<summary>" | --keys …',
     run: feedback,
   },
 ];

--- a/implementations/delivery/src/delivery.ts
+++ b/implementations/delivery/src/delivery.ts
@@ -1,6 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { parseArgs } from "node:util";
 import {
   CotalEndpoint,
   DEFAULT_SERVER,
@@ -9,6 +8,7 @@ import {
   mintCreds,
   newIdentity,
   type MembershipFeedHandle,
+  type ParsedArgs,
 } from "@cotal-ai/core";
 import { authDir, findCotalRoot, loadSpaceAuth } from "@cotal-ai/workspace";
 import { startMembership } from "./membership.js";
@@ -41,21 +41,7 @@ async function loadDeliveryCreds(v: Values): Promise<string> {
   );
 }
 
-function parse(argv: string[]): Values {
-  const { values } = parseArgs({
-    args: argv,
-    allowPositionals: false,
-    options: {
-      space: { type: "string" },
-      server: { type: "string" },
-      creds: { type: "string" },
-      shard: { type: "string" },
-      shards: { type: "string" },
-      "dev-mint": { type: "boolean" }, // standalone dev: mint a scoped delivery cred from the local signer
-    },
-  });
-  return values as Values;
-}
+// Parsing lives in the dispatcher now, driven by the `deliver` command's declared flags.
 
 /**
  * Run the delivery daemon: the server-side Plane-3 durable backstop. A thin composition root that
@@ -66,8 +52,8 @@ function parse(argv: string[]): Values {
  * for standalone dev). N=1 only — `shards > 1` (or a non-zero shard) is HARD-REJECTED (the partition
  * seam ships, operating sharded delivery is deferred to the channel-prefix grammar; see core-sub-fabric.md).
  */
-export async function runDelivery(argv: string[]): Promise<void> {
-  const v = parse(argv);
+export async function runDelivery(args: ParsedArgs): Promise<void> {
+  const v = args.values as Values;
   const shard = v.shard ? Number(v.shard) : 0;
   const shards = v.shards ? Number(v.shards) : 1;
   if (shards !== 1 || shard !== 0)

--- a/implementations/delivery/src/index.ts
+++ b/implementations/delivery/src/index.ts
@@ -15,7 +15,15 @@ const deliveryCommands: Command[] = [
     group: "Manager",
     summary:
       "run the delivery daemon — the server-side Plane-3 durable backstop [--space <s>] [--server <url>] [--creds <file>] (auth mode only; N=1)",
-    run: (argv) => runDelivery(argv),
+    flags: [
+      { name: "space", type: "string", value: "<s>", description: "space to serve (required; the scoped cred doesn't encode it)" },
+      { name: "server", type: "string", value: "<url>", description: "broker URL (default: the local mesh)" },
+      { name: "creds", type: "string", value: "<file>", description: "pre-minted scoped delivery cred" },
+      { name: "shard", type: "string", value: "<n>", description: "shard index (N=1 only; non-zero is rejected)" },
+      { name: "shards", type: "string", value: "<n>", description: "shard count (N=1 only; >1 is rejected)" },
+      { name: "dev-mint", type: "boolean", description: "standalone dev: mint a scoped delivery cred from the local signer" },
+    ],
+    run: (args) => runDelivery(args),
   },
 ];
 

--- a/implementations/manager/src/commands.ts
+++ b/implementations/manager/src/commands.ts
@@ -1,4 +1,3 @@
-import { parseArgs } from "node:util";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
@@ -15,6 +14,7 @@ import {
   type Command,
   type ControlReply,
   type ControlTier,
+  type ParsedArgs,
   type Profile,
 } from "@cotal-ai/core";
 import {
@@ -28,6 +28,7 @@ import {
   pruneStaleMeshes,
   removeMesh,
   renderWorkspaceError,
+  targetFlags,
   type MeshTarget,
 } from "@cotal-ai/workspace";
 import { Manager } from "./manager.js";
@@ -125,41 +126,8 @@ export async function resolveManagerTarget(
   return { space: target.space, server: target.server, creds };
 }
 
-function parse(argv: string[]): Values {
-  const { values, positionals } = parseArgs({
-    args: argv,
-    allowPositionals: true,
-    options: {
-      space: { type: "string" },
-      server: { type: "string" },
-      name: { type: "string" },
-      role: { type: "string" },
-      agent: { type: "string" },
-      config: { type: "string" },
-      model: { type: "string" }, // start: model override, wins over the agent file's `model:`
-      resume: { type: "string" }, // start: fork an existing session id into the mesh (host-local; claude only)
-      roster: { type: "string" },
-      creds: { type: "string" },
-      runtime: { type: "string" }, // supervise: force pty | tmux | cmux (default pty)
-      "console-port": { type: "string" },
-      drive: { type: "boolean" },
-      transcript: { type: "boolean" },
-      "no-transcript": { type: "boolean" },
-      spawn: { type: "string" }, // comma-separated agent names to pre-spawn at startup
-      launch: { type: "string" }, // supervise: a resolved mesh-manifest launch spec (cotal up -f / spawn -f)
-      cwd: { type: "string" }, // working directory to root the spawned agent at
-    },
-  });
-  // These commands are flags-only — reject stray positionals instead of silently ignoring them
-  // (e.g. `cotal supervise up`, fat-fingering `cotal up`).
-  if (positionals.length) {
-    const x = positionals[0];
-    const hint = x === "up" ? " — did you mean `cotal up`?" : x === "go" ? " — did you mean `cotal go`?" : "";
-    console.error(c.red(`✗ unexpected argument: ${x}${hint}`));
-    process.exit(1);
-  }
-  return values as Values;
-}
+// Parsing lives in the dispatcher now, driven by each command's declared flags — these
+// commands declare no positionals, so a stray one (`cotal supervise up`) is a usage error there.
 
 /** Connect a short-lived client with the resolved creds, send one control request to the manager,
  *  disconnect. The target is already reachability- + auth-preflighted by {@link resolveManagerTarget}
@@ -205,8 +173,8 @@ function failIfNotOk(reply: ControlReply): void {
   }
 }
 
-async function start(argv: string[]): Promise<void> {
-  const v = parse(argv);
+async function start(args: ParsedArgs): Promise<void> {
+  const v = args.values as Values;
   if (!v.name) {
     console.error(c.red("--name is required"));
     process.exit(1);
@@ -236,8 +204,8 @@ async function start(argv: string[]): Promise<void> {
   );
 }
 
-async function stop(argv: string[]): Promise<void> {
-  const v = parse(argv);
+async function stop(args: ParsedArgs): Promise<void> {
+  const v = args.values as Values;
   if (!v.name) {
     console.error(c.red("--name is required"));
     process.exit(1);
@@ -254,8 +222,8 @@ async function stop(argv: string[]): Promise<void> {
   console.log(c.dim(`✓ stopped ${v.name}`));
 }
 
-async function ps(argv: string[]): Promise<void> {
-  const v = parse(argv);
+async function ps(args: ParsedArgs): Promise<void> {
+  const v = args.values as Values;
   const t = await resolveManagerTarget(v, "control-caller-privileged");
   const reply = await ask(t.space, t.server, "ps", undefined, t.creds);
   failIfNotOk(reply);
@@ -290,8 +258,8 @@ async function ps(argv: string[]): Promise<void> {
   }
 }
 
-async function attach(argv: string[]): Promise<void> {
-  const v = parse(argv);
+async function attach(args: ParsedArgs): Promise<void> {
+  const v = args.values as Values;
   if (!v.name) {
     console.error(c.red("--name is required"));
     process.exit(1);
@@ -318,8 +286,8 @@ async function attach(argv: string[]): Promise<void> {
 // contiguous, which is what `cmuxManagerRunning` pgreps for.
 const RUNTIME_OVERRIDES: readonly RuntimeMode[] = ["pty", "tmux", "cmux"];
 
-async function runManager(argv: string[], defaultRuntime: RuntimeMode): Promise<void> {
-  const v = parse(argv);
+async function runManager(args: ParsedArgs, defaultRuntime: RuntimeMode): Promise<void> {
+  const v = args.values as Values;
   let runtime = defaultRuntime;
   if (defaultRuntime === "auto" && v.runtime) {
     if (!RUNTIME_OVERRIDES.includes(v.runtime as RuntimeMode)) {
@@ -434,7 +402,16 @@ const managerCommands: Command[] = [
     group: "Manager",
     summary:
       "run a manager — [--runtime <pty|tmux|cmux>] (default pty; tmux/cmux are explicit-only, each teammate in its own window/tab) [--space <s>] [--server <url>] [--console-port <n>] [--roster <file>] [--launch <spec>]",
-    run: (argv) => runManager(argv, "auto"),
+    flags: [
+      { name: "space", type: "string", value: "<s>", description: "space to supervise (default: this folder's auth space)" },
+      { name: "server", type: "string", value: "<url>", description: "broker URL (default: the local mesh)" },
+      { name: "runtime", type: "string", value: "<pty|tmux|cmux>", description: "agent runtime (default pty; tmux/cmux are explicit-only)" },
+      { name: "console-port", type: "string", value: "<n>", description: "protocol-console port" },
+      { name: "roster", type: "string", value: "<file>", description: "declarative roster to boot at startup" },
+      { name: "launch", type: "string", value: "<spec>", description: "resolved mesh-manifest launch spec (cotal up -f / spawn -f)" },
+      { name: "spawn", type: "string", value: "<names>", description: "comma-separated personas to pre-spawn at startup" },
+    ],
+    run: (args) => runManager(args, "auto"),
   },
   {
     kind: "command",
@@ -442,6 +419,18 @@ const managerCommands: Command[] = [
     group: "Control plane",
     summary:
       "ask the manager to spawn a persona — --name <persona> [--role <r>] [--agent <a>] [--config <file>] [--model <m>] [--cwd <dir>] [--resume <id> (pair with --cwd)] (loads .cotal/agents/<persona>.md; the peer joins under its name:)",
+    flags: [
+      ...targetFlags,
+      { name: "name", type: "string", value: "<persona>", description: "persona to spawn (required; loads .cotal/agents/<name>.md)" },
+      { name: "role", type: "string", value: "<r>", description: "role override (wins over the agent file's role:)" },
+      { name: "agent", type: "string", value: "<a>", description: "connector type (claude, opencode, hermes …)" },
+      { name: "config", type: "string", value: "<file>", description: "agent file path (overrides --name resolution)" },
+      { name: "model", type: "string", value: "<m>", description: "model override (wins over the agent file's model:)" },
+      { name: "cwd", type: "string", value: "<dir>", description: "working directory to root the spawned agent at" },
+      { name: "resume", type: "string", value: "<id>", description: "fork an existing session id into the mesh (pair with --cwd)" },
+      { name: "transcript", type: "boolean", description: "mirror the session transcript to tr-<name>" },
+      { name: "no-transcript", type: "boolean", description: "explicit default: no transcript mirror" },
+    ],
     run: start,
   },
   {
@@ -449,6 +438,7 @@ const managerCommands: Command[] = [
     name: "stop",
     group: "Control plane",
     summary: "ask the manager to stop an agent — --name <n>",
+    flags: [...targetFlags, { name: "name", type: "string", value: "<n>", description: "managed agent to stop (required)" }],
     run: stop,
   },
   {
@@ -456,6 +446,7 @@ const managerCommands: Command[] = [
     name: "ps",
     group: "Control plane",
     summary: "list managed agents + their mesh status",
+    flags: [...targetFlags],
     run: ps,
   },
   {
@@ -463,6 +454,7 @@ const managerCommands: Command[] = [
     name: "attach",
     group: "Control plane",
     summary: "stream + drive an agent's terminal (pty runtime) — --name <n>",
+    flags: [...targetFlags, { name: "name", type: "string", value: "<n>", description: "managed agent to attach to (required)" }],
     run: attach,
   },
 ];

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "gen:schema": "node scripts/generate-cotal-schema.mjs",
     "test": "pnpm -r --if-present test",
     "check": "pnpm typecheck && pnpm test && pnpm smoke:view && pnpm smoke:spawn-from-anywhere && pnpm smoke:spawn-from-anywhere:live && pnpm smoke:connect && pnpm smoke:core-boundary && pnpm smoke:preflight && pnpm smoke:ci",
-    "smoke:ci": "pnpm smoke:read-acl:auth && pnpm smoke:sub-acl:auth && pnpm smoke:self-serve-join:auth && pnpm smoke:control-auth && pnpm smoke:manager-split && pnpm smoke:deprovision && pnpm smoke:control-reply-bound && pnpm smoke:channels:auth && pnpm smoke:e2e:acl && pnpm smoke:plane3:auth && pnpm smoke:delivery-lease:auth && pnpm smoke:delivery-leave-tombstone:auth && pnpm smoke:delivery-reconnect:auth && pnpm smoke:delivery-cred:auth && pnpm smoke:delivery-reply-injection:auth && pnpm smoke:membership:auth && pnpm smoke:membership-feed-confinement:auth && pnpm smoke:wildcard-backfill && pnpm smoke:opencode && pnpm smoke:opencode-coop && pnpm smoke:opencode-transcript && pnpm smoke:transcript-grant && pnpm smoke:persona-acl",
+    "smoke:ci": "pnpm smoke:read-acl:auth && pnpm smoke:sub-acl:auth && pnpm smoke:self-serve-join:auth && pnpm smoke:control-auth && pnpm smoke:manager-split && pnpm smoke:deprovision && pnpm smoke:control-reply-bound && pnpm smoke:channels:auth && pnpm smoke:e2e:acl && pnpm smoke:plane3:auth && pnpm smoke:delivery-lease:auth && pnpm smoke:delivery-leave-tombstone:auth && pnpm smoke:delivery-reconnect:auth && pnpm smoke:delivery-cred:auth && pnpm smoke:delivery-reply-injection:auth && pnpm smoke:membership:auth && pnpm smoke:membership-feed-confinement:auth && pnpm smoke:wildcard-backfill && pnpm smoke:opencode && pnpm smoke:opencode-coop && pnpm smoke:opencode-transcript && pnpm smoke:transcript-grant && pnpm smoke:persona-acl && pnpm smoke:cli-kernel && pnpm smoke:flag-inventory",
     "clean:dry": "git clean -ndX -- node_modules .pnpm-store packages extensions implementations examples remotion",
     "clean": "git clean -fdX -- node_modules .pnpm-store packages extensions implementations examples remotion",
     "cotal": "tsx bin/cotal.ts",
@@ -93,7 +93,9 @@
     "smoke:delivery-boot-retry:auth": "tsx packages/core/smoke/delivery-boot-retry.smoke.ts",
     "smoke:delivery-old-manager": "tsx implementations/cli/smoke/delivery-old-manager-preflight.smoke.ts",
     "smoke:delivery-reconnect:auth": "tsx packages/core/smoke/delivery-reconnect.smoke.ts",
-    "smoke:delivery-broker-coupling": "tsx implementations/delivery/smoke/delivery-broker-coupling.smoke.ts"
+    "smoke:delivery-broker-coupling": "tsx implementations/delivery/smoke/delivery-broker-coupling.smoke.ts",
+    "smoke:cli-kernel": "tsx implementations/cli/smoke/command-kernel.smoke.ts",
+    "smoke:flag-inventory": "tsx bin/smoke/flag-inventory.smoke.ts"
   },
   "dependencies": {
     "@cotal-ai/cli": "workspace:*",

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -1,3 +1,4 @@
+import { parseArgs, type ParseArgsOptionsConfig } from "node:util";
 import type { Extension } from "./registry.js";
 
 /** One shell-completion candidate. `value` is inserted on the command line; `description`
@@ -17,6 +18,29 @@ export interface CompletionResult {
   directive?: "default" | "nospace" | "nofiles";
 }
 
+/** One declared flag. The single source for parsing, `--help`, usage errors, and flag
+ *  completion — a command never hand-rolls `parseArgs` for a declared flag. */
+export interface FlagSpec {
+  /** Long name without dashes (`space`, `dry-run`). */
+  readonly name: string;
+  readonly type: "string" | "boolean";
+  /** Single-character short alias (`f` for `-f`). */
+  readonly short?: string;
+  /** Metavar shown in help for string flags, e.g. `<url>`. Defaults to `<value>`. */
+  readonly value?: string;
+  /** One-line help text. */
+  readonly description?: string;
+}
+
+/** What a command's `run` receives: the declared flags parsed strictly (an undeclared flag is
+ *  a usage error rendered by the dispatcher), the positionals, and the raw argv for the rare
+ *  command that needs it verbatim (e.g. the completion dispatcher). */
+export interface ParsedArgs {
+  readonly values: Record<string, string | boolean | undefined>;
+  readonly positionals: string[];
+  readonly raw: readonly string[];
+}
+
 /**
  * The contract for a composable CLI command — an {@link Extension} of kind
  * `"command"`. An implementation (the mesh CLI, the manager …) self-registers its
@@ -28,17 +52,60 @@ export interface Command extends Extension {
   readonly summary: string;
   /** Help grouping header (e.g. "Mesh", "Control plane"). Defaults to "Commands". */
   readonly group?: string;
-  /** One-line usage shown by `cotal <cmd> --help` and on an invalid-argument error.
-   *  Falls back to `summary` when unset. */
+  /** Overrides the generated usage line — for sub-grammar commands
+   *  (`send <dm <agent> | msg <channel> | ask <role>> "<text>"`) the generator can't express. */
   readonly usage?: string;
   /** Hide from the top-level help listing while keeping it runnable — for dev/test aids
    *  (e.g. `demo`) that clutter the surface but stay documented and invocable. */
   readonly hidden?: boolean;
-  run(argv: string[]): Promise<void>;
+  /** Declared flags — parsed by the dispatcher ({@link parseCommandArgs}), rendered into help
+   *  and completion. Omit for a command that takes no flags. */
+  readonly flags?: readonly FlagSpec[];
+  /** Positionals help label (e.g. `"<name-or-path>"`, `"<subcommand> …"`). Present ⇒
+   *  positionals are allowed; absent ⇒ a stray positional is a usage error. */
+  readonly positionals?: string;
+  /** Skip parsing: `run` sees only {@link ParsedArgs.raw}/`positionals` verbatim. For the
+   *  completion dispatcher, whose argv is another command's half-typed line. */
+  readonly rawArgs?: boolean;
+  run(args: ParsedArgs): Promise<void>;
   /** Optional shell-completion provider, owned by the command exactly as `run` is. Given the
    *  args typed so far (everything after the command name; the last element is the word being
    *  completed, possibly empty), returns the candidates for that position. Runs on every <TAB>
    *  via the hidden `__complete` dispatcher, so it MUST be import-light and side-effect-free —
-   *  no network, no spawns. Omit it to offer no argument completion for this command. */
+   *  no network, no spawns. Omit it to offer no argument completion for this command.
+   *  Flag-name candidates are generated from {@link Command.flags} by the dispatcher; this hook
+   *  only supplies positional/value candidates. */
   complete?(argv: string[]): CompletionResult | Promise<CompletionResult>;
+}
+
+/** Parse `argv` against a command's declared flags — strict: an undeclared flag or a stray
+ *  positional (when the command declares none) throws `parseArgs`' usage error, which the
+ *  dispatcher renders as one red line plus the command's help. */
+export function parseCommandArgs(cmd: Command, argv: string[]): ParsedArgs {
+  if (cmd.rawArgs) return { values: {}, positionals: [...argv], raw: argv };
+  const options: ParseArgsOptionsConfig = {};
+  for (const f of cmd.flags ?? []) {
+    options[f.name] = f.short ? { type: f.type, short: f.short } : { type: f.type };
+  }
+  const { values, positionals } = parseArgs({
+    args: [...argv],
+    options,
+    allowPositionals: cmd.positionals !== undefined,
+    strict: true,
+  });
+  return { values: values as ParsedArgs["values"], positionals, raw: argv };
+}
+
+/** The generated usage line: `cotal <name> [<positionals>] [flags…]`, honoring an explicit
+ *  {@link Command.usage} override. One source for `--help` and usage errors. */
+export function commandUsage(cmd: Command): string {
+  if (cmd.usage) return cmd.usage;
+  const parts = [`cotal ${cmd.name}`];
+  if (cmd.positionals) parts.push(cmd.positionals);
+  for (const f of cmd.flags ?? []) {
+    const long = `--${f.name}`;
+    const metavar = f.type === "string" ? ` ${f.value ?? "<value>"}` : "";
+    parts.push(`[${f.short ? `-${f.short}|` : ""}${long}${metavar}]`);
+  }
+  return parts.join(" ");
 }

--- a/packages/workspace/src/flags.ts
+++ b/packages/workspace/src/flags.ts
@@ -1,0 +1,13 @@
+import type { FlagSpec } from "@cotal-ai/core";
+
+/**
+ * The shared mesh-target flag bundle: which space, which broker, and (off-registry) which
+ * credential. Every command that connects to a mesh spreads THIS bundle instead of declaring
+ * its own copies, so the target vocabulary cannot drift between commands. Resolution order is
+ * `resolveMeshTarget`'s: explicit flags > the folder's project > the registry/`current` mesh.
+ */
+export const targetFlags: readonly FlagSpec[] = [
+  { name: "space", type: "string", value: "<s>", description: "target space (default: the resolved mesh)" },
+  { name: "server", type: "string", value: "<url>", description: "broker URL (overrides the mesh registry entry)" },
+  { name: "creds", type: "string", value: "<path>", description: "creds file for an off-registry connection" },
+];

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -1,5 +1,7 @@
 export * from "./auth-paths.js";
 export * from "./bin-path.js";
+export * from "./flags.js";
+export * from "./provenance.js";
 export * from "./mesh-registry.js";
 export * from "./mesh-target.js";
 export * from "./preflight.js";

--- a/packages/workspace/src/provenance.ts
+++ b/packages/workspace/src/provenance.ts
@@ -1,0 +1,17 @@
+/**
+ * One consistent voice for CLI provenance, on stderr: which on-disk source a command RESOLVED
+ * its configuration from, and what it WROTE where. Commands must never silently pick up state
+ * from a directory or silently drop files — every read of config (persona file, mesh entry,
+ * config.json layer) and every write (creds, seeded files) gets one dim arrow line. stderr so
+ * it never pollutes machine-readable stdout; plain text so this layer needs no color dep.
+ */
+export const provenance = {
+  /** `→ using <what>: <source>` — the source that WON resolution (say which layer/path). */
+  read(what: string, source: string): void {
+    process.stderr.write(`→ using ${what}: ${source}\n`);
+  },
+  /** `→ wrote <what>: <dest>` — announce every file the command created or replaced. */
+  wrote(what: string, dest: string): void {
+    process.stderr.write(`→ wrote ${what}: ${dest}\n`);
+  },
+};


### PR DESCRIPTION
Stage 1 of the CLI rework (plan: `.internal/plans/cli-rework.md`, approved on `#review.cli-rework`). Mechanical kernel migration — **no command surface change** beyond the deliberate tightenings listed below.

## What

- **Core `Command` contract** gains declarative `flags` / `positionals` specs and `rawArgs`; `run()` receives `ParsedArgs` ({values, positionals, raw}) instead of raw argv. `parseCommandArgs` (strict) and `commandUsage` live in core next to the contract.
- **Dispatcher** (`@cotal-ai/cli` `runCli`) parses from the declared specs, renders usage errors, and generates real per-command `--help` (usage line + flag table). The `__complete` dispatcher now offers declared flag names on a `-` prefix — completion can no longer drift from what parsing accepts.
- **Shared target bundle** (`@cotal-ai/workspace` `targetFlags`): `--space/--server/--creds` declared once, spread by every mesh-client command (send/console/demo/web/personas/channels/history/start/stop/ps/attach). The launch bundle lands in stage 2a with the `spawn`/`start` merge.
- **Provenance reporter** (`@cotal-ai/workspace` `provenance`): `→ using <what>: <source>` / `→ wrote <what>: <dest>` on stderr. Wired into `spawn` (persona resolution + creds write); the rest of the surface adopts it in stage 2.
- All 26 commands across cli/manager/delivery migrated; every per-command `parseArgs` is deleted.

## Deliberate tightenings (all fail-loud; documented in the flag-inventory smoke)

- Commands whose positionals were accepted-but-ignored now reject them (`setup`/`go`/`up`/`down`/`join`/`console`/`demo`/`web`).
- Manager commands accepted the UNION of all manager flags (e.g. `cotal stop --model x` silently ignored); each now accepts exactly its own set. The dead `--drive` flag is gone.
- `supervise` no longer accepts `--creds` (it never used it).
- `feedback` keeps its own dual-mode parsing (`rawArgs`) until the intake server splits out in stage 2b.

## Tests

- New `smoke:cli-kernel` — parse semantics (strict flags, shorts, positional gating, rawArgs passthrough), `commandUsage` generation, flag-name completion.
- New `smoke:flag-inventory` — the golden per-command flag inventory at the composition root (`bin/smoke/`, where cli+manager+delivery legally compose); any future flag change must consciously edit the golden.
- Both wired into `smoke:ci`. Full `pnpm check` green locally (typecheck, unit tests, view/spawn-from-anywhere(+live)/connect/core-boundary/preflight, full smoke:ci).