### PR TITLE
fix(opencode): consume cancelled peer deliveries

### DIFF
--- a/extensions/connector-opencode/smoke/turn-wedge.smoke.ts
+++ b/extensions/connector-opencode/smoke/turn-wedge.smoke.ts
@@ -12,7 +12,8 @@
  *   4. if that native turn errors, the injected batch is NOT acked and can be injected again;
  *   5. a directed DM that auto-drives and errors is retried after a bounded delay;
  *   6. a HUMAN turn still clears busy, then a second normal channel message MUST drive a turn
- *      (prompt_async #2) — the original wedge fix still holds.
+ *      (prompt_async #2) — the original wedge fix still holds;
+ *   7. a user interrupt consumes the surfaced peer batch instead of redriving it.
  * Run: pnpm smoke:opencode
  */
 import { strict as assert } from "node:assert";
@@ -181,6 +182,26 @@ try {
   await pub.multicast("still there?", { channel: "team" });
   await waitForPrompts(4);
   check("a channel message STILL drives after a human turn (no busy wedge)", prompts.length === 4, prompts);
+
+  // (7) Explicit user Stop/Cancel is not a model/provider failure. The surfaced Cotal batch is already
+  //     in the agent window, so cancelling it should dismiss/ack it and must NOT keep replaying it.
+  await fire(hooks, { type: "tui.command.execute", properties: { command: "session.interrupt", sessionID: SID } });
+  await fire(hooks, {
+    type: "session.error",
+    properties: {
+      sessionID: SID,
+      error: { name: "MessageAbortedError", data: { message: "The operation was aborted" } },
+    },
+  });
+  await sleep(1_200);
+  check("explicit user interrupt does not retry-drive cancelled peer traffic", prompts.length === 4, prompts);
+  await pub.multicast("after cancel", { channel: "team" });
+  await waitForPrompts(5);
+  check(
+    "new peer traffic still drives after interrupt without replaying the cancelled batch",
+    prompts.length === 5 && promptText(prompts[4]).includes("after cancel") && !promptText(prompts[4]).includes("still there?"),
+    prompts,
+  );
 
   console.log(`\nOPENCODE TURN-WEDGE TEST PASSED ✅  (${pass} checks)`);
 } finally {

--- a/extensions/connector-opencode/src/plugin.ts
+++ b/extensions/connector-opencode/src/plugin.ts
@@ -44,6 +44,7 @@ function log(msg: string): void {
 const guard = globalThis as { __cotalOpencodeHooks?: Hooks };
 const ERROR_RETRY_INITIAL_MS = 1_000;
 const ERROR_RETRY_MAX_MS = 30_000;
+const INTERRUPT_INTENT_TTL_MS = 30_000;
 
 export const cotal: Plugin = async () => {
   // No identity → a plain `opencode`, not a launcher-spawned agent. Stay inert.
@@ -95,6 +96,7 @@ export const cotal: Plugin = async () => {
   let awaitingTurnEnd = false; // a turn is in flight → ignore a duplicate idle that isn't its end
   let errorRetryTimer: ReturnType<typeof setTimeout> | undefined;
   let errorRetryMs = ERROR_RETRY_INITIAL_MS;
+  let interruptIntent: { sessionID?: string; expires: number } | undefined;
   // Transcript mirror → `tr-<name>`: opt-in via COTAL_TRANSCRIPT (the connector's buildLaunch / the
   // manager set it for managed sessions; a personal opencode never mirrors). EVENT-DRIVEN — fed from
   // the OpenCode event hook below (message.updated → assistant roles, message.part.updated → parts)
@@ -158,6 +160,22 @@ export const cotal: Plugin = async () => {
     if (resetDelay) errorRetryMs = ERROR_RETRY_INITIAL_MS;
   }
 
+  function markInterruptIntent(sessionID?: string): void {
+    if (!busy && !awaitingTurnEnd) return;
+    interruptIntent = { sessionID, expires: Date.now() + INTERRUPT_INTENT_TTL_MS };
+  }
+
+  function clearInterruptIntent(): void {
+    interruptIntent = undefined;
+  }
+
+  function consumeInterruptIntent(sessionID?: string): boolean {
+    const intent = interruptIntent;
+    interruptIntent = undefined;
+    if (!intent || Date.now() > intent.expires) return false;
+    return !intent.sessionID || !sessionID || intent.sessionID === sessionID;
+  }
+
   function scheduleErrorRetry(): void {
     if (errorRetryTimer || pendingForWake() === 0) return;
     const delay = errorRetryMs;
@@ -180,6 +198,7 @@ export const cotal: Plugin = async () => {
     briefed = false;
     surfaced = [];
     awaitingTurnEnd = false;
+    clearInterruptIntent();
     clearErrorRetry(true);
     transcript?.reset(); // hard session boundary: drop any buffered parts so `/new` never mirrors them
     if (previous) {
@@ -318,6 +337,7 @@ export const cotal: Plugin = async () => {
       awaitingTurnEnd = false;
       ackSurfaced(); // our driven turn: ack the surfaced batch (the sole ack site)
     }
+    clearInterruptIntent();
     clearErrorRetry(true);
     if (pendingForWake() > 0) void drive();
   }
@@ -412,14 +432,22 @@ export const cotal: Plugin = async () => {
           // `busy` stays stuck and every later push is buffered behind a turn that already failed.
           if (event.properties.sessionID && !ours(event.properties.sessionID)) return;
           if (!busy && !awaitingTurnEnd) return; // no turn to fail — stray error
+          const interrupted = consumeInterruptIntent(event.properties.sessionID);
           busy = false;
           if (awaitingTurnEnd) {
             awaitingTurnEnd = false;
-            abandonSurfaced(); // failed turn: leave inbox unacked so the batch can retry on a later safe turn
+            if (interrupted) ackSurfaced(); // explicit user Stop/Cancel: treat the surfaced batch as dismissed, not failed
+            else abandonSurfaced(); // failed turn: leave inbox unacked so the batch can retry on a later safe turn
           }
           await safeStatus("idle");
-          scheduleErrorRetry();
+          if (!interrupted) scheduleErrorRetry();
+          else clearErrorRetry(true);
           break;
+        case "tui.command.execute": {
+          const p = event.properties as { command?: string; sessionID?: string };
+          if (p.command === "session.interrupt") markInterruptIntent(p.sessionID);
+          break;
+        }
         case "session.deleted":
           if (!ours(event.properties.info.id)) return;
           await safeStatus("offline");


### PR DESCRIPTION
What:\n- Treat an explicit OpenCode session interrupt as a consumed surfaced Cotal batch.\n- Keep ordinary session errors retryable.\n- Add OpenCode smoke coverage that cancelled peer traffic is not redriven and later peer traffic still wakes normally.\n\nTests:\n- pnpm smoke:opencode\n- pnpm --filter @cotal-ai/connector-opencode typecheck