### PR TITLE
fix(cli): report detached stack components

### DIFF
--- a/bin/smoke/up-stack-live.smoke.ts
+++ b/bin/smoke/up-stack-live.smoke.ts
@@ -18,6 +18,7 @@ import { createConnection, createServer, type AddressInfo } from "node:net";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { renderDetachedSummary } from "../../implementations/cli/src/lib/up-report.js";
 
 // Ephemeral OS-assigned port: no fixed-port collision across back-to-back / concurrent runs.
 const freePort = (): Promise<number> =>
@@ -46,6 +47,7 @@ const ok = (name: string, cond: boolean, extra?: unknown) => {
   console.log(`  ✓ ${name}`);
 };
 const cli = (...args: string[]) => spawnSync(TSX, [CLI, ...args], { cwd: root, env, encoding: "utf8", timeout: 120_000 });
+const plain = (text: string) => text.replace(/\x1b\[[0-9;]*m/g, "");
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 const alive = (pid: number) => {
   try {
@@ -68,6 +70,19 @@ const cliIn = (cwd: string, ...args: string[]) => spawnSync(TSX, [CLI, ...args],
 const pids: number[] = [];
 let startedOccupant = false;
 try {
+  ok("detached summary omits unavailable mode-dependent components", renderDetachedSummary({
+    pid: 42,
+    delivery: false,
+    authService: false,
+    manager: false,
+  }) === "✓ running in the background: nats-server (pid 42) - stop with: cotal down");
+  ok("detached summary reports partial component availability independently", renderDetachedSummary({
+    pid: 42,
+    delivery: true,
+    authService: false,
+    manager: false,
+  }) === "✓ running in the background: nats-server (pid 42), delivery daemon - stop with: cotal down");
+
   // Default-port collision: `up` without an explicit `--server` should allocate a free port and
   // record it, not fail with "use --server ...:<port>". If the developer already has a real :4222
   // broker, leave it alone; otherwise start a sandbox occupant and tear it down below.
@@ -87,7 +102,12 @@ try {
   // 1) the full stack comes up from ONE command, JWT-authed by default.
   const up = cli("up", "--detach", "--server", SERVER);
   ok("up --detach exits 0", up.status === 0, up.stdout + up.stderr);
-  ok("up --detach reports the background mesh", /mesh running in the background/.test(up.stdout), up.stdout);
+  ok(
+    "auth up reports the exact running component set",
+    /^✓ running in the background: nats-server \(pid \d+\), delivery daemon, manager - stop with: cotal down$/m.test(plain(up.stdout)),
+    up.stdout,
+  );
+  ok("old generic background wording is absent", !/mesh running in the background/.test(up.stdout), up.stdout);
   for (const [file, label] of [["nats.pid", "nats-server"], ["delivery.pid", "delivery daemon"], ["manager.pid", "manager"]] as const) {
     const pid = pidOf(file);
     pids.push(pid);
@@ -120,6 +140,20 @@ try {
   }
   ok("all pid files removed by down", (["nats.pid", "delivery.pid", "manager.pid"] as const).every((f) => !existsSync(join(root, ".cotal", f))));
   ok("all three processes are dead + broker port closed", dead, pids.filter(alive));
+
+  // Open mode in the SAME root retains static-auth files from the prior boot. Reporting follows the
+  // effective live mode, not stale on-disk auth material: broker + manager, never delivery/auth-service.
+  ok("static auth material remains before the open-mode reporting check", existsSync(join(root, ".cotal", "auth")));
+  const open = cli("up", "--detach", "--open", "--server", SERVER);
+  ok("open up --detach exits 0", open.status === 0, open.stdout + open.stderr);
+  ok(
+    "open up reports the exact running component set",
+    /^✓ running in the background: nats-server \(pid \d+\), manager - stop with: cotal down$/m.test(plain(open.stdout)),
+    open.stdout,
+  );
+  ok("open summary omits auth-only components", !/running in the background:.*(?:delivery daemon|user-auth service)/.test(open.stdout), open.stdout);
+  const openDown = cli("down");
+  ok("open down exits 0", openDown.status === 0, openDown.stdout + openDown.stderr);
 
   console.log(`\nUP-STACK LIVE SMOKE OK ✅ (${pass} checks)`);
 } finally {

--- a/implementations/auth/smoke/user-auth-launch.smoke.ts
+++ b/implementations/auth/smoke/user-auth-launch.smoke.ts
@@ -53,6 +53,7 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
   else { fail++; console.log(`  ✗ FAIL: ${name}`, extra ?? ""); }
 };
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const plain = (text: string) => text.replace(/\x1b\[[0-9;]*m/g, "");
 const until = async (cond: () => boolean, ms = 8000): Promise<boolean> => {
   const end = Date.now() + ms;
   while (!cond() && Date.now() < end) await wait(100);
@@ -124,6 +125,11 @@ try {
   const up = await cotal(["up", "--user-auth", "--idp", base, "--detach", "--server", SERVER, "--space", SPACE]);
   check("up exits 0", up.status === 0, up.out);
   check("up announces the user-auth service + login line", up.out.includes("user-auth service up") && up.out.includes(`cotal login --idp ${base}`), up.out);
+  check(
+    "up summary reports the complete user-auth component set",
+    /^✓ running in the background: nats-server \(pid \d+\), delivery daemon, user-auth service, manager - stop with: cotal down$/m.test(plain(up.out)),
+    up.out,
+  );
   const stateDir = userAuthStateDir(root, SPACE);
   for (const f of ["callout.json", "issuer.json", "owner-secret.json", "idp.json", "service-keys.json", "auth-service.json"])
     check(`space-scoped state exists: ${f}`, existsSync(join(stateDir, f)));

--- a/implementations/cli/src/commands/up.ts
+++ b/implementations/cli/src/commands/up.ts
@@ -53,7 +53,8 @@ import { resolveSpace } from "../lib/status.js";
 import { c } from "../ui.js";
 import { resolveNatsServer } from "../lib/nats-bin.js";
 import { cotalPath, cotalRoot } from "../lib/paths.js";
-import { ensureControlPlane, stopDelivery } from "../lib/delivery-proc.js";
+import { renderDetachedSummary } from "../lib/up-report.js";
+import { deliveryUp, ensureControlPlane, stopDelivery } from "../lib/delivery-proc.js";
 import { managerHasDeliveryMarker, managerUp, stopManager } from "../lib/manager-proc.js";
 import { loadManifest, type PreparedManifest } from "../lib/manifest/index.js";
 import { buildLaunchSpec, genRunId, manifestToChannels, preflightConnectors, writeLaunchSpec } from "../lib/manifest/apply.js";
@@ -223,7 +224,7 @@ export async function up(args: ParsedArgs): Promise<void> {
   }
 
   if (values.detach) {
-    const { pid, source, authService } = await startMeshDetached({
+    const { pid, source, authService, delivery, manager } = await startMeshDetached({
       server,
       storeDir: values["store-dir"],
       space: values.space,
@@ -234,7 +235,7 @@ export async function up(args: ParsedArgs): Promise<void> {
       runtime: values.runtime,
     });
     console.log(c.dim(`Started nats-server (${source}).`));
-    console.log(c.green(`✓ mesh running in the background (pid ${pid}) - stop with: cotal down`));
+    console.log(c.green(renderDetachedSummary({ pid, delivery, authService: wantUser && authService, manager })));
     // A user mesh whose auth service never became ready is recorded + running (a re-`cotal up`
     // heals it), but this `up` did NOT deliver what was asked — automation must see that in the
     // exit code, not only in the red line above.
@@ -542,7 +543,7 @@ export interface DetachOpts {
  */
 export async function startMeshDetached(
   opts: DetachOpts = {},
-): Promise<{ server: string; pid: number; source: string; controlPlane: boolean; authService: boolean }> {
+): Promise<{ server: string; pid: number; source: string; controlPlane: boolean; authService: boolean; delivery: boolean; manager: boolean }> {
   const server = opts.server ?? DEFAULT_SERVER;
   const useAuth = !opts.open;
   const space = opts.space ?? resolveSpace(process.cwd());
@@ -589,7 +590,15 @@ export async function startMeshDetached(
   });
   // Bring up the delivery daemon WITH the detached broker (auth mode only; `cotal down` tears both down).
   const controlPlane = await startDeliveryWithBroker(space, server, { runtime: opts.runtime, launch: opts.launch });
-  return { server, pid: child.pid ?? 0, source, controlPlane, authService: svc.ok };
+  return {
+    server,
+    pid: child.pid ?? 0,
+    source,
+    controlPlane,
+    authService: svc.ok,
+    delivery: useAuth && deliveryUp(),
+    manager: managerUp(),
+  };
 }
 
 /** THE FLIP, open-boot edition: `--open` must never boot a credless broker over a root whose

--- a/implementations/cli/src/lib/up-report.ts
+++ b/implementations/cli/src/lib/up-report.ts
@@ -1,0 +1,15 @@
+export interface DetachedStatus {
+  pid: number;
+  delivery: boolean;
+  authService: boolean;
+  manager: boolean;
+}
+
+/** Render only components confirmed running for this detached boot. */
+export function renderDetachedSummary(status: DetachedStatus): string {
+  const components = [`nats-server (pid ${status.pid})`];
+  if (status.delivery) components.push("delivery daemon");
+  if (status.authService) components.push("user-auth service");
+  if (status.manager) components.push("manager");
+  return `✓ running in the background: ${components.join(", ")} - stop with: cotal down`;
+}


### PR DESCRIPTION
## Summary
- replace the generic `cotal up --detach` success line with the confirmed background component set
- gate delivery reporting by effective auth mode and process liveness
- cover static-auth, open, user-auth, and partial-degradation output exactly

## Tests
- `pnpm typecheck`
- `pnpm smoke:up-stack:live` (22 checks)
- `pnpm smoke:user-auth-launch:live` (50 checks)

## Review
Final engineering, security, and critic reviews approved with no remaining findings.