### PR TITLE
feat(frontier-faces): ray to 3rd slot + slogan on the header left

### DIFF
--- a/examples/04-frontier-faces/frontier-tower.yaml
+++ b/examples/04-frontier-faces/frontier-tower.yaml
@@ -23,23 +23,23 @@ agent: opencode
 agents:
   sven: agents/sven.md
   david: agents/david.md
+  rayan: agents/rayan.md
   garry: agents/garry.md
   steve: agents/steve.md
-  rayan: agents/rayan.md
   mira: agents/mira.md
 
 channels:
   # Everyone — the open broadcast panel.
   general:
     description: The whole panel. Open broadcast to every agent.
-    subscribe: [sven, david, garry, steve, rayan, mira]
-    allowPublish: [sven, david, garry, steve, rayan, mira]
+    subscribe: [sven, david, rayan, garry, steve, mira]
+    allowPublish: [sven, david, rayan, garry, steve, mira]
 
   # No hedging — the spiciest opinions on the panel.
   hot-takes:
     description: Unfiltered opinions, the spiciest takes on the panel.
-    subscribe: [sven, david, garry, steve, rayan, mira]
-    allowPublish: [sven, david, garry, steve, rayan, mira]
+    subscribe: [sven, david, rayan, garry, steve, mira]
+    allowPublish: [sven, david, rayan, garry, steve, mira]
 
   # The two founders — ask them about Cotal.
   cotal:

--- a/examples/04-frontier-faces/web/studio.html
+++ b/examples/04-frontier-faces/web/studio.html
@@ -27,7 +27,6 @@
            background:linear-gradient(180deg, rgba(13,7,38,.7), transparent); flex:none; }
   .lockup { display:flex; align-items:center; gap:10px; }
   .lockup b { font-size:16px; font-weight:700; letter-spacing:.3px; }
-  .lockup .sub { font-size:11px; color:var(--dim); }
   /* the Cotal brand mark (gold interlocking rings) */
   .logo { width:22px; height:22px; display:block; flex:none; filter:drop-shadow(0 0 6px rgba(233,196,106,.5)); }
   .sign .lk .logo { width:28px; height:28px; filter:drop-shadow(0 0 9px rgba(233,196,106,.45)); }
@@ -173,9 +172,8 @@
 </head>
 <body>
   <header>
-    <div class="lockup"><img class="logo" src="cotal-mark.svg" alt="Cotal" /><div><b>Cotal</b></div></div>
+    <div class="lockup"><img class="logo" src="cotal-mark.svg" alt="Cotal" /><div><b>Cotal</b><div class="slogan">The open standard for agent coordination</div></div></div>
     <div class="grow"></div>
-    <div class="slogan">The open standard for agent coordination</div>
     <div class="chip"><b id="space">…</b></div>
     <div class="chip"><b id="count">0</b> agents</div>
     <div class="status" id="conn"><span class="live"></span><span id="conn-t">connecting…</span></div>

--- a/examples/04-frontier-faces/web/studio.html
+++ b/examples/04-frontier-faces/web/studio.html
@@ -173,7 +173,7 @@
 </head>
 <body>
   <header>
-    <div class="lockup"><img class="logo" src="cotal-mark.svg" alt="Cotal" /><div><b>Cotal</b> <span class="sub">· frontier tower</span></div></div>
+    <div class="lockup"><img class="logo" src="cotal-mark.svg" alt="Cotal" /><div><b>Cotal</b></div></div>
     <div class="grow"></div>
     <div class="slogan">The open standard for agent coordination</div>
     <div class="chip"><b id="space">…</b></div>


### PR DESCRIPTION
Follow-up to #178 (already merged) — three tweaks that landed on the branch after that merge:

- **Roster order**: move **ray** to the 3rd slot (sven, david, rayan, garry, steve, mira), in the agent list and the channel member arrays.
- **Header de-dupe**: remove the duplicated "frontier tower" text from the top-left lockup (it already shows as the "Frontier Tower" chip on the right).
- **Slogan on the left**: move the protocol tagline "The open standard for agent coordination" into the left brand lockup under "Cotal"; the right keeps the chips. Dropped the now-unused `.sub` CSS.

Diff is just `frontier-tower.yaml` + `web/studio.html`.