### PR TITLE
fix(cli): auto-select port for cotal up collisions

### DIFF
--- a/bin/smoke/up-stack-live.smoke.ts
+++ b/bin/smoke/up-stack-live.smoke.ts
@@ -21,12 +21,15 @@ import { join, resolve } from "node:path";
 
 const PORT = 14341; // unique across the live smokes (no back-to-back port collision)
 const SERVER = `nats://127.0.0.1:${PORT}`;
+const DEFAULT_SERVER = "nats://127.0.0.1:4222";
 const WT = resolve(import.meta.dirname, "..", "..");
 const CLI = join(WT, "bin", "cotal.ts");
 const TSX = join(WT, "node_modules", ".bin", "tsx");
 
 const home = mkdtempSync(join(tmpdir(), "cotal-upstack-home-"));
 const root = mkdtempSync(join(tmpdir(), "cotal-upstack-root-"));
+const autoRoot = mkdtempSync(join(tmpdir(), "cotal-upstack-auto-"));
+const occupantRoot = mkdtempSync(join(tmpdir(), "cotal-upstack-occupant-"));
 const env = { ...process.env, COTAL_HOME: home };
 
 let pass = 0;
@@ -46,15 +49,34 @@ const alive = (pid: number) => {
   }
 };
 const pidOf = (file: string) => Number(readFileSync(join(root, ".cotal", file), "utf8").trim());
-const portOpen = () =>
+const portOpenAt = (port: number) =>
   new Promise<boolean>((res) => {
-    const s = createConnection({ host: "127.0.0.1", port: PORT }, () => { s.destroy(); res(true); });
+    const s = createConnection({ host: "127.0.0.1", port }, () => { s.destroy(); res(true); });
     s.on("error", () => res(false));
     s.setTimeout(400, () => { s.destroy(); res(false); });
   });
+const portOpen = () => portOpenAt(PORT);
+const cliIn = (cwd: string, ...args: string[]) => spawnSync(TSX, [CLI, ...args], { cwd, env, encoding: "utf8", timeout: 120_000 });
 
 const pids: number[] = [];
+let startedOccupant = false;
 try {
+  // Default-port collision: `up` without an explicit `--server` should allocate a free port and
+  // record it, not fail with "use --server ...:<port>". If the developer already has a real :4222
+  // broker, leave it alone; otherwise start a sandbox occupant and tear it down below.
+  if (!(await portOpenAt(4222))) {
+    const occupant = cliIn(occupantRoot, "up", "--detach", "--open");
+    ok("default-port occupant starts for auto-port regression", occupant.status === 0, occupant.stdout + occupant.stderr);
+    startedOccupant = true;
+  }
+  const auto = cliIn(autoRoot, "up", "--detach", "--open", "--space", "auto");
+  ok("up --detach auto-selects a free port when :4222 is occupied", auto.status === 0, auto.stdout + auto.stderr);
+  const autoEntry = JSON.parse(readFileSync(join(home, "meshes", `${encodeURIComponent("auto")}.json`), "utf8")) as { server: string };
+  ok("auto-port mesh is not recorded on the default server", autoEntry.server !== DEFAULT_SERVER, autoEntry);
+  ok("auto-port mesh broker is reachable", await portOpenAt(Number(new URL(autoEntry.server).port)), autoEntry);
+  cliIn(autoRoot, "down");
+  if (startedOccupant) cliIn(occupantRoot, "down");
+
   // 1) the full stack comes up from ONE command, JWT-authed by default.
   const up = cli("up", "--detach", "--server", SERVER);
   ok("up --detach exits 0", up.status === 0, up.stdout + up.stderr);
@@ -95,7 +117,9 @@ try {
   console.log(`\nUP-STACK LIVE SMOKE OK ✅ (${pass} checks)`);
 } finally {
   spawnSync(TSX, [CLI, "down"], { cwd: root, env, encoding: "utf8" });
+  spawnSync(TSX, [CLI, "down"], { cwd: autoRoot, env, encoding: "utf8" });
+  if (startedOccupant) spawnSync(TSX, [CLI, "down"], { cwd: occupantRoot, env, encoding: "utf8" });
   for (const p of pids) if (alive(p)) { try { process.kill(p, "SIGTERM"); } catch { /* gone */ } }
   rmSync(home, { recursive: true, force: true });
-  rmSync(root, { recursive: true, force: true });
+  for (const d of [root, autoRoot, occupantRoot]) rmSync(d, { recursive: true, force: true });
 }

--- a/docs/setup-internals.md
+++ b/docs/setup-internals.md
@@ -74,6 +74,10 @@ old-manager preflight → **delivery daemon** (auth mode only) → **manager** �
 ([`lib/delivery-proc.ts`](../implementations/cli/src/lib/delivery-proc.ts)). The detached
 processes, all stopped by `cotal down`:
 
+With no explicit `--server`, `cotal up` auto-selects a free local port when the default broker
+address is already held by another root or an unrecorded broker; an explicit `--server` remains
+fail-loud on collision.
+
 - **Mesh:** `startMeshDetached`
   ([`commands/up.ts`](../implementations/cli/src/commands/up.ts)) is the one place that boots a
   background nats-server (foreground `up` and `up --detach` both route through it). Writes

--- a/implementations/cli/src/commands/up.ts
+++ b/implementations/cli/src/commands/up.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { createServer } from "node:net";
 import {
   mkdirSync,
   writeFileSync,
@@ -68,32 +69,36 @@ export async function up(args: ParsedArgs): Promise<void> {
     });
     return;
   }
-  const server = values.server ?? DEFAULT_SERVER;
+  let server = values.server ?? DEFAULT_SERVER;
   const host = values.host ?? "127.0.0.1";
   if (await isReachable(server)) {
     const space = values.space ?? resolveSpace(process.cwd());
     const root = cotalRoot();
-    // A broker is already on this port. Only treat it as a no-op refresh when the registry confirms
-    // it's THIS exact mesh (same server + root + space). Anything else — a different space/root, or a
-    // broker we never recorded — we must NOT adopt: recording our space over it would let a later
-    // `spawn --space <s>` load the wrong root's creds. Today one broker serves one space (auth binds
-    // them), so a different space on this port can't be added to it yet — fail loudly and tell the
-    // user to free the port. (Hosting several spaces on one broker is the planned multi-space work.)
+    // A broker is already on this port. Same root means "this project is already up" unless the
+    // operator explicitly asked for a second space in the same `.cotal/` root (unsupported today: pid,
+    // auth, and logs are root-scoped). Different root / unrecorded broker on the implicit default port
+    // gets a fresh free port instead of making the user hunt for one.
     const held = loadMeshes().find((m) => m.server === server);
-    if (held && held.root === root && held.space === space) {
+    if (held && held.root === root && (held.space === space || values.space === undefined)) {
       // A refresh of the SAME already-running mesh — its mode is fixed by how the live broker was
       // started; preserve `held.mode` rather than relabel it from this invocation's `--open`.
-      recordOurMesh({ space, server, root, mode: held.mode, ts: new Date().toISOString() });
-      console.log(c.green(`✓ NATS already running at ${server}`));
+      recordOurMesh({ space: held.space, server, root, mode: held.mode, ts: new Date().toISOString() });
+      console.log(c.green(`✓ mesh "${held.space}" already running at ${server}`));
       return;
     }
     const who = held ? `mesh "${held.space}" (${held.root})` : "a broker not started here";
-    console.error(
-      c.red(
-        `✗ ${server} is already in use by ${who} — to run "${space}" use \`--server nats://${host}:<port>\` with a free port`,
-      ),
-    );
-    process.exit(1);
+    if (values.server === undefined && (!held || held.root !== root)) {
+      const next = await serverWithFreePort(server, host);
+      console.log(c.dim(`${server} is already in use by ${who}; starting "${space}" at ${next} instead`));
+      server = next;
+    } else {
+      console.error(
+        c.red(
+          `✗ ${server} is already in use by ${who} — to run "${space}" use \`--server nats://${host}:<port>\` with a free port`,
+        ),
+      );
+      process.exit(1);
+    }
   }
 
   if (values.detach) {
@@ -444,6 +449,29 @@ async function waitReady(server: string, creds?: string): Promise<boolean> {
     await new Promise((r) => setTimeout(r, 200));
   }
   return false;
+}
+
+async function serverWithFreePort(server: string, host: string): Promise<string> {
+  const url = new URL(server);
+  url.port = String(await freePort(host));
+  return url.toString();
+}
+
+function freePort(host: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.unref();
+    srv.once("error", reject);
+    srv.listen(0, host, () => {
+      const addr = srv.address();
+      const port = typeof addr === "object" && addr ? addr.port : undefined;
+      srv.close((err) => {
+        if (err) reject(err);
+        else if (port) resolve(port);
+        else reject(new Error("could not allocate a free port"));
+      });
+    });
+  });
 }
 
 /** One-time space infrastructure once the server accepts connections: pre-create the space's


### PR DESCRIPTION
## What
- Let bare `cotal up` choose a free local port when the default broker address is already held by another root or an unrecorded broker.
- Keep explicit `--server` fail-loud on collision.
- Treat bare same-root re-entry as an idempotent already-running mesh.

## Tests
- `pnpm build`
- `pnpm --filter @cotal-ai/cli typecheck`
- `pnpm smoke:up-stack:live`