### PR TITLE
fix(core): kill the cred-lifetime Windows flake (deterministic stale-auth)

### DIFF
--- a/packages/core/smoke/cred-lifetime-auth.smoke.ts
+++ b/packages/core/smoke/cred-lifetime-auth.smoke.ts
@@ -115,13 +115,18 @@ try {
   const expired = newIdentity();
   const expiredCreds = await mintCreds(auth, expired, "probe", { expiresAt: now - 1 });
   check("expired copied cred is broker-denied on connect", await tryConnect(expiredCreds, expired.id) === "rejected");
-  // D5 slice 6: the probe CLASSIFIES credential death — an expired cred on a LIVE broker is
-  // "stale-auth" (repair: doctor auth), never conflated with "wrong creds" or "mesh down".
-  // Give the probe a generous connect budget: the default 1s doctor timeout can be beaten by a slow
-  // CI/Windows TCP+auth round-trip, misclassifying a provably-expired cred as "unreachable". The
-  // classification (expired -> stale-auth) is what's under test here, not connect latency.
-  const staleProbe = await probeConnect(SERVERS, { creds: expiredCreds, timeoutMs: 8000 });
+  // D5 slice 6: the probe CLASSIFIES credential death — a provably-expired cred is "stale-auth"
+  // (repair: doctor auth), never conflated with "wrong creds" or "mesh down". The classification
+  // reads the cred's own JWT exp LOCALLY, so it does not depend on the connect outcome — it can't be
+  // flaked by a slow CI/Windows handshake racing the broker's rejection against the socket close.
+  const staleProbe = await probeConnect(SERVERS, { creds: expiredCreds });
   check("probeConnect classifies an expired cred as stale-auth (the structured diagnostic)", !staleProbe.ok && staleProbe.reason === "stale-auth", staleProbe);
+  // Reachability-independent BY CONSTRUCTION: the same expired cred against a broker that never
+  // answers is still stale-auth (the dead cred is the actionable truth). This is the exact scenario
+  // that used to flake — a bare transport failure instead of a clean AuthorizationError — and it now
+  // resolves deterministically on every OS regardless of connect latency.
+  const deadProbe = await probeConnect("nats://127.0.0.1:1", { creds: expiredCreds, timeoutMs: 500 });
+  check("probeConnect classifies an expired cred as stale-auth even when unreachable (the flake, killed)", !deadProbe.ok && deadProbe.reason === "stale-auth", deadProbe);
 
   const fresh = newIdentity();
   const freshCreds = await mintCreds(auth, fresh, "probe", { expiresInSeconds: 60 });

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -3183,10 +3183,12 @@ export async function isReachable(
 
 /** What a connect attempt told us about the server — the distinction {@link isReachable} flattens.
  *  `auth-required` means a server answered but rejected these creds (so it IS up); `stale-auth`
- *  means the server is up and the PRESENTED CREDENTIAL ITSELF is dead — expired by its bounded
- *  lifetime (the broker's "authentication expired", or a cred that is locally provably expired) —
- *  the D5 credential-death event, whose repair is `doctor auth`, never a registry prune;
- *  `unreachable` means nothing answered (refused / timeout / a stale registry entry). */
+ *  means the PRESENTED CREDENTIAL ITSELF is dead — expired by its bounded lifetime, either because
+ *  the broker said "authentication expired" or because the cred is LOCALLY PROVABLY expired (its own
+ *  JWT `exp` is past). The local check is decided without a round-trip, so a slow or failed connect
+ *  never downgrades a dead cred to `unreachable`; the repair is `doctor auth` either way, never a
+ *  registry prune (the D5 credential-death event). `unreachable` means nothing usable answered and
+ *  the cred is not provably dead (refused / timeout / a stale registry entry). */
 export type ProbeResult =
   | { ok: true }
   | { ok: false; reason: "auth-required" }
@@ -3213,19 +3215,21 @@ export async function probeConnect(
     await nc.close();
     return { ok: true };
   } catch (e) {
-    if (e instanceof UserAuthenticationExpiredError) return { ok: false, reason: "stale-auth" };
-    if (e instanceof AuthorizationError) {
-      // The broker's denial is generic; local knowledge isn't. A presented cred that is PROVABLY
-      // expired by its own JWT is stale-auth (credential death), not "wrong mesh/creds" — the
-      // repair differs (doctor auth vs re-target), so the classification must too. Unreadable
-      // content stays a plain rejection (no false stale diagnosis from garbage).
-      if (typeof opts.creds === "string") {
-        try {
-          if (inspectCredHealth(opts.creds).state === "expired") return { ok: false, reason: "stale-auth" };
-        } catch { /* not introspectable — keep the wire truth */ }
-      }
-      return { ok: false, reason: "auth-required" };
+    // A presented cred that is PROVABLY expired by its own JWT is stale-auth (credential death) —
+    // and that is knowable LOCALLY, without the network, so it is decided FIRST, before the error
+    // type. On the wire the broker's rejection and the socket close race: a slow CI/Windows handshake
+    // can surface a bare transport failure (→ "unreachable") instead of a clean AuthorizationError,
+    // which used to misclassify a dead cred. Reading the cred removes that timing dependency entirely,
+    // so the classification is deterministic. Unreadable content falls through to the wire truth (no
+    // false stale diagnosis from garbage).
+    if (typeof opts.creds === "string") {
+      try {
+        if (inspectCredHealth(opts.creds).state === "expired") return { ok: false, reason: "stale-auth" };
+      } catch { /* not introspectable — keep the wire truth */ }
     }
+    if (e instanceof UserAuthenticationExpiredError) return { ok: false, reason: "stale-auth" };
+    // The broker answered but rejected these creds (so it IS up) — auth-required, not stale-auth.
+    if (e instanceof AuthorizationError) return { ok: false, reason: "auth-required" };
     return { ok: false, reason: "unreachable" };
   }
 }


### PR DESCRIPTION
## The flake

`smoke:cred-lifetime` (Windows CI, auth shard) intermittently failed:

```
✗ probeConnect classifies an expired cred as stale-auth  { ok: false, reason: 'unreachable' }
```

## Root cause

`probeConnect` classified a connect error by TYPE: `AuthorizationError → stale-auth/auth-required`, everything else → `unreachable`. The local `inspectCredHealth` check (which knows the cred is expired from its JWT, no network) was buried *inside* the `AuthorizationError` branch.

On a slow CI/Windows handshake, the broker's auth rejection and the socket close **race**: the client sometimes surfaces a bare transport error instead of a clean `AuthorizationError`, so it fell through to `unreachable` — misclassifying a provably-dead cred. The timeout was never the trigger (an earlier fix bumped it to 8s and it still flaked); the **error type** is the non-deterministic part.

## Fix

A cred's death is knowable **locally** (its JWT `exp`), so decide it first: hoist the `inspectCredHealth` expired check **above** the error-type dispatch. A provably-expired cred is now `stale-auth` regardless of how (or whether) the connect failed — deterministic on every OS, zero network-timing dependency. Repair is `doctor auth` either way.

Side effect (intended): expired-cred + down-mesh now reports the dead cred (the actionable, blocking fact) instead of only `unreachable`. No-creds probes are unchanged (still `unreachable`).

## Verification

- `smoke:cred-lifetime` run **5×** locally, green each time.
- New **reachability-independent regression guard**: an expired cred against a dead port (`nats://127.0.0.1:1`) must classify `stale-auth` — this exercises the exact "transport error, not auth error" path that flaked, deterministically on every platform. Dropped the ineffective 8s test band-aid.
- No regression: `smoke:preflight` (65 checks, no-creds `unreachable` path intact) and `smoke:doctor-auth` (20 checks) green.

Type: `@cotal-ai/core`. No changeset included (version bump left to you).