### PR TITLE
chore(release): align @cotal-ai/web to 0.11.3

### DIFF
--- a/implementations/web/CHANGELOG.md
+++ b/implementations/web/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @cotal-ai/web
 
+## 0.11.3
+
+### Patch Changes
+
+- Version alignment: `@cotal-ai/web` joined the workspace's fixed release group, so its version now tracks the rest of the packages. It had lagged at 0.11.1 while the group reached 0.11.3; this republishes it at 0.11.3 to close the gap. No functional changes.
+
 ## 0.11.1
 
 ### Patch Changes

--- a/implementations/web/package.json
+++ b/implementations/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cotal-ai/web",
   "description": "Cotal browser observability dashboard — adds the `web` command to the cotal CLI (install: cotal ext add @cotal-ai/web).",
-  "version": "0.11.1",
+  "version": "0.11.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Why

`@cotal-ai/web` was missing from the changeset `fixed` group, so it drifted to `0.11.1` while the rest of the workspace reached `0.11.3`. It's now in the group (previous PR), but a normal changeset would carry the **whole** group forward to `0.11.4` rather than fill the gap at `0.11.3`.

## What

Set `@cotal-ai/web` version to `0.11.3` directly (+ a CHANGELOG note). No functional change — this is a version alignment.

## How it publishes

On merge, `changesets.yml` runs the publish step (`pnpm build && pnpm publish -r --provenance`). `pnpm publish -r` skips every package already on npm and publishes only the new version, so it ships **just `@cotal-ai/web@0.11.3`**. `web` already carries a valid `repository` field, so provenance passes (unlike the pi 422). The GitHub Release step no-ops (`v0.11.3` already exists).

After this, `web` tracks the group and rides the next bump (to `0.11.4`) normally.