### PR TITLE
fix(cli): default persona reads-permitted, not auto-subscribed to all

### DIFF
--- a/implementations/cli/src/commands/setup.ts
+++ b/implementations/cli/src/commands/setup.ts
@@ -404,13 +404,19 @@ function writeDemoAgent(path: string, body: string): void {
 
 /** The default persona `cotal spawn` (no name) launches: a generic mesh agent, seeded once and
  *  then the user's to shape. Unlike the demo team it's never refreshed (seed-if-absent), so any
- *  edits stand; deleting it just means the next `cotal setup` writes a fresh copy. */
+ *  edits stand; deleting it just means the next `cotal setup` writes a fresh copy.
+ *
+ *  Read scope is split intentionally: the ACTIVE set (`subscribe`) is just `general`, so a fresh
+ *  agent isn't firehosed every channel on the mesh at boot, while the read ACL (`allowSubscribe:
+ *  [">"]`) still PERMITS it to read anything — it just has to `cotal_join` a channel to start
+ *  receiving it. (`subscribe: [">"]` would auto-subscribe to every channel, the old behavior.) */
 const DEFAULT_AGENT = `---
 name: default_agent
 role: default
 description: An agent on the mesh
 tags: []
-subscribe: [">"]
+subscribe: [general]
+allowSubscribe: [">"]
 allowPublish: [">"]
 capabilities: [spawn]
 ---


### PR DESCRIPTION
## Problem

The `cotal setup` default-agent template seeded every default agent with:

```yaml
subscribe: [">"]
allowPublish: [">"]
# no allowSubscribe
```

The agent-file loader defaults `allowSubscribe` to `subscribe` when omitted, so a fresh default agent both **auto-subscribed to** and was **permitted** every channel on the mesh. On join it received the full replay of every channel — a boot firehose (observed as hundreds of channel-delivery wake-ups from unrelated review/test panels).

## Fix

Split the two read scopes, which the schema already distinguishes:

```yaml
subscribe: [general]      # ACTIVE set — general only at boot, no firehose
allowSubscribe: [">"]     # read ACL — MAY read anything; join a channel to receive it
allowPublish: [">"]       # unchanged
capabilities: [spawn]     # unchanged
```

A default agent now boots on `general` only and reaches other channels by explicitly `cotal_join`-ing them — which its `[">"]` read ACL still permits. This matches the already-corrected local `.cotal/agents/default.md`; only the code template that regenerates it was still emitting the broad default.

## Verification

- Rebuilt `@cotal-ai/cli`; `tsc` typecheck clean.
- Ran the emitted template through the real `loadAgentFile` loader: parses to `subscribe=[general]`, `allowSubscribe=[">"]`, satisfies the `subscribe ⊆ allowSubscribe` invariant, and confirms it is not subscribed to `>`.
- Only `setup.ts:413` carried a source-level `subscribe: [">"]`; demo personas, examples, and the connector fallback already use `general`.
