### PR TITLE
feat(cli): allow env default agent harness

### DIFF
--- a/bin/cotal.ts
+++ b/bin/cotal.ts
@@ -29,10 +29,10 @@ process.stdout.on("error", (e: NodeJS.ErrnoException) => {
   throw e;
 });
 
-// The manager's default agent type is "cotal" (StartAgentOpts.agent ?? "cotal"); make it a real
-// Claude coder so a bare cotal_spawn / `cotal spawn --detach <persona>` (no --agent) brings up a
-// Claude Code session. Revisited at the start→spawn merge (stage 2a): still needed — the default
-// rides the MANAGER side of the control plane, not the removed CLI verb.
+// The manager's built-in default agent type is "cotal" (when COTAL_DEFAULT_AGENT is unset); make it
+// a real Claude coder so a bare cotal_spawn / `cotal spawn --detach <persona>` (no --agent) brings
+// up a Claude Code session. Revisited at the start→spawn merge (stage 2a): still needed — the
+// default rides the MANAGER side of the control plane, not the removed CLI verb.
 registry.register({ ...claudeConnector, name: "cotal" });
 
 // Bare `cotal` prints help; explicit `cotal setup` runs guided setup. The published binary is

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -345,7 +345,8 @@ like `Connector`/`Command`: `pty` ships with the manager; `tmux` and `cmux` are 
 a `RuntimeProvider` on import (the manager resolves them from the registry, with no compile-time
 dependency on them). Selectable backends:
 
-- **`pty` (default).** The manager spawns the real `claude` (plugin plus env) in a
+- **`pty` (default).** The manager spawns the default agent harness (`COTAL_DEFAULT_AGENT`, or
+  Claude when unset) in a
   pseudo-terminal it owns via **`@lydell/node-pty`** (prebuilt binaries for mac/Linux/Windows ×
   x64/arm64: zero compiler, zero `node-gyp`, ABI-stable). A real native TUI. The human watches
   or types in via `cotal attach <name>` (stream the PTY), and the manager keeps full OS-signal

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -144,6 +144,12 @@ files under
 [`examples/01-lateral-coordination/agents/`](../examples/01-lateral-coordination/agents/) to
 point at with `--config`.
 
+**Default harness.** If no launcher passes `--agent` / `agent`, Cotal uses
+`COTAL_DEFAULT_AGENT` when set, otherwise Claude. For example, start the stack with
+`COTAL_DEFAULT_AGENT=opencode cotal up --detach` to make later `cotal_spawn(...)` calls launch
+OpenCode by default. Foreground `cotal spawn` reads the same variable. An explicit per-spawn
+`--agent claude` / `agent: "claude"` still wins.
+
 **Define one at runtime.** `cotal_persona(name, prompt, model?)` sends the persona to the
 manager, which writes the same `.cotal/agents/<name>.md` file (via `saveAgentFile`) and
 announces it on the mesh. A later `cotal_spawn(name, role?, agent?, model?)` auto-discovers it, so

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,6 +94,10 @@ cotal web --space main               # open the browser dashboard (cotal ext add
 cotal down                           # stop the background mesh, delivery daemon, and manager
 ```
 
+By default, `cotal spawn` and `cotal_spawn` launch Claude. Set `COTAL_DEFAULT_AGENT=opencode`
+or `COTAL_DEFAULT_AGENT=hermes` to change the default harness for spawns that do not pass
+`--agent` / `agent`. An explicit `--agent` always wins.
+
 Feedback flows through your agent too: tell it "send feedback: ..." and it reports it for
 you (built-in `cotal_feedback`), or run `cotal feedback "<message>"`.
 

--- a/extensions/connector-core/smoke/spawn-args.smoke.ts
+++ b/extensions/connector-core/smoke/spawn-args.smoke.ts
@@ -40,7 +40,7 @@ check("model forwarded", rec?.req.args?.model === "sonnet", rec?.req.args?.model
 // backstop) — the request must carry the long spawn window, not fall back to the 5s op default.
 check("request outlives the readiness wait (SPAWN_TIMEOUT_MS, not the 5s default)", rec?.timeoutMs === SPAWN_TIMEOUT_MS, rec?.timeoutMs);
 
-// Name-only: agent/model absent → undefined, so the manager applies its defaults (Claude, file model).
+// Name-only: agent/model absent → undefined, so the manager applies its defaults (env/Claude, file model).
 await a.spawn("plain");
 check("name-only: agent undefined", rec?.req.args?.agent === undefined);
 check("name-only: model undefined", rec?.req.args?.model === undefined);

--- a/extensions/connector-core/src/agent.ts
+++ b/extensions/connector-core/src/agent.ts
@@ -499,7 +499,7 @@ export class MeshAgent extends EventEmitter {
    *  not the 5s op default.
    *  How it lands — a detached PTY, a tmux window, a cmux tab — is the manager's
    *  runtime; from here it just joins the mesh as a lateral peer. `opts.agent` picks
-   *  the harness (default the manager's `cotal`/Claude), `opts.model` overrides the
+   *  the harness (default the manager's `COTAL_DEFAULT_AGENT`, else `cotal`/Claude), `opts.model` overrides the
    *  persona file's `model:`, and `opts.cwd` roots the new peer at a different folder/repo
    *  than the manager's workspace — the same knobs the operator's `cotal spawn --detach` carries, so
    *  the agent and operator spawn doors share one control-op contract. (Session `resume` is

--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -476,7 +476,7 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
         agent: z
           .string()
           .optional()
-          .describe("Optional harness the new peer runs on — the agent/connector type (claude, opencode, hermes), NOT the persona to spawn (that's `name`). Defaults to the manager's default (Claude)."),
+          .describe("Optional harness the new peer runs on — the agent/connector type (claude, opencode, hermes), NOT the persona to spawn (that's `name`). Defaults to the manager's COTAL_DEFAULT_AGENT, else Claude."),
         model: z
           .string()
           .optional()

--- a/implementations/cli/src/commands/spawn.ts
+++ b/implementations/cli/src/commands/spawn.ts
@@ -27,6 +27,8 @@ import {
 import {
   authDir,
   credsFlag,
+  defaultAgentOverride,
+  defaultAgentType,
   launchFlags,
   loadMeshes,
   provenance,
@@ -170,7 +172,7 @@ async function spawnDetached(
     name: ref,
     identity: values.name,
     role: values.role,
-    agent: values.agent,
+    agent: values.agent ?? defaultAgentOverride(),
     config: values.config,
     model: values.model,
     cwd: values.cwd,
@@ -339,7 +341,7 @@ export async function spawn(args: ParsedArgs): Promise<void> {
   // Which of the operator's personal MCP servers to share with this agent: declared in the cotal
   // config (global ~/.config/cotal + the target mesh's .cotal), narrowed by an optional
   // --share-tools selection. Default (no config) is none — the connector launches isolated.
-  const agentType = values.agent ?? "claude";
+  const agentType = values.agent ?? defaultAgentType("claude");
   const mcpServers = connectorServers(
     loadCotalConfig(target.root),
     agentType,

--- a/implementations/manager/smoke/start-overrides.smoke.ts
+++ b/implementations/manager/smoke/start-overrides.smoke.ts
@@ -11,6 +11,7 @@
  *      spawn loudly (no silent drop).
  *   4. RESOLVED GUARD — a manifest launch (`resolved`) REJECTS imperative overrides.
  *   5. allowSubscribe default follows an overridden subscribe (override → creds source is one).
+ *   6. COTAL_DEFAULT_AGENT picks the manager's default harness when opts.agent is absent.
  * Run: pnpm smoke:start-overrides
  */
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
@@ -160,6 +161,22 @@ const j = (v: unknown) => JSON.stringify(v);
   check("resolved + subscribe rejected", r2.ok === false && /rejects imperative overrides/.test(r2.error ?? ""), r2);
   const r3 = await mgr.startAgent({ name: "mfst", agent: "smoke-ov", config: cfg, resolved, identity: "x" });
   check("resolved + identity rejected", r3.ok === false && /rejects imperative overrides/.test(r3.error ?? ""), r3);
+}
+
+// 8 — COTAL_DEFAULT_AGENT supplies the manager-side default harness.
+{
+  const prev = process.env.COTAL_DEFAULT_AGENT;
+  process.env.COTAL_DEFAULT_AGENT = "smoke-ov";
+  try {
+    lastOpts = undefined;
+    const r = await mgr.startAgent({ name: "plain" });
+    check("COTAL_DEFAULT_AGENT spawn succeeds", r.ok === true, r);
+    check("COTAL_DEFAULT_AGENT used as manager default", (r.data as { agent?: string })?.agent === "smoke-ov", r.data);
+    check("env default reaches LaunchOpts", lastOpts?.space === "smoke" && /^plain(-\d+)?$/.test(lastOpts?.name ?? ""), lastOpts);
+  } finally {
+    if (prev === undefined) delete process.env.COTAL_DEFAULT_AGENT;
+    else process.env.COTAL_DEFAULT_AGENT = prev;
+  }
 }
 
 console.log(failures ? `\nSTART-OVERRIDES SMOKE FAILED ❌ (${failures} failed)` : "\nstart-overrides smoke: all checks passed");

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -24,7 +24,7 @@ import {
   CONTROL_SELF_SERVICE,
   CONTROL_ADMIN,
 } from "@cotal-ai/core";
-import { authDir, findCotalRoot, loadSpaceAuth, resolveOnPath } from "@cotal-ai/workspace";
+import { authDir, defaultAgentType, findCotalRoot, loadSpaceAuth, resolveOnPath } from "@cotal-ai/workspace";
 import type { AgentDef, AttachSession, Connector, ControlReply, ControlRequest, ControlTier, ManagerLeaseInfo, MeshLaunchAgent, SpaceAuth } from "@cotal-ai/core";
 import {
   createRuntime,
@@ -86,7 +86,7 @@ export interface StartAgentOpts {
    *  `.cotal/agents/<name>.md`. NOT the mesh identity: the spawned peer presents under the file's
    *  own `name:` (auto-numbered on collision). The file must exist (no silent default-ACL fallback). */
   name: string;
-  /** Connector / agent type — resolved from the registry. Defaults to `"cotal"`. */
+  /** Connector / agent type — resolved from the registry. Defaults to `COTAL_DEFAULT_AGENT`, else `"cotal"`. */
   agent?: string;
   role?: string;
   /** Explicit agent-file path that overrides the `name` ref for *which file to load* (identity still
@@ -645,7 +645,7 @@ export class Manager {
       const refErr = this.nameError(ref);
       if (refErr) return { ok: false, error: refErr };
     }
-    const agent = opts.agent ?? "cotal";
+    const agent = opts.agent ?? defaultAgentType("cotal");
 
     // Capacity check first (cheap, fail-fast). Everything from here to the reserve below is
     // SYNCHRONOUS (existsSync / registry / accessSync / readFileSync — no await), so the gate stays

--- a/packages/workspace/src/default-agent.ts
+++ b/packages/workspace/src/default-agent.ts
@@ -1,0 +1,11 @@
+export const DEFAULT_AGENT_ENV = "COTAL_DEFAULT_AGENT";
+
+/** The operator-level default connector/agent harness, when set. */
+export function defaultAgentOverride(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  return env[DEFAULT_AGENT_ENV]?.trim() || undefined;
+}
+
+/** Resolve the default connector/agent harness with the product fallback for this launch path. */
+export function defaultAgentType(fallback: string, env: NodeJS.ProcessEnv = process.env): string {
+  return defaultAgentOverride(env) ?? fallback;
+}

--- a/packages/workspace/src/flags.ts
+++ b/packages/workspace/src/flags.ts
@@ -26,7 +26,7 @@ export const targetFlags = [spaceFlag, serverFlag, credsFlag] as const satisfies
 export const launchFlags = [
   { name: "name", type: "string", value: "<n>", description: "presence name (defaults from the persona file)" },
   { name: "config", type: "string", value: "<path>", description: "agent file path (for a file outside .cotal/agents)" },
-  { name: "agent", type: "string", value: "<a>", description: "connector type (claude, opencode, hermes …)" },
+  { name: "agent", type: "string", value: "<a>", description: "connector type (claude, opencode, hermes …); defaults from COTAL_DEFAULT_AGENT" },
   { name: "role", type: "string", value: "<r>", description: "role override (wins over the agent file's role:)" },
   { name: "model", type: "string", value: "<m>", description: "model override (wins over the agent file's model:)" },
   { name: "cwd", type: "string", value: "<dir>", description: "working directory to root the agent at" },

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -2,6 +2,7 @@ export * from "./auth-paths.js";
 export * from "./bin-path.js";
 export * from "./colors.js";
 export * from "./connect.js";
+export * from "./default-agent.js";
 export * from "./extensions.js";
 export * from "./flags.js";
 export * from "./provenance.js";


### PR DESCRIPTION
## Summary
- add COTAL_DEFAULT_AGENT as the operator default connector for foreground, detached, and agent-initiated spawns when no agent is specified
- keep existing Claude defaults when the env var is unset
- document the env var and cover manager default selection in smoke tests

## Tests
- pnpm smoke:start-overrides
- pnpm typecheck