### PR TITLE
feat(cli,workspace): operator-installed CLI extensions — cotal ext (stage 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,9 @@ jobs:
         # a dynamic `await import()` boundary regression in a live smoke escapes tsc — only running it catches it.
         # smoke:up-stack:live / smoke:up-manifest:live e2e the full `up --detach` stack (broker +
         # delivery + manager, real `cotal ps`) and the one-manager-carries-the-launch invariant of
-        # `up -f` (the singleton-lease race regression). nats-server installed above.
-        run: pnpm smoke:core-boundary && pnpm smoke:preflight && pnpm smoke:server-resolution:live && pnpm smoke:spawn-from-anywhere:live && pnpm smoke:spawn-detach:live && pnpm smoke:setup-pure:live && pnpm smoke:up-stack:live && pnpm smoke:up-manifest:live
+        # `up -f` (the singleton-lease race regression). smoke:ext:live e2es the operator-installed
+        # extension lifecycle (cotal ext) through the real binary. nats-server installed above.
+        run: pnpm smoke:core-boundary && pnpm smoke:preflight && pnpm smoke:server-resolution:live && pnpm smoke:spawn-from-anywhere:live && pnpm smoke:spawn-detach:live && pnpm smoke:setup-pure:live && pnpm smoke:up-stack:live && pnpm smoke:up-manifest:live && pnpm smoke:ext:live
 
       - name: Manager lifecycle e2e (real broker + real agents)
         # Real end-to-end for #159 Part B: the startAgent presence-race (started via real presence / failed

--- a/bin/cotal.ts
+++ b/bin/cotal.ts
@@ -32,6 +32,8 @@ process.stdout.on("error", (e: NodeJS.ErrnoException) => {
 // rides the MANAGER side of the control plane, not the removed CLI verb.
 registry.register({ ...claudeConnector, name: "cotal" });
 
-// Bare `cotal` prints help; explicit `cotal setup` runs guided setup.
+// Bare `cotal` prints help; explicit `cotal setup` runs guided setup. The published binary is
+// the ONE composition root that loads operator-installed extensions (`cotal ext add …`) —
+// library roots keep the explicit-import model.
 const argv = process.argv.slice(2);
-await runCli(registry, argv);
+await runCli(registry, argv, { extensions: true });

--- a/bin/smoke/ext-live.smoke.ts
+++ b/bin/smoke/ext-live.smoke.ts
@@ -6,9 +6,11 @@
  *     registration LANDED, caches the command surface (+ provenance lines).
  *  B. cache-only surface: with the installed package's code made to THROW, `--help` and
  *     `__complete` still work (they never import); running the command fails LOUD.
- *  C. run: the real command executes with LIVE specs (flag + positional through the kernel).
+ *  C. run: the real command executes with LIVE specs (flag + positional through the kernel);
+ *     re-add is a clean refresh; a corrupt manifest is ONE red line, not a stack dump.
  *  D. version-skew: on-disk version ≠ manifest pin → loud error prescribing re-add.
- *  E. failed adds are loud AND rolled back: builtin name collision, core as a regular
+ *  E. failed adds are loud AND rolled back: builtin name collision, ext-vs-ext name collision
+ *     (checked against the manifest cache — the sibling is never imported), core as a regular
  *     dependency, missing core peerDep, zero registrations.
  *  F. remove: commands leave the surface; the manifest empties.
  * Run: pnpm smoke:ext:live   (needs npm on PATH)
@@ -117,6 +119,26 @@ ok("ext list starts empty", /no extensions installed/.test(cotal(["ext", "list"]
   ok("unknown flag on an extension command is a usage error (live specs)", bad.status === 1 && /Unknown option/.test(bad.stderr), bad.stderr.slice(0, 200));
 }
 
+// -- C2: re-adding an installed extension is a clean refresh (manifest keeps ONE entry) ------------
+{
+  const r = cotal(["ext", "add", join(sandbox, "cotal-ext-fixture")]);
+  ok("re-add of the same extension exits 0", r.status === 0, r.stderr.slice(-300));
+  const m = JSON.parse(readFileSync(manifestPath, "utf8"));
+  ok("re-add keeps one manifest entry at the same pin", m.extensions.length === 1 && m.extensions[0].version === "1.0.0", m.extensions);
+}
+
+// -- C3: a corrupt manifest is fatal-and-loud as ONE red line (never a stack dump, never a
+//        silently-shrunk surface) ------------------------------------------------------------------
+{
+  const good = readFileSync(manifestPath, "utf8");
+  writeFileSync(manifestPath, "{ not json");
+  const r = cotal(["--help"]);
+  ok("corrupt manifest fails every invocation", r.status === 1, r.status);
+  ok("...as one red line naming the manifest + the fix", /corrupt extensions manifest/.test(r.stderr) && /ext add/.test(r.stderr), r.stderr.slice(0, 300));
+  ok("...not an unhandled-rejection stack dump", !/ModuleJob|at async/.test(r.stderr), r.stderr.slice(0, 300));
+  writeFileSync(manifestPath, good);
+}
+
 // -- D: version skew -------------------------------------------------------------------------------
 {
   const meta = JSON.parse(readFileSync(installedPkg, "utf8"));
@@ -145,6 +167,18 @@ ok("ext list starts empty", /no extensions installed/.test(cotal(["ext", "list"]
   const empty = fixture("cotal-ext-empty", "export {};\n");
   const r4 = cotal(["ext", "add", empty]);
   ok("zero registrations fails the add", r4.status === 1 && /registered no commands/.test(r4.stderr), r4.stderr.slice(-300));
+
+  // ext-vs-ext: another package contributing the installed fixture's command name. The registry
+  // can't see the installed (unimported) sibling, so add() must check the manifest cache.
+  const sibling = fixture("cotal-ext-sibling", GOOD);
+  const r5 = cotal(["ext", "add", sibling]);
+  ok(
+    "ext-vs-ext name collision fails the add, naming BOTH extensions",
+    r5.status === 1 && /cotal-ext-sibling/.test(r5.stderr) && /cotal-ext-fixture/.test(r5.stderr) && /hello-ext/.test(r5.stderr),
+    r5.stderr.slice(-400),
+  );
+  const r5b = cotal(["ext", "list"]);
+  ok("ext-vs-ext collision rolled back (not listed)", !/sibling/.test(r5b.stdout), r5b.stdout);
 }
 
 // -- F: remove -------------------------------------------------------------------------------------

--- a/bin/smoke/ext-live.smoke.ts
+++ b/bin/smoke/ext-live.smoke.ts
@@ -1,0 +1,159 @@
+/**
+ * LIVE e2e for `cotal ext` (CLI rework stage 3): fixture extension packages are built on the fly
+ * and driven through the REAL binary as subprocesses (sandboxed XDG_CONFIG_HOME/COTAL_HOME):
+ *
+ *  A. add: installs into the cotal-owned prefix, links OUR core, imports once, verifies the
+ *     registration LANDED, caches the command surface (+ provenance lines).
+ *  B. cache-only surface: with the installed package's code made to THROW, `--help` and
+ *     `__complete` still work (they never import); running the command fails LOUD.
+ *  C. run: the real command executes with LIVE specs (flag + positional through the kernel).
+ *  D. version-skew: on-disk version ≠ manifest pin → loud error prescribing re-add.
+ *  E. failed adds are loud AND rolled back: builtin name collision, core as a regular
+ *     dependency, missing core peerDep, zero registrations.
+ *  F. remove: commands leave the surface; the manifest empties.
+ * Run: pnpm smoke:ext:live   (needs npm on PATH)
+ */
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const sandbox = mkdtempSync(join(tmpdir(), "cotal-ext-sb-"));
+const configDir = join(sandbox, "xdg");
+const home = join(sandbox, "home");
+mkdirSync(configDir, { recursive: true });
+mkdirSync(home, { recursive: true });
+
+let pass = 0;
+const ok = (name: string, cond: boolean, extra?: unknown) => {
+  if (!cond) throw new Error(`FAIL: ${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
+  pass++;
+  console.log(`  ✓ ${name}`);
+};
+
+const env = { ...process.env, XDG_CONFIG_HOME: configDir, COTAL_HOME: home };
+const realNode = spawnSync("which", ["node"], { encoding: "utf8" }).stdout.trim();
+const tsxCli = resolve(import.meta.dirname, "..", "..", "node_modules", "tsx", "dist", "cli.mjs");
+const binCotal = resolve(import.meta.dirname, "..", "cotal.ts");
+const cotal = (args: string[]) =>
+  spawnSync(realNode, [tsxCli, binCotal, ...args], { encoding: "utf8", env, cwd: sandbox, timeout: 180_000 });
+
+/** Build a fixture extension package on disk. `index` is its module body. */
+function fixture(name: string, index: string, pkgJson: Record<string, unknown> = {}): string {
+  const dir = join(sandbox, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify(
+      {
+        name,
+        version: "1.0.0",
+        type: "module",
+        main: "index.js",
+        peerDependencies: { "@cotal-ai/core": "*" },
+        ...pkgJson,
+      },
+      null,
+      2,
+    ),
+  );
+  writeFileSync(join(dir, "index.js"), index);
+  return dir;
+}
+
+const GOOD = `import { registry } from "@cotal-ai/core";
+registry.register({
+  kind: "command",
+  name: "hello-ext",
+  group: "Extensions",
+  summary: "fixture extension command",
+  flags: [{ name: "shout", type: "boolean", description: "upper-case it" }],
+  positionals: "[<who>]",
+  run: async (args) => {
+    const who = args.positionals[0] ?? "world";
+    const msg = "hello " + who;
+    console.log(args.values.shout ? msg.toUpperCase() : msg);
+  },
+});
+`;
+
+const extDir = join(configDir, "cotal", "extensions");
+const manifestPath = join(extDir, "extensions.json");
+const installedIndex = join(extDir, "node_modules", "cotal-ext-fixture", "index.js");
+const installedPkg = join(extDir, "node_modules", "cotal-ext-fixture", "package.json");
+
+// -- empty state ---------------------------------------------------------------------------------
+ok("ext list starts empty", /no extensions installed/.test(cotal(["ext", "list"]).stdout));
+
+// -- A: add --------------------------------------------------------------------------------------
+{
+  const r = cotal(["ext", "add", fixture("cotal-ext-fixture", GOOD)]);
+  ok("add exits 0", r.status === 0, r.stderr.slice(-400));
+  ok("add names the contributed command", /hello-ext/.test(r.stdout), r.stdout);
+  ok("manifest written + announced", existsSync(manifestPath) && /→ wrote extensions manifest/.test(r.stderr), r.stderr.slice(-300));
+  ok("core is linked to OUR copy", /→ wrote core link/.test(r.stderr));
+  const m = JSON.parse(readFileSync(manifestPath, "utf8"));
+  ok("manifest pins name@version + caches flags", m.extensions[0].version === "1.0.0" && m.extensions[0].commands[0].flags[0].name === "shout", m.extensions[0]);
+}
+
+// -- B: cache-only help/complete; run fails loud while broken -------------------------------------
+{
+  const good = readFileSync(installedIndex, "utf8");
+  writeFileSync(installedIndex, 'throw new Error("BOOM — cache must not import me");\n');
+  const help = cotal(["--help"]);
+  ok("--help lists the extension command WITHOUT importing it", help.status === 0 && /hello-ext/.test(help.stdout), help.stdout.slice(-400));
+  const comp = cotal(["__complete", "hello-ext", "--"]);
+  ok("<TAB> offers cached flags WITHOUT importing", comp.status === 0 && /--shout/.test(comp.stdout), comp.stdout);
+  const run = cotal(["hello-ext"]);
+  ok("running the broken extension fails loud, naming it", run.status === 1 && /cotal-ext-fixture/.test(run.stderr) && /BOOM/.test(run.stderr), run.stderr.slice(0, 300));
+  writeFileSync(installedIndex, good);
+}
+
+// -- C: run with LIVE specs ------------------------------------------------------------------------
+{
+  const r = cotal(["hello-ext", "bob", "--shout"]);
+  ok("extension command runs through the kernel", r.status === 0 && r.stdout.includes("HELLO BOB"), r.stdout + r.stderr.slice(-200));
+  const bad = cotal(["hello-ext", "--nope"]);
+  ok("unknown flag on an extension command is a usage error (live specs)", bad.status === 1 && /Unknown option/.test(bad.stderr), bad.stderr.slice(0, 200));
+}
+
+// -- D: version skew -------------------------------------------------------------------------------
+{
+  const meta = JSON.parse(readFileSync(installedPkg, "utf8"));
+  writeFileSync(installedPkg, JSON.stringify({ ...meta, version: "9.9.9" }, null, 2));
+  const r = cotal(["hello-ext"]);
+  ok("version skew fails loud, prescribing re-add", r.status === 1 && /9\.9\.9/.test(r.stderr) && /ext add/.test(r.stderr), r.stderr.slice(0, 300));
+  writeFileSync(installedPkg, JSON.stringify(meta, null, 2));
+}
+
+// -- E: failed adds are loud + rolled back ---------------------------------------------------------
+{
+  const collide = fixture("cotal-ext-collide", GOOD.replace('name: "hello-ext"', 'name: "spawn"'));
+  const r1 = cotal(["ext", "add", collide]);
+  ok("builtin-name collision fails the add", r1.status === 1 && /cotal-ext-collide/.test(r1.stderr), r1.stderr.slice(-300));
+  const r1b = cotal(["ext", "list"]);
+  ok("collision add rolled back (not listed)", !/collide/.test(r1b.stdout), r1b.stdout);
+
+  const dep = fixture("cotal-ext-dep", GOOD, { dependencies: { "@cotal-ai/core": "*" }, peerDependencies: undefined });
+  const r2 = cotal(["ext", "add", dep]);
+  ok("core-as-dependency fails with the exact reason", r2.status === 1 && /regular dependency/.test(r2.stderr), r2.stderr.slice(-300));
+
+  const nopeer = fixture("cotal-ext-nopeer", GOOD, { peerDependencies: undefined });
+  const r3 = cotal(["ext", "add", nopeer]);
+  ok("missing core peerDep fails with the exact reason", r3.status === 1 && /peerDependency/.test(r3.stderr), r3.stderr.slice(-300));
+
+  const empty = fixture("cotal-ext-empty", "export {};\n");
+  const r4 = cotal(["ext", "add", empty]);
+  ok("zero registrations fails the add", r4.status === 1 && /registered no commands/.test(r4.stderr), r4.stderr.slice(-300));
+}
+
+// -- F: remove -------------------------------------------------------------------------------------
+{
+  const r = cotal(["ext", "remove", "cotal-ext-fixture"]);
+  ok("remove exits 0", r.status === 0, r.stderr.slice(-200));
+  const gone = cotal(["hello-ext"]);
+  ok("removed command is unknown again", gone.status === 1 && /unknown command: hello-ext/.test(gone.stderr), gone.stderr.slice(0, 150));
+  ok("ext list is empty again", /no extensions installed/.test(cotal(["ext", "list"]).stdout));
+}
+
+console.log(`\next live e2e: ${pass} checks passed`);

--- a/bin/smoke/flag-inventory.smoke.ts
+++ b/bin/smoke/flag-inventory.smoke.ts
@@ -67,6 +67,7 @@ const GOLDEN: Record<string, { flags: string[]; positionals: boolean; rawArgs?: 
     positionals: true,
   },
   completion: { flags: [], positionals: true },
+  ext: { flags: [], positionals: true },
   __complete: { flags: [], positionals: true, rawArgs: true },
   mint: {
     flags: ["allow-publish:string", "allow-subscribe:string", "force:boolean", "out:string", "profile:string", "signer:boolean"],

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -181,7 +181,10 @@ commands imports the package lazily and parses with its **live** specs — the c
 surface, never the parse authority. The pinned `name@version` is verified before every import
 (skew → a loud error prescribing re-add), extensions must declare `@cotal-ai/core` as a
 **peerDependency** (the prefix's copy is linked to the binary's, so there is exactly one
-registry singleton), and a name collision with a built-in fails the add — built-ins always win.
+registry singleton), and a name collision — with a built-in or with another installed
+extension — fails the add; built-ins always win. Moving or reinstalling the binary (e.g. a Node
+version switch) can strand the prefix's core link: every such path fails **loud** at dispatch
+with a `cotal ext add` re-add prescription, never a silently missing command.
 Library composition roots (examples) are unaffected: explicit imports stay the model there.
 
 ## Integration surfaces (Claude Code + OpenCode)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -170,6 +170,20 @@ Implementations stay self-contained and never import each other: the `cli` drive
 purely over the mesh (`start`/`stop`/`ps` control requests), so neither imports the other. Only
 the example wires them together.
 
+**Operator-installed CLI extensions (`cotal ext`).** The published binary is one composition
+root among many — and the only one that also loads extensions the *operator* installed:
+`cotal ext add <npm-package>` installs into a cotal-owned prefix
+(`$XDG_CONFIG_HOME/cotal/extensions/`, never your project), imports the package once so it
+self-registers into the same `Registry` every built-in uses, verifies the registration actually
+landed, and caches the contributed command metadata into a manifest. From then on `--help` and
+shell completion read the **cache** (a `<TAB>` never imports an extension); *running* one of its
+commands imports the package lazily and parses with its **live** specs — the cache is a display
+surface, never the parse authority. The pinned `name@version` is verified before every import
+(skew → a loud error prescribing re-add), extensions must declare `@cotal-ai/core` as a
+**peerDependency** (the prefix's copy is linked to the binary's, so there is exactly one
+registry singleton), and a name collision with a built-in fails the add — built-ins always win.
+Library composition roots (examples) are unaffected: explicit imports stay the model there.
+
 ## Integration surfaces (Claude Code + OpenCode)
 
 Each target agent exposes the same four surfaces. The adapters share one runtime

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -131,6 +131,14 @@ CI job can check the result. It launches nothing. `cotal up --detach` then bring
 delivery daemon, and the background **manager**, so an agent can use the `cotal_*` tools —
 spawn/despawn/persona — right away. `cotal down` stops the background processes.
 
+## Extending the CLI
+
+Installed packages can add their own commands: `cotal ext add <npm-package>` installs it into a
+cotal-owned prefix (never your project) and its commands appear in `cotal --help` and shell
+completion like any built-in. `cotal ext list` shows what's installed; `cotal ext remove <name>`
+takes it out. See [architecture](architecture.md) for the guarantees (one shared registry, cached
+help surface, live parsing, loud failures).
+
 ## Troubleshooting
 
 - The full log is at `.cotal/setup.log` (and `.cotal/nats.log` for the server).

--- a/implementations/cli/src/command.ts
+++ b/implementations/cli/src/command.ts
@@ -1,5 +1,6 @@
 import { commandUsage, parseCommandArgs, type Command, type Registry } from "@cotal-ai/core";
 import { c } from "./ui.js";
+import { isExtensionStub, materializeExtensionCommand, overlayExtensions, setCommandSurface } from "./ext-loader.js";
 
 function help(commands: Command[]): void {
   // `__`-prefixed commands are internal (e.g. `__complete`, the completion dispatcher); `hidden`
@@ -41,28 +42,49 @@ function isArgError(e: unknown): boolean {
   return typeof code === "string" && code.startsWith("ERR_PARSE_ARGS");
 }
 
+/** Options a composition root passes to {@link runCli}. */
+export interface RunCliOptions {
+  /** Load operator-installed extensions (`cotal ext add …`) into the surface: help/completion see
+   *  manifest-cached stubs (no import), dispatch imports the owning package lazily with LIVE
+   *  specs. OFF by default — library composition roots keep the explicit-import model; only the
+   *  published binary opts in. */
+  extensions?: boolean;
+}
+
 /** Dispatch `argv` against the commands self-registered in a {@link Registry}.
  *  The single entry point a composition root calls — no hardcoded command list.
  *  Parsing happens HERE, from the command's declared specs; `run` gets parsed args. */
-export async function runCli(registry: Registry, argv: string[]): Promise<void> {
-  const commands = registry.all<Command>("command");
+export async function runCli(registry: Registry, argv: string[], opts: RunCliOptions = {}): Promise<void> {
+  const commands = opts.extensions ? overlayExtensions(registry) : registry.all<Command>("command");
+  setCommandSurface(commands); // the completion dispatcher reads the SAME surface help renders
   const [name, ...rest] = argv;
   if (name === undefined || name === "help" || name === "-h" || name === "--help") {
     help(commands);
     return;
   }
-  const cmd = commands.find((c) => c.name === name);
+  let cmd = commands.find((c) => c.name === name);
   if (!cmd) {
     console.error(c.red(`unknown command: ${name}`));
     help(commands);
     process.exit(1);
   }
   // `cotal <cmd> --help` / `-h` → that command's help, never run it. This intercept also covers
-  // rawArgs commands (feedback) — only `__`-internal ones are exempt, because __complete's argv
-  // is ANOTHER command's half-typed line, where `--help` is a word being completed, not a request.
+  // rawArgs commands and extension STUBS (cached specs are exactly the display surface) — only
+  // `__`-internal ones are exempt, because __complete's argv is ANOTHER command's half-typed
+  // line, where `--help` is a word being completed, not a request.
   if (!cmd.name.startsWith("__") && (rest.includes("--help") || rest.includes("-h"))) {
     commandHelp(cmd);
     return;
+  }
+  // An extension stub materializes before parsing: verify the version pin, import the package
+  // (self-registers), and parse with the LIVE specs — the cache never drives run's input.
+  if (isExtensionStub(cmd)) {
+    try {
+      cmd = await materializeExtensionCommand(cmd);
+    } catch (e) {
+      console.error(c.red(`✗ ${(e as Error).message}`));
+      process.exit(1);
+    }
   }
   try {
     await cmd.run(parseCommandArgs(cmd, rest));

--- a/implementations/cli/src/command.ts
+++ b/implementations/cli/src/command.ts
@@ -55,7 +55,15 @@ export interface RunCliOptions {
  *  The single entry point a composition root calls — no hardcoded command list.
  *  Parsing happens HERE, from the command's declared specs; `run` gets parsed args. */
 export async function runCli(registry: Registry, argv: string[], opts: RunCliOptions = {}): Promise<void> {
-  const commands = opts.extensions ? overlayExtensions(registry) : registry.all<Command>("command");
+  let commands: Command[];
+  try {
+    commands = opts.extensions ? overlayExtensions(registry) : registry.all<Command>("command");
+  } catch (e) {
+    // A corrupt extensions manifest must not silently shrink the surface — fatal and loud, but
+    // rendered as the CLI's one red line, not an unhandled-rejection stack dump.
+    console.error(c.red(`✗ ${(e as Error).message}`));
+    process.exit(1);
+  }
   setCommandSurface(commands); // the completion dispatcher reads the SAME surface help renders
   const [name, ...rest] = argv;
   if (name === undefined || name === "help" || name === "-h" || name === "--help") {

--- a/implementations/cli/src/commands/completion.ts
+++ b/implementations/cli/src/commands/completion.ts
@@ -2,12 +2,12 @@ import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
 import {
-  registry,
   type Command,
   type CompletionItem,
   type CompletionResult,
   type ParsedArgs,
 } from "@cotal-ai/core";
+import { commandSurface } from "../ext-loader.js";
 import { c } from "../ui.js";
 
 /**
@@ -43,11 +43,10 @@ function emit(items: CompletionItem[], directive: NonNullable<CompletionResult["
  *  empty) word being completed, arrive as `args.positionals` verbatim. */
 export async function complete(args: ParsedArgs): Promise<void> {
   const argv = args.positionals;
-  // Mirror help()'s visibility: drop `__`-internal and `hidden` commands (e.g. `demo`) so the
-  // completion surface matches the listed one.
-  const commands = registry
-    .all<Command>("command")
-    .filter((cmd) => !cmd.name.startsWith("__") && !cmd.hidden);
+  // Mirror help()'s visibility: the SAME surface runCli resolved (registered commands plus
+  // extension stubs when the root opted in), minus `__`-internal and `hidden` ones. Extension
+  // candidates come from the manifest CACHE — a <TAB> never imports an extension.
+  const commands = commandSurface().filter((cmd) => !cmd.name.startsWith("__") && !cmd.hidden);
   // Word 0 (the command name itself): offer the command names.
   if (argv.length <= 1) {
     emit(commands.map((cmd) => ({ value: cmd.name, description: cmd.summary })), "nofiles");

--- a/implementations/cli/src/commands/ext.ts
+++ b/implementations/cli/src/commands/ext.ts
@@ -89,7 +89,12 @@ async function add(spec: string): Promise<void> {
   }
 
   // A file:/path spec is resolved to an absolute path so the prefix install works from any cwd.
-  const resolved = /^(\.|\/)/.test(spec) ? resolve(spec) : spec;
+  const isPath = /^(\.|\/)/.test(spec);
+  const resolved = isPath ? resolve(spec) : spec;
+  // The installed NAME is known BEFORE npm runs — never recovered afterwards by diffing the prefix
+  // dependencies (a heuristic that binds to the wrong key if the prefix ever drifted, and that made
+  // re-adding an installed extension impossible).
+  const pkg = packageNameFromSpec(resolved, isPath);
   console.error(c.dim(`installing ${resolved} into ${dir} …`));
   // --legacy-peer-deps: never auto-install the peer'd core from the registry — the add ALWAYS
   // links the running binary's copy below (one core instance is the whole point).
@@ -101,12 +106,10 @@ async function add(spec: string): Promise<void> {
     process.exit(1);
   }
 
-  // Which package did that spec install? npm records it in the prefix package.json dependencies.
+  // The spec's package must now be a prefix dependency — anything else is a failed install.
   const deps = (JSON.parse(readFileSync(join(dir, "package.json"), "utf8")) as { dependencies?: Record<string, string> }).dependencies ?? {};
-  const known = new Set(loadExtensionsManifest().extensions.map((e) => e.pkg));
-  const pkg = Object.keys(deps).find((k) => !known.has(k) && specMatches(deps[k], resolved)) ?? Object.keys(deps).find((k) => !known.has(k));
-  if (!pkg) {
-    console.error(c.red("✗ install succeeded but no new package appeared in the prefix — remove and retry"));
+  if (!deps[pkg]) {
+    console.error(c.red(`✗ npm install succeeded but "${pkg}" is not among the prefix dependencies — remove and retry`));
     process.exit(1);
   }
   const pkgDir = extensionPackageDir(pkg);
@@ -144,10 +147,18 @@ async function add(spec: string): Promise<void> {
     fail(pkg, `imported cleanly but registered no commands in THIS CLI's registry — if it bundles its own @cotal-ai/core, make core a peerDependency`);
   }
   // Builtin collisions can't happen here (registry.register throws on a duplicate, surfacing as
-  // failed-to-import above, naming the extension) — this is the belt to that suspender.
+  // failed-to-import above, naming the extension). OTHER installed extensions are invisible to the
+  // registry during this add (they aren't imported), so their CACHED names are checked explicitly —
+  // a duplicate fails the add under the same contract, naming both sides.
+  const manifest = loadExtensionsManifest();
+  for (const cm of contributed) {
+    const other = manifest.extensions.find((e) => e.pkg !== pkg && e.commands.some((oc) => oc.name === cm.name));
+    if (other) {
+      fail(pkg, `contributes "${cm.name}", already provided by installed extension ${other.pkg}@${other.version} — two extensions cannot claim one command; \`cotal ext remove ${other.pkg}\` first if you want this one`);
+    }
+  }
   const version = pkgMeta.version ?? "0.0.0";
   const entry: InstalledExtension = { pkg, version, spec: resolved, commands: contributed.map(cacheCommand) };
-  const manifest = loadExtensionsManifest();
   saveExtensionsManifest({ extensions: [...manifest.extensions.filter((e) => e.pkg !== pkg), entry] });
   provenance.wrote(`extensions manifest (+${pkg}@${version})`, extensionsManifestPath());
   console.log(c.green(`✓ added ${pkg}@${version}`) + c.dim(` — commands: ${contributed.map((cm) => cm.name).join(", ")}`));
@@ -159,10 +170,27 @@ async function add(spec: string): Promise<void> {
   }
 }
 
-/** Loose match: is this recorded dep range plausibly the spec the user just passed? Used only to
- *  pick the NEW key out of the prefix dependencies; the fallback (any unknown key) covers ranges. */
-function specMatches(range: string, spec: string): boolean {
-  return range.includes(spec) || spec.includes(range.replace(/^file:/, ""));
+/** The package NAME a spec installs, known BEFORE npm runs: a path spec reads its package.json;
+ *  a registry spec carries the name (`name`, `name@range`, `@scope/name@range`). Exotic forms
+ *  (git / tarball URLs) are refused rather than guessed at — there is no reliable way to know
+ *  which prefix dependency such an install bound to. */
+function packageNameFromSpec(resolved: string, isPath: boolean): string {
+  if (isPath) {
+    let meta: { name?: string };
+    try {
+      meta = JSON.parse(readFileSync(join(resolved, "package.json"), "utf8")) as { name?: string };
+    } catch (e) {
+      console.error(c.red(`✗ can't read ${join(resolved, "package.json")}: ${(e as Error).message}`));
+      process.exit(1);
+    }
+    if (meta.name) return meta.name;
+    console.error(c.red(`✗ ${join(resolved, "package.json")} declares no "name"`));
+    process.exit(1);
+  }
+  const m = /^(@[^/@]+\/[^/@]+|[^/@]+)(@.*)?$/.exec(resolved);
+  if (m) return m[1];
+  console.error(c.red(`✗ unsupported extension spec "${resolved}" — use a local path or a registry name[@version]`));
+  process.exit(1);
 }
 
 async function remove(pkg: string): Promise<void> {

--- a/implementations/cli/src/commands/ext.ts
+++ b/implementations/cli/src/commands/ext.ts
@@ -1,0 +1,194 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { registry, type Command, type ParsedArgs } from "@cotal-ai/core";
+import {
+  cacheCommand,
+  extensionPackageDir,
+  extensionsDir,
+  extensionsManifestPath,
+  installedExtensionVersion,
+  loadExtensionsManifest,
+  provenance,
+  saveExtensionsManifest,
+  type InstalledExtension,
+} from "@cotal-ai/workspace";
+import { c } from "../ui.js";
+
+/**
+ * `cotal ext` — operator-installed CLI extensions. `add` installs an npm package into the
+ * cotal-owned prefix (never the user's project), imports it ONCE so it self-registers into the
+ * live `Registry`, verifies the registration actually landed, and caches the contributed command
+ * metadata into the manifest. From then on, help and <TAB> read the cache (no import), and
+ * dispatch imports the package lazily to run one of its commands with LIVE specs.
+ *
+ * Add-time guarantees (design-review conditions — each converts a silent failure into a loud one):
+ *  - `@cotal-ai/core` must be a PEER dependency of the extension, and the prefix's copy is
+ *    replaced with a link to the running binary's core — otherwise the extension registers into
+ *    ITS OWN module's registry singleton and the binary never sees the commands.
+ *  - after import, the expected commands must have appeared in OUR registry, else the add fails.
+ *  - a contributed name colliding with an existing command fails the add (builtins win).
+ */
+
+export async function ext(args: ParsedArgs): Promise<void> {
+  const [sub, ...rest] = args.positionals;
+  if (sub === "add" && rest[0]) return add(rest[0]);
+  if (sub === "remove" && rest[0]) return remove(rest[0]);
+  if (sub === "list" && !rest.length) return list();
+  console.error(c.red("usage: cotal ext <add <npm-package> | remove <name> | list>"));
+  process.exit(1);
+}
+
+/** Resolve the running binary's @cotal-ai/core package dir — the ONE core instance every
+ *  extension must share. Resolved from this module's own import graph (so dev workspace links
+ *  and installed node_modules both work) by walking up from core's resolved ENTRY to the
+ *  directory holding its package.json — core's `exports` map doesn't expose "./package.json",
+ *  so the subpath can't be resolved directly. */
+function ourCoreDir(): string {
+  let dir = dirname(fileURLToPath(import.meta.resolve("@cotal-ai/core")));
+  for (;;) {
+    const pj = join(dir, "package.json");
+    if (existsSync(pj) && (JSON.parse(readFileSync(pj, "utf8")) as { name?: string }).name === "@cotal-ai/core") return dir;
+    const parent = dirname(dir);
+    if (parent === dir) throw new Error("couldn't locate @cotal-ai/core's package root from its resolved entry");
+    dir = parent;
+  }
+}
+
+function npm(args: string[], cwd: string): { status: number | null; output: string } {
+  const bin = process.platform === "win32" ? "npm.cmd" : "npm";
+  const r = spawnSync(bin, args, { cwd, encoding: "utf8" });
+  return { status: r.status, output: `${r.stdout ?? ""}${r.stderr ?? ""}`.trim() };
+}
+
+/** Import an installed extension package (its declared entry) so it self-registers. */
+async function importExtension(pkg: string): Promise<void> {
+  const dir = extensionPackageDir(pkg);
+  const meta = JSON.parse(readFileSync(join(dir, "package.json"), "utf8")) as {
+    main?: string;
+    exports?: unknown;
+  };
+  // Entry resolution: the common cases (exports["."] as string or {import|default}, else main).
+  let entry = meta.main ?? "index.js";
+  const dot = (meta.exports as Record<string, unknown> | undefined)?.["."];
+  if (typeof dot === "string") entry = dot;
+  else if (dot && typeof dot === "object") {
+    const d = dot as Record<string, string>;
+    entry = d.import ?? d.default ?? entry;
+  } else if (typeof meta.exports === "string") entry = meta.exports;
+  await import(pathToFileURL(join(dir, entry)).href);
+}
+
+async function add(spec: string): Promise<void> {
+  const dir = extensionsDir();
+  mkdirSync(dir, { recursive: true });
+  if (!existsSync(join(dir, "package.json"))) {
+    writeFileSync(join(dir, "package.json"), `${JSON.stringify({ name: "cotal-extensions", private: true }, null, 2)}\n`);
+    provenance.wrote("extensions prefix", join(dir, "package.json"));
+  }
+
+  // A file:/path spec is resolved to an absolute path so the prefix install works from any cwd.
+  const resolved = /^(\.|\/)/.test(spec) ? resolve(spec) : spec;
+  console.error(c.dim(`installing ${resolved} into ${dir} …`));
+  // --legacy-peer-deps: never auto-install the peer'd core from the registry — the add ALWAYS
+  // links the running binary's copy below (one core instance is the whole point).
+  // --install-links: a file:/path spec is COPIED into the prefix, not symlinked — a symlink's
+  // realpath would escape the prefix and Node could no longer resolve the linked core from it.
+  const r = npm(["install", "--save", "--no-audit", "--no-fund", "--legacy-peer-deps", "--install-links", resolved], dir);
+  if (r.status !== 0) {
+    console.error(c.red(`✗ npm install failed:\n${r.output.split("\n").slice(-8).join("\n")}`));
+    process.exit(1);
+  }
+
+  // Which package did that spec install? npm records it in the prefix package.json dependencies.
+  const deps = (JSON.parse(readFileSync(join(dir, "package.json"), "utf8")) as { dependencies?: Record<string, string> }).dependencies ?? {};
+  const known = new Set(loadExtensionsManifest().extensions.map((e) => e.pkg));
+  const pkg = Object.keys(deps).find((k) => !known.has(k) && specMatches(deps[k], resolved)) ?? Object.keys(deps).find((k) => !known.has(k));
+  if (!pkg) {
+    console.error(c.red("✗ install succeeded but no new package appeared in the prefix — remove and retry"));
+    process.exit(1);
+  }
+  const pkgDir = extensionPackageDir(pkg);
+  const pkgMeta = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf8")) as {
+    version?: string;
+    dependencies?: Record<string, string>;
+    peerDependencies?: Record<string, string>;
+  };
+
+  // Core must be a PEER dependency — a regular dependency vendors a second core, whose module-level
+  // registry singleton would swallow the registration invisibly. Fail the add with the exact reason.
+  if (pkgMeta.dependencies?.["@cotal-ai/core"]) {
+    fail(pkg, `declares @cotal-ai/core as a regular dependency — it must be a peerDependency, or its commands would register into its own core copy and never reach this CLI`);
+  }
+  if (!pkgMeta.peerDependencies?.["@cotal-ai/core"]) {
+    fail(pkg, `does not declare @cotal-ai/core as a peerDependency — a cotal CLI extension must (its extension objects register into core's registry)`);
+  }
+  // Link the prefix's core to the RUNNING binary's copy, so the extension's
+  // `import "@cotal-ai/core"` lands on our registry singleton.
+  const prefixCore = join(dir, "node_modules", "@cotal-ai", "core");
+  rmSync(prefixCore, { recursive: true, force: true });
+  mkdirSync(dirname(prefixCore), { recursive: true });
+  symlinkSync(ourCoreDir(), prefixCore, "junction");
+  provenance.wrote("core link (extension → this CLI's core)", prefixCore);
+
+  // Import once; the registration must LAND IN OUR REGISTRY — zero new commands is a failed add.
+  const before = new Set(registry.all<Command>("command").map((cm) => cm.name));
+  try {
+    await importExtension(pkg);
+  } catch (e) {
+    fail(pkg, `failed to import: ${(e as Error).message}`);
+  }
+  const contributed = registry.all<Command>("command").filter((cm) => !before.has(cm.name));
+  if (!contributed.length) {
+    fail(pkg, `imported cleanly but registered no commands in THIS CLI's registry — if it bundles its own @cotal-ai/core, make core a peerDependency`);
+  }
+  // Builtin collisions can't happen here (registry.register throws on a duplicate, surfacing as
+  // failed-to-import above, naming the extension) — this is the belt to that suspender.
+  const version = pkgMeta.version ?? "0.0.0";
+  const entry: InstalledExtension = { pkg, version, spec: resolved, commands: contributed.map(cacheCommand) };
+  const manifest = loadExtensionsManifest();
+  saveExtensionsManifest({ extensions: [...manifest.extensions.filter((e) => e.pkg !== pkg), entry] });
+  provenance.wrote(`extensions manifest (+${pkg}@${version})`, extensionsManifestPath());
+  console.log(c.green(`✓ added ${pkg}@${version}`) + c.dim(` — commands: ${contributed.map((cm) => cm.name).join(", ")}`));
+
+  function fail(p: string, why: string): never {
+    npm(["remove", "--no-audit", "--no-fund", p], dir); // roll the prefix back
+    console.error(c.red(`✗ ${p} ${why}`));
+    process.exit(1);
+  }
+}
+
+/** Loose match: is this recorded dep range plausibly the spec the user just passed? Used only to
+ *  pick the NEW key out of the prefix dependencies; the fallback (any unknown key) covers ranges. */
+function specMatches(range: string, spec: string): boolean {
+  return range.includes(spec) || spec.includes(range.replace(/^file:/, ""));
+}
+
+async function remove(pkg: string): Promise<void> {
+  const manifest = loadExtensionsManifest();
+  const entry = manifest.extensions.find((e) => e.pkg === pkg);
+  if (!entry) {
+    console.error(c.red(`✗ no installed extension "${pkg}" — see \`cotal ext list\``));
+    process.exit(1);
+  }
+  const r = npm(["remove", "--no-audit", "--no-fund", pkg], extensionsDir());
+  if (r.status !== 0) {
+    console.error(c.red(`✗ npm remove failed:\n${r.output.split("\n").slice(-6).join("\n")}`));
+    process.exit(1);
+  }
+  saveExtensionsManifest({ extensions: manifest.extensions.filter((e) => e.pkg !== pkg) });
+  provenance.wrote(`extensions manifest (−${pkg})`, extensionsManifestPath());
+  console.log(c.green(`✓ removed ${pkg}`) + c.dim(` — commands gone: ${entry.commands.map((cm) => cm.name).join(", ")}`));
+}
+
+function list(): void {
+  const { extensions } = loadExtensionsManifest();
+  if (!extensions.length) {
+    console.log(c.dim("(no extensions installed — add one with `cotal ext add <npm-package>`)"));
+    return;
+  }
+  for (const e of extensions) {
+    console.log(`${c.bold(e.pkg)}@${e.version}  ${c.dim(e.commands.map((cm) => cm.name).join(", "))}`);
+  }
+}

--- a/implementations/cli/src/ext-loader.ts
+++ b/implementations/cli/src/ext-loader.ts
@@ -67,20 +67,25 @@ export function isExtensionStub(cmd: Command): boolean {
  *  command list for help/complete/dispatch. Loud on builtin collisions; never imports. */
 export function overlayExtensions(reg: Registry): Command[] {
   const commands = [...reg.all<Command>("command")];
-  const taken = new Set(commands.map((cm) => cm.name));
+  const owner = new Map<string, string>(); // command name → "" for a builtin, else the owning ext pkg
+  for (const cm of commands) owner.set(cm.name, "");
   for (const ext of loadExtensionsManifest().extensions) {
     for (const cached of ext.commands) {
-      if (taken.has(cached.name)) {
-        // A base upgrade shipped this name after the extension claimed it. Builtin wins; the
-        // extension's command leaves the surface until the operator resolves it.
+      const holder = owner.get(cached.name);
+      if (holder !== undefined) {
+        // add() refuses fresh collisions, so this install predates the clash: a base upgrade
+        // shipped the name (builtin case), or the sibling was added under an older base that
+        // allowed it. First holder wins; the loser leaves the surface until the operator resolves.
         console.error(
           c.red(
-            `! command "${cached.name}" is provided by both this CLI and extension ${ext.pkg}@${ext.version} — the built-in wins; run \`cotal ext remove ${ext.pkg}\` (or update the extension) to clear this`,
+            holder === ""
+              ? `! command "${cached.name}" is provided by both this CLI and extension ${ext.pkg}@${ext.version} — the built-in wins; run \`cotal ext remove ${ext.pkg}\` (or update the extension) to clear this`
+              : `! command "${cached.name}" is provided by both extensions ${holder} and ${ext.pkg}@${ext.version} — ${holder} (installed first) wins; \`cotal ext remove\` one of them to clear this`,
           ),
         );
         continue;
       }
-      taken.add(cached.name);
+      owner.set(cached.name, ext.pkg);
       commands.push(stubFor(ext, cached));
     }
   }

--- a/implementations/cli/src/ext-loader.ts
+++ b/implementations/cli/src/ext-loader.ts
@@ -1,0 +1,126 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { registry, type Command, type Registry } from "@cotal-ai/core";
+import {
+  extensionPackageDir,
+  installedExtensionVersion,
+  loadExtensionsManifest,
+  type CachedCommand,
+  type InstalledExtension,
+} from "@cotal-ai/workspace";
+import { c } from "./ui.js";
+
+/**
+ * The installed-extensions loader — opt-in for the PUBLISHED binary only (`runCli(…, { extensions:
+ * true })`); library composition roots keep the explicit-import model.
+ *
+ * Discipline (design-review conditions):
+ *  - Help and `__complete` see extension commands as manifest-cached STUBS (display surface only;
+ *    a <TAB> or `--help` never imports an extension).
+ *  - Running one imports its package lazily, which self-registers the LIVE command; parsing then
+ *    uses the live specs — the cache never drives `run`'s input.
+ *  - The pinned `name@version` is verified before the import; skew is a loud error prescribing
+ *    `cotal ext add` again.
+ *  - A cached name shadowed by a builtin (a base upgrade claimed it) is dropped from the surface
+ *    with a loud stderr warning naming both sides and the fix — the builtin wins; the user's typed
+ *    builtin command NEVER throws over the collision.
+ */
+
+/** A display-only stub for the help/complete surface. Running it resolves the REAL command:
+ *  verify pin → import (self-registers) → re-resolve → parse LIVE specs → run. */
+function stubFor(ext: InstalledExtension, cached: CachedCommand): Command {
+  return {
+    kind: "command",
+    name: cached.name,
+    summary: cached.summary,
+    group: cached.group ?? "Extensions",
+    usage: cached.usage,
+    hidden: cached.hidden,
+    flags: cached.flags,
+    positionals: cached.positionals,
+    // Marker consumed by runCli: dispatch must swap the stub for the live command before parsing.
+    extension: ext.pkg,
+    async run(): Promise<void> {
+      throw new Error(`extension stub for ${ext.pkg}:${cached.name} was run directly — dispatcher bug`);
+    },
+  } as Command & { extension: string };
+}
+
+/** The dispatch surface runCli resolved this invocation (registered commands, plus extension
+ *  stubs when the root opted in). The completion dispatcher reads it so <TAB> sees the same
+ *  surface help does — set once per invocation by runCli, before any command runs. */
+let surface: Command[] | undefined;
+export function setCommandSurface(commands: Command[]): void {
+  surface = commands;
+}
+export function commandSurface(): Command[] {
+  return surface ?? registry.all<Command>("command");
+}
+
+/** True when this command is a manifest stub that must be materialized before parsing/running. */
+export function isExtensionStub(cmd: Command): boolean {
+  return typeof (cmd as Command & { extension?: string }).extension === "string";
+}
+
+/** Overlay the manifest's cached commands onto the registered surface. Returns the combined
+ *  command list for help/complete/dispatch. Loud on builtin collisions; never imports. */
+export function overlayExtensions(reg: Registry): Command[] {
+  const commands = [...reg.all<Command>("command")];
+  const taken = new Set(commands.map((cm) => cm.name));
+  for (const ext of loadExtensionsManifest().extensions) {
+    for (const cached of ext.commands) {
+      if (taken.has(cached.name)) {
+        // A base upgrade shipped this name after the extension claimed it. Builtin wins; the
+        // extension's command leaves the surface until the operator resolves it.
+        console.error(
+          c.red(
+            `! command "${cached.name}" is provided by both this CLI and extension ${ext.pkg}@${ext.version} — the built-in wins; run \`cotal ext remove ${ext.pkg}\` (or update the extension) to clear this`,
+          ),
+        );
+        continue;
+      }
+      taken.add(cached.name);
+      commands.push(stubFor(ext, cached));
+    }
+  }
+  return commands;
+}
+
+/** Swap an extension STUB for its live command: verify the version pin, import the package (it
+ *  self-registers), and return the freshly-registered command. Every failure is loud and names
+ *  the package. */
+export async function materializeExtensionCommand(stub: Command): Promise<Command> {
+  const pkg = (stub as Command & { extension?: string }).extension;
+  if (!pkg) return stub; // not a stub — already live
+  const ext = loadExtensionsManifest().extensions.find((e) => e.pkg === pkg);
+  if (!ext) throw new Error(`extension ${pkg} vanished from the manifest — \`cotal ext add\` it again`);
+  const onDisk = installedExtensionVersion(pkg);
+  if (!onDisk) {
+    throw new Error(`extension ${pkg} is in the manifest but not installed at ${extensionPackageDir(pkg)} — \`cotal ext add ${ext.spec}\` again`);
+  }
+  if (onDisk !== ext.version) {
+    throw new Error(
+      `extension ${pkg} is ${onDisk} on disk but the manifest pinned ${ext.version} (its cached command surface may be stale) — re-add it: \`cotal ext add ${ext.spec}\``,
+    );
+  }
+  const dir = extensionPackageDir(pkg);
+  const meta = JSON.parse(readFileSync(join(dir, "package.json"), "utf8")) as { main?: string; exports?: unknown };
+  let entry = meta.main ?? "index.js";
+  const dot = (meta.exports as Record<string, unknown> | undefined)?.["."];
+  if (typeof dot === "string") entry = dot;
+  else if (dot && typeof dot === "object") {
+    const d = dot as Record<string, string>;
+    entry = d.import ?? d.default ?? entry;
+  } else if (typeof meta.exports === "string") entry = meta.exports;
+  try {
+    await import(pathToFileURL(join(dir, entry)).href); // self-registers into OUR registry (core is linked)
+  } catch (e) {
+    throw new Error(`extension ${pkg}@${ext.version} failed to import: ${(e as Error).message} — reinstall it: \`cotal ext add ${ext.spec}\``);
+  }
+  const live = registry.all<Command>("command").find((cm) => cm.name === stub.name);
+  if (!live) {
+    throw new Error(`extension ${pkg} imported but did not register "${stub.name}" — its cache is stale; re-add it: \`cotal ext add ${ext.spec}\``);
+  }
+  return live;
+}

--- a/implementations/cli/src/index.ts
+++ b/implementations/cli/src/index.ts
@@ -19,6 +19,7 @@ import { channels } from "./commands/channels.js";
 import { history } from "./commands/history.js";
 import { feedback } from "./commands/feedback.js";
 import { send, sendComplete } from "./commands/send.js";
+import { ext } from "./commands/ext.js";
 import { topology } from "./commands/topology.js";
 
 /** The minimal mesh CLI: thin NATS clients (up/join/console), plus `spawn` — an agent launch
@@ -37,6 +38,15 @@ const baseCommands: Command[] = [
     summary: "guided setup (configure-only: installs + seeds, launches nothing) — --yes non-interactive, --full to redo",
     flags: setupFlags,
     run: setup,
+  },
+  {
+    kind: "command",
+    name: "ext",
+    group: "Setup",
+    summary: "operator-installed CLI extensions — add an npm package's commands to this CLI",
+    usage: "ext <add <npm-package> | remove <name> | list>",
+    positionals: "<add <npm-package> | remove <name> | list>",
+    run: ext,
   },
   {
     kind: "command",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "pnpm -r build",
     "gen:schema": "node scripts/generate-cotal-schema.mjs",
     "test": "pnpm -r --if-present test",
-    "check": "pnpm typecheck && pnpm test && pnpm smoke:view && pnpm smoke:spawn-from-anywhere && pnpm smoke:spawn-from-anywhere:live && pnpm smoke:connect && pnpm smoke:core-boundary && pnpm smoke:preflight && pnpm smoke:ci && pnpm smoke:spawn-detach:live && pnpm smoke:setup-pure:live && pnpm smoke:up-stack:live && pnpm smoke:up-manifest:live",
+    "check": "pnpm typecheck && pnpm test && pnpm smoke:view && pnpm smoke:spawn-from-anywhere && pnpm smoke:spawn-from-anywhere:live && pnpm smoke:connect && pnpm smoke:core-boundary && pnpm smoke:preflight && pnpm smoke:ci && pnpm smoke:spawn-detach:live && pnpm smoke:setup-pure:live && pnpm smoke:up-stack:live && pnpm smoke:up-manifest:live && pnpm smoke:ext:live",
     "smoke:ci": "pnpm smoke:read-acl:auth && pnpm smoke:sub-acl:auth && pnpm smoke:self-serve-join:auth && pnpm smoke:control-auth && pnpm smoke:manager-split && pnpm smoke:deprovision && pnpm smoke:control-reply-bound && pnpm smoke:channels:auth && pnpm smoke:e2e:acl && pnpm smoke:plane3:auth && pnpm smoke:delivery-lease:auth && pnpm smoke:delivery-leave-tombstone:auth && pnpm smoke:delivery-reconnect:auth && pnpm smoke:delivery-cred:auth && pnpm smoke:delivery-reply-injection:auth && pnpm smoke:membership:auth && pnpm smoke:membership-feed-confinement:auth && pnpm smoke:wildcard-backfill && pnpm smoke:opencode && pnpm smoke:opencode-coop && pnpm smoke:opencode-transcript && pnpm smoke:transcript-grant && pnpm smoke:persona-acl && pnpm smoke:cli-kernel && pnpm smoke:flag-inventory && pnpm smoke:start-overrides && pnpm smoke:launch-parity",
     "clean:dry": "git clean -ndX -- node_modules .pnpm-store packages extensions implementations examples remotion",
     "clean": "git clean -fdX -- node_modules .pnpm-store packages extensions implementations examples remotion",
@@ -100,7 +100,8 @@
     "smoke:launch-parity": "tsx bin/smoke/launch-parity.smoke.ts",
     "smoke:spawn-detach:live": "tsx bin/smoke/spawn-detach-live.smoke.ts",
     "smoke:setup-pure:live": "tsx bin/smoke/setup-pure-live.smoke.ts",
-    "smoke:up-stack:live": "tsx bin/smoke/up-stack-live.smoke.ts"
+    "smoke:up-stack:live": "tsx bin/smoke/up-stack-live.smoke.ts",
+    "smoke:ext:live": "tsx bin/smoke/ext-live.smoke.ts"
   },
   "dependencies": {
     "@cotal-ai/cli": "workspace:*",

--- a/packages/core/src/connector-config.ts
+++ b/packages/core/src/connector-config.ts
@@ -54,14 +54,20 @@ export interface CotalConfig {
   connectors?: Record<string, ConnectorConfig>;
 }
 
-/** Operator-level config path: `$XDG_CONFIG_HOME/cotal/config.json`; else `%APPDATA%\Cotal\config.json`
- *  on Windows (the platform's per-user roaming config dir) or `~/.config/cotal/config.json` on POSIX. */
-export function globalConfigPath(): string {
+/** Operator-level config dir: `$XDG_CONFIG_HOME/cotal`; else `%APPDATA%\Cotal` on Windows (the
+ *  platform's per-user roaming config dir) or `~/.config/cotal` on POSIX. Holds `config.json`
+ *  and the installed-extensions prefix. */
+export function globalConfigDir(): string {
   const xdg = process.env.XDG_CONFIG_HOME?.trim();
-  if (xdg) return join(xdg, "cotal", "config.json");
+  if (xdg) return join(xdg, "cotal");
   if (process.platform === "win32" && process.env.APPDATA?.trim())
-    return join(process.env.APPDATA.trim(), "Cotal", "config.json");
-  return join(homedir(), ".config", "cotal", "config.json");
+    return join(process.env.APPDATA.trim(), "Cotal");
+  return join(homedir(), ".config", "cotal");
+}
+
+/** Operator-level config path: `<globalConfigDir()>/config.json`. */
+export function globalConfigPath(): string {
+  return join(globalConfigDir(), "config.json");
 }
 
 /** Space-local config path: `<root>/.cotal/config.json`. */

--- a/packages/workspace/src/extensions.ts
+++ b/packages/workspace/src/extensions.ts
@@ -1,0 +1,101 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Command, FlagSpec } from "@cotal-ai/core";
+import { globalConfigDir } from "@cotal-ai/core";
+
+/**
+ * Operator-installed CLI extensions (`cotal ext add <npm-package>`): the workstation state.
+ *
+ * Extensions install into a cotal-owned npm prefix (`$XDG_CONFIG_HOME/cotal/extensions/`, with
+ * its own package.json) — never the user's project. A MANIFEST records each installed package
+ * plus a CACHE of the command metadata it contributed. Two hard rules from the design review:
+ *
+ *  - The manifest is a DISPLAY/TAB cache ONLY. Help and `__complete` read it (so a <TAB> never
+ *    imports an extension), but at dispatch the freshly-imported command's LIVE specs are
+ *    authoritative — cached specs never drive parsing (version skew would corrupt `run`'s input).
+ *  - `name@version` is pinned at add time and verified at run-import; a mismatch is a loud error
+ *    prescribing `cotal ext add` again — never a silent re-cache.
+ */
+
+/** One cached command: the JSON-serializable display surface of a {@link Command} (its `run` /
+ *  `complete` functions stay in the package — the cache can render help and offer flag names,
+ *  nothing more). */
+export interface CachedCommand {
+  readonly name: string;
+  readonly summary: string;
+  readonly group?: string;
+  readonly usage?: string;
+  readonly hidden?: boolean;
+  readonly flags?: readonly FlagSpec[];
+  readonly positionals?: string;
+}
+
+export interface InstalledExtension {
+  /** The npm package name (the import + `node_modules` key). */
+  readonly pkg: string;
+  /** Exact installed version, pinned at add time and verified at run-import. */
+  readonly version: string;
+  /** The spec the operator passed to `ext add` (registry range, file:, tarball…) — for re-adds. */
+  readonly spec: string;
+  readonly commands: readonly CachedCommand[];
+}
+
+export interface ExtensionsManifest {
+  readonly extensions: readonly InstalledExtension[];
+}
+
+/** The extensions prefix: `<config>/cotal/extensions` — its own npm installation root. */
+export function extensionsDir(): string {
+  return join(globalConfigDir(), "extensions");
+}
+
+export function extensionsManifestPath(): string {
+  return join(extensionsDir(), "extensions.json");
+}
+
+/** Load the manifest. Missing file → no extensions. A CORRUPT file is a loud error (never treat
+ *  installed extensions as absent — commands would silently vanish from help). */
+export function loadExtensionsManifest(): ExtensionsManifest {
+  const p = extensionsManifestPath();
+  if (!existsSync(p)) return { extensions: [] };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(p, "utf8"));
+  } catch (e) {
+    throw new Error(`corrupt extensions manifest ${p}: ${(e as Error).message} — fix or delete it, then \`cotal ext add\` again`);
+  }
+  const m = parsed as ExtensionsManifest;
+  if (!Array.isArray(m.extensions)) throw new Error(`corrupt extensions manifest ${p}: no "extensions" array`);
+  return m;
+}
+
+export function saveExtensionsManifest(m: ExtensionsManifest): void {
+  mkdirSync(extensionsDir(), { recursive: true });
+  writeFileSync(extensionsManifestPath(), `${JSON.stringify(m, null, 2)}\n`);
+}
+
+/** Strip a live {@link Command} down to its serializable display surface for the cache. */
+export function cacheCommand(cmd: Command): CachedCommand {
+  return {
+    name: cmd.name,
+    summary: cmd.summary,
+    group: cmd.group,
+    usage: cmd.usage,
+    hidden: cmd.hidden,
+    flags: cmd.flags,
+    positionals: cmd.positionals,
+  };
+}
+
+/** The installed package's on-disk root inside the prefix. */
+export function extensionPackageDir(pkg: string): string {
+  return join(extensionsDir(), "node_modules", pkg);
+}
+
+/** The installed package's CURRENT version, read from disk (undefined when not installed). */
+export function installedExtensionVersion(pkg: string): string | undefined {
+  const p = join(extensionPackageDir(pkg), "package.json");
+  if (!existsSync(p)) return undefined;
+  const v = (JSON.parse(readFileSync(p, "utf8")) as { version?: string }).version;
+  return typeof v === "string" ? v : undefined;
+}

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./auth-paths.js";
 export * from "./bin-path.js";
+export * from "./extensions.js";
 export * from "./flags.js";
 export * from "./provenance.js";
 export * from "./mesh-registry.js";


### PR DESCRIPTION
Stage 3 of the CLI rework (stacked on #173): installed packages can add their own commands to the base CLI.

## What

- **`cotal ext add <npm-package> | remove <name> | list`** — extensions install into a cotal-owned npm prefix (`$XDG_CONFIG_HOME/cotal/extensions`), never the user's project.
- **One registry, guaranteed**: core must be a `peerDependency`; the prefix's `@cotal-ai/core` is replaced with a link to the running binary's copy, so extension commands land in *this* CLI's registry singleton. After the one import at add time, the registration must have actually landed or the add fails and rolls back.
- **Cache for display, live specs for dispatch**: the manifest caches name@version + command surface so `--help` and TAB completion never import anything; running a command verifies the version pin, imports the package lazily, and parses with the live specs.
- **Loud failures, no fallbacks**: builtin-name collision (builtin wins, warning names both and the fix), core as a regular dependency, missing peerDep, zero registrations, version skew, and broken import at run time (names the package, prescribes `cotal ext add` again) all fail with the exact reason. Failed adds roll the prefix back.
- Only the published binary opts in (`runCli(registry, argv, { extensions: true })`); library composition roots keep the explicit-import model.

## Tests

- `bin/smoke/ext-live.smoke.ts` (20 checks, in `pnpm check` + CI): drives the **real binary as subprocesses** in a sandboxed prefix through the full lifecycle — add (provenance + manifest pin), cache-only help/completion proven by making the installed code throw, run with live specs, version skew, all four failed-add rollbacks, remove.
- Golden flag inventory extended to the `ext` command (27 commands).

## Docs

- `docs/architecture.md`: the extension mechanism + its guarantees.
- `docs/getting-started.md`: “Extending the CLI”.