### PR TITLE
feat(cli): install web extension during setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ cotal up --detach  # start the mesh (+ delivery daemon + manager)
 cotal spawn me     # drive a session: talk to your agent; it messages and spawns peers
 cotal spawn david  # bring in an expert teammate (also: sven, the guide)
 cotal console      # watch the mesh live: presence, channels, messages
-cotal web          # the same, in the browser (once: cotal ext add cotal-web)
+cotal web          # the same, in the browser (setup installs the web extension)
 cotal down         # stop everything
 ```
 

--- a/bin/smoke/setup-pure-live.smoke.ts
+++ b/bin/smoke/setup-pure-live.smoke.ts
@@ -3,18 +3,19 @@
  * REAL subprocess in a sandboxed COTAL_HOME with claude/opencode OFF the PATH, and must:
  *   A. exit 0 — configuring a machine never depends on (or mutates) running state;
  *   B. LAUNCH NOTHING — no broker appears on the default port, no manager pid file lands;
- *   C. WRITE the personas (david/sven/me/default) + the onboarded stamp, each announced with a
- *      provenance `→ wrote` line on stderr;
+ *   C. WRITE the personas (david/sven/me/default), install cotal-web in a sandboxed config dir,
+ *      and write the onboarded stamp, with persona/stamp writes announced on stderr;
  *   D. a REPEAT run (now onboarded) prints the status card, still launches nothing, and exits 0;
  *   E. the removed `--open` flag and the deleted `go` command fail loud.
  * Run: pnpm smoke:setup-pure:live
  */
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, symlinkSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 const home = mkdtempSync(join(tmpdir(), "cotal-setup-home-"));
+const configHome = mkdtempSync(join(tmpdir(), "cotal-setup-config-"));
 
 let pass = 0;
 const ok = (name: string, cond: boolean, extra?: unknown) => {
@@ -23,14 +24,16 @@ const ok = (name: string, cond: boolean, extra?: unknown) => {
   console.log(`  ✓ ${name}`);
 };
 
-// A minimal PATH: node reachable, but NO claude/opencode (setup must skip connector installs,
+// A minimal PATH: node/npm reachable, but NO claude/opencode (setup must skip connector installs,
 // not launch or prompt) and NO nats-server (locating falls back to the bundled binary; setup
 // must NOT need a runnable broker — it never starts one). The CLI is invoked by absolute
 // node + tsx entry, so the stripped PATH can't break the runner itself.
 const binDir = mkdtempSync(join(tmpdir(), "cotal-setup-bin-"));
 const realNode = spawnSync("which", ["node"], { encoding: "utf8" }).stdout.trim();
+const realNpm = spawnSync("which", ["npm"], { encoding: "utf8" }).stdout.trim();
 symlinkSync(realNode, join(binDir, "node"));
-const env = { ...process.env, COTAL_HOME: home, PATH: binDir, COTAL_SKIP_ASSIST: "1" };
+symlinkSync(realNpm, join(binDir, "npm"));
+const env = { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: configHome, PATH: binDir, COTAL_SKIP_ASSIST: "1" };
 const tsxCli = resolve(import.meta.dirname, "..", "..", "node_modules", "tsx", "dist", "cli.mjs");
 const binCotal = resolve(import.meta.dirname, "..", "cotal.ts");
 
@@ -56,6 +59,8 @@ for (const f of ["david.md", "sven.md", "me.md", "default.md"]) {
   ok(`persona ${f} written`, existsSync(join(proj, ".cotal", "agents", f)));
 }
 ok("onboarded stamp written", existsSync(join(home, "onboarded.json")));
+const extManifest = JSON.parse(readFileSync(join(configHome, "cotal", "extensions", "extensions.json"), "utf8"));
+ok("web extension installed in sandboxed config", extManifest.extensions?.some((e: { commands?: { name?: string }[] }) => e.commands?.some((c) => c.name === "web")) === true);
 ok("provenance announces persona writes", /→ wrote persona: .*david\.md/.test(first.stderr), first.stderr.slice(-500));
 ok("provenance announces the onboarded stamp", /→ wrote onboarded stamp/.test(first.stderr));
 

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -64,8 +64,7 @@ The rest:
 
 - **Observability.** Traces and presence live on the mesh, so any observer can render
   them: `cotal console` (terminal) or `cotal web` (browser dashboard with presence,
-  installed once via `cotal ext add cotal-web` —
-  channels, and a live feed; see [web.md](web.md)).
+  installed automatically by `cotal setup` — channels, and a live feed; see [web.md](web.md)).
 - **History & late join.** A late participant replays recent messages and the current
   roster, then goes live.
 - **Isolation.** Spaces do not see each other; many can run on one machine.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,7 +34,10 @@ and **starts nothing**. The first time, it walks you through:
 3. **Adds two experts plus your own session.** By default: **david**, the engineer (how
    Cotal works); **sven**, the guide (what to build); and **me**, the session you drive. It also
    seeds a generic `default` persona. Every file it writes is announced with a `→ wrote …` line.
-4. **Offers a global install.** Run via `npx` with no global `cotal`, it offers to
+4. **Installs the dashboard extension.** It runs the same installer as
+   `cotal ext add cotal-web`, so `cotal web` is available after setup. If npm or the
+   registry is unavailable, setup warns and tells you the retry command.
+5. **Offers a global install.** Run via `npx` with no global `cotal`, it offers to
    `npm i -g cotal-ai` so you can just type `cotal` (default yes).
 
 When it finishes, **nothing is running** — it prints the commands to start things. Bring the
@@ -43,7 +46,6 @@ stack up, then spawn an agent:
 ```bash
 cotal up --detach          # start the mesh + delivery daemon + manager (JWT-authed by default)
 cotal spawn me             # drive a session (or david / sven)
-cotal ext add cotal-web    # once: install the dashboard extension
 cotal web                  # open the browser dashboard
 cotal console              # watch the mesh live in this terminal
 cotal down                 # stop everything
@@ -67,7 +69,7 @@ cotal · status
 ✓ NATS     nats://127.0.0.1:4222
 ✓ plugin   installed
 ○ mesh     down — start: cotal up --detach
-○ web      not installed — add: cotal ext add cotal-web
+○ web      down — start: cotal web
 ○ manager  not running — spawns start it, or: cotal supervise
 ```
 
@@ -75,9 +77,10 @@ It probes the current folder — the mesh, the browser dashboard, and the manage
 plane behind `cotal_spawn` / `despawn` / `persona`) — and for anything down it shows the exact
 command to start it. It starts nothing itself; `cotal setup` only configures.
 
-The dashboard is an extension (`cotal ext add cotal-web`, once) and runs at
-`http://cotal.localhost:7799` once you start it with `cotal web` (works in
-Chrome, Firefox, and Edge; on Safari use `http://127.0.0.1:7799`).
+The dashboard is an extension that setup installs automatically. It runs at
+`http://cotal.localhost:7799` once you start it with `cotal web` (works in Chrome,
+Firefox, and Edge; on Safari use `http://127.0.0.1:7799`). If setup could not
+install it, retry with `cotal ext add cotal-web`.
 
 You drive Cotal through an agent: spawn one and talk to it. It has the tools to message
 peers, spawn teammates, and send feedback.
@@ -90,7 +93,7 @@ cotal spawn                          # the default agent (edit .cotal/agents/def
 cotal spawn me                       # the session you drive (consults david/sven)
 cotal spawn david                    # ask the engineer (or sven, the guide)
 cotal console --space main           # live mesh view in the terminal (TUI)
-cotal web --space main               # open the browser dashboard (cotal ext add cotal-web, once)
+cotal web --space main               # open the browser dashboard
 cotal down                           # stop the background mesh, delivery daemon, and manager
 ```
 

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -52,7 +52,7 @@ Save it as `cotal.yaml` and run:
 cotal topology view -f cotal.yaml      # validate + render the access graph (no broker needed)
 cotal up -f cotal.yaml                 # broker + channels + agents, all fresh
 cotal ps --space main                  # see the agents the manager booted
-cotal web --space main                 # ...or in the browser (once: cotal ext add cotal-web)
+cotal web --space main                 # ...or in the browser
 cotal down                             # stop the whole mesh
 ```
 

--- a/docs/protocol-view.md
+++ b/docs/protocol-view.md
@@ -16,7 +16,7 @@ re-implements the wire semantics. The wire is the source of truth; these are ren
 |---|---|---|---|
 | **console** | `cotal console` | interactive terminal: drive it, drill in | Ink / React (TTY) |
 | **stream** | `cotal console --plain`, pipes | passive line log: tail it, grep it, CI | plain ANSI |
-| **web** | `cotal web` (via `cotal ext add cotal-web`) | operator dashboard: see what needs you | HTTP + SSE, vanilla JS |
+| **web** | `cotal web` (setup-installed extension) | operator dashboard: see what needs you | HTTP + SSE, vanilla JS |
 
 `console` auto-selects: a real TTY gets the Ink TUI, a pipe or `--plain` gets the stream.
 The web dashboard is a **god-view** (it self-mints an

--- a/docs/setup-internals.md
+++ b/docs/setup-internals.md
@@ -92,11 +92,12 @@ fail-loud on collision.
   (`cotal_spawn`/`despawn`/`purge`/`persona`). Writes `.cotal/manager.pid` and
   `.cotal/manager.log`; `managerUp()` checks pid liveness for setup's status card.
 
-The **web dashboard** is *not* part of `cotal up` — it ships as the `cotal-web` extension
-(`cotal ext add cotal-web`); start it with `cotal web` (re-execs the CLI
-detached; `.cotal/web.pid` / `.cotal/web.log`), addressed as `http://cotal.localhost:7799` (binds
-loopback; `*.localhost` resolves in Chrome/Firefox/Edge, Safari may need plain `127.0.0.1`).
-`webUp()` probes the port for setup's status card.
+The **web dashboard** is *not* part of `cotal up` — it ships as the `cotal-web` extension.
+`cotal setup` installs it automatically by reusing the same path as `cotal ext add cotal-web`
+(best-effort; failed install leaves the manual retry command). Start it with `cotal web`
+(re-execs the CLI detached; `.cotal/web.pid` / `.cotal/web.log`), addressed as
+`http://cotal.localhost:7799` (binds loopback; `*.localhost` resolves in Chrome/Firefox/Edge,
+Safari may need plain `127.0.0.1`). `webUp()` probes the port for setup's status card.
 
 All re-execs resolve this CLI via `selfArgv()` / `selfCotal()`
 ([`lib/self-exec.ts`](../implementations/cli/src/lib/self-exec.ts)) = `[node, ...loaderFlags,

--- a/docs/web.md
+++ b/docs/web.md
@@ -1,7 +1,7 @@
 # `cotal web`: observability dashboard
 
-The dashboard ships as the `cotal-web` extension — install it once with
-`cotal ext add cotal-web` and the `web` command appears in the CLI.
+The dashboard ships as the `cotal-web` extension. `cotal setup` installs it automatically;
+if that failed, run `cotal ext add cotal-web` and the `web` command appears in the CLI.
 
 > A read-only browser **god-view** of one space: who is online, what they are doing, the
 > channels, the direct messages, and the live feed. It sees everything (chat, DMs, anycast),

--- a/implementations/cli/src/commands/setup.ts
+++ b/implementations/cli/src/commands/setup.ts
@@ -12,7 +12,7 @@ import { resolveNatsServer } from "../lib/nats-bin.js";
 import { isOnboarded, markOnboarded } from "../lib/onboard.js";
 import { machineStatus, meshStatus, onPath, webUp, WEB_URL } from "../lib/status.js";
 import { managerUp } from "../lib/manager-proc.js";
-import { cotalOnPath, displayCmd, isNpx } from "../lib/self-exec.js";
+import { cotalOnPath, displayCmd, isNpx, selfArgv } from "../lib/self-exec.js";
 import { cotalPath } from "../lib/paths.js";
 
 const ONBOARD_VERSION = "2";
@@ -109,6 +109,7 @@ async function runFirstRun(yes: boolean): Promise<void> {
   p.log.success("Added david (the engineer), sven (the guide), and your session (me); spawn them when your mesh is up");
   log.line("demo-agents: wrote david + sven + me");
 
+  await ensureWebExtension();
   await offerGlobalInstall(yes);
 
   markOnboarded(ONBOARD_VERSION);
@@ -233,6 +234,7 @@ function claudePluginStep(): Step {
  *  missing (announced). Nothing is launched — the card tells you what's down and how to start it. */
 async function runEnsure(): Promise<void> {
   seedDefaultAgent(); // ensure `cotal spawn` (no name) always has a default to launch
+  await ensureWebExtension();
   await readyCard(process.cwd());
 }
 
@@ -244,6 +246,33 @@ function webInstalled(): boolean {
   } catch {
     return false; // corrupt manifest — the card stays honest ("not installed"); `ext` commands surface the error
   }
+}
+
+/** Install the dashboard extension once, without turning setup into a launch command. This reuses the
+ *  public `ext add` path in a child process so package install, peer linking, command verification,
+ *  and manifest writes stay identical to an explicit `cotal ext add cotal-web`. Best-effort: setup is
+ *  still useful on locked-down machines where npm/registry access is unavailable. */
+async function ensureWebExtension(): Promise<void> {
+  if (webInstalled()) return;
+  const spec = defaultWebExtensionSpec();
+  const s = p.spinner();
+  s.start("Installing the web dashboard extension");
+  const [bin, ...argv] = selfArgv();
+  const r = spawnSync(bin, [...argv, "ext", "add", spec], { encoding: "utf8" });
+  if (r.status === 0) {
+    s.stop("Installed the web dashboard extension");
+    if (r.stderr) process.stderr.write(r.stderr);
+    if (r.stdout) process.stdout.write(r.stdout);
+    return;
+  }
+  s.stop("Couldn't install the web dashboard extension");
+  const tail = `${r.stdout ?? ""}${r.stderr ?? ""}`.trim().split("\n").slice(-6).join("\n");
+  p.log.warn(`${tail ? `${tail}\n\n` : ""}Install it later with ${dim(`${displayCmd()} ext add cotal-web`)}.`);
+}
+
+function defaultWebExtensionSpec(): string {
+  const local = join(import.meta.dirname, "..", "..", "..", "web");
+  return existsSync(join(local, "package.json")) ? local : "cotal-web";
 }
 
 /** The `cotal · status` one-glance card: machine + mesh + web + manager status (read-only
@@ -260,7 +289,7 @@ async function readyCard(cwd: string): Promise<void> {
       line(m.nats !== "missing", `NATS     ${dim(m.nats === "missing" ? "missing" : m.nats)}`),
       line(m.claudePlugin, `plugin   ${dim(m.claudePlugin ? "installed" : "not installed")}`),
       line(mesh.reachable, `mesh     ${dim(mesh.reachable ? `${mesh.server} · space ${mesh.space}` : `down — start: ${cmd} up --detach`)}`),
-      line(web, `web      ${dim(web ? WEB_URL : webInstalled() ? `down — start: ${cmd} web` : `not installed — add: ${cmd} ext add cotal-web`)}`),
+      line(web, `web      ${dim(web ? WEB_URL : webInstalled() ? `down — start: ${cmd} web` : `not installed — retry: ${cmd} setup`)}`),
       line(mgr, `manager  ${dim(mgr ? "running" : `not running — start: ${cmd} up, or: ${cmd} supervise`)}`),
       "",
       `start the mesh:  ${dim(`${cmd} up --detach`)}`,


### PR DESCRIPTION
## Summary
- have setup install the cotal-web extension through the same ext add path operators use
- keep setup configure-only: the dashboard command is installed, not launched
- update docs and setup smoke coverage for the setup-installed dashboard

## Tests
- pnpm build
- pnpm --filter @cotal-ai/cli typecheck
- pnpm smoke:setup-pure:live