### PR TITLE
feat(console): authoritative membership in the topology lens

### DIFF
--- a/docs/mesh-view.md
+++ b/docs/mesh-view.md
@@ -60,6 +60,7 @@ interface MeshSnapshot {
   channels:  { channel: string; messages: number }[];
   feed:      FeedEntry[];       // classified + coalesced + windowed
   views:     ViewItem[];        // peer-published renderable views (json-render specs), newest last
+  membership?: MembershipSnapshot; // broker-authoritative channel membership (needs the delivery daemon)
   rates:     { msgsPerSec: number };
   status:    { connected: boolean; space: string; dmVisible: boolean; error?: string };
   signals:   MeshSignals;       // derived operator signals (below)
@@ -103,7 +104,7 @@ visible (god-view / open mode); a chat-only observer leaves it empty.
 | golden-signal counts | `signals.counts` | ✓ tiles strip |  | ✓ tiles |
 | needs-you / blocked | `signals.waiting` | ✓ rail (`n`) |  | ✓ NEEDS-YOU rail |
 | direct-message lens | `signals.dms` | ✓ lens (`d`) |  | ✓ DM view |
-| topology (who-talks-to-whom) | `feed` + `agents` (derived) | ✓ lens (`t`, 3 variants) |  |  |
+| topology (membership + who-talks-to-whom) | `feed` + `agents` + `membership` | ✓ lens (`t`, 3 variants) |  | ✓ graph |
 | peer-pushed views (json-render) | `views` | ✓ lens (`V`) |  |  |
 | message / agent **detail** | `feed` / `agents` | ✓ select → detail |  | ✓ row / thread |
 | search / filter | client | ✓ `/` | (grep) | ✓ mode chips |
@@ -112,7 +113,14 @@ visible (god-view / open mode); a chat-only observer leaves it empty.
 Both interactive surfaces render every model field. The console adds the signals as an always-on
 tiles strip, a NEEDS-YOU rail (`n`), and a DM lens (`d`); the topology lens (`t`) folds the feed
 plus roster into a who-talks-to-whom graph client-side and renders it three switchable ways
-(`v` / `1`–`3`): swimlane sequence, adjacency heat matrix, and a ring node-link map. The views
+(`v` / `1`–`3`): swimlane sequence, adjacency heat matrix, and a ring node-link map. It also
+overlays the **broker-authoritative membership** feed (`readMembership`/`watchMembership`, the
+same source as the web graph) when available: silent subscribers appear as nodes, subscriptions
+as resting spokes (live solid-faint, durable-offline dashed), and wide readers (`>`/`*`) carry a
+`≫` badge; a header pill reads `membership: live / stale / traffic-only`. The map carries the
+full membership rendering, the matrix a light `∘`/`◌` marker, the sequence stays a traffic
+timeline. With no delivery daemon (or on an open mesh whose bare cred cannot read the feed) the
+lens degrades to the traffic-only view and the pill reads `traffic-only`. The views
 lens (`V`) shows the latest peer-published json-render view, validated against the console's
 fixed Ink component catalog (an invalid spec shows its rejection reason instead); the tiles strip
 renders through the same catalog, so the console dogfoods its own guardrail. The stream is

--- a/implementations/cli/smoke/topo-membership.smoke.ts
+++ b/implementations/cli/smoke/topo-membership.smoke.ts
@@ -1,0 +1,79 @@
+/**
+ * Topology membership smoke (no NATS, no test runner) — run with: pnpm smoke:topo-membership
+ *
+ * Asserts foldTopo overlays the broker-authoritative membership feed onto the traffic graph:
+ * silent subscribers become nodes, subscriptions become live/durable links, wide readers are
+ * badged (no per-hub spoke), bounded wildcards expand against known channels, a member that also
+ * has traffic is NOT double-counted, and an absent feed degrades to exactly the pre-change fold.
+ */
+import type { MembershipSnapshot, Presence } from "@cotal-ai/core";
+import type { FeedEntry } from "../src/console/mesh.js";
+import { foldTopo, membershipFreshness } from "../src/console/ui/topo/model.js";
+
+let failures = 0;
+function check(label: string, cond: boolean): void {
+  console.log(`${cond ? "✓" : "✗"} ${label}`);
+  if (!cond) failures++;
+}
+
+const NOW = 1_000_000_000_000;
+const agent = (id: string, name: string, status: Presence["status"] = "idle"): Presence => ({
+  card: { id, name, kind: "agent", role: name }, status, ts: NOW,
+});
+const feedMsg = (fromName: string, channel: string): FeedEntry => ({
+  id: fromName + channel, ts: NOW - 1000, from: { id: "ID_" + fromName, name: fromName },
+  delivery: "multicast", channel, text: "hi",
+});
+
+// Roster: alice is present + will have traffic; the membership feed also names a SILENT subscriber
+// (bea, no traffic, not in roster) and a durable-offline member (cid) and a wide reader (wide).
+const agents: Presence[] = [agent("ID_alice", "alice", "working")];
+const feed: FeedEntry[] = [feedMsg("alice", "general")];
+const membership: MembershipSnapshot = {
+  asOf: NOW,
+  members: [
+    { id: "ID_alice", live: ["general"], durable: [], observedAt: NOW }, // also has traffic → must merge
+    { id: "ID_bea", live: ["general"], durable: [], observedAt: NOW }, // SILENT subscriber
+    { id: "ID_cid", live: [], durable: ["backend"], observedAt: NOW }, // durable-offline member
+    { id: "ID_wide", live: [">"], durable: [], observedAt: NOW }, // wide reader
+    { id: "ID_team", live: ["team.>"], durable: [], observedAt: NOW }, // bounded wildcard
+  ],
+};
+const knownChannels = ["general", "backend", "team.build", "team.qa"];
+
+// nameOf resolves the extra members (not in roster) to stable short names.
+const nameOf = (id: string) => id.replace(/^ID_/, "");
+const g = foldTopo(feed, agents, { membership, knownChannels, now: NOW, nameOf });
+
+const node = (name: string) => g.byKey.get("a:" + name);
+const links = (name: string) => g.memberships.filter((m) => m.agent === "a:" + name);
+
+check("silent subscriber becomes a node (member, lastTs 0)", node("bea")?.member === true && node("bea")?.lastTs === 0);
+check("silent subscriber → live link to its channel", links("bea").some((l) => l.channel === "c:general" && l.state === "live"));
+check("silent channel hub materialized", g.byKey.has("c:general"));
+check("durable-offline member → durable link", links("cid").some((l) => l.channel === "c:backend" && l.state === "durable"));
+check("durable channel hub materialized", g.byKey.has("c:backend"));
+check("wide reader flagged, no per-hub spoke", node("wide")?.wide === true && links("wide").length === 0);
+check("bounded wildcard expands to both concretes (live)", (() => {
+  const l = links("team").map((m) => m.channel).sort();
+  return l.length === 2 && l[0] === "c:team.build" && l[1] === "c:team.qa" && links("team").every((m) => m.state === "live");
+})());
+
+// No double-count: alice has traffic AND membership → exactly one node, member:true, edge preserved.
+const aliceNodes = g.nodes.filter((n) => n.key === "a:alice");
+check("member with traffic → single node, member:true", aliceNodes.length === 1 && aliceNodes[0].member === true);
+check("member with traffic keeps its traffic edge", g.edges.some((e) => e.src === "a:alice" && e.dst === "c:general"));
+
+// Freshness pill.
+check("freshness: available + fresh asOf → live", membershipFreshness(NOW, g.membership).label === "live");
+check("freshness: available + old asOf → stale", membershipFreshness(NOW + 60_000, g.membership).label === "stale");
+
+// Degrade: no membership → identical to the pre-change fold (regression guard).
+const bare = foldTopo(feed, agents, { now: NOW });
+check("degrade: no membership → empty memberships", bare.memberships.length === 0);
+check("degrade: membership.available false", bare.membership.available === false);
+check("degrade: freshness reads traffic-only", membershipFreshness(NOW, bare.membership).label === "traffic-only");
+check("degrade: node set matches a plain fold (no phantom nodes)", bare.nodes.filter((n) => n.kind === "agent").length === 1);
+
+console.log(`\n${failures === 0 ? "TOPO-MEMBERSHIP SMOKE OK ✅" : "TOPO-MEMBERSHIP SMOKE FAILED ❌"} (${failures} failed)`);
+process.exit(failures === 0 ? 0 : 1);

--- a/implementations/cli/src/console/app.tsx
+++ b/implementations/cli/src/console/app.tsx
@@ -396,6 +396,9 @@ export function App({
         <Topo
           feed={mesh.feed}
           agents={mesh.agents}
+          membership={mesh.membership}
+          channels={mesh.channels}
+          nameOf={mesh.nameOf}
           variant={topoVariant}
           width={size.cols}
           height={bodyH}

--- a/implementations/cli/src/console/ui/topo/Map.tsx
+++ b/implementations/cli/src/console/ui/topo/Map.tsx
@@ -84,7 +84,8 @@ export function RingMap({
   // Geometry: labels live on an ellipse, the hub box at the center.
   const labelOf = (n: TopoNode) => {
     const role = n.role && n.role !== n.name ? "/" + n.role : "";
-    return STATUS[n.status ?? "offline"].dot + " " + trunc(n.name + role, 22);
+    const wide = n.wide ? " ≫" : ""; // "reads all" — a wide subscriber (> / *)
+    return STATUS[n.status ?? "offline"].dot + " " + trunc(n.name + role, 22) + wide;
   };
   const maxLabel = Math.max(...ring.map((n) => labelOf(n).length));
   const cx = Math.floor(width / 2);
@@ -106,6 +107,30 @@ export function RingMap({
   const hubRow = (key: string) => hubY + 1 + hubs.findIndex((n) => n.key === key);
 
   const grid = blankGrid(width, height);
+
+  // Membership spokes — the broker-authoritative subscription skeleton, drawn UNDER traffic so hot
+  // edges overdraw it. Live = solid faint; durable-only or offline agent = dashed dim. Only channel
+  // hubs carry membership (agents→channels); a wide reader shows the ≫ badge, not a spoke per hub.
+  for (const link of graph.memberships) {
+    const from = pos.get(link.agent);
+    if (!from) continue;
+    const agentNode = graph.byKey.get(link.agent);
+    const offline = link.state === "durable" || (agentNode?.status ?? "offline") === "offline";
+    const row = hubRow(link.channel);
+    if (row < hubY + 1) continue; // hub not materialized (shouldn't happen — merge adds it)
+    let to: { x: number; y: number };
+    let head: string;
+    if (from.x < hubX) (to = { x: hubX - 1, y: row }), (head = "▶");
+    else if (from.x > hubX + hubW - 1) (to = { x: hubX + hubW, y: row }), (head = "◀");
+    else (to = { x: cx, y: from.y < cy ? hubY - 1 : hubY + hubH }), (head = from.y < cy ? "▼" : "▲");
+    const pts = walk(from.x, from.y, to.x, to.y);
+    pts.forEach((p, i) => {
+      if (p.y < 0 || p.y >= height || p.x < 0 || p.x >= width) return;
+      if (offline && i % 2 === 1) return; // durable/offline spoke goes dashed
+      if (grid[p.y][p.x].ch !== " ") return; // never overwrite existing ink (traffic drawn later still wins)
+      stamp(grid[p.y], p.x, i === pts.length - 1 ? head : p.ch, { dim: true });
+    });
+  }
 
   // Edges — ascending by rate so hot traffic overdraws cool; spotlight the selection.
   for (const e of graph.edges) {

--- a/implementations/cli/src/console/ui/topo/Matrix.tsx
+++ b/implementations/cli/src/console/ui/topo/Matrix.tsx
@@ -35,7 +35,13 @@ export function Matrix({
 }) {
   const rows = graph.nodes.filter((n) => n.kind === "agent");
   const inbound = new Set(graph.edges.map((e) => e.dst));
-  const cols = graph.nodes.filter((n) => inbound.has(n.key));
+  // Membership state per (agent → channel), and the channels it touches — so a silent subscriber's
+  // channel still gets a column even with zero traffic.
+  const memberState = new Map<string, "live" | "durable">(
+    graph.memberships.map((m) => [m.agent + "|" + m.channel, m.state]),
+  );
+  const memberChans = new Set(graph.memberships.map((m) => m.channel));
+  const cols = graph.nodes.filter((n) => inbound.has(n.key) || memberChans.has(n.key));
   const edgeOf = new Map<string, TopoEdge>(graph.edges.map((e) => [e.key, e]));
 
   const [cur, setCur] = useState({ r: 0, c: 0 });
@@ -128,12 +134,17 @@ export function Matrix({
                   </Text>
                 );
               const e = edgeOf.get(row.key + "→" + col.key);
-              if (!e)
+              if (!e) {
+                // No traffic — but a broker-authoritative member of this channel still shows a faint
+                // marker (∘ live subscriber, ◌ durable-offline), so silent subscribers are visible.
+                const ms = memberState.get(row.key + "|" + col.key);
+                const mark = ms === "live" ? "  ∘" : ms === "durable" ? "  ◌" : "  ·";
                 return (
                   <Text key={col.key} dimColor inverse={selected} color={selected ? "cyan" : undefined}>
-                    {"  ·".padEnd(CELL_W)}
+                    {mark.padEnd(CELL_W)}
                   </Text>
                 );
+              }
               const lvl = heatLevel(e.rate);
               const txt = (HEAT[Math.max(1, lvl)] + " " + e.count).padEnd(CELL_W);
               if (selected)

--- a/implementations/cli/src/console/ui/topo/Topo.tsx
+++ b/implementations/cli/src/console/ui/topo/Topo.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo } from "react";
 import { Box, Text, useFocus } from "ink";
-import type { Presence } from "@cotal-ai/core";
+import type { MembershipSnapshot, Presence } from "@cotal-ai/core";
 import type { FeedEntry, FocusId } from "../../mesh.js";
-import { foldTopo } from "./model.js";
+import { foldTopo, membershipFreshness } from "./model.js";
 import { Sequence } from "./Sequence.js";
 import { Matrix } from "./Matrix.js";
 import { RingMap } from "./Map.js";
@@ -19,6 +19,9 @@ const MARKS = ["①", "②", "③"] as const;
 export function Topo({
   feed,
   agents,
+  membership,
+  channels,
+  nameOf,
   variant,
   width,
   height,
@@ -29,6 +32,10 @@ export function Topo({
 }: {
   feed: FeedEntry[];
   agents: Presence[];
+  membership?: MembershipSnapshot;
+  channels: { channel: string; messages: number }[];
+  /** Id → display name from the shared model (resolves endpoints and silent members too). */
+  nameOf?: (id: string) => string;
   variant: TopoVariant;
   width: number;
   height: number;
@@ -43,8 +50,13 @@ export function Topo({
   }, [isFocused, onFocus]);
 
   // The 1s age tick in App re-renders this tree, so `now` stays fresh between snapshots.
-  const graph = useMemo(() => foldTopo(feed, agents), [feed, agents]);
+  const knownChannels = channels.map((c) => c.channel);
+  const graph = useMemo(
+    () => foldTopo(feed, agents, { membership, knownChannels: channels.map((c) => c.channel), nameOf }),
+    [feed, agents, membership, nameOf, knownChannels.join(",")], // eslint-disable-line react-hooks/exhaustive-deps
+  );
   const msgs = graph.edges.reduce((n, e) => n + e.count, 0);
+  const fresh = membershipFreshness(graph.now, graph.membership);
   const active = isFocused && !blocked;
   const innerW = Math.max(8, width - 4); // border + paddingX
   const innerH = Math.max(1, height - 3); // border + title row
@@ -77,7 +89,9 @@ export function Topo({
             </Text>
           </Text>
         ))}
-        <Text dimColor>{" · window " + Math.round(graph.windowMs / 60_000) + "m · " + msgs + " msgs"}</Text>
+        <Text dimColor>{" · window " + Math.round(graph.windowMs / 60_000) + "m · " + msgs + " msgs · "}</Text>
+        <Text dimColor>membership: </Text>
+        <Text color={fresh.color} dimColor={!fresh.color}>{fresh.label}</Text>
       </Text>
       {body}
     </Box>

--- a/implementations/cli/src/console/ui/topo/model.ts
+++ b/implementations/cli/src/console/ui/topo/model.ts
@@ -3,7 +3,8 @@
 // (sequence / matrix / map); render-agnostic and stateless — `now` is injectable,
 // so the fold is deterministic and the recency kernel needs no stored EWMA state.
 
-import type { Presence, PresenceStatus } from "@cotal-ai/core";
+import type { MembershipSnapshot, Presence, PresenceStatus } from "@cotal-ai/core";
+import { subjectMatches } from "@cotal-ai/core";
 import type { FeedDelivery, FeedEntry } from "../../mesh.js";
 
 export type TopoNodeKind = "agent" | "channel" | "service";
@@ -18,6 +19,21 @@ export interface TopoNode {
   role?: string;
   /** Last involvement inside the window (0 = present but silent). */
   lastTs: number;
+  /** Present in the broker-authoritative membership feed (agents only). */
+  member?: boolean;
+  /** Subscribes `>` or `*` — a wide "reads all" reader; badged, not spoked per hub. */
+  wide?: boolean;
+}
+
+/** A broker-authoritative membership link — an agent subscribes a channel. Kept SEPARATE from
+ *  traffic {@link TopoEdge}s (which carry rate/count): a membership link has no traffic, so folding
+ *  it into edges would prune it (heatLevel 0) or create phantom empty matrix columns. */
+export interface TopoMembership {
+  agent: string; // TopoNode.key ("a:...")
+  channel: string; // TopoNode.key ("c:...")
+  /** Which broker arm proves it: `live` (a current CONNZ subscription) vs `durable` (registry only,
+   *  i.e. a member whose connection is currently down). */
+  state: "live" | "durable";
 }
 
 export interface TopoEdge {
@@ -36,13 +52,20 @@ export interface TopoGraph {
   nodes: TopoNode[];
   /** Ascending by rate — renderers overdraw hot edges last. */
   edges: TopoEdge[];
+  /** Broker-authoritative membership links (the resting subscription skeleton). */
+  memberships: TopoMembership[];
   byKey: Map<string, TopoNode>;
   windowMs: number;
   now: number;
+  /** Membership feed freshness — `available` false ⇒ the lens is traffic-only. */
+  membership: { asOf?: number; available: boolean };
 }
 
 const RATE_TAU_MS = 20_000;
 export const DEFAULT_TOPO_WINDOW_MS = 120_000;
+export const MEMBERSHIP_STALE_MS = 45_000; // mirror the web dashboard's FEED_STALE_MS
+
+const isWild = (pat: string): boolean => pat.includes("*") || pat.includes(">");
 
 /** The target node(s) a feed entry talks to — the single place delivery → node mapping lives. */
 export function targetsOf(e: FeedEntry): { key: string; kind: TopoNodeKind; name: string }[] {
@@ -62,7 +85,16 @@ export function targetsOf(e: FeedEntry): { key: string; kind: TopoNodeKind; name
 export function foldTopo(
   feed: FeedEntry[],
   agents: Presence[],
-  opts?: { windowMs?: number; now?: number },
+  opts?: {
+    windowMs?: number;
+    now?: number;
+    /** Broker-authoritative membership feed (from MeshView). Absent ⇒ traffic-only. */
+    membership?: MembershipSnapshot;
+    /** Channel registry names, for expanding bounded wildcard subscriptions. */
+    knownChannels?: string[];
+    /** id → display name (defaults to the roster, then an 8-char id prefix). */
+    nameOf?: (id: string) => string;
+  },
 ): TopoGraph {
   const now = opts?.now ?? Date.now();
   const windowMs = opts?.windowMs ?? DEFAULT_TOPO_WINDOW_MS;
@@ -113,6 +145,38 @@ export function foldTopo(
     }
   }
 
+  // Overlay broker-authoritative membership: silent subscribers become nodes, subscriptions become
+  // resting spokes. Resolve id→name against the roster so a member that ALSO has traffic merges onto
+  // the same node (no double-count), keeping the fold otherwise unchanged when membership is absent.
+  const memberships: TopoMembership[] = [];
+  const rosterById = new Map(agents.map((p) => [p.card.id, p.card.name]));
+  const nameFor = opts?.nameOf ?? ((id: string) => rosterById.get(id) ?? id.slice(0, 8));
+  const membership = opts?.membership;
+  if (membership) {
+    const known = new Set<string>([
+      ...[...byKey.values()].filter((n) => n.kind === "channel").map((n) => n.name),
+      ...(opts?.knownChannels ?? []),
+    ]);
+    for (const m of membership.members) {
+      const node = touch("a:" + nameFor(m.id), "agent", nameFor(m.id), 0);
+      node.member = true;
+      // Which channels this agent subscribes, and whether it's a wide reader.
+      const chans = new Map<string, "live" | "durable">();
+      let wide = false;
+      for (const pat of m.live ?? []) {
+        if (pat === ">" || pat === "*") wide = true;
+        else if (isWild(pat)) for (const ch of known) { if (subjectMatches(pat, ch)) chans.set(ch, "live"); }
+        else chans.set(pat, "live");
+      }
+      for (const ch of m.durable ?? []) if (!chans.has(ch)) chans.set(ch, "durable");
+      if (wide) node.wide = true;
+      for (const [ch, state] of chans) {
+        touch("c:" + ch, "channel", ch, 0); // materialize a hub even if silent
+        memberships.push({ agent: node.key, channel: "c:" + ch, state });
+      }
+    }
+  }
+
   // Agents keep roster order (traffic-only senders appended by name); hubs alphabetical.
   const rosterOrder = new Map(agents.map((p, i) => ["a:" + p.card.name, i]));
   const all = [...byKey.values()];
@@ -129,10 +193,26 @@ export function foldTopo(
   return {
     nodes: [...agentNodes, ...hub("channel"), ...hub("service")],
     edges: [...edges.values()].sort((a, b) => a.rate - b.rate),
+    memberships,
     byKey,
     windowMs,
     now,
+    membership: {
+      asOf: membership?.asOf,
+      // Available once we've read a feed with either a heartbeat (asOf) or at least one member.
+      available: membership !== undefined && (membership.asOf !== undefined || membership.members.length > 0),
+    },
   };
+}
+
+/** Membership feed freshness for the lens header pill — mirrors the web dashboard's pill. */
+export function membershipFreshness(
+  now: number,
+  m: TopoGraph["membership"],
+): { label: string; color?: string } {
+  if (!m.available) return { label: "traffic-only" };
+  const age = m.asOf ? now - m.asOf : Infinity;
+  return age < MEMBERSHIP_STALE_MS ? { label: "live", color: "green" } : { label: "stale", color: "yellow" };
 }
 
 // Heat shading shared by the matrix and map: rate → 5 intensity steps.

--- a/implementations/cli/src/view/mesh-view.ts
+++ b/implementations/cli/src/view/mesh-view.ts
@@ -12,6 +12,7 @@ import type {
   CotalMessage,
   DeliveryMode,
   EndpointRef,
+  MembershipSnapshot,
   Presence,
   PresenceStatus,
   ViewSpec,
@@ -100,6 +101,10 @@ export interface MeshSnapshot {
   rates: { msgsPerSec: number; activity: number[] };
   status: { connected: boolean; space: string; dmVisible: boolean; error?: string };
   signals: MeshSignals;
+  // Broker-authoritative channel membership (delivery-daemon CONNZ ∪ durable registry), when the
+  // feed is readable (admin cred + a running daemon). Undefined ⇒ the topology lens degrades to
+  // its traffic-derived view. The topology lens overlays this to show silent subscribers.
+  membership?: MembershipSnapshot;
   nameOf: (id: string) => string; // unicast target id → display name
 }
 
@@ -182,6 +187,9 @@ export class MeshView extends EventEmitter {
   // Participant mode: the operator has spoken, so it's a presence-registered peer and its own
   // inbox (`inst.<selfId>.*`) is captured — replies land in the DM lens. Off = pure observer.
   private participant = false;
+  private membership?: MembershipSnapshot; // authoritative membership feed, when readable
+  private membershipWatch?: { stop(): void };
+  private membershipTimer?: ReturnType<typeof setTimeout>; // debounce the watch's replay burst
 
   private readonly window: number;
   private readonly tapSubject?: string;
@@ -222,6 +230,7 @@ export class MeshView extends EventEmitter {
     );
     void this.prefill();
     void this.refreshChannels();
+    void this.startMembership();
     this.timers.push(setInterval(() => this.flush(), TICK_MS));
     this.timers.push(setInterval(() => void this.refreshChannels(), CHANNELS_MS));
     this.timers.push(setInterval(() => (this.dirty = true), 1000)); // refresh ages + decay rate
@@ -235,7 +244,37 @@ export class MeshView extends EventEmitter {
     this.ep.off("error", this.onError);
     this.ep.off("roster", this.onRoster);
     this.ep.off("presence", this.onPresence);
+    this.membershipWatch?.stop();
+    clearTimeout(this.membershipTimer);
     await this.ep.stop();
+  }
+
+  /** Populate + watch the broker-authoritative membership feed. Best-effort: on an open mesh (bare
+   *  cred) or a space with no delivery daemon the KV bucket isn't openable, so this stays silent and
+   *  the topology lens degrades to its traffic-derived view — exactly like `prefillDms`. A membership
+   *  fault must NOT set `this.error` (that drives connection health; a missing feed is normal). */
+  private async startMembership(): Promise<void> {
+    await this.loadMembership();
+    try {
+      this.membershipWatch = await this.ep.watchMembership(() => this.scheduleMembership());
+    } catch {
+      /* no feed / cred can't open the bucket → traffic-only */
+    }
+  }
+
+  /** Debounce the watch's replay burst into one re-read (mirrors the web dashboard's 150ms). */
+  private scheduleMembership(): void {
+    clearTimeout(this.membershipTimer);
+    this.membershipTimer = setTimeout(() => void this.loadMembership(), 150);
+  }
+
+  private async loadMembership(): Promise<void> {
+    try {
+      this.membership = await this.ep.readMembership();
+      this.dirty = true;
+    } catch {
+      /* keep the last snapshot; never surface as a connection error */
+    }
   }
 
   snapshot(): MeshSnapshot {
@@ -256,6 +295,7 @@ export class MeshView extends EventEmitter {
         error: this.error,
       },
       signals: this.signals(),
+      membership: this.membership,
       nameOf: this.nameOf,
     };
   }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "smoke:auth": "tsx packages/core/smoke-auth.ts",
     "smoke:orientation": "tsx extensions/connector-core/smoke/orientation.smoke.ts",
     "smoke:view": "tsx implementations/cli/smoke/view.smoke.ts",
+    "smoke:topo-membership": "tsx implementations/cli/smoke/topo-membership.smoke.ts",
     "smoke:members": "tsx packages/core/smoke/members.smoke.ts",
     "smoke:control-reply-bound": "tsx packages/core/smoke/control-reply-bound.smoke.ts",
     "smoke:plane3:auth": "tsx packages/core/smoke/plane3-auth.smoke.ts",


### PR DESCRIPTION
## What

Closes the one real gap where the web dashboard beat the console. The topology lens (`t`) was **traffic-derived only** — a fold of the last ~120s of messages — so it couldn't show a **subscribed-but-silent** agent, couldn't distinguish **live** vs **durable-offline** membership, and had no freshness signal. It now overlays the **broker-authoritative membership feed** (`readMembership`/`watchMembership` — the exact source the web `/graph` uses: delivery-daemon CONNZ ∪ durable registry).

- **MeshView** reads the feed once + watches it (150ms-debounced re-read), best-effort: on an open mesh or a space with no delivery daemon the read throws and is caught → the lens stays exactly as before (`prefillDms`-style degrade; never surfaced as a connection error). Exposed as `MeshSnapshot.membership`.
- **`foldTopo`** merges it onto the traffic graph: silent subscribers become member nodes, subscriptions become resting spokes (live / durable), wide readers (`>`/`*`) get a `≫` badge (no spoke-per-hub), bounded wildcards (`team.>`) expand against the channel registry via core `subjectMatches`, and ids resolve through the roster so a member that **also** has traffic isn't double-counted. Membership links are kept **separate** from traffic edges (they have no rate).
- **Renderers:** the **map** (③) draws the full membership skeleton under traffic (live solid-faint, durable/offline dashed) + the wide badge; the **matrix** (②) shows a light `∘`/`◌` marker for member-without-traffic cells; the **sequence** (①) stays a traffic timeline. A header pill reads `membership: live / stale / traffic-only`.

No core change (the feed + methods already exist); no SPEC change.

**Stacked on #206** (`feat/console-participant`) — retarget to main as the chain merges.

## Verified
- `pnpm typecheck` clean; `smoke:view` (MeshView) still green (no regression).
- **New hermetic `smoke:topo-membership` (15 checks):** silent subscriber → member node + live link; durable-offline → durable link; `>` → wide, no spoke; `team.>` → expands to both concretes; member-with-traffic → single node (no double-count) with its edge preserved; freshness live/stale; **degrade** (no feed → empty memberships, `available:false`, node set identical to a plain fold).
- **Live end-to-end** against a sandboxed **auth mesh + delivery daemon**: an admin observer's MeshView reads the feed (with a daemon `asOf` heartbeat), a provisioned **subscribed-but-silent** agent appears in it, and `foldTopo` surfaces it as a member node with a live spoke to `#general` — matching the web graph. Plus the real TUI on the open demo mesh shows `membership: traffic-only` and degrades cleanly.