### PR TITLE
feat(cli): make setup seed one agent by default

### DIFF
--- a/.changeset/tame-onboarding-setup.md
+++ b/.changeset/tame-onboarding-setup.md
@@ -1,5 +1,24 @@
 ---
+"cotal-ai": minor
+"@cotal-ai/core": minor
+"@cotal-ai/workspace": minor
 "@cotal-ai/cli": minor
+"@cotal-ai/manager": minor
+"@cotal-ai/delivery": minor
+"@cotal-ai/cmux": minor
+"@cotal-ai/tmux": minor
+"@cotal-ai/connector-core": minor
+"@cotal-ai/connector-claude-code": minor
+"@cotal-ai/connector-hermes": minor
+"@cotal-ai/connector-opencode": minor
+"cotal-web": minor
 ---
 
-Make `cotal setup` seed only the default persona by default, with the guided david/sven/me team behind `--demo` or `--full`.
+Release the 0.10 line with the onboarding and local-stack work since 0.9.1:
+
+- Rework the CLI around dispatcher-parsed commands, operator-installed extensions (`cotal ext`), and extension-packaged web/demo surfaces.
+- Make `cotal setup` configure-only: it checks prerequisites, installs the Claude plugin and web dashboard extension, seeds one default persona, and keeps the guided david/sven/me team behind `--demo` or `--full`.
+- Have `cotal up` own the local stack (broker, delivery daemon, and manager), with safer teardown, manifest launch handling, and automatic free-port selection for default-port collisions.
+- Collapse foreground and detached launches into one `spawn` grammar, with hardened manager readiness behavior and default persona / default agent environment overrides.
+- Strengthen auth, credential lifetime/rotation, delivery, and OpenCode cancellation handling.
+- Refresh README and getting-started onboarding around `npx cotal-ai setup`, then `cotal up --detach`, `cotal web`, `cotal spawn`, and `cotal down`.

--- a/.changeset/tame-onboarding-setup.md
+++ b/.changeset/tame-onboarding-setup.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/cli": minor
+---
+
+Make `cotal setup` seed only the default persona by default, with the guided david/sven/me team behind `--demo` or `--full`.

--- a/README.md
+++ b/README.md
@@ -77,46 +77,59 @@ JetStream has run in production for years. We didn't invent the hard parts.
 
 ## Quick start
 
-One command configures your machine — plugin, personas, connector — then a second brings up the
-local mesh:
+Cotal installs one command, `cotal`, that runs your own local web for agents. Install it, then
+configure your machine once:
 
 ```bash
-npx cotal-ai setup   # configure: needs Node 20+; NATS ships bundled — installs the plugin, seeds personas
-npx cotal-ai up      # start the mesh + delivery daemon + a detached manager
+npm i -g cotal-ai    # needs Node 20+ (a nats-server ships bundled)
+cotal setup          # one-time: checks, installs the Claude plugin, seeds one agent — launches nothing
 ```
 
-Guided setup, **configure-only**. The **first run** checks prerequisites (locates
-`nats-server` — bundled, or your own on PATH), lets you pick connectors (Claude installs a
-plugin; Codex/OpenCode auto-wire at spawn), and adds two experts plus your session: **david**
-the engineer, **sven** the guide, and **me**, the one you drive. It **launches nothing** and
-prints the commands to start things. If a step fails, it hands you to an interactive Claude
-with the failure context, then retries.
+> Just kicking the tires? `npx cotal-ai setup` runs without installing, and offers to add the global
+> `cotal` at the end (default yes) — the everyday commands below assume it's on your PATH.
 
-Then bring the mesh up with `cotal up`. It is **JWT-authed** by default (sender authenticity +
-per-agent ACLs, with the server-side delivery daemon for the durable backstop) and starts a
-detached **manager** alongside, so `cotal spawn --detach` works right after; pass `cotal up --open`
-for a frictionless open, loopback-only, live-only mesh (no auth, no daemon).
+`cotal setup` is **configure-only**: it gets your machine ready and **starts nothing**. The first run
+checks prerequisites (locates `nats-server` — bundled, or your own on PATH), installs the connector
+you pick (Claude installs a plugin; OpenCode auto-wires at spawn), and seeds **one agent**
+(`.cotal/agents/default.md`). If a step fails, it hands you to an interactive Claude with the failure
+context, then retries.
+
+Now bring up a mesh and talk to an agent — the whole loop is three commands:
+
+```bash
+cotal up --detach    # start the mesh + delivery daemon + a manager, in the background
+cotal spawn          # launch your agent in this terminal and talk to it (Ctrl-C to leave)
+cotal down           # stop everything
+```
+
+`cotal up` is **JWT-authed** by default (sender authenticity + per-agent ACLs, with the server-side
+delivery daemon for the durable backstop) and starts a detached **manager** alongside, so
+`cotal spawn --detach` / `cotal_spawn` work right after. Pass `cotal up --open` for a frictionless
+open, loopback-only, live-only mesh (no auth, no daemon).
+
+**The commands you'll use most:**
+
+```bash
+cotal spawn david    # a guided teammate (first: `cotal setup --demo` seeds david, sven, and me)
+cotal console        # watch the mesh live here: presence, channels, messages
+cotal web            # the same in the browser (setup installs the web extension)
+cotal down           # stop the background mesh, delivery daemon, and manager
+```
 
 > [!NOTE]
 > **Want each teammate in its own terminal?** Run the manager with `cotal supervise --runtime cmux`
 > (a **[cmux](https://cmux.com)** tab per agent) or `--runtime tmux` (a **[tmux](https://github.com/tmux/tmux/wiki)** window per agent). Otherwise they run in the
 > background on the same mesh, watched with `cotal console` or the dashboard.
 
-When you're all set up, here are the commands you'll use most:
-
-```bash
-cotal up --detach  # start the mesh (+ delivery daemon + manager)
-cotal spawn me     # drive a session: talk to your agent; it messages and spawns peers
-cotal spawn david  # bring in an expert teammate (also: sven, the guide)
-cotal console      # watch the mesh live: presence, channels, messages
-cotal web          # the same, in the browser (setup installs the web extension)
-cotal down         # stop everything
-```
-
 > [!TIP]
 > **Using a coding agent?** `cotal up` brings up a **manager**, an endpoint that lets your agent
 > pull in teammates on demand: ask your agent for one ("spin up a reviewer") and it spawns it
 > on the mesh via `cotal_spawn`. See [docs/claude-code-integration.md](docs/claude-code-integration.md).
+
+**Run it your way:** a whole team from one [`cotal.yaml` manifest](docs/manifest.md), agents in
+cmux/tmux panes, [OpenCode](extensions/connector-opencode) or [Hermes](extensions/connector-hermes)
+instead of Claude, or the guided expert team (`cotal setup --demo`). Start at
+[docs/getting-started.md](docs/getting-started.md).
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -77,26 +77,25 @@ JetStream has run in production for years. We didn't invent the hard parts.
 
 ## Quick start
 
-Cotal installs one command, `cotal`, for your local agent mesh. Install it, configure once,
-then start the mesh and watch an agent join:
+Cotal's guided setup is one command on a fresh machine:
 
 ```bash
-npm i -g cotal-ai  # needs Node 20+; a nats-server ships bundled
-cotal setup        # one-time configure: plugin, web dashboard, one default agent; starts nothing
+npx cotal-ai setup  # checks your machine, installs `cotal`, and configures your first agent mesh
+```
+
+It gets your machine ready and **starts nothing**: checks Node/NATS, lets you pick connectors
+(Claude installs a plugin; OpenCode auto-wires at spawn), installs the web dashboard extension,
+seeds one default agent, and offers to put `cotal` on your PATH. Then run:
+
+```bash
 cotal up --detach  # start the local mesh + delivery daemon + manager
 cotal web          # open the browser view of the mesh
 cotal spawn        # launch your default agent here and talk to it (Ctrl-C to leave)
 cotal down         # stop the mesh, delivery daemon, manager, and web
 ```
 
-> Just kicking the tires? `npx cotal-ai setup` runs without installing, and offers to add the global
-> `cotal` at the end (default yes) — the everyday commands below assume it's on your PATH.
-
-`cotal setup` is **configure-only**: it gets your machine ready and **starts nothing**. The first run
-checks prerequisites (locates `nats-server` — bundled, or your own on PATH), installs the connector
-you pick (Claude installs a plugin; OpenCode auto-wires at spawn), installs the dashboard extension,
-and seeds **one agent** (`.cotal/agents/default.md`). If a step fails, it hands you to an interactive
-Claude with the failure context, then retries.
+If setup hits a step it cannot finish, it hands you to an interactive Claude with the failure
+context, then retries.
 
 Once the mesh is up, `cotal web` and `cotal console` watch the same live space; `cotal spawn`
 launches the default agent in this terminal. `cotal up` is **JWT-authed** by default (sender

--- a/README.md
+++ b/README.md
@@ -77,12 +77,16 @@ JetStream has run in production for years. We didn't invent the hard parts.
 
 ## Quick start
 
-Cotal installs one command, `cotal`, that runs your own local web for agents. Install it, then
-configure your machine once:
+Cotal installs one command, `cotal`, for your local agent mesh. Install it, configure once,
+then start the mesh and watch an agent join:
 
 ```bash
-npm i -g cotal-ai    # needs Node 20+ (a nats-server ships bundled)
-cotal setup          # one-time: checks, installs the Claude plugin, seeds one agent — launches nothing
+npm i -g cotal-ai  # needs Node 20+; a nats-server ships bundled
+cotal setup        # one-time configure: plugin, web dashboard, one default agent; starts nothing
+cotal up --detach  # start the local mesh + delivery daemon + manager
+cotal web          # open the browser view of the mesh
+cotal spawn        # launch your default agent here and talk to it (Ctrl-C to leave)
+cotal down         # stop the mesh, delivery daemon, manager, and web
 ```
 
 > Just kicking the tires? `npx cotal-ai setup` runs without installing, and offers to add the global
@@ -90,30 +94,21 @@ cotal setup          # one-time: checks, installs the Claude plugin, seeds one a
 
 `cotal setup` is **configure-only**: it gets your machine ready and **starts nothing**. The first run
 checks prerequisites (locates `nats-server` — bundled, or your own on PATH), installs the connector
-you pick (Claude installs a plugin; OpenCode auto-wires at spawn), and seeds **one agent**
-(`.cotal/agents/default.md`). If a step fails, it hands you to an interactive Claude with the failure
-context, then retries.
+you pick (Claude installs a plugin; OpenCode auto-wires at spawn), installs the dashboard extension,
+and seeds **one agent** (`.cotal/agents/default.md`). If a step fails, it hands you to an interactive
+Claude with the failure context, then retries.
 
-Now bring up a mesh and talk to an agent — the whole loop is three commands:
+Once the mesh is up, `cotal web` and `cotal console` watch the same live space; `cotal spawn`
+launches the default agent in this terminal. `cotal up` is **JWT-authed** by default (sender
+authenticity + per-agent ACLs, with the server-side delivery daemon for the durable backstop). Pass
+`cotal up --open` for a frictionless open, loopback-only, live-only mesh (no auth, no daemon).
 
-```bash
-cotal up --detach    # start the mesh + delivery daemon + a manager, in the background
-cotal spawn          # launch your agent in this terminal and talk to it (Ctrl-C to leave)
-cotal down           # stop everything
-```
-
-`cotal up` is **JWT-authed** by default (sender authenticity + per-agent ACLs, with the server-side
-delivery daemon for the durable backstop) and starts a detached **manager** alongside, so
-`cotal spawn --detach` / `cotal_spawn` work right after. Pass `cotal up --open` for a frictionless
-open, loopback-only, live-only mesh (no auth, no daemon).
-
-**The commands you'll use most:**
+Want the guided team too? Add it explicitly, then spawn the teammates you want:
 
 ```bash
-cotal spawn david    # a guided teammate (first: `cotal setup --demo` seeds david, sven, and me)
-cotal console        # watch the mesh live here: presence, channels, messages
-cotal web            # the same in the browser (setup installs the web extension)
-cotal down           # stop the background mesh, delivery daemon, and manager
+cotal setup --demo  # add david (engineer), sven (guide), and me (driving session)
+cotal spawn david   # or: cotal spawn sven / cotal spawn me
+cotal console       # terminal view of presence, channels, and messages
 ```
 
 > [!NOTE]

--- a/bin/smoke/setup-pure-live.smoke.ts
+++ b/bin/smoke/setup-pure-live.smoke.ts
@@ -3,10 +3,11 @@
  * REAL subprocess in a sandboxed COTAL_HOME with claude/opencode OFF the PATH, and must:
  *   A. exit 0 — configuring a machine never depends on (or mutates) running state;
  *   B. LAUNCH NOTHING — no broker appears on the default port, no manager pid file lands;
- *   C. WRITE the personas (david/sven/me/default), install cotal-web in a sandboxed config dir,
- *      and write the onboarded stamp, with persona/stamp writes announced on stderr;
- *   D. a REPEAT run (now onboarded) prints the status card, still launches nothing, and exits 0;
- *   E. the removed `--open` flag and the deleted `go` command fail loud.
+ *   C. WRITE the default persona, install cotal-web in a sandboxed config dir, and write the
+ *      onboarded stamp, with persona/stamp writes announced on stderr;
+ *   D. `setup --demo` on an onboarded machine writes the guided team;
+ *   E. a REPEAT run (now onboarded) prints the status card, still launches nothing, and exits 0;
+ *   F. the removed `--open` flag and the deleted `go` command fail loud.
  * Run: pnpm smoke:setup-pure:live
  */
 import { spawnSync } from "node:child_process";
@@ -54,23 +55,33 @@ ok("no manager pid file", !existsSync(join(home, "manager.pid")));
 ok("no nats/delivery logs (nothing started)", !existsSync(join(home, "nats.log")) && !existsSync(join(home, "delivery.log")));
 ok("output never claims to start anything", !/running at|manager up|mesh running/i.test(first.stdout + first.stderr), (first.stdout + first.stderr).slice(-300));
 
-// C — the writes happened (in the INVOKING folder's .cotal) and were announced.
-for (const f of ["david.md", "sven.md", "me.md", "default.md"]) {
-  ok(`persona ${f} written`, existsSync(join(proj, ".cotal", "agents", f)));
+// C — the default persona write happened (in the INVOKING folder's .cotal) and was announced.
+ok("default persona written", existsSync(join(proj, ".cotal", "agents", "default.md")));
+for (const f of ["david.md", "sven.md", "me.md"]) {
+  ok(`demo persona ${f} not written by default`, !existsSync(join(proj, ".cotal", "agents", f)));
 }
 ok("onboarded stamp written", existsSync(join(home, "onboarded.json")));
 const extManifest = JSON.parse(readFileSync(join(configHome, "cotal", "extensions", "extensions.json"), "utf8"));
 ok("web extension installed in sandboxed config", extManifest.extensions?.some((e: { commands?: { name?: string }[] }) => e.commands?.some((c) => c.name === "web")) === true);
-ok("provenance announces persona writes", /→ wrote persona: .*david\.md/.test(first.stderr), first.stderr.slice(-500));
+ok("provenance announces default persona write", /→ wrote default persona: .*default\.md/.test(first.stderr), first.stderr.slice(-500));
 ok("provenance announces the onboarded stamp", /→ wrote onboarded stamp/.test(first.stderr));
 
-// D — repeat run: status card, still nothing launched, exit 0.
+// D — `--demo` on an already-configured machine adds the guided team without launching anything.
+const demo = cotal(["setup", "--demo"], proj);
+ok("demo setup exits 0", demo.status === 0, { status: demo.status, err: demo.stderr.slice(-300) });
+for (const f of ["david.md", "sven.md", "me.md"]) {
+  ok(`demo persona ${f} written`, existsSync(join(proj, ".cotal", "agents", f)));
+}
+ok("demo provenance announces persona writes", /→ wrote persona: .*david\.md/.test(demo.stderr), demo.stderr.slice(-500));
+ok("demo setup still launches nothing", !existsSync(join(home, "manager.pid")) && !existsSync(join(home, "nats.log")));
+
+// E — repeat run: status card, still nothing launched, exit 0.
 const second = cotal(["setup"], proj);
 ok("repeat run exits 0", second.status === 0, { status: second.status, err: second.stderr.slice(-300) });
 ok("repeat run shows the status card", /cotal · status/.test(second.stdout + second.stderr), (second.stdout + second.stderr).slice(-300));
 ok("repeat run still launches nothing", !existsSync(join(home, "manager.pid")) && !existsSync(join(home, "nats.log")));
 
-// E — removed surface fails loud.
+// F — removed surface fails loud.
 const open = cotal(["setup", "--open"], proj);
 ok("removed --open flag errors", open.status === 1 && /Unknown option/.test(open.stderr), open.stderr.slice(0, 200));
 const go = cotal(["go"], proj);

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -37,12 +37,13 @@ happens to be on the mesh.
 **Two commands:**
 
 ```
-cotal setup      # one-time: installs the plugin, seeds personas — launches nothing
+cotal setup      # one-time: installs the plugin, seeds one agent — launches nothing
 cotal up         # brings up the mesh + delivery daemon + a detached manager
 ```
 
 `cotal setup` configures your machine — it installs the cotal plugin (so the repo's Claude
-sessions get the `cotal_*` tools) and seeds the demo personas — and launches nothing. `cotal up`
+sessions get the `cotal_*` tools) and seeds one `default` persona (add the guided david/sven/me
+team with `cotal setup --demo`) — and launches nothing. `cotal up`
 then brings up the whole local stack: the broker, the delivery daemon, and a detached manager, so
 `cotal spawn --detach` / `cotal_spawn` work right away. Use `cotal_persona` to mint a teammate,
 `cotal_spawn` to bring it online, and `cotal_despawn` to tear it down. Re-running either is
@@ -50,7 +51,7 @@ idempotent.
 
 Under the hood these are the existing pieces, so you can also run them by hand:
 
-- `cotal setup` (one-time plugin install + persona seed)
+- `cotal setup` (one-time plugin install + one-agent seed; `--demo` adds the guided team)
 - `cotal up` (broker + delivery daemon + manager) — add `--open` for an unauthenticated dev mesh
 - `cotal supervise --runtime cmux --space <s>` (a manager with each teammate in its own cmux tab; drop `--runtime` for the default pty runtime)
 - `cotal spawn <name> --space <s>` (a foreground Claude on the mesh; a bare name with no

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,14 +6,14 @@ This page is the fastest way to a running local mesh.
 ## Install and run
 
 ```bash
-npm install -g cotal-ai   # recommended: puts `cotal` on your PATH
-cotal                      # runs setup
+npm install -g cotal-ai   # puts `cotal` on your PATH (needs Node 20+)
+cotal setup                # one-time, configure-only — launches nothing
 ```
 
-Prefer `npx`? `npx cotal-ai` works too. Setup then offers to install `cotal` globally
-(default yes) so you can just type `cotal`. Decline and the hints stay `npx cotal-ai …`;
-everything still works, because the background processes `cotal up` starts invoke their own
-resolved path, not a global `cotal`.
+Bare `cotal` prints help; `cotal setup` runs guided setup. Prefer `npx`? `npx cotal-ai setup`
+works too, and offers to install the global `cotal` at the end (default yes) so you can just type
+`cotal`. Decline and the hints stay `npx cotal-ai …`; everything still works, because the background
+processes `cotal up` starts invoke their own resolved path, not a global `cotal`.
 
 Requirements:
 
@@ -23,7 +23,7 @@ Requirements:
 
 ## First run
 
-`cotal` with no command runs `setup`. Setup is **configure-only** — it gets your machine ready
+`cotal setup` runs guided setup. Setup is **configure-only** — it gets your machine ready
 and **starts nothing**. The first time, it walks you through:
 
 1. **Checks.** Verifies Node 20+ and **locates** a `nats-server` (bundled, or your own on PATH —
@@ -31,9 +31,10 @@ and **starts nothing**. The first time, it walks you through:
 2. **Picks connectors.** Choose which agents join your web (Claude or OpenCode; detected
    ones are pre-selected). Claude installs a plugin, because its wake channel needs one.
    OpenCode needs no install; it auto-wires when you `cotal spawn` it.
-3. **Adds two experts plus your own session.** By default: **david**, the engineer (how
-   Cotal works); **sven**, the guide (what to build); and **me**, the session you drive. It also
-   seeds a generic `default` persona. Every file it writes is announced with a `→ wrote …` line.
+3. **Seeds one agent.** The generic `default` persona a bare `cotal spawn` launches — yours to
+   shape. Want a guided team to talk to instead? `cotal setup --demo` also seeds **david** (the
+   engineer, how Cotal works), **sven** (the guide, what to build), and **me** (the session you
+   drive). Every file it writes is announced with a `→ wrote …` line.
 4. **Installs the dashboard extension.** It runs the same installer as
    `cotal ext add cotal-web`, so `cotal web` is available after setup. If npm or the
    registry is unavailable, setup warns and tells you the retry command.
@@ -41,15 +42,17 @@ and **starts nothing**. The first time, it walks you through:
    `npm i -g cotal-ai` so you can just type `cotal` (default yes).
 
 When it finishes, **nothing is running** — it prints the commands to start things. Bring the
-stack up, then spawn an agent:
+mesh up and talk to your agent — the whole loop is three commands:
 
 ```bash
 cotal up --detach          # start the mesh + delivery daemon + manager (JWT-authed by default)
-cotal spawn me             # drive a session (or david / sven)
-cotal web                  # open the browser dashboard
-cotal console              # watch the mesh live in this terminal
+cotal spawn                # launch your agent here and talk to it (Ctrl-C to leave)
 cotal down                 # stop everything
 ```
+
+Open the browser dashboard with `cotal web` (setup installs the extension; if it warned, retry with
+`cotal ext add cotal-web`). Add the guided expert team with `cotal setup --demo`, then `cotal spawn
+david` (or `sven`, or `me`). Watch the mesh in this terminal anytime with `cotal console`.
 
 `cotal up` is **JWT-authed** by default (sender authenticity + per-agent ACLs), the
 **server-side delivery daemon** comes up with it for the durable backstop, and a detached
@@ -62,7 +65,7 @@ failure context. Type `/exit` to return, and it retries.
 
 ## After the first run
 
-Every later `cotal` prints a **read-only status card**:
+Every later `cotal setup` prints a **read-only status card**:
 
 ```
 cotal · status
@@ -70,7 +73,7 @@ cotal · status
 ✓ plugin   installed
 ○ mesh     down — start: cotal up --detach
 ○ web      down — start: cotal web
-○ manager  not running — spawns start it, or: cotal supervise
+○ manager  not running — start: cotal up, or: cotal supervise
 ```
 
 It probes the current folder — the mesh, the browser dashboard, and the manager (the control
@@ -89,9 +92,8 @@ Prefer commands?
 
 ```bash
 cotal up --detach                    # start the mesh + delivery daemon + manager
-cotal spawn                          # the default agent (edit .cotal/agents/default.md)
-cotal spawn me                       # the session you drive (consults david/sven)
-cotal spawn david                    # ask the engineer (or sven, the guide)
+cotal spawn                          # your agent (edit .cotal/agents/default.md)
+cotal spawn david                    # a guided expert — needs `cotal setup --demo` first (also sven, me)
 cotal console --space main           # live mesh view in the terminal (TUI)
 cotal web --space main               # open the browser dashboard
 cotal down                           # stop the background mesh, delivery daemon, and manager
@@ -108,13 +110,14 @@ or `COTAL_DEFAULT_AGENT=hermes` to change the default harness for spawns that do
 Feedback flows through your agent too: tell it "send feedback: ..." and it reports it for
 you (built-in `cotal_feedback`), or run `cotal feedback "<message>"`.
 
-Run `cotal setup --full` to redo the full guided flow, for example to repair something.
+`cotal setup --demo` adds the guided team (david, sven, me) to an already-configured machine.
+`cotal setup --full` redoes the whole guided flow (team included), for example to repair something.
 
 ## Launch a team from a manifest
 
-The guided flow gives you the default experts. To run a **specific team** instead — your own
-channels, agents, and who may read and post where — describe it once in a `cotal.yaml` (copy the
-runnable starter from **[manifest.md](manifest.md)**) and launch it:
+The guided flow gives you one agent (or the expert team with `--demo`). To run a **specific team**
+instead — your own channels, agents, and who may read and post where — describe it once in a
+`cotal.yaml` (copy the runnable starter from **[manifest.md](manifest.md)**) and launch it:
 
 ```bash
 cotal topology view -f cotal.yaml    # validate + see the access graph (no broker needed)
@@ -138,11 +141,11 @@ npx cotal-ai setup --yes     # configure: install the plugin + seed personas (la
 npx cotal-ai up --detach     # start the mesh + delivery daemon + manager
 ```
 
-`setup --yes` accepts every default with no prompts — it installs the plugin, writes the experts
-and your driving session, and exits non-zero with the log path if a step fails, so an agent or a
-CI job can check the result. It launches nothing. `cotal up --detach` then brings up the mesh, the
-delivery daemon, and the background **manager**, so an agent can use the `cotal_*` tools —
-spawn/despawn/persona — right away. `cotal down` stops the background processes.
+`setup --yes` accepts every default with no prompts — it installs the plugin, seeds your default
+agent, and exits non-zero with the log path if a step fails, so an agent or a CI job can check the
+result (add `--demo` for the guided david/sven/me team). It launches nothing. `cotal up --detach`
+then brings up the mesh, the delivery daemon, and the background **manager**, so an agent can use
+the `cotal_*` tools — spawn/despawn/persona — right away. `cotal down` stops the background processes.
 
 ## Extending the CLI
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,9 +11,9 @@ cotal setup                # one-time, configure-only — launches nothing
 ```
 
 Bare `cotal` prints help; `cotal setup` runs guided setup. Prefer `npx`? `npx cotal-ai setup`
-works too, and offers to install the global `cotal` at the end (default yes) so you can just type
-`cotal`. Decline and the hints stay `npx cotal-ai …`; everything still works, because the background
-processes `cotal up` starts invoke their own resolved path, not a global `cotal`.
+works too, and offers to install the global `cotal` at the end so you can just type `cotal`.
+Decline and the hints stay `npx cotal-ai …`; everything still works, because the background processes
+`cotal up` starts invoke their own resolved path, not a global `cotal`.
 
 Requirements:
 
@@ -39,7 +39,7 @@ and **starts nothing**. The first time, it walks you through:
    `cotal ext add cotal-web`, so `cotal web` is available after setup. If npm or the
    registry is unavailable, setup warns and tells you the retry command.
 5. **Offers a global install.** Run via `npx` with no global `cotal`, it offers to
-   `npm i -g cotal-ai` so you can just type `cotal` (default yes).
+   `npm i -g cotal-ai` so you can just type `cotal`.
 
 When it finishes, **nothing is running** — it prints the commands to start things. Bring the
 mesh up and talk to your agent — the whole loop is three commands:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -137,7 +137,7 @@ created). See
 A coding agent can set Cotal up for you with two non-interactive commands:
 
 ```bash
-npx cotal-ai setup --yes     # configure: install the plugin + seed personas (launches nothing)
+npx cotal-ai setup --yes     # configure: install the plugin + seed one agent (launches nothing)
 npx cotal-ai up --detach     # start the mesh + delivery daemon + manager
 ```
 

--- a/implementations/cli/src/commands/setup.ts
+++ b/implementations/cli/src/commands/setup.ts
@@ -25,7 +25,8 @@ const NATS_RELEASES_URL = "https://github.com/nats-io/nats-server/releases";
  *  mesh mode is `cotal up [--open]`'s concern (where `--open` already lived; `--auth` simply died
  *  with the launch behavior). An unknown-option error rejects them, nothing silently. */
 export const setupFlags = [
-  { name: "full", type: "boolean", description: "redo the full guided flow" },
+  { name: "full", type: "boolean", description: "redo the full guided flow (implies --demo)" },
+  { name: "demo", type: "boolean", description: "also seed the guided expert team (david, sven, me)" },
   { name: "yes", type: "boolean", short: "y", description: "non-interactive accept-all (agents/CI)" },
 ] as const satisfies readonly FlagSpec[];
 
@@ -35,18 +36,21 @@ export const setupFlags = [
  * no web, no manager, no delivery daemon, no cmux/tmux session — launching is `cotal up` /
  * `cotal web` / `cotal supervise`). Every file it writes is announced (`→ wrote …`). First run
  * (no onboarded stamp) gets the full narrated flow; later runs get a status card. `--full`
- * forces the full flow. Each failed step offers an interactive Claude handoff
- * (COTAL_SKIP_ASSIST=1 disables).
+ * forces the full flow. By default it seeds ONE agent (the `default` persona a bare `cotal spawn`
+ * launches); the guided expert team (david/sven/me) is opt-in via `--demo` (and `--full`). Each
+ * failed step offers an interactive Claude handoff (COTAL_SKIP_ASSIST=1 disables).
  */
 export async function setup(args: ParsedArgs): Promise<void> {
   const values = args.values as FlagValues<typeof setupFlags>;
-  if (!isOnboarded() || values.full || values.yes) await runFirstRun(Boolean(values.yes));
-  else await runEnsure();
+  const demo = Boolean(values.demo) || Boolean(values.full); // --full is the whole guided flow ⇒ team
+  if (!isOnboarded() || values.full || values.yes) await runFirstRun(Boolean(values.yes), demo);
+  else await runEnsure(demo);
 }
 
-/** The full, narrated first-run experience. `yes` = non-interactive accept-all. Configure-only:
- *  prerequisites are CHECKED (never started); the finale tells the user what to run. */
-async function runFirstRun(yes: boolean): Promise<void> {
+/** The full, narrated first-run experience. `yes` = non-interactive accept-all; `demo` also seeds
+ *  the guided expert team. Configure-only: prerequisites are CHECKED (never started); the finale
+ *  tells the user what to run. */
+async function runFirstRun(yes: boolean, demo: boolean): Promise<void> {
   splash();
   p.intro(brandBold("Welcome to Cotal"));
   note(
@@ -98,16 +102,14 @@ async function runFirstRun(yes: boolean): Promise<void> {
     }
   }
 
-  // Two experts plus your own driving session, by default. These are setup-managed: refreshed when
-  // DEMO_AGENTS changes (so persona edits actually land), but a file you've taken ownership of is
-  // backed up first, never silently lost — see writeDemoAgent. Every write is announced.
-  mkdirSync(cotalPath("agents"), { recursive: true });
-  for (const [name, body] of Object.entries(DEMO_AGENTS)) {
-    writeDemoAgent(cotalPath("agents", `${name}.md`), body);
-  }
-  seedDefaultAgent(); // the generic persona `cotal spawn` (no name) launches
-  p.log.success("Added david (the engineer), sven (the guide), and your session (me); spawn them when your mesh is up");
-  log.line("demo-agents: wrote david + sven + me");
+  // Your agent: the generic `default` persona a bare `cotal spawn` launches — one agent, yours to
+  // shape. This is the whole first-run default; the guided expert team is opt-in right below.
+  seedDefaultAgent();
+  p.log.success("Seeded your agent (.cotal/agents/default.md) — spawn it with `cotal spawn` once your mesh is up");
+  log.line("default-agent: wrote default.md");
+  // The guided expert team (david the engineer + sven the guide + me, your session) is opt-in:
+  // `cotal setup --demo` (or `--full`). Keeps the default first run to one agent, not a crowd.
+  if (demo) seedDemoTeam(log);
 
   await ensureWebExtension();
   await offerGlobalInstall(yes);
@@ -115,17 +117,35 @@ async function runFirstRun(yes: boolean): Promise<void> {
   markOnboarded(ONBOARD_VERSION);
   provenance.wrote("onboarded stamp", join(homeCotalDir(), "onboarded.json"));
   const cmd = displayCmd();
+  // The finale is the whole loop, minimal by default: start the mesh, talk to your one agent, stop.
+  // With --demo it names the team; without, it points at --demo (and the optional dashboard).
+  const driveLines = demo
+    ? [
+        `${ok("✓")} start the mesh      ${dim(`${cmd} up --detach`)}`,
+        `${ok("✓")} drive a session     ${dim(`${cmd} spawn me`)}`,
+        `${ok("✓")} ask the experts     ${dim(`${cmd} spawn david · ${cmd} spawn sven`)}`,
+        `${ok("✓")} watch the mesh      ${dim(`${cmd} console`)}`,
+        `${ok("✓")} stop everything     ${dim(`${cmd} down`)}`,
+      ]
+    : [
+        `${ok("✓")} start the mesh      ${dim(`${cmd} up --detach`)}`,
+        `${ok("✓")} talk to your agent  ${dim(`${cmd} spawn`)}`,
+        `${ok("✓")} watch the mesh      ${dim(`${cmd} console`)}`,
+        `${ok("✓")} stop everything     ${dim(`${cmd} down`)}`,
+      ];
+  const tail = demo
+    ? [dim(`Visual dashboard: ${cmd} ext add cotal-web · then ${cmd} web`)]
+    : [
+        dim(`Want a visual dashboard? ${cmd} ext add cotal-web · then ${cmd} web`),
+        dim(`Want a guided team (david the engineer, sven the guide)? ${cmd} setup --demo`),
+      ];
   note(
     [
       "Everything is configured — nothing has been started. Bring your mesh up when you're ready:",
       "",
-      `${ok("✓")} start the mesh      ${dim(`${cmd} up --detach`)}`,
-      `${ok("✓")} open the dashboard  ${dim(`${cmd} web`)}`,
-      `${ok("✓")} drive a session     ${dim(`${cmd} spawn me`)}`,
-      `${ok("✓")} ask the experts     ${dim(`${cmd} spawn david · ${cmd} spawn sven`)}`,
-      `${ok("✓")} watch the mesh      ${dim(`${cmd} console`)}`,
-      `${ok("✓")} stop everything     ${dim(`${cmd} down`)}`,
+      ...driveLines,
       "",
+      ...tail,
       dim(`Cotal not working? Tell your agent to send feedback (built-in cotal_feedback), or run ${cmd} feedback "<msg>".`),
     ].join("\n"),
     "You're set",
@@ -231,9 +251,11 @@ function claudePluginStep(): Step {
 }
 
 /** The compact repeat-run: a one-glance status card, plus re-seeding the default persona if it's
- *  missing (announced). Nothing is launched — the card tells you what's down and how to start it. */
-async function runEnsure(): Promise<void> {
+ *  missing (announced). Nothing is launched — the card tells you what's down and how to start it.
+ *  `--demo` here adds the guided team to an already-configured machine (no need to re-narrate). */
+async function runEnsure(demo: boolean): Promise<void> {
   seedDefaultAgent(); // ensure `cotal spawn` (no name) always has a default to launch
+  if (demo) seedDemoTeam(); // `cotal setup --demo` on a configured machine: add the team, then card
   await ensureWebExtension();
   await readyCard(process.cwd());
 }
@@ -283,6 +305,7 @@ async function readyCard(cwd: string): Promise<void> {
   const web = await webUp();
   const mgr = managerUp();
   const cmd = displayCmd();
+  const hasDemo = existsSync(cotalPath("agents", "david.md")); // the guided team is present ⇒ richer hint
   const line = (on: boolean, text: string) => `${on ? ok("✓") : dim("○")} ${text}`;
   note(
     [
@@ -293,7 +316,10 @@ async function readyCard(cwd: string): Promise<void> {
       line(mgr, `manager  ${dim(mgr ? "running" : `not running — start: ${cmd} up, or: ${cmd} supervise`)}`),
       "",
       `start the mesh:  ${dim(`${cmd} up --detach`)}`,
-      `drive it:        ${dim(`${cmd} spawn me`)}   ${dim("(or david / sven)")}`,
+      // Match the hint to what's actually on disk: the guided team (with --demo) vs the one default agent.
+      hasDemo
+        ? `drive it:        ${dim(`${cmd} spawn me`)}   ${dim("(or david / sven)")}`
+        : `drive it:        ${dim(`${cmd} spawn`)}   ${dim("(talk to your agent · guided team: " + cmd + " setup --demo)")}`,
       `watch it:        ${dim(`${cmd} console`)}   ${dim("(live TUI in this terminal)")}`,
       `more:            ${dim(`${cmd} web · ${cmd} down · ${cmd} feedback "<msg>" · ${cmd} --help`)}`,
     ].join("\n"),
@@ -402,6 +428,20 @@ function seedDefaultAgent(): void {
   mkdirSync(cotalPath("agents"), { recursive: true });
   writeFileSync(path, DEFAULT_AGENT);
   provenance.wrote("default persona", path);
+}
+
+/** Seed the guided expert team — david (the engineer), sven (the guide), me (your session) — the
+ *  opt-in richer first experience (`cotal setup --demo` / `--full`). These are setup-managed, unlike
+ *  the seed-once default: refreshed when a DEMO_AGENTS body changes so persona edits actually land,
+ *  but a file you've taken ownership of is backed up first, never silently lost (see writeDemoAgent).
+ *  Every write is announced; `log` (present only in the narrated first run) also records it. */
+function seedDemoTeam(log?: { line(msg: string): void }): void {
+  mkdirSync(cotalPath("agents"), { recursive: true });
+  for (const [name, body] of Object.entries(DEMO_AGENTS)) {
+    writeDemoAgent(cotalPath("agents", `${name}.md`), body);
+  }
+  p.log.success("Added the guided team — david (the engineer), sven (the guide), and your session (me); spawn them when your mesh is up");
+  log?.line("demo-agents: wrote david + sven + me");
 }
 
 const DEMO_AGENTS: Record<string, string> = {


### PR DESCRIPTION
## Summary
- make `cotal setup` seed only the generic default persona by default
- gate the guided david/sven/me team behind `cotal setup --demo` / `--full`
- update onboarding docs and setup smoke coverage for the default, demo, and web-extension setup paths

## Verification
- `pnpm typecheck`
- `pnpm smoke:setup-pure:live`