### PR TITLE
fix(connector-claude-code): reconcile wakes lost before channel activation

### DIFF
--- a/.changeset/pending-wake-boot-race.md
+++ b/.changeset/pending-wake-boot-race.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/connector-claude-code": patch
+---
+
+Fix the boot lost-wake race that left a session spawned with a message already pending permanently deaf: reconcile the wake once the claude/channel handshake activates, and add a 30s idle reconciler that re-nudges whenever wake-pending messages sit in the inbox while the session is idle.

--- a/extensions/connector-claude-code/src/mcp.ts
+++ b/extensions/connector-claude-code/src/mcp.ts
@@ -204,11 +204,12 @@ async function main(): Promise<void> {
   // One wake-nudge path, shared by incoming messages and the Stop→idle flush. It stays a stable
   // function gated on a *mutable* `channelActive` flag (flipped true only after the MCP
   // handshake confirms the client speaks claude/channel — see below). If it fires before then it
-  // simply no-ops; a *buffered* message waits in the inbox and is drained at the next
-  // UserPromptSubmit, so nothing is lost. This only ever *wakes* a turn (drainInbox and the focus
-  // ingest ack-drop are the ack sites). One exception: a focus @mention's body was already
-  // ack-dropped at ingest (not buffered), so a missed mention-wake is recoverable only by an
-  // explicit cotal_inbox pull (recall) — there is no buffered copy to drain.
+  // simply no-ops; the *buffered* message stays in the inbox and the post-handshake reconcile +
+  // idle reconciler below re-fire the wake, so the message still surfaces without a human turn.
+  // This only ever *wakes* a turn (drainInbox and the focus ingest ack-drop are the ack sites).
+  // One exception: a focus @mention's body was already ack-dropped at ingest (not buffered), so a
+  // missed mention-wake is recoverable only by an explicit cotal_inbox pull (recall) — there is
+  // no buffered copy to drain.
   let channelActive = false;
   const nudge = (item?: InboxItem, pullHint?: string): void => {
     if (!channelActive) return;
@@ -262,6 +263,24 @@ async function main(): Promise<void> {
   process.stderr.write(
     `[cotal-connector] client capabilities: ${JSON.stringify(clientCaps ?? {})} → channel ${channelActive ? "ACTIVE" : "off"}\n`,
   );
+
+  // Post-activation reconcile: an "incoming" that fired before the flag flipped was nudge-dropped
+  // — a spawn with a DM already pending delivers within ms of the durable bind, well before this
+  // point — and JetStream redelivery never re-emits it (ingest's pending-duplicate branch only
+  // refreshes the ack handle). Without a re-fired wake the session sits idle-but-deaf forever.
+  if (agent.pendingWake() > 0) nudge();
+
+  // Idle reconciler — the self-healing net for every lost-wake class, not just the boot race: the
+  // client declares claude/channel at the handshake but registers its notification handler
+  // asynchronously (observed ~1.4s later), so even the reconcile above can land in a window where
+  // the push is silently discarded client-side. A nudge has no ack, so re-derive from state:
+  // wake-pending messages while idle ⇒ a wake was lost ⇒ fire it again. pendingWake() is the same
+  // mode-and-channel-aware predicate as the Stop→idle flush (held quiet/dnd ambient never wakes),
+  // and a delivered wake drains the inbox on its UserPromptSubmit, so re-nudges stop themselves —
+  // no storm. unref: never holds the process open.
+  setInterval(() => {
+    if (channelActive && agent.status === "idle" && agent.pendingWake() > 0) nudge();
+  }, 30_000).unref();
 
   process.stderr.write(
     `[cotal-connector] MCP ready (stdio) — space="${config.space}" name="${config.name}"${config.role ? ` role="${config.role}"` : ""}\n`,


### PR DESCRIPTION
## Symptom

An agent spawned **with a DM already pending** in its JetStream durable consumer becomes a permanent zombie: presence is fine, the consumer pulls fine, but it never takes a turn. Observed live on a real space (spawn-on-dm, 2026-07-12):

- `12:43:53` session spawned; NATS connect + durable consumer `dm_<id>` bound at `:55.825`
- the pending DM was delivered within ms → `ingest()` buffered it and emitted its one `"incoming"` → `nudge()`
- MCP transport connected at `:55.868` (`channelActive` flips there), but the client registered its `notifications/claude/channel` handler only at `:57.245` ("Channel notifications registered") — the nudge landed inside that ~1.4s window and was silently discarded
- every 60s JetStream redelivery hit the pending-duplicate branch in `ingest()`, which only refreshes the ack handle and returns without re-emitting — so no re-nudge, ever
- net: the message sat buffered and unacked forever while the session idled

Confirmed by sending a second DM: it took the new-item path, re-nudged (channel live by then), and that one turn drained **both** messages.

## Mechanism (at upstream/main)

- `extensions/connector-claude-code/src/mcp.ts:212-214` — `nudge()` is gated on the mutable `channelActive`, `false` until post-handshake
- `mcp.ts:133` — `agent.start()` kicks off the mesh connect in the background, so a pending message can arrive and emit `"incoming"` (`mcp.ts:235-240`) **before** `await server.connect(transport)` (`mcp.ts:252`) flips the flag (`mcp.ts:257-261`)
- even after the flip there is a second loss window: the client declares the `claude/channel` capability at the handshake but registers its notification handler asynchronously (~1.4s later in the observed trace), and a notification has no ack — a push in that window vanishes
- `extensions/connector-core/src/agent.ts:264-268` — a redelivered duplicate of a still-pending item only refreshes the ack handle (correctly, to keep one entry and never downgrade a durable ack) and returns without emitting, so redelivery can never heal a lost wake
- the comment at `mcp.ts:204-211` assumed a buffered message "is drained at the next UserPromptSubmit, so nothing is lost" — a freshly spawned agent that never gets a human turn has no next UserPromptSubmit

## Fix

Two parts, both re-deriving the wake from state instead of trusting any single notification to land:

1. **Post-activation reconcile** — immediately after `channelActive` flips, if `pendingWake() > 0`, fire the nudge once. Covers everything that emitted `"incoming"` while the gate was closed.
2. **Idle reconciler** — a 30s `setInterval` (unref'd): if the channel is active, the session is idle, and `pendingWake() > 0`, re-nudge. This is the self-healing net for the whole lost-wake class (handler-not-yet-registered window, a dropped notification, any future race), not just this boot ordering.

`pendingWake()` is the same mode-and-channel-aware predicate the Stop→idle flush already uses, so held quiet/dnd ambient still never wakes a turn. No storm risk: a delivered wake drains the inbox on its UserPromptSubmit, which zeroes the predicate; the gate on `status === "idle"` keeps it silent mid-turn and while blocked on a permission. I considered also re-emitting from `ingest()`'s duplicate branch, but the reconciler subsumes it without touching the shared dedup logic, so I left that branch alone.

## Verification

- root cause and the dual-drain confirmation observed on a live mesh (timeline above) **before** writing the fix; the patched build has not been soaked against a live mesh
- `pnpm typecheck` clean across the workspace; `pnpm test` passes; `pnpm build` of the connector bundles the new paths into `dist/mcp.cjs`
- there is no existing harness that drives `mcp.ts`'s `main()` with a real MCP client, so the reconcile paths have no hermetic test; happy to add one if you can point me at a preferred harness shape
