### PR TITLE
fix(pi): add repository field to package.json (unblock the 0.11.3 release)

### DIFF
--- a/extensions/pi/package.json
+++ b/extensions/pi/package.json
@@ -2,6 +2,11 @@
   "name": "@cotal-ai/pi",
   "version": "0.11.3",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Cotal-AI/Cotal.git",
+    "directory": "extensions/pi"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Why

The `0.11.3` release (version PR #224) failed at the npm publish step:

```
📦 @cotal-ai/pi@0.11.3 → registry.npmjs.org
[E422] Error verifying sigstore provenance bundle: Failed to validate repository information:
       package.json: "repository.url" is "", expected "https://github.com/Cotal-AI/Cotal"
```

`extensions/pi/package.json` had no `repository` field. The release publishes with npm provenance (sigstore), which requires it. `@cotal-ai/pi` is the only publishable package missing it. The failure aborted the rest of the publish, so:

- `cotal-ai` (the binary), `@cotal-ai/pi`, `@cotal-ai/manager`, `@cotal-ai/cli`, `@cotal-ai/delivery`, `@cotal-ai/web` never reached `0.11.3` on npm (core/workspace/connector-*/orca did);
- no `v0.11.3` GitHub Release or tag was cut (the release step is gated on a successful publish and on `cotal-ai@<version>` being live on npm, both of which failed).

## Fix

Add the `repository` field to `extensions/pi/package.json`, matching every sibling package.

## Recovery

Merging this to `main` re-runs `changesets.yml`. With the changeset already consumed, it runs the publish command, which skips the packages already at `0.11.3` and publishes the remaining ones (including `cotal-ai@0.11.3`). The GitHub Release step then runs on success and cuts `v0.11.3` + tag + notes.