### PR TITLE
feat(manager): add COTAL_DETACH_KEY to rebind the cotal attach detach key

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -330,7 +330,10 @@ dependency on them). Selectable backends:
   pseudo-terminal it owns via **`@lydell/node-pty`** (prebuilt binaries for mac/Linux/Windows ×
   x64/arm64: zero compiler, zero `node-gyp`, ABI-stable). A real native TUI. The human watches
   or types in via `cotal attach <name>` (stream the PTY), and the manager keeps full OS-signal
-  control (group-kill, restart). No external software to install.
+  control (group-kill, restart). No external software to install. Detach with **Ctrl-]** (the
+  agent keeps running); set **`COTAL_DETACH_KEY`** to `ctrl-<char>` (e.g. `ctrl-b`) to rebind it
+  when Ctrl-] clashes with a keybinding inside the agent's TUI — an unparseable value errors, and
+  attach prints the active key when it is overridden.
 - **`tmux` (integration).** Each agent gets its own window in a shared per-space [tmux](https://github.com/tmux/tmux/wiki) session.
   This is a true plug-in: the runtime lives in **`@cotal-ai/tmux`** and self-registers a
   `RuntimeProvider` on import (opt in with `import "@cotal-ai/tmux"`, which the `cotal` binary

--- a/implementations/manager/smoke/attach.smoke.ts
+++ b/implementations/manager/smoke/attach.smoke.ts
@@ -9,6 +9,7 @@
  */
 import { execFileSync } from "node:child_process";
 import { createRuntime } from "../src/index.js";
+import { detachKey } from "../src/attach-client.js";
 import "@cotal-ai/cmux"; // registers the `cmux` runtime provider
 import "@cotal-ai/tmux"; // registers the `tmux` runtime provider
 import type { LaunchSpec } from "@cotal-ai/core";
@@ -56,6 +57,35 @@ const cwd = process.cwd();
   check("auto resolves to pty even inside $TMUX (no auto-detect, no fallback)", createRuntime("auto", SESSION).kind === "pty");
   if (prevTmux === undefined) delete process.env.TMUX;
   else process.env.TMUX = prevTmux;
+}
+
+// Detach key (no fallbacks): default is Ctrl-] (0x1d); `COTAL_DETACH_KEY` rebinds it to a control
+// key; an unparseable value throws (named), never silently keeping the default.
+{
+  const prev = process.env.COTAL_DETACH_KEY;
+  delete process.env.COTAL_DETACH_KEY;
+  const def = detachKey();
+  check("detach: default is Ctrl-] (0x1d), not overridden", def.byte === 0x1d && def.label === "Ctrl-]" && !def.overridden);
+
+  process.env.COTAL_DETACH_KEY = "ctrl-b";
+  const cb = detachKey();
+  check("detach: COTAL_DETACH_KEY=ctrl-b → Ctrl-B (0x02), overridden", cb.byte === 0x02 && cb.label === "Ctrl-B" && cb.overridden);
+  process.env.COTAL_DETACH_KEY = "^b";
+  check("detach: caret form ^b parses the same", detachKey().byte === 0x02);
+  process.env.COTAL_DETACH_KEY = "ctrl-]";
+  check("detach: ctrl-] round-trips to the 0x1d default (overridden)", detachKey().byte === 0x1d && detachKey().overridden);
+
+  // Unparseable values throw, naming the var — INCLUDING a set-but-empty/whitespace one (no fallback
+  // to the default; only an unset var defaults).
+  for (const bad of ["esc", "", "  "]) {
+    process.env.COTAL_DETACH_KEY = bad;
+    check(
+      `detach: unparseable ${JSON.stringify(bad)} throws, naming the var (no silent fallback)`,
+      attachError(() => detachKey()).includes("COTAL_DETACH_KEY"),
+    );
+  }
+  if (prev === undefined) delete process.env.COTAL_DETACH_KEY;
+  else process.env.COTAL_DETACH_KEY = prev;
 }
 
 // tmux — watched natively: attach() points you at `tmux attach-session -t <session>` + `select-window -t @N`.

--- a/implementations/manager/src/attach-client.ts
+++ b/implementations/manager/src/attach-client.ts
@@ -1,7 +1,27 @@
 import WebSocket from "ws";
+import { c } from "./ui.js";
 
-/** Detach key — Ctrl-] (0x1d), as in telnet/ssh escape conventions. */
-const DETACH = 0x1d;
+/**
+ * The detach key — Ctrl-] (0x1d) by default, as in telnet/ssh escape conventions. `COTAL_DETACH_KEY`
+ * rebinds it to another control key when Ctrl-] clashes with a keybinding inside the agent's TUI;
+ * accepts `ctrl-<char>` or `^<char>` (e.g. `ctrl-b`, `^_`). Read at point of use, per the repo's
+ * `COTAL_*` convention. An unparseable value — including a set-but-empty or whitespace-only one —
+ * throws (named), never silently falling back; the caller turns that into a loud exit. Only an
+ * unset var = the Ctrl-] default.
+ */
+export function detachKey(): { byte: number; label: string; overridden: boolean } {
+  const spec = process.env.COTAL_DETACH_KEY;
+  if (spec === undefined) return { byte: 0x1d, label: "Ctrl-]", overridden: false };
+  const m = /^(?:ctrl-|\^)([a-z@[\\\]^_])$/i.exec(spec.trim());
+  if (!m) {
+    throw new Error(
+      `invalid COTAL_DETACH_KEY "${spec}" — expected ctrl-<char> or ^<char> for a control key ` +
+        `(a-z, or one of @ [ \\ ] ^ _), e.g. ctrl-b`,
+    );
+  }
+  const ch = m[1].toUpperCase();
+  return { byte: ch.charCodeAt(0) & 0x1f, label: `Ctrl-${ch}`, overridden: true };
+}
 
 /**
  * Terminal modes a full-screen child (a fullscreen TUI: OpenCode, or Claude under `/tui fullscreen`)
@@ -60,9 +80,18 @@ const lastIndexOfRe = (re: RegExp, s: string): number => {
 /**
  * Drive a manager's attach endpoint from the terminal: raw-mode stdin streams to
  * the PTY, PTY output streams to stdout, and SIGWINCH-style resizes are forwarded.
- * Ctrl-] detaches without killing the agent.
+ * The detach key (Ctrl-] by default, {@link detachKey}) detaches without killing the agent.
  */
 export function attachClient(url: string): Promise<void> {
+  // Resolve the detach key before connecting so a bad COTAL_DETACH_KEY fails loudly up front
+  // (matching the manager's other fail-fast exits) instead of after an attach we'd only tear down.
+  let detach: ReturnType<typeof detachKey>;
+  try {
+    detach = detachKey();
+  } catch (e) {
+    console.error(c.red(`✗ ${(e as Error).message}`));
+    process.exit(1);
+  }
   return new Promise<void>((resolve, reject) => {
     const ws = new WebSocket(url);
     const stdin = process.stdin;
@@ -106,7 +135,7 @@ export function attachClient(url: string): Promise<void> {
     const sendResize = () =>
       ws.send(`r:${process.stdout.columns ?? 80},${process.stdout.rows ?? 24}`);
     const onInput = (d: Buffer) => {
-      if (d.length === 1 && d[0] === DETACH) {
+      if (d.length === 1 && d[0] === detach.byte) {
         ws.close();
         return;
       }
@@ -162,6 +191,9 @@ export function attachClient(url: string): Promise<void> {
     };
 
     ws.on("open", () => {
+      // Make an override visible (the CLI's "attached to X — Ctrl-] to detach" hint still prints the
+      // default label). Only on override, so the default case stays free of duplicate noise.
+      if (detach.overridden) console.error(c.dim(`detach key: ${detach.label} (via COTAL_DETACH_KEY)`));
       if (stdin.isTTY) stdin.setRawMode(true);
       stdin.resume();
       sendResize();


### PR DESCRIPTION
## What

`cotal attach`'s detach key was a hardcoded **Ctrl-]** (`0x1d`). `COTAL_DETACH_KEY` rebinds it to another control key — `ctrl-<char>` or `^<char>` (e.g. `ctrl-b`, `^_`) — for when Ctrl-] clashes with a keybinding inside the agent's own TUI. Unset ⇒ the Ctrl-] default, unchanged.

## Design

- Parsing lives in a single exported `detachKey(): { byte, label, overridden }` — the one validate-or-throw source.
- **No fallbacks.** An unparseable value — including a *set-but-empty* or whitespace-only one — throws, naming the var; `attachClient` turns that into a loud `✗ …` exit *before* connecting. Only an unset var defaults to Ctrl-].
- **Visible config.** When the key is overridden, attach prints `detach key: Ctrl-B (via COTAL_DETACH_KEY)` on connect (stderr — never touches the PTY stream), so the env-picked-up setting is surfaced.

## Scope / CLI-rework coordination

Touches **only** `attach-client.ts`, its smoke, and docs — deliberately **not** `commands.ts` — so it lands cleanly ahead of the CLI rework moving `attach-client.ts` into `implementations/cli` (Stage 2a). `detachKey()` is exported so that move can wire the `attached to X — Ctrl-] to detach` hint to `detachKey().label` and retire the one remaining cosmetic gap (the static hint still shows the literal `Ctrl-]` under override until then; the connect-time line corrects it).

## Tests

- Added detach-key parsing checks (default, `ctrl-b`/`^b`, `ctrl-]` round-trip to `0x1d`, and throw-on-unparseable incl. empty/whitespace) to `attach.smoke.ts`.
- Verified end-to-end against the real attach stack (real pty child + real `AttachEndpoint` over a real WebSocket + real `attachClient`): the overridden key detaches and the old Ctrl-] is ignored; **the agent process stays alive across detach**; an invalid key exits non-zero before attaching. Existing `attach-repaint` smoke and full workspace typecheck green.
- Reviewed with a Codex pass; its one real finding (set-but-empty value silently defaulting) is fixed here.
