### PR TITLE
chore(release): add @cotal-ai/web to the fixed version group

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,6 +10,7 @@
       "@cotal-ai/cli",
       "@cotal-ai/manager",
       "@cotal-ai/delivery",
+      "@cotal-ai/web",
       "@cotal-ai/cmux",
       "@cotal-ai/orca",
       "@cotal-ai/tmux",


### PR DESCRIPTION
## Why

`@cotal-ai/web` was the only publishable, non-example package missing from the changeset `fixed` group in `.changeset/config.json`. The other 15 packages (incl. the sibling surfaces `cli`/`manager`/`delivery`/`auth`) are locked to one shared version, so a changeset touching any of them bumps them all. `web` sat outside that group and drifted off the line: it stayed at `0.11.1` while the group reached `0.11.3` (its `*` peer ranges plus `onlyUpdatePeerDependentsWhenOutOfRange` meant it was never force-bumped either).

This is an oversight, not intentional independent versioning.

## Change

Add `@cotal-ai/web` to the `fixed` array (alongside the other implementations). Config-only.

## Effect

From the next release, `web` versions in lockstep with the group. It is not retroactively republished here (no changeset, no publish); it will catch up to the group's version on the next bump. If you want `web` aligned immediately (e.g. cut `@cotal-ai/web@0.11.3` now), that's a separate changeset + release.