### PR TITLE
fix(connector-opencode): close the plugin bundle over its runtime deps

### DIFF
--- a/.changeset/opencode-plugin-peer-closure.md
+++ b/.changeset/opencode-plugin-peer-closure.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/connector-opencode": minor
+---
+
+The OpenCode plugin bundle is now closed over its runtime dependencies, so `cotal spawn --agent opencode` works from an installed extension. It previously kept a runtime import of `@opencode-ai/plugin` (a peer that `cotal ext add` never installs), which OpenCode could not resolve; it skips such a plugin silently, so the agent never joined the mesh and the launcher sat for 60s before aborting with "agent session never came up". The only use of that import was `tool()`, an identity function for type inference, so the tool definitions are now plain `ToolDefinition` literals and the import is type-only. The `@opencode-ai/*` bundler externals are gone as well, so a future value import is inlined rather than silently escaping the bundle.

--- a/extensions/connector-opencode/package.json
+++ b/extensions/connector-opencode/package.json
@@ -20,19 +20,16 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json --emitDeclarationOnly && pnpm run bundle",
-    "bundle": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/index.js --external:@cotal-ai/core --external:@opencode-ai/plugin --external:@opencode-ai/sdk && esbuild src/plugin.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/plugin.bundle.js --external:@opencode-ai/plugin --external:@opencode-ai/sdk && esbuild src/serve.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/serve.js --external:@opencode-ai/plugin --external:@opencode-ai/sdk",
+    "bundle": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/index.js --external:@cotal-ai/core && esbuild src/plugin.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/plugin.bundle.js && esbuild src/serve.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/serve.js",
     "prepublishOnly": "pnpm run build"
   },
   "peerDependencies": {
-    "@cotal-ai/core": ">=0.1.0",
-    "@opencode-ai/plugin": "^1.16.2",
-    "@opencode-ai/sdk": "^1.16.2"
+    "@cotal-ai/core": ">=0.1.0"
   },
   "devDependencies": {
     "@cotal-ai/core": "workspace:*",
     "@cotal-ai/connector-core": "workspace:*",
     "@opencode-ai/plugin": "^1.16.2",
-    "@opencode-ai/sdk": "^1.16.2",
     "esbuild": "^0.28.0",
     "tsx": "^4.22.4"
   },

--- a/extensions/connector-opencode/src/tools.ts
+++ b/extensions/connector-opencode/src/tools.ts
@@ -1,13 +1,19 @@
 /**
  * The Cotal tool surface for OpenCode, rendered from the **shared** {@link cotalToolSpecs}
  * (the same source the Claude Code MCP connector renders) as OpenCode-native plugin
- * tools (the `tool()` helper). One source of truth → the cotal_* surface can't drift across
- * adapters: an OpenCode peer gets the same tools (incl. channels / join / leave / channel_info).
+ * tools ({@link ToolDefinition} literals). One source of truth → the cotal_* surface can't drift
+ * across adapters: an OpenCode peer gets the same tools (incl. channels / join / leave / channel_info).
  *
  * The one OpenCode-specific tool is `cotal_inbox`: automatic traffic remains owned by the driver,
  * while the tool destructively pulls only quiet ambient (plus read-only focus recall).
+ *
+ * The definitions are plain literals, NOT OpenCode's `tool()` helper: `tool()` is an identity
+ * function for type inference only, so importing it would make `@opencode-ai/plugin` a RUNTIME
+ * dependency of this bundle. It resolves from the host's opencode process, not ours, and an
+ * installed extension has no copy of it, so the import fails and OpenCode skips the plugin
+ * silently. A type-only import keeps the bundle self-contained.
  */
-import { tool, type ToolDefinition } from "@opencode-ai/plugin";
+import type { ToolDefinition } from "@opencode-ai/plugin";
 import { cotalToolSpecs, type MeshAgent, type AgentConfig } from "@cotal-ai/connector-core";
 
 /** Build the cotal_* tool map wired to one mesh agent, rendered from the shared specs. */
@@ -15,7 +21,7 @@ export function buildCotalTools(agent: MeshAgent, config: AgentConfig): Record<s
   const tools: Record<string, ToolDefinition> = {};
   for (const spec of cotalToolSpecs(config, "opencode")) {
     if (spec.name === "cotal_inbox") {
-      tools.cotal_inbox = tool({
+      tools.cotal_inbox = {
         description:
           "Pull and clear quiet-channel ambient waiting for you. Connector-managed automatic traffic stays queued; in focus mode, normal channel recall is also shown read-only.",
         args: {},
@@ -23,18 +29,18 @@ export function buildCotalTools(agent: MeshAgent, config: AgentConfig): Record<s
           const r = await spec.run(agent, config, { scope: "pull-only" });
           return r.isError ? `⚠ ${r.text}` : r.text;
         },
-      });
+      };
       continue;
     }
-    tools[spec.name] = tool({
+    tools[spec.name] = {
       description: spec.description,
-      // The shared spec carries a Zod raw shape; OpenCode's tool() takes the same (zod via tool.schema).
+      // The shared spec carries a Zod raw shape, which is what OpenCode's tool `args` takes.
       args: (spec.schema ?? {}) as Record<string, never>,
       async execute(args: unknown) {
         const r = await spec.run(agent, config, (args ?? {}) as any);
         return r.isError ? `⚠ ${r.text}` : r.text;
       },
-    });
+    };
   }
   return tools;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,9 +214,6 @@ importers:
       '@opencode-ai/plugin':
         specifier: ^1.16.2
         version: 1.16.2
-      '@opencode-ai/sdk':
-        specifier: ^1.16.2
-        version: 1.16.2
       esbuild:
         specifier: ^0.28.0
         version: 0.28.0


### PR DESCRIPTION
## The bug

`cotal spawn --agent opencode` sits for 60s and aborts with `agent session never came up`, whenever the connector runs as an installed extension (i.e. anyone who installs cotal from npm). Reproduced live before changing anything.

`dist/plugin.bundle.js` kept a **runtime** import of `@opencode-ai/plugin`:

```js
import { tool } from "@opencode-ai/plugin";   // tools.ts value import, kept external by esbuild
```

Nothing provides it in `~/.config/cotal/extensions`:

- `ext add` installs with `npm --legacy-peer-deps`, which is there to stop npm pulling a second `@cotal-ai/core` from the registry, but it skips **every** peer, not just that one.
- `bindExtensionPeers` then links only peers matching `@cotal-ai/` (`extensions.ts:207`).

So `@opencode-ai/plugin` falls through both nets. The prefix lockfile records it as peer metadata only, never installed.

It fails invisibly: OpenCode logs `failed to load plugin` when a plugin's factory *throws*, but a plugin whose **module resolution** fails is skipped in total silence. No plugin means no mesh join, no `[cotal-session]` handshake, and `serve.ts` waits out its full 60s.

## The fix

`tool()` is `export function tool(input) { return input; }`, an identity function for type inference. `tool.schema` is never used (the zod shape comes from connector-core's `spec.schema`), and `ToolDefinition` was already a type import. So the dependency buys nothing at runtime and costs a 61MB closure (`effect`, `@ai-sdk/provider`, `zod`).

1. `tools.ts`: type-only import, tool definitions as plain `ToolDefinition` literals.
2. Drop `--external:@opencode-ai/*` from all three esbuild commands (`--external:@cotal-ai/core` stays on `index.js`, which does register into the binary's registry). Those flags are what let a value import silently escape the bundle; without them esbuild inlines it, so this class of bug cannot recur.
3. Drop both `@opencode-ai/*` peers (`sdk` was referenced nowhere in `src/`). `@opencode-ai/plugin` stays a devDependency for the type.

`plugin.bundle.js` deliberately still inlines its own core: it runs inside OpenCode's process, not the CLI's, so there is no registry singleton to share.

## Verification

| Check | Result |
|---|---|
| Clean-room import (no `node_modules` up the tree), old vs new | old: `Cannot find package '@opencode-ai/plugin'`; new: `OK ['cotal']` |
| Real `cotal ext add` of this build | pulled **zero** `@opencode-ai`; core still symlinked to the binary's copy |
| Real `cotal spawn --agent opencode` | survived past 90s, no abort, session `ses_09056c4b…` |
| Mesh join | agent appeared on the roster |
| Tool surface | agent on the fixed bundle: 18 `cotal_*` tools, `cotal_roster` + `cotal_dm` exercised live, no errors |
| `pnpm typecheck` | passes, repo-wide |

Reviewed on the mesh. Confirmed independently: literals are behavior-identical (the 1.18 host duck-types `args`/`description`/`execute`, with no identity or prototype dependency), inlining core in the plugin bundle is correct, `import type` emits no runtime require under `verbatimModuleSyntax`, and no real host-version guarantee is lost (an npm peer would constrain a separately installed library copy, not the external `opencode` binary).

## Follow-ups, not in this PR

- `bin/smoke/seed-tarball-live.smoke.ts` checks the bundle is *packaged* but not that it is *closed over its deps*. A clean-room import assertion would have caught this in CI.
- `extensions/pi` has the same latent build-flag shape (`@earendil-works/*` externals). Its host imports are currently type-only so it emits no bare imports, but the shape invites the same silent failure.