### PR TITLE
ci: shard smoke suite + cache nats; fix cotal down teardown race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,91 +8,124 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+# Same coverage as before, fanned across parallel jobs so wall-clock is the slowest job, not the sum:
+#   • unit  — typecheck + build + unit tests + the broker-free view/pack checks (fast).
+#   • smoke — the protocol/security suite (smoke:ci), round-robin sharded across runners by
+#             bin/smoke/shard.mjs (each smoke still runs in its own broker; shards are on separate
+#             runners, so no cross-smoke port contention).
+#   • live  — the Linux-only live/lifecycle e2es (real broker + real agents, tmux/cmux/opencode).
+# `ci-ok` fans them back in for a single required status.
 jobs:
-  check:
-    timeout-minutes: 30
+  unit:
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6.0.8
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6.0.8
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Typecheck
+        run: pnpm typecheck
+      - name: Build
+        run: pnpm build
+      - name: Unit tests
+        run: pnpm test
+      - name: View smoke
+        run: pnpm smoke:view
+      - name: Verify Claude connector package
+        run: pnpm --filter @cotal-ai/connector-claude-code pack --dry-run
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
+  smoke:
+    name: smoke (shard ${{ matrix.shard }}/4)
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6.0.8
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Cache nats-server
+        id: nats
+        uses: actions/cache@v4
+        with:
+          path: ~/nats-bin
+          key: nats-server-v2.10.22-${{ runner.os }}
       - name: Install nats-server
+        if: steps.nats.outputs.cache-hit != 'true'
         run: |
           NATS_VERSION=v2.10.22
           curl -fsSL "https://github.com/nats-io/nats-server/releases/download/${NATS_VERSION}/nats-server-${NATS_VERSION}-linux-amd64.tar.gz" -o /tmp/nats-server.tar.gz
           tar -xzf /tmp/nats-server.tar.gz -C /tmp
-          sudo install "/tmp/nats-server-${NATS_VERSION}-linux-amd64/nats-server" /usr/local/bin/nats-server
-          nats-server --version
+          mkdir -p ~/nats-bin
+          install "/tmp/nats-server-${NATS_VERSION}-linux-amd64/nats-server" ~/nats-bin/nats-server
+      - name: nats-server on PATH
+        run: echo "$HOME/nats-bin" >> "$GITHUB_PATH"
+      - name: Build
+        run: pnpm build
+      - name: Protocol & security smoke tests (shard ${{ matrix.shard }}/4)
+        run: node bin/smoke/shard.mjs ${{ matrix.shard }} 4
 
+  live:
+    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6.0.8
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Cache nats-server
+        id: nats
+        uses: actions/cache@v4
+        with:
+          path: ~/nats-bin
+          key: nats-server-v2.10.22-${{ runner.os }}
+      - name: Install nats-server
+        if: steps.nats.outputs.cache-hit != 'true'
+        run: |
+          NATS_VERSION=v2.10.22
+          curl -fsSL "https://github.com/nats-io/nats-server/releases/download/${NATS_VERSION}/nats-server-${NATS_VERSION}-linux-amd64.tar.gz" -o /tmp/nats-server.tar.gz
+          tar -xzf /tmp/nats-server.tar.gz -C /tmp
+          mkdir -p ~/nats-bin
+          install "/tmp/nats-server-${NATS_VERSION}-linux-amd64/nats-server" ~/nats-bin/nats-server
+      - name: nats-server on PATH
+        run: echo "$HOME/nats-bin" >> "$GITHUB_PATH"
       - name: Install tmux
         run: tmux -V || (sudo apt-get update && sudo apt-get install -y tmux)
-
-      - name: Typecheck
-        run: pnpm typecheck
-
-      - name: Test
-        run: pnpm test
-
-      - name: Smoke test
-        run: pnpm smoke:view
-
-      - name: Protocol & security smoke tests
-        run: pnpm smoke:ci
-
-      - name: Core boundary, mesh preflight & resolution smoke tests
-        # Core-never-imports-workspace boundary guard (smoke:core-boundary), the broker-free preflight
-        # decision tree incl. the prune-authority rules (smoke:preflight, now in @cotal-ai/workspace),
-        # the live manager target-resolution regression (smoke:server-resolution:live), and the live
-        # spawn-from-anywhere registry/auth-path e2e (smoke:spawn-from-anywhere:live). The last one is
-        # gated here AND in `pnpm check` deliberately: CLI smoke files are outside package typecheck, so
-        # a dynamic `await import()` boundary regression in a live smoke escapes tsc — only running it catches it.
-        # smoke:up-stack:live / smoke:up-manifest:live e2e the full `up --detach` stack (broker +
-        # delivery + manager, real `cotal ps`) and the one-manager-carries-the-launch invariant of
-        # `up -f` (the singleton-lease race regression). smoke:ext:live e2es the operator-installed
-        # extension lifecycle (cotal ext) through the real binary. smoke:readiness:live e2es the
-        # #159 B1 launch readiness window with a real slow-joining agent (spawn/launch clients must
-        # outlive the manager's real-outcome reply). nats-server installed above.
+      - name: Build
+        run: pnpm build
+      # Broker-free boundary/preflight guards + the live target-resolution / spawn-from-anywhere /
+      # readiness / up-stack / up-manifest / ext / dogfood e2es (real broker, real agents).
+      - name: Core boundary, mesh preflight & resolution
         run: pnpm smoke:core-boundary && pnpm smoke:preflight && pnpm smoke:server-resolution:live && pnpm smoke:spawn-from-anywhere:live && pnpm smoke:spawn-detach:live && pnpm smoke:readiness:live && pnpm smoke:setup-pure:live && pnpm smoke:up-stack:live && pnpm smoke:up-manifest:live && pnpm smoke:ext:live && pnpm smoke:dogfood:live
-
       - name: Manager lifecycle e2e (real broker + real agents)
-        # Real end-to-end for #159 Part B: the startAgent presence-race (started via real presence / failed
-        # on process exit), deprovision-on-despawn, and shutdown teardown — verified against a real JWT-auth
-        # broker with real agent processes and direct broker-footprint inspection (durables/ACL/creds). Uses
-        # real pty processes, so Linux-only (not in the cross-platform smoke:ci). nats-server installed above.
         run: pnpm smoke:lifecycle-e2e
-
       - name: Runtime smoke tests (tmux)
-        # Exercises the tmux Runtime + TerminalLayout end to end (driver, lifecycle by stable
-        # @window_id/%pane_id, P3 env -i isolation, attach hints). dist is built by Typecheck above.
-        # Includes the privateLaunch no-leak guard: a live pane's command carries no env secret.
         run: pnpm smoke:runtime
-
       - name: cmux launcher secret-hygiene smoke
-        # The cmux pane launcher writes the agent's env (creds + control token) to a 0o600 file in a
-        # 0o700 dir, never a world-readable /tmp script or the returned command line. Exercises
-        # paneCommand directly (no cmux CLI needed), so it runs here.
         run: pnpm smoke:cmux
-
       - name: OpenCode cooperative-stop smoke test
-        # The opencode plugin's control-plane cooperative shutdown: a {op:"shutdown"} makes the plugin
-        # leave the mesh (publish offline presence) instead of waiting out the presence TTL. Drives the
-        # real plugin closure (in a subprocess) under Node against a real broker; the real opencode
-        # (Bun) runtime — incl. Bun-on-Windows named pipes — is not in CI yet (no opencode binary here).
-        # (smoke:opencode / turn-wedge is intentionally not wired here — it depends on open-mode stream
-        # auto-setup that is currently broken independent of this change; tracked separately.)
         run: pnpm smoke:opencode-coop
 
-      - name: Verify Claude connector package
-        run: pnpm --filter @cotal-ai/connector-claude-code pack --dry-run
+  ci-ok:
+    # Single required status: green only if unit + every smoke shard + live all passed.
+    if: always()
+    needs: [unit, smoke, live]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gate
+        run: |
+          echo "unit=${{ needs.unit.result }} smoke=${{ needs.smoke.result }} live=${{ needs.live.result }}"
+          [ "${{ needs.unit.result }}" = "success" ] && [ "${{ needs.smoke.result }}" = "success" ] && [ "${{ needs.live.result }}" = "success" ]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,15 +3,15 @@ name: Windows
 # Native-Windows gate. Kept separate from the ubuntu `CI` workflow because the command set differs
 # (no tmux/runtime/Hermes — those are Unix-only) and the broker install is Windows-specific.
 #
-# TWO LANES, deliberately split (a single all-or-nothing soak job is a permanently-red ignored check):
-#   • `required` — typecheck + build + unit tests + the GREEN, broker-free seam smokes (resolver /
-#     env-isolation / view / core-boundary / preflight), the `.cmd` launch matrix (`smoke:windows`,
-#     validated green-in-logs on windows-latest), and the protocol/security suite. Gating: a red here
-#     is a real Windows regression.
-#   • `smoke`    — the live-broker soak (`continue-on-error`): server-resolution + spawn-manifest +
-#     cooperative-stop (WS4), each its own step so one cleanup failure can't mask the next. Genuinely
-#     green now, but broker-timing-dependent — promote into `required` once proven stable across runs.
-#     See .internal/plans/windows-native-support.md.
+# Lanes:
+#   • required — Windows-specific, BROKER-FREE checks: typecheck + build + unit tests + the seam
+#     smokes (resolver / env-isolation / view / core-boundary / preflight), the `.cmd` launch matrix
+#     (smoke:windows) + control-plane seams, and secret-fs ACL hardening. No nats-server needed.
+#   • smoke    — the protocol/security suite (smoke:ci), round-robin sharded across runners by
+#     bin/smoke/shard.mjs (each smoke spins its own broker; shards are separate runners). REQUIRED.
+#   • soak     — the live-broker soak (continue-on-error, non-blocking): server-resolution +
+#     spawn-manifest + cooperative-stop. Promote into the gate once proven stable across runs.
+#   windows-ok fans required + smoke back in for a single status. See .internal/plans/windows-native-support.md.
 
 on:
   pull_request:
@@ -22,137 +22,150 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  # REQUIRED lane — must stay green. typecheck/build/test carry no POSIX assumptions, and the seam
-  # smokes here are broker-free + launch-mechanism-independent (resolver, P3 env-isolation) or the
-  # already-green protocol suite, so a red is a real regression, not a soak artifact.
+  # REQUIRED lane — Windows-specific + broker-free, so a red is a real Windows regression.
   required:
     name: Windows / required
-    timeout-minutes: 30
+    timeout-minutes: 25
     runs-on: windows-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6.0.8
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6.0.8
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
-
-      # Default pnpm install keeps optionalDependencies. Do NOT add --omit=optional / --no-optional:
-      # @lydell/node-pty ships its prebuilt ConPTY binary as a per-platform optional dep, and the
-      # @eplightning/nats-server-win32-* fallback binaries are optional deps too.
+      # Default pnpm install keeps optionalDependencies (@lydell/node-pty ConPTY + the
+      # @eplightning/nats-server-win32-* fallback binaries are per-platform optional deps).
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Typecheck
+        run: pnpm typecheck
+      - name: Build
+        run: pnpm build
+      - name: Unit tests
+        run: pnpm test
+      # Broker-free seam smokes: PATHEXT/`.exe`-preference resolution, P3 child-env isolation
+      # (launches node.exe directly), pure protocol/view/preflight checks.
+      - name: Broker-free seam smokes
+        run: pnpm smoke:view && pnpm smoke:core-boundary && pnpm smoke:preflight && pnpm smoke:env-isolate
+      # The `.cmd`/`.bat` launch matrix (PATHEXT resolution + cmd-arg byte-for-byte quoting + orphan
+      # reap) + authenticated control-plane seams. Deterministic, broker-free.
+      - name: Windows launch + control-plane matrix (smoke:windows)
+        run: pnpm smoke:windows
+      # Secrets at rest: 0o600/0o700 is a no-op on Windows, so secret files/dirs are locked down via
+      # an NTFS ACL (icacls). Asserts the broad inherited access is actually stripped.
+      - name: Secrets-at-rest ACL hardening (smoke:secret-fs)
+        run: pnpm smoke:secret-fs
 
-      # smoke:ci spins its own nats-server from PATH. Checksum-pinned (supply-chain gate) since this
-      # lane is REQUIRED. PowerShell string `-ne` is case-insensitive, so the uppercase Get-FileHash
-      # output compares equal to the lowercase pin.
+  # REQUIRED lane — the protocol/security suite, sharded. Each shard spins its own nats-server.
+  smoke:
+    name: Windows / smoke (shard ${{ matrix.shard }}/4)
+    timeout-minutes: 25
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6.0.8
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Cache nats-server
+        id: nats
+        uses: actions/cache@v4
+        with:
+          path: ~/nats-bin
+          key: nats-server-v2.10.22-${{ runner.os }}
+      # Checksum-pinned (supply-chain gate). PowerShell `-ne` is case-insensitive, so the uppercase
+      # Get-FileHash output compares equal to the lowercase pin.
       - name: Install nats-server
+        if: steps.nats.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
           $NatsVersion = "v2.10.22"
           $Sha256 = "33c8a0c6feb441ec4c7007e0af9ef2a45356d6809cd08ec4871a3d659fc74e91"
           $Name = "nats-server-$NatsVersion-windows-amd64"
           $Zip = Join-Path $env:RUNNER_TEMP "$Name.zip"
-          $InstallDir = Join-Path $env:RUNNER_TEMP $Name
           Invoke-WebRequest -Uri "https://github.com/nats-io/nats-server/releases/download/$NatsVersion/$Name.zip" -OutFile $Zip
           $Actual = (Get-FileHash $Zip -Algorithm SHA256).Hash
           if ($Actual -ne $Sha256) { throw "nats-server zip checksum mismatch: got $Actual expected $Sha256" }
           Expand-Archive -Path $Zip -DestinationPath $env:RUNNER_TEMP -Force
-          # $GITHUB_PATH only affects LATER steps, so verify here via the absolute path.
-          "$InstallDir" >> $env:GITHUB_PATH
-          & "$InstallDir\nats-server.exe" --version
-
-      - name: Typecheck
-        run: pnpm typecheck
-
+          New-Item -ItemType Directory -Force -Path "$HOME\nats-bin" | Out-Null
+          Copy-Item "$env:RUNNER_TEMP\$Name\nats-server.exe" "$HOME\nats-bin\nats-server.exe" -Force
+      - name: nats-server on PATH
+        shell: pwsh
+        run: |
+          "$HOME\nats-bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          & "$HOME\nats-bin\nats-server.exe" --version
       - name: Build
         run: pnpm build
+      - name: Protocol & security smoke tests (shard ${{ matrix.shard }}/4)
+        run: node bin/smoke/shard.mjs ${{ matrix.shard }} 4
 
-      - name: Unit tests
-        run: pnpm test
-
-      # Broker-free seam smokes — launch-mechanism-independent: PATHEXT/`.exe`-preference resolution,
-      # P3 child-env isolation (launches node.exe directly), and pure protocol/view/preflight checks.
-      - name: Broker-free seam smokes
-        run: pnpm smoke:view && pnpm smoke:core-boundary && pnpm smoke:preflight && pnpm smoke:env-isolate
-
-      # The `.cmd`/`.bat` launch matrix (PATHEXT resolution + cmd-arg byte-for-byte quoting + orphan
-      # reap) + the authenticated control-plane seams (first-frame token auth, shutdown routing,
-      # fatal-bind-on-squat, pre-auth DoS bound). Deterministic, broker-free, validated green-in-logs
-      # on windows-latest → an ENFORCED required gate (no continue-on-error: a regression fails it).
-      - name: Windows launch + control-plane matrix (smoke:windows)
-        run: pnpm smoke:windows
-
-      # Secrets at rest: 0o600/0o700 is a no-op on Windows, so secret files/dirs are locked down via
-      # an NTFS ACL (icacls). This asserts the broad inherited access is actually stripped.
-      - name: Secrets-at-rest ACL hardening (smoke:secret-fs)
-        run: pnpm smoke:secret-fs
-
-      - name: Protocol & security smoke tests
-        run: pnpm smoke:ci
-
-  # SOAK lane — non-blocking until green. The `.cmd` launch matrix is the mechanism still settling;
-  # the live-broker smokes are split into independent steps (each continue-on-error) so one's cleanup
-  # failure can't mask the next (the `&&`-chain used to short-circuit spawn-manifest:live entirely).
-  smoke:
+  # SOAK lane — non-blocking. The live-broker smokes are split into independent steps (each
+  # continue-on-error) so one's cleanup failure can't mask the next.
+  soak:
     name: Windows / smoke (soak — non-blocking)
     timeout-minutes: 30
     runs-on: windows-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6.0.8
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6.0.8
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
+      - name: Cache nats-server
+        id: nats
+        uses: actions/cache@v4
+        with:
+          path: ~/nats-bin
+          key: nats-server-v2.10.22-${{ runner.os }}
       - name: Install nats-server
+        if: steps.nats.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
           $NatsVersion = "v2.10.22"
           $Sha256 = "33c8a0c6feb441ec4c7007e0af9ef2a45356d6809cd08ec4871a3d659fc74e91"
           $Name = "nats-server-$NatsVersion-windows-amd64"
           $Zip = Join-Path $env:RUNNER_TEMP "$Name.zip"
-          $InstallDir = Join-Path $env:RUNNER_TEMP $Name
           Invoke-WebRequest -Uri "https://github.com/nats-io/nats-server/releases/download/$NatsVersion/$Name.zip" -OutFile $Zip
           $Actual = (Get-FileHash $Zip -Algorithm SHA256).Hash
           if ($Actual -ne $Sha256) { throw "nats-server zip checksum mismatch: got $Actual expected $Sha256" }
           Expand-Archive -Path $Zip -DestinationPath $env:RUNNER_TEMP -Force
-          "$InstallDir" >> $env:GITHUB_PATH
-          & "$InstallDir\nats-server.exe" --version
-
-      # Live smokes run the built dist (tsx bin/cotal.ts -> dist), not src — build before them.
+          New-Item -ItemType Directory -Force -Path "$HOME\nats-bin" | Out-Null
+          Copy-Item "$env:RUNNER_TEMP\$Name\nats-server.exe" "$HOME\nats-bin\nats-server.exe" -Force
+      - name: nats-server on PATH
+        shell: pwsh
+        run: |
+          "$HOME\nats-bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          & "$HOME\nats-bin\nats-server.exe" --version
       - name: Build
         run: pnpm build
-
-      # Live-broker smokes, each its own step (continue-on-error) so a cleanup failure can't mask the
-      # other. Deliberately EXCLUDED until made Windows-aware: smoke:runtime/smoke:tmux (tmux),
-      # smoke:attach (sleep/tmux), smoke:spawn-from-anywhere:live (asserts 0700),
-      # smoke:up-manifest:live (asserts 0600), smoke:manager-singleton:live (sh -c lsof|xargs).
       - name: Live — server resolution
         continue-on-error: true
         run: pnpm smoke:server-resolution:live
-
       - name: Live — spawn manifest
         continue-on-error: true
         run: pnpm smoke:spawn-manifest:live
-
-      # WS4: a cooperative graceful stop publishes OFFLINE presence over the named-pipe control plane
-      # (not TTL expiry). node:net abstracts the AF_UNIX socket ↔ Windows named pipe, so the real wire
-      # is exercised here against a live broker.
       - name: Live — cooperative stop (WS4 offline presence)
         continue-on-error: true
         run: pnpm smoke:cooperative-stop:live
+
+  windows-ok:
+    # Single required status for the native-Windows gate: green only if required + every shard passed.
+    if: always()
+    needs: [required, smoke]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gate
+        run: |
+          echo "required=${{ needs.required.result }} smoke=${{ needs.smoke.result }}"
+          [ "${{ needs.required.result }}" = "success" ] && [ "${{ needs.smoke.result }}" = "success" ]

--- a/bin/smoke/dogfood-live.smoke.ts
+++ b/bin/smoke/dogfood-live.smoke.ts
@@ -17,11 +17,19 @@
  */
 import { spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
-const AUTH_PORT = 14361;
-const WEB_PORT = 14371;
+// Ephemeral OS-assigned ports: no fixed-port collision across back-to-back / concurrent runs.
+const freePort = (): Promise<number> =>
+  new Promise((res, rej) => {
+    const s = createServer();
+    s.on("error", rej);
+    s.listen(0, "127.0.0.1", () => { const p = (s.address() as AddressInfo).port; s.close(() => res(p)); });
+  });
+const AUTH_PORT = await freePort();
+const WEB_PORT = await freePort();
 const REPO = resolve(import.meta.dirname, "..", "..");
 
 const sandbox = mkdtempSync(join(tmpdir(), "cotal-dogfood-"));

--- a/bin/smoke/readiness-window-live.smoke.ts
+++ b/bin/smoke/readiness-window-live.smoke.ts
@@ -15,8 +15,27 @@
  */
 import { spawn as spawnProc, type ChildProcess } from "node:child_process";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+/** An ephemeral, collision-safe loopback port (ask the OS for a free one, then release it). */
+const freePort = (): Promise<number> =>
+  new Promise((res, rej) => {
+    const s = createServer();
+    s.on("error", rej);
+    s.listen(0, "127.0.0.1", () => {
+      const p = (s.address() as AddressInfo).port;
+      s.close(() => res(p));
+    });
+  });
+/** Resolve once the child has actually exited (or immediately if it already has); bounded by ms. */
+const awaitExit = (p: ChildProcess, ms = 5000): Promise<void> =>
+  new Promise((r) => {
+    if (p.exitCode !== null || p.signalCode !== null) return r();
+    p.once("exit", () => r());
+    setTimeout(r, ms).unref?.();
+  });
 
 const home = mkdtempSync(join(tmpdir(), "cotal-readiness-home-"));
 process.env.COTAL_HOME = home;
@@ -37,7 +56,7 @@ const ok = (name: string, cond: boolean, extra?: unknown) => {
 };
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-const PORT = 14487;
+const PORT = await freePort();
 const SERVER = `nats://127.0.0.1:${PORT}`;
 const SPACE = "readiness-e2e";
 // Past the 5s op default (what the old clients died at), inside the ~30s readiness backstop with
@@ -153,5 +172,8 @@ try {
   await ep?.stop().catch(() => {});
   await driver?.stop().catch(() => {});
   await mgr?.stop().catch(() => {});
-  for (const k of kids) k.kill("SIGKILL");
+  await Promise.all(kids.map((k) => {
+    k.kill("SIGKILL");
+    return awaitExit(k);
+  }));
 }

--- a/bin/smoke/shard.mjs
+++ b/bin/smoke/shard.mjs
@@ -1,0 +1,45 @@
+/**
+ * Run a round-robin SHARD of the `smoke:ci` chain, so CI can fan the (serial) protocol/security
+ * suite across N parallel runners without dropping or duplicating a single smoke.
+ *
+ *   node bin/smoke/shard.mjs <shardIndex> <shardCount>
+ *
+ * The list is derived from the `smoke:ci` script in package.json — the ONE source of truth, so a
+ * smoke added there is automatically distributed (no shard membership to hand-maintain). Round-robin
+ * (index % count) interleaves the list, which balances runtime better than contiguous slices.
+ * Each smoke runs in its own `pnpm` subprocess (separate broker/ports) exactly as the serial chain
+ * does; the shards run on SEPARATE runners, so there is no cross-smoke port contention within a shard.
+ */
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const shard = Number(process.argv[2]);
+const count = Number(process.argv[3]);
+if (!Number.isInteger(shard) || !Number.isInteger(count) || count < 1 || shard < 0 || shard >= count) {
+  console.error(`usage: node bin/smoke/shard.mjs <shardIndex 0..N-1> <shardCount N>  (got: ${process.argv[2]} ${process.argv[3]})`);
+  process.exit(2);
+}
+
+const pkg = JSON.parse(readFileSync(fileURLToPath(new URL("../../package.json", import.meta.url)), "utf8"));
+const chain = pkg.scripts?.["smoke:ci"];
+if (!chain) { console.error("no `smoke:ci` script in package.json"); process.exit(2); }
+
+// "pnpm a && pnpm b && …" → ["pnpm a", "pnpm b", …]
+const all = chain.split("&&").map((s) => s.trim()).filter(Boolean);
+const mine = all.filter((_, i) => i % count === shard);
+
+console.log(`smoke:ci shard ${shard}/${count} — ${mine.length} of ${all.length} smokes:\n  ${mine.join("\n  ")}\n`);
+
+const isWin = process.platform === "win32";
+for (const cmd of mine) {
+  const [bin, ...args] = cmd.split(/\s+/);
+  console.log(`\n===== ${cmd} =====`);
+  // shell:true on Windows so `pnpm` resolves to pnpm.cmd; the tokens are our own fixed script names.
+  const r = spawnSync(bin, args, { stdio: "inherit", shell: isWin });
+  if (r.status !== 0) {
+    console.error(`\n✗ shard ${shard}/${count} FAILED at: ${cmd} (exit ${r.status})`);
+    process.exit(r.status || 1);
+  }
+}
+console.log(`\n✓ smoke:ci shard ${shard}/${count} passed (${mine.length} smokes)`);

--- a/bin/smoke/spawn-detach-live.smoke.ts
+++ b/bin/smoke/spawn-detach-live.smoke.ts
@@ -16,8 +16,27 @@
  */
 import { spawn as spawnProc, spawnSync, type ChildProcess } from "node:child_process";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+/** An ephemeral, collision-safe loopback port (ask the OS for a free one, then release it). */
+const freePort = (): Promise<number> =>
+  new Promise((res, rej) => {
+    const s = createServer();
+    s.on("error", rej);
+    s.listen(0, "127.0.0.1", () => {
+      const p = (s.address() as AddressInfo).port;
+      s.close(() => res(p));
+    });
+  });
+/** Resolve once the child has actually exited (or immediately if it already has); bounded by ms. */
+const awaitExit = (p: ChildProcess, ms = 5000): Promise<void> =>
+  new Promise((r) => {
+    if (p.exitCode !== null || p.signalCode !== null) return r();
+    p.once("exit", () => r());
+    setTimeout(r, ms).unref?.();
+  });
 
 const home = mkdtempSync(join(tmpdir(), "cotal-detach-home-"));
 process.env.COTAL_HOME = home;
@@ -37,7 +56,7 @@ const ok = (name: string, cond: boolean, extra?: unknown) => {
 };
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-const PORT = 14461;
+const PORT = await freePort();
 const SERVER = `nats://127.0.0.1:${PORT}`;
 const SPACE = "detach-e2e";
 
@@ -245,5 +264,8 @@ try {
   console.log(`\nspawn-detach live e2e: ${pass} checks passed`);
 } finally {
   await mgr?.stop().catch(() => {});
-  for (const k of kids) k.kill("SIGKILL");
+  await Promise.all(kids.map((k) => {
+    k.kill("SIGKILL");
+    return awaitExit(k);
+  }));
 }

--- a/bin/smoke/up-stack-live.smoke.ts
+++ b/bin/smoke/up-stack-live.smoke.ts
@@ -14,12 +14,19 @@
  * Run: pnpm smoke:up-stack:live
  */
 import { spawnSync } from "node:child_process";
-import { createConnection } from "node:net";
+import { createConnection, createServer, type AddressInfo } from "node:net";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
-const PORT = 14341; // unique across the live smokes (no back-to-back port collision)
+// Ephemeral OS-assigned port: no fixed-port collision across back-to-back / concurrent runs.
+const freePort = (): Promise<number> =>
+  new Promise((res, rej) => {
+    const s = createServer();
+    s.on("error", rej);
+    s.listen(0, "127.0.0.1", () => { const p = (s.address() as AddressInfo).port; s.close(() => res(p)); });
+  });
+const PORT = await freePort();
 const SERVER = `nats://127.0.0.1:${PORT}`;
 const DEFAULT_SERVER = "nats://127.0.0.1:4222";
 const WT = resolve(import.meta.dirname, "..", "..");

--- a/implementations/cli/smoke/server-resolution-live.smoke.ts
+++ b/implementations/cli/smoke/server-resolution-live.smoke.ts
@@ -15,8 +15,20 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { once } from "node:events";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+/** An ephemeral, collision-safe loopback port (ask the OS for a free one, then release it). */
+const freePort = (): Promise<number> =>
+  new Promise((res, rej) => {
+    const s = createServer();
+    s.on("error", rej);
+    s.listen(0, "127.0.0.1", () => {
+      const p = (s.address() as AddressInfo).port;
+      s.close(() => res(p));
+    });
+  });
 
 // Sandbox the registry BEFORE importing workspace — homeCotalDir() reads COTAL_HOME per call.
 const home = mkdtempSync(join(tmpdir(), "cotal-ps-resolve-home-"));
@@ -51,14 +63,16 @@ async function waitReady(server: string): Promise<void> {
   throw new Error(`broker ${server} never came up`);
 }
 
-const OTHER = "nats://127.0.0.1:14999"; // the recorded mesh's broker (non-default port)
-const OVERRIDE = "nats://127.0.0.1:7777"; // a second live broker for --server override / raw-open
+const PORT_OTHER = await freePort();
+const PORT_OVERRIDE = await freePort();
+const OTHER = `nats://127.0.0.1:${PORT_OTHER}`; // the recorded mesh's broker (non-default port)
+const OVERRIDE = `nats://127.0.0.1:${PORT_OVERRIDE}`; // a second live broker for --server override / raw-open
 const ts = new Date(0).toISOString();
 
 try {
   // Two live OPEN brokers (open ⇒ no creds to mint — keeps the smoke free of a creds-issuing broker).
-  startBroker(14999);
-  startBroker(7777);
+  startBroker(PORT_OTHER);
+  startBroker(PORT_OVERRIDE);
   await waitReady(OTHER);
   await waitReady(OVERRIDE);
   recordMesh({ space: "team-alpha", server: OTHER, root: projectRoot, mode: "open", ts });

--- a/implementations/cli/smoke/spawn-from-anywhere-live.smoke.ts
+++ b/implementations/cli/smoke/spawn-from-anywhere-live.smoke.ts
@@ -14,10 +14,28 @@
  * never pkill, so a co-running broker on :4222 is untouched. Run: pnpm smoke:spawn-from-anywhere:live
  */
 import { spawn, type ChildProcess } from "node:child_process";
-import { createServer, type Server } from "node:net";
+import { createServer, type AddressInfo, type Server } from "node:net";
 import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+/** An ephemeral, collision-safe loopback port (ask the OS for a free one, then release it). */
+const freePort = (): Promise<number> =>
+  new Promise((res, rej) => {
+    const s = createServer();
+    s.on("error", rej);
+    s.listen(0, "127.0.0.1", () => {
+      const p = (s.address() as AddressInfo).port;
+      s.close(() => res(p));
+    });
+  });
+/** Resolve once the child has actually exited (or immediately if it already has); bounded by ms. */
+const awaitExit = (p: ChildProcess, ms = 5000): Promise<void> =>
+  new Promise((r) => {
+    if (p.exitCode !== null || p.signalCode !== null) return r();
+    p.once("exit", () => r());
+    setTimeout(r, ms).unref?.();
+  });
 
 // Sandbox the machine-home BEFORE importing core — homeCotalDir() reads COTAL_HOME per call, so the
 // real ~/.cotal is never touched.
@@ -66,13 +84,17 @@ function project(label: string): string {
 }
 
 const projA = project("projA");
-const SRV_OPEN = "nats://127.0.0.1:4455";
-const SRV_AUTH = "nats://127.0.0.1:4456";
+const PORT_OPEN = await freePort();
+const PORT_AUTH = await freePort();
+const PORT_NOTNATS = await freePort();
+const SRV_OPEN = `nats://127.0.0.1:${PORT_OPEN}`;
+const SRV_AUTH = `nats://127.0.0.1:${PORT_AUTH}`;
+const SRV_NOTNATS = `nats://127.0.0.1:${PORT_NOTNATS}`;
 const ts = "2026-06-22T00:00:00.000Z";
 
 try {
   // A + B(live ok) + D: open broker on a NON-default port, recorded for projA.
-  startBroker(4455, false);
+  startBroker(PORT_OPEN, false);
   await waitReady(SRV_OPEN, "ok");
   recordMesh({ space: "alpha", server: SRV_OPEN, root: projA, mode: "open", ts });
 
@@ -108,7 +130,7 @@ try {
   );
 
   // B(auth-required): the unreachable-vs-auth split against a REAL auth broker.
-  startBroker(4456, true);
+  startBroker(PORT_AUTH, true);
   await waitReady(SRV_AUTH, "auth-required");
   const credless = await probeConnect(SRV_AUTH, { timeoutMs: 800 });
   ok(
@@ -123,8 +145,8 @@ try {
   ok("E: isReachable(live open broker) → true", (await isReachable(SRV_OPEN)) === true);
   ok("E: isReachable(live AUTH broker) → true (credless, no auth-error log)", (await isReachable(SRV_AUTH)) === true);
   notNats = createServer((s) => s.end("hello, not nats\r\n"));
-  await new Promise<void>((res) => notNats!.listen(4457, "127.0.0.1", res));
-  ok("E: isReachable(non-NATS listener) → false (not 'any open port')", (await isReachable("nats://127.0.0.1:4457")) === false);
+  await new Promise<void>((res) => notNats!.listen(PORT_NOTNATS, "127.0.0.1", res));
+  ok("E: isReachable(non-NATS listener) → false (not 'any open port')", (await isReachable(SRV_NOTNATS)) === false);
 
   // C: prune-on-real-death. Kill ONLY our 4455 child, then the entry must prune.
   const opener = kids[0]!;
@@ -139,15 +161,15 @@ try {
 
   console.log(`\nspawn-from-anywhere live e2e: ${pass} checks passed`);
 } finally {
-  for (const cp of kids) {
+  await Promise.all(kids.map((cp) => {
     try {
       cp.kill("SIGKILL");
     } catch {
       /* already gone */
     }
-  }
+    return awaitExit(cp);
+  }));
   try { notNats?.close(); } catch { /* already closed */ }
-  await sleep(300);
   for (const d of [home, projA]) rmSync(d, { recursive: true, force: true });
 }
 process.exit(0);

--- a/implementations/cli/smoke/up-manifest-live.smoke.ts
+++ b/implementations/cli/smoke/up-manifest-live.smoke.ts
@@ -10,15 +10,23 @@
  * Needs `nats-server` on PATH. Run: pnpm smoke:up-manifest:live
  */
 import { spawnSync } from "node:child_process";
-import { createConnection } from "node:net";
+import { createConnection, createServer, type AddressInfo } from "node:net";
 import { mkdtempSync, rmSync, writeFileSync, existsSync, statSync, readdirSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
-const PORT = 14311;
-const DECOY_PORT = 14312; // the manifest declares this; --server overrides it to PORT
+// Ephemeral free ports + a per-run space: repeated or concurrent runs never collide on a fixed port
+// nor contaminate each other's `supervise` scan (the old fixed 14311 / "upf-live" flaked locally).
+const freePort = (): Promise<number> =>
+  new Promise((res, rej) => {
+    const s = createServer();
+    s.on("error", rej);
+    s.listen(0, "127.0.0.1", () => { const p = (s.address() as AddressInfo).port; s.close(() => res(p)); });
+  });
+const PORT = await freePort();
+const DECOY_PORT = await freePort(); // the manifest declares this; --server overrides it to PORT
 const SERVER = `nats://127.0.0.1:${PORT}`;
-const SPACE = "upf-live";
+const SPACE = `upf-live-${process.pid}`;
 const WT = resolve(import.meta.dirname, "..", "..", "..");
 const CLI = join(WT, "bin", "cotal.ts");
 const TSX = join(WT, "node_modules", ".bin", "tsx");
@@ -74,10 +82,11 @@ channels:
 `,
 );
 
+let mgrPid = NaN;
 try {
   // 1) fresh up -f with a --server OVERRIDE (the manifest declares the decoy port; the flag wins).
   const up = cli("up", "-f", manifest, "--server", SERVER);
-  ok("up -f reports the mesh is up", /mesh "upf-live" up/.test(up.stdout), up.stdout + up.stderr);
+  ok("up -f reports the mesh is up", up.stdout.includes(`mesh "${SPACE}" up`), up.stdout + up.stderr);
   ok("up -f reports seeded channels", /seeded 2 channel/.test(up.stdout), up.stdout);
   // Regression guard (checked BEFORE any settle sleep, while a lease-race loser would still be
   // alive): the launch rides THE one control-plane manager — two supervises here means the plain
@@ -86,7 +95,7 @@ try {
   await sleep(1500);
   ok("broker bound the --server OVERRIDE port (not the manifest's)", await portOpen(PORT));
   ok("manifest's declared port was NOT used (override won)", !(await portOpen(DECOY_PORT)));
-  const mgrPid = Number(readFileSync(join(root, ".cotal", "manager.pid"), "utf8").trim());
+  mgrPid = Number(readFileSync(join(root, ".cotal", "manager.pid"), "utf8").trim());
   ok("the recorded manager is alive (not a lease-race loser)", Number.isFinite(mgrPid) && alive(mgrPid), mgrPid);
   const mgrCmd = spawnSync("ps", ["-p", String(mgrPid), "-o", "command="], { encoding: "utf8" }).stdout;
   ok("the recorded manager carries the launch spec", /--launch\b/.test(mgrCmd), mgrCmd);
@@ -109,19 +118,22 @@ try {
   ok("...and redirects to spawn -f", /spawn -f/.test(again.stderr), again.stderr);
 
   // 5) down tears the mesh down + clears the run dir — including the manager (nothing orphaned).
-  //    Poll: the SIGTERM'd manager shuts down gracefully, which can take a few seconds on slow CI.
+  //    `cotal down` now awaits real exit; keep a backstop poll keyed on the EXACT manager pid
+  //    (precise — a name scan can be contaminated by an unrelated run) in case of a slow CI reap.
   down();
   let torn = false;
-  for (let i = 0; i < 24 && !torn; i++) {
-    await sleep(500);
-    torn = !(await portOpen(PORT)) && supervisors().length === 0;
+  for (let i = 0; i < 60 && !torn; i++) {
+    torn = !alive(mgrPid) && !(await portOpen(PORT));
+    if (!torn) await sleep(500);
   }
-  ok("broker + manager are gone after down (no orphaned supervise)", torn, supervisors());
+  ok("broker + manager are gone after down (no orphaned supervise)", torn, { mgrAlive: alive(mgrPid), portOpen: await portOpen(PORT), supervisors: supervisors() });
   ok("transient run dir cleaned by down", !existsSync(runDir));
 
   console.log(`\nUP-MANIFEST LIVE SMOKE OK ✅ (${pass} checks)`);
 } finally {
   down();
+  // Belt-and-suspenders: if down somehow didn't reap the manager, don't leave an orphan behind.
+  if (Number.isFinite(mgrPid) && alive(mgrPid)) { try { process.kill(mgrPid, "SIGKILL"); } catch { /* already gone */ } }
   rmSync(home, { recursive: true, force: true });
   rmSync(root, { recursive: true, force: true });
 }

--- a/implementations/cli/src/commands/down.ts
+++ b/implementations/cli/src/commands/down.ts
@@ -23,11 +23,13 @@ export async function down(args: ParsedArgs): Promise<void> {
     ["nats.pid", "nats-server"],
   ];
   let any = false;
+  // Sequential, in declared order (manager → delivery → web → nats): the manager's graceful shutdown
+  // releases its lease OVER nats, so nats must outlive it. Each stop awaits the real exit.
   for (const [file, label] of targets) {
     const pidPath = cotalPath(file);
     if (!existsSync(pidPath)) continue;
     any = true;
-    stop(pidPath, label);
+    await stop(pidPath, label);
   }
   // Non-pid control-plane artifacts: the delivery daemon's scoped creds + the manager's delivery-aware
   // marker. Drop them with the processes so a stale creds file / marker never lingers.
@@ -45,13 +47,36 @@ export async function down(args: ParsedArgs): Promise<void> {
   }
 }
 
-function stop(pidPath: string, label: string): void {
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const isAlive = (pid: number): boolean => {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+};
+
+/** Stop one recorded process and AWAIT its actual exit — SIGTERM starts a graceful shutdown (a
+ *  manager reaps its agents and releases its JetStream lease over NATS, which isn't instant), so
+ *  returning before the process is really gone would let callers (and `up`-style smokes) race a
+ *  still-dying manager. Poll the pid, escalate to SIGKILL if it overstays, then confirm it's gone. */
+async function stop(pidPath: string, label: string): Promise<void> {
   const pid = Number(readFileSync(pidPath, "utf8").trim());
+  // Drop the pidfile up front so a concurrent `down` can't double-signal a reused pid.
+  rmSync(pidPath, { force: true });
+  if (!Number.isFinite(pid)) return;
   try {
     process.kill(pid, "SIGTERM");
-    console.log(c.green(`✓ stopped ${label} (pid ${pid})`));
   } catch {
     console.log(c.dim(`${label} (pid ${pid}) was not running.`));
+    return;
   }
-  rmSync(pidPath);
+  const graceDeadline = Date.now() + 15_000;
+  while (isAlive(pid) && Date.now() < graceDeadline) await sleep(100);
+  if (isAlive(pid)) {
+    try { process.kill(pid, "SIGKILL"); } catch { /* raced to exit */ }
+    const hardDeadline = Date.now() + 3_000;
+    while (isAlive(pid) && Date.now() < hardDeadline) await sleep(100);
+  }
+  console.log(
+    isAlive(pid)
+      ? c.red(`✗ ${label} (pid ${pid}) did not exit`)
+      : c.green(`✓ stopped ${label} (pid ${pid})`),
+  );
 }

--- a/implementations/manager/smoke/lifecycle-e2e.smoke.ts
+++ b/implementations/manager/smoke/lifecycle-e2e.smoke.ts
@@ -18,6 +18,7 @@
 import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -35,7 +36,15 @@ import { authDir, saveSpaceAuth } from "@cotal-ai/workspace";
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "../../.."); // worktree root — the agent process runs here so `@cotal-ai/core` resolves
 const STUB = join(here, "e2e-stub.mjs");
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+// OS-assigned free port (collision-safe at allocation) — the old random port had no bind guard, so
+// a rare collision could attach isReachable() to a FOREIGN broker and fail auth downstream.
+const freePort = (): Promise<number> =>
+  new Promise((res, rej) => {
+    const s = createServer();
+    s.on("error", rej);
+    s.listen(0, "127.0.0.1", () => { const p = (s.address() as AddressInfo).port; s.close(() => res(p)); });
+  });
+const PORT = await freePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 let pass = 0, fail = 0;


### PR DESCRIPTION
Accelerates CI without dropping any coverage, and fixes the teardown race that was letting red live smokes through.

## CI speedup (same tests, parallel)
- **Shard `smoke:ci`** (33 serial smokes) across **4 parallel runners** via `bin/smoke/shard.mjs` — a round-robin runner keyed off the `smoke:ci` script itself (single source of truth; new smokes auto-distribute, nothing to hand-maintain). Shards run on separate runners, so there's no cross-smoke port contention.
- `ci.yml` → `unit` + `smoke` (matrix ×4) + `live` jobs with a single `ci-ok` gate. `windows.yml` → `required` (broker-free) + `smoke` (matrix ×4) + `soak` with a `windows-ok` gate.
- **Cache `nats-server`** instead of re-downloading + re-checksumming it every run.
- Wall-clock is now the slowest shard, not the sum of the chain.

## Root-cause fix: `cotal down` teardown race
`down.ts stop()` SIGTERM'd the manager/broker then returned **immediately** without awaiting exit — so every `up`-style teardown raced a still-dying manager. That's the `up-manifest:live` "no orphaned supervise" flake that just let a red `check` merge. Rewrote `stop()` to poll the pid until gone (SIGKILL escalation) → `cotal down` is now synchronous for users *and* tests.

## De-flake the live smokes (robust, verified)
- **Ephemeral OS-assigned ports** (no fixed-port collision across back-to-back / concurrent runs): up-manifest, up-stack, dogfood, lifecycle-e2e, spawn-detach, readiness, spawn-from-anywhere, server-resolution.
- **Await actual child exit** on teardown instead of kill-then-sleep.
- up-manifest: per-run space + poll keyed on the exact manager pid + orphan reap in `finally`.

Verified locally: every de-flaked smoke green (up-manifest passed **3× back-to-back** — the exact collision case), and the shard runner exercised end-to-end.