### PR TITLE
fix(cli): install cotal globally on npx setup by ignoring npx's PATH shim

### DIFF
--- a/implementations/cli/smoke/install.smoke.ts
+++ b/implementations/cli/smoke/install.smoke.ts
@@ -6,9 +6,9 @@
  * proves the gate (npx + no global `cotal`) and that a failed install is handled gracefully (the
  * feature is best-effort and must never throw / abort setup).
  */
-import { mkdtempSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { isNpx, cotalOnPath } from "../src/lib/self-exec.js";
 import { offerGlobalInstall } from "../src/commands/setup.js";
 
@@ -56,6 +56,29 @@ try {
 }
 check("npx install path: failed install handled gracefully (no throw)", !threw);
 check("nothing actually installed: `cotal` still not on PATH", cotalOnPath() === false);
+
+// 3) Regression: npx prepends its own `<cache>/_npx/<hash>/node_modules/.bin` (holding a throwaway
+//    `cotal`, since cotal-ai declares that bin) to PATH. That shim must NOT count as installed —
+//    else `npx cotal-ai setup` skips the global-install offer and hands out `cotal …` hints the
+//    user can't run once npx exits. This is the exact PATH the earlier `= prefix` reset stripped.
+const cotalExe = () => (process.platform === "win32" ? "cotal.cmd" : "cotal");
+function seedCotal(dir: string): string {
+  mkdirSync(dir, { recursive: true });
+  const f = join(dir, cotalExe());
+  writeFileSync(f, "#!/bin/sh\n");
+  chmodSync(f, 0o755);
+  return dir;
+}
+const npxBin = seedCotal(join(prefix, "_npx", "deadbeef", "node_modules", ".bin"));
+const realBin = seedCotal(join(prefix, "realbin"));
+
+process.env.PATH = npxBin; // only the ephemeral npx shim is reachable
+check("npx `_npx/.../.bin/cotal` shim on PATH ⇒ cotalOnPath() ignores it (false)", cotalOnPath() === false);
+
+process.env.PATH = [npxBin, realBin].join(delimiter); // ephemeral shim + a durable install
+check("a durable `cotal` alongside the npx shim ⇒ cotalOnPath() true", cotalOnPath() === true);
+
+process.env.PATH = prefix; // restore the deterministic no-cotal PATH
 
 process.argv[1] = realArgv1;
 console.log(failures ? `\n${failures} check(s) failed` : "\nall checks passed");

--- a/implementations/cli/src/lib/self-exec.ts
+++ b/implementations/cli/src/lib/self-exec.ts
@@ -14,12 +14,17 @@ export function isNpx(): boolean {
   return /[/\\]_npx[/\\]/.test(process.argv[1] ?? "");
 }
 
-/** Is a `cotal` executable resolvable on PATH? A pure PATH scan (no exec): `cotal --version`
- *  isn't a real command, so probing it via `onPath` would always report cotal as missing. */
+/** Is a *durable* `cotal` executable resolvable on PATH? A pure PATH scan (no exec): `cotal
+ *  --version` isn't a real command, so probing it via `onPath` would always report cotal missing.
+ *  Skips npx's transient shim: `npm exec` (npx) prepends the package's own
+ *  `<cache>/_npx/<hash>/node_modules/.bin` to PATH, and since `cotal-ai` declares a `cotal` bin,
+ *  that dir holds a throwaway `cotal`. Counting it would make a bare `npx cotal-ai setup` conclude
+ *  `cotal` is already installed — skipping the global-install offer and printing `cotal …` hints
+ *  the user can't run once npx exits. That shim is exactly what we're offering to make permanent. */
 export function cotalOnPath(): boolean {
   const exts = process.platform === "win32" ? ["", ".cmd", ".exe", ".bat"] : [""];
   for (const dir of (process.env.PATH ?? "").split(delimiter)) {
-    if (!dir) continue;
+    if (!dir || isEphemeralNpxBin(dir)) continue;
     for (const ext of exts) {
       try {
         accessSync(join(dir, `cotal${ext}`), constants.X_OK);
@@ -30,6 +35,13 @@ export function cotalOnPath(): boolean {
     }
   }
   return false;
+}
+
+/** A PATH entry npx (`npm exec`) injected for the current run only — its `_npx` cache
+ *  `node_modules/.bin`. A `cotal` shim there disappears when npx exits, so it must not count as
+ *  `cotal` being installed. Matches the `_npx` cache segment on POSIX and Windows. */
+function isEphemeralNpxBin(dir: string): boolean {
+  return /[/\\]_npx[/\\]/.test(dir);
 }
 
 /** The copy-paste command prefix for user-facing hints: `cotal` when it's on PATH, `npx cotal-ai`


### PR DESCRIPTION
## Problem

On a fresh machine, `npx cotal-ai setup` left the user with **no durable `cotal` command** — even after opening a new terminal. Setup completed cleanly, but the guided global-install step never happened.

## Root cause

`offerGlobalInstall()` gates on:

```ts
if (!isNpx() || cotalOnPath()) return;
```

npx (`npm exec`) prepends its transient `<cache>/_npx/<hash>/node_modules/.bin` to `PATH`, and because the `cotal-ai` package declares a `cotal` bin, that dir holds a **throwaway `cotal` shim**. So inside the setup run `cotalOnPath()` resolved `.../_npx/<hash>/node_modules/.bin/cotal` and returned `true` → the gate concluded cotal was already installed → skipped the install. Once npx exits, the shim vanishes and the user has no `cotal`.

The same false positive corrupted `displayCmd()` (shared predicate), so the finale card printed `cotal up`, `cotal spawn`, … — commands the user couldn't run.

## Fix

Make `cotalOnPath()` skip `_npx` cache entries when scanning `PATH`, so the ephemeral shim no longer counts as an installed cotal. This fixes both the skipped install and the wrong finale hints (an npx run without a durable `cotal` now correctly shows `npx cotal-ai …`).

## Tests

`implementations/cli/smoke/install.smoke.ts` now seeds a real `_npx/.../node_modules/.bin/cotal` on `PATH` and asserts `cotalOnPath()` ignores it, plus a durable install alongside it still counts. The prior smoke masked the bug by resetting `PATH` to a bare temp dir (stripping the exact `_npx` entry that triggers it).

- `pnpm smoke:install` — green
- `pnpm --filter @cotal-ai/cli typecheck` — clean

## End-to-end validation (fresh `node:20-slim`, linux/amd64)

| | Global-install offer | `cotal` after setup |
|---|---|---|
| Published `cotal-ai@0.10.0` | skipped silently | **absent** — bug reproduced |
| With this fix | `Installed — you can now run cotal` | `/usr/local/bin/cotal`, `cotal --help` runs |

## Note — separate, out of scope

The Docker run also surfaced an unrelated gap: on linux-x64 a real `npm i -g cotal-ai` does not pull the optional `@eplightning/nats-server-linux-x64` binary, so `cotal setup`/`up` fails at the NATS-locate step unless `nats-server` is already on PATH. Different root cause; not addressed here. It did not cause the reported issue (that user's setup reached the finale, so their platform resolved NATS).