### PR TITLE
feat(console): attach a live agent terminal

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,7 +133,8 @@ and configures them.
   `ps`.
 - **Pluggable runtimes.** Spawning is abstracted behind a `Runtime` contract (like pm2 or
   docker for agent TUIs): **`pty`** ships built-in (the manager owns a pseudo-terminal;
-  watch or type via `cotal attach`); **`tmux`** and **`cmux`** are extensions that put
+  watch or type via `cotal attach`, or in-process from the console's `a` key, which reuses
+  the same attach client); **`tmux`** and **`cmux`** are extensions that put
   each teammate in its own window/tab (explicit opt-ins that throw when the extension
   isn't loaded, never a silent fallback); **byo** is the floor (a human's own terminal,
   tracked via presence); **host** (Agent SDK, true mid-turn interrupt) is the documented

--- a/docs/watch-a-mesh.md
+++ b/docs/watch-a-mesh.md
@@ -59,7 +59,11 @@ they are: `p` pauses or resumes with no confirm (recoverable; the roster shows a
 badge merged from a low-rate `ps` poll, since a frozen agent's presence reads offline), `D`
 kills behind a confirm (`y` graceful stop, `f` force-kill), and the `:` palette adds
 `spawn <persona> [name]`, `status <agent>`, `ps`, and `purge` (type the space name to confirm,
-like the space delete).
+like the space delete). `a` on a roster agent (or `:attach <agent>`) suspends the console and
+hands the terminal to the agent's live PTY over the manager's loopback attach endpoint;
+`Ctrl-]` (or `COTAL_DETACH_KEY`) returns and repaints the console, with the observer running in
+the background throughout. Attach is `canControl`-gated, pty-runtime only (tmux/cmux are watched
+natively and flash their own hint), and same-host only (the socket is loopback).
 
 **Operator participant mode.** By default the operator is invisible, and a message it sends is
 one-way: an agent's DM reply has no inbox to land in. On the operator's **first send** (`:dm` /

--- a/implementations/cli/src/commands/agents.ts
+++ b/implementations/cli/src/commands/agents.ts
@@ -87,13 +87,22 @@ export async function attach(args: ParsedArgs): Promise<void> {
     console.error(c.red("--name is required"));
     process.exit(1);
   }
+  // A bad COTAL_DETACH_KEY fails loudly before connecting (attachClient itself just throws — the
+  // console turns the same error into a notice instead).
+  let detach: ReturnType<typeof detachKey>;
+  try {
+    detach = detachKey();
+  } catch (e) {
+    console.error(c.red(`✗ ${(e as Error).message}`));
+    process.exit(1);
+  }
   // Operator attach is a cross-agent (admin) op — same reasoning as stop (the operator isn't the
   // spawner; admin reaches any agent). Scoped `control-caller-admin`: ctl.<admin> only.
   const t = await resolveControlTarget(v, "control-caller-admin");
   const reply = await askManager(t.space, t.server, "attach", { name: v.name }, t.creds, CONTROL_ADMIN);
   failIfNotOk(reply);
   const { ws } = reply.data as { ws: string };
-  console.error(c.dim(`attached to ${v.name} — ${detachKey().label} to detach`));
+  console.error(c.dim(`attached to ${v.name} — ${detach.label} to detach`));
   await attachClient(ws);
   console.error(c.dim(`\ndetached from ${v.name}`));
 }

--- a/implementations/cli/src/console/app.tsx
+++ b/implementations/cli/src/console/app.tsx
@@ -10,7 +10,7 @@ import {
 } from "@cotal-ai/core";
 import { useMesh } from "./mesh.js";
 import { control, type ControlCtx } from "./control.js";
-import { attachClient } from "../lib/attach-client.js";
+import { attachClient, detachKey } from "../lib/attach-client.js";
 import { Tabs } from "./ui/Tabs.js";
 import { Roster } from "./ui/Roster.js";
 import { Feed } from "./ui/Feed.js";
@@ -189,9 +189,11 @@ export function App({
     if (!attachTarget) return;
     let cancelled = false;
     void (async () => {
+      let failed = false;
       try {
         await attachClient(attachTarget.ws);
       } catch (e) {
+        failed = true;
         if (!cancelled) setNotice("attach: " + (e as Error).message);
       } finally {
         try {
@@ -201,7 +203,8 @@ export function App({
         }
         if (!cancelled) {
           setAttachTarget(null);
-          setNotice(`detached from ${attachTarget.name}`);
+          // On failure the catch's error notice must survive the resume — don't overwrite it.
+          if (!failed) setNotice(`detached from ${attachTarget.name}`);
         }
       }
     })();
@@ -252,6 +255,13 @@ export function App({
   const handleAttach = useCallback(
     (name: string) => {
       if (!canControl) return setNotice("no control authority — pass --creds, or run against a mesh whose auth you hold");
+      // Validate COTAL_DETACH_KEY before suspending: a bad value stays a notice (never blanks the
+      // screen, never exits the console — attachClient would only throw it after the takeover).
+      try {
+        detachKey();
+      } catch (e) {
+        return setNotice("attach: " + (e as Error).message);
+      }
       setNotice(`attaching to ${name}…`);
       void ctl("attach", { name }, CONTROL_ADMIN)
         .then((r) => {

--- a/implementations/cli/src/console/app.tsx
+++ b/implementations/cli/src/console/app.tsx
@@ -1,3 +1,4 @@
+import { writeSync } from "node:fs";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Box, Text, useApp, useFocusManager, useInput, useStdout } from "ink";
 import {
@@ -9,6 +10,7 @@ import {
 } from "@cotal-ai/core";
 import { useMesh } from "./mesh.js";
 import { control, type ControlCtx } from "./control.js";
+import { attachClient } from "../lib/attach-client.js";
 import { Tabs } from "./ui/Tabs.js";
 import { Roster } from "./ui/Roster.js";
 import { Feed } from "./ui/Feed.js";
@@ -75,6 +77,7 @@ export function App({
   const [confirm, setConfirm] = useState<ConfirmTarget | null>(null);
   const [compose, setCompose] = useState<ComposeTarget | null>(null);
   const [notice, setNotice] = useState<string | undefined>();
+  const [attachTarget, setAttachTarget] = useState<{ name: string; ws: string } | null>(null);
 
   const overlay = helpOpen || detail !== null;
   const blocked = overlay || search.active || palette.active || confirm !== null || compose !== null;
@@ -113,7 +116,7 @@ export function App({
 
   // Focus the right pane after an overlay closes, or when switching into/out of a view.
   useEffect(() => {
-    if (overlay || confirm) return;
+    if (overlay || confirm || attachTarget) return;
     if (railOverlay) focus("needsyou");
     else if (mode === "dm") focus("dmpeers");
     else if (mode === "topo") focus("topo");
@@ -177,6 +180,36 @@ export function App({
     return () => clearTimeout(t);
   }, [notice]);
 
+  // Suspend the console and hand the terminal to the agent's PTY. The `attachTarget` render commits
+  // App→null + gates the top-level useInput, so Ink releases stdin (ref-counted raw mode) BEFORE
+  // attachClient grabs it. The observer endpoint + MeshView keep running in the background (App
+  // stays mounted). On detach (Ctrl-]) or ws close, re-assert the console's alt-screen/alt-scroll/
+  // cursor — attachClient leaves us in the main buffer after a full-screen child — then resume.
+  useEffect(() => {
+    if (!attachTarget) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        await attachClient(attachTarget.ws);
+      } catch (e) {
+        if (!cancelled) setNotice("attach: " + (e as Error).message);
+      } finally {
+        try {
+          writeSync(process.stdout.fd, "\x1b[?1049h\x1b[?1007h\x1b[?25h");
+        } catch {
+          /* stdout gone */
+        }
+        if (!cancelled) {
+          setAttachTarget(null);
+          setNotice(`detached from ${attachTarget.name}`);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [attachTarget]);
+
   useEffect(() => {
     const onResize = () => setSize({ cols: stdout.columns || 80, rows: stdout.rows || 24 });
     stdout.on("resize", onResize);
@@ -212,6 +245,23 @@ export function App({
         .catch((e) => setNotice(`${op}: ` + (e as Error).message));
     },
     [ctl, pausedIds],
+  );
+  // Attach: open the agent's live PTY. Keyed by NAME (a manager-managed agent needn't be a mesh
+  // roster peer — same as `cotal attach --name`). Resolve the manager's loopback WS via the attach
+  // control op (admin tier + per-action mint, like kill/pause), then suspend the console.
+  const handleAttach = useCallback(
+    (name: string) => {
+      if (!canControl) return setNotice("no control authority — pass --creds, or run against a mesh whose auth you hold");
+      setNotice(`attaching to ${name}…`);
+      void ctl("attach", { name }, CONTROL_ADMIN)
+        .then((r) => {
+          const ws = (r.data as { ws?: string } | undefined)?.ws;
+          if (!r.ok || !ws) return setNotice(`attach: ${r.error ?? "no ws endpoint"}`);
+          setAttachTarget({ name, ws });
+        })
+        .catch((e) => setNotice("attach: " + (e as Error).message));
+    },
+    [canControl, ctl],
   );
   const feedCompose = useCallback(
     () => setCompose({ kind: "channel", channel: activeChannel === "all" ? "general" : activeChannel, value: "" }),
@@ -294,6 +344,7 @@ export function App({
       confirmPurge: () => setConfirm({ kind: "purge", space: ep.space }),
       ensureParticipant,
       recordOutboundDm,
+      startAttach: handleAttach,
     };
     runCommand(line, ctx, !!canWrite, !!canControl);
   };
@@ -353,9 +404,12 @@ export function App({
         if (idx < tabs.length) setActiveChannel(tabs[idx]);
       }
     },
-    { isActive: !palette.active && confirm === null && compose === null },
+    { isActive: !attachTarget && !palette.active && confirm === null && compose === null },
   );
 
+  // Attached: render nothing so Ink releases stdin/stdout to the agent PTY (the suspend effect owns
+  // the terminal). App stays mounted → the observer endpoint + MeshView survive in the background.
+  if (attachTarget) return null;
   if (helpOpen) return <Help focusedId={focusedId} width={size.cols} height={size.rows} />;
   if (detail) return <Detail target={detail} feed={mesh.feed} width={size.cols} height={size.rows} />;
   if (confirm)
@@ -422,6 +476,7 @@ export function App({
               onOpenDetail={openAgent}
               onKill={canControl ? handleKill : undefined}
               onPause={canControl ? handlePause : undefined}
+              onAttach={canControl ? (p) => handleAttach(p.card.name) : undefined}
               paused={pausedIds}
               onCompose={canWrite ? rosterCompose : undefined}
             />

--- a/implementations/cli/src/console/commands.ts
+++ b/implementations/cli/src/console/commands.ts
@@ -34,6 +34,8 @@ export interface CommandCtx {
   ensureParticipant: () => Promise<void>;
   /** Record an outbound DM locally so the DM lens shows both sides of the thread. */
   recordOutboundDm: (toId: string, text: string) => void;
+  /** Attach to a managed agent's live terminal (suspends the console). */
+  startAttach: (name: string) => void;
 }
 
 export interface ConsoleCommand {
@@ -188,6 +190,17 @@ export const COMMANDS: ConsoleCommand[] = [
       } catch (e) {
         ctx.notify("status: " + (e as Error).message);
       }
+    },
+  },
+  {
+    name: "attach",
+    summary: "open a managed agent's terminal (Ctrl-] to detach)",
+    usage: "attach <agent>",
+    control: true,
+    run: (ctx, rest) => {
+      const name = rest.replace(/^@/, "").trim().split(/\s+/)[0] ?? "";
+      if (!name) return ctx.notify("usage: attach <agent>");
+      ctx.startAttach(name);
     },
   },
   {

--- a/implementations/cli/src/console/ui/Help.tsx
+++ b/implementations/cli/src/console/ui/Help.tsx
@@ -39,6 +39,7 @@ export function Help({
               ["↑↓ / j k", "move selection"],
               ["Enter", "open agent detail"],
               ["p", "pause / resume agent"],
+              ["a", "attach agent terminal (Ctrl-] detach)"],
               ["D", "kill agent (y stop · f force)"],
             ];
   const global: [string, string][] = [

--- a/implementations/cli/src/console/ui/Roster.tsx
+++ b/implementations/cli/src/console/ui/Roster.tsx
@@ -59,6 +59,7 @@ export function Roster({
   onOpenDetail,
   onKill,
   onPause,
+  onAttach,
   paused,
   onCompose,
 }: {
@@ -74,6 +75,8 @@ export function Roster({
   onKill?: (p: Presence) => void;
   /** Pause/resume toggle on the selected agent — recoverable, so it fires without a confirm. */
   onPause?: (p: Presence) => void;
+  /** Attach to the selected agent's live terminal. */
+  onAttach?: (p: Presence) => void;
   /** Ids the manager reports as paused — authoritative over presence for the badge. */
   paused?: Set<string>;
   onCompose?: (p: Presence) => void;
@@ -97,6 +100,8 @@ export function Roster({
         onKill(list[selClamped]);
       else if (input === "p" && onPause && list[selClamped]?.card.kind === "agent")
         onPause(list[selClamped]);
+      else if (input === "a" && onAttach && list[selClamped]?.card.kind === "agent")
+        onAttach(list[selClamped]);
       else if (input === "c" && onCompose && list[selClamped]?.card.kind === "agent")
         onCompose(list[selClamped]);
       else if (key.return && list.length) onOpenDetail(list[selClamped]);

--- a/implementations/cli/src/console/ui/StatusBar.tsx
+++ b/implementations/cli/src/console/ui/StatusBar.tsx
@@ -38,7 +38,7 @@ export function StatusBar({
           (railOpen ? "n hide-rail" : "n needs-you") +
           " · d DMs · V views" +
           (canWrite ? " · c compose" : "") +
-          (canControl ? " · p pause · D kill" : "") +
+          (canControl ? " · p pause · a attach · D kill" : "") +
           " · / search · [ ] chan · ? help · q quit";
   return (
     <Box width={width} paddingX={1}>

--- a/implementations/cli/src/lib/attach-client.ts
+++ b/implementations/cli/src/lib/attach-client.ts
@@ -6,8 +6,9 @@ import { c } from "../ui.js";
  * rebinds it to another control key when Ctrl-] clashes with a keybinding inside the agent's TUI;
  * accepts `ctrl-<char>` or `^<char>` (e.g. `ctrl-b`, `^_`). Read at point of use, per the repo's
  * `COTAL_*` convention. An unparseable value — including a set-but-empty or whitespace-only one —
- * throws (named), never silently falling back; the caller turns that into a loud exit. Only an
- * unset var = the Ctrl-] default.
+ * throws (named), never silently falling back; each caller owns the failure mode (the standalone
+ * `cotal attach` command exits loudly, the console flashes a notice). Only an unset var = the
+ * Ctrl-] default.
  */
 export function detachKey(): { byte: number; label: string; overridden: boolean } {
   const spec = process.env.COTAL_DETACH_KEY;
@@ -83,15 +84,10 @@ const lastIndexOfRe = (re: RegExp, s: string): number => {
  * The detach key (Ctrl-] by default, {@link detachKey}) detaches without killing the agent.
  */
 export function attachClient(url: string): Promise<void> {
-  // Resolve the detach key before connecting so a bad COTAL_DETACH_KEY fails loudly up front
-  // (matching the manager's other fail-fast exits) instead of after an attach we'd only tear down.
-  let detach: ReturnType<typeof detachKey>;
-  try {
-    detach = detachKey();
-  } catch (e) {
-    console.error(c.red(`✗ ${(e as Error).message}`));
-    process.exit(1);
-  }
+  // Resolve the detach key before connecting so a bad COTAL_DETACH_KEY fails up front (a named
+  // throw, before an attach we'd only tear down). The caller owns the failure mode: the standalone
+  // command exits loudly, the console catches its awaited rejection into a notice.
+  const detach = detachKey();
   return new Promise<void>((resolve, reject) => {
     const ws = new WebSocket(url);
     const stdin = process.stdin;
@@ -134,7 +130,13 @@ export function attachClient(url: string): Promise<void> {
 
     const sendResize = () =>
       ws.send(`r:${process.stdout.columns ?? 80},${process.stdout.rows ?? 24}`);
-    const onInput = (d: Buffer) => {
+    const onInput = (data: Buffer | string) => {
+      // Under the console, Ink has called stdin.setEncoding("utf8") — and an encoding persists on
+      // the stream after Ink releases raw mode — so data arrives as a STRING there (standalone
+      // `cotal attach` gets Buffers). Normalize first: the 1-byte detach compare below would
+      // otherwise silently never match (a one-char string is not the number 0x1d) and Ctrl-] would just forward to the
+      // child, making detach impossible.
+      const d = Buffer.isBuffer(data) ? data : Buffer.from(data, "utf8");
       if (d.length === 1 && d[0] === detach.byte) {
         ws.close();
         return;

--- a/implementations/manager/smoke/attach-control-live.smoke.ts
+++ b/implementations/manager/smoke/attach-control-live.smoke.ts
@@ -1,0 +1,105 @@
+/**
+ * Attach control-op live smoke — run with: pnpm smoke:attach-control:live (needs nats-server + node).
+ *
+ * The console's attach reuses the CLI attach flow: a per-action control-caller-admin cred →
+ * requestControl(ADMIN, {op:"attach", args:{name}}) → the manager returns the WS attach URL, which
+ * attachClient then streams (that data path is covered by attach-repaint.smoke.ts). This guards the
+ * console's dependency end-to-end against a real broker + Manager + pty agent: attach returns a
+ * loopback ws for a live pty agent, and errors (not crashes) for a missing one.
+ */
+import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  CONTROL_ADMIN,
+  CotalEndpoint,
+  isReachable,
+  createSpaceAuth,
+  mintCreds,
+  serverConfig,
+  newIdentity,
+  setupSpaceStreams,
+  registry,
+  type Connector,
+  type LaunchOpts,
+  type LaunchSpec,
+} from "@cotal-ai/core";
+import { authDir, saveSpaceAuth } from "@cotal-ai/workspace";
+import { Manager } from "../src/manager.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "../../..");
+const STUB = join(here, "e2e-stub.mjs");
+const PORT = 20000 + Math.floor(Math.random() * 40000);
+const SERVERS = `nats://127.0.0.1:${PORT}`;
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+let pass = 0, fail = 0;
+const check = (n: string, c: boolean, extra?: unknown) => { c ? (pass++, console.log("  ✓ " + n)) : (fail++, console.log("  ✗ FAIL: " + n, extra ?? "")); };
+
+/** One control request with a per-action admin cred — the console's exact flow (console/control.ts). */
+async function callAttach(space: string, auth: Awaited<ReturnType<typeof createSpaceAuth>>, name: string) {
+  const creds = await mintCreds(auth, newIdentity(), "control-caller-admin");
+  const ep = new CotalEndpoint({ space, servers: SERVERS, creds, channels: [], consume: false, registerPresence: false, watchPresence: false, card: { name: "console-smoke", kind: "endpoint" } });
+  ep.on("error", () => {});
+  await ep.start();
+  try {
+    return await ep.requestControl(CONTROL_ADMIN, { op: "attach", args: { name } });
+  } finally {
+    await ep.stop();
+  }
+}
+
+const space = `attach-${randomUUID().slice(0, 8)}`;
+const auth = await createSpaceAuth(space);
+const dir = mkdtempSync(join(tmpdir(), "cotal-attach-"));
+const workspaceRoot = join(dir, "ws");
+mkdirSync(join(workspaceRoot, ".cotal", "agents"), { recursive: true });
+saveSpaceAuth(authDir(workspaceRoot), auth);
+writeFileSync(join(workspaceRoot, ".cotal", "agents", "w1.md"), "---\nname: w1\nrole: worker\n---\n");
+writeFileSync(join(dir, "server.conf"), serverConfig(auth, { port: PORT, storeDir: join(dir, "js") }));
+const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+
+const envFor = (o: LaunchOpts): Record<string, string> => ({
+  COTAL_SPACE: o.space, COTAL_SERVERS: String(o.servers ?? SERVERS), COTAL_CREDS: String(o.creds),
+  COTAL_ID: String(o.id), COTAL_NAME: o.name, PATH: process.env.PATH ?? "",
+});
+const stubCon: Connector = { kind: "connector", name: "e2e-stub", requires: ["node"], buildLaunch: (o): LaunchSpec => ({ command: "node", args: [STUB], env: envFor(o) }) };
+registry.register(stubCon);
+
+const mgr = new Manager({ space, servers: SERVERS, runtime: "pty", workspaceRoot });
+
+try {
+  let up = false;
+  for (let i = 0; i < 50; i++) { if (await isReachable(SERVERS)) { up = true; break; } await wait(200); }
+  if (!up) throw new Error(`auth nats-server did not come up on ${PORT}`);
+  const provCreds = await mintCreds(auth, newIdentity(), "provisioner");
+  await setupSpaceStreams({ servers: SERVERS, space, creds: provCreds });
+  await mgr.start();
+
+  const r1 = await mgr.startAgent({ name: "w1", agent: "e2e-stub", cwd: repoRoot });
+  check("spawn: pty stub agent started", r1.ok === true, r1);
+
+  // The console's attach path: admin-tier control op → { ws }.
+  const ra = await callAttach(space, auth, "w1");
+  const ws = (ra.data as { ws?: string } | undefined)?.ws;
+  check("attach: returns ok with a ws url", ra.ok === true && typeof ws === "string", ra);
+  check("attach: ws is a loopback /attach/<name> endpoint", !!ws && /^ws:\/\/127\.0\.0\.1:\d+\/attach\/w1$/.test(ws), ws);
+
+  // A missing agent errors, not crashes (the console flashes r.error).
+  const rMiss = await callAttach(space, auth, "ghost");
+  check("attach: missing agent → {ok:false} with an error", rMiss.ok === false && typeof rMiss.error === "string", rMiss);
+} catch (e) {
+  fail++;
+  console.error("  ✗ scenario threw:", (e as Error).message);
+} finally {
+  try { await mgr.stop(); } catch { /* already down */ }
+  srv.kill("SIGKILL");
+  await new Promise<void>((res) => { if (srv.exitCode !== null || srv.signalCode !== null) return res(); srv.once("exit", () => res()); setTimeout(res, 3000); });
+  rmSync(dir, { recursive: true, force: true });
+}
+
+console.log(`\n${fail === 0 ? "ATTACH-CONTROL SMOKE OK ✅" : "ATTACH-CONTROL SMOKE FAILED ❌"}  (${pass} passed, ${fail} failed)`);
+process.exit(fail === 0 ? 0 : 1);

--- a/implementations/manager/smoke/console-attach-live.smoke.ts
+++ b/implementations/manager/smoke/console-attach-live.smoke.ts
@@ -1,0 +1,175 @@
+/**
+ * Console attach live smoke — run with: pnpm smoke:console-attach:live (needs nats-server + node;
+ * the script chains `pnpm build` first because the console under test runs the BUILT dists).
+ *
+ * attach-control-live.smoke.ts guards the control-op half (admin mint → {ws}); this drives the
+ * REAL console TUI under a pty through the risky half — the in-place Ink suspend/resume
+ * (console/app.tsx): `:attach` must hand the terminal to the agent's live PTY (App→null releases
+ * stdin so typed bytes reach the child), Ctrl-] must detach and repaint the console, and an
+ * invalid COTAL_DETACH_KEY must stay a notice — never exit the console (the standalone-CLI
+ * `process.exit` regression this file pins down).
+ *
+ * The tmux harness can't deliver the raw 0x1d detach byte; node-pty (already the pty runtime's
+ * dependency) can, which is what makes this automatable at all.
+ */
+import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn as ptySpawn, type IPty } from "@lydell/node-pty";
+import { isReachable, setupSpaceStreams, registry, type Connector, type LaunchSpec } from "@cotal-ai/core";
+import { Manager } from "../src/manager.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "../../..");
+const TSX = join(repoRoot, "node_modules", ".bin", "tsx");
+const COTAL = join(repoRoot, "bin", "cotal.ts");
+const PORT = 20000 + Math.floor(Math.random() * 40000);
+const SERVERS = `nats://127.0.0.1:${PORT}`;
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+let pass = 0, fail = 0;
+const check = (n: string, c: boolean, extra?: unknown) => { c ? (pass++, console.log("  ✓ " + n)) : (fail++, console.log("  ✗ FAIL: " + n, extra ?? "")); };
+
+// A trivial pty child: prints a banner, then echoes stdin — a visible, typeable terminal. It never
+// joins the mesh, so startAgent reports "uncertain" readiness but keeps it managed (attachable).
+const CHILD =
+  "process.stdout.write('ATTACH-ECHO-READY\\r\\n'); process.stdin.setRawMode?.(true); " +
+  "process.stdin.on('data', d => process.stdout.write(d)); setInterval(() => {}, 1e9);";
+const echoCon: Connector = {
+  kind: "connector",
+  name: "echo",
+  requires: ["node"],
+  buildLaunch: (): LaunchSpec => ({ command: "node", args: ["-e", CHILD], env: { PATH: process.env.PATH ?? "" } }),
+};
+registry.register(echoCon);
+
+/** One console session under a real pty: cumulative output capture + a marker poll. */
+class ConsoleSession {
+  out = "";
+  exited: { code: number } | undefined;
+  private p: IPty;
+  constructor(space: string, home: string, extraEnv: Record<string, string> = {}) {
+    this.p = ptySpawn(TSX, [COTAL, "console", "--space", space, "--server", SERVERS], {
+      name: "xterm-256color",
+      cols: 120,
+      rows: 32,
+      cwd: repoRoot,
+      env: {
+        PATH: process.env.PATH ?? "",
+        HOME: process.env.HOME ?? "",
+        TERM: "xterm-256color",
+        COTAL_HOME: home,
+        ...extraEnv,
+      },
+    });
+    this.p.onData((d) => (this.out += d));
+    this.p.onExit((e) => (this.exited = { code: e.exitCode }));
+  }
+  /** Poll the cumulative output (from `from`) for `marker`; false on timeout, never throws. */
+  async waitFor(marker: string, timeoutMs: number, from = 0): Promise<boolean> {
+    const t0 = Date.now();
+    while (Date.now() - t0 < timeoutMs) {
+      if (this.out.slice(from).includes(marker)) return true;
+      if (this.exited) return this.out.slice(from).includes(marker);
+      await wait(100);
+    }
+    return false;
+  }
+  write(s: string): void {
+    this.p.write(s);
+  }
+  async close(): Promise<void> {
+    if (this.exited) return;
+    this.p.kill();
+    for (let i = 0; i < 30 && !this.exited; i++) await wait(100);
+  }
+}
+
+const space = `attachui-${randomUUID().slice(0, 8)}`;
+const dir = mkdtempSync(join(tmpdir(), "cotal-console-attach-"));
+const workspaceRoot = join(dir, "ws");
+const home = join(dir, "home");
+mkdirSync(join(workspaceRoot, ".cotal", "agents"), { recursive: true });
+writeFileSync(join(workspaceRoot, ".cotal", "agents", "echo.md"), "---\nname: echo\nrole: worker\n---\n");
+// Sandboxed registry (COTAL_HOME): the console resolves `--space` through it — an open-mode entry
+// pointing at our broker, exactly what `cotal up` would have recorded. Never touches ~/.cotal.
+mkdirSync(join(home, "meshes"), { recursive: true });
+writeFileSync(
+  join(home, "meshes", `${space}.json`),
+  JSON.stringify({ space, server: SERVERS, root: workspaceRoot, mode: "open", ts: new Date().toISOString() }),
+);
+const srv = spawn("nats-server", ["-js", "-p", String(PORT), "-sd", join(dir, "js")], { stdio: "ignore" });
+
+const mgr = new Manager({ space, servers: SERVERS, runtime: "pty", workspaceRoot });
+(mgr as unknown as { readinessTimeoutMs: number }).readinessTimeoutMs = 2500; // echo never mesh-joins — don't wait the full window
+
+let session: ConsoleSession | undefined;
+try {
+  let up = false;
+  for (let i = 0; i < 50; i++) { if (await isReachable(SERVERS)) { up = true; break; } await wait(200); }
+  if (!up) throw new Error(`nats-server did not come up on ${PORT}`);
+  await setupSpaceStreams({ servers: SERVERS, space });
+  await mgr.start();
+
+  const r1 = await mgr.startAgent({ name: "echo", agent: "echo", cwd: repoRoot });
+  check("spawn: echo pty agent launched (uncertain readiness, kept managed)", r1.ok === false && /uncertain/i.test(String(r1.error)), r1);
+
+  // — Scenario 1: attach → type through → detach → repaint —
+  session = new ConsoleSession(space, home);
+  check("console: TUI paints the space status bar", await session.waitFor(`${space} · #`, 30_000), session.out.slice(-400));
+
+  session.write(":");
+  await wait(400); // let the palette open before typing into it (one pty chunk could outrun Ink's per-key handling)
+  session.write("attach echo");
+  await wait(200);
+  session.write("\r");
+  check("attach: console suspends and streams the agent's live screen", await session.waitFor("ATTACH-ECHO-READY", 15_000), session.out.slice(-400));
+
+  const typedFrom = session.out.length;
+  session.write("PING-4711");
+  check("attach: typed input reaches the child pty and echoes back (Ink released stdin)", await session.waitFor("PING-4711", 10_000, typedFrom), session.out.slice(typedFrom).slice(-400));
+
+  const detachFrom = session.out.length;
+  session.write("\x1d"); // Ctrl-] — the detach byte tmux couldn't deliver
+  const repainted = await session.waitFor("\x1b[?1049h", 10_000, detachFrom);
+  check("detach: console re-enters its alt screen", repainted, session.out.slice(detachFrom).slice(-400));
+  check("detach: notice confirms it", await session.waitFor("detached from echo", 10_000, detachFrom), session.out.slice(detachFrom).slice(-400));
+  check("detach: status bar repaints", await session.waitFor(`${space} · #`, 10_000, detachFrom), session.out.slice(detachFrom).slice(-400));
+
+  session.write("q");
+  for (let i = 0; i < 50 && !session.exited; i++) await wait(100);
+  check("quit: console exits cleanly after a full attach cycle", session.exited !== undefined && session.exited.code === 0, session.exited);
+  await session.close();
+
+  // — Scenario 2: invalid COTAL_DETACH_KEY stays a notice; the console survives —
+  session = new ConsoleSession(space, home, { COTAL_DETACH_KEY: "bogus" });
+  check("bad key: TUI paints", await session.waitFor(`${space} · #`, 30_000), session.out.slice(-400));
+
+  const attach2From = session.out.length;
+  session.write(":");
+  await wait(400);
+  session.write("attach echo");
+  await wait(200);
+  session.write("\r");
+  check("bad key: invalid COTAL_DETACH_KEY becomes a notice", await session.waitFor("invalid COTAL_DETACH_KEY", 10_000, attach2From), session.out.slice(attach2From).slice(-400));
+  check("bad key: console did NOT exit", session.exited === undefined, session.exited);
+  check("bad key: never suspended into the agent", !session.out.slice(attach2From).includes("ATTACH-ECHO-READY"));
+
+  session.write("q");
+  for (let i = 0; i < 50 && !session.exited; i++) await wait(100);
+  check("bad key: console still quits cleanly on q", session.exited !== undefined && session.exited.code === 0, session.exited);
+} catch (e) {
+  fail++;
+  console.error("  ✗ scenario threw:", (e as Error).message);
+} finally {
+  try { await session?.close(); } catch { /* already down */ }
+  try { await mgr.stop(); } catch { /* already down */ }
+  srv.kill("SIGKILL");
+  await new Promise<void>((res) => { if (srv.exitCode !== null || srv.signalCode !== null) return res(); srv.once("exit", () => res()); setTimeout(res, 3000); });
+  rmSync(dir, { recursive: true, force: true });
+}
+
+console.log(`\n${fail === 0 ? "CONSOLE-ATTACH SMOKE OK ✅" : "CONSOLE-ATTACH SMOKE FAILED ❌"}  (${pass} passed, ${fail} failed)`);
+process.exit(fail === 0 ? 0 : 1);

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "smoke:opencode-transcript": "tsx extensions/connector-opencode/smoke/transcript-mirror.smoke.ts",
     "smoke:attach": "tsx implementations/manager/smoke/attach.smoke.ts",
     "smoke:attach-repaint": "tsx implementations/manager/smoke/attach-repaint.smoke.ts",
+    "smoke:attach-control:live": "tsx implementations/manager/smoke/attach-control-live.smoke.ts",
     "smoke:manager-console": "pnpm --filter @cotal-ai/manager... build && tsx implementations/manager/smoke/console-assets.smoke.ts",
     "smoke:windows": "tsx implementations/manager/smoke/windows-launch.smoke.ts",
     "smoke:secret-fs": "tsx packages/core/smoke/secret-fs.smoke.ts",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "smoke:attach": "tsx implementations/manager/smoke/attach.smoke.ts",
     "smoke:attach-repaint": "tsx implementations/manager/smoke/attach-repaint.smoke.ts",
     "smoke:attach-control:live": "tsx implementations/manager/smoke/attach-control-live.smoke.ts",
+    "smoke:console-attach:live": "pnpm build && tsx implementations/manager/smoke/console-attach-live.smoke.ts",
     "smoke:manager-console": "pnpm --filter @cotal-ai/manager... build && tsx implementations/manager/smoke/console-assets.smoke.ts",
     "smoke:windows": "tsx implementations/manager/smoke/windows-launch.smoke.ts",
     "smoke:secret-fs": "tsx packages/core/smoke/secret-fs.smoke.ts",


### PR DESCRIPTION
## What

Closes the #1 control gap — the console couldn't open or drive a running agent's terminal (the classic lazygit/k9s "look inside the process" move). Now **`a`** on a roster agent (or **`:attach <agent>`**) suspends the console and hands the terminal to the agent's live PTY over the manager's WS attach endpoint; **`Ctrl-]`** (or `COTAL_DETACH_KEY`) returns and repaints.

- **Reuses everything that already exists** — the manager's `attach` op (returns a loopback ws after own-child/admin authz, rejects non-pty runtimes) and the CLI's `attach-client`. The console resolves the ws via a per-action `control-caller-admin` mint (the exact path kill/pause use) and streams it.
- **Suspends Ink in place, no rebuild:** on attach the App renders `null` and gates its top-level `useInput`, so Ink releases stdin (ref-counted raw mode) *before* `attachClient` grabs it; the observer endpoint + MeshView keep running in the background (App stays mounted), so the console repaints current state on return. On detach the effect re-asserts alt-screen/alt-scroll/cursor (attach-client leaves the main buffer after a full-screen child).
- `canControl`-gated, pty-runtime only (tmux/cmux are watched natively and flash their own hint), same-host only (the ws is loopback). Keyed by name, so it works for a managed agent even if it isn't a mesh roster peer (like `cotal attach --name`).

**Stacked on #208** (`feat/console-membership`) — retarget to main as the chain merges.

## Verified
- `pnpm typecheck` clean; existing `smoke:attach` (pty-vs-tmux gating) still green.
- **New `smoke:attach-control:live` (4 checks):** against a real broker + Manager + pty agent, the console's exact control-op path (`control-caller-admin` mint → `requestControl(ADMIN, {op:"attach"})`) returns a valid `ws://127.0.0.1:…/attach/<name>`, and a missing agent errors (not crashes). The attachClient data path + terminal hygiene is already covered by `attach-repaint.smoke`.
- **Live tmux end-to-end:** broker + Manager + a pty echo-agent → console `:attach echo` suspends the UI (Ink → null), the agent terminal takes over, typing `HELLO-FROM-CONSOLE` reaches the agent and echoes back (bidirectional I/O), and the console process/MeshView stay alive in the background. (Detach byte delivery through `tmux send-keys` is a harness quirk; the detach+repaint path is smoke-covered.)

## Notes
No core change — reuses  + . No SPEC change.