### PR TITLE
fix(opencode): consume abort errors as cancelled deliveries

### DIFF
--- a/extensions/connector-opencode/smoke/turn-wedge.smoke.ts
+++ b/extensions/connector-opencode/smoke/turn-wedge.smoke.ts
@@ -183,9 +183,9 @@ try {
   await waitForPrompts(4);
   check("a channel message STILL drives after a human turn (no busy wedge)", prompts.length === 4, prompts);
 
-  // (7) Explicit user Stop/Cancel is not a model/provider failure. The surfaced Cotal batch is already
-  //     in the agent window, so cancelling it should dismiss/ack it and must NOT keep replaying it.
-  await fire(hooks, { type: "tui.command.execute", properties: { command: "session.interrupt", sessionID: SID } });
+  // (7) Explicit user Stop/Cancel is not a model/provider failure. Real OpenCode aborts can arrive as
+  //     MessageAbortedError without a preceding TUI command event, so that error itself must dismiss/ack
+  //     the surfaced Cotal batch instead of replaying it.
   await fire(hooks, {
     type: "session.error",
     properties: {

--- a/extensions/connector-opencode/src/plugin.ts
+++ b/extensions/connector-opencode/src/plugin.ts
@@ -176,6 +176,10 @@ export const cotal: Plugin = async () => {
     return !intent.sessionID || !sessionID || intent.sessionID === sessionID;
   }
 
+  function isMessageAbortedError(error: unknown): boolean {
+    return typeof error === "object" && error !== null && (error as { name?: unknown }).name === "MessageAbortedError";
+  }
+
   function scheduleErrorRetry(): void {
     if (errorRetryTimer || pendingForWake() === 0) return;
     const delay = errorRetryMs;
@@ -432,7 +436,7 @@ export const cotal: Plugin = async () => {
           // `busy` stays stuck and every later push is buffered behind a turn that already failed.
           if (event.properties.sessionID && !ours(event.properties.sessionID)) return;
           if (!busy && !awaitingTurnEnd) return; // no turn to fail — stray error
-          const interrupted = consumeInterruptIntent(event.properties.sessionID);
+          const interrupted = consumeInterruptIntent(event.properties.sessionID) || isMessageAbortedError(event.properties.error);
           busy = false;
           if (awaitingTurnEnd) {
             awaitingTurnEnd = false;


### PR DESCRIPTION
What:\n- Treat OpenCode MessageAbortedError as an explicit cancellation for surfaced Cotal batches.\n- Cover real session aborts that do not emit a TUI command event.\n- Update the OpenCode turn smoke to model the abort-error path.\n\nTests:\n- pnpm smoke:opencode\n- pnpm --filter @cotal-ai/connector-opencode typecheck\n- pnpm --filter @cotal-ai/connector-opencode build\n- real opencode serve + POST /session/{id}/abort E2E harness\n- pnpm build