### PR TITLE
feat: add connector model variants

### DIFF
--- a/bin/smoke/flag-inventory.smoke.ts
+++ b/bin/smoke/flag-inventory.smoke.ts
@@ -55,10 +55,11 @@ const GOLDEN: Record<string, { flags: string[]; positionals: boolean; rawArgs?: 
       "config:string", "creds:string", "cwd:string", "detach:boolean:d", "dry-run:boolean",
       "file:string:f", "model:string", "name:string", "no-transcript:boolean",
       "prompt:string", "resume:string", "role:string", "runtime:string", "server:string",
-      "share-tools:string", "space:string", "subscribe:string", "transcript:boolean",
+      "share-tools:string", "space:string", "subscribe:string", "transcript:boolean", "variant:string",
     ],
     positionals: true,
   },
+  models: { flags: [...TARGET, "agent:string", "refresh:boolean"], positionals: false },
   personas: {
     flags: [
       ...TARGET, "force:boolean", "from:string", "model:string", "prompt:string", "role:string",

--- a/bin/smoke/launch-parity.smoke.ts
+++ b/bin/smoke/launch-parity.smoke.ts
@@ -29,7 +29,7 @@ process.env.COTAL_CAPABILITIES = "spawn";
  *  Types are erased at runtime, so this list is the golden — a StartAgentOpts change must
  *  consciously edit it. */
 const START_OP_KEYS = new Set([
-  "name", "identity", "agent", "role", "config", "model", "resume", "transcript", "cwd",
+  "name", "identity", "agent", "role", "config", "model", "variant", "resume", "transcript", "cwd",
   "prompt", "subscribe", "allowSubscribe", "allowPublish", "shareTools",
 ]);
 

--- a/bin/smoke/spawn-detach-live.smoke.ts
+++ b/bin/smoke/spawn-detach-live.smoke.ts
@@ -76,6 +76,7 @@ const e2eCon: Connector = {
   kind: "connector",
   name: "e2e",
   requires: ["node"],
+  supportsModelVariant: true,
   buildLaunch: (o) => {
     lastOpts = o;
     return {
@@ -137,7 +138,7 @@ try {
     run("spawn", [
       "poet", "--detach", "--agent", "e2e", "--space", SPACE, "--name", "bard",
       "--prompt", "compose", "--subscribe", "ops,ops.x", "--allow-subscribe", "ops,ops.>",
-      "--allow-publish", "ops", "--model", "fancy", "--cwd", agentCwd, "--share-tools", "alpha",
+      "--allow-publish", "ops", "--model", "fancy", "--variant", "high", "--cwd", agentCwd, "--share-tools", "alpha",
     ]),
   );
   ok("detached spawn reached the connector", lastOpts !== undefined);
@@ -147,6 +148,7 @@ try {
   ok("allow-subscribe override arrived", JSON.stringify(lastOpts?.allowSubscribe) === JSON.stringify(["ops", "ops.>"]), lastOpts?.allowSubscribe);
   ok("allow-publish override arrived", JSON.stringify(lastOpts?.allowPublish) === JSON.stringify(["ops"]), lastOpts?.allowPublish);
   ok("model override arrived", lastOpts?.model === "fancy", lastOpts?.model);
+  ok("variant override arrived", lastOpts?.variant === "high", lastOpts?.variant);
   ok("share-tools narrowed the config servers", JSON.stringify(Object.keys(lastOpts?.mcpServers ?? {})) === JSON.stringify(["alpha"]), lastOpts?.mcpServers);
   ok("persona role survived (no override given)", lastOpts?.role === "writer", lastOpts?.role);
   // --cwd is proven by the real child: it wrote its actual working directory.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -427,7 +427,7 @@ browser).
   standalone `cotal console` node that discovers managers over the mesh and aggregates their
   streams.
 
-**Control schema (first cut):** `start {role, name, agent}` · `stop {name, graceful?}` ·
+**Control schema (first cut):** `start {role, name, agent, model?, variant?}` · `models {agent?, refresh?}` · `stop {name, graceful?}` ·
 `definePersona {name, persona, model?}` · `ps` · `status {instance}` · `attach {instance}` ·
 `bind {instance, config}`. These are control-plane request/reply messages any authorized node
 (CLI, dashboard, or an agent) can send; spawning is policy-gated. `definePersona` writes

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -137,7 +137,7 @@ run`). They differ only in how they *run* the spec:
 
 | Launcher | How to point at a file |
 |---|---|
-| Manager (supervised PTY) | `cotal spawn --detach dave` (auto-discovers `.cotal/agents/dave.md` in the manager's workspace) or `--config <persona-or-path>` for an explicit persona ref/file; the SAME grammar as the foreground launch — `--model`, `--cwd`, `--prompt`, ACL overrides, `--share-tools` all apply. View via console / `cotal attach`. |
+| Manager (supervised PTY) | `cotal spawn --detach dave` (auto-discovers `.cotal/agents/dave.md` in the manager's workspace) or `--config <persona-or-path>` for an explicit persona ref/file; the SAME grammar as the foreground launch — `--model`, `--variant`, `--cwd`, `--prompt`, ACL overrides, `--share-tools` all apply. View via console / `cotal attach`. |
 | Foreground (`cotal spawn`) | `cotal spawn <persona>` for `.cotal/agents/<persona>.md`, or `--config <persona-or-path>` when a flag is clearer. The real Claude TUI takes over this terminal (run it inside a cmux/tmux pane to multiplex). Works from **any directory** — it joins the running mesh via the registry (see below), no `cd` into the project that ran `cotal up`. |
 
 `.cotal/` is gitignored (user-local, like `.claude/`). The demo ships committed example
@@ -153,14 +153,16 @@ as `--config`; an explicit positional persona or `--config` wins.
 `COTAL_DEFAULT_AGENT` when set, otherwise Claude. For example, start the stack with
 `COTAL_DEFAULT_AGENT=opencode cotal up --detach` to make later `cotal_spawn(...)` calls launch
 OpenCode by default. Foreground `cotal spawn` reads the same variable. An explicit per-spawn
-`--agent claude` / `agent: "claude"` still wins.
+`--agent claude` / `agent: "claude"` still wins. Selector UIs can ask the manager for connector
+catalogs with `cotal models --agent opencode`; connectors that expose a catalog report model ids
+and variant names without Cotal hardcoding provider lists.
 
 **Define one at runtime.** `cotal_persona(name, prompt, model?)` sends the persona to the
 manager, which writes the same `.cotal/agents/<name>.md` file (via `saveAgentFile`) and
-announces it on the mesh. A later `cotal_spawn(name, role?, agent?, model?)` auto-discovers it, so
+announces it on the mesh. A later `cotal_spawn(name, role?, agent?, model?, variant?)` auto-discovers it, so
 a peer can mint a teammate's persona on the fly and bring it online with no hand-written file. The
 agent spawn door carries the same knobs as the operator's `cotal spawn --detach` — `role`, `agent` (harness)
-and `model` (overrides the persona file's `model:`) — set at spawn because they are policy, not
+and `model` / `variant` (override the persona file's selectors) — set at spawn because they are policy, not
 persona content.
 
 **Resume an existing session (fork, never hijack).** `--resume <session-id>` pulls an existing

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,6 +108,10 @@ By default, `cotal spawn` and `cotal_spawn` launch Claude. Set `COTAL_DEFAULT_AG
 or `COTAL_DEFAULT_AGENT=hermes` to change the default harness for spawns that do not pass
 `--agent` / `agent`. An explicit `--agent` always wins.
 
+For connector-provided model selectors, ask the manager: `cotal models --agent opencode` lists
+OpenCode model ids and available variants. Use them with `cotal spawn --agent opencode --model
+provider/model --variant high`.
+
 Feedback flows through your agent too: tell it "send feedback: ..." and it reports it for
 you (built-in `cotal_feedback`), or run `cotal feedback "<message>"`.
 

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -44,7 +44,8 @@ channels:
 
 > **Harness:** `agent: claude` runs each agent as Claude Code (which must be installed). Use
 > `agent: opencode` for OpenCode — its models use `provider/model` form (e.g.
-> `anthropic/claude-sonnet-4-6`). You can also set the harness per agent.
+> `anthropic/claude-sonnet-4-6`) and may expose variants (`cotal models --agent opencode`).
+> You can also set the harness per agent.
 
 Save it as `cotal.yaml` and run:
 
@@ -123,6 +124,7 @@ agents:
   builder:                              # 2) a persona file + overrides (manifest wins)
     persona: ./agents/builder.md
     model: sonnet
+    variant: high
     role: implementer
     instructions: Prefer the smallest change that works.
   lead:                                 # 3) inline (no file): needs at least model or instructions
@@ -132,10 +134,10 @@ agents:
     instructions: Coordinate the team.
 ```
 
-Per-agent keys: `persona`, `agent` (harness override), `model`, `role`, `description`,
+Per-agent keys: `persona`, `agent` (harness override), `model`, `variant`, `role`, `description`,
 `instructions`, `capabilities` (e.g. `[spawn]`), `personaPermissions` (override the top-level
-policy). Model strings pass to the harness as-is — for Claude use the short form (`opus`,
-`sonnet`) or the full id; for OpenCode use `provider/model`.
+policy). Model strings and variants pass to the harness as-is — for Claude use the short form
+(`opus`, `sonnet`) or the full id; for OpenCode use `provider/model` plus an optional variant.
 
 ### `channels:` — the three access verbs
 

--- a/extensions/connector-claude-code/src/extension.ts
+++ b/extensions/connector-claude-code/src/extension.ts
@@ -37,6 +37,7 @@ export const claudeConnector: Connector = {
   supportsResume: true, // renders `--resume <id> --fork-session` (fork-from, never hijack) — see buildLaunch
 
   buildLaunch(opts: LaunchOpts): LaunchSpec {
+    if (opts.variant) throw new Error("claude connector: model variants are not supported");
     // Operator MCP servers shared with this agent (default none — see the --mcp-config block).
     const shared = opts.mcpServers ?? {};
     // claude auths via macOS Keychain / an OAuth token, not an env key → forward NO provider key.
@@ -124,7 +125,10 @@ export const claudeConnector: Connector = {
       model ??= def.model;
     }
     // The `--model` flag wins over the agent file, and applies even with no agent file.
-    if (model) args.push("--model", model);
+    if (model) {
+      args.push("--model", model);
+      env.COTAL_MODEL = model;
+    }
 
     // Fork an existing session INTO the mesh (opts.resume, an opaque host-local id). `--fork-session`
     // is pushed in the SAME branch — resume here is fork-only, never a hijack: claude mints a NEW

--- a/extensions/connector-core/smoke/spawn-args.smoke.ts
+++ b/extensions/connector-core/smoke/spawn-args.smoke.ts
@@ -1,7 +1,7 @@
 /**
- * cotal_spawn parity smoke — proves the MCP spawn door carries the same harness/model knobs as the
+ * cotal_spawn parity smoke — proves the MCP spawn door carries the same harness/model/variant knobs as the
  * operator's `cotal spawn --detach`. The `cotal_spawn` tool forwards to MeshAgent.spawn, which puts `agent`
- * and `model` into the manager's `start` control op; the manager's opStart already consumes both.
+ * plus model selectors into the manager's `start` control op; the manager's opStart already consumes them.
  * No NATS: the MeshAgent constructor builds an endpoint but never connects, so we swap in a
  * recording `ep` and mark connected. Run with: pnpm smoke:spawn-args
  */
@@ -28,22 +28,24 @@ let rec: { tier: ControlTier; req: ControlRequest; timeoutMs?: number } | undefi
 };
 (a as unknown as { _connected: boolean })._connected = true;
 
-// Full knobs: harness + model ride through to the manager's `start` op.
-await a.spawn("rev", "reviewer", { agent: "opencode", model: "sonnet" });
+// Full knobs: harness + model selectors ride through to the manager's `start` op.
+await a.spawn("rev", "reviewer", { agent: "opencode", model: "sonnet", variant: "high" });
 check("op is start", rec?.req.op === "start", rec?.req.op);
 check("rides the privileged control subject", rec?.tier === CONTROL_PRIVILEGED);
 check("name forwarded", rec?.req.args?.name === "rev");
 check("role forwarded", rec?.req.args?.role === "reviewer");
 check("agent (harness) forwarded", rec?.req.args?.agent === "opencode", rec?.req.args?.agent);
 check("model forwarded", rec?.req.args?.model === "sonnet", rec?.req.args?.model);
+check("variant forwarded", rec?.req.args?.variant === "high", rec?.req.args?.variant);
 // #159 B1: the manager replies to `start` only on a real outcome (join / exit / ~30s readiness
 // backstop) — the request must carry the long spawn window, not fall back to the 5s op default.
 check("request outlives the readiness wait (SPAWN_TIMEOUT_MS, not the 5s default)", rec?.timeoutMs === SPAWN_TIMEOUT_MS, rec?.timeoutMs);
 
-// Name-only: agent/model absent → undefined, so the manager applies its defaults (env/Claude, file model).
+// Name-only: agent/model/variant absent → undefined, so the manager applies its defaults (env/Claude, file model).
 await a.spawn("plain");
 check("name-only: agent undefined", rec?.req.args?.agent === undefined);
 check("name-only: model undefined", rec?.req.args?.model === undefined);
+check("name-only: variant undefined", rec?.req.args?.variant === undefined);
 check("name-only: role undefined", rec?.req.args?.role === undefined);
 
 console.log(`\nSPAWN-ARGS SMOKE ${failures === 0 ? "OK ✅" : "FAILED ❌"}`);

--- a/extensions/connector-core/src/agent.ts
+++ b/extensions/connector-core/src/agent.ts
@@ -35,6 +35,7 @@ export const SPAWN_TIMEOUT_MS = 40_000;
 function buildMeta(config: AgentConfig): Record<string, string> | undefined {
   const meta: Record<string, string> = { ...(config.meta ?? {}) };
   if (config.model) meta.model = config.model;
+  if (config.variant) meta.variant = config.variant;
   if (config.connector) meta.connector = config.connector;
   return Object.keys(meta).length ? meta : undefined;
 }
@@ -499,17 +500,17 @@ export class MeshAgent extends EventEmitter {
    *  not the 5s op default.
    *  How it lands — a detached PTY, a tmux window, a cmux tab — is the manager's
    *  runtime; from here it just joins the mesh as a lateral peer. `opts.agent` picks
-   *  the harness (default the manager's `COTAL_DEFAULT_AGENT`, else `cotal`/Claude), `opts.model` overrides the
-   *  persona file's `model:`, and `opts.cwd` roots the new peer at a different folder/repo
+   *  the harness (default the manager's `COTAL_DEFAULT_AGENT`, else `cotal`/Claude), `opts.model` /
+   *  `opts.variant` override the persona file's model selectors, and `opts.cwd` roots the new peer at a different folder/repo
    *  than the manager's workspace — the same knobs the operator's `cotal spawn --detach` carries, so
    *  the agent and operator spawn doors share one control-op contract. (Session `resume` is
    *  intentionally NOT forwarded here: forking a host-local `~/.claude` transcript is an
    *  operator-local intent, kept off the peer-facing spawn door — see #159.) */
-  async spawn(name: string, role?: string, opts?: { agent?: string; model?: string; cwd?: string }): Promise<ControlReply> {
+  async spawn(name: string, role?: string, opts?: { agent?: string; model?: string; variant?: string; cwd?: string }): Promise<ControlReply> {
     this.assertConnected();
     return this.ep.requestControl(CONTROL_PRIVILEGED, {
       op: "start",
-      args: { name, role, agent: opts?.agent, model: opts?.model, cwd: opts?.cwd },
+      args: { name, role, agent: opts?.agent, model: opts?.model, variant: opts?.variant, cwd: opts?.cwd },
     }, SPAWN_TIMEOUT_MS);
   }
 

--- a/extensions/connector-core/src/config.ts
+++ b/extensions/connector-core/src/config.ts
@@ -59,6 +59,9 @@ export interface AgentConfig {
    *  `COTAL_MODEL`. Rides {@link AgentCard.meta}.model as display-only discovery metadata; omitted
    *  when the operator didn't pin one (the harness default isn't knowable from here). */
   model?: string;
+  /** Connector-defined model variant (for example reasoning effort), from `variant:` or
+   *  `COTAL_VARIANT`. Display-only discovery metadata. */
+  variant?: string;
   token?: string;
   user?: string;
   pass?: string;
@@ -145,6 +148,7 @@ export function configFromEnv(env: NodeJS.ProcessEnv = process.env): AgentConfig
     meta: def?.meta,
     capabilities: splitList(env.COTAL_CAPABILITIES).length ? splitList(env.COTAL_CAPABILITIES) : def?.capabilities,
     model: env.COTAL_MODEL?.trim() || def?.model || undefined,
+    variant: env.COTAL_VARIANT?.trim() || def?.variant || undefined,
     servers: env.COTAL_SERVERS?.trim() || link?.servers || DEFAULT_SERVER,
     subscribe: resolvedSubscribe,
     allowSubscribe: resolvedAllowSub,

--- a/extensions/connector-core/src/tool-specs.ts
+++ b/extensions/connector-core/src/tool-specs.ts
@@ -481,6 +481,10 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
           .string()
           .optional()
           .describe("Optional model override (e.g. opus, sonnet) — wins over the persona file's model:."),
+        variant: z
+          .string()
+          .optional()
+          .describe("Optional model variant override (connector-defined; for OpenCode, a model variant such as high/max/low)."),
         cwd: z
           .string()
           .optional()
@@ -493,9 +497,9 @@ export function cotalToolSpecs(config: AgentConfig, source = "connector"): Cotal
         // boundary. Resume lives only on the operator CLI (`cotal spawn --resume`, foreground or
         // --detach); a peer-facing, capability-gated resume is deferred (see #159).
       },
-      async run(agent, _config, { name, role, agent: agentType, model, cwd }: { name: string; role?: string; agent?: string; model?: string; cwd?: string }) {
+      async run(agent, _config, { name, role, agent: agentType, model, variant, cwd }: { name: string; role?: string; agent?: string; model?: string; variant?: string; cwd?: string }) {
         try {
-          const reply = await agent.spawn(name, role, { agent: agentType, model, cwd });
+          const reply = await agent.spawn(name, role, { agent: agentType, model, variant, cwd });
           if (!reply.ok) return err(`Couldn't spawn ${name}: ${reply.error ?? "manager refused"}`);
           const d = reply.data as { name?: string; mode?: string } | undefined;
           const actual = d?.name ?? name; // the manager auto-numbers on a collision — report what it spawned

--- a/extensions/connector-hermes/src/extension.ts
+++ b/extensions/connector-hermes/src/extension.ts
@@ -35,6 +35,7 @@ export const hermesConnector: Connector = {
     // ignores opts it doesn't render, so without this guard `resume` would be dropped without a word.
     if (opts.resume)
       throw new Error("the Hermes connector does not support resuming an existing session (resume)");
+    if (opts.variant) throw new Error("the Hermes connector does not support model variants (variant)");
     // OS allow-list + the named model-provider key (Hermes is model-agnostic; any one unlocks a
     // provider), forwarded BY NAME — never `...process.env` — so the operator's unrelated secrets
     // don't reach the gateway child (P3).
@@ -56,7 +57,10 @@ export const hermesConnector: Connector = {
     // gateway model — resolving here is the one place that honors the file's model for Hermes.
     const fileModel = opts.configPath ? loadAgentFile(opts.configPath).model : undefined;
     const model = opts.model ?? fileModel ?? process.env.HERMES_MODEL;
-    if (model) env.HERMES_MODEL = model;
+    if (model) {
+      env.HERMES_MODEL = model;
+      env.COTAL_MODEL = model;
+    }
     return { command: TSX, args: [LAUNCH_ENTRY], env };
   },
 };

--- a/extensions/connector-opencode/src/extension.ts
+++ b/extensions/connector-opencode/src/extension.ts
@@ -1,6 +1,7 @@
+import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { resolve } from "node:path";
-import { loadAgentFile, registry, type Connector, type LaunchOpts, type LaunchSpec } from "@cotal-ai/core";
+import { loadAgentFile, registry, type Connector, type LaunchOpts, type LaunchSpec, type ModelCatalog, type ModelInfo } from "@cotal-ai/core";
 import { aclEnv, launchEnv, controlEndpoint, MODEL_PROVIDER_KEYS, transcriptChannel } from "@cotal-ai/connector-core";
 
 /** The bundled in-process plugin (esbuild → `dist/plugin.bundle.js`). `opencode serve` loads it by
@@ -12,6 +13,80 @@ const PLUGIN_ENTRY = fileURLToPath(new URL("./plugin.bundle.js", import.meta.url
 /** The launcher shim (`dist/serve.js`): starts `opencode serve` with the plugin, then attaches a
  *  foreground `opencode` TUI to the exact session the plugin drives (see serve.ts). */
 const SERVE_SHIM = fileURLToPath(new URL("./serve.js", import.meta.url));
+
+function discoveryEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env.OPENCODE_CONFIG_CONTENT;
+  for (const k of Object.keys(env)) if (k.startsWith("COTAL_")) delete env[k];
+  return env;
+}
+
+function execErrorMessage(e: unknown): string {
+  const err = e as Error & { stderr?: Buffer | string };
+  const stderr = Buffer.isBuffer(err.stderr) ? err.stderr.toString("utf8") : err.stderr;
+  return (stderr?.trim() || err.message).replace(/\s+/g, " ");
+}
+
+function readJsonBlock(lines: string[], start: number): { value: unknown; end: number } {
+  const parts: string[] = [];
+  for (let i = start; i < lines.length; i++) {
+    parts.push(lines[i]);
+    try {
+      return { value: JSON.parse(parts.join("\n")), end: i };
+    } catch {
+      // Keep accumulating the pretty-printed JSON object.
+    }
+  }
+  throw new Error("opencode models output ended before a model metadata JSON block closed");
+}
+
+function parseModels(stdout: string): ModelInfo[] {
+  const lines = stdout.split(/\r?\n/);
+  const models: ModelInfo[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const id = lines[i].trim();
+    if (!/^[^\s/]+\/\S+$/.test(id)) continue;
+
+    let raw: Record<string, unknown> | undefined;
+    if (lines[i + 1]?.trim().startsWith("{")) {
+      const block = readJsonBlock(lines, i + 1);
+      i = block.end;
+      if (block.value && typeof block.value === "object" && !Array.isArray(block.value)) raw = block.value as Record<string, unknown>;
+    }
+
+    const variantsRaw = raw?.variants;
+    const variants = variantsRaw && typeof variantsRaw === "object" && !Array.isArray(variantsRaw)
+      ? Object.entries(variantsRaw as Record<string, unknown>)
+        .filter(([, v]) => !(v && typeof v === "object" && !Array.isArray(v) && (v as { disabled?: unknown }).disabled === true))
+        .map(([name, v]) => ({ name, ...(v && typeof v === "object" && !Array.isArray(v) ? { options: v as Record<string, unknown> } : {}) }))
+      : undefined;
+
+    const provider = typeof raw?.providerID === "string" ? raw.providerID : id.split("/", 1)[0];
+    models.push({
+      id,
+      provider,
+      ...(typeof raw?.name === "string" ? { name: raw.name } : {}),
+      ...(variants?.length ? { variants } : {}),
+    });
+  }
+  return models;
+}
+
+function listOpenCodeModels(opts: { refresh?: boolean } = {}): ModelCatalog {
+  const args = ["models", "--pure", "--verbose"];
+  if (opts.refresh) args.push("--refresh");
+  try {
+    const stdout = execFileSync("opencode", args, {
+      encoding: "utf8",
+      env: discoveryEnv(),
+      stdio: ["ignore", "pipe", "pipe"],
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    return { source: "opencode models --pure --verbose", models: parseModels(stdout) };
+  } catch (e) {
+    throw new Error(`opencode models failed: ${execErrorMessage(e)}`);
+  }
+}
 
 /**
  * The OpenCode connector: launches a watchable `opencode` TUI bound to the agent's session, using
@@ -32,6 +107,8 @@ export const opencodeConnector: Connector = {
   name: "opencode",
   transcriptChannel, // the shared `tr-<name>` convention (connector-core), exposed via the contract
   requires: ["opencode"],
+  supportsModelVariant: true,
+  listModels: listOpenCodeModels,
   buildLaunch(opts: LaunchOpts): LaunchSpec {
     // Resuming an existing session isn't wired for opencode: the connector runs `opencode serve` +
     // a plugin that CREATES its own session then attaches a TUI, so a fork must plumb into
@@ -95,23 +172,34 @@ export const opencodeConnector: Connector = {
       },
     };
 
-    // An agent file carries identity (read in-session via COTAL_AGENT_FILE) plus persona + model.
-    // The model is a config default (the session — and the attached TUI — use it); the persona is
+    // An agent file carries identity (read in-session via COTAL_AGENT_FILE) plus persona + model/variant.
+    // The model/variant are config defaults (the session — and the attached TUI — use them); the persona is
     // applied in-session by the plugin (opencode has no `--append-system-prompt`).
     let model = opts.model;
+    let variant = opts.variant;
     if (opts.configPath) {
       const path = resolve(opts.configPath);
       env.COTAL_AGENT_FILE = path; // plugin reads persona from it
       const def = loadAgentFile(path);
       model ??= def.model;
+      variant ??= def.variant;
     }
-    // The `--model` flag wins over the agent file, and applies even with no agent file. Pin it to a
-    // dedicated primary agent made the default, so an operator's own `default_agent` in
-    // ~/.config/opencode (with its own model) can't override the model a Cotal spawn asks for — the
-    // session the plugin drives runs the persona's model, not the operator's default agent's.
+    // The `--model` / `--variant` flags win over the agent file, and apply even with no agent file.
+    // Pin them to a dedicated primary agent made the default, so an operator's own `default_agent` in
+    // ~/.config/opencode (with its own model) can't override what a Cotal spawn asks for — the session
+    // the plugin drives runs the persona's selectors, not the operator's default agent's.
+    const cotalAgent: Record<string, unknown> = { mode: "primary" };
     if (model) {
       config.model = model;
-      config.agent = { cotal: { mode: "primary", model } };
+      env.COTAL_MODEL = model;
+      cotalAgent.model = model;
+    }
+    if (variant) {
+      env.COTAL_VARIANT = variant;
+      cotalAgent.variant = variant;
+    }
+    if (model || variant) {
+      config.agent = { cotal: cotalAgent };
       config.default_agent = "cotal";
     }
 

--- a/implementations/cli/src/commands/models.ts
+++ b/implementations/cli/src/commands/models.ts
@@ -1,0 +1,52 @@
+import { CONTROL_PRIVILEGED, registry, type CompletionResult, type Connector, type ConnectorModelCatalog, type FlagSpec, type FlagValues, type ModelInfo, type ParsedArgs } from "@cotal-ai/core";
+import { loadMeshes, targetFlags } from "@cotal-ai/workspace";
+import { c } from "../ui.js";
+import { askManager, failIfNotOk, resolveControlTarget } from "../lib/control.js";
+import { completingFlagValue } from "../lib/completion.js";
+
+export const modelsFlags = [
+  ...targetFlags,
+  { name: "agent", type: "string", value: "<connector>", description: "connector to inspect (default: all registered connectors)" },
+  { name: "refresh", type: "boolean", description: "ask the connector to refresh its provider cache" },
+] as const satisfies readonly FlagSpec[];
+
+export function modelsComplete(argv: string[]): CompletionResult {
+  const flag = completingFlagValue(argv, modelsFlags);
+  if (flag?.name === "space") return { items: loadMeshes().map((m) => ({ value: m.space })), directive: "nofiles" };
+  if (flag?.name === "agent") return { items: registry.all<Connector>("connector").map((c) => ({ value: c.name })), directive: "nofiles" };
+  if (flag?.name === "creds") return { items: [], directive: "default" };
+  return { items: [], directive: "nofiles" };
+}
+
+export async function models(args: ParsedArgs): Promise<void> {
+  const v = args.values as FlagValues<typeof modelsFlags>;
+  const t = await resolveControlTarget(v, "control-caller-privileged");
+  const reply = await askManager(t.space, t.server, "models", { agent: v.agent, refresh: v.refresh === true }, t.creds, CONTROL_PRIVILEGED);
+  failIfNotOk(reply);
+  const rows = Array.isArray(reply.data) ? reply.data as ConnectorModelCatalog[] : [reply.data as ConnectorModelCatalog];
+  for (const row of rows) renderCatalog(row);
+}
+
+function renderCatalog(row: ConnectorModelCatalog): void {
+  if (!row.supported) {
+    console.log(`${c.bold(row.agent)}  ${c.dim("no model catalog exposed")}`);
+    return;
+  }
+  if (row.error) {
+    console.log(`${c.bold(row.agent)}  ${c.red(row.error)}`);
+    return;
+  }
+  console.log(c.bold(row.agent) + (row.source ? c.dim(`  ${row.source}`) : ""));
+  if (!row.models.length) {
+    console.log(c.dim("  (no models reported)"));
+    return;
+  }
+  const pad = Math.max(...row.models.map((m) => m.id.length));
+  for (const model of row.models) renderModel(model, pad);
+}
+
+function renderModel(model: ModelInfo, pad: number): void {
+  const name = model.name && model.name !== model.id ? c.dim(`  ${model.name}`) : "";
+  console.log(`  ${model.id.padEnd(pad)}${name}`);
+  if (model.variants?.length) console.log(c.dim(`  ${"".padEnd(pad)}  variants: ${model.variants.map((v) => v.name).join(", ")}`));
+}

--- a/implementations/cli/src/commands/spawn.ts
+++ b/implementations/cli/src/commands/spawn.ts
@@ -213,6 +213,7 @@ async function spawnDetached(
     agent: values.agent ?? defaultAgentOverride(),
     config: managerConfigRef,
     model: values.model,
+    variant: values.variant,
     cwd: values.cwd,
     resume: values.resume, // host-local session id; the manager preflights connector resume support
     prompt: values.prompt,
@@ -253,6 +254,10 @@ export async function spawn(args: ParsedArgs): Promise<void> {
   // rather than silently spawn a fresh one (no fallbacks). An absent flag (undefined) is fine.
   if (values.resume !== undefined && !values.resume.trim()) {
     console.error("--resume needs a session id (got an empty value)");
+    process.exit(1);
+  }
+  if (values.variant !== undefined && !values.variant.trim()) {
+    console.error("--variant needs a variant name (got an empty value)");
     process.exit(1);
   }
   // Transcript mirroring to `tr-<name>` is OFF by default. Tri-state: true (--transcript),
@@ -328,6 +333,20 @@ export async function spawn(args: ParsedArgs): Promise<void> {
   if (target.source === "registry" || target.source === "current")
     console.error(c.dim(`→ joining mesh ${space} (${server}) as ${name}`));
 
+  const agentType = values.agent ?? defaultAgentType("claude");
+  let connector: Connector;
+  try {
+    connector = registry.resolve<Connector>("connector", agentType);
+  } catch (e) {
+    console.error(c.red(`✗ ${(e as Error).message}`));
+    process.exit(1);
+  }
+  const variant = values.variant ?? def.variant;
+  if (variant && !connector.supportsModelVariant) {
+    console.error(c.red(`✗ ${agentType} connector does not support model variants (variant)`));
+    process.exit(1);
+  }
+
   // Auth mode (`.cotal/auth` present): mint a stable identity + scoped creds for this agent
   // and pre-create its bind-only durables, via a short-lived privileged provisioner — the
   // same onboarding the manager does, so the foreground launch joins the authed mesh too.
@@ -380,14 +399,12 @@ export async function spawn(args: ParsedArgs): Promise<void> {
   // Which of the operator's personal MCP servers to share with this agent: declared in the cotal
   // config (global ~/.config/cotal + the target mesh's .cotal), narrowed by an optional
   // --share-tools selection. Default (no config) is none — the connector launches isolated.
-  const agentType = values.agent ?? defaultAgentType("claude");
   const mcpServers = connectorServers(
     loadCotalConfig(target.root),
     agentType,
     parseShareSelection(values["share-tools"]),
   );
 
-  const connector = registry.resolve<Connector>("connector", agentType);
   const spec = connector.buildLaunch({
     space,
     name,
@@ -398,6 +415,7 @@ export async function spawn(args: ParsedArgs): Promise<void> {
     configPath: path,
     // Model override (wins over the agent file's `model:`) — launch-grammar parity with --detach.
     model: values.model,
+    variant,
     subscribe,
     allowSubscribe,
     allowPublish,

--- a/implementations/cli/src/index.ts
+++ b/implementations/cli/src/index.ts
@@ -9,6 +9,7 @@ import { join } from "./commands/join.js";
 import { console_ } from "./commands/console.js";
 import { spawn, spawnComplete, spawnFlags } from "./commands/spawn.js";
 import { attach, attachFlags, managedAgentComplete, ps, psFlags, stop, stopFlags } from "./commands/agents.js";
+import { models, modelsComplete, modelsFlags } from "./commands/models.js";
 import { c } from "./ui.js";
 import { personas, personasComplete } from "./commands/personas.js";
 import { completion, completionComplete, complete } from "./commands/completion.js";
@@ -237,6 +238,15 @@ const baseCommands: Command[] = [
     flags: spawnFlags,
     run: spawn,
     complete: spawnComplete,
+  },
+  {
+    kind: "command",
+    name: "models",
+    group: "Agents",
+    summary: "list connector model catalogs and variants from the manager",
+    flags: modelsFlags,
+    run: models,
+    complete: modelsComplete,
   },
   {
     kind: "command",

--- a/implementations/cli/src/lib/manifest/apply.ts
+++ b/implementations/cli/src/lib/manifest/apply.ts
@@ -24,6 +24,7 @@ export function hashAgent(a: PreparedAgent): string {
   const stable = JSON.stringify({
     agent: a.agentType,
     model: a.model ?? null,
+    variant: a.variant ?? null,
     role: a.role ?? null,
     body: a.body ?? null,
     capabilities: [...a.capabilities].sort(),
@@ -41,6 +42,7 @@ function toLaunchAgent(a: PreparedAgent): MeshLaunchAgent {
     agent: a.agentType,
     role: a.role,
     model: a.model,
+    variant: a.variant,
     description: a.description,
     body: a.body,
     capabilities: a.capabilities.length ? a.capabilities : undefined,
@@ -124,6 +126,9 @@ export function preflightConnectors(prepared: PreparedManifest): string {
     }
     const missing = (connector.requires ?? []).filter((bin) => !resolveOnPath(bin));
     if (missing.length) problems.push(`${type} needs ${missing.join(", ")} on PATH`);
+    const variantUsers = prepared.agents.filter((a) => a.agentType === type && a.variant);
+    if (variantUsers.length && !connector.supportsModelVariant)
+      problems.push(`${type} does not support model variants (used by ${variantUsers.map((a) => a.name).join(", ")})`);
   }
   return problems.join("; ");
 }

--- a/implementations/cli/src/lib/manifest/model.ts
+++ b/implementations/cli/src/lib/manifest/model.ts
@@ -44,6 +44,8 @@ export interface ResolvedAgent {
   persona?: string;
   /** Manifest override of the persona's model (or the inline model). */
   model?: string;
+  /** Manifest override of the persona's connector-defined model variant. */
+  variant?: string;
   role?: string;
   /** Manifest card blurb (override / inline). */
   description?: string;

--- a/implementations/cli/src/lib/manifest/prepare.ts
+++ b/implementations/cli/src/lib/manifest/prepare.ts
@@ -3,7 +3,7 @@
  * (read from disk) with the manifest. Pure: it takes already-loaded {@link AgentDef}s so it stays
  * unit-testable; the fs/live I/O lives in {@link ./preflight.js}.
  *
- * Behavior fields (model/role/description/body) are persona-default + manifest-override. Access is
+ * Behavior fields (model/variant/role/description/body) are persona-default + manifest-override. Access is
  * governed by {@link PersonaPermissions}: under `reject` the manifest is the sole source; under
  * `include` a persona's own grants are inherited **only for channels the manifest does not declare**
  * (one authority per channel), concrete-only (wildcards rejected), and surfaced loudly.
@@ -37,6 +37,7 @@ export interface PreparedAgent {
   persona?: string;
   /** Effective values (manifest override ?? persona default). */
   model?: string;
+  variant?: string;
   role?: string;
   description?: string;
   /** Effective persona body (manifest `instructions` REPLACES the file body; sole body for inline). */
@@ -65,6 +66,7 @@ export function prepareAgent(agent: ResolvedAgent, persona: AgentDef | undefined
 
   // Behavior: persona default, manifest override wins. Inline `instructions` REPLACE the body.
   const model = agent.model ?? persona?.model;
+  const variant = agent.variant ?? persona?.variant;
   const role = agent.role ?? persona?.role;
   const description = agent.description ?? persona?.description;
   const body = agent.instructions ?? persona?.persona;
@@ -132,6 +134,7 @@ export function prepareAgent(agent: ResolvedAgent, persona: AgentDef | undefined
       agentType: agent.agentType,
       persona: agent.persona,
       model,
+      variant,
       role,
       description,
       body,

--- a/implementations/cli/src/lib/manifest/resolve.ts
+++ b/implementations/cli/src/lib/manifest/resolve.ts
@@ -165,6 +165,7 @@ function resolveAgents(
     agentType: connector(name, entry.agent),
     persona: entry.persona ? personaPath(entry.persona) : undefined,
     model: entry.model,
+    variant: entry.variant,
     role: entry.role,
     description: entry.description,
     instructions: entry.instructions,

--- a/implementations/cli/src/lib/manifest/schema.ts
+++ b/implementations/cli/src/lib/manifest/schema.ts
@@ -22,6 +22,7 @@ const AgentEntryObject = z
      *  top-level `agent:` default; one of the two must be set (no silent default — matches roster). */
     agent: z.string().min(1).optional(),
     model: z.string().min(1).optional(),
+    variant: z.string().min(1).optional(),
     role: z.string().min(1).optional(),
     description: z.string().optional(),
     instructions: z.string().optional(),
@@ -29,9 +30,9 @@ const AgentEntryObject = z
     /** Per-agent override of the top-level `personaPermissions` policy. */
     personaPermissions: PersonaPermissions.optional(),
   })
-  .refine((v) => v.persona !== undefined || v.model !== undefined || v.instructions !== undefined, {
+  .refine((v) => v.persona !== undefined || v.model !== undefined || v.variant !== undefined || v.instructions !== undefined, {
     message:
-      "inline agent (no `persona:`) needs at least `model` or `instructions` — otherwise reference a persona file",
+      "inline agent (no `persona:`) needs at least `model`, `variant`, or `instructions` — otherwise reference a persona file",
   });
 
 /** An `agents:` value is a string (bare persona path) OR the object above. A plain `z.union`

--- a/implementations/manager/smoke/manifest-launch.smoke.ts
+++ b/implementations/manager/smoke/manifest-launch.smoke.ts
@@ -11,7 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Manager } from "../src/manager.js";
 import { loadLaunchSpec, materializePersona, launchAgentToStartOpts, launchSpecForRun } from "../src/launch.js";
-import { createSpaceAuth, registry, type Connector, type LaunchSpec, type AgentHandle, type MeshLaunchAgent, type MeshLaunchSpec } from "@cotal-ai/core";
+import { createSpaceAuth, registry, type Connector, type DurableProvisioner, type LaunchSpec, type AgentHandle, type MeshLaunchAgent, type MeshLaunchSpec } from "@cotal-ai/core";
 
 let failures = 0;
 function check(label: string, cond: boolean, extra?: unknown): void {
@@ -45,6 +45,7 @@ const resolved: MeshLaunchAgent = {
   agent: "smoke-launch",
   role: "researcher",
   model: "opus",
+  variant: "high",
   description: "Quick web researcher.",
   body: "Research the web; report in 3 bullets.",
   capabilities: ["spawn"],
@@ -59,7 +60,7 @@ const personaPath = materializePersona(root, runId, resolved);
   const md = readFileSync(personaPath, "utf8");
   check("transient persona lives under .cotal/run/<runId>/agents", personaPath.includes(join(".cotal", "run", runId, "agents")));
   check("not under .cotal/agents", !personaPath.includes(join(".cotal", "agents", "scout")));
-  check("carries identity/role/model", /name: scout/.test(md) && /role: researcher/.test(md) && /model: opus/.test(md));
+  check("carries identity/role/model/variant", /name: scout/.test(md) && /role: researcher/.test(md) && /model: opus/.test(md) && /variant: high/.test(md));
   check("carries the persona body", md.includes("Research the web"));
   check("has a generated-artifact header", /Generated runtime artifact/.test(md));
   check("NO authoritative ACL frontmatter", !/^(subscribe|allowSubscribe|allowPublish|capabilities):/m.test(md), md);
@@ -68,6 +69,13 @@ const personaPath = materializePersona(root, runId, resolved);
 // --- startAgent({ resolved }): creds minted from the resolved policy, no file authority ----------
 const mgr = new Manager({ space: "demo", servers: undefined, runtime: "pty", workspaceRoot: root });
 (mgr as unknown as { auth: unknown }).auth = await createSpaceAuth("demo");
+const fakeProvisioner: DurableProvisioner = {
+  provisionDmInbox: async () => {},
+  provisionDlvInbox: async () => {},
+  commitAcl: async () => {},
+  provisionTaskQueue: async () => {},
+};
+(mgr as unknown as { withProvisioner: <T>(fn: (prov: DurableProvisioner) => Promise<T>) => Promise<T> }).withProvisioner = async (fn) => fn(fakeProvisioner);
 const fakeSession = { cols: 80, rows: 24, backlog: () => Buffer.alloc(0), onData: () => () => {}, onExit: () => () => {}, write: () => {}, resize: () => {} };
 const fakeHandle = (name: string): AgentHandle => ({ name, kind: "fake", status: () => "running", stop: () => {}, interrupt: () => {}, attach: () => fakeSession });
 (mgr as unknown as { runtime: { kind: string; spawn: (n: string, s: LaunchSpec) => AgentHandle } }).runtime = { kind: "fake", spawn: (name) => fakeHandle(name) };
@@ -82,15 +90,28 @@ const fakeHandle = (name: string): AgentHandle => ({ name, kind: "fake", status:
   off: () => {},
   getRoster: () => [...(mgr as unknown as { agents: Map<string, { id: string; name: string }> }).agents.values()].map((a) => ({ card: { id: a.id, name: a.name }, status: "idle" })),
 };
-const recCon: Connector = { kind: "connector", name: "smoke-launch", requires: ["node"], buildLaunch: () => ({ command: "true", args: [], env: {} }) };
+let seenVariant: string | undefined;
+const recCon: Connector = {
+  kind: "connector",
+  name: "smoke-launch",
+  requires: ["node"],
+  supportsModelVariant: true,
+  buildLaunch: (opts) => {
+    seenVariant = opts.variant;
+    return { command: "true", args: [], env: {} };
+  },
+};
 registry.register(recCon);
 
 {
   // Note: there is NO .cotal/agents/scout.md — only the transient file. A non-resolved spawn would
   // fail "no persona scout"; the resolved path must succeed from the launch object alone.
-  const reply = await mgr.startAgent(launchAgentToStartOpts(resolved, personaPath));
+  const startOpts = launchAgentToStartOpts(resolved, personaPath);
+  check("launchAgentToStartOpts carries variant", startOpts.variant === "high", startOpts.variant);
+  const reply = await mgr.startAgent(startOpts);
   check("resolved spawn succeeds with no persona file in .cotal/agents", reply.ok === true, reply);
   check("identity is the resolved name", reply.ok && reply.data?.name === "scout", reply.ok && reply.data?.name);
+  check("variant is forwarded to the connector", seenVariant === "high", seenVariant);
 
   const acl = credAcl(join(root, ".cotal", "auth", "creds", "scout.creds"));
   check("read ACL = resolved allowSubscribe (general+ops+review)", ["general", "ops", "review"].every((ch) => acl.sub.some((s) => s.endsWith("." + ch))), acl.sub);
@@ -124,6 +145,7 @@ function writeSpec(name: string, body: unknown): string {
   throws("unsafe role token rejected", () => loadLaunchSpec(writeSpec("a2.json", agent1({ role: "a/b" }))));
   throws("unsafe capability token rejected", () => loadLaunchSpec(writeSpec("a3.json", agent1({ capabilities: ["spawn x"] }))));
   throws("non-alphanumeric hash rejected", () => loadLaunchSpec(writeSpec("a4.json", agent1({ hash: "../../etc" }))));
+  throws("empty variant rejected", () => loadLaunchSpec(writeSpec("a5.json", agent1({ variant: "" }))));
   // Policy re-validation at the manager boundary — --launch must not be a looser manifest format.
   throws("wildcard scope in launch policy rejected", () => loadLaunchSpec(writeSpec("p1.json", agent1({ subscribe: ["team.>"], allowSubscribe: ["team.>"] }))));
   throws("subscribe ⊄ allowSubscribe rejected", () => loadLaunchSpec(writeSpec("p2.json", agent1({ subscribe: ["general"], allowSubscribe: [] }))));
@@ -140,7 +162,7 @@ function writeSpec(name: string, body: unknown): string {
     space: "demo",
     runId: runId2,
     agents: [{
-      name: "scout", agent: "smoke-launch", role: "researcher", model: "opus", description: "Quick researcher.",
+      name: "scout", agent: "smoke-launch", role: "researcher", model: "opus", variant: "high", description: "Quick researcher.",
       body: "Research; 3 bullets.", capabilities: ["spawn"], subscribe: ["general"], allowSubscribe: ["general", "ops"],
       allowPublish: ["general"], personaPath: undefined, hash: "abc123",
     }],

--- a/implementations/manager/src/launch.ts
+++ b/implementations/manager/src/launch.ts
@@ -24,6 +24,7 @@ const LaunchAgentSchema = z.strictObject({
   agent: z.string().regex(TOKEN, "agent must be a connector token ([A-Za-z0-9_-])"),
   role: z.string().regex(TOKEN, "role must be a route-safe token ([A-Za-z0-9_-])").optional(),
   model: z.string().optional(),
+  variant: z.string().min(1).optional(),
   description: z.string().optional(),
   body: z.string().optional(),
   capabilities: z.array(z.string().regex(TOKEN, "capability must be a safe token ([A-Za-z0-9_-])")).optional(),
@@ -109,7 +110,7 @@ function validateLaunchPolicy(a: MeshLaunchAgent): void {
 }
 
 /** Materialize one resolved agent's persona to a transient file the connector reads, and return its
- *  path. Carries only what a connector needs (identity/role/model/description + body) plus a loud
+ *  path. Carries only what a connector needs (identity/role/model/variant/description + body) plus a loud
  *  generated-artifact header — never ACL/capability frontmatter (creds come from the spec's policy). */
 export function materializePersona(root: string, runId: string, a: MeshLaunchAgent): string {
   // 0700 dirs created component-by-component, refusing a symlinked parent (writes can't escape the
@@ -120,6 +121,7 @@ export function materializePersona(root: string, runId: string, a: MeshLaunchAge
   const fm = ["---", `name: ${a.name}`];
   if (a.role) fm.push(`role: ${scalar(a.role)}`);
   if (a.model) fm.push(`model: ${scalar(a.model)}`);
+  if (a.variant) fm.push(`variant: ${scalar(a.variant)}`);
   if (a.description) fm.push(`description: ${scalar(a.description)}`);
   fm.push("---", "");
   const src = a.personaPath ?? "the manifest";
@@ -130,17 +132,18 @@ export function materializePersona(root: string, runId: string, a: MeshLaunchAge
   return path;
 }
 
-/** Build the manager spawn opts for a launch agent: identity/role/model + the resolved object
+/** Build the manager spawn opts for a launch agent: identity/role/model/variant + the resolved object
  *  (which carries the ACL authority) + the materialized configPath. */
 export function launchAgentToStartOpts(a: MeshLaunchAgent, configPath: string): {
   name: string;
   agent: string;
   role?: string;
   model?: string;
+  variant?: string;
   config: string;
   resolved: MeshLaunchAgent;
 } {
-  return { name: a.name, agent: a.agent, role: a.role, model: a.model, config: configPath, resolved: a };
+  return { name: a.name, agent: a.agent, role: a.role, model: a.model, variant: a.variant, config: configPath, resolved: a };
 }
 
 /** Quote a frontmatter scalar so the agent-file parser reads it back unchanged (it strips a matching

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -25,7 +25,7 @@ import {
   CONTROL_ADMIN,
 } from "@cotal-ai/core";
 import { authDir, defaultAgentType, findCotalRoot, loadSpaceAuth, resolveOnPath } from "@cotal-ai/workspace";
-import type { AgentDef, AttachSession, Connector, ControlReply, ControlRequest, ControlTier, ManagerLeaseInfo, MeshLaunchAgent, SpaceAuth } from "@cotal-ai/core";
+import type { AgentDef, AttachSession, Connector, ConnectorModelCatalog, ControlReply, ControlRequest, ControlTier, ManagerLeaseInfo, MeshLaunchAgent, SpaceAuth } from "@cotal-ai/core";
 import {
   createRuntime,
   type AgentHandle,
@@ -98,6 +98,8 @@ export interface StartAgentOpts {
   identity?: string;
   /** Model override (the `--model` flag). Takes precedence over the agent file's `model:`. */
   model?: string;
+  /** Model variant override (the `--variant` flag). Takes precedence over the agent file's `variant:`. */
+  variant?: string;
   /** Opaque host-local session id to FORK into the mesh (the `--resume` flag), forwarded verbatim to
    *  the connector. Only ever set from imperative control args (`opStart`), NEVER from `resolved` —
    *  the manifest path stays resume-free by construction. Unsupported connectors throw at buildLaunch. */
@@ -385,6 +387,8 @@ export class Manager {
         return this.opAttach(args, caller, admin);
       case "ps":
         return { ok: true, data: this.list() };
+      case "models":
+        return this.opModels(args);
       case "status": {
         const a = this.list().find((x) => x.name === name);
         return a ? { ok: true, data: a } : { ok: false, error: `no agent "${name}"` };
@@ -554,6 +558,8 @@ export class Manager {
     // but a raw control message could otherwise slip an empty value through and silently start fresh.
     if (args.resume !== undefined && !String(args.resume).trim())
       return Promise.resolve({ ok: false, error: "resume: session id must not be empty" });
+    if (args.variant !== undefined && !String(args.variant).trim())
+      return Promise.resolve({ ok: false, error: "variant: must not be empty" });
     // ACL overrides arrive as string arrays or not at all — a malformed value is a bad request,
     // not something to coerce (no fallbacks).
     const strList = (v: unknown, flag: string): string[] | undefined => {
@@ -578,6 +584,7 @@ export class Manager {
         config: args.config ? String(args.config) : undefined,
         identity: args.identity ? String(args.identity) : undefined,
         model: args.model ? String(args.model) : undefined,
+        variant: args.variant ? String(args.variant) : undefined,
         resume: args.resume ? String(args.resume) : undefined,
         transcript: typeof args.transcript === "boolean" ? args.transcript : undefined,
         cwd: args.cwd ? String(args.cwd) : undefined,
@@ -589,6 +596,43 @@ export class Manager {
       },
       caller,
     );
+  }
+
+  /** Return connector-provided model catalogs for selector UIs. Optional by connector: a host with no
+   *  local model-list API reports `supported:false` rather than blocking the manager. */
+  private async opModels(args: Record<string, unknown>): Promise<ControlReply> {
+    const requested = String(args.agent ?? "").trim();
+    const refresh = args.refresh === true;
+    const one = async (connector: Connector): Promise<ConnectorModelCatalog> => {
+      if (!connector.listModels) return { agent: connector.name, supported: false, models: [] };
+      const missing = (connector.requires ?? []).filter((bin) => !resolveOnPath(bin));
+      if (missing.length)
+        return {
+          agent: connector.name,
+          supported: true,
+          models: [],
+          error: `${connector.name} harness needs ${missing.join(", ")} on PATH — not found`,
+        };
+      try {
+        const catalog = await connector.listModels({ refresh });
+        return { agent: connector.name, supported: true, ...catalog };
+      } catch (e) {
+        return { agent: connector.name, supported: true, models: [], error: (e as Error).message };
+      }
+    };
+
+    if (requested) {
+      let connector: Connector;
+      try {
+        connector = registry.resolve<Connector>("connector", requested);
+      } catch (e) {
+        return { ok: false, error: (e as Error).message };
+      }
+      const result = await one(connector);
+      return result.error ? { ok: false, error: result.error } : { ok: true, data: result };
+    }
+
+    return { ok: true, data: await Promise.all(registry.all<Connector>("connector").map(one)) };
   }
 
   /** Boot one resolved agent from a mesh-manifest launch spec, for `cotal spawn -f` onto a RUNNING
@@ -688,7 +732,7 @@ export class Manager {
       return { ok: false, error: `${agent} connector does not support resuming an existing session (resume)` };
 
     // Resolve the launch profile: IDENTITY (free-form `name:`) + role + read/post ACL + capabilities
-    // + model. Either from a fully-resolved manifest launch object (`opts.resolved`, whose `config`
+    // + model/variant. Either from a fully-resolved manifest launch object (`opts.resolved`, whose `config`
     // is a materialized transient persona — the file is NOT the access authority), or from the
     // persona file. The number rides the IDENTITY (socrates → socrates-2), not the file ref — a
     // redelivered identical spawn yields a fresh numbered agent (MAX_AGENTS bounds the blast radius).
@@ -699,6 +743,7 @@ export class Manager {
     let allowPublish: string[] | undefined;
     let capabilities: string[] | undefined;
     let model = opts.model;
+    let variant = opts.variant;
     if (opts.resolved) {
       // A manifest launch is the access + identity authority: imperative overrides arriving
       // alongside `resolved` are a caller contract error, not something to merge (no fallbacks).
@@ -712,6 +757,7 @@ export class Manager {
       allowPublish = r.allowPublish;
       capabilities = r.capabilities;
       model = opts.model ?? r.model;
+      variant = opts.variant ?? r.variant;
     } else {
       let def: AgentDef;
       try {
@@ -733,9 +779,12 @@ export class Manager {
       allowSubscribe = opts.allowSubscribe ?? def.allowSubscribe ?? subscribe ?? ["general"];
       allowPublish = opts.allowPublish ?? def.allowPublish;
       capabilities = def.capabilities;
+      variant = opts.variant ?? def.variant;
     }
     const idErr = this.nameError(identityName);
     if (idErr) return { ok: false, error: opts.resolved ? `launch agent: ${idErr}` : `persona ${configPath}: ${idErr}` };
+    if (variant && !connector.supportsModelVariant)
+      return { ok: false, error: `${agent} connector does not support model variants (variant)` };
 
     const name = this.uniqueName(identityName);
     this.reserved.add(name);
@@ -806,6 +855,7 @@ export class Manager {
         servers: this.servers,
         configPath,
         model,
+        variant,
         // Fork an existing session into the mesh. Taken straight from `opts.resume` (the imperative
         // control arg), never from `opts.resolved` — so the manifest launch path carries no resume by
         // construction. An unsupported connector throws here before any process is spawned.

--- a/packages/core/src/agent-file.ts
+++ b/packages/core/src/agent-file.ts
@@ -11,13 +11,14 @@
  *   allowSubscribe: [general]  # read ACL — channels it MAY read; omit ⇒ same as `subscribe`
  *   allowPublish: [general]    # post ACL — channels it may publish to; omit ⇒ DENY (default-deny)
  *   model: opus                # optional CLI/model override
+ *   variant: high              # optional connector-defined model variant
  *   capabilities: [spawn]  # control-plane capabilities (spawn → may start/despawn others)
  *   theme: dark            # any unmodelled key is kept verbatim in AgentDef.meta, so a
  *                          #   connector can read its own launcher hints without core knowing them
  *   ---
  *   <the Markdown body is the persona — an appended system prompt>
  *
- * A launcher resolves a name (or path) to one of these, hands the persona/model
+ * A launcher resolves a name (or path) to one of these, hands the persona/model/variant
  * to the agent process at spawn, and passes the file through so the joined
  * session reads its own card from it. Part of the wire contract's onboarding
  * half, alongside the join link.
@@ -55,6 +56,8 @@ export interface AgentDef {
   muted?: string[];
   /** Model override handed to the agent CLI (e.g. `claude --model`). */
   model?: string;
+  /** Connector-defined model variant handed to the launcher (e.g. OpenCode reasoning effort). */
+  variant?: string;
   /** Capabilities this agent may exercise on the control plane (auth mode → minted into the
    *  cred's publish allow-list). Today `spawn` is the only one: it grants publish to the
    *  privileged control subject (start/purge/definePersona/named stop). Default-deny when
@@ -186,7 +189,7 @@ export function loadAgentFile(path: string): AgentDef {
 
   // Sweep every scalar frontmatter key we don't model into meta, verbatim — connector launcher
   // hints ride here so core stays ignorant of surface-specific keys.
-  const known = new Set(["name", "role", "kind", "description", "tags", "subscribe", "allowSubscribe", "allowPublish", "quiet", "muted", "model", "capabilities", "owner"]);
+  const known = new Set(["name", "role", "kind", "description", "tags", "subscribe", "allowSubscribe", "allowPublish", "quiet", "muted", "model", "variant", "capabilities", "owner"]);
   const meta: Record<string, string> = {};
   for (const [k, v] of Object.entries(fm)) if (!known.has(k) && typeof v === "string") meta[k] = v;
 
@@ -202,6 +205,7 @@ export function loadAgentFile(path: string): AgentDef {
     quiet,
     muted,
     model: str("model"),
+    variant: str("variant"),
     capabilities: list("capabilities"),
     owner: str("owner"),
     meta: Object.keys(meta).length ? meta : undefined,
@@ -227,6 +231,7 @@ export function saveAgentFile(path: string, def: AgentDef): void {
   if (def.quiet?.length) lines.push(`quiet: [${def.quiet.map(fmItem).join(", ")}]`);
   if (def.muted?.length) lines.push(`muted: [${def.muted.map(fmItem).join(", ")}]`);
   if (def.model) lines.push(`model: ${fmScalar(def.model)}`);
+  if (def.variant) lines.push(`variant: ${fmScalar(def.variant)}`);
   if (def.capabilities?.length) lines.push(`capabilities: [${def.capabilities.map(fmItem).join(", ")}]`);
   if (def.owner) lines.push(`owner: ${fmScalar(def.owner)}`);
   if (def.meta) for (const [k, v] of Object.entries(def.meta)) lines.push(`${k}: ${fmScalar(v)}`);

--- a/packages/core/src/connector.ts
+++ b/packages/core/src/connector.ts
@@ -38,6 +38,11 @@ export interface LaunchOpts {
    *  agent file's `model:` and is applied even when no agent file is present. Each connector
    *  renders it in its host form (Claude `--model`, OpenCode `config.model`, Hermes `HERMES_MODEL`). */
   model?: string;
+  /** Optional model variant selector — a connector-defined variant of the selected/default model
+   *  (for example provider-specific reasoning effort). Takes precedence over the agent file's
+   *  `variant:`. A connector that supports variants renders it in its host form; unsupported
+   *  connectors fail loud rather than silently ignoring it. */
+  variant?: string;
   /** An initial message for the session to act on the moment it starts. Connectors
    *  that support an auto-submitted first prompt (Claude Code) deliver it; others
    *  ignore it. Used to make a driving session greet the operator on launch. */
@@ -88,6 +93,39 @@ export interface LaunchSpec {
   control?: { path: string; token: string };
 }
 
+/** One provider-specific model variant. `options` is opaque connector metadata for UIs; core never
+ *  interprets it or feeds it back into launch. */
+export interface ModelVariantInfo {
+  name: string;
+  options?: Record<string, unknown>;
+}
+
+/** One model a connector can launch. `id` is the value to pass as {@link LaunchOpts.model}; variants
+ *  are selected separately via {@link LaunchOpts.variant}. */
+export interface ModelInfo {
+  id: string;
+  name?: string;
+  provider?: string;
+  variants?: ModelVariantInfo[];
+}
+
+/** Connector-provided model catalog. Optional by design: some hosts have no local model-list API. */
+export interface ModelCatalog {
+  source?: string;
+  models: ModelInfo[];
+}
+
+export interface ModelCatalogOpts {
+  refresh?: boolean;
+}
+
+/** Manager-facing wrapper for one connector's catalog lookup. */
+export interface ConnectorModelCatalog extends ModelCatalog {
+  agent: string;
+  supported: boolean;
+  error?: string;
+}
+
 /**
  * A bridge that knows how to launch one agent type (Claude Code, OpenCode, the CLI
  * peer …) as a Cotal mesh node — an {@link Extension} of kind `"connector"`.
@@ -99,6 +137,9 @@ export interface Connector extends Extension {
   readonly kind: "connector";
   readonly name: string;
   buildLaunch(opts: LaunchOpts): LaunchSpec;
+  /** Optional model catalog hook. The manager calls this for selector UIs; launch remains authority-free
+   *  and still accepts any string the operator supplies. */
+  listModels?(opts?: ModelCatalogOpts): ModelCatalog | Promise<ModelCatalog>;
   /** The channel this connector publishes an agent's transcript mirror to (see
    *  {@link LaunchOpts.transcript}). OPTIONAL — like {@link LaunchOpts.prompt}, only connectors that
    *  actually mirror (Claude Code, OpenCode) implement it; one that doesn't (e.g. Hermes) omits it. The
@@ -127,4 +168,7 @@ export interface Connector extends Extension {
    *  stays as the backstop. Only a connector that forks-from a prior session (never hijacks it) sets
    *  this `true`. */
   readonly supportsResume?: boolean;
+  /** Whether this connector can honor {@link LaunchOpts.variant}. Default-deny so a variant request
+   *  fails before provisioning side effects in the manager. */
+  readonly supportsModelVariant?: boolean;
 }

--- a/packages/core/src/launch.ts
+++ b/packages/core/src/launch.ts
@@ -16,6 +16,7 @@ export interface MeshLaunchAgent {
   agent: string;
   role?: string;
   model?: string;
+  variant?: string;
   description?: string;
   /** Persona body — materialized to a transient, non-authoritative file the connector reads. */
   body?: string;

--- a/packages/workspace/src/flags.ts
+++ b/packages/workspace/src/flags.ts
@@ -29,6 +29,7 @@ export const launchFlags = [
   { name: "agent", type: "string", value: "<a>", description: "connector type (claude, opencode, hermes …); defaults from COTAL_DEFAULT_AGENT" },
   { name: "role", type: "string", value: "<r>", description: "role override (wins over the agent file's role:)" },
   { name: "model", type: "string", value: "<m>", description: "model override (wins over the agent file's model:)" },
+  { name: "variant", type: "string", value: "<v>", description: "model variant override (connector-defined; wins over the agent file's variant:)" },
   { name: "cwd", type: "string", value: "<dir>", description: "working directory to root the agent at" },
   { name: "prompt", type: "string", value: "<text>", description: "initial prompt auto-submitted at start" },
   { name: "resume", type: "string", value: "<id>", description: "fork an existing session id into the mesh (claude only; detached: pair with --cwd)" },


### PR DESCRIPTION
## Summary
- add connector model catalog support and a `cotal models` command
- propagate connector-defined model variants through agent files, manifests, spawn, manager launch, and MCP spawn
- wire OpenCode variants and reject variants for connectors that do not support them

## Review notes
- fixed the flag-inventory golden for the new `spawn --variant` flag during review

## Tests
- `pnpm typecheck`
- `pnpm smoke:spawn-args`
- `pnpm smoke:manifest-launch`
- `pnpm smoke:flag-inventory`
- `pnpm smoke:launch-parity`
- `pnpm smoke:install`
- `pnpm smoke:start-overrides`
- `pnpm smoke:cli-kernel`
- `pnpm smoke:spawn-from-anywhere`
- `pnpm exec tsx implementations/cli/smoke/manifest.smoke.ts`
- `opencode models --pure --verbose`