### PR TITLE
Add connector-codex: OpenAI Codex CLI as an autonomous mesh worker

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -18,6 +18,7 @@
       "@cotal-ai/connector-claude-code",
       "@cotal-ai/connector-hermes",
       "@cotal-ai/connector-opencode",
+      "@cotal-ai/connector-codex",
       "@cotal-ai/pi",
       "@cotal-ai/auth"
     ]

--- a/extensions/connector-codex/.gitignore
+++ b/extensions/connector-codex/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/extensions/connector-codex/README.md
+++ b/extensions/connector-codex/README.md
@@ -1,0 +1,23 @@
+# @cotal-ai/connector-codex
+
+Cotal connector for the OpenAI Codex CLI: spawns Codex as an autonomous mesh worker.
+
+A thin Node shim owns the mesh agent and drives Codex headlessly, turn by turn:
+`codex exec` starts a thread, and every later turn resumes it with
+`codex exec resume <threadId>`, so the worker keeps its conversation state across
+messages while the shim serves the `cotal_*` tools to Codex over MCP. Push delegation:
+the mesh wakes the worker — the worker does not poll.
+
+Works with whatever auth the local `codex` binary already has (ChatGPT subscription
+login, or an API-key provider from `~/.codex/config.toml`), under the operator's own
+account.
+
+```bash
+cotal spawn worker --agent codex --detach
+```
+
+Notes
+
+- Codex MCP tool calls require `--dangerously-bypass-approvals-and-sandbox`; the shim
+  passes it (the default approval policy auto-cancels mesh tool calls otherwise).
+- `codex exec` reads stdin when it is an open pipe; the shim always closes it.

--- a/extensions/connector-codex/package.json
+++ b/extensions/connector-codex/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@cotal-ai/connector-codex",
+  "description": "Cotal connector for the OpenAI Codex CLI: a Node shim owns the mesh agent and drives codex exec turns, with the cotal_* tools served over local streamable HTTP MCP.",
+  "version": "0.13.1",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Cotal-AI/Cotal.git",
+    "directory": "extensions/connector-codex"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json --emitDeclarationOnly && pnpm run bundle",
+    "bundle": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/index.js --external:@cotal-ai/core && esbuild src/serve.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/serve.js --banner:js=\"import { createRequire as __cotalCreateRequire } from 'node:module'; const require = __cotalCreateRequire(import.meta.url);\"",
+    "prepublishOnly": "pnpm run build"
+  },
+  "peerDependencies": {
+    "@cotal-ai/core": ">=0.1.0"
+  },
+  "devDependencies": {
+    "@cotal-ai/core": "workspace:*",
+    "@cotal-ai/connector-core": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "esbuild": "^0.28.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/extensions/connector-codex/src/index.ts
+++ b/extensions/connector-codex/src/index.ts
@@ -1,0 +1,88 @@
+// connector-codex — Connector extension (loaded by the cotal CLI / manager).
+//
+// buildLaunch returns a Node shim (dist/serve.js) that owns ONE MeshAgent and drives the
+// OpenAI Codex CLI as a chain of `codex exec` / `codex exec resume <threadId>` turns, with
+// the cotal_* tool surface served to codex over a local streamable-HTTP MCP server.
+//
+// Template: @cotal-ai/connector-opencode (shim pattern). @cotal-ai/core stays external
+// (peer dependency — `cotal ext add` links it to the CLI's copy); connector-core helpers
+// are bundled in.
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+import { loadAgentFile, registry, type Connector, type LaunchOpts, type LaunchSpec } from "@cotal-ai/core";
+import {
+  MODEL_PROVIDER_KEYS,
+  launchEnv,
+  aclEnv,
+  userAuthEnv,
+  connectorLaunchOptions,
+  controlEndpoint,
+} from "@cotal-ai/connector-core";
+
+const SERVE_SHIM = fileURLToPath(new URL("./serve.js", import.meta.url));
+
+export const codexConnector: Connector = {
+  kind: "connector",
+  name: "codex",
+  requires: ["codex"],
+  supportsModelVariant: true, // variant → `-c model_reasoning_effort="<variant>"`
+  // v1 fail-loud surface: no resume, no transcript mirror (no transcriptChannel), no tool-sharing.
+  buildLaunch(opts: LaunchOpts): LaunchSpec {
+    if (opts.resume)
+      throw new Error(
+        "codex connector: resuming/forking an existing session (resume) is not implemented (v1) — spawn fresh instead.",
+      );
+    if (opts.mcpServers && Object.keys(opts.mcpServers).length > 0)
+      throw new Error(
+        "codex connector: sharing operator MCP servers with the agent is not implemented (v1).",
+      );
+    if (opts.transcript === true)
+      throw new Error("codex connector: transcript mirroring is not implemented (v1).");
+
+    const env: Record<string, string> = {
+      ...launchEnv({ providerKeys: MODEL_PROVIDER_KEYS }),
+      ...aclEnv(opts),
+      ...userAuthEnv(opts),
+      COTAL_SPACE: opts.space,
+      COTAL_NAME: opts.name,
+    };
+    if (opts.role) env.COTAL_ROLE = opts.role;
+    if (opts.id) env.COTAL_ID = opts.id;
+    if (opts.creds) env.COTAL_CREDS = opts.creds;
+    if (opts.servers) env.COTAL_SERVERS = opts.servers;
+    if (opts.prompt) env.COTAL_CODEX_PROMPT = opts.prompt;
+    // Working root for codex turns (and any per-agent state). The manager's workspace by default.
+    env.COTAL_CODEX_HOME = opts.workspaceRoot ?? process.cwd();
+
+    let model = opts.model;
+    let variant = opts.variant;
+    if (opts.configPath) {
+      const path = resolve(opts.configPath);
+      env.COTAL_AGENT_FILE = path;
+      const def = loadAgentFile(path);
+      model ??= def.model;
+      variant ??= def.variant;
+    }
+    if (model) env.COTAL_MODEL = model;
+    if (variant) env.COTAL_VARIANT = variant;
+
+    // launchOptions → raw `-c key=value` codex config overrides (the connector's option surface).
+    const overrides: string[] = [];
+    for (const [k, v] of connectorLaunchOptions("codex", opts.launchOptions))
+      overrides.push(`${k}=${typeof v === "string" ? v : JSON.stringify(v)}`);
+    if (overrides.length) env.COTAL_CODEX_OVERRIDES = JSON.stringify(overrides);
+
+    const control = controlEndpoint(opts.space, opts.name);
+    env.COTAL_CONTROL_SOCKET = control.path;
+    env.COTAL_CONTROL_TOKEN = control.token;
+
+    return {
+      command: process.execPath,
+      args: [SERVE_SHIM],
+      env,
+      control,
+    };
+  },
+};
+
+registry.register(codexConnector);

--- a/extensions/connector-codex/src/serve.ts
+++ b/extensions/connector-codex/src/serve.ts
@@ -1,0 +1,342 @@
+// connector-codex — the serve shim (LaunchSpec.command = node, args = [dist/serve.js]).
+//
+// Owns ONE MeshAgent for the lifetime of the agent and drives the Codex CLI as a chain of
+// non-interactive turns:
+//
+//   turn 1:  codex exec  <persona + orientation [+ initial prompt]>
+//   turn N:  codex exec resume <threadId>  <formatInjection(drainInbox())>
+//
+// Every turn gets `-c mcp_servers.cotal.url="http://127.0.0.1:<port>/mcp"` — a local
+// streamable-HTTP MCP server (this process) exposing the full cotal_* tool surface bound to
+// the ONE MeshAgent, so mesh state (inbox acks, presence, joins) survives across turns.
+// Peer messages that arrive mid-turn queue in the MeshAgent inbox and become the next turn.
+import { spawn, type ChildProcess } from "node:child_process";
+import { createServer as createNetServer } from "node:net";
+import { createServer as createHttpServer, type IncomingMessage } from "node:http";
+import { once } from "node:events";
+import { loadAgentFile, type PresenceStatus } from "@cotal-ai/core";
+import {
+  configFromEnv,
+  hasIdentity,
+  MeshAgent,
+  registerCotalTools,
+  startControlServer,
+  formatInjection,
+  ORIENTATION_BOOTSTRAP,
+  MESH_FIRST_STEER,
+} from "@cotal-ai/connector-core";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+const TURN_TIMEOUT_MS = Number(process.env.COTAL_CODEX_TURN_TIMEOUT_MS ?? 15 * 60 * 1000);
+const log = (msg: string): void => void process.stderr.write(`[cotal-codex] ${msg}\n`);
+const errMsg = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+
+/** One `codex exec --json` event line — only the fields the turn loop reads. */
+interface CodexEvent {
+  type?: string;
+  thread_id?: string;
+  error?: { message?: string };
+  item?: { type?: string; text?: string; message?: string };
+}
+
+async function freePort(): Promise<number> {
+  const srv = createNetServer();
+  srv.listen(0, "127.0.0.1");
+  await once(srv, "listening");
+  const port = (srv.address() as { port: number }).port;
+  await new Promise<void>((r) => srv.close(() => r()));
+  return port;
+}
+
+function readBody(req: IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      const raw = Buffer.concat(chunks).toString("utf8");
+      if (!raw) return resolve(undefined);
+      try {
+        resolve(JSON.parse(raw));
+      } catch (e) {
+        reject(e as Error);
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+async function main(): Promise<void> {
+  if (!hasIdentity())
+    throw new Error(
+      "connector-codex serve: no COTAL_* identity in the environment — this shim is only launched by the cotal manager (not a managed session).",
+    );
+
+  const config = configFromEnv();
+  config.connector = "codex";
+  const workRoot = process.env.COTAL_CODEX_HOME?.trim() || process.cwd();
+  const initialPrompt = process.env.COTAL_CODEX_PROMPT;
+  const overrides: string[] = process.env.COTAL_CODEX_OVERRIDES
+    ? (JSON.parse(process.env.COTAL_CODEX_OVERRIDES) as string[])
+    : [];
+
+  // Persona body (markdown after the frontmatter) — configFromEnv reads the frontmatter
+  // (name/role/channels), the body is ours to hand codex as its first turn.
+  let persona: string | undefined;
+  if (process.env.COTAL_AGENT_FILE) {
+    try {
+      persona = loadAgentFile(process.env.COTAL_AGENT_FILE).persona;
+    } catch (e) {
+      throw new Error(`connector-codex: cannot read agent file ${process.env.COTAL_AGENT_FILE}: ${errMsg(e)}`);
+    }
+  }
+
+  const agent = new MeshAgent(config);
+  agent.on("error", (e) => log(`mesh error: ${errMsg(e)}`));
+  agent.start();
+
+  // ---- cotal MCP over local streamable HTTP (stateless: fresh server per request, one shared agent)
+  const port = await freePort();
+  const mcpUrl = `http://127.0.0.1:${port}/mcp`;
+  const http = createHttpServer(async (req, res) => {
+    if (!req.url?.startsWith("/mcp")) {
+      res.writeHead(404).end();
+      return;
+    }
+    try {
+      const body = await readBody(req);
+      const server = new McpServer(
+        { name: "cotal", version: "0.1.0" },
+        { instructions: `${ORIENTATION_BOOTSTRAP} ${MESH_FIRST_STEER}` },
+      );
+      registerCotalTools(server, agent, config, "codex");
+      const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+      res.on("close", () => {
+        void transport.close();
+        void server.close();
+      });
+      await server.connect(transport);
+      await transport.handleRequest(req, res, body);
+    } catch (e) {
+      log(`mcp request error: ${errMsg(e)}`);
+      if (!res.headersSent) res.writeHead(500).end();
+    }
+  });
+  http.listen(port, "127.0.0.1");
+  await once(http, "listening");
+  log(`cotal MCP for codex on ${mcpUrl}`);
+
+  // ---- turn loop state
+  let threadId: string | undefined;
+  let child: ChildProcess | undefined;
+  let stopping = false;
+  let wakeTimer: NodeJS.Timeout | undefined;
+
+  const codexEnv = (): NodeJS.ProcessEnv => {
+    const env = { ...process.env };
+    for (const k of Object.keys(env)) if (k.startsWith("COTAL_")) delete env[k];
+    return env;
+  };
+
+  function codexArgs(): string[] {
+    const args = ["exec"];
+    if (threadId) args.push("resume", threadId);
+    args.push(
+      "--json",
+      "--skip-git-repo-check",
+      "--dangerously-bypass-approvals-and-sandbox",
+      "-c",
+      `mcp_servers.cotal.url="${mcpUrl}"`,
+    );
+    if (config.model) args.push("--model", config.model);
+    if (config.variant) args.push("-c", `model_reasoning_effort="${config.variant}"`);
+    for (const o of overrides) args.push("-c", o);
+    args.push("-"); // prompt on stdin — immune to argv length limits and leading-dash text
+    return args;
+  }
+
+  function runTurn(prompt: string): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const proc = spawn("codex", codexArgs(), {
+        cwd: workRoot,
+        env: codexEnv(),
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      child = proc;
+      proc.stdin?.write(prompt);
+      proc.stdin?.end();
+
+      let sawCompleted = false;
+      let failure: string | undefined;
+      let buf = "";
+      const onLine = (line: string): void => {
+        if (!line.startsWith("{")) return;
+        let ev: CodexEvent;
+        try {
+          ev = JSON.parse(line) as CodexEvent;
+        } catch {
+          return;
+        }
+        if (ev.type === "thread.started" && ev.thread_id && !threadId) {
+          threadId = ev.thread_id;
+          log(`codex thread ${threadId}`);
+        } else if (ev.type === "turn.completed") {
+          sawCompleted = true;
+        } else if (ev.type === "turn.failed") {
+          failure = ev.error?.message ?? JSON.stringify(ev);
+        } else if (ev.type === "item.completed" && ev.item?.type === "agent_message") {
+          log(`codex says: ${String(ev.item.text ?? "").slice(0, 400)}`);
+        } else if (ev.type === "item.completed" && ev.item?.type === "error") {
+          log(`codex warning: ${ev.item.message}`);
+        }
+      };
+      proc.stdout?.on("data", (d: Buffer) => {
+        buf += d.toString();
+        for (let i; (i = buf.indexOf("\n")) >= 0; ) {
+          onLine(buf.slice(0, i).trim());
+          buf = buf.slice(i + 1);
+        }
+      });
+      let errTail = "";
+      proc.stderr?.on("data", (d: Buffer) => {
+        errTail = (errTail + d.toString()).slice(-4000);
+      });
+
+      const timer = setTimeout(() => {
+        log(`turn timed out after ${TURN_TIMEOUT_MS}ms — killing codex`);
+        proc.kill("SIGKILL");
+      }, TURN_TIMEOUT_MS);
+
+      proc.on("error", (e) => {
+        clearTimeout(timer);
+        child = undefined;
+        reject(new Error(`codex spawn failed: ${e.message}`));
+      });
+      proc.on("close", (code, signal) => {
+        clearTimeout(timer);
+        child = undefined;
+        if (buf.trim()) onLine(buf.trim());
+        if (failure) return reject(new Error(`codex turn failed: ${failure}`));
+        if (code !== 0 || !sawCompleted)
+          return reject(
+            new Error(
+              `codex exec exited code=${code} signal=${signal} completed=${sawCompleted}: ${errTail.trim().split("\n").slice(-3).join(" | ")}`,
+            ),
+          );
+        resolve();
+      });
+    });
+  }
+
+  const setStatusSafe = async (status: PresenceStatus, activity?: string): Promise<void> => {
+    try {
+      await agent.setStatus(status, activity);
+    } catch {
+      /* pre-connect / transient — presence is advisory */
+    }
+  };
+
+  // ---- inbox pump: one turn at a time; messages landing mid-turn queue and become the next turn
+  let pumping = false;
+  async function pump(): Promise<void> {
+    if (pumping || stopping) return;
+    pumping = true;
+    try {
+      for (;;) {
+        if (stopping || agent.pendingWake() === 0) break;
+        const injection = formatInjection(agent.drainInbox(undefined, "automatic"));
+        if (!injection) break;
+        await setStatusSafe("working", "codex turn");
+        try {
+          await runTurn(injection);
+        } catch (e) {
+          log(`turn failed: ${errMsg(e)}`);
+          break; // don't spin — wait for the next wake
+        }
+      }
+    } finally {
+      pumping = false;
+      await setStatusSafe("idle");
+    }
+  }
+  const scheduleWake = (delay = 300): void => {
+    if (stopping) return;
+    clearTimeout(wakeTimer);
+    wakeTimer = setTimeout(() => void pump(), delay);
+  };
+
+  // ---- cooperative shutdown (manager control frame, signals)
+  async function shutdown(code = 0): Promise<void> {
+    if (stopping) return;
+    stopping = true;
+    clearTimeout(wakeTimer);
+    try {
+      child?.kill("SIGTERM");
+    } catch {
+      /* already gone */
+    }
+    try {
+      await agent.stop();
+    } catch {
+      /* best-effort — exiting anyway */
+    }
+    try {
+      http.close();
+    } catch {
+      /* best-effort — exiting anyway */
+    }
+    process.exit(code);
+  }
+  process.on("SIGINT", () => void shutdown(0));
+  process.on("SIGTERM", () => void shutdown(0));
+  const controlPath = process.env.COTAL_CONTROL_SOCKET;
+  const controlToken = process.env.COTAL_CONTROL_TOKEN;
+  if (controlPath && controlToken) {
+    startControlServer(
+      agent,
+      { path: controlPath, token: controlToken },
+      async () => ({}), // codex has no lifecycle hooks — the control plane is shutdown-only
+      { fatalBind: true, onShutdown: () => void shutdown(0) },
+    );
+  }
+
+  // ---- wait for the mesh link, then boot turn: persona + orientation (+ optional launch prompt)
+  const deadline = Date.now() + 60_000;
+  while (!agent.connected && Date.now() < deadline)
+    await new Promise((r) => setTimeout(r, 250));
+  if (!agent.connected)
+    throw new Error("connector-codex: mesh connection not established within 60s — aborting (is the broker up?)");
+  log(`joined mesh "${config.space}" as ${config.name} (${agent.id})`);
+
+  const bootParts = [
+    `You are "${config.name}"${config.role ? ` (role: ${config.role})` : ""} — an agent on the Cotal mesh (space "${config.space}"), hosted on the OpenAI Codex CLI.`,
+    `Peers reach you via mesh channels and DMs. Use the cotal_* tools (MCP server "cotal") to read and reply: cotal_send for channels, cotal_dm for direct messages. Work delivered to you arrives as "messages from peers" blocks; a turn that ends without sending a reply is INVISIBLE to peers — always report back over the mesh.`,
+    ORIENTATION_BOOTSTRAP,
+    MESH_FIRST_STEER,
+  ];
+  const briefing = agent.channelBriefing();
+  if (briefing) bootParts.push(briefing);
+  if (persona) bootParts.push(`## Your persona\n\n${persona}`);
+  if (initialPrompt) bootParts.push(initialPrompt);
+
+  await setStatusSafe("working", "orienting");
+  try {
+    await runTurn(bootParts.join("\n\n"));
+  } catch (e) {
+    log(`boot turn failed: ${errMsg(e)}`);
+    await shutdown(1);
+    return;
+  }
+  await setStatusSafe("idle");
+  log("boot turn complete — waiting for peer messages");
+
+  agent.on("incoming", () => scheduleWake());
+  agent.on("wake", () => scheduleWake(0));
+  agent.on("mention-wake", () => scheduleWake(0));
+  scheduleWake(0); // catch anything buffered during boot
+}
+
+main().catch((e: unknown) => {
+  process.stderr.write(`[cotal-codex] fatal: ${e instanceof Error ? (e.stack ?? e.message) : String(e)}\n`);
+  process.exit(1);
+});

--- a/extensions/connector-codex/tsconfig.json
+++ b/extensions/connector-codex/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,21 @@ importers:
         specifier: ^4.22.4
         version: 4.22.4
 
+  extensions/connector-codex:
+    devDependencies:
+      '@cotal-ai/connector-core':
+        specifier: workspace:*
+        version: link:../connector-core
+      '@cotal-ai/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
+      esbuild:
+        specifier: ^0.28.0
+        version: 0.28.1
+
   extensions/connector-core:
     dependencies:
       '@modelcontextprotocol/sdk':


### PR DESCRIPTION
This adds `extensions/connector-codex`, which spawns the OpenAI Codex CLI as a full mesh
worker: `cotal spawn worker --agent codex --detach`.

**Design.** A thin Node shim owns the mesh agent and drives Codex headlessly one turn at a
time: the first turn runs `codex exec`, every later turn `codex exec resume <threadId>`, so
the worker keeps conversation state across mesh messages. The shim serves the `cotal_*`
tools to Codex over MCP. Delegation is push-based — the mesh wakes the worker; the worker
never polls. Auth is whatever the local `codex` binary already has (ChatGPT subscription
login or a configured API provider), under the operator's own account.

**The shim, in detail.** The persistent process `cotal spawn` launches is not Codex — it
is a small Node supervisor (`dist/serve.js`) that owns everything durable about the
worker: the `MeshAgent` identity and inbox from connector-core, and a loopback MCP
endpoint. That endpoint is a streamable-HTTP server on an ephemeral `127.0.0.1` port that
constructs a fresh `McpServer` per request (`sessionIdGenerator: undefined`), so there is
no MCP session state to lose across harness respawns — every request binds to the one
long-lived agent. Codex is pointed at it per invocation with
`-c mcp_servers.cotal.url="…"`, so nothing global is touched.

Delivery is event-driven, never polled. `agent.on("incoming")` schedules a wake with a
300 ms debounce so a burst of peer messages coalesces into one turn; explicit wake and
mention events schedule immediately. The pump is single-flight: while `pendingWake() > 0`
it drains the inbox, formats the batch into one injection prompt (the
`📨 Cotal — N new message(s)` block, one bullet per item, reply instructions appended),
and runs exactly one harness turn. Messages that arrive mid-turn simply buffer in the
inbox; the loop re-checks after the child exits, so they become the next turn.

A turn is a fresh process: `codex exec` the first time, `codex exec resume <threadId>`
after that, with `--json --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox`
(headless Codex otherwise auto-cancels MCP calls), optional `--model` and
`-c model_reasoning_effort=…`, and the prompt delivered on stdin (`-`) with stdin then
closed — immune to argv length limits and leading-dash text. Stdout is newline-JSON:
`thread.started` mints the thread id exactly once, and success requires `turn.completed`,
not just exit 0. The child environment is a copy of the shim's with every `COTAL_*`
variable stripped, so a harness can never inherit mesh identity. Presence flips to
`working` for the duration of the turn and back to `idle` in the pump's `finally`.

Because all conversational memory lives server-side in the Codex thread, crash-tolerance
is structural rather than added on: a wedged turn hits the 15-minute timeout and is
SIGKILLed, and the next wake spawns a process that resumes the same thread. The delivery
semantics into the harness are deliberately at-most-once, and worth stating plainly for
review: `drainInbox` acks durables at drain time — before the child spawns — and the
failure branch breaks rather than retries ("don't spin — wait for the next wake"), so a
batch whose turn died after drain is not redelivered; it survives only in the shim's log.
We took that trade because replaying a possibly-half-executed agent turn replays its side
effects. A rotating `handledIds` window deduplicates live/durable copies, so the
at-most-once guarantee holds from the broker all the way into the model's context.

**Code standards.** TypeScript under the shared strict `tsconfig.base.json` (NodeNext,
`verbatimModuleSyntax`), typed against the `Connector` / `LaunchOpts` / `LaunchSpec`
surface. The package contract mirrors the sibling connectors: `types` field + `types`
exports condition, `typecheck` script, declaration emit + esbuild bundles in `build`,
`files` whitelist, `publishConfig`, `prepublishOnly`. `@cotal-ai/connector-codex` is added
to the changesets `fixed` group so it versions in lockstep, and `pnpm-lock.yaml` carries
the new workspace importer (`pnpm install --frozen-lockfile` verified).

**Prior art & lineage.** Three Codex architectures have existed around this repo, and this
PR is deliberately the third:

1. *Pull-only* — the npm `@cotal-ai/connector-codex` 0.1.x experiment (connector-core
   0.2.0): Codex sandboxes lifecycle hooks away from the control socket and has no
   `claude/channel` analog to wake an idle TUI, so the model was asked to poll
   `cotal_inbox`. Removed in 5b3eb21e (archived on `archive/connector-codex`) after
   headless sessions joined the mesh but never acted on it.
2. *Live host-mode* — #97 drives a `codex app-server` thread over JSON-RPC
   (`turn/start` / `turn/steer`): true live-session push with mid-turn steering,
   currently reply-driven.
3. *Push-by-respawn (this PR)* — the persistent process is the shim, not the harness, so
   the idle-wake problem never arises: each drained inbox batch becomes a fresh
   `codex exec resume <threadId>` turn, and the agent keeps full deliberate `cotal_*`
   tool use. It needs only `exec` + `resume` from Codex — no hooks, no wake channel, no
   host server. Complementary to #97 rather than competing (host-mode buys steering;
   respawn buys minimal harness surface). If you'd like the npm name reserved for a
   future host connector I'm happy to rename this one — otherwise it can supersede at
   the next minor.

**Testing.** Builds in-tree (`pnpm --filter "@cotal-ai/connector-codex..." run build`),
`pnpm --filter @cotal-ai/connector-codex run typecheck` passes, the esm bundle imports
clean, and `pack --dry-run` ships exactly `dist/` + manifest. Live-verified on a real
mesh with this same shim logic: spawn joins under the manager, DM round-trip, multi-turn
thread resume holds context, clean stop. We've also run it as a benchmark arm across a
20+ task suite (hermetic, subscription-authed) without a dropped turn.

**Notes for reviewers.**
- Codex's default approval policy auto-cancels MCP tool calls in headless runs; the shim
  passes `--dangerously-bypass-approvals-and-sandbox` on `exec`.
- `codex exec` slurps stdin when handed an open pipe; the shim closes stdin explicitly.


https://claude.ai/code/session_012MLLWMoW1gTp8fft1bWNQv
