### PR TITLE
fix(cli): space-backup post-merge review remediation (Windows ACLs + cut-committed crash window)

### DIFF
--- a/bin/smoke/backup-restore-live.smoke.ts
+++ b/bin/smoke/backup-restore-live.smoke.ts
@@ -1,6 +1,6 @@
 /** Live full/registry backup, restore, isolation, checkpoint, and ordinary-resume lifecycle. */
 import assert from "node:assert/strict";
-import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess, type SpawnSyncReturns } from "node:child_process";
 import { createHash } from "node:crypto";
 import { createServer, type AddressInfo } from "node:net";
 import { cpSync, existsSync, lstatSync, mkdtempSync, readdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
@@ -646,6 +646,60 @@ async function preservationCommitCrashScenario(): Promise<void> {
   }
 }
 
+/** The coordinator dies in the window between the manager stopping its children and the cut-committed
+ *  journal write, THEN the manager dies. The commit-intent marker lets recovery finish the cut forward
+ *  instead of deleting it and losing the retained inventory. A crash one step EARLIER (before the
+ *  marker, genuinely pre-commit) must still abort — proving the recovery is surgical, not eager. */
+async function preservationStopCrashRecoveryScenario(): Promise<void> {
+  const alive = (pid: number): boolean => { try { process.kill(pid, 0); return true; } catch (e) { return (e as NodeJS.ErrnoException).code === "EPERM"; } };
+  const bootAndCrash = async (suffix: string, hook: string): Promise<{ root: string; home: string; server: string; space: string; run: (...a: string[]) => SpawnSyncReturns<string>; journalPath: string }> => {
+    const root = realpathSync.native(mkdtempSync(join(tmpdir(), `cotal-preserve-stop-${suffix}-root-`)));
+    const home = realpathSync.native(mkdtempSync(join(tmpdir(), `cotal-preserve-stop-${suffix}-home-`)));
+    const port = await freePort();
+    const server = `nats://127.0.0.1:${port}`;
+    const space = `backup_preserve_stop_${suffix}`;
+    const env = { ...process.env, COTAL_HOME: home };
+    const run = (...args: string[]) => spawnSync(tsx, [cliPath, ...args], { cwd: root, env, encoding: "utf8", timeout: 240_000 });
+    const journalPath = join(root, ".cotal", "maintenance", "v1", "journal.json");
+    assert.equal(run("up", "--detach", "--open", "--server", server, "--space", space).status, 0, `${suffix} up`);
+    const mgrPid = Number(readFileSync(join(root, ".cotal", "manager.pid"), "utf8").trim());
+    const crashed = spawnSync(tsx, [cliPath, "down", "--preserve-state"],
+      { cwd: root, env: { ...env, [hook]: "1" }, encoding: "utf8", timeout: 240_000 });
+    assert.equal((JSON.parse(readFileSync(journalPath, "utf8")) as { state: string }).state, "cut-intent", `${suffix} parked at cut-intent`);
+    if (alive(mgrPid)) process.kill(mgrPid, "SIGKILL");
+    await waitUntil(() => !alive(mgrPid), `${suffix} manager dead`);
+    return { root, home, server, space, run, journalPath };
+  };
+
+  // Case A — the fix: crash AFTER the manager committed (children stopped). Recovery must NOT delete
+  // the journal; it finishes the cut forward to ready with the inventory intact.
+  const a = await bootAndCrash("commit", "COTAL_SMOKE_EXIT_AFTER_MANAGER_STOP_BEFORE_JOURNAL");
+  try {
+    const recovered = a.run("down", "--preserve-state");
+    assert.equal(recovered.status, 0, `stop-window cut recovery\nstdout:\n${recovered.stdout}\nstderr:\n${recovered.stderr}`);
+    assert.equal(existsSync(a.journalPath), true, "the preserved cut journal survives recovery (not deleted)");
+    assert.equal((JSON.parse(readFileSync(a.journalPath, "utf8")) as { state: string }).state, "ready");
+  } finally {
+    a.run("down");
+    rmSync(a.root, { recursive: true, force: true });
+    rmSync(a.home, { recursive: true, force: true });
+  }
+
+  // Case B — surgical: crash BEFORE the commit-intent marker (genuinely pre-commit, nothing stopped).
+  // Recovery must still abort, not finish forward.
+  const b = await bootAndCrash("precommit", "COTAL_SMOKE_EXIT_AFTER_CUT_INTENT_BEFORE_COMMIT");
+  try {
+    const aborted = b.run("down", "--preserve-state");
+    assert.notEqual(aborted.status, 0, "a genuinely pre-commit crash still aborts, not finishes forward");
+    assert.match(aborted.stderr, /lost its manager before commit; the cut intent was aborted/);
+    assert.equal(existsSync(b.journalPath), false, "the pre-commit cut is abandoned (nothing was stopped)");
+  } finally {
+    b.run("down");
+    rmSync(b.root, { recursive: true, force: true });
+    rmSync(b.home, { recursive: true, force: true });
+  }
+}
+
 /** Command races against a pre-commit restore: a live claim refuses ordinary up, repeated restore,
  *  and explicit rollback; a provably stale claim is recoverable by the explicit clean command. */
 async function restoreClaimRaceScenario(): Promise<void> {
@@ -776,6 +830,7 @@ async function backupRestoreCycleScenario(): Promise<void> {
 
 await missingPidfileListenerScenario();
 await preservationCommitCrashScenario();
+await preservationStopCrashRecoveryScenario();
 await restoreClaimRaceScenario();
 await backupRestoreCycleScenario();
 await scenario("open");

--- a/implementations/cli/smoke/backup.smoke.ts
+++ b/implementations/cli/smoke/backup.smoke.ts
@@ -1,6 +1,7 @@
 /** Hermetic CLI backup artifact and maintenance-grammar smoke. */
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { createServer, type AddressInfo } from "node:net";
 import { join } from "node:path";
@@ -8,7 +9,7 @@ import { createArtifactWriter, stageArtifact } from "../src/lib/backup-artifact.
 import { down } from "../src/commands/down.js";
 import { backupComplete, chunkQueue, isStoppedKvWatcher } from "../src/commands/backup.js";
 import { upComplete } from "../src/commands/up.js";
-import { ensurePrivateAttemptsDir } from "../src/lib/isolated-broker.js";
+import { createAttemptClone, ensurePrivateAttemptsDir } from "../src/lib/isolated-broker.js";
 import { isManagerCommitResult, isManagerFinalizeResult } from "../src/lib/restore.js";
 import { authorityFingerprint } from "../src/lib/maintenance-files.js";
 import { assertEndpointUnreachable } from "../src/lib/endpoint-cut.js";
@@ -78,6 +79,47 @@ try {
     mkdirSync(redirected);
     symlinkSync(redirected, join(redirectedRoot, ".cotal"));
     assert.throws(() => ensurePrivateAttemptsDir(redirectedRoot), /not a real directory/);
+  }
+
+  // The maintenance-attempt tree holds the store clone, quarantine, sanitized snapshots, and the
+  // broker `.conf` (plaintext creds) — the crown jewels. Assert privacy the way the boundary is
+  // actually enforced per platform: POSIX mode bits, and on win32 the NTFS ACL, since mode bits are
+  // a no-op there and privacy comes from hardenPrivate's icacls grant (mirrors secret-fs.smoke.ts).
+  const isWin = process.platform === "win32";
+  const winUser = isWin ? execFileSync("whoami", { encoding: "utf8" }).trim() : "";
+  const assertPrivateDir = (dir: string, label: string): void => {
+    if (!isWin) {
+      assert.equal(statSync(dir).mode & 0o777, 0o700, `${label} is 0700`);
+      return;
+    }
+    const acl = execFileSync("icacls", [dir], { encoding: "utf8" });
+    assert.ok(!/\bEveryone\b/i.test(acl) && !/\bAuthenticated Users\b/i.test(acl) && !/\\Users:/i.test(acl),
+      `${label} ACL strips Everyone / Authenticated Users / Users`);
+    assert.ok(/\\SYSTEM:/i.test(acl) && /\\Administrators:/i.test(acl) && acl.toLowerCase().includes(winUser.toLowerCase()),
+      `${label} ACL grants owner + SYSTEM + Administrators`);
+  };
+
+  {
+    // realpath-canonical root: ensurePrivateAttemptsDir refuses a non-canonical path, and macOS
+    // tmpdir is /var → /private/var symlinked.
+    mkdirSync(join(root, "priv-maint"));
+    const privRoot = realpathSync.native(join(root, "priv-maint"));
+    const attempts = ensurePrivateAttemptsDir(privRoot);
+    // Every level of the tree, not just the leaf — a permissive .cotal or maintenance parent would
+    // expose the attempts subtree by inheritance on win32.
+    assertPrivateDir(join(privRoot, ".cotal"), ".cotal");
+    assertPrivateDir(join(privRoot, ".cotal", "maintenance"), "maintenance");
+    assertPrivateDir(attempts.path, "attempts");
+
+    // A clone copies the whole store; the clone root and its bytes must be private too.
+    const sourceStore = join(root, "priv-source-store");
+    mkdirSync(sourceStore);
+    writeFileSync(join(sourceStore, "stream.dat"), Buffer.from([7, 8, 9]));
+    const clone = createAttemptClone(privRoot, sourceStore, "priv-attempt");
+    assertPrivateDir(clone.path, "attempt clone");
+    assert.deepEqual(readFileSync(join(clone.path, "stream.dat")), Buffer.from([7, 8, 9]));
+    clone.cleanup();
+    assert.ok(!existsSync(clone.path), "clone cleanup removes the clone");
   }
 
   const queue = chunkQueue();

--- a/implementations/cli/src/commands/down.ts
+++ b/implementations/cli/src/commands/down.ts
@@ -5,17 +5,21 @@ import {
   abortMaintenanceCut,
   acquireMaintenanceLock,
   beginMaintenanceCut,
+  clearPreservationCommitIntent,
   clearPreservationPrepareIntent,
   completeMaintenanceCut,
   loadMeshes,
   localProcessPath,
   readMaintenanceJournal,
+  readMaintenanceResumeDocument,
+  readPreservationCommitIntent,
   readPreservationPrepareIntent,
   readStoreIdentity,
   recordPreservationManagerCommit,
   releaseMaintenanceLock,
   removeMeshesByRoot,
   sameStoreIdentity,
+  writePreservationCommitIntent,
   writePreservationPrepareIntent,
   type LocalProcess,
   type LocalProcessContext,
@@ -249,6 +253,20 @@ export async function stopLocalProcess(component: LocalProcess, context: LocalPr
   }
 }
 
+/** The principal keys of every retained agent in a preservation inventory — the dot-form ids that
+ *  appear in the presence roster, so a caller can tell which retained agents are still live. */
+function retainedPrincipalKeys(inventory: unknown): Set<string> {
+  const agents = ((inventory as { agents?: Array<{
+    identity?: { mode?: string; id?: string; owner?: string; actor?: string };
+  }> }).agents ?? []);
+  return new Set(agents.map((agent) => {
+    if (agent.identity?.mode === "user" && agent.identity.owner && agent.identity.actor)
+      return principalKey(agent.identity.owner, agent.identity.actor).key;
+    if (agent.identity?.id) return principalKey(DEV_OWNER, agent.identity.id).key;
+    return undefined;
+  }).filter((id): id is string => Boolean(id)));
+}
+
 async function preserveStateDown(storeOverride?: string): Promise<void> {
   const root = cotalRoot();
   const matching = loadMeshes().filter((mesh) => mesh.root === root);
@@ -274,6 +292,9 @@ async function preserveStateDown(storeOverride?: string): Promise<void> {
 
     let attemptId: string;
     let resume;
+    // Set when recovery force-commits a cut whose manager died AFTER stopping children (commit-intent
+    // present): the shared commit block below is then skipped — the cut is already committed.
+    let managerCommitJournaled = false;
     if (existing?.state === "cut-intent" || existing?.state === "cut-committed") {
       attemptId = existing.cut.attemptId;
       resume = existing.resume;
@@ -284,11 +305,34 @@ async function preserveStateDown(storeOverride?: string): Promise<void> {
         const manager = all.find((component) => component.name === "manager");
         if (!manager) throw new Error("local process registry has no manager descriptor");
         if (!processAlive(manager, context)) {
-          // Pre-commit, nothing was stopped with suppression: abandon instead of wedging.
-          abortMaintenanceCut(lock);
+          const committing = readPreservationCommitIntent(root);
+          if (!committing || committing.attemptId !== attemptId) {
+            // No commit intent recorded: the child-stopping RPC was never invoked, so nothing was
+            // stopped with suppression. Safe to abandon instead of wedging.
+            abortMaintenanceCut(lock);
+            clearPreservationPrepareIntent(lock);
+            throw new Error(`preservation attempt ${attemptId} lost its manager before commit; the cut intent was aborted - heal the stack with \`cotal up\` if needed, then rerun \`cotal down --preserve-state\``);
+          }
+          // Commit intent is durable: the manager was asked to stop its children and may already have
+          // done so. Deleting the cut here would lose the retained inventory (this was the bug). While
+          // the broker outlives the manager in this window, confirm no retained principal is still live
+          // before finishing forward; if the broker is already gone we cannot check, but preserving the
+          // cut still beats deleting it. Then journal cut-committed and finish WITHOUT the dead manager.
+          if (await isReachable(mesh.server)) {
+            const retained = retainedPrincipalKeys(readMaintenanceResumeDocument(root, existing.resume).inventory);
+            if (retained.size) {
+              const stillLive = (await readPresenceWithoutConsumer(mesh.space, mesh.server))
+                .roster.filter((presence) => retained.has(presence.card.id)).map((presence) => presence.card.id);
+              if (stillLive.length)
+                throw new Error(`preservation attempt ${attemptId} lost its manager mid-commit and ${stillLive.length} retained principal(s) are still live (${stillLive.join(", ")}); the cut intent is PRESERVED for inspection - stop them, then rerun \`cotal down --preserve-state\``);
+            }
+          }
+          recordPreservationManagerCommit(lock, { operation: "commitPreservation", attemptId, state: "preserved" });
+          clearPreservationCommitIntent(lock);
           clearPreservationPrepareIntent(lock);
-          throw new Error(`preservation attempt ${attemptId} lost its manager before commit; the cut intent was aborted - heal the stack with \`cotal up\` if needed, then rerun \`cotal down --preserve-state\``);
+          managerCommitJournaled = true;
         }
+        if (!managerCommitJournaled) {
         const retryTarget = await resolveControlTarget({ space: mesh.space, server: mesh.server }, "control-caller-admin");
         // Plane-3 fence precedes the re-prepared inventory, exactly as on the fresh path.
         const retryDelivery = all.find((component) => component.name === "delivery");
@@ -312,6 +356,7 @@ async function preserveStateDown(storeOverride?: string): Promise<void> {
           abortMaintenanceCut(lock);
           clearPreservationPrepareIntent(lock);
           throw new Error(`preservation attempt ${attemptId} no longer matches its manager's inventory (${(cause as Error).message}); the stale cut intent was aborted - rerun \`cotal down --preserve-state\``);
+        }
         }
       }
     } else {
@@ -346,15 +391,7 @@ async function preserveStateDown(storeOverride?: string): Promise<void> {
       const plan = prepared.data as { inventory?: unknown; failures?: unknown[]; state?: string } | undefined;
       if (!plan?.inventory || (plan.failures?.length ?? 0) !== 0 || (plan.state !== "prepared" && plan.state !== "preserved"))
         throw new Error("manager returned an invalid or incomplete preservation plan");
-      const inventoryAgents = ((plan.inventory as { agents?: Array<{
-        identity?: { mode?: string; id?: string; owner?: string; actor?: string };
-      }> }).agents ?? []);
-      const retainedPrincipals = new Set(inventoryAgents.map((agent) => {
-        if (agent.identity?.mode === "user" && agent.identity.owner && agent.identity.actor)
-          return principalKey(agent.identity.owner, agent.identity.actor).key;
-        if (agent.identity?.id) return principalKey(DEV_OWNER, agent.identity.id).key;
-        return undefined;
-      }).filter((id): id is string => Boolean(id)));
+      const retainedPrincipals = retainedPrincipalKeys(plan.inventory);
       let observed = await readPresenceWithoutConsumer(mesh.space, mesh.server);
       retainedPrincipals.add(observed.managerId);
       let unmanaged = observed.roster.filter((presence) => !retainedPrincipals.has(presence.card.id));
@@ -388,14 +425,19 @@ async function preserveStateDown(storeOverride?: string): Promise<void> {
       clearPreservationPrepareIntent(lock);
     }
 
-    // The manager's preservation commitment is journaled BEFORE any process stops: from
-    // cut-committed onward, retries finish the remaining stopped/unreachable checks idempotently
-    // without requiring the (by then intentionally dead) manager.
-    if (existing?.state !== "cut-committed") {
+    // Stop the children through the manager, then journal cut-committed. A commit-intent marker is
+    // written FIRST (the stop RPC is about to execute) and cleared once cut-committed is durable, so a
+    // crash in the gap leaves proof the stop may already have run — recovery finishes forward instead
+    // of deleting the cut. `managerCommitJournaled` means a dead-manager recovery already committed above.
+    if (existing?.state !== "cut-committed" && !managerCommitJournaled) {
       const manager = all.find((component) => component.name === "manager");
       if (!manager) throw new Error("local process registry has no manager descriptor");
       if (!processAlive(manager, context))
         throw new Error("cannot complete preservation because the attempt-bound manager is not alive to prove every retained child stopped; recovery must preserve the cut-intent journal for inspection");
+      // Fault window: cut-intent journaled but the child-stopping RPC not yet invoked (no commit
+      // intent). A crash here is genuinely pre-commit — recovery MUST still abort, not finish forward.
+      if (process.env.COTAL_SMOKE_EXIT_AFTER_CUT_INTENT_BEFORE_COMMIT === "1") process.exit(93);
+      writePreservationCommitIntent(lock, { attemptId });
       const target = await resolveControlTarget({ space: mesh.space, server: mesh.server }, "control-caller-admin");
       const commit = await askManager(
         target.space,
@@ -410,7 +452,12 @@ async function preserveStateDown(storeOverride?: string): Promise<void> {
       const result = commit.data as { state?: string; failures?: unknown[] } | undefined;
       if (result?.state !== "preserved" || (result.failures?.length ?? 0) !== 0)
         throw new Error("manager could not prove every retained child stopped");
+      // Fault window: the manager has COMMITTED (children stopped, preservation irreversible) but the
+      // coordinator has not yet journaled cut-committed. A crash here leaves the journal at cut-intent
+      // WITH the commit-intent marker set — the exact window recovery must not treat as pre-commit.
+      if (process.env.COTAL_SMOKE_EXIT_AFTER_MANAGER_STOP_BEFORE_JOURNAL === "1") process.exit(92);
       recordPreservationManagerCommit(lock, { operation: "commitPreservation", attemptId, state: "preserved" });
+      clearPreservationCommitIntent(lock);
       if (process.env.COTAL_SMOKE_EXIT_AFTER_PRESERVATION_MANAGER_COMMIT === "1") process.exit(90);
     }
 

--- a/implementations/cli/src/lib/isolated-broker.ts
+++ b/implementations/cli/src/lib/isolated-broker.ts
@@ -1,7 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { randomBytes, randomUUID } from "node:crypto";
 import {
-  chmodSync,
   constants,
   copyFileSync,
   lstatSync,
@@ -18,6 +17,7 @@ import { createServer } from "node:net";
 import { connect, type NatsConnection } from "@nats-io/transport-node";
 import {
   backupProfilePermissions,
+  hardenPrivate,
   isReachable,
   restoreProfilePermissions,
   type BackupPermissionScope,
@@ -47,7 +47,11 @@ export function ensurePrivateAttemptsDir(root: string): PrivateAttemptsDirectory
     const stat = lstatSync(current, { bigint: true });
     if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error(`maintenance path is not a real directory: ${current}`);
     if (process.getuid && stat.uid !== BigInt(process.getuid())) throw new Error(`maintenance path is not owned by the current user: ${current}`);
-    chmodSync(current, 0o700);
+    // This tree holds the store clone, quarantine, sanitized snapshots, and the broker `.conf`
+    // (plaintext maintenance creds). `hardenPrivate` reasserts 0700 on POSIX and sets an
+    // inheritable owner-only NTFS ACL on win32 — where both the create mode AND the getuid
+    // ownership check above are no-ops — so children born here inherit the private ACL. Fails closed.
+    hardenPrivate(current, "dir");
   }
   const canonical = realpathSync.native(current);
   if (canonical !== current) throw new Error(`maintenance attempt directory is not canonical: ${current}`);
@@ -101,7 +105,7 @@ function copyTree(source: string, destination: string): void {
   const sourceStat = lstatSync(source);
   if (!sourceStat.isDirectory() || sourceStat.isSymbolicLink()) throw new Error(`backup source store is not a real directory: ${source}`);
   mkdirSync(destination, { mode: 0o700 });
-  chmodSync(destination, 0o700);
+  hardenPrivate(destination, "dir"); // clone subtree is store bytes — private on win32 too
   for (const name of readdirSync(source)) {
     const from = join(source, name);
     const to = join(destination, name);
@@ -128,6 +132,7 @@ export function createAttemptClone(root: string, sourceStore: string, attemptId:
     if ((error as NodeJS.ErrnoException).code === "EEXIST") throw new Error(`backup attempt clone already exists: ${path}`);
     throw error;
   }
+  hardenPrivate(path, "dir"); // clone root holds the full store copy — private on win32 too
   const stat = lstatSync(path, { bigint: true });
   const identity = { dev: stat.dev, ino: stat.ino };
   try {
@@ -334,6 +339,10 @@ export async function startIsolatedBroker(options: {
   writeFileSync(configPath, authenticatedConfig(account, port, options.storeDir, logins), { flag: "wx", mode: 0o600 });
   writeFileSync(logPath, "", { flag: "wx", mode: 0o600 });
   writeFileSync(pidsPath, "", { flag: "wx", mode: 0o600 });
+  // The `.conf` embeds the plaintext maintenance login. `wx` above keeps the exclusive create
+  // (never write over a pre-planted file); harden the win32 ACL after, where mode 0o600 is a no-op.
+  // The attempts dir is already hardened inheritable, but harden the secret file explicitly too.
+  hardenPrivate(configPath, "file");
   const fileIdentity = (path: string): IsolatedRunFile => {
     const stat = lstatSync(path, { bigint: true });
     return { path, dev: stat.dev.toString(), ino: stat.ino.toString() };

--- a/implementations/cli/src/lib/restore.ts
+++ b/implementations/cli/src/lib/restore.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 import {
-  chmodSync,
   constants,
   fsyncSync,
   lstatSync,
@@ -22,6 +21,7 @@ import {
   deliveryBucket,
   downloadStreamSnapshot,
   finalizeStreamRestore,
+  hardenPrivate,
   initiateStreamRestore,
   LEASE_TTL_MS,
   managerBucket,
@@ -253,8 +253,12 @@ function isManagerFinalizeEvidence(
 }
 
 function createOwnedDirectory(path: string): void {
+  // The restore target, quarantine, and sanitized dirs hold whole-stream snapshots (chat + DMs).
+  // `hardenPrivate` reasserts 0700 on POSIX and sets an owner-only NTFS ACL on win32, where the
+  // create mode is a no-op — and fails closed if it cannot, so a snapshot never lands under an
+  // inherited permissive ACL.
   mkdirSync(path, { mode: 0o700 });
-  chmodSync(path, 0o700);
+  hardenPrivate(path, "dir");
 }
 
 function canonicalFuturePath(path: string): string {

--- a/packages/workspace/smoke/maintenance.smoke.ts
+++ b/packages/workspace/smoke/maintenance.smoke.ts
@@ -24,7 +24,10 @@ import {
   prepareAlternateRestore,
   prepareMissingSourceRestore,
   prepareSamePathRestore,
+  clearPreservationCommitIntent,
   clearPreservationPrepareIntent,
+  readPreservationCommitIntent,
+  writePreservationCommitIntent,
   readMaintenanceJournal,
   readMaintenanceResumeDocument,
   readPreservationPrepareIntent,
@@ -1322,6 +1325,30 @@ if (process.platform !== "win32") {
   clearPreservationPrepareIntent(lock);
   check("cleared prepare intent reads as undefined again", readPreservationPrepareIntent(p.root) === undefined);
   clearPreservationPrepareIntent(lock);
+  releaseMaintenanceLock(lock);
+}
+
+// The commit intent is written AFTER cut-intent but BEFORE the child-stopping RPC, so a crash in
+// that window proves the stop may already have run and recovery must not delete the cut.
+{
+  const p = project("commit-intent");
+  const lock = acquireMaintenanceLock(p.root);
+  check("no commit intent reads as undefined", readPreservationCommitIntent(p.root) === undefined);
+  expectCode("commit intent without a cut-intent journal is refused", "invalid-transition", () =>
+    writePreservationCommitIntent(lock, { attemptId: "commit-1" }));
+  const resume = writeMaintenanceResumeDocument(lock, { version: 1, inventory: [], launch: { server: normalEndpoint } });
+  beginMaintenanceCut(lock, {
+    attemptId: "commit-1", space: "commit-space", mode: "auth", sourcePath: p.store, resume,
+    launch: { server: normalEndpoint },
+  });
+  expectCode("commit intent for a different attempt than the journal is refused", "invalid-transition", () =>
+    writePreservationCommitIntent(lock, { attemptId: "commit-2" }));
+  writePreservationCommitIntent(lock, { attemptId: "commit-1" });
+  check("commit intent survives a crash and names the committing attempt",
+    readPreservationCommitIntent(p.root)?.attemptId === "commit-1");
+  clearPreservationCommitIntent(lock);
+  check("cleared commit intent reads as undefined again", readPreservationCommitIntent(p.root) === undefined);
+  clearPreservationCommitIntent(lock);
   releaseMaintenanceLock(lock);
 }
 

--- a/packages/workspace/src/maintenance.ts
+++ b/packages/workspace/src/maintenance.ts
@@ -449,6 +449,7 @@ export interface MaintenancePaths {
   readonly journal: string;
   readonly resume: string;
   readonly prepareIntent: string;
+  readonly commitIntent: string;
   readonly lock: string;
   readonly reaper: string;
 }
@@ -513,6 +514,7 @@ export function maintenancePaths(root: string): MaintenancePaths {
     journal: join(versionDir, "journal.json"),
     resume: join(versionDir, "resume.json"),
     prepareIntent: join(versionDir, "prepare-intent.json"),
+    commitIntent: join(versionDir, "commit-intent.json"),
     lock: join(maintenanceDir, "lock.json"),
     reaper: join(maintenanceDir, "lock-reaper.json"),
   };
@@ -1759,6 +1761,70 @@ export function clearPreservationPrepareIntent(lock: MaintenanceLock): void {
   const paths = maintenancePaths(lock.root);
   try {
     unlinkSync(paths.prepareIntent);
+    fsyncDirectory(paths.versionDir);
+  } catch (error) {
+    if (errno(error) !== "ENOENT") throw error;
+  }
+}
+
+/** Written AFTER the cut-intent journal but BEFORE the manager is asked to stop its children, so a
+ *  coordinator crash in that window leaves proof the stop RPC may already have executed. Without it,
+ *  recovery sees a bare cut-intent and wrongly assumes nothing was stopped — then deletes the cut and
+ *  loses the retained inventory. Cleared once cut-committed is durably journaled. */
+export interface PreservationCommitIntent {
+  readonly attemptId: string;
+}
+
+function validCommitIntent(value: unknown): value is PreservationCommitIntent {
+  const intent = value as PreservationCommitIntent;
+  return Boolean(intent && typeof intent === "object" &&
+    exactObjectKeys(intent, ["attemptId"]) &&
+    typeof intent.attemptId === "string" && ATTEMPT_ID.test(intent.attemptId));
+}
+
+export function writePreservationCommitIntent(lock: MaintenanceLock, intent: PreservationCommitIntent): void {
+  assertLock(lock);
+  if (!validCommitIntent(intent))
+    maintenanceError("invalid-transition", "preservation commit intent is invalid", { root: lock.root });
+  const paths = maintenancePaths(lock.root);
+  ensureLayout(paths);
+  const journal = readMaintenanceJournal(lock.root);
+  if (!journal || journal.state !== "cut-intent" || journal.cut.attemptId !== intent.attemptId)
+    maintenanceError("invalid-transition", "commit intent requires a cut-intent journal for the same attempt", {
+      root: lock.root, paths: [paths.journal],
+    });
+  atomicWrite(paths.commitIntent, intent);
+}
+
+export function readPreservationCommitIntent(root: string): PreservationCommitIntent | undefined {
+  const paths = maintenancePaths(root);
+  let raw: string;
+  try {
+    const stat = lstatSync(paths.commitIntent);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 16 * 1024)
+      maintenanceError("journal-corrupt", "preservation commit intent is not a bounded regular file", { paths: [paths.commitIntent] });
+    raw = readFileSync(paths.commitIntent, "utf8");
+  } catch (error) {
+    if (errno(error) === "ENOENT") return undefined;
+    if (isMaintenanceError(error)) throw error;
+    maintenanceError("journal-corrupt", "preservation commit intent cannot be read", { paths: [paths.commitIntent] });
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw!);
+  } catch {
+    maintenanceError("journal-corrupt", "preservation commit intent cannot be parsed", { paths: [paths.commitIntent] });
+  }
+  if (!validCommitIntent(parsed))
+    maintenanceError("journal-corrupt", "preservation commit intent is invalid", { paths: [paths.commitIntent] });
+  return parsed;
+}
+
+export function clearPreservationCommitIntent(lock: MaintenanceLock): void {
+  assertLock(lock);
+  const paths = maintenancePaths(lock.root);
+  try {
+    unlinkSync(paths.commitIntent);
     fsyncDirectory(paths.versionDir);
   } catch (error) {
     if (errno(error) !== "ENOENT") throw error;


### PR DESCRIPTION
Remediates the verified findings from the post-merge review of the space-backup feature (#244). Two independent bugs, each reproduced/verified before fixing.

## 1. Harden every intermediate maintenance dir on Windows (security)

The original Windows-ACL fix hardened only the two final artifact dirs. Every intermediate in the same class relied on POSIX mode bits (a no-op on win32): the maintenance attempt tree, the full JetStream store clone, quarantine + sanitized stores, the restore target, and the broker `.conf` (which embeds a plaintext maintenance login). On a shared Windows host with a permissive inherited ACL, an unprivileged local user could read the store clone offline — the whole space's chat, DMs, and ACLs — without touching NATS. `ensurePrivateAttemptsDir`'s ownership check is also POSIX-only.

**Fix:** route every private maintenance dir through `hardenPrivate` (0700 POSIX / inheritable owner-only NTFS ACL, fail-closed) before secret bytes land; harden the `.conf` explicitly.

**Test:** the `backup-cli` smoke (runs on the Windows CI shards) asserts the attempt tree and a clone are private by reading the NTFS ACL back with `icacls` (broad SIDs stripped), the same readback `secret-fs.smoke.ts` uses; POSIX asserts 0700.

## 2. Don't delete a preserved cut when the manager dies after committing (recoverability)

`down --preserve-state` stopped the retained children (`commitPreservation`) and only then journaled `cut-committed`. A coordinator crash in that window left the journal at `cut-intent` while the stop had already run; if the manager then died, recovery assumed "nothing was stopped" and **deleted the journal** — losing the retained inventory.

**Reproduced live** (new unsafe-side fault hook: crash after the manager commits, kill the manager, retry → journal deleted).

**Fix:** a durable `commit-intent` marker written after `cut-intent` but before the child-stopping RPC, cleared once `cut-committed` is journaled. Recovery now distinguishes genuinely-pre-commit (abort, as before) from stop-may-have-run (finish the cut **forward** without the dead manager, after confirming via presence that no retained principal is still live; if one is, the cut is **preserved** for inspection, never deleted). The same repro now recovers to `ready` with the inventory intact.

**Test:** a live scenario covering both the finish-forward fix and the still-abort pre-commit case, plus hermetic `commit-intent` journal tests.

## Verified
- `smoke:backup-cli` (hermetic, incl. ACL readback branch) — green
- `smoke:backup-perms:live`, `smoke:backup-restore:live` (incl. the new crash-recovery scenario) — green
- `packages/workspace` maintenance smoke (203 checks) — green
- full typecheck — green
- win32 ACL branch: exercised on the Windows CI shards (the oracle)

## Follow-ups filed (not in this PR)
- #252 — ordinary-resume orphans retained agents on a crash before `resume-active` (the sibling "journal-after-action" bug; confirmed by code, faithful live repro needs a new installable test-connector harness).
- #250 — unverified concurrent-resume broker race.