### PR TITLE
feat(console): full operator control — fix kill, add pause/resume, spawn/purge/status

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -138,10 +138,19 @@ and configures them.
   isn't loaded, never a silent fallback); **byo** is the floor (a human's own terminal,
   tracked via presence); **host** (Agent SDK, true mid-turn interrupt) is the documented
   upgrade path ([roadmap](roadmap.md)).
+- **Pause and resume.** Optional `pause`/`resume` on the Runtime contract freeze an agent
+  in place (POSIX `SIGSTOP`/`SIGCONT` to its process group). Only the `pty` backend owns a
+  real process, so only it implements them (POSIX only; Windows/ConPTY errors loud);
+  `tmux`/`cmux` reply "not supported by the `<kind>` runtime" rather than degrading.
+  Authority matches a named `stop` (privileged tier reaches your own child, admin any).
+  Paused-ness lives in the manager's managed state (`ps`/`status` report `paused`), not
+  presence: a SIGSTOPped agent cannot heartbeat, so its presence key TTLs out to `offline`;
+  surfaces merge `ps` by id instead (the console shows a `⏸ paused` badge). A graceful
+  `stop` on a paused agent resumes it first (SIGTERM is not delivered to a stopped process).
 - **Control schema:** `start {role, name, agent, model?, variant?}` · `models {agent?,
-  refresh?}` · `stop {name, graceful?}` · `definePersona {name, persona, model?}` · `ps` ·
-  `status` · `attach` · `bind`, request/reply messages any authorized node can send,
-  policy-gated ([identity & auth](identity-and-auth.md)).
+  refresh?}` · `stop {name, graceful?}` · `pause`/`resume {name}` · `definePersona {name,
+  persona, model?}` · `ps` · `status` · `attach` · `bind`, request/reply messages any
+  authorized node can send, policy-gated ([identity & auth](identity-and-auth.md)).
 - **Bounded spawn.** A synchronous gate caps concurrent + in-flight agents and a
   minimum-lifetime floor bounds spawn↔despawn churn, so a capability-holding but
   compromised peer cannot fork-bomb the host.

--- a/docs/watch-a-mesh.md
+++ b/docs/watch-a-mesh.md
@@ -45,8 +45,21 @@ tiles strip, and toggleable lenses:
 | `t`, then `v` / `1`–`3` | the topology lens: who-talks-to-whom, as a swimlane, a heat matrix, or a ring map |
 | `/` | search / filter the feed |
 | `:` | the command palette |
+| `p` / `D` | pause–resume / kill the selected agent (control-gated, below) |
 | arrows / `h` `l` | move focus; select a row for its detail card |
 | `?` · `b` · `q` | help · back to overview · quit |
+
+**Operator control.** Watching stays read-only, but the console can also drive the
+[manager](architecture.md#manager-agent-supervisor): the observer endpoint never carries
+control; each action makes its own tier-scoped request. On an auth mesh the console mints a
+per-action, five-minute control cred from the trust material it holds (its own god-view cred
+stays read-only); on an open mesh it goes bare; an explicit `--creds` is used as-is. That gate
+is `canControl`, distinct from `canWrite` (chat publishes). Affordances follow how destructive
+they are: `p` pauses or resumes with no confirm (recoverable; the roster shows a `⏸ paused`
+badge merged from a low-rate `ps` poll, since a frozen agent's presence reads offline), `D`
+kills behind a confirm (`y` graceful stop, `f` force-kill), and the `:` palette adds
+`spawn <persona> [name]`, `status <agent>`, `ps`, and `purge` (type the space name to confirm,
+like the space delete).
 
 The stream is line-oriented, so the signals stay out of it; it is just a timestamped log of
 presence changes and messages, ready for `grep`.

--- a/implementations/cli/src/commands/console.ts
+++ b/implementations/cli/src/commands/console.ts
@@ -35,6 +35,12 @@ export async function console_(args: ParsedArgs): Promise<void> {
     }
   })();
   const canWrite = !creds || !!values.creds;
+  // Control (kill/pause/spawn/purge) is broader than chat-write: it doesn't ride the observer
+  // endpoint — each action makes its own tier-scoped request (see console/control.ts). Possible
+  // whenever we can produce an authorized caller: bare on an open mesh, the operator's --creds,
+  // or a fresh per-action mint from the held trust material.
+  const canControl = !creds || !!values.creds || !!auth;
+  const controlCtx = { server, auth, creds: values.creds ? creds : undefined };
 
   // No TTY (piped/headless) or --plain → the passive line stream; Ink needs a real terminal, and a
   // stream can't host the picker, so it falls back to the RESOLVED mesh's space (not the cwd's).
@@ -72,11 +78,14 @@ export async function console_(args: ParsedArgs): Promise<void> {
     process.exit(0);
   });
 
-  const { waitUntilExit } = render(createElement(Root, { server, creds, space, canWrite, name: operator }), {
-    exitOnCtrlC: true,
-    maxFps: 30,
-    incrementalRendering: true,
-  });
+  const { waitUntilExit } = render(
+    createElement(Root, { server, creds, space, canWrite, canControl, controlCtx, name: operator }),
+    {
+      exitOnCtrlC: true,
+      maxFps: 30,
+      incrementalRendering: true,
+    },
+  );
   await waitUntilExit();
   restore();
 }

--- a/implementations/cli/src/console/app.tsx
+++ b/implementations/cli/src/console/app.tsx
@@ -1,7 +1,14 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Box, Text, useApp, useFocusManager, useInput, useStdout } from "ink";
-import type { CotalEndpoint, Presence } from "@cotal-ai/core";
+import {
+  CONTROL_ADMIN,
+  CONTROL_PRIVILEGED,
+  type ControlTier,
+  type CotalEndpoint,
+  type Presence,
+} from "@cotal-ai/core";
 import { useMesh } from "./mesh.js";
+import { control, type ControlCtx } from "./control.js";
 import { Tabs } from "./ui/Tabs.js";
 import { Roster } from "./ui/Roster.js";
 import { Feed } from "./ui/Feed.js";
@@ -40,11 +47,15 @@ export function App({
   tapSubject,
   onBack,
   canWrite,
+  canControl,
+  controlCtx,
 }: {
   ep: CotalEndpoint;
   tapSubject?: string;
   onBack?: () => void;
   canWrite?: boolean;
+  canControl?: boolean;
+  controlCtx?: Omit<ControlCtx, "space">;
 }) {
   const mesh = useMesh(ep, { tapSubject });
   const { exit } = useApp();
@@ -118,6 +129,47 @@ export function App({
     return () => clearInterval(t);
   }, []);
 
+  // Per-action control against the manager for THIS space (see console/control.ts — the observer
+  // endpoint never carries control; each action makes its own tier-scoped request).
+  const ctl = useCallback(
+    (op: string, args: Record<string, unknown>, tier: ControlTier) =>
+      control({ space: ep.space, server: controlCtx?.server ?? "", auth: controlCtx?.auth, creds: controlCtx?.creds }, op, args, tier),
+    [ep.space, controlCtx],
+  );
+
+  // Paused-ness lives in the manager's managed-state, NOT presence — a SIGSTOPped agent's
+  // heartbeat freezes, so its presence key TTLs out to "offline" and would lie. Poll `ps` at a
+  // low rate and merge by non-forgeable id; fail QUIET and stop polling when no manager answers
+  // (an open mesh without a supervisor must not spin or flash errors).
+  const [pausedIds, setPausedIds] = useState<Set<string>>(new Set());
+  const psDead = useRef(false);
+  useEffect(() => {
+    if (!canControl || !controlCtx) return;
+    psDead.current = false;
+    let alive = true;
+    const poll = async () => {
+      if (!alive || psDead.current) return;
+      const r = await ctl("ps", {}, CONTROL_PRIVILEGED).catch(() => ({ ok: false as const, error: "" }));
+      if (!alive) return;
+      if (!r.ok) {
+        psDead.current = true; // no manager on this mesh — don't keep knocking
+        return;
+      }
+      const list = (r.data ?? []) as { id: string; paused?: boolean }[];
+      setPausedIds((prev) => {
+        const next = new Set(list.filter((a) => a.paused).map((a) => a.id));
+        if (next.size === prev.size && [...next].every((id) => prev.has(id))) return prev;
+        return next;
+      });
+    };
+    void poll();
+    const t = setInterval(() => void poll(), 3000);
+    return () => {
+      alive = false;
+      clearInterval(t);
+    };
+  }, [canControl, controlCtx, ctl]);
+
   // Auto-clear the transient action notice.
   useEffect(() => {
     if (!notice) return;
@@ -141,6 +193,26 @@ export function App({
   const openAgent = useCallback((p: Presence) => setDetail({ kind: "agent", agent: p }), []);
   const openMessage = useCallback((e: FeedEntry) => setDetail({ kind: "message", entry: e }), []);
   const handleKill = useCallback((p: Presence) => setConfirm({ kind: "kill", name: p.card.name }), []);
+  // Pause/resume toggle — recoverable, so no confirm (graduated destructiveness). Admin tier: the
+  // console operator is never the spawner.
+  const handlePause = useCallback(
+    (p: Presence) => {
+      const op = pausedIds.has(p.card.id) ? "resume" : "pause";
+      void ctl(op, { name: p.card.name }, CONTROL_ADMIN)
+        .then((r) => {
+          setNotice(r.ok ? `${op === "pause" ? "paused" : "resumed"} ${p.card.name}` : `${op}: ${r.error ?? "failed"}`);
+          if (r.ok)
+            setPausedIds((prev) => {
+              const next = new Set(prev);
+              if (op === "pause") next.add(p.card.id);
+              else next.delete(p.card.id);
+              return next;
+            });
+        })
+        .catch((e) => setNotice(`${op}: ` + (e as Error).message));
+    },
+    [ctl, pausedIds],
+  );
   const feedCompose = useCallback(
     () => setCompose({ kind: "channel", channel: activeChannel === "all" ? "general" : activeChannel, value: "" }),
     [activeChannel],
@@ -194,19 +266,27 @@ export function App({
       back: onBack,
       exit,
       notify: setNotice,
+      control: ctl,
+      confirmPurge: () => setConfirm({ kind: "purge", space: ep.space }),
     };
-    runCommand(line, ctx, !!canWrite);
+    runCommand(line, ctx, !!canWrite, !!canControl);
   };
 
-  // Confirmed destructive action (kill only; space-delete is handled in the picker).
-  const onConfirmed = () => {
+  // Confirmed destructive action (kill/purge; space-delete is handled in the picker). Kill goes
+  // on the ADMIN tier with a per-action mint — the privileged tier only reaches a caller's own
+  // spawned child, and the console's observer cred can't publish control at all.
+  const onConfirmed = (opts?: { force?: boolean }) => {
     const c = confirm;
     setConfirm(null);
     if (c?.kind === "kill") {
-      void ep
-        .requestControl("manager", { op: "stop", args: { name: c.name } })
-        .then((r) => setNotice(r.ok ? `stopped ${c.name}` : `stop: ${r.error ?? "failed"}`))
+      const graceful = !opts?.force;
+      void ctl("stop", { name: c.name, graceful }, CONTROL_ADMIN)
+        .then((r) => setNotice(r.ok ? `${graceful ? "stopped" : "force-killed"} ${c.name}` : `stop: ${r.error ?? "failed"}`))
         .catch((e) => setNotice("stop: " + (e as Error).message));
+    } else if (c?.kind === "purge") {
+      void ctl("purge", {}, CONTROL_ADMIN)
+        .then((r) => setNotice(r.ok ? "purged space history" : `purge: ${r.error ?? "failed"}`))
+        .catch((e) => setNotice("purge: " + (e as Error).message));
     }
   };
 
@@ -311,7 +391,9 @@ export function App({
               blocked={blocked}
               onFocus={onFocus}
               onOpenDetail={openAgent}
-              onKill={canWrite ? handleKill : undefined}
+              onKill={canControl ? handleKill : undefined}
+              onPause={canControl ? handlePause : undefined}
+              paused={pausedIds}
               onCompose={canWrite ? rosterCompose : undefined}
             />
             <Feed
@@ -361,6 +443,7 @@ export function App({
           query={palette.query}
           snapshot={mesh}
           canWrite={!!canWrite}
+          canControl={!!canControl}
           width={size.cols}
           onChange={(q) => setPalette((p) => ({ ...p, query: q }))}
           onRun={runPaletteLine}
@@ -385,6 +468,7 @@ export function App({
         railOpen={railOpen}
         canBack={!!onBack}
         canWrite={!!canWrite}
+        canControl={!!canControl}
         width={size.cols}
       />
     </Box>

--- a/implementations/cli/src/console/commands.ts
+++ b/implementations/cli/src/console/commands.ts
@@ -1,8 +1,16 @@
 // The console's `:` command catalog — the operator's send/control verbs. A small local list (NOT
 // the CLI `Command` registry, which is argv/process-exit shaped). The catalog drives both execution
-// and the palette's autocomplete. Write commands publish over the mesh via the observer endpoint;
-// they are gated on `canWrite` (open mode, or a privileged --creds).
-import { CONTROL_PRIVILEGED, resolvePeer, AmbiguousPeerError, type CotalEndpoint } from "@cotal-ai/core";
+// and the palette's autocomplete. Write commands publish over the mesh via the observer endpoint,
+// gated on `canWrite` (open mode, or a privileged --creds). Control commands go through
+// `ctx.control` (a per-action tier-scoped request — see console/control.ts), gated on `canControl`.
+import {
+  CONTROL_PRIVILEGED,
+  resolvePeer,
+  AmbiguousPeerError,
+  type ControlReply,
+  type ControlTier,
+  type CotalEndpoint,
+} from "@cotal-ai/core";
 import type { MeshSnapshot } from "../view/mesh-view.js";
 import { mentionsIn } from "../lib/mentions.js";
 
@@ -10,20 +18,25 @@ export interface CommandCtx {
   ep: CotalEndpoint;
   snapshot: MeshSnapshot;
   activeChannel: string;
-  setMode: (m: "normal" | "dm" | "topo") => void;
+  setMode: (m: "normal" | "dm" | "topo" | "views") => void;
   setActiveChannel: (c: string) => void;
   toggleRail: () => void;
   openHelp: () => void;
   back?: () => void; // to the space overview
   exit: () => void;
   notify: (msg: string) => void; // transient status line
+  /** One control request against the manager, with per-action authorization. */
+  control: (op: string, args: Record<string, unknown>, tier: ControlTier) => Promise<ControlReply>;
+  /** Open the type-the-space-name purge confirm (the palette never purges directly). */
+  confirmPurge: () => void;
 }
 
 export interface ConsoleCommand {
   name: string;
   summary: string;
   usage?: string;
-  write?: boolean; // requires canWrite (publishes / controls)
+  write?: boolean; // requires canWrite (publishes over the observer endpoint)
+  control?: boolean; // requires canControl (manager control plane)
   run(ctx: CommandCtx, rest: string): Promise<void> | void;
 }
 
@@ -113,16 +126,64 @@ export const COMMANDS: ConsoleCommand[] = [
   {
     name: "ps",
     summary: "list manager-spawned agents",
+    control: true,
     run: async (ctx) => {
       try {
-        const r = await ctx.ep.requestControl(CONTROL_PRIVILEGED, { op: "ps" });
+        const r = await ctx.control("ps", {}, CONTROL_PRIVILEGED);
         if (!r.ok) return ctx.notify("ps: " + (r.error ?? "failed"));
-        const list = (r.data as { name: string }[]) ?? [];
-        ctx.notify(list.length ? "agents: " + list.map((a) => a.name).join(", ") : "no managed agents");
+        const list = (r.data as { name: string; paused?: boolean }[]) ?? [];
+        ctx.notify(
+          list.length
+            ? "agents: " + list.map((a) => a.name + (a.paused ? " ⏸" : "")).join(", ")
+            : "no managed agents",
+        );
       } catch (e) {
         ctx.notify("ps: " + (e as Error).message);
       }
     },
+  },
+  {
+    name: "spawn",
+    summary: "spawn an agent from a persona",
+    usage: "spawn <persona> [name]",
+    control: true,
+    run: async (ctx, rest) => {
+      const [persona, identity] = rest.trim().split(/\s+/).filter(Boolean);
+      if (!persona) return ctx.notify("usage: spawn <persona> [name]");
+      try {
+        const r = await ctx.control("start", identity ? { name: persona, identity } : { name: persona }, CONTROL_PRIVILEGED);
+        if (!r.ok) return ctx.notify("spawn: " + (r.error ?? "failed"));
+        ctx.notify(`spawned ${(r.data as { name?: string })?.name ?? persona}`);
+      } catch (e) {
+        ctx.notify("spawn: " + (e as Error).message);
+      }
+    },
+  },
+  {
+    name: "status",
+    summary: "one managed agent's state",
+    usage: "status <agent>",
+    control: true,
+    run: async (ctx, rest) => {
+      const name = rest.replace(/^@/, "").trim().split(/\s+/)[0] ?? "";
+      if (!name) return ctx.notify("usage: status <agent>");
+      try {
+        const r = await ctx.control("status", { name }, CONTROL_PRIVILEGED);
+        if (!r.ok) return ctx.notify("status: " + (r.error ?? "failed"));
+        const a = r.data as { name: string; role?: string; mode: string; status: string; paused?: boolean; mesh: string; uptimeMs: number };
+        ctx.notify(
+          `${a.name}${a.role ? " (" + a.role + ")" : ""} · ${a.mode} · ${a.paused ? "paused" : a.status} · mesh ${a.mesh} · up ${Math.round(a.uptimeMs / 60000)}m`,
+        );
+      } catch (e) {
+        ctx.notify("status: " + (e as Error).message);
+      }
+    },
+  },
+  {
+    name: "purge",
+    summary: "clear the space's history (confirm)",
+    control: true,
+    run: (ctx) => ctx.confirmPurge(),
   },
   { name: "dms", summary: "toggle the DM lens", run: (ctx) => ctx.setMode("dm") },
   { name: "topo", summary: "toggle the topology lens", run: (ctx) => ctx.setMode("topo") },
@@ -133,7 +194,7 @@ export const COMMANDS: ConsoleCommand[] = [
 ];
 
 /** Parse + dispatch a typed palette line. Unknown / read-only-blocked commands notify and no-op. */
-export function runCommand(line: string, ctx: CommandCtx, canWrite: boolean): void {
+export function runCommand(line: string, ctx: CommandCtx, canWrite: boolean, canControl: boolean): void {
   const trimmed = line.trim();
   if (!trimmed) return;
   const name = trimmed.split(/\s+/)[0].toLowerCase();
@@ -141,5 +202,6 @@ export function runCommand(line: string, ctx: CommandCtx, canWrite: boolean): vo
   const cmd = COMMANDS.find((c) => c.name === name);
   if (!cmd) return ctx.notify(`unknown command: ${name}`);
   if (cmd.write && !canWrite) return ctx.notify("read-only — pass --creds to send");
+  if (cmd.control && !canControl) return ctx.notify("no control authority — pass --creds, or run against a mesh whose auth you hold");
   void cmd.run(ctx, rest);
 }

--- a/implementations/cli/src/console/control.ts
+++ b/implementations/cli/src/console/control.ts
@@ -1,0 +1,44 @@
+import {
+  CONTROL_ADMIN,
+  mintCreds,
+  newIdentity,
+  type ControlReply,
+  type ControlTier,
+  type SpaceAuth,
+} from "@cotal-ai/core";
+import { askManager } from "../lib/control.js";
+
+/** Everything the console needs to reach the manager's control plane, threaded from the
+ *  command's resolved connection. `auth` present ⇔ auth mesh (we mint per action); `creds`
+ *  is an operator-passed `--creds` file's contents (used as-is); both absent ⇔ open mesh. */
+export interface ControlCtx {
+  space: string;
+  server: string;
+  auth?: SpaceAuth;
+  creds?: string;
+}
+
+/**
+ * One control request from the console, with per-action authorization — the console analog of
+ * the CLI's `stop`/`attach` flow and the web's channel-purger mint: the console's own observer
+ * cred is read-only by design (no `ctl.*` publish), so each action mints an EPHEMERAL,
+ * tier-scoped caller cred (5-min TTL, `control-caller-admin`/`-privileged` — each holds only its
+ * own tier's publish grant) from the held trust material, uses it for one request/reply on a
+ * transient endpoint, and lets it fall out of scope. Nothing touches disk. On an open mesh the
+ * request goes bare; an explicit `--creds` is trusted as the operator's chosen authority.
+ */
+export async function control(
+  ctx: ControlCtx,
+  op: string,
+  args: Record<string, unknown>,
+  tier: ControlTier,
+): Promise<ControlReply> {
+  const callCreds = ctx.auth
+    ? await mintCreds(
+        ctx.auth,
+        newIdentity(),
+        tier === CONTROL_ADMIN ? "control-caller-admin" : "control-caller-privileged",
+      )
+    : ctx.creds;
+  return askManager(ctx.space, ctx.server, op, args, callCreds, tier);
+}

--- a/implementations/cli/src/console/root.tsx
+++ b/implementations/cli/src/console/root.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { CotalEndpoint, chatWildcard } from "@cotal-ai/core";
 import { App } from "./app.js";
+import type { ControlCtx } from "./control.js";
 import { SpacePicker } from "./ui/SpacePicker.js";
 
 /** The read-only observer the console watches a space through — invisible to peers. Built once
@@ -36,12 +37,17 @@ export function Root({
   creds,
   space,
   canWrite,
+  canControl,
+  controlCtx,
   name,
 }: {
   server: string;
   creds?: string;
   space?: string;
   canWrite?: boolean;
+  canControl?: boolean;
+  /** Trust material for per-action control mints — space-less; App adds its own space. */
+  controlCtx?: Omit<ControlCtx, "space">;
   name?: string;
 }) {
   const [selected, setSelected] = useState<string | undefined>(space);
@@ -62,6 +68,8 @@ export function Root({
       tapSubject={creds ? chatWildcard(selected) : undefined}
       onBack={space === undefined ? () => setSelected(undefined) : undefined}
       canWrite={canWrite}
+      canControl={canControl}
+      controlCtx={controlCtx}
     />
   );
 }

--- a/implementations/cli/src/console/ui/CommandPalette.tsx
+++ b/implementations/cli/src/console/ui/CommandPalette.tsx
@@ -5,7 +5,7 @@ import { COMMANDS } from "../commands.js";
 
 const CAP = 6; // suggestion rows; the palette is a fixed CAP+1 rows tall so the layout doesn't jump
 
-type Sugg = { value: string; label: string; summary?: string; write?: boolean };
+type Sugg = { value: string; label: string; summary?: string; write?: boolean; control?: boolean };
 
 /** Suggestions for the current token: the command name (no space yet), or an @agent / #channel arg. */
 function suggest(query: string, snap: MeshSnapshot): { items: Sugg[]; tokenStart: number; matchLen: number } {
@@ -16,6 +16,7 @@ function suggest(query: string, snap: MeshSnapshot): { items: Sugg[]; tokenStart
       label: c.name,
       summary: c.summary,
       write: c.write,
+      control: c.control,
     }));
     return { items, tokenStart: 0, matchLen: q.length };
   }
@@ -46,6 +47,7 @@ export function CommandPalette({
   query,
   snapshot,
   canWrite,
+  canControl,
   width,
   onChange,
   onRun,
@@ -55,6 +57,7 @@ export function CommandPalette({
   query: string;
   snapshot: MeshSnapshot;
   canWrite: boolean;
+  canControl?: boolean;
   width: number;
   onChange: (q: string) => void;
   onRun: (line: string) => void;
@@ -110,7 +113,7 @@ export function CommandPalette({
               {s.label.slice(m)}
             </Text>
             {s.summary ? <Text dimColor>{"   " + s.summary}</Text> : null}
-            {s.write && !canWrite ? <Text color="red">{"  read-only"}</Text> : null}
+            {(s.write && !canWrite) || (s.control && !canControl) ? <Text color="red">{"  read-only"}</Text> : null}
           </Text>
         );
       })}

--- a/implementations/cli/src/console/ui/Confirm.tsx
+++ b/implementations/cli/src/console/ui/Confirm.tsx
@@ -1,14 +1,16 @@
 import { useState } from "react";
 import { Box, Text, useInput } from "ink";
 
-/** A destructive action awaiting confirmation. `kill` is a quick y/n; `deleteSpace` (irreversible)
- *  requires typing the space name. */
+/** A destructive action awaiting confirmation. `kill` is a quick y/n (with `f` for a hard kill);
+ *  `deleteSpace` and `purge` (irreversible) require typing the space name. */
 export type ConfirmTarget =
   | { kind: "kill"; name: string }
-  | { kind: "deleteSpace"; space: string };
+  | { kind: "deleteSpace"; space: string }
+  | { kind: "purge"; space: string };
 
 /** Full-screen red danger overlay. Owns input while shown. Calls onConfirm only when the gate is
- *  satisfied (y for kill, exact name typed for deleteSpace); Esc/n cancels. */
+ *  satisfied (y/f for kill, exact name typed for deleteSpace/purge); Esc/n cancels. Kill's choice
+ *  travels in the callback: `y`/Enter → graceful stop (default), `f` → force (hard kill). */
 export function Confirm({
   target,
   width,
@@ -19,20 +21,21 @@ export function Confirm({
   target: ConfirmTarget;
   width: number;
   height: number;
-  onConfirm: () => void;
+  onConfirm: (opts?: { force?: boolean }) => void;
   onCancel: () => void;
 }) {
   const [typed, setTyped] = useState("");
-  const match = target.kind === "deleteSpace" && typed === target.space;
+  const match = target.kind !== "kill" && typed === target.space;
 
   useInput((input, key) => {
     if (key.escape) return onCancel();
     if (target.kind === "kill") {
-      if (input === "y" || input === "Y") return onConfirm();
-      if (input === "n" || input === "N" || key.return) return onCancel();
+      if (input === "y" || input === "Y" || key.return) return onConfirm();
+      if (input === "f" || input === "F") return onConfirm({ force: true });
+      if (input === "n" || input === "N") return onCancel();
       return;
     }
-    // deleteSpace: type the name to arm Enter
+    // deleteSpace / purge: type the name to arm Enter
     if (key.return) {
       if (match) onConfirm();
       return;
@@ -60,14 +63,23 @@ export function Confirm({
             Stop agent <Text bold>{target.name}</Text> via the manager?
           </Text>
           <Box marginTop={1}>
-            <Text dimColor>y = stop · n / Esc = cancel</Text>
+            <Text dimColor>y = stop (graceful) · f = force-kill · n / Esc = cancel</Text>
           </Box>
         </Box>
       ) : (
         <Box marginTop={1} flexDirection="column">
           <Text>
-            Delete space <Text bold>{target.space}</Text> —{" "}
-            <Text color="red">irreversible</Text> (all history + presence gone).
+            {target.kind === "deleteSpace" ? (
+              <>
+                Delete space <Text bold>{target.space}</Text> —{" "}
+                <Text color="red">irreversible</Text> (all history + presence gone).
+              </>
+            ) : (
+              <>
+                Purge <Text bold>{target.space}</Text>'s history (all channels + DMs) —{" "}
+                <Text color="red">irreversible</Text> (agents stay up).
+              </>
+            )}
           </Text>
           <Box marginTop={1}>
             <Text dimColor>type the name to confirm: </Text>
@@ -75,7 +87,7 @@ export function Confirm({
             <Text inverse> </Text>
           </Box>
           <Box marginTop={1}>
-            <Text dimColor>{match ? "Enter = delete" : "Esc = cancel"}</Text>
+            <Text dimColor>{match ? (target.kind === "deleteSpace" ? "Enter = delete" : "Enter = purge") : "Esc = cancel"}</Text>
           </Box>
         </Box>
       )}

--- a/implementations/cli/src/console/ui/Help.tsx
+++ b/implementations/cli/src/console/ui/Help.tsx
@@ -38,7 +38,8 @@ export function Help({
           : [
               ["↑↓ / j k", "move selection"],
               ["Enter", "open agent detail"],
-              ["D", "kill agent (confirm)"],
+              ["p", "pause / resume agent"],
+              ["D", "kill agent (y stop · f force)"],
             ];
   const global: [string, string][] = [
     ["Tab / ← → / h l", "switch panel"],
@@ -48,7 +49,7 @@ export function Help({
     ["d", "direct-message lens"],
     ["t", "topology lens (v / 1-3 variants)"],
     ["V", "views lens (peer-pushed views)"],
-    [":", "command palette (send / call / ask)"],
+    [":", "command palette (send / call / spawn / purge / status)"],
     ["c", "compose to channel / DM selected agent"],
     ["r", "reply to current message"],
     ["D", "delete — kill agent / drop space"],

--- a/implementations/cli/src/console/ui/Roster.tsx
+++ b/implementations/cli/src/console/ui/Roster.tsx
@@ -3,28 +3,34 @@ import { Box, Text, useFocus, useInput } from "ink";
 import type { Presence } from "@cotal-ai/core";
 import { agentColor, STATUS, ago } from "./theme.js";
 
-function RosterRow({ p, selected, wide }: { p: Presence; selected: boolean; wide: boolean }) {
+function RosterRow({ p, selected, wide, paused }: { p: Presence; selected: boolean; wide: boolean; paused: boolean }) {
   const isAgent = p.card.kind === "agent";
   const s = STATUS[p.status];
-  // Selected: one uniform cyan bar (like the tabs); unselected: the normal colored row.
+  // A manager-paused (SIGSTOPped) agent can't heartbeat, so presence soon reads "offline" — the
+  // managed-state badge is authoritative and replaces the status so a frozen agent isn't misread
+  // as dead.
   if (selected) {
-    const kind = wide ? (isAgent ? "  " + s.word : "  endpoint") : "";
+    const kind = wide ? (paused && isAgent ? "  paused" : isAgent ? "  " + s.word : "  endpoint") : "";
     const act = p.activity ? "  " + p.activity : "";
     return (
       <Text inverse bold color="cyan" wrap="truncate-end">
-        {(isAgent ? s.dot : "⚙") + " " + p.card.name + kind + act + "  " + ago(p.ts)}
+        {(isAgent ? (paused ? "⏸" : s.dot) : "⚙") + " " + p.card.name + kind + act + "  " + ago(p.ts)}
       </Text>
     );
   }
   return (
     <Text wrap="truncate-end">
-      <Text color={isAgent ? s.color : "gray"}>{isAgent ? s.dot : "⚙"} </Text>
+      <Text color={isAgent ? (paused ? "yellow" : s.color) : "gray"}>{isAgent ? (paused ? "⏸" : s.dot) : "⚙"} </Text>
       <Text color={isAgent ? agentColor(p.card.name) : undefined} dimColor={!isAgent}>
         {p.card.name}
       </Text>
       {wide ? (
         isAgent ? (
-          <Text color={s.color}>{"  " + s.word}</Text>
+          paused ? (
+            <Text color="yellow">{"  paused"}</Text>
+          ) : (
+            <Text color={s.color}>{"  " + s.word}</Text>
+          )
         ) : (
           <Text dimColor>{"  endpoint"}</Text>
         )
@@ -52,6 +58,8 @@ export function Roster({
   onFocus,
   onOpenDetail,
   onKill,
+  onPause,
+  paused,
   onCompose,
 }: {
   agents: Presence[];
@@ -64,6 +72,10 @@ export function Roster({
   onFocus: (id: "roster" | "feed") => void;
   onOpenDetail: (p: Presence) => void;
   onKill?: (p: Presence) => void;
+  /** Pause/resume toggle on the selected agent — recoverable, so it fires without a confirm. */
+  onPause?: (p: Presence) => void;
+  /** Ids the manager reports as paused — authoritative over presence for the badge. */
+  paused?: Set<string>;
   onCompose?: (p: Presence) => void;
 }) {
   const { isFocused } = useFocus({ id: "roster" });
@@ -83,6 +95,8 @@ export function Roster({
       else if (key.downArrow || input === "j") setSel((v) => Math.min(list.length - 1, v + 1));
       else if (input === "D" && onKill && list[selClamped]?.card.kind === "agent")
         onKill(list[selClamped]);
+      else if (input === "p" && onPause && list[selClamped]?.card.kind === "agent")
+        onPause(list[selClamped]);
       else if (input === "c" && onCompose && list[selClamped]?.card.kind === "agent")
         onCompose(list[selClamped]);
       else if (key.return && list.length) onOpenDetail(list[selClamped]);
@@ -123,6 +137,7 @@ export function Roster({
             p={p}
             selected={isFocused && start + i === selClamped}
             wide={wide}
+            paused={paused?.has(p.card.id) ?? false}
           />
         ))
       )}

--- a/implementations/cli/src/console/ui/StatusBar.tsx
+++ b/implementations/cli/src/console/ui/StatusBar.tsx
@@ -12,6 +12,7 @@ export function StatusBar({
   railOpen,
   canBack,
   canWrite,
+  canControl,
   width,
 }: {
   status: MeshState["status"];
@@ -22,6 +23,7 @@ export function StatusBar({
   railOpen: boolean;
   canBack?: boolean;
   canWrite?: boolean;
+  canControl?: boolean;
   width: number;
 }) {
   const keys =
@@ -35,7 +37,8 @@ export function StatusBar({
           ": cmd · j/k select · Enter detail · " +
           (railOpen ? "n hide-rail" : "n needs-you") +
           " · d DMs · V views" +
-          (canWrite ? " · c compose · D kill" : "") +
+          (canWrite ? " · c compose" : "") +
+          (canControl ? " · p pause · D kill" : "") +
           " · / search · [ ] chan · ? help · q quit";
   return (
     <Box width={width} paddingX={1}>

--- a/implementations/manager/smoke/pause-resume-live.smoke.ts
+++ b/implementations/manager/smoke/pause-resume-live.smoke.ts
@@ -1,0 +1,199 @@
+/**
+ * Pause/resume live-broker smoke — run with: pnpm smoke:pause-resume:live (needs nats-server + node).
+ *
+ * Drives the REAL wire path the console uses (per-action tier-scoped creds → requestControl), against
+ * a real JWT-auth broker + real Manager + a real agent process (e2e-stub.mjs):
+ *
+ *   1. pause freezes the process (OS state `T`), reply carries {paused:true}, `ps` reports it;
+ *   2. resume thaws it, {paused:false}, state leaves `T`;
+ *   3. TIER: a non-spawner on the privileged subject is DENIED pause/stop (admin required) — the
+ *      regression guard for the console's old mis-tiered kill — while admin reaches any agent;
+ *   4. CRED SCOPE: the minted control-caller-admin JWT may publish ONLY its own tier's subject;
+ *   5. an unsupported runtime (no owned pid) errors loud, not silently;
+ *   6. graceful stop of a PAUSED agent completes (SIGCONT-before-SIGTERM — would otherwise hang).
+ */
+import { randomUUID } from "node:crypto";
+import { spawn, execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  CONTROL_ADMIN,
+  CONTROL_PRIVILEGED,
+  CotalEndpoint,
+  isReachable,
+  createSpaceAuth,
+  mintCreds,
+  serverConfig,
+  newIdentity,
+  setupSpaceStreams,
+  registry,
+  type AgentHandle,
+  type Connector,
+  type ControlTier,
+  type LaunchOpts,
+  type LaunchSpec,
+} from "@cotal-ai/core";
+import { authDir, saveSpaceAuth } from "@cotal-ai/workspace";
+import { Manager } from "../src/manager.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "../../..");
+const STUB = join(here, "e2e-stub.mjs");
+const PORT = 20000 + Math.floor(Math.random() * 40000);
+const SERVERS = `nats://127.0.0.1:${PORT}`;
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+let pass = 0, fail = 0;
+const check = (name: string, cond: boolean, extra?: unknown) => {
+  if (cond) { pass++; console.log(`  ✓ ${name}`); }
+  else { fail++; console.log(`  ✗ FAIL: ${name}`, extra ?? ""); }
+};
+
+/** OS process state letter (`T` = stopped) — POSIX ps, present on mac + Linux. */
+const stateOf = (pid: number): string => {
+  try {
+    return execFileSync("ps", ["-o", "state=", "-p", String(pid)], { encoding: "utf8" }).trim();
+  } catch {
+    return ""; // process gone
+  }
+};
+
+/** One control request with a fresh per-action tier-scoped cred — the console's exact flow. */
+async function callControl(
+  space: string,
+  auth: Awaited<ReturnType<typeof createSpaceAuth>>,
+  tier: ControlTier,
+  op: string,
+  args: Record<string, unknown>,
+) {
+  const creds = await mintCreds(
+    auth,
+    newIdentity(),
+    tier === CONTROL_ADMIN ? "control-caller-admin" : "control-caller-privileged",
+  );
+  const ep = new CotalEndpoint({
+    space,
+    servers: SERVERS,
+    creds,
+    channels: [],
+    consume: false,
+    registerPresence: false,
+    watchPresence: false,
+    card: { name: "console-smoke", kind: "endpoint" },
+  });
+  ep.on("error", () => {});
+  await ep.start();
+  try {
+    return await ep.requestControl(tier, { op, args });
+  } finally {
+    await ep.stop();
+  }
+}
+
+const space = `pause-${randomUUID().slice(0, 8)}`;
+const auth = await createSpaceAuth(space);
+const dir = mkdtempSync(join(tmpdir(), "cotal-pause-"));
+const workspaceRoot = join(dir, "ws");
+mkdirSync(join(workspaceRoot, ".cotal", "agents"), { recursive: true });
+saveSpaceAuth(authDir(workspaceRoot), auth);
+writeFileSync(join(workspaceRoot, ".cotal", "agents", "w1.md"), "---\nname: w1\nrole: worker\n---\n");
+writeFileSync(join(dir, "server.conf"), serverConfig(auth, { port: PORT, storeDir: join(dir, "js") }));
+const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+
+const envFor = (o: LaunchOpts): Record<string, string> => ({
+  COTAL_SPACE: o.space, COTAL_SERVERS: String(o.servers ?? SERVERS), COTAL_CREDS: String(o.creds),
+  COTAL_ID: String(o.id), COTAL_NAME: o.name, PATH: process.env.PATH ?? "",
+});
+const stubCon: Connector = {
+  kind: "connector", name: "e2e-stub", requires: ["node"],
+  buildLaunch: (o): LaunchSpec => ({ command: "node", args: [STUB], env: envFor(o) }),
+};
+registry.register(stubCon);
+
+const mgr = new Manager({ space, servers: SERVERS, runtime: "pty", workspaceRoot });
+
+try {
+  let up = false;
+  for (let i = 0; i < 50; i++) { if (await isReachable(SERVERS)) { up = true; break; } await wait(200); }
+  if (!up) throw new Error(`auth nats-server did not come up on ${PORT}`);
+  const provCreds = await mintCreds(auth, newIdentity(), "provisioner");
+  await setupSpaceStreams({ servers: SERVERS, space, creds: provCreds });
+  await mgr.start();
+
+  const r1 = await mgr.startAgent({ name: "w1", agent: "e2e-stub", cwd: repoRoot });
+  check("spawn: stub agent started", r1.ok === true, r1);
+  const managed = (mgr as unknown as { agents: Map<string, { id: string; handle: AgentHandle; paused?: boolean }> }).agents;
+  const pid = managed.get("w1")?.handle.pid ?? 0;
+  check("spawn: pty handle owns a pid", pid > 0, pid);
+
+  // 4 — cred scope: the admin caller cred publishes ONLY the admin control subject.
+  const adminJwt = await mintCreds(auth, newIdentity(), "control-caller-admin");
+  const payload = JSON.parse(
+    Buffer.from((adminJwt.match(/BEGIN NATS USER JWT-+\n([^\n]+)/)?.[1] ?? "").split(".")[1], "base64url").toString(),
+  ) as { nats?: { pub?: { allow?: string[] } } };
+  const allow = payload.nats?.pub?.allow ?? [];
+  check("cred scope: control-caller-admin pubs ctl.admin only", allow.some((s) => s.includes(".ctl.admin.")), allow);
+  check("cred scope: …and NOT the privileged subject", !allow.some((s) => s.includes(".ctl.manager.")), allow);
+
+  // 1 — pause via the ADMIN tier (the console's flow): reply + real OS freeze + ps reports it.
+  const rp = await callControl(space, auth, CONTROL_ADMIN, "pause", { name: "w1" });
+  check("pause: admin-tier reply {ok, paused:true}", rp.ok === true && (rp.data as { paused?: boolean }).paused === true, rp);
+  await wait(300);
+  check("pause: child process is OS-stopped (state T)", stateOf(pid).startsWith("T"), stateOf(pid));
+  const rps = await callControl(space, auth, CONTROL_PRIVILEGED, "ps", {});
+  const w1 = ((rps.data as { name: string; paused?: boolean }[]) ?? []).find((a) => a.name === "w1");
+  check("ps: reports paused:true", rps.ok === true && w1?.paused === true, w1);
+
+  // 3 — tier: a NON-spawner on the privileged subject is denied pause and stop (admin required).
+  const rDenyPause = await callControl(space, auth, CONTROL_PRIVILEGED, "pause", { name: "w1" });
+  check("tier: privileged non-spawner pause is denied", rDenyPause.ok === false && /not authorized/.test(rDenyPause.error ?? ""), rDenyPause);
+  const rDenyStop = await callControl(space, auth, CONTROL_PRIVILEGED, "stop", { name: "w1" });
+  check("tier: privileged non-spawner stop is denied (old console-kill bug)", rDenyStop.ok === false && /not authorized/.test(rDenyStop.error ?? ""), rDenyStop);
+
+  // 2 — resume: reply + the process leaves the stopped state.
+  const rr = await callControl(space, auth, CONTROL_ADMIN, "resume", { name: "w1" });
+  check("resume: admin-tier reply {ok, paused:false}", rr.ok === true && (rr.data as { paused?: boolean }).paused === false, rr);
+  await wait(300);
+  check("resume: child process left state T", !stateOf(pid).startsWith("T"), stateOf(pid));
+
+  // 5 — unsupported runtime: a handle without pause (tmux/cmux shape) errors loud.
+  managed.set("fake", {
+    id: "fake-id",
+    handle: {
+      name: "fake", kind: "tmux", status: () => "running" as const,
+      stop: () => {}, interrupt: () => {}, attach: () => { throw new Error("n/a"); },
+    },
+    // The op only needs id/handle/spawner; cast keeps the stub minimal.
+  } as never);
+  const rf = await callControl(space, auth, CONTROL_ADMIN, "pause", { name: "fake" });
+  check("unsupported runtime: pause errors 'not supported by the tmux runtime'", rf.ok === false && /not supported by the tmux runtime/.test(rf.error ?? ""), rf);
+  managed.delete("fake");
+
+  // 6 — graceful stop of a PAUSED agent completes (SIGCONT-first guard).
+  await callControl(space, auth, CONTROL_ADMIN, "pause", { name: "w1" });
+  check("re-pause for the stop test", stateOf(pid).startsWith("T") || (managed.get("w1")?.paused ?? false));
+  const rs = await callControl(space, auth, CONTROL_ADMIN, "stop", { name: "w1", graceful: true });
+  check("graceful stop of a paused agent replies ok", rs.ok === true, rs);
+  let gone = false;
+  for (let i = 0; i < 40 && !gone; i++) {
+    await wait(200);
+    gone = stateOf(pid) === "";
+  }
+  check("graceful stop of a paused agent actually exits (SIGCONT before SIGTERM)", gone, stateOf(pid));
+} catch (e) {
+  fail++;
+  console.error("  ✗ scenario threw:", (e as Error).message);
+} finally {
+  try { await mgr.stop(); } catch { /* already down */ }
+  srv.kill("SIGKILL");
+  await new Promise<void>((resolveExit) => {
+    if (srv.exitCode !== null || srv.signalCode !== null) return resolveExit();
+    srv.once("exit", () => resolveExit());
+    setTimeout(resolveExit, 3000);
+  });
+  rmSync(dir, { recursive: true, force: true });
+}
+
+console.log(`\n${fail === 0 ? "PAUSE-RESUME SMOKE OK ✅" : "PAUSE-RESUME SMOKE FAILED ❌"}  (${pass} passed, ${fail} failed)`);
+process.exit(fail === 0 ? 0 : 1);

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -145,6 +145,10 @@ interface ManagedAgent {
   spawner: string;
   startedAt: number;
   handle: AgentHandle;
+  /** Frozen via the `pause` op (SIGSTOP). Lives HERE, not in presence: a stopped process can't
+   *  heartbeat (its key TTLs out to offline) and the manager's cred can't write a peer's presence
+   *  key — managed-state is the one honest home. Surfaced by `ps`/`status`. */
+  paused?: boolean;
   /** This agent's local control endpoint (path + first-frame auth token), when its connector runs
    *  one. Kept in memory only (never persisted — token hygiene) so a graceful stop on a signal-less
    *  runtime (ConPTY/Windows) can send a cooperative `{op:"shutdown"}` over it instead of a hard
@@ -376,6 +380,11 @@ export class Manager {
         if (!name) return { ok: false, error: "self-stop not allowed on privileged subject; send it on the self-service subject" };
         return this.opStop(args, caller, admin);
       }
+      case "pause":
+      case "resume": {
+        if (!name) return { ok: false, error: `${req.op} requires a target name` };
+        return this.opPauseResume(req.op, args, caller, admin);
+      }
       case "definePersona":
         return this.opDefinePersona(args, caller, admin);
       case "purge":
@@ -442,6 +451,10 @@ export class Manager {
    *  never swallowed silently. Being the single stop chokepoint, guarding here covers all callers at once. */
   private stopHandle(a: ManagedAgent, graceful: boolean): void {
     try {
+      // A paused (SIGSTOPped) process won't receive SIGTERM until it runs again — resume first so
+      // a graceful stop can't hang the grace window. SIGKILL lands regardless, but resuming
+      // uniformly is cheap and keeps the paths identical.
+      if (a.paused && a.handle.resume) a.handle.resume();
       if (graceful && process.platform === "win32" && a.control) controlShutdown(a.control);
       a.handle.stop({ graceful });
     } catch (e) {
@@ -1042,6 +1055,32 @@ export class Manager {
     return { ok: true, data: { name, stopped: true, graceful } };
   }
 
+  /** Freeze / unfreeze a managed agent in place (SIGSTOP/SIGCONT on runtimes that own the
+   *  process). Same authority as a named stop — privileged tier reaches only the caller's own
+   *  child, admin any — because a pause is a lifecycle intervention, just a recoverable one.
+   *  A runtime without an owned pid (tmux/cmux) or platform support (win32) errors loud. */
+  private opPauseResume(
+    op: "pause" | "resume",
+    args: Record<string, unknown>,
+    caller: string,
+    admin: boolean,
+  ): ControlReply {
+    const name = String(args.name ?? "").trim();
+    const a = this.agents.get(name);
+    if (!a) return { ok: false, error: `no agent "${name}"` };
+    const denied = this.authorizeNamed(a, caller, admin);
+    if (denied) return { ok: false, error: denied };
+    const fn = op === "pause" ? a.handle.pause : a.handle.resume;
+    if (!fn) return { ok: false, error: `${op} is not supported by the ${a.handle.kind} runtime` };
+    try {
+      fn.call(a.handle);
+    } catch (e) {
+      return { ok: false, error: (e as Error).message };
+    }
+    a.paused = op === "pause"; // idempotent — re-pausing re-signals harmlessly
+    return { ok: true, data: { name, paused: a.paused } };
+  }
+
   /** Open a short-lived PROVISIONER connection, run the onboarding ops on it, and drain it (closure (ii),
    *  residual 2). The DM/DLV consumer-create surface — the irreducible onboarding power — lives only for
    *  this window, never as a standing grant on the long-lived supervisor. A provision-only endpoint
@@ -1170,6 +1209,7 @@ export class Manager {
       space: this.space,
       mode: a.handle.kind,
       status: a.handle.status(),
+      paused: a.paused ?? false,
       uptimeMs: Date.now() - a.startedAt,
       mesh: roster.get(a.name)?.status ?? "absent",
     }));

--- a/implementations/manager/src/runtime/pty.ts
+++ b/implementations/manager/src/runtime/pty.ts
@@ -135,6 +135,20 @@ export class PtyRuntime implements Runtime {
       interrupt: () => {
         if (alive) proc.write("\x03");
       },
+      // POSIX-only: ConPTY delivers no job-control signals, so pause errors loud on Windows
+      // rather than pretending (no fallbacks). Signal the process GROUP (forkpty makes the child
+      // a session leader): freezing the agent must also freeze whatever subprocess it spawned,
+      // the same scope `interrupt`'s ^C reaches.
+      pause: () => {
+        if (process.platform === "win32")
+          throw new Error("pause is not supported on Windows (ConPTY has no POSIX job control)");
+        if (alive) process.kill(-proc.pid, "SIGSTOP");
+      },
+      resume: () => {
+        if (process.platform === "win32")
+          throw new Error("pause/resume is not supported on Windows (ConPTY has no POSIX job control)");
+        if (alive) process.kill(-proc.pid, "SIGCONT");
+      },
       attach: (): AttachSession => ({
         get cols() {
           return cols;

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "smoke:preflight": "tsx packages/workspace/smoke/preflight.smoke.ts",
     "smoke:server-resolution:live": "tsx implementations/cli/smoke/server-resolution-live.smoke.ts",
     "smoke:cooperative-stop:live": "tsx implementations/manager/smoke/cooperative-stop-live.smoke.ts",
+    "smoke:pause-resume:live": "tsx implementations/manager/smoke/pause-resume-live.smoke.ts",
     "smoke:lifecycle-e2e": "tsx implementations/manager/smoke/lifecycle-e2e.smoke.ts",
     "smoke:spawn-args": "tsx extensions/connector-core/smoke/spawn-args.smoke.ts",
     "smoke:install": "tsx implementations/cli/smoke/install.smoke.ts",

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -39,6 +39,12 @@ export interface AgentHandle {
    *  it's a hard, immediate kill. */
   stop(opts?: { graceful?: boolean }): void;
   interrupt(): void;
+  /** Freeze the agent in place (POSIX SIGSTOP to its process group). Present only on backends
+   *  that own a real process (pty) — a backend that can't suspend omits it and the manager
+   *  errors rather than degrading. */
+  pause?(): void;
+  /** Resume a paused agent (SIGCONT). Present iff {@link pause} is. */
+  resume?(): void;
   /** Open a live attach. Throws on backends that can't stream (e.g. tmux/cmux, which
    *  you attach to natively). */
   attach(): AttachSession;


### PR DESCRIPTION
## What

Makes the console a real "lazygit for Cotal" operator surface. **Stacked on #197** (`feat/console-views`) — retarget to `main` once #197 merges.

### The bug this fixes
`D`-kill sent `requestControl("manager", …)` — the *privileged* tier, where the manager only stops your own spawned child — using the console's self-minted god-view `admin` cred, which has **no `ctl.*` publish grant**. So on any auth mesh, kill silently did nothing. Now every control action mints a **per-action, tier-scoped caller cred** from held trust material (open mesh: bare; `--creds`: as-is) and targets the right tier — the same pattern the CLI (`askManager`) and web (channel-purger) already use. Gated on a new `canControl`, distinct from chat-write.

### New capability: pause/resume (new wire ops)
Freeze an agent in place — `SIGSTOP`/`SIGCONT` to the pty process group (POSIX only; tmux/cmux have no owned pid and win32 has no job-control signals, so both error loud, no fallback). Same authority as a named stop. Paused-ness lives in the manager's **managed-state** (`ps`/`status`), not presence — a stopped agent can't heartbeat, so its presence would TTL to "offline" and lie; the console merges `ps` by id and shows a `⏸ paused` badge. A graceful stop of a paused agent resumes it first (SIGTERM isn't delivered to a stopped process).

### Console affordances (graduated destructiveness)
- `p` on a roster agent → pause/resume, no confirm (recoverable).
- `D` → kill behind a confirm: `y` graceful stop, `f` force-kill.
- `:` palette: `spawn <persona> [name]`, `status <agent>`, `ps`, `purge` (type-the-name confirm).
- Every action flashes its result; StatusBar/Help updated.

## Verified
- `pnpm typecheck` + `pnpm test` clean; view/connect/lifecycle-e2e smokes pass.
- **New `pause-resume-live` smoke (15 checks)** against a real broker + manager + process: real OS freeze (state `T`), tier denial for a non-spawner (regression guard for the old kill bug), `control-caller-admin` cred scoped to `ctl.admin` only, unsupported-runtime error, and graceful-stop-of-paused (SIGCONT-first).
- Live TUI: kill confirm renders the graceful/force choice; `p` and `:ps` reach the manager end-to-end (an old v0.10 manager on the running mesh returns `unknown op: pause`, confirming the console wire works — the new op is proven by the smoke).

## Notes
- No SPEC/schema change: control op vocabulary is implementation-defined (SPEC §5 defines only the envelope).
- `docs/architecture.md` + `docs/protocol-view.md` updated in-change.