### PR TITLE
fix(cli): resolve seed paths through bin symlinks

### DIFF
--- a/.changeset/resolve-seed-bin-symlink.md
+++ b/.changeset/resolve-seed-bin-symlink.md
@@ -1,0 +1,6 @@
+---
+"cotal-ai": patch
+"@cotal-ai/cli": patch
+---
+
+Resolve package-manager bin symlinks before locating the connector seed generation and bundled payloads.

--- a/bin/smoke/seed-tarball-live.smoke.ts
+++ b/bin/smoke/seed-tarball-live.smoke.ts
@@ -6,7 +6,9 @@
  *  - the `cotal-ai` tarball ships the `seeded-connectors/<name>` payloads (prepack) with concrete deps
  *  - a first command on the installed binary seeds all four built-ins from those bundled payloads
  *    (`shippedSourceDir` published branch), installing each from the durable store under the isolated
- *    config (never a repo path)
+ *    config (never a repo path). Driven through the `.bin/cotal` SYMLINK npm publishes, the way a user
+ *    reaches an installed binary: `process.argv[1]` is then the link, whose parents hold no
+ *    `package.json` and no `seeded-connectors/`, so only resolving it reaches the payloads
  *  - each connector registers into THE BINARY'S single `@cotal-ai/core` (ext add asserts this; a
  *    dual-core install would fail it), recorded `source:"seeded"`
  *
@@ -14,7 +16,7 @@
  * Run: pnpm smoke:seed-tarball:live
  */
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -71,13 +73,18 @@ try {
   });
   check("npm install of the tarball closure succeeded", install.status === 0, install.stderr?.split("\n").slice(-6).join("\n"));
 
-  const bin = join(prefix, "node_modules", "cotal-ai", "dist", "cotal.js");
-  check("installed binary present", existsSync(bin));
+  const packageBin = join(prefix, "node_modules", "cotal-ai", "dist", "cotal.js");
+  check("installed binary present", existsSync(packageBin));
   check("seeded-connectors present in the installed package", existsSync(join(prefix, "node_modules", "cotal-ai", "seeded-connectors")));
   check("single @cotal-ai/core hoisted in the prefix", existsSync(join(prefix, "node_modules", "@cotal-ai", "core")));
 
   console.log("seeding from the published layout …");
-  const list = spawnSync("node", [bin, "ext", "list"], { encoding: "utf8", env: { ...process.env, XDG_CONFIG_HOME: cfg } });
+  const npmBin = join(prefix, "node_modules", ".bin", "cotal");
+  const invokedBin = process.platform === "win32" ? packageBin : npmBin;
+  if (process.platform !== "win32") {
+    check("npm installed cotal through a bin symlink", existsSync(npmBin) && lstatSync(npmBin).isSymbolicLink());
+  }
+  const list = spawnSync("node", [invokedBin, "ext", "list"], { encoding: "utf8", env: { ...process.env, XDG_CONFIG_HOME: cfg } });
   const out = list.stdout ?? "";
   for (const n of ["claude", "opencode", "hermes", "pi"]) {
     check(`seeded connector:${n} from the tarball binary`, out.includes(`connector:${n}`), list.stderr);

--- a/implementations/cli/smoke/seed.smoke.ts
+++ b/implementations/cli/smoke/seed.smoke.ts
@@ -11,12 +11,14 @@
  *  - a forged `COTAL_EXT_SEEDING` gets no seed-child treatment
  *  - an ambiguous (pending, dead-parent) child marker is fail-loud
  *  - concurrent first boots do not collide or falsely report "interrupted"
+ *  - the binary invoked through a bin SYMLINK (how every global install runs) still resolves its
+ *    generation and payloads
  *
  * Requires the binary built (`pnpm --filter cotal-ai... build`); `pnpm smoke:seed` does that first.
  * Run: pnpm smoke:seed
  */
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, posix, win32 } from "node:path";
 import { defaultAgentType } from "@cotal-ai/workspace";
@@ -329,6 +331,31 @@ check("path spec: a registry name is NOT a path (versioned)", !isPathSpec("conne
   check("parallel boots: all exit 0 (one seeds, the rest wait then no-op)", results.every((r) => r.code === 0), results.map((r) => r.code));
   check("parallel boots: none falsely reports 'interrupted'", !results.some((r) => /interrupted/i.test(r.err)));
   check("parallel boots: exactly four connectors seeded (no double-seed)", listNames(cfg).length === 4);
+}
+
+// ── the GLOBAL-INSTALL shape: the binary reached through a bin SYMLINK ────────────────────────────
+// `npm i -g cotal-ai` publishes `<prefix>/bin/cotal` as a symlink INTO the package, and Node leaves
+// `process.argv[1]` pointing at the symlink, whose own parents hold no `package.json` and no
+// `seeded-connectors/`. Every other case here spawns the real `dist/cotal.js` (an entry that happens to
+// sit inside the package), so this is the only one that covers how an installed binary is actually run.
+// Skipped on Windows: npm publishes `.cmd`/`.ps1` shims there that exec the real path, so the symlink
+// shape does not exist, and unprivileged `symlinkSync` is EPERM regardless.
+if (process.platform !== "win32") {
+  const cfg = track(freshCfg());
+  const linkDir = track(mkdtempSync(join(tmpdir(), "cotal-seed-binlink-")));
+  const link = join(linkDir, "cotal");
+  symlinkSync(BIN, link);
+  const r = spawnSync("node", [link, "ext", "list"], { encoding: "utf8", env: { ...process.env, XDG_CONFIG_HOME: cfg } });
+  const out = r.stdout ?? "";
+  const names = ["claude", "opencode", "hermes", "pi"].filter((n) => out.includes(`connector:${n}`));
+  if (names.length !== 4) console.log(`[diag] symlinked boot status=${r.status}\n--stdout--\n${out}\n--stderr--\n${r.stderr}`);
+  check("symlinked bin: boot resolves the generation (no 'cannot determine' fail)", !/cannot determine the seed generation/.test(r.stderr ?? ""), r.stderr);
+  check("symlinked bin: all four built-ins seeded", names.length === 4, names);
+  // The generation must be the cotal-ai VERSION, i.e. resolved through the link into the package —
+  // not some unrelated `package.json` found by walking up out of the link's own directory.
+  const version = readJson(join(REPO, "bin", "package.json")).version;
+  check("symlinked bin: generation is the cotal-ai version (walked from the real path)", readJson(join(seedDir(cfg), "stamp.json")).generation === version, version);
+  check("symlinked bin: payloads copied into that generation's durable store", existsSync(join(seedDir(cfg), "store", version)));
 }
 
 for (const c of cleanup) rmSync(c, { recursive: true, force: true });

--- a/implementations/cli/src/seed/paths.ts
+++ b/implementations/cli/src/seed/paths.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, writeFileSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { basename, dirname, join } from "node:path";
 import { globalConfigDir } from "@cotal-ai/core";
@@ -83,16 +83,26 @@ export function seedStorePath(generation: string, name: string): string {
   return join(seedStoreDir(), generation, name);
 }
 
+/** Resolve package-manager bin symlinks before looking for package-owned files. */
+function entryScript(): string {
+  const entry = process.argv[1];
+  if (!entry) throw new Error("cannot resolve the cotal entry script: no entry script (process.argv[1])");
+  try {
+    return realpathSync(entry);
+  } catch (e) {
+    throw new Error(`cannot resolve the cotal entry script ${entry}: ${(e as Error).message}`);
+  }
+}
+
 /**
  * The seed generation: this `cotal-ai` binary's version. Ties a reconcile-refresh to the shipped
  * payload changing — including the bundled `connector-core`, so a `cotal-ai` upgrade re-seeds the
  * connectors that carry version-coupled behavior (e.g. the v0.4 lifecycle parse). Read from the
- * nearest `package.json` above the entry script (`cotal-ai` published, or `bin/package.json` in a
- * dev `tsx bin/cotal.ts` run). Fails loud if unreadable — a generation-less seed can't gate refresh.
+ * nearest `package.json` above the {@link entryScript} (`cotal-ai` published, or `bin/package.json` in
+ * a dev `tsx bin/cotal.ts` run). Fails loud if unreadable — a generation-less seed can't gate refresh.
  */
 export function seedGeneration(): string {
-  const entry = process.argv[1];
-  if (!entry) throw new Error("cannot determine the seed generation: no entry script (process.argv[1])");
+  const entry = entryScript();
   let dir = dirname(entry);
   for (;;) {
     const pj = join(dir, "package.json");
@@ -116,15 +126,16 @@ function repoRootFromHere(): string {
 /**
  * The shipped payload directory for one built-in connector — the source the reconcile copies into the
  * durable store. Dev resolves `extensions/<pkg-dir>` from this module's location (NEVER `cwd`);
- * published resolves `<cotal-ai>/seeded-connectors/<name>` beside the entry (the `bin` prepublish
- * copy). Fails loud if neither carries a `package.json` — a build missing its seeded connectors.
+ * published resolves `<cotal-ai>/seeded-connectors/<name>` beside the {@link entryScript} (the `bin`
+ * prepublish copy). Fails loud if neither carries a `package.json` — a build missing its seeded
+ * connectors.
  */
 export function shippedSourceDir(name: string): string {
   const pkg = OFFICIAL_CONNECTORS[name];
   if (!pkg) throw new Error(`"${name}" is not a first-party connector; only ${SEED_BUILTINS.join(", ")} are seeded`);
   const devDir = join(repoRootFromHere(), "extensions", pkg.split("/")[1]);
   if (existsSync(join(devDir, "package.json"))) return devDir;
-  const pubDir = join(dirname(process.argv[1] ?? ""), "..", "seeded-connectors", name);
+  const pubDir = join(dirname(entryScript()), "..", "seeded-connectors", name);
   if (existsSync(join(pubDir, "package.json"))) return pubDir;
   throw new Error(
     `no shipped payload for connector "${name}" (looked in ${devDir} and ${pubDir}) - this cotal-ai build is missing its seeded connectors`,


### PR DESCRIPTION
## What
- resolve the invoked cotal entry script before walking to package.json
- use the resolved entry for published seeded-connectors payload lookup
- exercise both a direct bin symlink and npm's installed .bin symlink
- add a patch changeset for cotal-ai and @cotal-ai/cli

## Why
Global npm installs invoke cotal through a symlink. Node preserves that symlink in process.argv[1], so cotal-ai@0.11.4 walked outside the package and failed before every real command.

## Tests
- pnpm smoke:seed (52 passed)
- pnpm smoke:seed-tarball:live (16 passed)
- pnpm typecheck