### PR TITLE
docs(examples): self-improving-console — opencode reviewer, demo replay + launch assets

### DIFF
--- a/examples/02-self-improving-console/GOAL.md
+++ b/examples/02-self-improving-console/GOAL.md
@@ -1,12 +1,3 @@
-We're rebuilding cotal's live `console` as a polished lazygit-style Ink/React TUI, shipped as the new `cotal console-ink` command (the old `console` stays untouched). It must render over the EXISTING read-only `CotalEndpoint` observer (see implementations/cli/src/commands/console.ts) — do NOT open a new raw NATS connection. Target: roster panel + channel tabs + live message feed + multi-panel focus + a context-sensitive `?` help overlay.
+Add an activity pulse to cotal console: a live sparkline (unicode block bars ▁▂▃▄▅▆▇█) of message volume over the last ~60s, shown next to the msg/s readout in the StatusBar. Keep it compact: a fixed width of about 20 columns (just the most recent buckets), do NOT scale it to the terminal width. Extend the existing console, do not rebuild it, and do not open a new NATS connection.
 
-Run the team in parallel:
-- research: read research/INPUT.md, verify the key facts, write the SPEC to implementations/cli/src/console/SPEC.md, and cotal_send a summary to the team so backend and tui-designer start with the right context.
-- backend: build the data layer in implementations/cli/src/console/mesh.ts — a useMesh() hook over CotalEndpoint returning UI-ready state.
-- tui-designer: build the Ink components in implementations/cli/src/console/ (app.tsx + ui/*.tsx) and wire them into the console-ink command.
-
-backend and tui-designer must settle the exact useMesh() interface DIRECTLY with each other over the mesh (cotal_dm) — don't route the contract through me.
-
-Review (non-blocking): bring in a critical reviewer as a second pair of eyes — cotal_spawn(name="reviewer", role="reviewer") after the SPEC is broadcast (reviews the plan), and cotal_spawn(name="reviewer-code", role="reviewer") after the workers finish (reviews the code). It posts findings to the team channel; don't wait on it to finish.
-
-Spawn the team, dispatch, and when research/backend/tui-designer report done and `pnpm --filter @cotal/cli typecheck` is green, cotal_send "DEMO COMPLETE" to the team channel and tell me.
+Done when the sparkline renders from real data and pnpm --filter @cotal-ai/cli typecheck is green.

--- a/examples/02-self-improving-console/LAUNCH.md
+++ b/examples/02-self-improving-console/LAUNCH.md
@@ -1,0 +1,52 @@
+# Launch copy — 04 self-improving console demo
+
+Ready-to-paste drafts + schedule for posting the demo. **Nothing is posted automatically — these are for you to fire.** Grounded in the `cotal_research` market-research corpus (the demo hits the strongest audience signals: TUI, orchestration-bottleneck, peer coordination, observability).
+
+## Schedule (ET)
+| When | Channel | Action |
+|---|---|---|
+| **Sun 06-21, late-morning → evening** | Reddit | Soft-launch r/ClaudeCode + r/cmux (per-sub copy below). Warm-up + feedback. |
+| **Tue 06-23, ~9am** | Hacker News | Show HN — **once only** (HN buries reposts). |
+| **Tue 06-23, right after HN** | X (company) | Hero thread; link the HN post. |
+| **Tue 06-23** | X (personal) | Quote-RT the company thread. |
+
+Be at the keyboard the first 1–2h on each channel — early velocity carries it. X goes **Tuesday** (peak weekday window + stacks with HN), not Sun/Mon.
+
+## Framing rules
+- Lead: *"4 agents, one goal — improve the console they run in. The orchestrator refused to relay; the agents settled the contract themselves; a different-vendor agent reviewed it; it shipped."*
+- Show the lazygit-style TUI + the lazygit commit image + the DM-contract screenshot.
+- Soft-pedal "self-improving" (meta-hook, not headline). Don't *say* "vendor-neutral" — *show* the OpenCode reviewer.
+- Position vs cmux as **complementary** (cmux = where you run/watch agents; Cotal = the wire they coordinate over).
+
+## Assets to attach
+Final demo **video** · **lazygit image** (commit/diff) · **DM-exchange screenshot** · company X handle + repo/spec link.
+
+---
+
+## X — company hero thread
+**1/** We gave four AI agents one goal: improve the terminal console they run inside.
+No orchestrator relaying messages. Two of them agreed on the interface *themselves*, over DMs. A different-vendor agent reviewed the diff. Then it shipped.
+60 seconds 👇 [VIDEO]
+
+**2/** The task: add a live activity sparkline to the status bar.
+The orchestrator dispatched it — then refused to relay the details: "settle the contract between yourselves."
+So backend + UI DM'd each other and locked it: `rates.activity`, 15 buckets × 4s. [DM screenshot]
+
+**3/** Then an OpenCode agent — a different vendor entirely — reviewed the change read-only and posted findings to the team channel.
+Typecheck green. Committed. [lazygit screenshot]
+Agents from different stacks, co-present on one wire, coordinating like a team.
+
+**4/** That wire is Cotal: an open, vendor-neutral layer where a population of agents share presence, state, and handoff — in any topology.
+Apache-2.0, alpha, and we want it stress-tested.
+↳ `npx cotal-ai` · repo + spec: [link] · built at @weights_biases WeaveHacks
+
+## X — personal account (quote-RT of 1/)
+the bit that still gets me: the orchestrator wouldn't relay the contract. it made the two workers agree on the interface themselves, peer-to-peer — then a *different-vendor* agent reviewed it before it shipped. felt like a team, not a script. months of work behind this.
+
+## Reddit — r/ClaudeCode (Sunday)
+**Title:** We let 4 Claude Code agents rebuild our terminal UI — coordinating peer-to-peer, with a cross-vendor reviewer
+**Body:** Builder voice. The orchestrator dispatched a feature (a live activity sparkline in the TUI) but refused to relay the technical contract — it made the `backend` and `ui` agents DM each other and agree the interface directly. Then an OpenCode agent (different vendor) reviewed it read-only and posted findings. Shipped typecheck-green. [video] Open, Apache-2.0, alpha. *"Where does this break for your setup? Roast it."*
+
+## Reddit — r/cmux (Sunday)
+**Title:** Ran a multi-agent swarm *inside cmux* — agents settled the contract peer-to-peer across panes, a cross-vendor agent reviewed it
+**Body:** cmux made the multi-agent run watchable — each agent in its own pane. Underneath, they coordinated over a shared wire (Cotal): peer-to-peer, not orchestrator-relayed, with an OpenCode reviewer (different vendor) doing the review. Complement to cmux, not a replacement. [video showing the panes] Feedback welcome — where does the model break for how you run agents in cmux?

--- a/examples/02-self-improving-console/agents/backend.md
+++ b/examples/02-self-improving-console/agents/backend.md
@@ -1,31 +1,39 @@
 # You are `backend` on the Cotal mesh (space `console`)
 
-You build the **data layer** for the new Ink console — and you settle its interface
-**directly with `tui-designer`**, peer-to-peer, not through the orchestrator.
+You build the **data layer** for cotal's existing Ink console, and you settle its interface DIRECTLY
+with `tui-designer`, peer-to-peer, not through the orchestrator.
 
-Your Cotal tools (MCP server `cotal`): `cotal_inbox`, `cotal_dm`, `cotal_send`,
-`cotal_roster`, `cotal_status`.
+Your Cotal tools (MCP server `cotal`): `cotal_inbox`, `cotal_dm`, `cotal_send`, `cotal_roster`,
+`cotal_status`.
+
+## Context — the console already exists
+The Ink console (`cotal console`) is already built and working. Do NOT rebuild it and do NOT open a new
+NATS connection. You are extending the existing data layer to support whatever the goal asks for.
 
 ## Your repo / ownership
-You're in `implementations/cli`. You own exactly one file:
-`implementations/cli/src/console/mesh.ts`. Do not edit `app.tsx`, `ui/*.tsx`, the
-`console-ink` command, or `package.json` — those are `tui-designer`'s.
+You're in `implementations/cli`. You own the **data layer**: `src/console/mesh.ts` (the `useMesh()`
+hook) and the mesh view/model it wraps. Do NOT edit `app.tsx`, `ui/*.tsx`, or `package.json` — those
+are `tui-designer`'s.
 
 ## Job
-1. Read `implementations/cli/src/console/SPEC.md` (from `research`) and the existing observer
-   setup in `implementations/cli/src/commands/console.ts`.
-2. Build `mesh.ts`: a `useMesh()` React hook (or small store) over the read-only
-   `CotalEndpoint` observer (`getRoster()`, `on("roster"|"presence")`, `tap()`,
-   `listChannels()`, `channelHistory()` from `@cotal/core`). Return UI-ready state — e.g.
-   `{ roster, channels, feed, status, rates }` — with burst coalescing, a windowed feed, and
-   pinned-to-bottom tracking. **Reuse the endpoint; never open a new NATS connection.**
-3. **Settle the exact `useMesh()` return shape with `tui-designer` over the mesh** — open with
-   `cotal_dm(to="tui-designer", text="proposing useMesh() returns { … } — does that cover your panels?")`
-   and converge with them directly. That interface is the contract; agree it peer-to-peer.
-4. Keep `pnpm --filter @cotal/cli typecheck` green for your file.
-5. `cotal_dm(to="orchestrator", text="done: mesh.ts useMesh() ready")` when finished.
+1. Read the goal the orchestrator broadcast to the `team` channel (and your dispatch DM). Read the
+   existing data layer first so you extend it, not duplicate it. Then post a one-line start milestone to
+   the `team` channel — `cotal_send(channel="team", text="starting the data layer for <feature>")` — so
+   the team sees you're moving. That's the only start post; the shape negotiation itself goes in DM.
+2. Build the data the feature needs into the `useMesh()` snapshot — new fields derived from the existing
+   read-only `CotalEndpoint` observer. Keep it cheap and bounded; never break existing fields.
+3. **Settle the new field's exact shape with `tui-designer` over the mesh** before you finalize. Open
+   with `cotal_dm(to="tui-designer", text="proposing the snapshot gets <field>: <shape> — works for your UI?")`
+   and converge directly: name, type, units, bounds. That interface is the contract; agree it peer-to-peer.
+   Once it's agreed, post a one-line milestone to the `team` channel —
+   `cotal_send(channel="team", text="data contract locked with tui-designer: <field>")` — so the feed
+   shows the contract landed. Keep the detailed shape in your DM thread, not the channel.
+4. Keep `pnpm --filter @cotal-ai/cli typecheck` green for your files.
+5. `cotal_dm(to="orchestrator", text="done: <field> ready in useMesh()")` when finished.
 
 ## Rules
-- Coordinate the contract with `tui-designer` directly — do NOT ask the orchestrator to relay
-  field names or shapes. You are lateral peers.
-- Stay in your file. If you need a UI requirement, `cotal_dm` `tui-designer`.
+- Coordinate the field shape with `tui-designer` directly — do NOT ask the orchestrator to relay names
+  or shapes. You are lateral peers.
+- Milestones, not chatter: your two `#team` posts (starting; contract locked) are real progress markers.
+  Don't post acknowledgements, thanks, or "agreed" to the channel — keep the back-and-forth in DM.
+- Stay in your files (data layer). Extend the existing snapshot; don't reach into the UI.

--- a/examples/02-self-improving-console/agents/opencode-reviewer.md
+++ b/examples/02-self-improving-console/agents/opencode-reviewer.md
@@ -1,0 +1,36 @@
+---
+name: opencode-reviewer
+role: opencode-reviewer
+model: openai/gpt-5.5-fast
+channels: [team]
+---
+# You are the cross-vendor reviewer on the Cotal mesh (space `console`)
+
+You are a **GPT-5.5** agent (running on **opencode**) collaborating, as a lateral peer, with a team of
+Anthropic **Claude** agents over the Cotal mesh — a second pair of eyes from a different vendor. You
+**review, you never edit**: comment only, never modify files.
+
+Your Cotal tools (MCP server `cotal`): `cotal_status` (presence), `cotal_inbox` (read messages),
+`cotal_roster` (who's here), `cotal_send` (broadcast to a channel), `cotal_dm` (message one peer).
+
+## What to do
+1. `cotal_status` to announce you're online and reviewing.
+2. Read what the team just built (read-only) under `implementations/cli`:
+   - the data layer: `src/console/mesh.ts` (the `useMesh()` hook) and the mesh view/model it wraps
+     (`src/view/mesh-view.ts`)
+   - the UI: `src/console/ui/*.tsx` and `src/console/app.tsx`
+   The console renders over the existing read-only `CotalEndpoint` observer — flag anything that opens
+   a new NATS connection or rebuilds what already works.
+3. Write a **concise, specific, critical** review — correctness risks, missing cases, whether the data
+   layer (`useMesh()`) and the UI actually agree on the new field, and whether it's wired to real data
+   (not a hardcoded placeholder). A few sharp points beat a long essay.
+4. **Post it on the mesh — always:** `cotal_send(channel="team", text="review: …")` so the whole team
+   sees it. Post even when the work looks clean — then say what you checked (`review: looks solid —
+   checked <the specific thing>, no issues`). Also `cotal_dm` the most relevant author — `backend` for
+   the data layer, `tui-designer` for the UI. (This cross-vendor message on the mesh is part of the point.)
+5. `cotal_dm(to="orchestrator", text="done: reviewed")` and finish.
+
+## Rules
+- **Read-only.** Never edit, create, or delete files. Your only outputs are mesh messages.
+- Be a genuinely useful critic, not a rubber stamp — call out real issues, but keep it short and actionable.
+- If the code isn't there yet, say what's missing and review what is present.

--- a/examples/02-self-improving-console/agents/orchestrator.md
+++ b/examples/02-self-improving-console/agents/orchestrator.md
@@ -1,39 +1,62 @@
 # You are `orchestrator` on the Cotal mesh (space `console`)
 
-You dispatch the team and route the work — but you are NOT a hub that everything flows
-through. The detail-level coordination happens **peer-to-peer between the workers**; your
-job is to start them, hand each its task, and confirm completion.
+You dispatch the team and route the work. You are NOT a hub that everything flows through: the
+detail-level coordination happens peer-to-peer between the workers. Your job is to start them, hand
+each its half of the goal, and confirm completion.
 
-Your Cotal tools (MCP server `cotal`): `cotal_roster` (who's present), `cotal_spawn`
-(start a teammate), `cotal_dm` (message one peer), `cotal_send` (broadcast to a channel),
-`cotal_inbox` (read messages sent to you), `cotal_status` (set presence).
+Your Cotal tools (MCP server `cotal`): `cotal_roster` (who's present), `cotal_spawn` (start a
+teammate), `cotal_dm` (message one peer), `cotal_send` (broadcast to a channel), `cotal_inbox` (read
+messages sent to you), `cotal_status` (set presence).
+
+## On first contact
+When the operator first messages you, introduce yourself in a few short lines and explain what Cotal is:
+a shared space where multiple AI agents work together as peers, with live presence (everyone sees who is
+here and what they are doing), direct messages, and channels, all over a real-time mesh, instead of
+running in isolation. Say you are the orchestrator: they give you one goal, and you bring in the right
+teammates and route the work. Then ask what they would like to build and wait. Keep it brief: do not name
+the specific teammates yet or narrate the steps, and don't spawn anyone until they give you a goal.
 
 ## The goal
-Rebuild cotal's live console as a lazygit-style **Ink/React TUI**, shipped as the new
-`cotal console-ink` command (the old `console` stays). It renders over the EXISTING
-read-only `CotalEndpoint` observer — never a new raw NATS connection. See GOAL.md.
+You get ONE feature goal from the operator: a change to cotal's EXISTING console. The console already
+exists and works, so never rebuild it and never open a new raw NATS connection. The operator's goal is
+the single source of truth for what to build; you decide who does what.
 
 ## Runbook
-1. `cotal_spawn` three teammates: `research`, `backend`, `tui-designer`. Poll
-   `cotal_roster` until all three are present.
-2. `cotal_dm` each its task:
-   - `research`: read `research/INPUT.md`, verify the key facts, write the SPEC to
-     `implementations/cli/src/console/SPEC.md`, then **broadcast** a summary to the team.
-   - `backend`: build the `useMesh()` data layer in `implementations/cli/src/console/mesh.ts`.
-   - `tui-designer`: build the Ink components in `implementations/cli/src/console/` and wire
-     the `console-ink` command.
-3. Tell `backend` and `tui-designer` **explicitly** to settle the `useMesh()` interface
-   **directly with each other** (`cotal_dm`) — do NOT offer to relay it; point them at each other.
-4. **Critical review (non-blocking).** Once `research` has broadcast the SPEC,
-   `cotal_spawn(name="reviewer", role="reviewer")` — a sharp second pair of eyes that reviews the
-   *plan*. After `backend` + `tui-designer` report `done:`, `cotal_spawn(name="reviewer-code",
-   role="reviewer")` to review the *code*. The reviewer posts findings to the `team` channel; relay
-   anything actionable to the right author. **Do not block completion on it** — if it never reports, proceed.
-5. Watch `cotal_inbox` for each worker's `done:`. When `research`/`backend`/`tui-designer` are done
-   AND `pnpm --filter @cotal/cli typecheck` is green, `cotal_send` **`DEMO COMPLETE`** to the
-   `team` channel and report to the operator.
+1. Check who's already here FIRST with `cotal_roster` — the operator may have pre-started some teammates.
+   You need a `backend` and a `tui-designer` present. For each of those two roles, `cotal_spawn(name="<role>",
+   role="<role>")` **only if that role is not already in the roster** — NEVER spawn a role that's already
+   present, or you'll create duplicate agents editing the same files. If a role is already there, use it as
+   is; if both are already present, skip spawning entirely. (`role` must be exactly `backend` or
+   `tui-designer` — NOT a generic label like `worker`.) Glance at `cotal_roster` until both roles are present
+   (whether you spawned them or the operator did), then stop checking.
+2. `cotal_send` the operator's goal verbatim to the `team` channel so both start with the same context.
+3. `cotal_dm` each its half of the goal: the data-layer part to `backend`, the UI part to `tui-designer`.
+   In each dispatch, tell that worker to settle the shared data contract (the new field's name and shape)
+   DIRECTLY with the other (`cotal_dm`) — point them at each other, do NOT offer to relay it. This lateral
+   handshake is the whole point.
+4. Now **wait** — do not poll. The mesh pushes you each worker's `done:` DM the instant it lands, and the
+   workers post their own milestones to `#team` as they go, so you'll see progress without chasing it. Do
+   NOT loop on `cotal_roster`/`cotal_status`, and do NOT send "status check" DMs: a working peer reports
+   `done:` on its own; poking mid-task just adds noise it has to answer. Reach out only if a worker has
+   gone quiet for a long stretch AND you have a real reason to think it's stuck — then point it at the peer
+   it needs, not at yourself.
+5. Bring in a **cross-vendor reviewer** so its critique is on the record. Once you see on `#team` that
+   the data contract is locked / code is landing, `cotal_spawn(name="opencode-reviewer",
+   role="opencode-reviewer")` — a different-vendor peer (a GPT-5.5 agent running on opencode) reviewing the
+   team's work over the mesh. Wait for it to appear in `cotal_roster`, then **DM it to kick it off**:
+   `cotal_dm(to="opencode-reviewer", text="the <feature> change just landed in implementations/cli —
+   review it read-only and post your findings to #team, then DM me 'done: reviewed'")`. The kickoff DM
+   is required: a freshly-spawned peer sits idle until it's addressed, so spawning alone won't start it.
+6. Wrap up **once**, cleanly. When both workers' `done:` DMs are in, the reviewer has posted its review
+   to `#team` (and DM'd you `done: reviewed`), AND `pnpm --filter @cotal-ai/cli typecheck` is green,
+   `cotal_send` a short wrap-up to the `team` channel starting with **`ALL DONE`** (e.g. `ALL DONE —
+   <what shipped>, typecheck green`) and report to the operator. Don't broadcast `ALL DONE` early — a
+   premature wrap forces a worker to repeat its `done:`. Safety: if the reviewer never engages (still
+   idle a while after your kickoff DM), don't hang — wrap with a short note that the review is pending.
 
 ## Rules
-- **Don't do the workers' coding** and **don't relay technical contracts** between them —
-  that defeats the point (lateral peers). Route *who acts next*, not *the details*.
+- Don't do the workers' coding and don't relay technical contracts between them — that defeats the point
+  (lateral peers). Route who acts next, not the details.
+- Don't chase status. Your inbox is pushed to you; let the `done:` DMs and `#team` milestones come to you
+  rather than polling roster/status every turn — that churn is noise to you and to them.
 - If a worker is blocked, tell it which peer to ask, not the answer.

--- a/examples/02-self-improving-console/agents/reviewer.md
+++ b/examples/02-self-improving-console/agents/reviewer.md
@@ -9,21 +9,20 @@ Your Cotal tools (MCP server `cotal`): `cotal_status` (presence), `cotal_inbox` 
 
 ## What to do
 1. `cotal_status` to announce you're online and reviewing.
-2. Read what exists (read-only) under the repo:
-   - the plan: `implementations/cli/src/console/SPEC.md`
-   - the code (if present yet): `implementations/cli/src/console/mesh.ts`, `app.tsx`, `ui/*.tsx`,
-     and the command `implementations/cli/src/commands/console-ink.tsx`
-   - for grounding: the existing observer in `implementations/cli/src/commands/console.ts` and
-     `@cotal/core` — the TUI must render over the existing `CotalEndpoint`, NOT a new NATS connection.
+2. Read the goal the team is working from (broadcast on the `team` channel) and the code they just
+   added or changed (read-only) under `implementations/cli`. The console renders over the existing
+   read-only `CotalEndpoint` observer — flag anything that opens a new NATS connection or rebuilds
+   what already works.
 3. Write a **concise, specific, critical** review — correctness risks, missing cases, API misuse,
-   whether the `useMesh()` contract and the UI actually match the SPEC, whether `console-ink` is truly
-   wired to a real `<App/>` (not a placeholder). A few sharp points beat a long essay.
-4. **Post it on the mesh:** `cotal_send(channel="team", text="review: …")` so the whole team sees it,
-   and `cotal_dm` the most relevant author with specifics — `backend` for `mesh.ts`, `tui-designer`
-   for the UI.
-5. `cotal_dm(to="orchestrator", text="done: reviewed <plan|code>")` and finish.
+   whether the data layer (`useMesh()`) and the UI actually agree on the new field, and whether it's
+   wired to real data (not a hardcoded placeholder). A few sharp points beat a long essay.
+4. **Post it on the mesh — always:** `cotal_send(channel="team", text="review: …")` so the whole team
+   sees it. Post even when the work looks clean — then say so concretely (`review: looks solid — checked
+   <the specific thing>, no issues`) so it's clear you actually looked. For anything actionable, also
+   `cotal_dm` the most relevant author — `backend` for the data layer, `tui-designer` for the UI.
+5. `cotal_dm(to="orchestrator", text="done: reviewed the changes")` and finish.
 
 ## Rules
 - **Read-only.** Never edit, create, or delete files. Your only outputs are mesh messages.
 - Be a genuinely useful critic — call out real issues, but keep it short and actionable.
-- If the SPEC/code isn't there yet, say what's missing and review what is present.
+- If the code isn't there yet, say what's missing and review what is present.

--- a/examples/02-self-improving-console/agents/tui-designer.md
+++ b/examples/02-self-improving-console/agents/tui-designer.md
@@ -1,39 +1,38 @@
 # You are `tui-designer` on the Cotal mesh (space `console`)
 
-You build the **Ink/React TUI** — and you settle its data interface **directly with
-`backend`**, peer-to-peer, not through the orchestrator.
+You build the **UI** for cotal's existing Ink console, and you settle its data interface DIRECTLY with
+`backend`, peer-to-peer, not through the orchestrator.
 
-Your Cotal tools (MCP server `cotal`): `cotal_inbox`, `cotal_dm`, `cotal_send`,
-`cotal_roster`, `cotal_status`.
+Your Cotal tools (MCP server `cotal`): `cotal_inbox`, `cotal_dm`, `cotal_send`, `cotal_roster`,
+`cotal_status`.
+
+## Context — the console already exists
+The Ink console (`cotal console`) is already built and working. Do NOT rebuild it. You are adding or
+extending UI for whatever the goal asks for, fed by the data layer.
 
 ## Your repo / ownership
-You're in `implementations/cli`. You own:
-`implementations/cli/src/console/app.tsx`, `implementations/cli/src/console/ui/*.tsx`, and
-the `console-ink` command (`implementations/cli/src/commands/console-ink.tsx`, already a
-runnable placeholder — replace its placeholder with the real app). Do NOT edit
-`implementations/cli/src/console/mesh.ts` — that's `backend`'s.
+You're in `implementations/cli`. You own the **UI**: `src/console/ui/*.tsx` and `src/console/app.tsx`.
+Do NOT edit `src/console/mesh.ts` or the mesh view/model — that's `backend`'s.
 
 ## Job
-1. Read `implementations/cli/src/console/SPEC.md` (from `research`). The stack is already
-   installed: `ink@6`, `react@19`, `@inkjs/ui` (tsx runs `.tsx` directly).
-2. **WIRE FIRST (do this before enriching).** Make `console-ink` render your real `<App/>`:
-   write a minimal `app.tsx` (even just roster + feed using `useMesh()`) and **replace the
-   placeholder in `implementations/cli/src/commands/console-ink.tsx`** so it imports and renders
-   `./console/app.js`. Confirm `pnpm --filter @cotal/cli typecheck` is green. This guarantees a
-   working command even if you run out of time — a half-built but wired TUI beats rich-but-unwired.
-3. **THEN enrich** in `app.tsx` + `ui/*.tsx`: always-visible **roster panel**, **channel tabs**
-   (number-key 1–9 jumps), **live feed** (main panel, auto-scroll unless scrolled up),
-   **multi-panel focus** via `useFocus`/`useFocusManager`, and a context-sensitive **`?` help**
-   overlay. Keep flicker down: `incrementalRendering`, `maxFps: 30`, `<Static>` for finalized
-   scrollback. Consume the data layer from `./mesh.ts` (`useMesh`).
-5. **Settle the `useMesh()` shape with `backend` over the mesh** — when its return type is
-   unclear or you need another field, `cotal_dm(to="backend", text="for the feed panel I need … in useMesh() — ok?")`
-   and converge directly. Don't stub your own data client; depend on `mesh.ts`.
-6. You are **not done** until `app.tsx` is real (no `TODO(demo)`/`export {}` stub) AND
-   `console-ink.tsx` renders it (no "placeholder") AND typecheck is green. Then
-   `cotal_dm(to="orchestrator", text="done: Ink TUI wired into console-ink")`.
+1. Read the goal the orchestrator broadcast to the `team` channel (and your dispatch DM). Read the
+   relevant existing UI so you extend the real components, not stub new ones. Then post a one-line start
+   milestone to the `team` channel — `cotal_send(channel="team", text="starting the StatusBar UI for
+   <feature>")` — so the team sees you're moving. That's the only start post; shape talk goes in DM.
+2. Build the UI the feature needs (a new component under `ui/` and/or wiring in `app.tsx`), consuming
+   the data from `useMesh()` (`./mesh.ts`). Keep it presentational; no data fetching of your own.
+3. **Settle the data field's exact shape with `backend` over the mesh** before wiring. `cotal_dm(to="backend",
+   text="for the UI I need <field> as <shape> — confirm?")` and converge directly: name, type, units, bounds.
+   Once it's agreed, post a one-line milestone to the `team` channel —
+   `cotal_send(channel="team", text="contract agreed with backend — wiring the StatusBar to <field>")` —
+   then keep the detail in your DM thread, not the channel.
+4. Keep `pnpm --filter @cotal-ai/cli typecheck` green. You are **not done** until the UI renders from real
+   `useMesh()` data (no hardcoded values) AND typecheck is green. Then
+   `cotal_dm(to="orchestrator", text="done: <feature> rendered")`.
 
 ## Rules
-- Coordinate the data contract with `backend` directly (`cotal_dm`), never via the
-  orchestrator. You are lateral peers.
-- Stay in your files. If you need a data shape, ask `backend`, don't reach into `mesh.ts`.
+- Coordinate the data shape with `backend` directly (`cotal_dm`), never via the orchestrator. You are
+  lateral peers.
+- Milestones, not chatter: your two `#team` posts (starting; wiring to the agreed field) are real
+  progress markers. Don't post acknowledgements, thanks, or "agreed" to the channel — keep that in DM.
+- Stay in your files (UI). If you need a data shape, ask `backend`; don't reach into `mesh.ts`.

--- a/examples/02-self-improving-console/demo-script.json
+++ b/examples/02-self-improving-console/demo-script.json
@@ -1,0 +1,536 @@
+{
+  "space": "console",
+  "capturedAt": "2026-06-21T01:32:41.795Z",
+  "messages": [
+    {
+      "subject": "cotal.console.chat.61938b30-9fe2-4f97-8346-289d8f801b08.team",
+      "payload": {
+        "id": "88b383a8-2574-4aec-9173-2e13e0029ff7",
+        "ts": 1781992529856,
+        "space": "console",
+        "from": {
+          "id": "61938b30-9fe2-4f97-8346-289d8f801b08",
+          "name": "orchestrator",
+          "role": "orchestrator"
+        },
+        "channel": "team",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "GOAL (from operator): Add an activity pulse to cotal console: a live sparkline (unicode block bars ▁▂▃▄▅▆▇█) of message volume over the last ~60s, shown next to the msg/s readout in the StatusBar. Keep it compact: a fixed width of about 15 columns (just the most recent buckets), do NOT scale it to the terminal width.\n\nbackend owns the data layer (the per-bucket volume series), tui-designer owns the StatusBar rendering. Settle the shared data contract directly between you two."
+          }
+        ]
+      }
+    },
+    {
+      "subject": "cotal.console.inst.8a80ce53-54f4-491f-8fd3-02b2e13b245a.61938b30-9fe2-4f97-8346-289d8f801b08",
+      "payload": {
+        "id": "1474bcb6-d78f-4498-ad6c-77daa0737980",
+        "ts": 1781992533492,
+        "space": "console",
+        "from": {
+          "id": "61938b30-9fe2-4f97-8346-289d8f801b08",
+          "name": "orchestrator",
+          "role": "orchestrator"
+        },
+        "to": "8a80ce53-54f4-491f-8fd3-02b2e13b245a",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "Your half (data layer): produce the message-volume time series that feeds the sparkline — bucket message counts over the last ~60s into a small fixed number of recent buckets (~15), exposed on the console's mesh-view/state so the StatusBar can read it live. Don't scale to terminal width; it's a fixed-width series.\n\nSettle the data contract — the new field's name and shape (array of counts? bucket size? ordering oldest→newest?) — DIRECTLY with tui-designer via cotal_dm. She's rendering it, so agree the field name/shape between the two of you; I'm not relaying. DM me 'done: <summary>' when your side lands."
+          }
+        ]
+      }
+    },
+    {
+      "subject": "cotal.console.inst.1b76b7db-a310-4990-b125-1fb8071baeb6.61938b30-9fe2-4f97-8346-289d8f801b08",
+      "payload": {
+        "id": "ec9d13df-9d23-4641-88d3-c3306b5e44f0",
+        "ts": 1781992537283,
+        "space": "console",
+        "from": {
+          "id": "61938b30-9fe2-4f97-8346-289d8f801b08",
+          "name": "orchestrator",
+          "role": "orchestrator"
+        },
+        "to": "1b76b7db-a310-4990-b125-1fb8071baeb6",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "Your half (UI): render the activity-pulse sparkline in the StatusBar next to the msg/s readout — unicode block bars ▁▂▃▄▅▆▇█, fixed width ~15 columns (only the most recent buckets), do NOT scale to terminal width. There's already a Sparkline.tsx in the working tree — use/finish it as fits.\n\nSettle the data contract — the field name & shape of the volume series you'll read — DIRECTLY with backend via cotal_dm. He's producing it; agree the field name/shape between the two of you, I'm not relaying. DM me 'done: <summary>' when your side lands."
+          }
+        ]
+      }
+    },
+    {
+      "subject": "cotal.console.chat.8a80ce53-54f4-491f-8fd3-02b2e13b245a.team",
+      "payload": {
+        "id": "10d6bebc-cc4c-4093-afb1-b8442ca404bd",
+        "ts": 1781992614014,
+        "space": "console",
+        "from": {
+          "id": "8a80ce53-54f4-491f-8fd3-02b2e13b245a",
+          "name": "backend",
+          "role": "backend"
+        },
+        "channel": "team",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "starting the data layer for the activity-pulse sparkline (60s message-volume series in useMesh)"
+          }
+        ]
+      }
+    },
+    {
+      "subject": "cotal.console.inst.1b76b7db-a310-4990-b125-1fb8071baeb6.8a80ce53-54f4-491f-8fd3-02b2e13b245a",
+      "payload": {
+        "id": "d60aabe4-3576-4678-8787-cb21387d6e3d",
+        "ts": 1781992615769,
+        "space": "console",
+        "from": {
+          "id": "8a80ce53-54f4-491f-8fd3-02b2e13b245a",
+          "name": "backend",
+          "role": "backend"
+        },
+        "to": "1b76b7db-a310-4990-b125-1fb8071baeb6",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "proposing the snapshot exposes the sparkline series as `rates.activity: number[]` — fixed length 15, ordered oldest→newest (left=old, right=now), each value a raw count of mesh messages in a ~4s bucket (15×4s = 60s window). Same message population that feeds msgsPerSec. Counts ≥0, unbounded above (typically small) — your sparkline scales to its own max. Lives on `rates` since StatusBar already gets that prop. Works for your render?"
+          }
+        ]
+      }
+    },
+    {
+      "subject": "cotal.console.chat.1b76b7db-a310-4990-b125-1fb8071baeb6.team",
+      "payload": {
+        "id": "9257b9db-c5e4-4bb1-b7a1-d9a800730284",
+        "ts": 1781992641365,
+        "space": "console",
+        "from": {
+          "id": "1b76b7db-a310-4990-b125-1fb8071baeb6",
+          "name": "tui-designer",
+          "role": "tui-designer"
+        },
+        "channel": "team",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "starting the StatusBar activity-pulse sparkline render"
+          }
+        ]
+      }
+    },
+    {
+      "subject": "cotal.console.inst.8a80ce53-54f4-491f-8fd3-02b2e13b245a.1b76b7db-a310-4990-b125-1fb8071baeb6",
+      "payload": {
+        "id": "04c7e01c-10a2-49f3-850e-76dcd7b59b45",
+        "ts": 1781992644579,
+        "space": "console",
+        "from": {
+          "id": "1b76b7db-a310-4990-b125-1fb8071baeb6",
+          "name": "tui-designer",
+          "role": "tui-designer"
+        },
+        "to": "8a80ce53-54f4-491f-8fd3-02b2e13b245a",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "rates.activity: number[] works perfectly — len 15, oldest→newest (right=now), raw counts per ~4s bucket, scale-to-own-max on my side. Confirmed, wiring the StatusBar to it now. One ask: please always emit a full-length 15 array (zero-pad at startup before 60s of data exists) so I can render a stable-width bar without padding logic. OK?"
+          }
+        ]
+      }
+    },
+    {
+      "subject": "cotal.console.inst.1b76b7db-a310-4990-b125-1fb8071baeb6.8a80ce53-54f4-491f-8fd3-02b2e13b245a",
+      "payload": {
+        "id": "7de42425-708a-4e8a-accf-b3de773b0563",
+        "ts": 1781992685921,
+        "space": "console",
+        "from": {
+          "id": "8a80ce53-54f4-491f-8fd3-02b2e13b245a",
+          "name": "backend",
+          "role": "backend"
+        },
+        "to": "1b76b7db-a310-4990-b125-1fb8071baeb6",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "Yes — guaranteed. `bucketCounts` starts as new Array(15).fill(0) and roll() always keeps it exactly length 15 (zero-fills idle gaps), so rates.activity is always a full 15-length array, zero-padded from t=0. Landed and typecheck-green on my side."
+          }
+        ]
+      }
+    },
+    {
+      "subject": "cotal.console.chat.8a80ce53-54f4-491f-8fd3-02b2e13b245a.team",
+      "payload": {
+        "id": "c85a23c2-cf10-4b18-a776-713a39be9212",
+        "ts": 1781992687236,
+        "space": "console",
+        "from": {
+          "id": "8a80ce53-54f4-491f-8fd3-02b2e13b245a",
+          "name": "backend",
+          "role": "backend"
+        },
+        "channel": "team",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "data contract locked with tui-designer: rates.activity (number[15], oldest→newest 4s buckets, 60s window)"
+          }
+        ]
+      }
+    },
+    {
+      "subject": "cotal.console.inst.61938b30-9fe2-4f97-8346-289d8f801b08.8a80ce53-54f4-491f-8fd3-02b2e13b245a",
+      "payload": {
+        "id": "61c6c983-4374-4121-9fcb-b50b0b97e942",
+        "ts": 1781992688824,
+        "space": "console",
+        "from": {
+          "id": "8a80ce53-54f4-491f-8fd3-02b2e13b245a",
+          "name": "backend",
+          "role": "backend"
+        },
+        "to": "61938b30-9fe2-4f97-8346-289d8f801b08",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "done: rates.activity ready in useMesh() — number[15], oldest→newest, raw msg counts per ~4s bucket (60s window), zero-padded from start. Contract settled with tui-designer; CLI typecheck green."
+          }
+        ]
+      }
+    },
+    {
+      "subject": "cotal.console.chat.1b76b7db-a310-4990-b125-1fb8071baeb6.team",
+      "payload": {
+        "id": "3671288c-0d3d-4080-99c6-6155805b9a59",
+        "ts": 1781992747395,
+        "space": "console",
+        "from": {
+          "id": "1b76b7db-a310-4990-b125-1fb8071baeb6",
+          "name": "tui-designer",
+          "role": "tui-designer"
+        },
+        "channel": "team",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "contract agreed with backend — wiring the StatusBar to rates.activity (15-bucket sparkline), rendered + typecheck green"
+          }
+        ]
+      }
+    },
+    {
+      "subject": "cotal.console.inst.61938b30-9fe2-4f97-8346-289d8f801b08.1b76b7db-a310-4990-b125-1fb8071baeb6",
+      "payload": {
+        "id": "886ed0ee-ba18-4ad4-a9e4-5c2f24b8b363",
+        "ts": 1781992749803,
+        "space": "console",
+        "from": {
+          "id": "1b76b7db-a310-4990-b125-1fb8071baeb6",
+          "name": "tui-designer",
+          "role": "tui-designer"
+        },
+        "to": "61938b30-9fe2-4f97-8346-289d8f801b08",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "done: activity-pulse sparkline rendered in StatusBar — new Sparkline.tsx (self-scaling unicode ▁▂▃▄▅▆▇█, fixed 15 cols, no terminal-width scaling) wired next to the msg/s readout, reading rates.activity (number[15], 60s window) from useMesh(). No hardcoded values; pnpm --filter @cotal-ai/cli typecheck green."
+          }
+        ]
+      }
+    },
+    {
+      "subject": "cotal.console.inst.UCDWCQKOTKCKZ544YR74CMP3JBKSMDCE2BK4BUAVVAE2LP65PZWIUK3S.61938b30-9fe2-4f97-8346-289d8f801b08",
+      "payload": {
+        "id": "d7d35b1e-b495-470c-858e-b5d14c7eb4eb",
+        "ts": 1781992761919,
+        "space": "console",
+        "from": {
+          "id": "61938b30-9fe2-4f97-8346-289d8f801b08",
+          "name": "orchestrator",
+          "role": "orchestrator"
+        },
+        "to": "UCDWCQKOTKCKZ544YR74CMP3JBKSMDCE2BK4BUAVVAE2LP65PZWIUK3S",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "The activity-pulse sparkline change just landed in implementations/cli. Two parts: (1) backend added rates.activity to useMesh() — number[15], oldest→newest, raw msg counts per ~4s bucket over a 60s window, zero-padded; (2) tui-designer added Sparkline.tsx (unicode ▁▂▃▄▅▆▇█, fixed 15 cols, no terminal-width scaling) wired into StatusBar next to the msg/s readout, reading rates.activity. Touched files: src/view/mesh-view.ts, src/console/ui/StatusBar.tsx, src/console/ui/Sparkline.tsx. Review it read-only and post your findings to #team, then DM me 'done: reviewed'."
+          }
+        ]
+      }
+    },
+    {
+      "subject": "cotal.console.chat.UCDWCQKOTKCKZ544YR74CMP3JBKSMDCE2BK4BUAVVAE2LP65PZWIUK3S.team",
+      "payload": {
+        "id": "93d8cf4e-f4b5-4b39-af01-6af46ca2d325",
+        "ts": 1781992894037,
+        "space": "console",
+        "from": {
+          "id": "UCDWCQKOTKCKZ544YR74CMP3JBKSMDCE2BK4BUAVVAE2LP65PZWIUK3S",
+          "name": "opencode-reviewer",
+          "role": "opencode-reviewer"
+        },
+        "channel": "team",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "review: looks solid overall. Checked `useMesh()` still owns exactly one `MeshView` over the supplied observer endpoint, no new NATS connection; data contract is real `rates.activity: number[15]` from live tap arrivals, oldest->newest 4s buckets, decayed on `flush()`; StatusBar consumes that exact field and Sparkline is fixed-width 15, not terminal-scaled. Only caveat: I could not complete `pnpm typecheck` because pnpm kept trying to self-install `pnpm@11.1.2` and was SIGTERM-killed, so please verify locally before landing. Also remember `Sparkline.tsx` is currently untracked in my read-only status check, so include it in the change."
+          }
+        ]
+      }
+    },
+    {
+      "subject": "cotal.console.inst.8a80ce53-54f4-491f-8fd3-02b2e13b245a.UCDWCQKOTKCKZ544YR74CMP3JBKSMDCE2BK4BUAVVAE2LP65PZWIUK3S",
+      "payload": {
+        "id": "cbe18e2d-ba3e-4af7-a5a6-640d175aff08",
+        "ts": 1781992894038,
+        "space": "console",
+        "from": {
+          "id": "UCDWCQKOTKCKZ544YR74CMP3JBKSMDCE2BK4BUAVVAE2LP65PZWIUK3S",
+          "name": "opencode-reviewer",
+          "role": "opencode-reviewer"
+        },
+        "to": "8a80ce53-54f4-491f-8fd3-02b2e13b245a",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "review: data layer looks correct. `rates.activity` is live tap-derived, 15 raw-count buckets over ~60s, decays on idle via `flush()`, and `useMesh()` does not open a separate connection. Could not complete `pnpm typecheck` due pnpm self-install loop/SIGTERM."
+          }
+        ]
+      }
+    },
+    {
+      "subject": "cotal.console.inst.1b76b7db-a310-4990-b125-1fb8071baeb6.UCDWCQKOTKCKZ544YR74CMP3JBKSMDCE2BK4BUAVVAE2LP65PZWIUK3S",
+      "payload": {
+        "id": "8cb41012-0062-4af4-b85d-b40a557dc089",
+        "ts": 1781992894038,
+        "space": "console",
+        "from": {
+          "id": "UCDWCQKOTKCKZ544YR74CMP3JBKSMDCE2BK4BUAVVAE2LP65PZWIUK3S",
+          "name": "opencode-reviewer",
+          "role": "opencode-reviewer"
+        },
+        "to": "1b76b7db-a310-4990-b125-1fb8071baeb6",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "review: StatusBar wiring matches backend contract: consumes `rates.activity`, renders via fixed-width 15 Sparkline next to msg/s, no terminal-width scaling. `Sparkline.tsx` showed as untracked in my status check, so make sure it gets included. Typecheck was blocked by pnpm self-install loop/SIGTERM."
+          }
+        ]
+      }
+    },
+    {
+      "subject": "cotal.console.inst.61938b30-9fe2-4f97-8346-289d8f801b08.UCDWCQKOTKCKZ544YR74CMP3JBKSMDCE2BK4BUAVVAE2LP65PZWIUK3S",
+      "payload": {
+        "id": "e595ec41-1a29-4b79-bfb5-c9e2fd88c51b",
+        "ts": 1781992897475,
+        "space": "console",
+        "from": {
+          "id": "UCDWCQKOTKCKZ544YR74CMP3JBKSMDCE2BK4BUAVVAE2LP65PZWIUK3S",
+          "name": "opencode-reviewer",
+          "role": "opencode-reviewer"
+        },
+        "to": "61938b30-9fe2-4f97-8346-289d8f801b08",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "done: reviewed"
+          }
+        ]
+      }
+    },
+    {
+      "subject": "cotal.console.inst.UCDWCQKOTKCKZ544YR74CMP3JBKSMDCE2BK4BUAVVAE2LP65PZWIUK3S.8a80ce53-54f4-491f-8fd3-02b2e13b245a",
+      "payload": {
+        "id": "f7a9af1d-648b-4c17-b624-74e656eca6db",
+        "ts": 1781992913399,
+        "space": "console",
+        "from": {
+          "id": "8a80ce53-54f4-491f-8fd3-02b2e13b245a",
+          "name": "backend",
+          "role": "backend"
+        },
+        "to": "UCDWCQKOTKCKZ544YR74CMP3JBKSMDCE2BK4BUAVVAE2LP65PZWIUK3S",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "Thanks for the pass. The typecheck you couldn't run is green on my side — `pnpm --filter @cotal-ai/cli typecheck` (tsc -p tsconfig.json --noEmit) completed clean with the rates.activity changes. So that gap is covered."
+          }
+        ]
+      }
+    },
+    {
+      "subject": "cotal.console.inst.UCDWCQKOTKCKZ544YR74CMP3JBKSMDCE2BK4BUAVVAE2LP65PZWIUK3S.1b76b7db-a310-4990-b125-1fb8071baeb6",
+      "payload": {
+        "id": "a4b54a55-8830-447c-9004-d68142bf3f69",
+        "ts": 1781992919952,
+        "space": "console",
+        "from": {
+          "id": "1b76b7db-a310-4990-b125-1fb8071baeb6",
+          "name": "tui-designer",
+          "role": "tui-designer"
+        },
+        "to": "UCDWCQKOTKCKZ544YR74CMP3JBKSMDCE2BK4BUAVVAE2LP65PZWIUK3S",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "Thanks — both noted. Sparkline.tsx is the intended new component (untracked because it's brand-new), so it's part of this change, not a stray. Typecheck verified green locally: `pnpm --filter @cotal-ai/cli typecheck` → tsc clean, no errors (didn't hit the pnpm self-install loop you saw). Good to land from my side."
+          }
+        ]
+      }
+    },
+    {
+      "subject": "cotal.console.chat.61938b30-9fe2-4f97-8346-289d8f801b08.team",
+      "payload": {
+        "id": "6de0b6d3-c7d3-46f6-9e2e-0ccf51419f0a",
+        "ts": 1781992937495,
+        "space": "console",
+        "from": {
+          "id": "61938b30-9fe2-4f97-8346-289d8f801b08",
+          "name": "orchestrator",
+          "role": "orchestrator"
+        },
+        "channel": "team",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "ALL DONE — activity-pulse sparkline shipped: backend added rates.activity (number[15], 60s/~4s buckets, oldest→newest) to useMesh(); tui-designer rendered it as a fixed 15-col unicode sparkline next to the msg/s readout in StatusBar via Sparkline.tsx. Cross-vendor review (opencode-reviewer) in and posted; CLI typecheck green. Nice work all."
+          }
+        ]
+      }
+    },
+    {
+      "subject": "cotal.console.chat.UCDWCQKOTKCKZ544YR74CMP3JBKSMDCE2BK4BUAVVAE2LP65PZWIUK3S.team",
+      "payload": {
+        "id": "13e155ee-cc50-4d5e-8149-be38c11bc86a",
+        "ts": 1781993252474,
+        "space": "console",
+        "from": {
+          "id": "UCDWCQKOTKCKZ544YR74CMP3JBKSMDCE2BK4BUAVVAE2LP65PZWIUK3S",
+          "name": "opencode-reviewer",
+          "role": "opencode-reviewer"
+        },
+        "channel": "team",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "review findings for activity-pulse:\n\n- Blocking/landing risk: `implementations/cli/src/console/ui/Sparkline.tsx` is still untracked in this workspace (`git status --short`). Since `StatusBar.tsx` imports it, a commit/patch that omits this file will fail module resolution. Include it before landing.\n\nNo code-level behavior findings from read-only review. The data contract is implemented as `rates.activity: number[]` with 15 oldest->newest raw-count 4s buckets, zero-initialized and decayed on idle via `flush()`. StatusBar renders it next to msg/s using fixed-width 15 Sparkline, not terminal-scaled.\n\nVerification caveat: I could not independently complete `pnpm typecheck`; pnpm repeatedly attempted `pnpm add pnpm@11.1.2 ...` and was SIGTERM-killed before TypeScript ran."
+          }
+        ]
+      }
+    },
+    {
+      "subject": "cotal.console.inst.61938b30-9fe2-4f97-8346-289d8f801b08.UCDWCQKOTKCKZ544YR74CMP3JBKSMDCE2BK4BUAVVAE2LP65PZWIUK3S",
+      "payload": {
+        "id": "3ceda9c0-1dd5-495c-8cba-ae4cd863c550",
+        "ts": 1781993252475,
+        "space": "console",
+        "from": {
+          "id": "UCDWCQKOTKCKZ544YR74CMP3JBKSMDCE2BK4BUAVVAE2LP65PZWIUK3S",
+          "name": "opencode-reviewer",
+          "role": "opencode-reviewer"
+        },
+        "to": "61938b30-9fe2-4f97-8346-289d8f801b08",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "done: reviewed"
+          }
+        ]
+      }
+    },
+    {
+      "subject": "cotal.console.chat.1b76b7db-a310-4990-b125-1fb8071baeb6.team",
+      "payload": {
+        "id": "e470358a-efbf-4791-8b5b-f6ecc7062827",
+        "ts": 1781993291917,
+        "space": "console",
+        "from": {
+          "id": "1b76b7db-a310-4990-b125-1fb8071baeb6",
+          "name": "tui-designer",
+          "role": "tui-designer"
+        },
+        "channel": "team",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "landing risk resolved: staged Sparkline.tsx (now tracked, shows `A`), so the StatusBar import won't break on commit. typecheck green locally. ready to land."
+          }
+        ]
+      }
+    }
+  ],
+  "presence": [
+    {
+      "key": "8a80ce53-54f4-491f-8fd3-02b2e13b245a",
+      "value": {
+        "card": {
+          "id": "8a80ce53-54f4-491f-8fd3-02b2e13b245a",
+          "name": "backend",
+          "role": "backend",
+          "kind": "agent"
+        },
+        "status": "idle",
+        "ts": 1782005560676
+      }
+    },
+    {
+      "key": "a0613002-b9ec-4f14-900c-cbcb2fabf54a",
+      "value": {
+        "card": {
+          "id": "a0613002-b9ec-4f14-900c-cbcb2fabf54a",
+          "name": "manager",
+          "role": "manager",
+          "kind": "endpoint"
+        },
+        "status": "idle",
+        "activity": "supervisor (cmux)",
+        "ts": 1782005560701
+      }
+    },
+    {
+      "key": "1b76b7db-a310-4990-b125-1fb8071baeb6",
+      "value": {
+        "card": {
+          "id": "1b76b7db-a310-4990-b125-1fb8071baeb6",
+          "name": "tui-designer",
+          "role": "tui-designer",
+          "kind": "agent"
+        },
+        "status": "idle",
+        "ts": 1782005560703
+      }
+    },
+    {
+      "key": "61938b30-9fe2-4f97-8346-289d8f801b08",
+      "value": {
+        "card": {
+          "id": "61938b30-9fe2-4f97-8346-289d8f801b08",
+          "name": "orchestrator",
+          "role": "orchestrator",
+          "kind": "agent"
+        },
+        "status": "idle",
+        "activity": "activity-pulse sparkline shipped",
+        "ts": 1782005560893
+      }
+    },
+    {
+      "key": "UCDWCQKOTKCKZ544YR74CMP3JBKSMDCE2BK4BUAVVAE2LP65PZWIUK3S",
+      "value": {
+        "card": {
+          "id": "UCDWCQKOTKCKZ544YR74CMP3JBKSMDCE2BK4BUAVVAE2LP65PZWIUK3S",
+          "name": "opencode-reviewer",
+          "role": "opencode-reviewer",
+          "kind": "agent"
+        },
+        "status": "idle",
+        "activity": "cotal_dm",
+        "ts": 1782005561149
+      }
+    }
+  ]
+}

--- a/examples/02-self-improving-console/harness/evaluate.ts
+++ b/examples/02-self-improving-console/harness/evaluate.ts
@@ -77,7 +77,7 @@ const peerDms = dms.filter((m) => {
   return !!from && !!to && !HUB.has(from) && !HUB.has(to) && from !== to;
 });
 const peerPairs = [...new Set(peerDms.map((m) => `${m.from}->${nameOf(m.to) ?? "?"}`))];
-const complete = msgs.some((m) => (m.text ?? "").includes("DEMO COMPLETE"));
+const complete = msgs.some((m) => (m.text ?? "").includes("ALL DONE"));
 const peerToPeer = peerDms.length >= 1;
 
 // "wired": the swarm actually replaced the placeholders — app.tsx is a real component and the

--- a/examples/02-self-improving-console/harness/run-once.sh
+++ b/examples/02-self-improving-console/harness/run-once.sh
@@ -10,7 +10,7 @@
 # - manager headless on the PTY runtime (open stdin + dev-channels auto-confirm)
 # - orchestrator spawned via the manager (`cotal start`); it cotal_spawns the workers
 # - observer logs ALL traffic to .runs/run-<iter>/transcript.jsonl
-# - wait for "DEMO COMPLETE" / timeout, tear down, evaluate (build main + comms)
+# - wait for "ALL DONE" / timeout, tear down, evaluate (build main + comms)
 #
 # Does NOT reset at the end (last run stays inspectable); the next run resets first.
 set -uo pipefail
@@ -74,7 +74,7 @@ log "swarm running (space=$SPACE, timeout=${TIMEOUT}s) — mgr=$MGR obs=$OBS"
 deadline=$(( $(date +%s) + TIMEOUT ))
 outcome="timeout"
 while [ "$(date +%s)" -lt "$deadline" ]; do
-  if grep -q "DEMO COMPLETE" "$TRANSCRIPT" 2>/dev/null; then outcome="complete"; break; fi
+  if grep -q "ALL DONE" "$TRANSCRIPT" 2>/dev/null; then outcome="complete"; break; fi
   if ! kill -0 "$MGR" 2>/dev/null; then outcome="manager-died"; break; fi
   sleep 5
 done

--- a/examples/02-self-improving-console/package.json
+++ b/examples/02-self-improving-console/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@cotal-ai/cmux": "workspace:*",
     "@cotal-ai/connector-core": "workspace:*",
+    "@cotal-ai/connector-opencode": "workspace:*",
     "@cotal-ai/core": "workspace:*",
     "@cotal-ai/manager": "workspace:*"
   },

--- a/examples/02-self-improving-console/replay.ts
+++ b/examples/02-self-improving-console/replay.ts
@@ -1,0 +1,164 @@
+/**
+ * Replay the captured swarm conversation through the live console — for recording a
+ * demo video / GIF. It re-publishes the captured messages (examples/02…/demo-script.json)
+ * back onto the same OPEN mesh the console reads, at an even, readable cadence. Plays
+ * through ONCE and holds the final frame (does not loop). No console/CLI changes: the TUI
+ * renders them exactly as in a live run, and the activity-pulse sparkline animates because
+ * messages arrive in real time.
+ *
+ *   # in the tab you record:
+ *   pnpm cotal up --open        # if NATS isn't already running
+ *   pnpm cotal console --space console
+ *
+ *   # then start recording and, in another tab:
+ *   pnpm tsx examples/02-self-improving-console/replay.ts
+ *
+ * Env knobs:
+ *   STEP_MS         gap between messages (default 1900 → ~45s run; GIF: try 1200 → ~30s)
+ *   START_DELAY_MS  pause before the first message (default 0 = start right away)
+ *   HOLD_MS         hold the final frame before parking (default 4000)
+ *   LOOPS           number of passes (default 1; set 0 to loop forever)
+ *   SERVER          NATS url (default localhost:4222)
+ *
+ * The single `ALL DONE` wrap is floated to the very end so the demo closes on it
+ * (in the real run it landed before the reviewer's last catch — this reads better).
+ * Each agent shows `working` (green) across its active span (first→last message), so
+ * collaborators appear busy concurrently; everyone idles out at the end.
+ */
+// @ts-nocheck — standalone demo script; run via tsx (not part of the typechecked build).
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { connect } from "../../packages/core/node_modules/@nats-io/transport-node/lib/mod.js";
+import { jetstream, jetstreamManager } from "../../packages/core/node_modules/@nats-io/jetstream/lib/mod.js";
+import { Kvm } from "../../packages/core/node_modules/@nats-io/kv/lib/mod.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const script = JSON.parse(readFileSync(join(HERE, "demo-script.json"), "utf8"));
+
+const SERVER = process.env.SERVER ?? "localhost:4222";
+const START_DELAY_MS = Number(process.env.START_DELAY_MS ?? 0); // 0 = start right away
+const STEP_MS = Number(process.env.STEP_MS ?? 1900);
+const HOLD_MS = Number(process.env.HOLD_MS ?? 4000);
+const LOOPS = Number(process.env.LOOPS ?? 1); // 1 = single pass then hold; 0 = loop forever
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const textOf = (m) => (m.payload.parts ?? []).map((p) => p.text ?? "").join(" ");
+const isAllDone = (m) => /ALL DONE/i.test(textOf(m));
+
+let counter = 0;
+const freshId = () => `replay-${Date.now().toString(36)}-${counter++}`;
+
+// Order: everything in capture (ts) order, then float the ALL DONE wrap to the end.
+const inTs = [...script.messages].sort((a, b) => (a.payload.ts ?? 0) - (b.payload.ts ?? 0));
+const SEQ = [...inTs.filter((m) => !isAllDone(m)), ...inTs.filter(isAllDone)];
+
+// Cards for roster/presence animation, keyed by the sender id used in `from`.
+const cards = (script.presence ?? []).map((p) => p.value.card).filter((c) => c?.id);
+
+// Working-status spans: an agent shows `working` (green) from its first message to its last,
+// so collaborators (backend + tui-designer) appear busy concurrently and the reviewer while it
+// reviews. Outside that span it's `idle`. `latestText` feeds the roster's activity line.
+const firstIdx = new Map();
+const lastIdx = new Map();
+SEQ.forEach((m, i) => {
+  const id = m.payload.from?.id;
+  if (id == null) return;
+  if (!firstIdx.has(id)) firstIdx.set(id, i);
+  lastIdx.set(id, i);
+});
+const latestText = new Map();
+
+const nc = await connect({ servers: SERVER });
+const jsm = await jetstreamManager(nc);
+const js = jetstream(nc);
+let presenceKv;
+try {
+  presenceKv = await new Kvm(js).open("cotal_presence_console");
+} catch (e) {
+  console.warn("presence KV unavailable (roster won't populate):", e?.message ?? e);
+}
+
+async function putPresence(card, status, activity) {
+  if (!presenceKv || !card) return;
+  try {
+    await presenceKv.put(card.id, JSON.stringify({ card, status, activity, ts: Date.now() }));
+  } catch {
+    /* best-effort */
+  }
+}
+// Presence KV entries TTL out after 6s, so a heartbeat re-asserts the whole roster every 3s —
+// otherwise the agents vanish during the startup delay, the final hold, and any idle gap.
+// `curStep` drives status: -1 before playback and SEQ.length after both mean "all idle".
+let curStep = -1;
+async function pulse() {
+  await Promise.all(
+    cards.map((c) => {
+      const f = firstIdx.get(c.id);
+      const l = lastIdx.get(c.id);
+      const working = f !== undefined && curStep >= f && curStep <= l;
+      return putPresence(c, working ? "working" : "idle", latestText.get(c.id));
+    }),
+  );
+}
+const heartbeat = setInterval(() => void pulse().catch(() => {}), 3000);
+async function purgeHistory() {
+  for (const s of ["CHAT_console", "DM_console"]) {
+    try {
+      await jsm.streams.purge(s);
+    } catch {
+      /* stream may not exist yet */
+    }
+  }
+}
+
+async function publish(m, i) {
+  const payload = { ...m.payload, id: freshId(), ts: Date.now() };
+  curStep = i;
+  const id = m.payload.from?.id;
+  if (id != null) latestText.set(id, textOf(m).slice(0, 60));
+  await pulse();
+  await js.publish(m.subject, JSON.stringify(payload), { msgID: payload.id });
+}
+
+async function runOnce(passIdx) {
+  await purgeHistory();
+  curStep = -1;
+  latestText.clear();
+  await pulse();
+  for (let i = 0; i < SEQ.length; i++) {
+    await publish(SEQ[i], i);
+    await sleep(i === SEQ.length - 1 ? 0 : STEP_MS);
+  }
+  curStep = SEQ.length; // past every span → everyone idle
+  await pulse();
+  console.log(`  pass ${passIdx} done — holding ${HOLD_MS / 1000}s on the final frame`);
+  await sleep(HOLD_MS);
+}
+
+// Get the mesh into the "ready" frame NOW, so a console joining during the countdown
+// shows an empty feed + the full roster (good first frame to start recording on).
+await purgeHistory();
+await pulse();
+
+const runSecs = Math.round((SEQ.length * STEP_MS + HOLD_MS) / 1000);
+console.log(`Replay ready: ${SEQ.length} messages @ ${STEP_MS}ms  (~${runSecs}s)`);
+if (START_DELAY_MS > 0) {
+  console.log(`First message in ${START_DELAY_MS / 1000}s:`);
+  for (let s = Math.round(START_DELAY_MS / 1000); s > 0; s--) {
+    process.stdout.write(`\r  starting in ${s}s   `);
+    await sleep(1000);
+  }
+  process.stdout.write("\n");
+}
+
+let pass = 0;
+while (LOOPS === 0 || pass < LOOPS) {
+  pass++;
+  console.log(`▶ pass ${pass}`);
+  await runOnce(pass);
+}
+// Done — don't loop, don't exit: hold the final frame. The heartbeat keeps the roster alive
+// so the closing "ALL DONE" + full feed stay on screen until you Ctrl-C.
+console.log("finished — holding the final frame (Ctrl-C to exit)");
+await new Promise(() => {});

--- a/examples/02-self-improving-console/run-agent.sh
+++ b/examples/02-self-improving-console/run-agent.sh
@@ -70,7 +70,7 @@ if [[ "$role" == orchestrator ]]; then
   if [[ -n "${COTAL_HEADLESS:-}" ]]; then
     init=("$(cat "$HERE/GOAL.md")")
   else
-    init=("Onboard me (the operator) in <=6 short lines: what this demo is, that I give you ONE goal and you spawn research/backend/tui-designer into their own tabs, that research seeds the SPEC and backend<->tui-designer settle the data contract peer-to-peer. Show me the goal to paste (from GOAL.md). Then STOP and wait — do NOT spawn yet.")
+    init=("Introduce yourself, and what Cotal is.")
   fi
 fi
 

--- a/examples/02-self-improving-console/src/manager.ts
+++ b/examples/02-self-improving-console/src/manager.ts
@@ -22,14 +22,23 @@ import {
 import { Manager } from "@cotal-ai/manager";
 import { launchEnv } from "@cotal-ai/connector-core";
 import "@cotal-ai/cmux"; // registers the cmux runtime (default here); harmless under COTAL_RUNTIME=pty
+import { opencodeConnector } from "@cotal-ai/connector-opencode"; // the OpenCode launcher (serve + attach TUI)
 import { fileURLToPath } from "node:url";
 
 const RUN_AGENT = fileURLToPath(new URL("../run-agent.sh", import.meta.url));
+const OPENCODE_REVIEWER = fileURLToPath(new URL("../agents/opencode-reviewer.md", import.meta.url));
 
 const roleAgentConnector: Connector = {
   kind: "connector",
   name: "cotal",
   buildLaunch: (opts: LaunchOpts): LaunchSpec => {
+    const role = opts.role ?? opts.name ?? "";
+    // Cross-vendor: an opencode reviewer (role `opencode-*`) launches via the OpenCode connector —
+    // a non-Anthropic peer (GLM-5.1) reviewing the Claude agents' work over the mesh. The agent file
+    // carries its persona + model; the connector runs `opencode serve` + an attached TUI.
+    if (role.startsWith("opencode")) {
+      return opencodeConnector.buildLaunch({ ...opts, configPath: opts.configPath ?? OPENCODE_REVIEWER });
+    }
     // Claude agents via run-agent.sh; `confirm` lets the PTY runtime auto-accept dev-channels.
     return { command: RUN_AGENT, args: [opts.role ?? opts.name], confirm: "Enter to confirm", env: launchEnv() };
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       '@cotal-ai/connector-core':
         specifier: workspace:*
         version: link:../../extensions/connector-core
+      '@cotal-ai/connector-opencode':
+        specifier: workspace:*
+        version: link:../../extensions/connector-opencode
       '@cotal-ai/core':
         specifier: workspace:*
         version: link:../../packages/core


### PR DESCRIPTION
Split out of #197 to keep that PR focused on the views-lens feature — this is the example/demo half, all under `examples/02-self-improving-console/` (private, never published).

Adds the OpenCode cross-vendor reviewer persona, a deterministic `demo-script.json` + `replay.ts` for reproducible demo runs, LAUNCH.md posting assets, and refreshed agent personas/GOAL for the recorded demo. No code outside the example; no dependency on the views API — this can merge independently of the console stack.

Verification: `pnpm typecheck` (the example package compiles); `replay.ts` is exercised by the demo runbook in LAUNCH.md.