### PR TITLE
feat(console): registry-first run-anywhere overview with a mesh picker

### DIFF
--- a/docs/watch-a-mesh.md
+++ b/docs/watch-a-mesh.md
@@ -28,11 +28,14 @@ cotal console                    # no --space on an open mesh → the admin over
 
 ![The cotal console: a live roster of agents and their all-activity feed in a terminal TUI](../assets/quickstart.gif)
 
-**Admin overview.** On an open mesh, `cotal console` with **no `--space`** opens a space picker:
-every space on the server (enumerated from its `CHAT_*` streams and presence buckets) with its
-agents, channels, and message counts. Pick one to drop into its console; `b` returns to the
-overview. `--space X` skips the picker. Under auth a server hosts a single space, so the console
-enters it directly (no overview).
+**Admin overview.** A bare `cotal console` is the run-anywhere view: it resolves from the mesh
+registry **only**, never the cwd, so a stray local `.cotal/` can neither hijack nor block it.
+With several meshes registered it opens a mesh picker first: every broker on the machine (space,
+server, mode, root); pick one to connect, `b` returns. On an open mesh with no `--space` a space
+picker follows: every space on the server (enumerated from its `CHAT_*` streams and presence
+buckets) with its agents, channels, and message counts; pick one to drop into its console.
+`--space X` skips the pickers. Under auth a server hosts a single space, so the console enters
+it directly (no space overview).
 
 **Lenses and keys** (TUI). The layout is a roster, a live feed, per-channel tabs, a golden-signal
 tiles strip, and toggleable lenses:

--- a/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
+++ b/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
@@ -25,8 +25,10 @@ const {
   loadMeshes,
   meshesDir,
   recordMesh,
+  registryTarget,
   removeMesh,
   resolveMeshTarget,
+  resolveRegistryTarget,
   setCurrent,
 } = await import("@cotal-ai/workspace");
 const { spawnComplete, spawnPersonaRef } = await import("../src/commands/spawn.js");
@@ -61,6 +63,8 @@ try {
   // 0 meshes → a bare resolve fails with one sentence, not a crash.
   assert.throws(() => resolveMeshTarget(neutral), /no mesh running/);
   check("0 meshes: resolve throws 'no mesh running'", true);
+  assert.throws(() => resolveRegistryTarget(), /no mesh running/);
+  check("0 meshes: registry-only resolve throws too", true);
 
   // …but completion must FAIL CLOSED, never throw — offer nothing rather than crash the shell.
   const prevCwd0 = process.cwd();
@@ -184,6 +188,22 @@ try {
     (e: Error) => /another mesh/.test(e.message) && /is running at/.test(e.message),
   );
   check("local project w/o its own entry won't silently join a mesh on the default port", true);
+
+  // Registry-ONLY resolution (the console's run-anywhere overview): the SAME stray local project
+  // that blocks resolveMeshTarget above neither hijacks nor blocks it — it takes no cwd at all.
+  const regCur = resolveRegistryTarget();
+  check("registry-only: N + current → 'current'", regCur.source === "current" && regCur.root === projB, regCur);
+  clearCurrent();
+  assert.throws(
+    () => resolveRegistryTarget(),
+    (e: unknown) => isWorkspaceTargetError(e) && e.code === "ambiguous-target",
+  );
+  check("registry-only: N without current → ambiguous-target", true);
+  setCurrent("teamB"); // restore for the completion checks below
+  check("registryTarget: entry → 'registry' target honoring recorded mode", (() => {
+    const t = registryTarget(entry("teamA", projA)); // mode "open" despite auth files on projA's disk
+    return t.source === "registry" && t.auth === undefined && t.root === projA;
+  })());
   rmSync(projC, { recursive: true, force: true });
 
   // Offline completion: lists the RESOLVED mesh's personas (current=teamB → projB), and is

--- a/implementations/cli/src/commands/console.ts
+++ b/implementations/cli/src/commands/console.ts
@@ -2,26 +2,69 @@ import { writeSync } from "node:fs";
 import { userInfo } from "node:os";
 import { createElement } from "react";
 import { render } from "ink";
-import { chatWildcard, type ParsedArgs } from "@cotal-ai/core";
-import { connectOrExit } from "../lib/connect.js";
+import { chatWildcard, mintCreds, newIdentity, type ParsedArgs, type SpaceAuth } from "@cotal-ai/core";
+import {
+  isWorkspaceTargetError,
+  loadMeshes,
+  preflightTarget,
+  pruneStaleMeshes,
+  registryTarget,
+  removeMesh,
+  renderWorkspaceError,
+  resolveRegistryTarget,
+  type MeshEntry,
+  type MeshTarget,
+} from "@cotal-ai/workspace";
+import { connectOrExit, preflightOrExit } from "../lib/connect.js";
 import { c } from "../ui.js";
 import { runLog } from "../render.js";
-import { Root, makeObserver } from "../console/root.js";
+import { Root, makeObserver, type MeshConn } from "../console/root.js";
 
 /**
  * `cotal console` — the live protocol view. A real terminal gets the lazygit-style Ink TUI; a pipe
- * or `--plain` gets the passive line stream. With no `--space` on an open mesh it opens an admin
- * overview of every space first (pick one to drill in, `b` to come back); `--space X` goes straight
- * in. Renders over a read-only observer whose lifecycle `useMesh` owns. See docs/mesh-view.md.
+ * or `--plain` gets the passive line stream. Bare (no flags) it is the run-anywhere overview:
+ * resolved from the registry ONLY — never the cwd, so a stray local `.cotal/` can neither hijack
+ * nor block it — and with several meshes registered the TTY opens a mesh overview of all of them
+ * (pick one to drill in, `b` to come back). On an open mesh with no `--space` a space overview
+ * follows; `--space X` goes straight in. Renders over a read-only observer whose lifecycle
+ * `useMesh` owns. See docs/mesh-view.md.
  */
 export async function console_(args: ParsedArgs): Promise<void> {
   const values = args.values as { space?: string; server?: string; plain?: boolean; creds?: string };
-  // Resolve WHICH running mesh (server + trust material) from any directory — same as `spawn`/`web`.
-  // Auth mode self-mints an admin god-view cred (the console shows DMs/anycast, which the narrower
-  // `observer` profile denies → NATS Authorization Violation); an authed server hosts exactly one
-  // space, so we enter it directly. Open mode connects bare; with no --space, the TTY shows the
-  // space overview. An explicit --creds wins.
-  const { server, space: resolvedSpace, creds, auth } = await connectOrExit(values, "admin");
+  const tui = !values.plain && process.stdout.isTTY === true;
+
+  // Which mesh(es)? Auth mode self-mints an admin god-view cred (the console shows DMs/anycast,
+  // which the narrower `observer` profile denies → NATS Authorization Violation); an authed server
+  // hosts exactly one space, so we enter it directly. Open mode connects bare. An explicit --creds
+  // wins.
+  let meshes: MeshEntry[] | undefined; // set → registry-picker mode, no upfront target
+  let server = "";
+  let resolvedSpace = "";
+  let creds: string | undefined;
+  let auth: SpaceAuth | undefined;
+  if (!values.space && !values.server && !values.creds) {
+    // Bare invocation: registry-only. The stream can't host a picker, so off-TTY the N>1 case
+    // resolves to `current` (or errors ambiguous) instead.
+    await pruneStaleMeshes();
+    const all = loadMeshes();
+    if (tui && all.length > 1) {
+      meshes = all;
+    } else {
+      let target: MeshTarget;
+      try {
+        target = resolveRegistryTarget();
+      } catch (e) {
+        if (!isWorkspaceTargetError(e)) throw e;
+        console.error(c.red(renderWorkspaceError({ kind: "target", error: e })));
+        process.exit(1);
+      }
+      creds = target.auth ? await mintCreds(target.auth, newIdentity(), "admin") : undefined;
+      await preflightOrExit(target, creds);
+      ({ server, space: resolvedSpace, auth } = target);
+    }
+  } else {
+    ({ server, space: resolvedSpace, creds, auth } = await connectOrExit(values, "admin"));
+  }
   // Auth pins its one space; open mode keeps --space (undefined → the overview picker).
   const space = auth ? resolvedSpace : values.space;
 
@@ -38,11 +81,31 @@ export async function console_(args: ParsedArgs): Promise<void> {
 
   // No TTY (piped/headless) or --plain → the passive line stream; Ink needs a real terminal, and a
   // stream can't host the picker, so it falls back to the RESOLVED mesh's space (not the cwd's).
-  if (values.plain || process.stdout.isTTY !== true) {
+  if (!tui) {
     const s = space ?? resolvedSpace;
     await runLog(makeObserver(s, server, creds, operator), s, creds ? chatWildcard(s) : undefined);
     return;
   }
+
+  // Registry-picker mode: connect on pick — same entry rules as the resolved path (recorded mode
+  // decides the admin mint, preflight confirms liveness and prunes a stale entry), but failures
+  // REJECT with the rendered one-line copy for the picker to show, instead of exiting the TUI.
+  const enterMesh = async (m: MeshEntry): Promise<MeshConn> => {
+    let target: MeshTarget;
+    try {
+      target = registryTarget(m);
+    } catch (e) {
+      if (!isWorkspaceTargetError(e)) throw e;
+      throw new Error(renderWorkspaceError({ kind: "target", error: e }));
+    }
+    const minted = target.auth ? await mintCreds(target.auth, newIdentity(), "admin") : undefined;
+    const r = await preflightTarget(target, minted);
+    if (!r.ok) {
+      if (r.prune) removeMesh(target.space);
+      throw new Error(renderWorkspaceError({ kind: "preflight", failure: r.kind, target, pruned: r.prune }));
+    }
+    return { server: target.server, creds: minted, space: target.auth ? target.space : undefined, canWrite: !minted };
+  };
 
   // Full-screen takeover + mouse-wheel scroll: the alternate screen gives a clean app-like
   // canvas (and restores the user's scrollback on exit), and xterm alt-scroll (?1007h) makes the
@@ -72,7 +135,10 @@ export async function console_(args: ParsedArgs): Promise<void> {
     process.exit(0);
   });
 
-  const { waitUntilExit } = render(createElement(Root, { server, creds, space, canWrite, name: operator }), {
+  const props = meshes
+    ? { meshes, enterMesh, name: operator }
+    : { server, creds, space, canWrite, name: operator };
+  const { waitUntilExit } = render(createElement(Root, props), {
     exitOnCtrlC: true,
     maxFps: 30,
     incrementalRendering: true,

--- a/implementations/cli/src/console/root.tsx
+++ b/implementations/cli/src/console/root.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from "react";
 import { CotalEndpoint, chatWildcard } from "@cotal-ai/core";
+import type { MeshEntry } from "@cotal-ai/workspace";
 import { App } from "./app.js";
+import { MeshPicker } from "./ui/MeshPicker.js";
 import { SpacePicker } from "./ui/SpacePicker.js";
 
 /** The read-only observer the console watches a space through — invisible to peers. Built once
@@ -25,11 +27,25 @@ export function makeObserver(
   return ep;
 }
 
+/** A picked mesh's live connection — what {@link Root}'s `enterMesh` resolves a registry entry
+ *  to. `space` set means the mesh pins one (auth); undefined opens its space overview. */
+export interface MeshConn {
+  server: string;
+  creds?: string;
+  space?: string;
+  canWrite: boolean;
+}
+
 /**
- * Console root. With a fixed `space` (explicit `--space`, or the single space under auth) it goes
- * straight into the per-space console. Without one (open mesh) it shows the space overview first;
- * picking a space mounts the console for it — `key={space}` forces a clean MeshView remount, and
- * `onBack` tears it down to return to the overview.
+ * Console root. Two entry modes:
+ *  • **Resolved** (`server` given — explicit flags, or a single registered mesh): with a fixed
+ *    `space` it goes straight into the per-space console; without one (open mesh) the space
+ *    overview shows first.
+ *  • **Registry** (`meshes` + `enterMesh` given — several meshes, bare invocation): the mesh
+ *    overview shows first; picking one connects and drills in — its space overview on an open
+ *    broker, its one pinned space under auth.
+ * Each level's back (`b`) tears down to the one above; `key={space}` forces a clean MeshView
+ * remount per selected space.
  */
 export function Root({
   server,
@@ -37,31 +53,73 @@ export function Root({
   space,
   canWrite,
   name,
+  meshes,
+  enterMesh,
 }: {
-  server: string;
+  server?: string;
   creds?: string;
   space?: string;
   canWrite?: boolean;
   name?: string;
+  /** Registry mode: the meshes to pick from (mutually exclusive with `server`). */
+  meshes?: MeshEntry[];
+  /** Registry mode: connect to a picked mesh — rejects with the rendered one-line error. */
+  enterMesh?: (m: MeshEntry) => Promise<MeshConn>;
 }) {
+  const [conn, setConn] = useState<MeshConn | undefined>(
+    server === undefined ? undefined : { server, creds, space, canWrite: canWrite ?? true },
+  );
   const [selected, setSelected] = useState<string | undefined>(space);
 
   // Build the observer lazily, once per selected space (App's useMesh owns start/stop).
   const ep = useMemo(
-    () => (selected === undefined ? null : makeObserver(selected, server, creds, name)),
-    [selected, server, creds, name],
+    () =>
+      selected === undefined || conn === undefined
+        ? null
+        : makeObserver(selected, conn.server, conn.creds, name),
+    [selected, conn, name],
   );
 
+  if (conn === undefined)
+    return (
+      <MeshPicker
+        meshes={meshes ?? []}
+        onSelect={async (m) => {
+          const c = await enterMesh!(m);
+          setConn(c);
+          setSelected(c.space);
+        }}
+      />
+    );
+
+  const backToMeshes =
+    meshes === undefined
+      ? undefined
+      : () => {
+          setConn(undefined);
+          setSelected(undefined);
+        };
+
   if (selected === undefined || ep === null)
-    return <SpacePicker server={server} creds={creds} canWrite={canWrite} onSelect={setSelected} />;
+    return (
+      <SpacePicker
+        server={conn.server}
+        creds={conn.creds}
+        canWrite={conn.canWrite}
+        onSelect={setSelected}
+        onBack={backToMeshes}
+      />
+    );
 
   return (
     <App
       key={selected}
       ep={ep}
-      tapSubject={creds ? chatWildcard(selected) : undefined}
-      onBack={space === undefined ? () => setSelected(undefined) : undefined}
-      canWrite={canWrite}
+      tapSubject={conn.creds ? chatWildcard(selected) : undefined}
+      // A pinned space (explicit --space, or the auth mesh's one space) has no space overview to
+      // return to — back goes to the mesh overview when there is one, else nowhere.
+      onBack={conn.space === undefined ? () => setSelected(undefined) : backToMeshes}
+      canWrite={conn.canWrite}
     />
   );
 }

--- a/implementations/cli/src/console/ui/MeshPicker.tsx
+++ b/implementations/cli/src/console/ui/MeshPicker.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from "react";
+import { Box, Text, useApp, useInput, useStdout } from "ink";
+import { loadMeshes, pruneStaleMeshes, type MeshEntry } from "@cotal-ai/workspace";
+import { agentColor } from "./theme.js";
+
+/** The run-anywhere landing view when SEVERAL meshes are registered: every broker on this machine
+ *  (space, server, mode, root) with a selection cursor. Enter connects and drops into that mesh —
+ *  its space overview on an open broker, straight into its one space under auth; `r` re-enumerates
+ *  (pruning dead entries). Self-sizing, mirrors SpacePicker. See docs/watch-a-mesh.md. */
+export function MeshPicker({
+  meshes: initial,
+  onSelect,
+}: {
+  meshes: MeshEntry[];
+  /** Connects to the mesh (mint + preflight) — rejects with the rendered one-line error. */
+  onSelect: (m: MeshEntry) => Promise<void>;
+}) {
+  const { exit } = useApp();
+  const { stdout } = useStdout();
+  const [size, setSize] = useState({ cols: stdout.columns || 80, rows: stdout.rows || 24 });
+  useEffect(() => {
+    const onResize = () => setSize({ cols: stdout.columns || 80, rows: stdout.rows || 24 });
+    stdout.on("resize", onResize);
+    return () => {
+      stdout.off("resize", onResize);
+    };
+  }, [stdout]);
+
+  const [meshes, setMeshes] = useState<MeshEntry[]>(initial);
+  const [sel, setSel] = useState(0);
+  const [busy, setBusy] = useState<string | undefined>(); // space being connected to
+  const [error, setError] = useState<string | undefined>();
+
+  const selClamped = Math.min(sel, Math.max(0, meshes.length - 1));
+
+  useInput(
+    (input, key) => {
+      if (input === "q") return exit();
+      if (input === "r") {
+        setError(undefined);
+        // Re-enumerate with the same stale-prune the command runs at startup, so a crashed
+        // broker's entry disappears on refresh rather than failing every Enter.
+        void pruneStaleMeshes().then(() => setMeshes(loadMeshes()));
+        return;
+      }
+      if (key.upArrow || input === "k") return setSel((v) => Math.max(0, v - 1));
+      if (key.downArrow || input === "j") return setSel((v) => Math.min(meshes.length - 1, v + 1));
+      if (key.return && meshes.length) {
+        const m = meshes[selClamped];
+        setBusy(m.space);
+        setError(undefined);
+        onSelect(m).catch((e: Error) => {
+          // A failed enter may have pruned the entry — reload so the list reflects it.
+          setBusy(undefined);
+          setError(e.message);
+          setMeshes(loadMeshes());
+        });
+      }
+    },
+    { isActive: !busy },
+  );
+
+  const capacity = Math.max(1, size.rows - 4 - (error ? 1 : 0)); // border (2) + title (1) + footer (1)
+  let start = 0;
+  if (meshes.length > capacity)
+    start = Math.min(Math.max(0, selClamped - Math.floor(capacity / 2)), meshes.length - capacity);
+  const visible = meshes.slice(start, start + capacity);
+
+  return (
+    <Box
+      flexDirection="column"
+      width={size.cols}
+      height={size.rows}
+      borderStyle="round"
+      borderColor="cyan"
+      paddingX={2}
+    >
+      <Text wrap="truncate-end">
+        <Text bold color="cyan">meshes</Text>
+        {meshes.length ? <Text dimColor>{"  · " + meshes.length}</Text> : null}
+      </Text>
+      <Box flexDirection="column" flexGrow={1}>
+        {meshes.length === 0 ? (
+          <Text dimColor>no mesh running — run `cotal up` in a project</Text>
+        ) : (
+          visible.map((m, i) => (
+            <Row key={m.space} m={m} selected={start + i === selClamped} busy={busy === m.space} />
+          ))
+        )}
+      </Box>
+      {error ? (
+        <Text color="red" wrap="truncate-end">
+          {error}
+        </Text>
+      ) : null}
+      <Text dimColor wrap="truncate-end">
+        ↑↓ select · Enter open · r refresh · q quit
+      </Text>
+    </Box>
+  );
+}
+
+function Row({ m, selected, busy }: { m: MeshEntry; selected: boolean; busy: boolean }) {
+  const stats = m.server + " · " + m.mode + " · " + m.root + (busy ? " · connecting…" : "");
+  if (selected)
+    return (
+      <Text inverse bold color="cyan" wrap="truncate-end">
+        {"▸ " + m.space + "   " + stats}
+      </Text>
+    );
+  return (
+    <Text wrap="truncate-end">
+      <Text dimColor>{"  "}</Text>
+      <Text color={agentColor(m.space)}>{m.space}</Text>
+      <Text dimColor>{"   " + stats}</Text>
+    </Text>
+  );
+}

--- a/implementations/cli/src/console/ui/SpacePicker.tsx
+++ b/implementations/cli/src/console/ui/SpacePicker.tsx
@@ -6,17 +6,20 @@ import { Confirm } from "./Confirm.js";
 
 /** The admin landing view: an overview of every space on the server (agents present, channels,
  *  messages) with a selection cursor. Enter drops into that space's console; `r` re-enumerates.
- *  Self-sizing (mirrors App) so the command just renders it. See docs/protocol-view.md. */
+ *  Self-sizing (mirrors App) so the command just renders it. See docs/watch-a-mesh.md. */
 export function SpacePicker({
   server,
   creds,
   canWrite,
   onSelect,
+  onBack,
 }: {
   server: string;
   creds?: string;
   canWrite?: boolean;
   onSelect: (space: string) => void;
+  /** Present when a mesh overview sits above this picker — `b` returns to it. */
+  onBack?: () => void;
 }) {
   const { exit } = useApp();
   const { stdout } = useStdout();
@@ -57,6 +60,7 @@ export function SpacePicker({
   useInput(
     (input, key) => {
       if (input === "q") return exit();
+      if (input === "b" && onBack) return onBack();
       if (input === "r") return setNonce((n) => n + 1);
       if (input === "D" && canWrite && list.length) return setDel(list[selClamped]);
       if (key.upArrow || input === "k") return setSel((v) => Math.max(0, v - 1));
@@ -113,7 +117,7 @@ export function SpacePicker({
         )}
       </Box>
       <Text dimColor wrap="truncate-end">
-        ↑↓ select · Enter open · r refresh{canWrite ? " · D delete" : ""} · q quit
+        ↑↓ select · Enter open{onBack ? " · b back" : ""} · r refresh{canWrite ? " · D delete" : ""} · q quit
       </Text>
     </Box>
   );

--- a/packages/workspace/src/mesh-target.ts
+++ b/packages/workspace/src/mesh-target.ts
@@ -161,6 +161,34 @@ function isGenuineSpace(root: string): boolean {
   return resolve(join(root, ".cotal")) !== resolve(homeCotalDir()) && existsSync(join(root, ".cotal"));
 }
 
+/** Registry entry → target, for surfaces that enumerate the registry themselves (the console's
+ *  run-anywhere overview): honors the recorded mode and the stale-auth-root guard exactly like the
+ *  resolver's registry branch. */
+export function registryTarget(m: MeshEntry): MeshTarget {
+  return targetFromEntry(m, m.server, "registry");
+}
+
+/**
+ * Registry-ONLY resolution — step 4 of {@link resolveMeshTarget} without the cwd branches, for
+ * read-only surfaces meant to run from anywhere (`console`): a stray local `.cotal/` must neither
+ * hijack the target nor block it (`default-occupied`). 0 ⇒ error; 1 ⇒ use it; N ⇒ `current` if
+ * set, else error naming each + its root.
+ */
+export function resolveRegistryTarget(): MeshTarget {
+  const meshes = loadMeshes();
+  if (meshes.length === 0) throw new MeshTargetError("no-meshes", "no mesh running");
+  if (meshes.length === 1) return targetFromEntry(meshes[0], meshes[0].server, "registry");
+
+  const current = getCurrent();
+  const cur = current ? findMesh(current) : undefined;
+  if (cur) return targetFromEntry(cur, cur.server, "current");
+
+  const names = meshes.map((m) => `${m.space} (${m.root})`);
+  throw new MeshTargetError("ambiguous-target", `multiple meshes running: ${names.join(", ")}`, {
+    available: names,
+  });
+}
+
 /**
  * Resolve the mesh target by precedence (first match wins):
  *  1. `--space` — registry lookup (errors if that space isn't running).
@@ -214,16 +242,5 @@ export function resolveMeshTarget(cwd: string, flags: ResolveFlags = {}): MeshTa
     return localTarget(root, DEFAULT_SERVER, "local-space");
   }
 
-  const meshes = loadMeshes();
-  if (meshes.length === 0) throw new MeshTargetError("no-meshes", "no mesh running");
-  if (meshes.length === 1) return targetFromEntry(meshes[0], meshes[0].server, "registry");
-
-  const current = getCurrent();
-  const cur = current ? findMesh(current) : undefined;
-  if (cur) return targetFromEntry(cur, cur.server, "current");
-
-  const names = meshes.map((m) => `${m.space} (${m.root})`);
-  throw new MeshTargetError("ambiguous-target", `multiple meshes running: ${names.join(", ")}`, {
-    available: names,
-  });
+  return resolveRegistryTarget();
 }


### PR DESCRIPTION
## What

A bare `cotal console` now resolves from the mesh registry **only** — never the cwd — so a stray local `.cotal/` can neither hijack the target nor block it with `default-occupied` ("another mesh is running at …"). With several meshes registered, a TTY opens a mesh overview of every broker on the machine (space · server · mode · root); pick one to drill into its spaces, `b` walks back up. Piped/`--plain` still resolves a single target (`current`, else a clear ambiguous error), and `--space`/`--server`/`--creds` behave exactly as before.

- `@cotal-ai/workspace`: new `resolveRegistryTarget()` (registry-only, no cwd) and `registryTarget(entry)`; `resolveMeshTarget` shares the registry tail.
- `@cotal-ai/cli`: new `MeshPicker` level above the space picker; per-mesh connect failures render inline in the picker instead of exiting the TUI; the same admin-mint + preflight + stale-prune rules apply on entry.

## Why

The console is the read-only run-anywhere view. Local-project-wins target precedence makes sense for write commands (`spawn`), but for the console it meant a leftover `.cotal/` dir anywhere up the tree could block the whole overview.

## Verified

- `pnpm typecheck` + `pnpm test` green; preflight/connect/view smokes pass; spawn-from-anywhere smoke extended with registry-only resolution checks (34 checks).
- Live: from a directory with a stray `.cotal/`, `cotal console` joins the registered mesh instead of erroring; with two registered meshes the picker → space overview → space console → back chain works against a live broker.