### PR TITLE
feat(console): channel delete, unread badges, harness tag, skills in detail

### DIFF
--- a/docs/mesh-view.md
+++ b/docs/mesh-view.md
@@ -100,13 +100,13 @@ visible (god-view / open mode); a chat-only observer leaves it empty.
 |---|---|---|---|---|
 | roster (status, activity, age) | `agents` / `endpoints` | ✓ panel | ✓ presence lines | ✓ sidebar |
 | all-activity feed | `feed` | ✓ feed panel | ✓ log | ✓ Monitor view |
-| channels plus counts | `channels` | ✓ tabs (`1`–`9`) |  | ✓ sidebar + Channel view |
+| channels plus counts, unread badges | `channels` (+ client state) | ✓ tabs (`1`–`9`, `+N`) |  | ✓ sidebar + Channel view |
 | golden-signal counts | `signals.counts` | ✓ tiles strip |  | ✓ tiles |
 | needs-you / blocked | `signals.waiting` | ✓ rail (`n`) |  | ✓ NEEDS-YOU rail |
 | direct-message lens | `signals.dms` | ✓ lens (`d`) |  | ✓ DM view |
 | topology (membership + who-talks-to-whom) | `feed` + `agents` + `membership` | ✓ lens (`t`, 3 variants) |  | ✓ graph |
 | peer-pushed views (json-render) | `views` | ✓ lens (`V`) |  |  |
-| message / agent **detail** | `feed` / `agents` | ✓ select → detail |  | ✓ row / thread |
+| message / agent **detail** (incl. skills, harness) | `feed` / `agents` | ✓ select → detail |  | ✓ row / thread |
 | search / filter | client | ✓ `/` | (grep) | ✓ mode chips |
 | msgs/s + activity sparkline, connected, dmVisible | `rates` / `status` | ✓ status bar |  | ✓ conn pill |
 
@@ -123,8 +123,12 @@ timeline. With no delivery daemon (or on an open mesh whose bare cred cannot rea
 lens degrades to the traffic-only view and the pill reads `traffic-only`. The views
 lens (`V`) shows the latest peer-published json-render view, validated against the console's
 fixed Ink component catalog (an invalid spec shows its rejection reason instead); the tiles strip
-renders through the same catalog, so the console dogfoods its own guardrail. The stream is
-line-oriented, so the signals stay out of it.
+renders through the same catalog, so the console dogfoods its own guardrail. Channel tabs carry a
+per-channel unread badge (`+N`, viewer-local: messages since that channel was last viewed, like
+the web sidebar's pill), the roster tags each agent with its harness when known (`cc` = Claude
+Code, `oc` = OpenCode … from the card's `meta.connector`, or the manager's launch record via the
+`ps` merge), and the agent detail adds `runs` / `model` / `skills` from the same sources. The
+stream is line-oriented, so the signals stay out of it.
 
 ## Future: not yet on the wire
 

--- a/docs/watch-a-mesh.md
+++ b/docs/watch-a-mesh.md
@@ -58,8 +58,10 @@ is `canControl`, distinct from `canWrite` (chat publishes). Affordances follow h
 they are: `p` pauses or resumes with no confirm (recoverable; the roster shows a `⏸ paused`
 badge merged from a low-rate `ps` poll, since a frozen agent's presence reads offline), `D`
 kills behind a confirm (`y` graceful stop, `f` force-kill), and the `:` palette adds
-`spawn <persona> [name]`, `status <agent>`, `ps`, and `purge` (type the space name to confirm,
-like the space delete). `a` on a roster agent (or `:attach <agent>`) suspends the console and
+`spawn <persona> [name]`, `status <agent>`, `ps`, `purge` (type the space name to confirm,
+like the space delete), and `delchan <channel>` (type the channel name to confirm) — the same
+admin purge op narrowed to one channel, a filtered purge of its history plus its registry entry;
+the web dashboard's channel delete is the same operation. `a` on a roster agent (or `:attach <agent>`) suspends the console and
 hands the terminal to the agent's live PTY over the manager's loopback attach endpoint;
 `Ctrl-]` (or `COTAL_DETACH_KEY`) returns and repaints the console, with the observer running in
 the background throughout. Attach is `canControl`-gated, pty-runtime only (tmux/cmux are watched

--- a/implementations/cli/src/console/app.tsx
+++ b/implementations/cli/src/console/app.tsx
@@ -1,5 +1,5 @@
 import { writeSync } from "node:fs";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, Text, useApp, useFocusManager, useInput, useStdout } from "ink";
 import {
   CONTROL_ADMIN,
@@ -12,7 +12,7 @@ import { useMesh } from "./mesh.js";
 import { control, type ControlCtx } from "./control.js";
 import { attachClient, detachKey } from "../lib/attach-client.js";
 import { Tabs } from "./ui/Tabs.js";
-import { Roster } from "./ui/Roster.js";
+import { Roster, harnessTag } from "./ui/Roster.js";
 import { Feed } from "./ui/Feed.js";
 import { NeedsYou } from "./ui/NeedsYou.js";
 import { Dm } from "./ui/Dm.js";
@@ -140,11 +140,16 @@ export function App({
     [ep.space, controlCtx],
   );
 
-  // Paused-ness lives in the manager's managed-state, NOT presence — a SIGSTOPped agent's
-  // heartbeat freezes, so its presence key TTLs out to "offline" and would lie. Poll `ps` at a
-  // low rate and merge by non-forgeable id; fail QUIET and stop polling when no manager answers
-  // (an open mesh without a supervisor must not spin or flash errors).
-  const [pausedIds, setPausedIds] = useState<Set<string>>(new Set());
+  // Managed-state lives in the manager, NOT presence — a SIGSTOPped agent's heartbeat freezes, so
+  // its presence key TTLs out to "offline" and would lie; and only the manager knows WHICH harness
+  // it launched (`agent` = connector, `mode` = runtime) for children whose card carries no meta.
+  // Poll `ps` at a low rate and merge by non-forgeable id; fail QUIET and stop polling when no
+  // manager answers (an open mesh without a supervisor must not spin or flash errors).
+  const [managed, setManaged] = useState<Map<string, { paused: boolean; agent?: string; mode?: string }>>(new Map());
+  const pausedIds = useMemo(
+    () => new Set([...managed.entries()].filter(([, m]) => m.paused).map(([id]) => id)),
+    [managed],
+  );
   const psDead = useRef(false);
   useEffect(() => {
     if (!canControl || !controlCtx) return;
@@ -158,11 +163,16 @@ export function App({
         psDead.current = true; // no manager on this mesh — don't keep knocking
         return;
       }
-      const list = (r.data ?? []) as { id: string; paused?: boolean }[];
-      setPausedIds((prev) => {
-        const next = new Set(list.filter((a) => a.paused).map((a) => a.id));
-        if (next.size === prev.size && [...next].every((id) => prev.has(id))) return prev;
-        return next;
+      const list = (r.data ?? []) as { id: string; paused?: boolean; agent?: string; mode?: string }[];
+      setManaged((prev) => {
+        const next = new Map(list.map((a) => [a.id, { paused: a.paused === true, agent: a.agent, mode: a.mode }]));
+        const same =
+          next.size === prev.size &&
+          [...next].every(([id, m]) => {
+            const p = prev.get(id);
+            return p !== undefined && p.paused === m.paused && p.agent === m.agent && p.mode === m.mode;
+          });
+        return same ? prev : next;
       });
     };
     void poll();
@@ -225,6 +235,58 @@ export function App({
   const counts: Record<string, number> = {};
   for (const ch of mesh.channels) counts[ch.channel] = ch.messages;
 
+  // Per-channel unread — pure client state over the cumulative channel counts (like the web's
+  // sidebar badges). Baseline at the FIRST snapshot that carries channels (history isn't unread);
+  // viewing a concrete channel keeps its watermark pinned to the live count (viewing clears);
+  // a channel that appears after the baseline has no watermark, so its whole count is unread.
+  const [seen, setSeen] = useState<Record<string, number> | null>(null);
+  useEffect(() => {
+    if (!mesh.channels.length) return;
+    setSeen((s) => {
+      if (s === null) {
+        const base: Record<string, number> = {};
+        for (const ch of mesh.channels) base[ch.channel] = ch.messages;
+        return base;
+      }
+      let next = s;
+      const bump = (channel: string, v: number) => {
+        if (next === s) next = { ...s };
+        next[channel] = v;
+      };
+      // A watermark above the live count means the stream was rewound (purge/delchan) — clamp it,
+      // or fresh messages would stay invisible until the count re-climbs past the old mark.
+      for (const ch of mesh.channels) {
+        const w = next[ch.channel];
+        if (w !== undefined && w > ch.messages) bump(ch.channel, ch.messages);
+      }
+      // Viewing a concrete channel pins its watermark to the live count (viewing clears).
+      const cur = counts[activeChannel];
+      if (activeChannel !== "all" && cur !== undefined && next[activeChannel] !== cur) bump(activeChannel, cur);
+      return next;
+    });
+    // counts derives from mesh.channels; activeChannel changes must also re-pin the watermark.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mesh.channels, activeChannel]);
+  const unread: Record<string, number> = {};
+  if (seen !== null)
+    for (const ch of mesh.channels) {
+      const n = ch.messages - (seen[ch.channel] ?? 0);
+      if (n > 0 && ch.channel !== activeChannel) unread[ch.channel] = n;
+    }
+
+  // id → short harness tag for the roster (what the agent IS): the card's self-published
+  // meta.connector first, the manager's launch record for children without card meta.
+  const harness = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const p of mesh.agents) {
+      const meta = p.card.meta as Record<string, unknown> | undefined;
+      const connector = typeof meta?.connector === "string" ? meta.connector : managed.get(p.card.id)?.agent;
+      const tag = harnessTag(connector);
+      if (tag) m.set(p.card.id, tag);
+    }
+    return m;
+  }, [mesh.agents, managed]);
+
   const onFocus = useCallback((id: FocusId) => setFocusedId(id), []);
   const openAgent = useCallback((p: Presence) => setDetail({ kind: "agent", agent: p }), []);
   const openMessage = useCallback((e: FeedEntry) => setDetail({ kind: "message", entry: e }), []);
@@ -238,10 +300,10 @@ export function App({
         .then((r) => {
           setNotice(r.ok ? `${op === "pause" ? "paused" : "resumed"} ${p.card.name}` : `${op}: ${r.error ?? "failed"}`);
           if (r.ok)
-            setPausedIds((prev) => {
-              const next = new Set(prev);
-              if (op === "pause") next.add(p.card.id);
-              else next.delete(p.card.id);
+            setManaged((prev) => {
+              const next = new Map(prev);
+              const cur = next.get(p.card.id);
+              next.set(p.card.id, { ...cur, paused: op === "pause" });
               return next;
             });
         })
@@ -352,6 +414,7 @@ export function App({
       notify: setNotice,
       control: ctl,
       confirmPurge: () => setConfirm({ kind: "purge", space: ep.space }),
+      confirmDelchan: (channel: string) => setConfirm({ kind: "delchan", channel }),
       ensureParticipant,
       recordOutboundDm,
       startAttach: handleAttach,
@@ -374,6 +437,23 @@ export function App({
       void ctl("purge", {}, CONTROL_ADMIN)
         .then((r) => setNotice(r.ok ? "purged space history" : `purge: ${r.error ?? "failed"}`))
         .catch((e) => setNotice("purge: " + (e as Error).message));
+    } else if (c?.kind === "delchan") {
+      // Same manager op as purge, narrowed by the channel arg (filtered STREAM.PURGE + registry
+      // key delete — the web dashboard's delete path). The deleted tab vanishes on the next
+      // channel poll; leave it now if it's the one being viewed, and drop its unread bookkeeping.
+      void ctl("purge", { channel: c.channel }, CONTROL_ADMIN)
+        .then((r) => {
+          if (!r.ok) return setNotice(`delchan: ${r.error ?? "failed"}`);
+          const purged = (r.data as { purged?: number } | undefined)?.purged;
+          setNotice(`deleted #${c.channel}${typeof purged === "number" ? ` · ${purged} messages purged` : ""}`);
+          setSeen((s) => {
+            if (s === null || !(c.channel in s)) return s;
+            const { [c.channel]: _gone, ...rest } = s;
+            return rest;
+          });
+          setActiveChannel((ch) => (ch === c.channel ? "all" : ch));
+        })
+        .catch((e) => setNotice("delchan: " + (e as Error).message));
     }
   };
 
@@ -421,7 +501,7 @@ export function App({
   // the terminal). App stays mounted → the observer endpoint + MeshView survive in the background.
   if (attachTarget) return null;
   if (helpOpen) return <Help focusedId={focusedId} width={size.cols} height={size.rows} />;
-  if (detail) return <Detail target={detail} feed={mesh.feed} width={size.cols} height={size.rows} />;
+  if (detail) return <Detail target={detail} feed={mesh.feed} width={size.cols} height={size.rows} managed={managed} />;
   if (confirm)
     return (
       <Confirm target={confirm} width={size.cols} height={size.rows} onConfirm={onConfirmed} onCancel={() => setConfirm(null)} />
@@ -440,7 +520,7 @@ export function App({
 
   return (
     <Box flexDirection="column" width={size.cols} height={size.rows}>
-      <Tabs tabs={tabs} active={activeChannel} counts={counts} width={size.cols} />
+      <Tabs tabs={tabs} active={activeChannel} counts={counts} unread={unread} width={size.cols} />
       {/* Golden-signal strip — rendered through json-render's Ink catalog (dogfoods the same
           renderer that paints peer-pushed views). */}
       <SpecView spec={tilesSpec(mesh.signals.counts, mesh.signals.oldestWaitingTs, size.cols)} />
@@ -488,6 +568,7 @@ export function App({
               onPause={canControl ? handlePause : undefined}
               onAttach={canControl ? (p) => handleAttach(p.card.name) : undefined}
               paused={pausedIds}
+              harness={harness}
               onCompose={canWrite ? rosterCompose : undefined}
             />
             <Feed

--- a/implementations/cli/src/console/commands.ts
+++ b/implementations/cli/src/console/commands.ts
@@ -29,6 +29,8 @@ export interface CommandCtx {
   control: (op: string, args: Record<string, unknown>, tier: ControlTier) => Promise<ControlReply>;
   /** Open the type-the-space-name purge confirm (the palette never purges directly). */
   confirmPurge: () => void;
+  /** Open the type-the-channel-name delete confirm for one channel's history + registry entry. */
+  confirmDelchan: (channel: string) => void;
   /** Upgrade the console to a participant on the operator's first send (presence + own inbox), so
    *  agents can reply. Idempotent, canWrite-gated. Await before the send. */
   ensureParticipant: () => Promise<void>;
@@ -208,6 +210,17 @@ export const COMMANDS: ConsoleCommand[] = [
     summary: "clear the space's history (confirm)",
     control: true,
     run: (ctx) => ctx.confirmPurge(),
+  },
+  {
+    name: "delchan",
+    summary: "delete one channel's history + registry entry (confirm)",
+    usage: "delchan <channel>",
+    control: true,
+    run: (ctx, rest) => {
+      const channel = rest.replace(/^#/, "").trim().split(/\s+/)[0] ?? "";
+      if (!channel) return ctx.notify("usage: delchan <channel>");
+      ctx.confirmDelchan(channel);
+    },
   },
   { name: "dms", summary: "toggle the DM lens", run: (ctx) => ctx.setMode("dm") },
   { name: "topo", summary: "toggle the topology lens", run: (ctx) => ctx.setMode("topo") },

--- a/implementations/cli/src/console/ui/Confirm.tsx
+++ b/implementations/cli/src/console/ui/Confirm.tsx
@@ -2,11 +2,12 @@ import { useState } from "react";
 import { Box, Text, useInput } from "ink";
 
 /** A destructive action awaiting confirmation. `kill` is a quick y/n (with `f` for a hard kill);
- *  `deleteSpace` and `purge` (irreversible) require typing the space name. */
+ *  `deleteSpace` and `purge` (irreversible) require typing the space name, `delchan` the channel name. */
 export type ConfirmTarget =
   | { kind: "kill"; name: string }
   | { kind: "deleteSpace"; space: string }
-  | { kind: "purge"; space: string };
+  | { kind: "purge"; space: string }
+  | { kind: "delchan"; channel: string };
 
 /** Full-screen red danger overlay. Owns input while shown. Calls onConfirm only when the gate is
  *  satisfied (y/f for kill, exact name typed for deleteSpace/purge); Esc/n cancels. Kill's choice
@@ -25,7 +26,8 @@ export function Confirm({
   onCancel: () => void;
 }) {
   const [typed, setTyped] = useState("");
-  const match = target.kind !== "kill" && typed === target.space;
+  const wanted = target.kind === "kill" ? undefined : target.kind === "delchan" ? target.channel : target.space;
+  const match = wanted !== undefined && typed === wanted;
 
   useInput((input, key) => {
     if (key.escape) return onCancel();
@@ -35,7 +37,7 @@ export function Confirm({
       if (input === "n" || input === "N") return onCancel();
       return;
     }
-    // deleteSpace / purge: type the name to arm Enter
+    // deleteSpace / purge / delchan: type the name to arm Enter
     if (key.return) {
       if (match) onConfirm();
       return;
@@ -74,6 +76,11 @@ export function Confirm({
                 Delete space <Text bold>{target.space}</Text> —{" "}
                 <Text color="red">irreversible</Text> (all history + presence gone).
               </>
+            ) : target.kind === "delchan" ? (
+              <>
+                Delete channel <Text bold>#{target.channel}</Text> —{" "}
+                <Text color="red">irreversible</Text> (its history + registry entry gone; other channels stay).
+              </>
             ) : (
               <>
                 Purge <Text bold>{target.space}</Text>'s history (all channels + DMs) —{" "}
@@ -87,7 +94,7 @@ export function Confirm({
             <Text inverse> </Text>
           </Box>
           <Box marginTop={1}>
-            <Text dimColor>{match ? (target.kind === "deleteSpace" ? "Enter = delete" : "Enter = purge") : "Esc = cancel"}</Text>
+            <Text dimColor>{match ? (target.kind === "purge" ? "Enter = purge" : "Enter = delete") : "Esc = cancel"}</Text>
           </Box>
         </Box>
       )}

--- a/implementations/cli/src/console/ui/Detail.tsx
+++ b/implementations/cli/src/console/ui/Detail.tsx
@@ -65,13 +65,27 @@ function MessageDetail({ entry, width }: { entry: FeedEntry; width: number }) {
   );
 }
 
-function AgentDetail({ agent, feed, width }: { agent: Presence; feed: FeedEntry[]; width: number }) {
+/** The manager's managed-state for one agent (from the console's low-rate `ps` merge). */
+export interface ManagedInfo {
+  paused: boolean;
+  agent?: string; // connector name the manager launched (e.g. "claude")
+  mode?: string; // runtime kind (pty / tmux / cmux)
+}
+
+function AgentDetail({ agent, feed, width, managed }: { agent: Presence; feed: FeedEntry[]; width: number; managed?: ManagedInfo }) {
   const { card, status, activity, ts } = agent;
   const s = STATUS[status];
   const mine = feed.filter(
     (e) => e.from.name === card.name || (e.toNames ?? []).includes(card.name),
   );
   const recent = mine.slice(-6).reverse();
+  // What the agent IS: the card's self-published harness metadata first (works on any mesh), the
+  // manager's launch record filling in for children whose card carries no meta. Omitted when
+  // neither knows — never faked.
+  const meta = card.meta as Record<string, unknown> | undefined;
+  const connector = typeof meta?.connector === "string" ? meta.connector : managed?.agent;
+  const runs = connector ? connector + (managed?.mode ? " · " + managed.mode : "") : undefined;
+  const model = typeof meta?.model === "string" ? meta.model : undefined;
   return (
     <Box flexDirection="column">
       <Field label="name">
@@ -103,6 +117,29 @@ function AgentDetail({ agent, feed, width }: { agent: Presence; feed: FeedEntry[
         <Field label="tags">
           <Text dimColor>{card.tags.join(", ")}</Text>
         </Field>
+      ) : null}
+      {runs ? (
+        <Field label="runs">
+          <Text>{runs}</Text>
+        </Field>
+      ) : null}
+      {model ? (
+        <Field label="model">
+          <Text dimColor>{model}</Text>
+        </Field>
+      ) : null}
+      {card.skills?.length ? (
+        <Box flexDirection="column">
+          <Field label="skills">
+            <Text dimColor>{String(card.skills.length)}</Text>
+          </Field>
+          {card.skills.map((sk, i) => (
+            <Text key={i} wrap="truncate-end">
+              <Text>{" ".repeat(11) + (sk.name || sk.id)}</Text>
+              {sk.description ? <Text dimColor>{"  " + sk.description}</Text> : null}
+            </Text>
+          ))}
+        </Box>
       ) : null}
       <Box marginTop={1} flexDirection="column">
         <Text bold>{"recent traffic (" + mine.length + ")"}</Text>
@@ -138,11 +175,14 @@ export function Detail({
   feed,
   width,
   height,
+  managed,
 }: {
   target: DetailTarget;
   feed: FeedEntry[];
   width: number;
   height: number;
+  /** id → managed-state, for the agent view's `runs` field (absent on unmanaged meshes). */
+  managed?: Map<string, ManagedInfo>;
 }) {
   const title = target.kind === "message" ? "message detail" : "agent detail";
   return (
@@ -162,7 +202,7 @@ export function Detail({
         {target.kind === "message" ? (
           <MessageDetail entry={target.entry} width={width - 4} />
         ) : (
-          <AgentDetail agent={target.agent} feed={feed} width={width - 4} />
+          <AgentDetail agent={target.agent} feed={feed} width={width - 4} managed={managed?.get(target.agent.card.id)} />
         )}
       </Box>
       <Box marginTop={1}>

--- a/implementations/cli/src/console/ui/Help.tsx
+++ b/implementations/cli/src/console/ui/Help.tsx
@@ -50,7 +50,7 @@ export function Help({
     ["d", "direct-message lens"],
     ["t", "topology lens (v / 1-3 variants)"],
     ["V", "views lens (peer-pushed views)"],
-    [":", "command palette (send / call / spawn / purge / status)"],
+    [":", "command palette (send / call / spawn / purge / delchan / status)"],
     ["c", "compose to channel / DM selected agent"],
     ["r", "reply to current message"],
     ["D", "delete — kill agent / drop space"],

--- a/implementations/cli/src/console/ui/Roster.tsx
+++ b/implementations/cli/src/console/ui/Roster.tsx
@@ -3,7 +3,16 @@ import { Box, Text, useFocus, useInput } from "ink";
 import type { Presence } from "@cotal-ai/core";
 import { agentColor, STATUS, ago } from "./theme.js";
 
-function RosterRow({ p, selected, wide, paused }: { p: Presence; selected: boolean; wide: boolean; paused: boolean }) {
+/** Short display tag for an agent's harness (which tool it IS): known connectors get a familiar
+ *  abbreviation (`cc` = Claude Code — "cotal" is its manager-default alias), anything else its
+ *  first two letters. Pure presentation; undefined in = undefined out (never fake a tag). */
+export function harnessTag(connector: string | undefined): string | undefined {
+  if (!connector) return undefined;
+  const known: Record<string, string> = { claude: "cc", cotal: "cc", opencode: "oc", hermes: "hm" };
+  return known[connector] ?? connector.slice(0, 2).toLowerCase();
+}
+
+function RosterRow({ p, selected, wide, paused, tag }: { p: Presence; selected: boolean; wide: boolean; paused: boolean; tag?: string }) {
   const isAgent = p.card.kind === "agent";
   const s = STATUS[p.status];
   // A manager-paused (SIGSTOPped) agent can't heartbeat, so presence soon reads "offline" — the
@@ -14,7 +23,7 @@ function RosterRow({ p, selected, wide, paused }: { p: Presence; selected: boole
     const act = p.activity ? "  " + p.activity : "";
     return (
       <Text inverse bold color="cyan" wrap="truncate-end">
-        {(isAgent ? (paused ? "⏸" : s.dot) : "⚙") + " " + p.card.name + kind + act + "  " + ago(p.ts)}
+        {(isAgent ? (paused ? "⏸" : s.dot) : "⚙") + " " + p.card.name + (tag ? " " + tag : "") + kind + act + "  " + ago(p.ts)}
       </Text>
     );
   }
@@ -24,6 +33,7 @@ function RosterRow({ p, selected, wide, paused }: { p: Presence; selected: boole
       <Text color={isAgent ? agentColor(p.card.name) : undefined} dimColor={!isAgent}>
         {p.card.name}
       </Text>
+      {tag ? <Text dimColor>{" " + tag}</Text> : null}
       {wide ? (
         isAgent ? (
           paused ? (
@@ -61,6 +71,7 @@ export function Roster({
   onPause,
   onAttach,
   paused,
+  harness,
   onCompose,
 }: {
   agents: Presence[];
@@ -79,6 +90,8 @@ export function Roster({
   onAttach?: (p: Presence) => void;
   /** Ids the manager reports as paused — authoritative over presence for the badge. */
   paused?: Set<string>;
+  /** id → short harness tag (see {@link harnessTag}); rows without an entry show no tag. */
+  harness?: Map<string, string>;
   onCompose?: (p: Presence) => void;
 }) {
   const { isFocused } = useFocus({ id: "roster" });
@@ -143,6 +156,7 @@ export function Roster({
             selected={isFocused && start + i === selClamped}
             wide={wide}
             paused={paused?.has(p.card.id) ?? false}
+            tag={harness?.get(p.card.id)}
           />
         ))
       )}

--- a/implementations/cli/src/console/ui/Tabs.tsx
+++ b/implementations/cli/src/console/ui/Tabs.tsx
@@ -1,15 +1,18 @@
 import { Box, Text } from "ink";
 
-/** The channel tab strip. `all` (firehose) is tab 1; channels follow. 1–9 jump directly. */
+/** The channel tab strip. `all` (firehose) is tab 1; channels follow. 1–9 jump directly.
+ *  `unread` adds a yellow `+N` badge (messages since the channel was last viewed) on inactive tabs. */
 export function Tabs({
   tabs,
   active,
   counts,
+  unread,
   width,
 }: {
   tabs: string[];
   active: string;
   counts: Record<string, number>;
+  unread?: Record<string, number>;
   width: number;
 }) {
   return (
@@ -19,6 +22,7 @@ export function Tabs({
           const isActive = t === active;
           const label = t === "all" ? "all" : "#" + t;
           const count = t === "all" ? undefined : counts[t];
+          const fresh = !isActive ? unread?.[t] : undefined;
           return (
             <Text key={t}>
               {i > 0 ? <Text dimColor>{"   "}</Text> : null}
@@ -26,6 +30,7 @@ export function Tabs({
               <Text color={isActive ? "cyan" : undefined} inverse={isActive} bold={isActive}>
                 {" " + label + (count !== undefined ? " " + count : "") + " "}
               </Text>
+              {fresh ? <Text color="yellow">{"+" + fresh}</Text> : null}
             </Text>
           );
         })}

--- a/implementations/manager/smoke/console-gaps-live.smoke.ts
+++ b/implementations/manager/smoke/console-gaps-live.smoke.ts
@@ -1,0 +1,152 @@
+/**
+ * Console web-parity features live smoke — run with: pnpm smoke:console-gaps:live (needs
+ * nats-server + node; the script chains `pnpm build` — the console under test runs the BUILT dists).
+ *
+ * Drives the REAL console TUI under node-pty (open mesh + Manager) through the features ported
+ * from the web dashboard: per-channel unread badges (baseline at startup — history is not unread;
+ * accrue while another tab is viewed; viewing pins the watermark), the roster's harness tag +
+ * `runs`/`model`/`skills` in the agent detail (from the card's self-published meta), and the
+ * `:delchan` flow (verb → type-the-channel-name confirm → deleted notice). The op itself is
+ * guarded server-side by purge-channel-live.smoke.ts; this covers the console half.
+ */
+import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn as ptySpawn, type IPty } from "@lydell/node-pty";
+import { CotalEndpoint, isReachable, setupSpaceStreams } from "@cotal-ai/core";
+import { Manager } from "../src/manager.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "../../..");
+const TSX = join(repoRoot, "node_modules", ".bin", "tsx");
+const COTAL = join(repoRoot, "bin", "cotal.ts");
+const PORT = 20000 + Math.floor(Math.random() * 40000);
+const SERVERS = `nats://127.0.0.1:${PORT}`;
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+let pass = 0, fail = 0;
+const check = (n: string, c: boolean, extra?: unknown) => { c ? (pass++, console.log("  ✓ " + n)) : (fail++, console.log("  ✗ FAIL: " + n, extra ?? "")); };
+
+const space = `gaps-${randomUUID().slice(0, 8)}`;
+const dir = mkdtempSync(join(tmpdir(), "cotal-gaps-"));
+const workspaceRoot = join(dir, "ws");
+const home = join(dir, "home");
+mkdirSync(join(workspaceRoot, ".cotal", "agents"), { recursive: true });
+mkdirSync(join(home, "meshes"), { recursive: true });
+writeFileSync(join(home, "meshes", `${space}.json`),
+  JSON.stringify({ space, server: SERVERS, root: workspaceRoot, mode: "open", ts: new Date().toISOString() }));
+const srv = spawn("nats-server", ["-js", "-p", String(PORT), "-sd", join(dir, "js")], { stdio: "ignore" });
+const mgr = new Manager({ space, servers: SERVERS, runtime: "pty", workspaceRoot });
+
+let out = "";
+let exited: number | undefined;
+let p: IPty | undefined;
+const waitFor = async (m: string, ms: number, from = 0) => {
+  const t0 = Date.now();
+  while (Date.now() - t0 < ms) { if (out.slice(from).includes(m)) return true; if (exited !== undefined) return out.slice(from).includes(m); await wait(100); }
+  return false;
+};
+
+let poster: CotalEndpoint | undefined;
+let stub: CotalEndpoint | undefined;
+try {
+  for (let i = 0; i < 50; i++) { if (await isReachable(SERVERS)) break; await wait(200); }
+  await setupSpaceStreams({ servers: SERVERS, space });
+  await mgr.start();
+
+  poster = new CotalEndpoint({ space, servers: SERVERS, card: { name: "poster", kind: "endpoint" }, consume: false, registerPresence: false, watchPresence: false });
+  poster.on("error", () => {});
+  await poster.start();
+  // A roster agent whose card self-publishes harness metadata + skills.
+  stub = new CotalEndpoint({
+    space, servers: SERVERS, consume: false, watchPresence: false,
+    card: {
+      name: "stubby", kind: "agent",
+      meta: { connector: "opencode", model: "test-model-9" },
+      skills: [{ id: "s1", name: "review", description: "reads diffs" }],
+    },
+  });
+  stub.on("error", () => {});
+  await stub.start();
+  await poster.multicast("baseline", { channel: "kept" }); // pre-start history — must NOT count as unread
+
+  p = ptySpawn(TSX, [COTAL, "console", "--space", space, "--server", SERVERS], {
+    name: "xterm-256color", cols: 140, rows: 36, cwd: repoRoot,
+    env: { PATH: process.env.PATH ?? "", HOME: process.env.HOME ?? "", TERM: "xterm-256color", COTAL_HOME: home },
+  });
+  p.onData((d) => (out += d));
+  p.onExit((e) => (exited = e.exitCode));
+
+  check("console paints", await waitFor(`${space} · #`, 30_000));
+  check("channel tab visible", await waitFor("#kept", 15_000));
+  await wait(1500); // let the first channel poll land + baseline settle
+  check("no fake unread at startup", !out.includes("+1"));
+  // The name and tag are separate Ink Text nodes with ANSI color codes between them — strip first.
+  const cleanHas = async (m: string, ms: number) => {
+    const t0 = Date.now();
+    while (Date.now() - t0 < ms) {
+      if (out.replace(/\x1b\[[0-9;?]*[a-zA-Z]/g, "").includes(m)) return true;
+      await wait(100);
+    }
+    return false;
+  };
+  check("roster shows the harness tag", await cleanHas("stubby oc", 10_000), out.replace(/\x1b\[[0-9;?]*[a-zA-Z]/g, "").slice(-400));
+
+  // Two background messages while viewing `all` → +2 badge.
+  await poster.multicast("m2", { channel: "kept" });
+  await poster.multicast("m3", { channel: "kept" });
+  check("unread badge +2 appears", await waitFor("+2", 15_000));
+
+  // View the channel (tab 2) → watermark pins; back to all; one more message → +1 (not +3).
+  p.write("2");
+  await wait(1500);
+  p.write("1");
+  await wait(500);
+  const mark = out.length;
+  await poster.multicast("m4", { channel: "kept" });
+  check("viewing cleared the watermark (+1, not +3)", await waitFor("+1", 15_000, mark), out.slice(mark).slice(-300));
+  check("no stale +3", !out.slice(mark).includes("+3"));
+
+  // Agent detail: focus the roster, open the first row.
+  p.write("l"); // focus roster
+  await wait(400);
+  p.write("\r");
+  check("detail: runs field", await waitFor("runs:", 8_000));
+  check("detail: connector value", await waitFor("opencode", 4_000));
+  check("detail: model", await waitFor("test-model-9", 4_000));
+  check("detail: skill listed", await waitFor("review", 4_000) && out.includes("reads diffs"));
+  p.write("\r"); // close detail
+  await wait(400);
+
+  // delchan flow: verb → typed-name confirm → notice.
+  const dm = out.length;
+  p.write(":");
+  await wait(400);
+  p.write("delchan kept");
+  await wait(200);
+  p.write("\r");
+  check("delchan confirm opens", await waitFor("Delete channel", 8_000, dm), out.slice(dm).slice(-300));
+  p.write("kept");
+  await wait(300);
+  p.write("\r");
+  check("delchan notice", await waitFor("deleted #kept", 10_000, dm), out.slice(dm).slice(-300));
+
+  p.write("q");
+  for (let i = 0; i < 50 && exited === undefined; i++) await wait(100);
+  check("console quits cleanly", exited === 0, exited);
+} catch (e) {
+  fail++;
+  console.error("  ✗ threw:", (e as Error).message);
+} finally {
+  try { p?.kill(); } catch { /* down */ }
+  try { await stub?.stop(); } catch { /* down */ }
+  try { await poster?.stop(); } catch { /* down */ }
+  try { await mgr.stop(); } catch { /* down */ }
+  srv.kill("SIGKILL");
+  await new Promise<void>((res) => { if (srv.exitCode !== null) return res(); srv.once("exit", () => res()); setTimeout(res, 3000); });
+  rmSync(dir, { recursive: true, force: true });
+}
+console.log(`\n${fail === 0 ? "CONSOLE-GAPS SMOKE OK ✅" : "CONSOLE-GAPS SMOKE FAILED ❌"}  (${pass} passed, ${fail} failed)`);
+process.exit(fail === 0 ? 0 : 1);

--- a/implementations/manager/smoke/purge-channel-live.smoke.ts
+++ b/implementations/manager/smoke/purge-channel-live.smoke.ts
@@ -1,0 +1,107 @@
+/**
+ * Channel-scoped purge live smoke — run with: pnpm smoke:purge-channel:live (needs nats-server).
+ *
+ * The console's `:delchan` narrows the manager's admin `purge` op with a `channel` arg: a filtered
+ * STREAM.PURGE on that channel across all senders plus its channel-registry key delete
+ * (core `clearChannel`, the web dashboard's delete path) under a per-op "channel-purger" mint —
+ * other channels' history must survive. Guards against a real auth broker + Manager: the narrow
+ * purge, the wildcard rejection, and the arg-less op still purging the whole space (regression).
+ */
+import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CONTROL_ADMIN,
+  CotalEndpoint,
+  isReachable,
+  createSpaceAuth,
+  mintCreds,
+  serverConfig,
+  newIdentity,
+  setupSpaceStreams,
+} from "@cotal-ai/core";
+import { authDir, saveSpaceAuth } from "@cotal-ai/workspace";
+import { Manager } from "../src/manager.js";
+
+const PORT = 20000 + Math.floor(Math.random() * 40000);
+const SERVERS = `nats://127.0.0.1:${PORT}`;
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+let pass = 0, fail = 0;
+const check = (n: string, c: boolean, extra?: unknown) => { c ? (pass++, console.log("  ✓ " + n)) : (fail++, console.log("  ✗ FAIL: " + n, extra ?? "")); };
+
+/** One control request with a per-action admin cred — the console's exact flow (console/control.ts). */
+async function callPurge(space: string, auth: Awaited<ReturnType<typeof createSpaceAuth>>, args: Record<string, unknown>) {
+  const creds = await mintCreds(auth, newIdentity(), "control-caller-admin");
+  const ep = new CotalEndpoint({ space, servers: SERVERS, creds, channels: [], consume: false, registerPresence: false, watchPresence: false, card: { name: "console-smoke", kind: "endpoint" } });
+  ep.on("error", () => {});
+  await ep.start();
+  try {
+    return await ep.requestControl(CONTROL_ADMIN, { op: "purge", args });
+  } finally {
+    await ep.stop();
+  }
+}
+
+const space = `delchan-${randomUUID().slice(0, 8)}`;
+const auth = await createSpaceAuth(space);
+const dir = mkdtempSync(join(tmpdir(), "cotal-delchan-"));
+const workspaceRoot = join(dir, "ws");
+mkdirSync(join(workspaceRoot, ".cotal", "agents"), { recursive: true });
+saveSpaceAuth(authDir(workspaceRoot), auth);
+writeFileSync(join(dir, "server.conf"), serverConfig(auth, { port: PORT, storeDir: join(dir, "js") }));
+const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+
+const mgr = new Manager({ space, servers: SERVERS, runtime: "pty", workspaceRoot });
+let poster: CotalEndpoint | undefined;
+let reader: CotalEndpoint | undefined;
+
+try {
+  let up = false;
+  for (let i = 0; i < 50; i++) { if (await isReachable(SERVERS)) { up = true; break; } await wait(200); }
+  if (!up) throw new Error(`auth nats-server did not come up on ${PORT}`);
+  const provCreds = await mintCreds(auth, newIdentity(), "provisioner");
+  await setupSpaceStreams({ servers: SERVERS, space, creds: provCreds });
+  await mgr.start();
+
+  poster = new CotalEndpoint({ space, servers: SERVERS, creds: await mintCreds(auth, newIdentity(), "operator"), card: { name: "poster", kind: "endpoint" }, consume: false, registerPresence: false, watchPresence: false });
+  poster.on("error", () => {});
+  await poster.start();
+  // History reads need the god-view profile (the operator cred can publish but not read the
+  // JS backlog) — the same "admin" cred the console/web observer runs on.
+  reader = new CotalEndpoint({ space, servers: SERVERS, creds: await mintCreds(auth, newIdentity(), "admin"), card: { name: "reader", kind: "endpoint" }, consume: false, registerPresence: false, watchPresence: false });
+  reader.on("error", () => {});
+  await reader.start();
+  await poster.multicast("one", { channel: "kept" });
+  await poster.multicast("two", { channel: "doomed" });
+  await poster.multicast("three", { channel: "doomed" });
+  check("setup: both channels have persisted history", (await reader.channelHistory("kept")).length === 1 && (await reader.channelHistory("doomed")).length === 2);
+
+  // The console's delchan path: admin purge op narrowed by the channel arg.
+  const r1 = await callPurge(space, auth, { channel: "doomed" });
+  const purged = (r1.data as { purged?: number } | undefined)?.purged;
+  check("delchan: purge {channel} → ok with the purged count", r1.ok === true && purged === 2, r1);
+  check("delchan: the channel's history is gone", (await reader.channelHistory("doomed")).length === 0);
+  check("delchan: other channels survive", (await reader.channelHistory("kept")).length === 1);
+
+  const rWild = await callPurge(space, auth, { channel: "team.>" });
+  check("delchan: wildcard channel → {ok:false}", rWild.ok === false && /wildcard/i.test(String(rWild.error)), rWild);
+
+  // Regression: the arg-less op still purges the whole space.
+  const rAll = await callPurge(space, auth, {});
+  check("purge: arg-less op still clears the space", rAll.ok === true && (await reader.channelHistory("kept")).length === 0, rAll);
+} catch (e) {
+  fail++;
+  console.error("  ✗ scenario threw:", (e as Error).message);
+} finally {
+  try { await reader?.stop(); } catch { /* already down */ }
+  try { await poster?.stop(); } catch { /* already down */ }
+  try { await mgr.stop(); } catch { /* already down */ }
+  srv.kill("SIGKILL");
+  await new Promise<void>((res) => { if (srv.exitCode !== null || srv.signalCode !== null) return res(); srv.once("exit", () => res()); setTimeout(res, 3000); });
+  rmSync(dir, { recursive: true, force: true });
+}
+
+console.log(`\n${fail === 0 ? "PURGE-CHANNEL SMOKE OK ✅" : "PURGE-CHANNEL SMOKE FAILED ❌"}  (${pass} passed, ${fail} failed)`);
+process.exit(fail === 0 ? 0 : 1);

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -5,8 +5,10 @@ import {
   DEFAULT_SERVER,
   MANAGER_LEASE_TTL_MS,
   agentFilePath,
+  clearChannel,
   clearSpaceHistory,
   connectorServers,
+  isConcreteChannel,
   deprovisionAgent,
   firstFreeName,
   loadAgentFile,
@@ -1112,10 +1114,25 @@ export class Manager {
   /** Purge the space's retained message backlog (chat, optionally DMs). Privileged — the manager mints a
    *  short-lived "purger" cred (same destructive grant as `cotal history clear`, isolated off the
    *  supervisor); regular agents are denied STREAM.PURGE under auth. Cleanup only: leaves live agents and
-   *  the TASK queue alone. */
+   *  the TASK queue alone. With `args.channel` it narrows to ONE channel — a filtered purge plus the
+   *  channel-registry key delete via {@link clearChannel}, under the tighter "channel-purger" mint (the
+   *  role holding the scoped STREAM.PURGE + channel-KV grants; the dashboard's delete uses the same). */
   private async opPurge(args: Record<string, unknown>, _caller: string): Promise<ControlReply> {
     const includeDms = args.includeDms === true;
     try {
+      if (args.channel !== undefined) {
+        const channel = String(args.channel).trim();
+        if (!isConcreteChannel(channel))
+          return { ok: false, error: `"${channel}" must be a concrete channel (no wildcard) to purge it` };
+        const creds = this.auth ? await mintCreds(this.auth, newIdentity(), "channel-purger") : undefined;
+        const result = await clearChannel({
+          servers: this.servers ?? DEFAULT_SERVER,
+          space: this.space,
+          channel,
+          creds,
+        });
+        return { ok: true, data: result };
+      }
       const creds = this.auth ? await mintCreds(this.auth, newIdentity(), "purger") : undefined;
       const result = await clearSpaceHistory({
         servers: this.servers ?? DEFAULT_SERVER,

--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
     "smoke:attach-repaint": "tsx implementations/manager/smoke/attach-repaint.smoke.ts",
     "smoke:attach-control:live": "tsx implementations/manager/smoke/attach-control-live.smoke.ts",
     "smoke:console-attach:live": "pnpm build && tsx implementations/manager/smoke/console-attach-live.smoke.ts",
+    "smoke:purge-channel:live": "tsx implementations/manager/smoke/purge-channel-live.smoke.ts",
+    "smoke:console-gaps:live": "pnpm build && tsx implementations/manager/smoke/console-gaps-live.smoke.ts",
     "smoke:manager-console": "pnpm --filter @cotal-ai/manager... build && tsx implementations/manager/smoke/console-assets.smoke.ts",
     "smoke:windows": "tsx implementations/manager/smoke/windows-launch.smoke.ts",
     "smoke:secret-fs": "tsx packages/core/smoke/secret-fs.smoke.ts",


### PR DESCRIPTION
Closes the remaining web-dashboard-parity gaps in the console TUI (all but the graph rendering, deliberately deferred), plus the harness marker.

## What

- **`:delchan <channel>`** — delete one channel's history + registry entry. Extends the manager's admin `purge` op with an optional `channel` arg (one purge grammar): a filtered `STREAM.PURGE` across all senders plus the channel-registry key delete via core `clearChannel` — the web dashboard's delete path — under a per-op `channel-purger` mint (the role holding exactly the scoped purge + channel-KV grants). Wildcards rejected. Console side: palette verb behind a type-the-channel-name confirm (same pattern as `purge`); the active tab falls back to `all` if it was the one deleted.
- **Per-channel unread badges** — inactive channel tabs show a yellow `+N` (messages since that channel was last viewed), like the web sidebar's pill. Viewer-local watermarks over the cumulative channel counts: baseline at startup (history is not unread), viewing pins, stream rewinds (purge/delchan) clamp.
- **Harness tag + `runs`/`model`/`skills` in detail** — the roster tags each agent with what it *is* (`cc` = Claude Code, `oc` = OpenCode, `hm` = Hermes, else the connector's first two letters) from the card's self-published `meta.connector`, falling back to the manager's launch record via the existing `ps` merge (widened from paused-only). Agent detail (Enter) adds `runs` (connector · runtime), `model`, and the card's `skills` list. Omitted when unknown — never faked.

## Verification

- `smoke:purge-channel:live` (new): real auth broker + Manager — narrow purge leaves other channels intact, wildcard rejected, arg-less op still space-purges (6/6).
- `smoke:console-gaps:live` (new): the real console TUI under node-pty — no fake unread at startup, badges accrue and viewing pins the watermark, harness tag renders, detail shows runs/model/skills, the full `:delchan` confirm flow, clean quit (14/14).
- `smoke:console-attach:live` (13/13) and `smoke:attach-control:live` (4/4) stay green; `pnpm typecheck` clean.

Docs: `protocol-view.md` control section + feature map updated; `web.md`'s stale "dashboard is read-only" reconciled with its existing channel-delete write path.

Stacked on #209.