### PR TITLE
feat(cli): add default spawn persona env

### DIFF
--- a/bin/smoke/spawn-detach-live.smoke.ts
+++ b/bin/smoke/spawn-detach-live.smoke.ts
@@ -7,8 +7,9 @@
  *     spawns it; the overrides arrive in the connector's LaunchOpts (flags > persona, e2e).
  *  B. `ps` lists the managed agent; `stop --name` tears it down; `ps` is empty again.
  *  C. `attach` replies a loopback ws:// URL and the socket actually opens (the pinned contract).
- *  D. the `start` tombstone errors, naming `spawn --detach` (subprocess through bin/cotal.ts).
- *  E. foreground `--creds` (no --detach) fails loud (subprocess).
+ *  D. `COTAL_DEFAULT_PERSONA` supplies the persona for a bare `spawn --detach`.
+ *  E. the `start` tombstone errors, naming `spawn --detach` (subprocess through bin/cotal.ts).
+ *  F. foreground `--creds` (no --detach) fails loud (subprocess).
  *
  * COTAL_HOME is sandboxed; kills ONLY the PIDs it spawns. Needs nats-server on PATH.
  * Run: pnpm smoke:spawn-detach:live   (build first — bin/cotal.ts subprocess checks run dist)
@@ -201,7 +202,29 @@ try {
   const psAfter = await capture(() => run("ps", ["--space", SPACE]));
   ok("ps is empty after stop", /no managed agents/.test(psAfter), psAfter);
 
-  // D — the start tombstone (true subprocess through bin/cotal.ts, i.e. built dist).
+  // D — COTAL_DEFAULT_PERSONA supplies the persona for a bare detached spawn. The identity still
+  // comes from --name, so this proves persona selection and identity override stay separate.
+  {
+    const prev = process.env.COTAL_DEFAULT_PERSONA;
+    process.env.COTAL_DEFAULT_PERSONA = "poet";
+    try {
+      lastOpts = undefined;
+      const envOut = await capture(() => run("spawn", ["--detach", "--agent", "e2e", "--space", SPACE, "--name", "envbard"]));
+      ok("COTAL_DEFAULT_PERSONA bare detached spawn reached the connector", lastOpts !== undefined);
+      ok(
+        "COTAL_DEFAULT_PERSONA picked poet while --name set identity",
+        /spawned .*envbard/.test(envOut) && lastOpts?.name === "envbard" && lastOpts?.role === "writer",
+        { envOut, name: lastOpts?.name, role: lastOpts?.role },
+      );
+      const envStop = await capture(() => run("stop", ["--name", "envbard", "--space", SPACE]));
+      ok("COTAL_DEFAULT_PERSONA spawned agent stops", /stopped envbard/.test(envStop), envStop);
+    } finally {
+      if (prev === undefined) delete process.env.COTAL_DEFAULT_PERSONA;
+      else process.env.COTAL_DEFAULT_PERSONA = prev;
+    }
+  }
+
+  // E — the start tombstone (true subprocess through bin/cotal.ts, i.e. built dist).
   const tomb = spawnSync("npx", ["tsx", join(import.meta.dirname, "..", "cotal.ts"), "start", "--name", "x"], {
     encoding: "utf8",
     env: { ...process.env, COTAL_HOME: home },
@@ -209,7 +232,7 @@ try {
   ok("tombstone exits non-zero", tomb.status === 1, tomb.status);
   ok("tombstone names spawn --detach", /spawn --detach/.test(tomb.stderr), tomb.stderr.slice(0, 200));
 
-  // E — foreground --creds fails loud.
+  // F — foreground --creds fails loud.
   const fg = spawnSync("npx", ["tsx", join(import.meta.dirname, "..", "cotal.ts"), "spawn", "poet", "--creds", "/tmp/x.creds"], {
     encoding: "utf8",
     env: { ...process.env, COTAL_HOME: home },

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -136,13 +136,17 @@ run`). They differ only in how they *run* the spec:
 
 | Launcher | How to point at a file |
 |---|---|
-| Manager (supervised PTY) | `cotal spawn --detach dave` (auto-discovers `.cotal/agents/dave.md` in the manager's workspace) or `--config <path>`; the SAME grammar as the foreground launch — `--model`, `--cwd`, `--prompt`, ACL overrides, `--share-tools` all apply. View via console / `cotal attach`. |
-| Foreground (`cotal spawn`) | `cotal spawn <name-or-path>`. The real Claude TUI takes over this terminal (run it inside a cmux/tmux pane to multiplex). Works from **any directory** — it joins the running mesh via the registry (see below), no `cd` into the project that ran `cotal up`. |
+| Manager (supervised PTY) | `cotal spawn --detach dave` (auto-discovers `.cotal/agents/dave.md` in the manager's workspace) or `--config <persona-or-path>` for an explicit persona ref/file; the SAME grammar as the foreground launch — `--model`, `--cwd`, `--prompt`, ACL overrides, `--share-tools` all apply. View via console / `cotal attach`. |
+| Foreground (`cotal spawn`) | `cotal spawn <persona>` for `.cotal/agents/<persona>.md`, or `--config <persona-or-path>` when a flag is clearer. The real Claude TUI takes over this terminal (run it inside a cmux/tmux pane to multiplex). Works from **any directory** — it joins the running mesh via the registry (see below), no `cd` into the project that ran `cotal up`. |
 
 `.cotal/` is gitignored (user-local, like `.claude/`). The demo ships committed example
 files under
 [`examples/01-lateral-coordination/agents/`](../examples/01-lateral-coordination/agents/) to
 point at with `--config`.
+
+**Default persona.** A bare `cotal spawn` uses the `default` persona unless
+`COTAL_DEFAULT_PERSONA=<name-or-path>` is set. The env value accepts the same catalog name or path
+as `--config`; an explicit positional persona or `--config` wins.
 
 **Default harness.** If no launcher passes `--agent` / `agent`, Cotal uses
 `COTAL_DEFAULT_AGENT` when set, otherwise Claude. For example, start the stack with

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,6 +94,10 @@ cotal web --space main               # open the browser dashboard (cotal ext add
 cotal down                           # stop the background mesh, delivery daemon, and manager
 ```
 
+By default, a bare `cotal spawn` uses `.cotal/agents/default.md`. Set
+`COTAL_DEFAULT_PERSONA=<name-or-path>` to change that fallback for spawns that do not pass a
+persona positional or `--config`. An explicit persona always wins.
+
 By default, `cotal spawn` and `cotal_spawn` launch Claude. Set `COTAL_DEFAULT_AGENT=opencode`
 or `COTAL_DEFAULT_AGENT=hermes` to change the default harness for spawns that do not pass
 `--agent` / `agent`. An explicit `--agent` always wins.

--- a/examples/01-lateral-coordination/README.md
+++ b/examples/01-lateral-coordination/README.md
@@ -118,12 +118,12 @@ Role + identity + a persona can come from an [agent file](./agents/) instead of 
 frontmatter is the identity, the Markdown body is the system prompt:
 
 ```
-cotal start --agent claude --name dave --config examples/01-lateral-coordination/agents/dave.md  # manager, detached PTY
-cotal spawn --agent claude --name dave --config examples/01-lateral-coordination/agents/dave.md  # foreground, in this terminal
-cotal spawn dave                                                                                 # …or the shorthand (./.cotal/agents/dave.md)
+cotal spawn --detach --agent claude --name dave --config examples/01-lateral-coordination/agents/dave.md  # manager, detached PTY
+cotal spawn --agent claude --name dave --config examples/01-lateral-coordination/agents/dave.md           # foreground, in this terminal
+cotal spawn dave                                                                                         # …or the shorthand (./.cotal/agents/dave.md)
 ```
 
-A bare `cotal start --name dave` also auto-discovers `.cotal/agents/dave.md` in the manager's
+A bare `cotal spawn --detach dave` also auto-discovers `.cotal/agents/dave.md` in the manager's
 workspace (gitignored, user-local). See [agent files](../../docs/claude-code-integration.md#agent-files-persona--identity).
 
 The bundled plugin reads `COTAL_*` from the env at spawn and auto-joins the mesh; the manager

--- a/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
+++ b/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
@@ -29,7 +29,7 @@ const {
   resolveMeshTarget,
   setCurrent,
 } = await import("@cotal-ai/workspace");
-const { spawnComplete } = await import("../src/commands/spawn.js");
+const { spawnComplete, spawnPersonaRef } = await import("../src/commands/spawn.js");
 const { listPersonas } = await import("../src/lib/personas.js");
 const { pruneStaleMeshes } = await import("../src/lib/meshes.js");
 
@@ -73,6 +73,11 @@ try {
 
   // 1 mesh → used automatically (source 'registry'), with its root + personas.
   recordMesh(entry("teamA", projA));
+  check("default persona: product fallback is default", spawnPersonaRef(undefined, [], {}) === "default");
+  check("default persona: blank env is ignored", spawnPersonaRef(undefined, [], { COTAL_DEFAULT_PERSONA: "  " }) === "default");
+  check("default persona: env overrides product fallback", spawnPersonaRef(undefined, [], { COTAL_DEFAULT_PERSONA: "reviewer" }) === "reviewer");
+  check("default persona: positional wins over env", spawnPersonaRef(undefined, ["researcher"], { COTAL_DEFAULT_PERSONA: "reviewer" }) === "researcher");
+  check("default persona: --config wins over positional/env", spawnPersonaRef("builder", ["researcher"], { COTAL_DEFAULT_PERSONA: "reviewer" }) === "builder");
   // Hardening: the registry dir is 0700 — its filenames are space names, so it must not be
   // world-traversable even though the file contents are already 0600.
   check(
@@ -188,6 +193,8 @@ try {
   try {
     const personas = spawnComplete([""]); // CompletionResult, not a Promise
     check("completion: lists the resolved mesh's personas (not cwd's)", personas.items.map((i) => i.value).join(",") === "builder", personas.items);
+    const configFlag = spawnComplete(["--config", ""]);
+    check("completion: --config lists the resolved mesh's personas", configFlag.items.map((i) => i.value).join(",") === "builder", configFlag.items);
     const spaces = spawnComplete(["--space", ""]);
     check("completion: --space lists the running spaces", spaces.items.map((i) => i.value).sort().join(",") === "teamA,teamB", spaces.items);
   } finally {

--- a/implementations/cli/src/commands/spawn.ts
+++ b/implementations/cli/src/commands/spawn.ts
@@ -29,6 +29,8 @@ import {
   credsFlag,
   defaultAgentOverride,
   defaultAgentType,
+  defaultPersonaOverride,
+  defaultPersonaRef,
   launchFlags,
   loadMeshes,
   provenance,
@@ -55,7 +57,15 @@ export function spawnComplete(argv: string[]): CompletionResult {
     return { items: registry.all<Connector>("connector").map((c) => ({ value: c.name })), directive: "nofiles" };
   if (flag?.name === "role")
     return { items: listDeclaredRoles().map((value) => ({ value, description: "declared role" })), directive: "nofiles" };
-  if (flag?.name === "config") return { items: [], directive: "default" };
+  if (flag?.name === "config") {
+    const current = argv[argv.length - 1] ?? "";
+    if (current.includes("/") || current.includes("\\") || current.endsWith(".md")) return { items: [], directive: "default" };
+    try {
+      return { items: personaItems(argv), directive: "nofiles" };
+    } catch {
+      return { items: [], directive: "nofiles" };
+    }
+  }
   if (flag && ["subscribe", "allow-subscribe", "allow-publish"].includes(flag.name))
     return { items: listDeclaredChannels().map((value) => ({ value, description: "declared channel" })), directive: "nofiles" };
   if (flag && ["cwd", "file", "creds"].includes(flag.name)) return { items: [], directive: "default" };
@@ -82,6 +92,11 @@ function personaItems(argv: string[]) {
     server: completedFlagValue(argv, spawnFlags, "server"),
   });
   return listPersonas(target.root).map((p) => ({ value: p.name }));
+}
+
+/** Persona selection precedence shared by foreground and detached spawn. */
+export function spawnPersonaRef(configFlag: string | undefined, positionals: readonly string[], env: NodeJS.ProcessEnv = process.env): string {
+  return configFlag ?? positionals[0] ?? defaultPersonaRef("default", env);
 }
 
 /**
@@ -179,10 +194,12 @@ async function spawnDetached(
   transcript: boolean | undefined,
 ): Promise<void> {
   // WHICH file the manager loads — the exact foreground precedence (`--config` > positional >
-  // `--name` > `default`); `--name` doubles as the ref fallback there too. Identity is separate:
+  // `COTAL_DEFAULT_PERSONA` > `default`). Identity is separate:
   // when `--name` is given it OVERRIDES the file's `name:` (foreground's `requested`), threaded
   // as the op's `identity` so it is never silently dropped in detached mode.
-  const ref = values.config ?? positionals[0] ?? values.name ?? "default";
+  const defaultPersona = defaultPersonaOverride();
+  const ref = spawnPersonaRef(values.config, positionals);
+  const managerConfigRef = values.config ?? (!positionals[0] && defaultPersona ? ref : undefined);
   const t = await resolveControlTarget(
     { space: values.space, server: values.server, creds: values.creds },
     "control-caller-privileged",
@@ -194,7 +211,7 @@ async function spawnDetached(
     identity: values.name,
     role: values.role,
     agent: values.agent ?? defaultAgentOverride(),
-    config: values.config,
+    config: managerConfigRef,
     model: values.model,
     cwd: values.cwd,
     resume: values.resume, // host-local session id; the manager preflights connector resume support
@@ -261,10 +278,11 @@ export async function spawn(args: ParsedArgs): Promise<void> {
   const target = await resolveTargetOrExit({ server: values.server, space: values.space });
   const { space, server, auth } = target;
 
-  // Where the config lives: --config, else the positional <name-or-path>, else --name
+  const defaultPersona = defaultPersonaOverride();
+  // Where the config lives: --config, else the positional <persona>, else COTAL_DEFAULT_PERSONA
   // (.cotal/agents/<name>.md under the TARGET mesh's root). With none, fall back to its `default`
   // persona — `cotal spawn` with no args launches `<root>/.cotal/agents/default.md`.
-  const ref = values.config ?? positionals[0] ?? values.name ?? "default";
+  const ref = spawnPersonaRef(values.config, positionals);
   const path = agentFilePath(target.root, ref);
   let def: AgentDef;
   try {
@@ -274,9 +292,9 @@ export async function spawn(args: ParsedArgs): Promise<void> {
     if (code === "ENOENT") {
       console.error(
         c.red(
-          ref === "default"
+          ref === "default" && !defaultPersona
             ? "✗ no default persona yet — run `cotal setup` to seed one, or name a persona: `cotal spawn <name>`"
-            : `✗ no persona "${ref}" in ${target.space}'s ${target.personaRoot} — use \`--config <path>\` for a file elsewhere`,
+            : `✗ no persona "${ref}"${!values.config && !positionals[0] && defaultPersona ? " from COTAL_DEFAULT_PERSONA" : ""} in ${target.space}'s ${target.personaRoot} — pass a catalog name, or use \`--config <path>\` for a file elsewhere`,
         ),
       );
     } else {
@@ -285,7 +303,7 @@ export async function spawn(args: ParsedArgs): Promise<void> {
     process.exit(1);
   }
 
-  // Provenance: say which persona file WON resolution (--config > positional > --name > default)
+  // Provenance: say which persona file WON resolution (--config > positional > COTAL_DEFAULT_PERSONA > default)
   // — the user must never wonder which directory their agent's definition came from.
   provenance.read("persona", path);
 

--- a/implementations/cli/src/index.ts
+++ b/implementations/cli/src/index.ts
@@ -223,8 +223,8 @@ const baseCommands: Command[] = [
     name: "spawn",
     group: "Agents",
     summary:
-      "launch an agent from a persona file — spawn [<name-or-path>] (defaults to the `default` persona); foreground in this terminal, or --detach via the manager — one grammar for both",
-    positionals: "[<name-or-path>]",
+      "launch an agent from a persona — spawn [<persona>] (defaults to COTAL_DEFAULT_PERSONA or `default`); --config accepts a persona name or path; foreground here, or --detach via the manager",
+    positionals: "[<persona>]",
     flags: spawnFlags,
     run: spawn,
     complete: spawnComplete,
@@ -242,7 +242,7 @@ const baseCommands: Command[] = [
     run: async () => {
       console.error(
         c.red(
-          "✗ `cotal start` was merged into `cotal spawn --detach` — one launch grammar for foreground and detached (persona positional or --name; --config/--model/--cwd/--prompt/--subscribe/--allow-*/--share-tools all apply)",
+          "✗ `cotal start` was merged into `cotal spawn --detach` — one launch grammar for foreground and detached (persona positional or --config; --name/--model/--cwd/--prompt/--subscribe/--allow-*/--share-tools all apply)",
         ),
       );
       process.exit(1);

--- a/packages/workspace/src/default-agent.ts
+++ b/packages/workspace/src/default-agent.ts
@@ -1,4 +1,5 @@
 export const DEFAULT_AGENT_ENV = "COTAL_DEFAULT_AGENT";
+export const DEFAULT_PERSONA_ENV = "COTAL_DEFAULT_PERSONA";
 
 /** The operator-level default connector/agent harness, when set. */
 export function defaultAgentOverride(env: NodeJS.ProcessEnv = process.env): string | undefined {
@@ -8,4 +9,14 @@ export function defaultAgentOverride(env: NodeJS.ProcessEnv = process.env): stri
 /** Resolve the default connector/agent harness with the product fallback for this launch path. */
 export function defaultAgentType(fallback: string, env: NodeJS.ProcessEnv = process.env): string {
   return defaultAgentOverride(env) ?? fallback;
+}
+
+/** The operator-level default persona ref (catalog name or path), when set. */
+export function defaultPersonaOverride(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  return env[DEFAULT_PERSONA_ENV]?.trim() || undefined;
+}
+
+/** Resolve the default persona ref with the product fallback. */
+export function defaultPersonaRef(fallback = "default", env: NodeJS.ProcessEnv = process.env): string {
+  return defaultPersonaOverride(env) ?? fallback;
 }

--- a/packages/workspace/src/flags.ts
+++ b/packages/workspace/src/flags.ts
@@ -24,8 +24,8 @@ export const targetFlags = [spaceFlag, serverFlag, credsFlag] as const satisfies
  * keeps it honest.
  */
 export const launchFlags = [
-  { name: "name", type: "string", value: "<n>", description: "presence name (defaults from the persona file)" },
-  { name: "config", type: "string", value: "<path>", description: "agent file path (for a file outside .cotal/agents)" },
+  { name: "name", type: "string", value: "<n>", description: "presence name override; does not choose the persona" },
+  { name: "config", type: "string", value: "<persona-or-path>", description: "persona catalog name or file path; defaults from COTAL_DEFAULT_PERSONA" },
   { name: "agent", type: "string", value: "<a>", description: "connector type (claude, opencode, hermes …); defaults from COTAL_DEFAULT_AGENT" },
   { name: "role", type: "string", value: "<r>", description: "role override (wins over the agent file's role:)" },
   { name: "model", type: "string", value: "<m>", description: "model override (wins over the agent file's model:)" },


### PR DESCRIPTION
## Summary
- add `COTAL_DEFAULT_PERSONA` as the fallback persona ref for bare `cotal spawn`
- keep `--config` as the explicit persona/catalog-or-path selector and clarify `--name` as identity-only
- cover foreground resolution, detached spawn behavior, completions, and docs

## Tests
- `pnpm smoke:spawn-from-anywhere`
- `pnpm smoke:cli-kernel`
- `pnpm smoke:flag-inventory`
- `pnpm smoke:launch-parity`
- `pnpm typecheck`
- `pnpm smoke:spawn-detach:live`
