### PR TITLE
fix(cli): complete nested command arguments

### DIFF
--- a/implementations/cli/smoke/command-kernel.smoke.ts
+++ b/implementations/cli/smoke/command-kernel.smoke.ts
@@ -10,6 +10,18 @@ import { complete } from "../src/commands/completion.js";
 
 const noop = async (): Promise<void> => {};
 
+async function completionOut(positionals: string[]): Promise<string> {
+  let out = "";
+  const realWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((s: string) => ((out += s), true)) as typeof process.stdout.write;
+  try {
+    await complete({ values: {}, positionals, raw: positionals });
+  } finally {
+    process.stdout.write = realWrite;
+  }
+  return out;
+}
+
 // --- flags parse strictly: strings, booleans, shorts -------------------------------------------
 {
   const cmd: Command = {
@@ -95,17 +107,35 @@ const noop = async (): Promise<void> => {};
 {
   const spawnCmd = registry.all<Command>("command").find((c) => c.name === "spawn");
   assert.ok(spawnCmd?.flags?.length, "spawn declares flags");
-  let out = "";
-  const realWrite = process.stdout.write.bind(process.stdout);
-  process.stdout.write = ((s: string) => ((out += s), true)) as typeof process.stdout.write;
-  try {
-    await complete({ values: {}, positionals: ["spawn", "--"], raw: ["spawn", "--"] });
-  } finally {
-    process.stdout.write = realWrite;
-  }
+  const out = await completionOut(["spawn", "--"]);
   assert.ok(out.includes("--space"), "flag completion lists --space");
   assert.ok(out.includes("--config"), "flag completion lists --config");
   assert.ok(out.trimEnd().endsWith(":nofiles"), "directive is nofiles");
+}
+
+// --- exact commands and flags-before-positionals stay inside the command grammar -----------------
+{
+  const exactSend = await completionOut(["send"]);
+  assert.ok(exactSend.includes("dm\tunicast to a peer"), "exact send completes send subcommands");
+  assert.ok(!exactSend.includes("spawn\t"), "exact send does not fall back to top-level commands");
+
+  const flaggedSend = await completionOut(["send", "--space", "demo", ""]);
+  assert.ok(flaggedSend.includes("msg\tbroadcast to a channel"), "flags before send subcommands are ignored");
+  assert.ok(!flaggedSend.includes("spawn\t"), "flagged send does not fall back to top-level commands");
+
+  const flaggedPersonas = await completionOut(["personas", "--space", "demo", ""]);
+  assert.ok(flaggedPersonas.includes("show\tprint a persona's card"), "flags before personas subcommands are ignored");
+
+  const exactUp = await completionOut(["up"]);
+  assert.ok(exactUp.includes("--space"), "exact flag-only commands offer their flags");
+  assert.ok(!exactUp.includes("setup\t"), "exact flag-only commands do not fall back to top-level commands");
+
+  const exactAttach = await completionOut(["attach", ""]);
+  assert.ok(exactAttach.includes("--name"), "attach with an empty next word offers flags");
+
+  const attachName = await completionOut(["attach", "--name", ""]);
+  assert.ok(!attachName.includes("--space"), "attach --name value completion does not fall back to flags");
+  assert.ok(attachName.trimEnd().endsWith(":nofiles"), "attach --name suppresses filename fallback");
 }
 
 console.log("✓ command-kernel smoke passed");

--- a/implementations/cli/src/commands/agents.ts
+++ b/implementations/cli/src/commands/agents.ts
@@ -1,8 +1,9 @@
-import { CONTROL_ADMIN, type FlagSpec, type FlagValues, type ParsedArgs } from "@cotal-ai/core";
-import { targetFlags } from "@cotal-ai/workspace";
+import { CONTROL_ADMIN, type CompletionResult, type FlagSpec, type FlagValues, type ParsedArgs } from "@cotal-ai/core";
+import { loadMeshes, targetFlags } from "@cotal-ai/workspace";
 import { c } from "../ui.js";
 import { askManager, failIfNotOk, resolveControlTarget } from "../lib/control.js";
 import { attachClient, detachKey } from "../lib/attach-client.js";
+import { completingFlagValue } from "../lib/completion.js";
 
 /**
  * The manager's operator clients — thin control-plane request/reply commands (`stop`/`ps`/
@@ -17,6 +18,16 @@ const nameFlag = (what: string) =>
 export const stopFlags = [...targetFlags, nameFlag("managed agent to stop (required)")] as const satisfies readonly FlagSpec[];
 export const psFlags = [...targetFlags] as const satisfies readonly FlagSpec[];
 export const attachFlags = [...targetFlags, nameFlag("managed agent to attach to (required)")] as const satisfies readonly FlagSpec[];
+
+export function managedAgentComplete(argv: string[]): CompletionResult {
+  const flag = completingFlagValue(argv, attachFlags);
+  if (flag?.name === "space") return { items: loadMeshes().map((m) => ({ value: m.space })), directive: "nofiles" };
+  if (flag?.name === "creds") return { items: [], directive: "default" };
+  if (flag?.name === "name") return { items: [], directive: "nofiles" };
+  if (argv.length <= 1)
+    return { items: attachFlags.map((f) => ({ value: `--${f.name}`, description: f.description })), directive: "nofiles" };
+  return { items: [], directive: "nofiles" };
+}
 
 export async function stop(args: ParsedArgs): Promise<void> {
   const v = args.values as FlagValues<typeof stopFlags>;

--- a/implementations/cli/src/commands/completion.ts
+++ b/implementations/cli/src/commands/completion.ts
@@ -47,27 +47,38 @@ export async function complete(args: ParsedArgs): Promise<void> {
   // extension stubs when the root opted in), minus `__`-internal and `hidden` ones. Extension
   // candidates come from the manifest CACHE — a <TAB> never imports an extension.
   const commands = commandSurface().filter((cmd) => !cmd.name.startsWith("__") && !cmd.hidden);
-  // Word 0 (the command name itself): offer the command names.
-  if (argv.length <= 1) {
+  // No command word yet: offer the command names. If the lone word is an exact command, many
+  // shells omitted the trailing empty cursor word; complete inside that command instead.
+  if (argv.length === 0) {
     emit(commands.map((cmd) => ({ value: cmd.name, description: cmd.summary })), "nofiles");
     return;
   }
   const cmd = commands.find((cmd) => cmd.name === argv[0]);
+  if (argv.length === 1 && cmd) return emitCommandCompletion(cmd, [""]);
+  if (argv.length === 1) {
+    emit(commands.map((cmd) => ({ value: cmd.name, description: cmd.summary })), "nofiles");
+    return;
+  }
+  return emitCommandCompletion(cmd, argv.slice(1));
+}
+
+async function emitCommandCompletion(cmd: Command | undefined, argv: string[]): Promise<void> {
   // A word starting with `-` completes against the command's DECLARED flags — generated from
   // the specs, so it can never drift from what parsing accepts. Value/positional completion
   // stays with the command's own `complete` hook below.
   const word = argv[argv.length - 1];
-  if (cmd && word.startsWith("-")) {
+  if (cmd && word.startsWith("-") && !word.includes("=")) {
     const items = (cmd.flags ?? []).map((f) => ({ value: `--${f.name}`, description: f.description }));
     emit(items, "nofiles");
     return;
   }
   if (!cmd?.complete) {
-    emit([], "default"); // unknown command, or one with no completer → defer to the shell
+    const items = (cmd?.flags ?? []).map((f) => ({ value: `--${f.name}`, description: f.description }));
+    emit(items, items.length ? "nofiles" : "default");
     return;
   }
   try {
-    const res = await cmd.complete(argv.slice(1));
+    const res = await cmd.complete(argv);
     emit(res.items, res.directive ?? "nofiles");
   } catch (e) {
     // No fallback: a completer that can't produce its authoritative set (e.g. a malformed agent

--- a/implementations/cli/src/commands/personas.ts
+++ b/implementations/cli/src/commands/personas.ts
@@ -10,7 +10,9 @@ import {
   type CompletionResult,
   type ParsedArgs,
 } from "@cotal-ai/core";
+import { loadMeshes, targetFlags } from "@cotal-ai/workspace";
 import { cotalRoot } from "../lib/paths.js";
+import { completingFlagValue, positionalsForCompletion } from "../lib/completion.js";
 import { listPersonas, listPersonaNames, personasDir } from "../lib/personas.js";
 import { openTransient, type ConnectValues } from "../lib/transient.js";
 import { c } from "../ui.js";
@@ -53,6 +55,21 @@ export async function personas(args: ParsedArgs): Promise<void> {
 
 /** Argument completion: subcommands, then persona names for `show`/`rm`. */
 export function personasComplete(argv: string[]): CompletionResult {
+  const flags = [
+    ...targetFlags,
+    { name: "role", type: "string" },
+    { name: "model", type: "string" },
+    { name: "prompt", type: "string" },
+    { name: "from", type: "string" },
+    { name: "verbose", type: "boolean", short: "v" },
+    { name: "running", type: "boolean" },
+    { name: "force", type: "boolean" },
+  ] as const;
+  const flag = completingFlagValue(argv, flags);
+  if (flag?.name === "space") return { items: loadMeshes().map((m) => ({ value: m.space })), directive: "nofiles" };
+  if (flag?.name === "from" || flag?.name === "creds") return { items: [], directive: "default" };
+
+  const positionals = positionalsForCompletion(argv, flags);
   const subs: CompletionResult = {
     items: [
       { value: "list", description: "list the persona catalog" },
@@ -63,8 +80,8 @@ export function personasComplete(argv: string[]): CompletionResult {
     ],
     directive: "nofiles",
   };
-  if (argv.length <= 1) return subs; // completing the subcommand
-  if (argv[0] === "show" || argv[0] === "edit" || argv[0] === "rm")
+  if (positionals.length <= 1) return subs; // completing the subcommand
+  if (positionals[0] === "show" || positionals[0] === "edit" || positionals[0] === "rm")
     return { items: listPersonaNames().map((value) => ({ value })), directive: "nofiles" };
   return { items: [], directive: "nofiles" };
 }

--- a/implementations/cli/src/commands/send.ts
+++ b/implementations/cli/src/commands/send.ts
@@ -5,7 +5,9 @@ import {
   type CompletionResult,
   type ParsedArgs,
 } from "@cotal-ai/core";
+import { loadMeshes, targetFlags } from "@cotal-ai/workspace";
 import { c } from "../ui.js";
+import { completingFlagValue, positionalsForCompletion } from "../lib/completion.js";
 import { openTransient } from "../lib/transient.js";
 import { listDeclaredChannels, listDeclaredRoles } from "../lib/personas.js";
 import { mentionsIn } from "../lib/mentions.js";
@@ -102,7 +104,13 @@ async function ask(values: ParsedArgs["values"], positionals: string[]): Promise
  *  decline rather than offer a silently-partial set; see {@link listDeclaredChannels}). `dm` offers
  *  nothing: peer presence is live, so it can't be completed offline. */
 export function sendComplete(argv: string[]): CompletionResult {
-  if (argv.length <= 1)
+  const flag = completingFlagValue(argv, targetFlags);
+  if (flag?.name === "creds") return { items: [], directive: "default" };
+  if (flag?.name === "space") return { items: loadMeshes().map((m) => ({ value: m.space })), directive: "nofiles" };
+  if (flag) return { items: [], directive: "nofiles" };
+
+  const positionals = positionalsForCompletion(argv, targetFlags);
+  if (positionals.length <= 1)
     return {
       items: [
         { value: "dm", description: "unicast to a peer" },
@@ -111,7 +119,7 @@ export function sendComplete(argv: string[]): CompletionResult {
       ],
       directive: "nofiles",
     };
-  const [mode, ...rest] = argv;
+  const [mode, ...rest] = positionals;
   if (mode === "msg" && rest.length <= 1)
     return {
       items: listDeclaredChannels().map((value) => ({ value, description: "declared channel" })),

--- a/implementations/cli/src/commands/spawn.ts
+++ b/implementations/cli/src/commands/spawn.ts
@@ -35,9 +35,10 @@ import {
   spaceFlag,
 } from "@cotal-ai/workspace";
 import { c } from "../ui.js";
+import { completedFlagValue, completingFlagValue, hasCompletedFlagValue, positionalsForCompletion } from "../lib/completion.js";
 import { preflightOrExit, resolveTargetOrExit } from "../lib/connect.js";
 import { askManager, failIfNotOk, resolveControlTarget, START_TIMEOUT_MS } from "../lib/control.js";
-import { listPersonas } from "../lib/personas.js";
+import { listDeclaredChannels, listDeclaredRoles, listPersonas } from "../lib/personas.js";
 import { spawnManifest } from "./spawn-manifest.js";
 
 /** Completion for `cotal spawn` — `--space <TAB>` lists the running meshes, and the first positional
@@ -45,13 +46,25 @@ import { spawnManifest } from "./spawn-manifest.js";
  *  probe — a <TAB> must stay cheap and never open the network), so it lists the *target* mesh's
  *  personas, not the cwd's. */
 export function spawnComplete(argv: string[]): CompletionResult {
-  if (argv[argv.length - 2] === "--space")
+  const flag = completingFlagValue(argv, spawnFlags);
+  if (flag?.name === "space")
     return { items: loadMeshes().map((m) => ({ value: m.space })), directive: "nofiles" };
+  if (flag?.name === "agent")
+    return { items: registry.all<Connector>("connector").map((c) => ({ value: c.name })), directive: "nofiles" };
+  if (flag?.name === "role")
+    return { items: listDeclaredRoles().map((value) => ({ value, description: "declared role" })), directive: "nofiles" };
+  if (flag?.name === "config") return { items: [], directive: "default" };
+  if (flag && ["subscribe", "allow-subscribe", "allow-publish"].includes(flag.name))
+    return { items: listDeclaredChannels().map((value) => ({ value, description: "declared channel" })), directive: "nofiles" };
+  if (flag && ["cwd", "file", "creds"].includes(flag.name)) return { items: [], directive: "default" };
+  if (flag?.name === "runtime")
+    return { items: ["pty", "tmux", "cmux"].map((value) => ({ value })), directive: "nofiles" };
+
+  const positionals = positionalsForCompletion(argv, spawnFlags);
   // Only the first word after `spawn` is the persona positional; once it's typed, defer to the shell.
-  if (argv.length <= 1) {
+  if (positionals.length <= 1 && !hasCompletedFlagValue(argv, spawnFlags, "config")) {
     try {
-      const target = resolveMeshTarget(process.cwd());
-      return { items: listPersonas(target.root).map((p) => ({ value: p.name })), directive: "nofiles" };
+      return { items: personaItems(argv), directive: "nofiles" };
     } catch {
       // No single target (no mesh, or several with no `current`) — fail CLOSED: offer no personas
       // rather than throw. `cotal spawn --space <TAB>` still lists the running meshes.
@@ -59,6 +72,14 @@ export function spawnComplete(argv: string[]): CompletionResult {
     }
   }
   return { items: [], directive: "nofiles" };
+}
+
+function personaItems(argv: string[]) {
+  const target = resolveMeshTarget(process.cwd(), {
+    space: completedFlagValue(argv, spawnFlags, "space"),
+    server: completedFlagValue(argv, spawnFlags, "server"),
+  });
+  return listPersonas(target.root).map((p) => ({ value: p.name }));
 }
 
 /**

--- a/implementations/cli/src/index.ts
+++ b/implementations/cli/src/index.ts
@@ -8,7 +8,7 @@ import { setup, setupFlags } from "./commands/setup.js";
 import { join } from "./commands/join.js";
 import { console_ } from "./commands/console.js";
 import { spawn, spawnComplete, spawnFlags } from "./commands/spawn.js";
-import { attach, attachFlags, ps, psFlags, stop, stopFlags } from "./commands/agents.js";
+import { attach, attachFlags, managedAgentComplete, ps, psFlags, stop, stopFlags } from "./commands/agents.js";
 import { c } from "./ui.js";
 import { personas, personasComplete } from "./commands/personas.js";
 import { completion, completionComplete, complete } from "./commands/completion.js";
@@ -255,6 +255,7 @@ const baseCommands: Command[] = [
     summary: "ask the manager to stop an agent — --name <n>",
     flags: stopFlags,
     run: stop,
+    complete: managedAgentComplete,
   },
   {
     kind: "command",
@@ -271,6 +272,7 @@ const baseCommands: Command[] = [
     summary: "stream + drive an agent's terminal (pty runtime) — --name <n>",
     flags: attachFlags,
     run: attach,
+    complete: managedAgentComplete,
   },
   {
     kind: "command",

--- a/implementations/cli/src/lib/completion.ts
+++ b/implementations/cli/src/lib/completion.ts
@@ -1,0 +1,64 @@
+import type { FlagSpec } from "@cotal-ai/core";
+
+/** The string flag whose value is currently being completed, if the cursor is in one. */
+export function completingFlagValue(argv: string[], flags: readonly FlagSpec[]): FlagSpec | undefined {
+  const prev = argv[argv.length - 2];
+  if (!prev) return undefined;
+  const flag = flagForToken(prev, flags);
+  return flag?.type === "string" ? flag : undefined;
+}
+
+/** Strip declared flags and their values, leaving the positional cursor shape for sub-grammars. */
+export function positionalsForCompletion(argv: string[], flags: readonly FlagSpec[]): string[] {
+  const out: string[] = [];
+  let positionalOnly = false;
+  for (let i = 0; i < argv.length; i++) {
+    const word = argv[i];
+    if (!positionalOnly && word === "--") {
+      positionalOnly = true;
+      continue;
+    }
+    if (!positionalOnly) {
+      const inline = /^--([^=]+)=/.exec(word);
+      if (inline && flagForLong(inline[1], flags)) continue;
+      const flag = flagForToken(word, flags);
+      if (flag) {
+        if (flag.type === "string" && i + 1 < argv.length) i++;
+        continue;
+      }
+    }
+    out.push(word);
+  }
+  return out;
+}
+
+export function hasCompletedFlagValue(argv: string[], flags: readonly FlagSpec[], name: string): boolean {
+  return completedFlagValue(argv, flags, name) !== undefined;
+}
+
+export function completedFlagValue(argv: string[], flags: readonly FlagSpec[], name: string): string | undefined {
+  for (let i = 0; i < argv.length; i++) {
+    const word = argv[i];
+    const inline = /^--([^=]+)=(.*)$/.exec(word);
+    if (inline) {
+      const flag = flagForLong(inline[1], flags);
+      if (flag?.name === name && inline[2] !== "") return inline[2];
+      continue;
+    }
+    const flag = flagForToken(word, flags);
+    if (flag?.name !== name || flag.type !== "string") continue;
+    const value = argv[i + 1];
+    if (value !== undefined && value !== "" && i + 1 < argv.length - 1) return value;
+  }
+  return undefined;
+}
+
+function flagForToken(token: string, flags: readonly FlagSpec[]): FlagSpec | undefined {
+  if (token.startsWith("--")) return flagForLong(token.slice(2), flags);
+  if (/^-[^-]$/.test(token)) return flags.find((f) => f.short === token.slice(1));
+  return undefined;
+}
+
+function flagForLong(name: string, flags: readonly FlagSpec[]): FlagSpec | undefined {
+  return flags.find((f) => f.name === name);
+}


### PR DESCRIPTION
## What\n- Treat exact command words as command-local completion requests instead of falling back to top-level commands.\n- Strip declared flags before subcommand/positional completion so inputs like `send --space demo msg <TAB>` work.\n- Add value completion handling for spawn/send/personas/attach/stop flags, while keeping `attach --name <TAB>` offline and non-misleading.\n\n## Tests\n- `pnpm build`\n- `pnpm smoke:cli-kernel`\n- `pnpm --filter @cotal-ai/cli typecheck`\n- Generated bash completion e2e for send, nested send msg, personas show, spawn --detach, attach, and attach --name`