### PR TITLE
fix(cli): recover legacy web extension installs

### DIFF
--- a/bin/smoke/ext-live.smoke.ts
+++ b/bin/smoke/ext-live.smoke.ts
@@ -140,6 +140,47 @@ ok("ext list starts empty", /no extensions installed/.test(cotal(["ext", "list"]
   writeFileSync(manifestPath, good);
 }
 
+// -- C4: legacy web package name recovers through the canonical @cotal-ai/web package -----------
+{
+  const good = JSON.parse(readFileSync(manifestPath, "utf8"));
+  writeFileSync(
+    manifestPath,
+    JSON.stringify(
+      {
+        extensions: [
+          ...good.extensions,
+          {
+            pkg: "cotal-web",
+            version: "0.10.0",
+            spec: "/tmp/no-longer-portable/implementations/web",
+            commands: [{ name: "web", summary: "legacy dashboard" }],
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+  const stale = cotal(["web"]);
+  ok(
+    "missing legacy cotal-web prescribes the canonical package, not the stale local path",
+    stale.status === 1 && /extension cotal-web/.test(stale.stderr) && /cotal ext add @cotal-ai\/web/.test(stale.stderr) && !/no-longer-portable/.test(stale.stderr),
+    stale.stderr.slice(0, 300),
+  );
+
+  const webExt = fixture("@cotal-ai/web", GOOD.replace('name: "hello-ext"', 'name: "web"'));
+  const added = cotal(["ext", "add", webExt]);
+  ok("adding @cotal-ai/web replaces legacy cotal-web", added.status === 0, added.stderr.slice(-400));
+  const updated = JSON.parse(readFileSync(manifestPath, "utf8"));
+  ok(
+    "manifest keeps @cotal-ai/web and drops cotal-web",
+    updated.extensions.some((e: { pkg?: string; spec?: string }) => e.pkg === "@cotal-ai/web" && e.spec === "@cotal-ai/web") &&
+      !updated.extensions.some((e: { pkg?: string }) => e.pkg === "cotal-web"),
+    updated.extensions,
+  );
+  ok("canonical remove also clears the web extension", cotal(["ext", "remove", "@cotal-ai/web"]).status === 0);
+}
+
 // -- D: version skew -------------------------------------------------------------------------------
 {
   const meta = JSON.parse(readFileSync(installedPkg, "utf8"));

--- a/implementations/cli/src/commands/ext.ts
+++ b/implementations/cli/src/commands/ext.ts
@@ -16,6 +16,17 @@ import {
 } from "@cotal-ai/workspace";
 import { c } from "../ui.js";
 
+const WEB_EXTENSION_PKG = "@cotal-ai/web";
+const LEGACY_WEB_EXTENSION_PKGS = new Set(["cotal-web"]);
+
+function manifestSpec(pkg: string, resolved: string): string {
+  return pkg === WEB_EXTENSION_PKG ? WEB_EXTENSION_PKG : resolved;
+}
+
+function isLegacyWebReplacement(pkg: string, other: InstalledExtension): boolean {
+  return pkg === WEB_EXTENSION_PKG && LEGACY_WEB_EXTENSION_PKGS.has(other.pkg);
+}
+
 /**
  * `cotal ext` — operator-installed CLI extensions. `add` installs an npm package into the
  * cotal-owned prefix (never the user's project), imports it ONCE so it self-registers into the
@@ -166,15 +177,20 @@ async function add(spec: string): Promise<void> {
   // registry during this add (they aren't imported), so their CACHED names are checked explicitly —
   // a duplicate fails the add under the same contract, naming both sides.
   const manifest = loadExtensionsManifest();
+  const replaced = new Set<string>();
   for (const cm of contributed) {
     const other = manifest.extensions.find((e) => e.pkg !== pkg && e.commands.some((oc) => oc.name === cm.name));
     if (other) {
+      if (isLegacyWebReplacement(pkg, other)) {
+        replaced.add(other.pkg);
+        continue;
+      }
       fail(pkg, `contributes "${cm.name}", already provided by installed extension ${other.pkg}@${other.version} - two extensions cannot claim one command; \`cotal ext remove ${other.pkg}\` first if you want this one`);
     }
   }
   const version = pkgMeta.version ?? "0.0.0";
-  const entry: InstalledExtension = { pkg, version, spec: resolved, commands: contributed.map(cacheCommand) };
-  saveExtensionsManifest({ extensions: [...manifest.extensions.filter((e) => e.pkg !== pkg), entry] });
+  const entry: InstalledExtension = { pkg, version, spec: manifestSpec(pkg, resolved), commands: contributed.map(cacheCommand) };
+  saveExtensionsManifest({ extensions: [...manifest.extensions.filter((e) => e.pkg !== pkg && !replaced.has(e.pkg)), entry] });
   provenance.wrote(`extensions manifest (+${pkg}@${version})`, extensionsManifestPath());
   console.log(c.green(`✓ added ${pkg}@${version}`) + c.dim(` - commands: ${contributed.map((cm) => cm.name).join(", ")}`));
 
@@ -210,19 +226,19 @@ function packageNameFromSpec(resolved: string, isPath: boolean): string {
 
 async function remove(pkg: string): Promise<void> {
   const manifest = loadExtensionsManifest();
-  const entry = manifest.extensions.find((e) => e.pkg === pkg);
+  const entry = manifest.extensions.find((e) => e.pkg === pkg) ?? (pkg === WEB_EXTENSION_PKG ? manifest.extensions.find((e) => LEGACY_WEB_EXTENSION_PKGS.has(e.pkg)) : undefined);
   if (!entry) {
     console.error(c.red(`✗ no installed extension "${pkg}" - see \`cotal ext list\``));
     process.exit(1);
   }
-  const r = npm(["remove", "--no-audit", "--no-fund", pkg], extensionsDir());
+  const r = npm(["remove", "--no-audit", "--no-fund", entry.pkg], extensionsDir());
   if (r.status !== 0) {
     console.error(c.red(`✗ npm remove failed:\n${r.output.split("\n").slice(-6).join("\n")}`));
     process.exit(1);
   }
-  saveExtensionsManifest({ extensions: manifest.extensions.filter((e) => e.pkg !== pkg) });
-  provenance.wrote(`extensions manifest (−${pkg})`, extensionsManifestPath());
-  console.log(c.green(`✓ removed ${pkg}`) + c.dim(` - commands gone: ${entry.commands.map((cm) => cm.name).join(", ")}`));
+  saveExtensionsManifest({ extensions: manifest.extensions.filter((e) => e.pkg !== entry.pkg) });
+  provenance.wrote(`extensions manifest (−${entry.pkg})`, extensionsManifestPath());
+  console.log(c.green(`✓ removed ${entry.pkg}`) + c.dim(` - commands gone: ${entry.commands.map((cm) => cm.name).join(", ")}`));
 }
 
 function list(): void {

--- a/implementations/cli/src/commands/setup.ts
+++ b/implementations/cli/src/commands/setup.ts
@@ -3,7 +3,7 @@ import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node
 import { join } from "node:path";
 import * as p from "@clack/prompts";
 import { registry, type Connector, type FlagSpec, type FlagValues, type ParsedArgs } from "@cotal-ai/core";
-import { homeCotalDir, loadExtensionsManifest, provenance } from "@cotal-ai/workspace";
+import { homeCotalDir, installedExtensionVersion, loadExtensionsManifest, provenance } from "@cotal-ai/workspace";
 import { brand, brandBold, dim, ok, note, splash } from "../lib/theme.js";
 import { runSteps, type Step } from "../lib/steps.js";
 import { abortIfCancel } from "../lib/cancel.js";
@@ -264,7 +264,7 @@ async function runEnsure(demo: boolean): Promise<void> {
  *  `@cotal-ai/web` in stage 4) — decides whether the ready-card says "start it" or "install it". */
 function webInstalled(): boolean {
   try {
-    return loadExtensionsManifest().extensions.some((e) => e.commands.some((cm) => cm.name === "web"));
+    return loadExtensionsManifest().extensions.some((e) => installedExtensionVersion(e.pkg) !== undefined && e.commands.some((cm) => cm.name === "web"));
   } catch {
     return false; // corrupt manifest — the card stays honest ("not installed"); `ext` commands surface the error
   }

--- a/implementations/cli/src/ext-loader.ts
+++ b/implementations/cli/src/ext-loader.ts
@@ -11,6 +11,21 @@ import {
 } from "@cotal-ai/workspace";
 import { c } from "./ui.js";
 
+const WEB_EXTENSION_PKG = "@cotal-ai/web";
+const LEGACY_WEB_EXTENSION_PKGS = new Set(["cotal-web"]);
+
+function reAddSpec(ext: InstalledExtension): string {
+  return ext.pkg === WEB_EXTENSION_PKG || LEGACY_WEB_EXTENSION_PKGS.has(ext.pkg) ? WEB_EXTENSION_PKG : ext.spec;
+}
+
+function importFailure(pkg: string, ext: InstalledExtension, e: unknown): Error {
+  const message = e instanceof Error ? e.message : String(e);
+  const compatibility = /does not provide an export named/.test(message) && /@cotal-ai\/(core|workspace)/.test(message)
+    ? " (the extension is not compatible with this cotal binary's linked @cotal-ai/* packages; update the binary and extension together)"
+    : "";
+  return new Error(`extension ${pkg}@${ext.version} failed to import: ${message}${compatibility} - reinstall it: \`cotal ext add ${reAddSpec(ext)}\``);
+}
+
 /**
  * The installed-extensions loader — opt-in for the PUBLISHED binary only (`runCli(…, { extensions:
  * true })`); library composition roots keep the explicit-import model.
@@ -102,11 +117,11 @@ export async function materializeExtensionCommand(stub: Command): Promise<Comman
   if (!ext) throw new Error(`extension ${pkg} vanished from the manifest - \`cotal ext add\` it again`);
   const onDisk = installedExtensionVersion(pkg);
   if (!onDisk) {
-    throw new Error(`extension ${pkg} is in the manifest but not installed at ${extensionPackageDir(pkg)} - \`cotal ext add ${ext.spec}\` again`);
+    throw new Error(`extension ${pkg} is in the manifest but not installed at ${extensionPackageDir(pkg)} - \`cotal ext add ${reAddSpec(ext)}\` again`);
   }
   if (onDisk !== ext.version) {
     throw new Error(
-      `extension ${pkg} is ${onDisk} on disk but the manifest pinned ${ext.version} (its cached command surface may be stale) - re-add it: \`cotal ext add ${ext.spec}\``,
+      `extension ${pkg} is ${onDisk} on disk but the manifest pinned ${ext.version} (its cached command surface may be stale) - re-add it: \`cotal ext add ${reAddSpec(ext)}\``,
     );
   }
   const dir = extensionPackageDir(pkg);
@@ -121,11 +136,11 @@ export async function materializeExtensionCommand(stub: Command): Promise<Comman
   try {
     await import(pathToFileURL(join(dir, entry)).href); // self-registers into OUR registry (core is linked)
   } catch (e) {
-    throw new Error(`extension ${pkg}@${ext.version} failed to import: ${(e as Error).message} - reinstall it: \`cotal ext add ${ext.spec}\``);
+    throw importFailure(pkg, ext, e);
   }
   const live = registry.all<Command>("command").find((cm) => cm.name === stub.name);
   if (!live) {
-    throw new Error(`extension ${pkg} imported but did not register "${stub.name}" - its cache is stale; re-add it: \`cotal ext add ${ext.spec}\``);
+    throw new Error(`extension ${pkg} imported but did not register "${stub.name}" - its cache is stale; re-add it: \`cotal ext add ${reAddSpec(ext)}\``);
   }
   return live;
 }


### PR DESCRIPTION
## What
- Treat legacy cotal-web manifest entries as @cotal-ai/web for recovery hints and replacement.
- Store @cotal-ai/web as the canonical re-add spec for web installs.
- Make setup ignore missing manifest-only web entries.
- Add live smoke coverage for stale cotal-web manifests.

## Tests
- pnpm --filter @cotal-ai/cli... build
- pnpm --filter @cotal-ai/cli typecheck
- pnpm --filter cotal-ai... build
- pnpm --filter cotal-ai typecheck
- pnpm smoke:ext:live