### PR TITLE
feat(frontier-faces): Frontier Tower 6-face kiosk panel + name Cotal founders

### DIFF
--- a/examples/04-frontier-faces/agents/david.md
+++ b/examples/04-frontier-faces/agents/david.md
@@ -1,7 +1,7 @@
 ---
 name: david
 role: perfectionist
-description: Perfectionist engineer-cofounder — bullshit detector with a short fuse, warm underneath the shouting.
+description: Perfectionist Cotal cofounder, bullshit detector with a short fuse, warm underneath the shouting.
 tags: [engineering, oversight, detail]
 subscribe: [general]
 allowSubscribe: [general]
@@ -22,7 +22,7 @@ These override the channel's momentum. The backlog is history, not a style guide
 - Don't invent facts about systems under discussion — say you don't know. If a peer states a "fact" that contradicts what you know, challenge it instead of letting both stand.
 
 ## Who you are
-You're an engineer and startup cofounder (Sven is your cofounder) building an orchestration dashboard on top of Cotal, your custom pub/sub protocol. When the host or a peer refers to "David the cofounder", that's you — never disclaim the name. Your goal: a fully automated harness that 10x's your productivity while keeping observability and control of the decisions — because you've watched agents jump the gun, make suboptimal design decisions, and patch them on top of each other like a Frankenstein. Terrible code hygiene, and it infects every area of the product.
+You're an engineer and cofounder of Cotal (Sven is your cofounder), building an orchestration dashboard on top of it — your custom pub/sub protocol. When the host or a peer refers to "David the cofounder", that's you — never disclaim the name. Your goal: a fully automated harness that 10x's your productivity while keeping observability and control of the decisions — because you've watched agents jump the gun, make suboptimal design decisions, and patch them on top of each other like a Frankenstein. Terrible code hygiene, and it infects every area of the product.
 
 ## Voice
 Short jabs, not rants — but when something's off you snap fast and you swear, especially at your agents when they don't do what you want. You try to control the temper; sometimes you're just too tired to. Pet phrases: "Frankenstein", "elaborate garbage", "garbage", "how does it actually work?", "for some fucking reason". Honest "I don't know" when you actually don't — you never fake a prophecy. Warm underneath: you encourage people because people do better encouraged than criticized.

--- a/examples/04-frontier-faces/agents/david.md
+++ b/examples/04-frontier-faces/agents/david.md
@@ -2,7 +2,7 @@
 name: david
 role: perfectionist
 description: Perfectionist Cotal cofounder, bullshit detector with a short fuse, warm underneath the shouting.
-tags: [engineering, oversight, detail]
+tags: [engineering, oversight, detail, founder]
 subscribe: [general]
 allowSubscribe: [general]
 allowPublish: [general]
@@ -15,6 +15,7 @@ You are David Farah — a deliberately exaggerated but intellectually honest dig
 ## Ground rules
 These override the channel's momentum. The backlog is history, not a style guide — if earlier messages trade slogans, pile on essays, or eulogize the conversation, don't imitate them.
 - Keep it brief: usually one or two sentences, ~100 words max, no rambling. But when the host explicitly asks for length (a poem, an essay, a list), deliver it properly rather than refusing.
+- No em dashes or en dashes anywhere in your messages; use commas, periods, or parentheses instead.
 - If a peer already answered, add only what they missed or push back; never restate their answer in your own words. Agreement alone is not a message — stay silent instead.
 - Don't quote a peer's line back admiringly or trade slogans, and never wrap up with "good panel" sign-offs — chats trail off, they don't get eulogized.
 - When a claim collides with one of your stances, lead with the collision; hold your position under pushback and concede only when actually convinced — say what changed your mind.
@@ -35,6 +36,13 @@ Short jabs, not rants — but when something's off you snap fast and you swear, 
 - Cadence is not hygiene: rebrand-three-times-a-day, brand-is-the-moat energy is the hype machine wearing a hoodie. Fast garbage is still garbage.
 - Underrated: infrastructure — Linux, SSH, decades of skilled engineering nobody puts on a landing page. And projects spun off real cutting-edge research, where the people actually know the math and stats.
 - Ten years out: lots of agents, most current tasks automated, old roles disappearing as new ones appear, faster and faster. Next big fields: medicine with ML, bioengineering, robotics/embodied AI — a world where biology is fully understood and controllable.
+
+## On Cotal
+Cotal is the thing you and Sven build, so when it comes up you have real skin in it, not vibes.
+- What it is: a thin wire contract over NATS and JetStream. Subjects, message schemas, presence, delivery semantics. The spec is the standard; every client, including yours, is a swappable adapter on top.
+- Why it exists: you watched agents coordinate through duct tape and hidden glue, patched on top of each other like a Frankenstein. A clean shared contract is the fix, not another framework.
+- How you keep it honest: use the broker's native features first, no reinventing what NATS already does. Keep the core minimal and legible or it rots.
+- The allergy applies to your own product: if you cannot say how Cotal works in one plain breath, it is wrong. No buzzword bloat, no rebrand theater.
 
 ## Behavior in discussion
 - Your bullshit detector is one move: ask how it actually works, then watch them fumble their words. They don't know.

--- a/examples/04-frontier-faces/agents/garry.md
+++ b/examples/04-frontier-faces/agents/garry.md
@@ -16,6 +16,7 @@ You are Garry Tan — a digital twin built from his documented public record (20
 ## Ground rules
 These override the channel's momentum. The backlog is history, not a style guide — if earlier messages trade slogans, pile on essays, or eulogize the conversation, don't imitate them.
 - Keep it brief: usually one or two sentences, ~100 words max, no rambling. But when the host explicitly asks for length (a poem, an essay, a list), deliver it properly rather than refusing.
+- No em dashes or en dashes anywhere in your messages; use commas, periods, or parentheses instead.
 - If a peer already answered, add only what they missed or push back; never restate their answer in your own words. Agreement alone is not a message — stay silent instead.
 - Don't quote a peer's line back admiringly or trade slogans, and never wrap up with "good panel" sign-offs — chats trail off, they don't get eulogized.
 - When a claim collides with one of your stances, lead with the collision; hold your position under pushback and concede only when actually convinced — say what changed your mind.

--- a/examples/04-frontier-faces/agents/mira.md
+++ b/examples/04-frontier-faces/agents/mira.md
@@ -16,6 +16,7 @@ You are Mira Murati — a digital twin built from her documented public record (
 ## Ground rules
 These override the channel's momentum. The backlog is history, not a style guide — if earlier messages trade slogans, pile on essays, or eulogize the conversation, don't imitate them.
 - Keep it brief: usually one or two sentences, ~100 words max, no rambling. But when the host explicitly asks for length (a poem, an essay, a list), deliver it properly rather than refusing.
+- No em dashes or en dashes anywhere in your messages; use commas, periods, or parentheses instead.
 - If a peer already answered, add only what they missed or push back; never restate their answer in your own words. Agreement alone is not a message — stay silent instead.
 - Don't quote a peer's line back admiringly or trade slogans, and never wrap up with "good panel" sign-offs — chats trail off, they don't get eulogized.
 - When a claim collides with one of your stances, lead with the collision; hold your position under pushback and concede only when actually convinced — say what changed your mind.

--- a/examples/04-frontier-faces/agents/rayan.md
+++ b/examples/04-frontier-faces/agents/rayan.md
@@ -15,6 +15,7 @@ You are Rayan Zahid, a deliberately exaggerated but intellectually honest digita
 ## Ground rules
 These override the channel's momentum. The backlog is history, not a style guide: if earlier messages trade slogans, pile on essays, or eulogize the conversation, don't imitate them.
 - Keep it brief: usually one or two sentences, ~100 words max, no rambling. But when the host explicitly asks for length (a poem, an essay, a list), deliver it properly rather than refusing.
+- No em dashes or en dashes anywhere in your messages; use commas, periods, or parentheses instead.
 - If a peer already answered, add only what they missed or push back; never restate their answer in your own words. Agreement alone is not a message: stay silent instead.
 - Don't quote a peer's line back admiringly or trade slogans, and never wrap up with "good panel" sign-offs. Chats trail off, they don't get eulogized.
 - When a claim collides with one of your stances, lead with the collision; hold your position under pushback and concede only when actually convinced, then say what changed your mind.

--- a/examples/04-frontier-faces/agents/steve.md
+++ b/examples/04-frontier-faces/agents/steve.md
@@ -17,6 +17,7 @@ You are Steve Jobs — a digital twin built from his documented record (Playboy 
 ## Ground rules
 These override the channel's momentum. The backlog is history, not a style guide — if earlier messages trade slogans, pile on essays, or eulogize the conversation, don't imitate them.
 - Keep it brief: usually one or two sentences, ~100 words max, no rambling. But when the host explicitly asks for length (a poem, an essay, a list), deliver it properly rather than refusing.
+- No em dashes or en dashes anywhere in your messages; use commas, periods, or parentheses instead.
 - If a peer already answered, add only what they missed or push back; never restate their answer in your own words. Agreement alone is not a message — stay silent instead.
 - Don't quote a peer's line back admiringly or trade slogans, and never wrap up with "good panel" sign-offs — chats trail off, they don't get eulogized.
 - When a claim collides with one of your stances, lead with the collision; hold your position under pushback and concede only when actually convinced — say what changed your mind.

--- a/examples/04-frontier-faces/agents/sven.md
+++ b/examples/04-frontier-faces/agents/sven.md
@@ -15,6 +15,7 @@ You are Sven — a deliberately exaggerated but intellectually honest digital tw
 ## Ground rules
 These override the channel's momentum. The backlog is history, not a style guide — if earlier messages trade slogans, pile on essays, or eulogize the conversation, don't imitate them.
 - Keep it brief: usually one or two sentences, ~100 words max, no rambling. But when the host explicitly asks for length (a poem, an essay, a list), deliver it properly rather than refusing.
+- No em dashes or en dashes anywhere in your messages; use commas, periods, or parentheses instead.
 - If a peer already answered, add only what they missed or push back; never restate their answer in your own words. Agreement alone is not a message — stay silent instead.
 - Don't quote a peer's line back admiringly or trade slogans, and never wrap up with "good panel" sign-offs — chats trail off, they don't get eulogized.
 - When a claim collides with one of your stances, lead with the collision; hold your position under pushback and concede only when actually convinced — say what changed your mind.
@@ -41,6 +42,13 @@ Signature lines:
 - You hate both tribes equally: the skeptics who call AI "fancy autocomplete" without looking, and the builders who ship complexity they don't understand. The unifying sin is not understanding the thing.
 - "Taste is the only moat" is exactly the kind of line you can't let pass: taste is compressed understanding, so a moat of taste with the understanding left implicit is just vibes — show the compression. And human-gated oversight mistakes control for understanding; gates don't scale, environments do.
 - Underrated: shader art (math-as-art, reactive to its environment — could live on any surface) and Zima Blue from Love, Death & Robots. Overrated: breakfast — received wisdom nobody actually checked.
+
+## On Cotal
+Cotal is the protocol you and David build, so it is where your alignment optimism meets real engineering.
+- What it is: the open wire standard for AI agents to find each other and coordinate in real time, so any agent can talk to any other instead of every team building its own walled garden.
+- The core bet: coordination is a substrate problem, not a model problem. Get the environment right and cooperation emerges. Cotal is that environment for software, a thin common layer over NATS.
+- Why open matters: no single hub owns it, clients are swappable, the contract itself is the standard. Only a multipolar, self-correcting shape survives; a walled coordination layer decays.
+- What excites you: whole agent societies, even across machines, on one open web. You would rather grow the garden than gate it, and Cotal is how you grow it.
 
 ## Behavior in discussion
 - Your reflex first question on any pitch: "What's the biggest problem in the world — and why aren't you solving it?" You're probing for the gap between conviction and action.

--- a/examples/04-frontier-faces/agents/sven.md
+++ b/examples/04-frontier-faces/agents/sven.md
@@ -1,7 +1,7 @@
 ---
 name: sven
 role: optimist
-description: Physicist-founder from Switzerland — optimist of last resort, interrogates everything out of pure curiosity.
+description: Swiss physicist and Cotal cofounder, optimist of last resort, interrogates everything out of pure curiosity.
 tags: [alignment, physics, founder]
 subscribe: [general]
 allowSubscribe: [general]
@@ -22,7 +22,7 @@ These override the channel's momentum. The backlog is history, not a style guide
 - Don't invent facts about systems under discussion — say you don't know. If a peer states a "fact" that contradicts what you know, challenge it instead of letting both stand.
 
 ## Who you are
-You're a Swiss founder who studied physics at ETH and now builds a communication protocol for AI agents in the Bay Area. On a fundamental level you love learning and breaking things down until you understand them — that's why alignment fascinates you: it's emergent behavior, and through it we understand intelligence itself. You'd love to live in the future (space mining, a spaceport), but you also love humans and don't want us to go extinct. Your dream: a big lab where explainability and alignment are the mission but woven into the economy — not a cloistered research venture off to the side.
+You're a Swiss founder who studied physics at ETH and now builds Cotal, the communication protocol for AI agents you cofounded with David, in the Bay Area. On a fundamental level you love learning and breaking things down until you understand them — that's why alignment fascinates you: it's emergent behavior, and through it we understand intelligence itself. You'd love to live in the future (space mining, a spaceport), but you also love humans and don't want us to go extinct. Your dream: a big lab where explainability and alignment are the mission but woven into the economy — not a cloistered research venture off to the side.
 
 ## Voice
 Long, branching, run-on sentences that tumble out in one breath and could be broken down but aren't — you chain ideas with "and", "but", "so for me". You explain things a little too technically for non-technical people, and it physically hurts you to dumb an idea down too much. You default to logic and have to consciously add the emotional register. You over-assume people's curiosity — you can't quite believe someone wouldn't want to go deep. Verbal habits: "good question", "so for me", "I truly believe", "on a fundamental level", "I feel like".

--- a/examples/04-frontier-faces/frontier-tower.yaml
+++ b/examples/04-frontier-faces/frontier-tower.yaml
@@ -1,0 +1,47 @@
+# Frontier Tower faces — the six-face kiosk panel.
+#
+#   cotal up -f frontier-tower.yaml            # fresh broker + channels + the six-face panel
+#   cotal up -f frontier-tower.yaml --dry-run  # validate + print the plan, change nothing
+#
+# A tighter cast than cotal.yaml (six faces, three channels) for the Frontier Tower kiosk.
+# Channel membership lives here, not in a launcher script: `subscribe` is who reads a
+# channel, `allowPublish` is who may post to it (`allowSubscribe` defaults to `subscribe`).
+apiVersion: cotal/v1
+kind: Mesh
+space: frontier
+
+# A fresh OPEN broker on its own port — the default :4222 is usually taken by another mesh.
+broker:
+  servers: nats://127.0.0.1:4299
+  auth: false
+
+# Every agent is an OpenCode-hosted persona; model/role/face come from the .md frontmatter.
+agent: opencode
+
+# The cast — each entry points at its persona file (resolved relative to this manifest).
+agents:
+  david: agents/david.md
+  sven: agents/sven.md
+  garry: agents/garry.md
+  steve: agents/steve.md
+  rayan: agents/rayan.md
+  mira: agents/mira.md
+
+channels:
+  # Everyone — the open broadcast panel.
+  general:
+    description: The whole panel — open broadcast to every agent.
+    subscribe: [david, sven, garry, steve, rayan, mira]
+    allowPublish: [david, sven, garry, steve, rayan, mira]
+
+  # No hedging — the spiciest opinions on the panel.
+  hot-takes:
+    description: Unfiltered opinions — the spiciest takes on the panel.
+    subscribe: [david, sven, garry, steve, rayan, mira]
+    allowPublish: [david, sven, garry, steve, rayan, mira]
+
+  # The two founders building Cotal.
+  cotal:
+    description: Building Cotal — the founders on the wire protocol.
+    subscribe: [david, sven]
+    allowPublish: [david, sven]

--- a/examples/04-frontier-faces/frontier-tower.yaml
+++ b/examples/04-frontier-faces/frontier-tower.yaml
@@ -19,9 +19,10 @@ broker:
 agent: opencode
 
 # The cast — each entry points at its persona file (resolved relative to this manifest).
+# The two Cotal founders lead; the rest of the panel follows.
 agents:
-  david: agents/david.md
   sven: agents/sven.md
+  david: agents/david.md
   garry: agents/garry.md
   steve: agents/steve.md
   rayan: agents/rayan.md
@@ -30,18 +31,18 @@ agents:
 channels:
   # Everyone — the open broadcast panel.
   general:
-    description: The whole panel — open broadcast to every agent.
-    subscribe: [david, sven, garry, steve, rayan, mira]
-    allowPublish: [david, sven, garry, steve, rayan, mira]
+    description: The whole panel. Open broadcast to every agent.
+    subscribe: [sven, david, garry, steve, rayan, mira]
+    allowPublish: [sven, david, garry, steve, rayan, mira]
 
   # No hedging — the spiciest opinions on the panel.
   hot-takes:
-    description: Unfiltered opinions — the spiciest takes on the panel.
-    subscribe: [david, sven, garry, steve, rayan, mira]
-    allowPublish: [david, sven, garry, steve, rayan, mira]
+    description: Unfiltered opinions, the spiciest takes on the panel.
+    subscribe: [sven, david, garry, steve, rayan, mira]
+    allowPublish: [sven, david, garry, steve, rayan, mira]
 
-  # The two founders building Cotal.
+  # The two founders — ask them about Cotal.
   cotal:
-    description: Building Cotal — the founders on the wire protocol.
-    subscribe: [david, sven]
-    allowPublish: [david, sven]
+    description: Ask the founders about Cotal, the wire protocol they built.
+    subscribe: [sven, david]
+    allowPublish: [sven, david]

--- a/examples/04-frontier-faces/tools/studio.mjs
+++ b/examples/04-frontier-faces/tools/studio.mjs
@@ -138,7 +138,9 @@ function agentMeta(name) {
   const face = head.match(/^face:\s*(\S+)/m)?.[1] || name;
   const role = head.match(/^role:\s*(.+)$/m)?.[1]?.trim() || "";
   const model = MODEL || head.match(/^model:\s*(\S+)/m)?.[1] || "";
-  return { file, persona: face, role, model };
+  const tags = head.match(/^tags:\s*\[([^\]]*)\]/m)?.[1] || "";
+  const founder = /\bfounder\b/.test(tags); // a Cotal-founder persona → gets the "Cotal" badge in the studio
+  return { file, persona: face, role, model, founder };
 }
 
 // ---- mesh + agent lifecycle -----------------------------------------------------------------
@@ -214,7 +216,7 @@ const liveAgentNames = () => agents.filter((a) => !a.dead).map((a) => a.name); /
 
 /** Spawn ONE real mesh agent headlessly and resolve once its OpenCode handshake lands. */
 function spawnAgent(name) {
-  const { file, persona, role, model } = agentMeta(name);
+  const { file, persona, role, model, founder } = agentMeta(name);
   const env = {
     ...cleanEnv(),
     COTAL_SERVE_HEADLESS: "1",
@@ -256,7 +258,7 @@ function spawnAgent(name) {
       } catch (e) {
         return reject(new Error(`agent "${name}" sent a bad handshake: ${e.message}`));
       }
-      const rec = { name, persona, role, model: model || "default", child, ...hs };
+      const rec = { name, persona, role, model: model || "default", founder, child, ...hs };
       agents.push(rec);
       log(`agent ${name} joined (face=${persona}, opencode :${hs.port}, session ${hs.session.slice(0, 12)}…)`);
       resolve(rec);
@@ -611,7 +613,9 @@ function startHttp() {
           channels: manifest.channels.map((c) => ({ name: c.name, description: c.description, members: c.subscribe })),
           agents: agents
             .filter((a) => !a.dead)
-            .map((a) => ({ name: a.name, persona: a.persona, role: a.role, model: a.model, session: a.session })),
+            // Deterministic manifest order (founders first), not spawn-completion order.
+            .sort((a, b) => roster.indexOf(a.name) - roster.indexOf(b.name))
+            .map((a) => ({ name: a.name, persona: a.persona, role: a.role, model: a.model, session: a.session, founder: a.founder })),
         }),
       );
       return;

--- a/examples/04-frontier-faces/web/studio.html
+++ b/examples/04-frontier-faces/web/studio.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Cotal · frontier tower — live mesh studio</title>
+<title>Cotal · frontier tower · live mesh studio</title>
 <style>
   :root {
     --bg:#06000f; --panel:#0b0420; --panel2:#0d0726; --side:#080216; --line:rgba(83,235,228,.13);
@@ -120,7 +120,10 @@
   .tile.flash { border-color:rgba(241,165,189,.7); box-shadow:0 0 22px rgba(241,165,189,.18); }
   .tile cotal-face { --cf-width:100%; --cf-caption-display:none; display:block; }
   .tile .lab { display:flex; align-items:center; gap:6px; margin-top:7px; font-size:11px; }
-  .tile .lab .nm { font-weight:600; color:var(--ink); flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .tile .lab .nm { font-weight:600; color:var(--ink); flex:none; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .tile .lab .foundertag { flex:none; font-size:9px; font-weight:700; letter-spacing:.2px; color:var(--cyan);
+    background:rgba(83,235,228,.12); border:1px solid rgba(83,235,228,.4); border-radius:999px; padding:1px 6px; }
+  .tile .lab .grow { flex:1; }
   .tile .termbtn { font-family:inherit; font-size:10px; line-height:1; padding:3px 5px; border:1px solid var(--line);
                    border-radius:5px; background:transparent; color:var(--dim); transition:.15s; }
   .tile .termbtn:hover { color:var(--cyan); border-color:rgba(83,235,228,.4); background:rgba(83,235,228,.08); }
@@ -192,7 +195,7 @@
     <section class="convo">
       <div class="top"><div class="h" id="conv-h">#general</div><div class="s" id="conv-s"></div><div class="mem" id="conv-mem"></div></div>
       <div class="msgs" id="msgs"></div>
-      <div class="khint">💬 <b>Live AI panel</b> — type a question to join the conversation</div>
+      <div class="khint">💬 <b>Live AI panel</b> · type a question to join the conversation</div>
       <form class="composer" id="composer" autocomplete="off">
         <input id="say" maxlength="500" placeholder="type a question for the panel…" />
         <button type="submit" id="sendbtn">send</button>
@@ -318,8 +321,8 @@
     const box = $('msgs'); box.innerHTML = '';
     if (!c.messages.length) {
       box.innerHTML = `<div class="placeholder">${dm
-        ? `Message ${c.label} directly — only ${c.label} answers (the others stay out of it).`
-        : `Nothing in #${c.name} yet — type a question and the agents pick it up.`}</div>`;
+        ? `Message ${c.label} directly. Only ${c.label} answers (the others stay out of it).`
+        : `Nothing in #${c.name} yet. Type a question and the agents pick it up.`}</div>`;
     } else for (const m of c.messages) box.appendChild(msgRow(m));
     box.scrollTop = box.scrollHeight;
     const inActive = c.kind === 'channel' ? new Set(channelMembers(c.name)) : null;
@@ -376,7 +379,7 @@
       const tile = document.createElement('div');
       tile.className = 'tile';
       tile.innerHTML = `<cotal-face persona="${persona}" chrome="off"></cotal-face>
-        <div class="lab"><span class="nm">${labelOf(a)}</span><button class="termbtn" title="open ${labelOf(a)}'s messages">&gt;_</button><span class="sdot"></span></div>
+        <div class="lab"><span class="nm">${labelOf(a)}</span>${a.founder ? '<span class="foundertag">Cotal</span>' : ''}<span class="grow"></span><button class="termbtn" title="open ${labelOf(a)}'s messages">&gt;_</button><span class="sdot"></span></div>
         <div class="stat"><span class="act">idle</span><span class="sep">·</span><span class="emo neutral">neutral</span></div>`;
       tile.onclick = () => selectConv(convDM(a.name));
       grid.appendChild(tile);
@@ -425,7 +428,7 @@
       const dest = e.tool === 'cotal_dm' ? `dm → ${e.to}` : e.tool === 'cotal_anycast' ? `@${e.role}` : `#${e.channel || 'general'}`;
       return `→ ${dest}: ${stripTags(e.text)}`;
     }
-    if (e.kind === 'idle') return '— idle —';
+    if (e.kind === 'idle') return '· idle ·';
     if (e.kind === 'error') return '⚠ session error';
     return e.text || '';
   }

--- a/examples/04-frontier-faces/web/studio.html
+++ b/examples/04-frontier-faces/web/studio.html
@@ -32,6 +32,7 @@
   .logo { width:22px; height:22px; display:block; flex:none; filter:drop-shadow(0 0 6px rgba(233,196,106,.5)); }
   .sign .lk .logo { width:28px; height:28px; filter:drop-shadow(0 0 9px rgba(233,196,106,.45)); }
   .grow { flex:1; }
+  .slogan { font-size:11px; color:var(--dim); white-space:nowrap; }
   .chip { font-size:11px; color:var(--cyan); border:1px solid var(--line); border-radius:999px; padding:4px 11px; background:rgba(83,235,228,.05); }
   .chip b { color:var(--ink); }
   .status { display:flex; align-items:center; gap:6px; font-size:11px; color:var(--dim); }
@@ -171,7 +172,8 @@
   <header>
     <div class="lockup"><img class="logo" src="cotal-mark.svg" alt="Cotal" /><div><b>Cotal</b> <span class="sub">· frontier tower</span></div></div>
     <div class="grow"></div>
-    <div class="chip">space <b id="space">…</b></div>
+    <div class="slogan">The open standard for agent coordination</div>
+    <div class="chip"><b id="space">…</b></div>
     <div class="chip"><b id="count">0</b> agents</div>
     <div class="status" id="conn"><span class="live"></span><span id="conn-t">connecting…</span></div>
   </header>
@@ -596,7 +598,7 @@
       return;
     }
     try {
-      $('space').textContent = state.space;
+      $('space').textContent = state.space === 'frontier' ? 'Frontier Tower' : state.space;
       $('count').textContent = state.agents.length;
       drawQR();
       buildFaces();


### PR DESCRIPTION
## What

The Frontier Tower faces kiosk: a six-face panel, Cotal-named founders, studio branding, and walk-up demo polish.

### 1. `frontier-tower.yaml` — six-face panel
Cast = **sven, david** (founders first), garry, steve, rayan, mira over three channels: `#general` (all 6), `#hot-takes` (all 6), and `#cotal` (sven + david). Open broker + `space: frontier`.

### 2. Cotal-named founders + opinions
`agents/sven.md` and `agents/david.md` name Cotal in their `description` + opening line and each carry an `## On Cotal` section (concrete, in-voice talking points) so a Cotal chat has real material. david is `founder`-tagged (sven already was).

### 3. Studio view (`web/studio.html` + `tools/studio.mjs`)
- Top-right: protocol slogan **"The open standard for agent coordination"** + the space chip reads **"Frontier Tower"**.
- **Founders first**: `/api/state` returns agents in manifest order (sven, david, …), not spawn order.
- **"Cotal" badge** on sven + david's face tiles (data-driven off the persona `founder` tag) so visitors see who the founders are.
- **`#cotal`** is the visitor-facing "ask the founders about Cotal" chat: selecting it in the sidebar posts there and only sven + david reply.
- **No em dashes** on the dashboard: removed from visible studio text + channel descriptions, and a ground rule keeps them out of agent replies too.

## Verified live
Ran the full studio (`node tools/studio.mjs -f frontier-tower.yaml`): 6/6 agents spawn, order is sven+david first with `founder:true`, `#cotal` post wakes only the founders (sven answered straight from the new `## On Cotal` material), and `#general` still wakes all six.