### PR TITLE
Add connector-agy: Google Antigravity CLI as an autonomous mesh worker

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -18,6 +18,7 @@
       "@cotal-ai/connector-claude-code",
       "@cotal-ai/connector-hermes",
       "@cotal-ai/connector-opencode",
+      "@cotal-ai/connector-agy",
       "@cotal-ai/pi",
       "@cotal-ai/auth"
     ]

--- a/extensions/connector-agy/.gitignore
+++ b/extensions/connector-agy/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/extensions/connector-agy/README.md
+++ b/extensions/connector-agy/README.md
@@ -1,0 +1,28 @@
+# @cotal-ai/connector-agy
+
+Cotal connector for the Google Antigravity CLI (`agy`): spawns Antigravity as an
+autonomous mesh worker.
+
+A Node shim owns the mesh agent and drives `agy -p` one turn at a time under a
+pseudo-TTY (agy drops its final response on a non-TTY stdout), resuming the same
+conversation across turns via `--conversation <id>` captured from the agy log. The shim
+serves the `cotal_*` tools over a local streamable-HTTP MCP endpoint, wired in through
+the global `~/.gemini/config/mcp_config.json` for the lifetime of the worker and removed
+on shutdown.
+
+Works with the operator's own Google sign-in; models are whatever the local `agy`
+account offers (e.g. Gemini 3.1 Pro at High reasoning).
+
+```bash
+cotal spawn worker --agent agy --detach
+```
+
+Notes
+
+- One agy worker per machine: the connector merges a single `cotal` entry into the
+  global agy MCP config and fails loudly if one already exists (a leftover entry from an
+  unclean shutdown must be deleted before respawning).
+- `--add-dir <workRoot>` is passed on every turn so files land in the work directory
+  rather than agy's own workspace scratch.
+- `COTAL_AGY_STATELESS=1` switches to a rolling-digest fallback (persona + recent
+  transcript per turn) if conversation resume ever misbehaves.

--- a/extensions/connector-agy/package.json
+++ b/extensions/connector-agy/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@cotal-ai/connector-agy",
+  "description": "Cotal connector for the Google Antigravity CLI (agy): a Node shim owns the mesh agent and drives per-turn `agy -p` runs under a pseudo-TTY, serving the cotal_* tools over local streamable HTTP MCP wired in via the global ~/.gemini/config/mcp_config.json.",
+  "version": "0.13.1",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Cotal-AI/Cotal.git",
+    "directory": "extensions/connector-agy"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json --emitDeclarationOnly && pnpm run bundle",
+    "bundle": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/index.js --external:@cotal-ai/core && esbuild src/serve.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/serve.js --banner:js=\"import { createRequire as __cotalCreateRequire } from 'node:module'; const require = __cotalCreateRequire(import.meta.url);\"",
+    "prepublishOnly": "pnpm run build"
+  },
+  "peerDependencies": {
+    "@cotal-ai/core": ">=0.1.0"
+  },
+  "devDependencies": {
+    "@cotal-ai/core": "workspace:*",
+    "@cotal-ai/connector-core": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "esbuild": "^0.28.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/extensions/connector-agy/src/index.ts
+++ b/extensions/connector-agy/src/index.ts
@@ -1,0 +1,97 @@
+// connector-agy — Connector extension (loaded by the cotal CLI / manager).
+//
+// buildLaunch returns a Node shim (dist/serve.js) that owns ONE MeshAgent and drives the
+// Google Antigravity CLI (`agy`) as a chain of non-interactive `agy -p` turns (each wrapped
+// in a pseudo-TTY via `script -qec`), with the cotal_* tool surface served to agy over a
+// local streamable-HTTP MCP server wired in through the GLOBAL
+// ~/.gemini/config/mcp_config.json (agy has no per-invocation MCP flag).
+//
+// Template: @cotal-ai/connector-codex (shim pattern). @cotal-ai/core stays external
+// (peer dependency — `cotal ext add` links it to the CLI's copy); connector-core helpers
+// are bundled in.
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+import { loadAgentFile, registry, type Connector, type LaunchOpts, type LaunchSpec } from "@cotal-ai/core";
+import {
+  MODEL_PROVIDER_KEYS,
+  launchEnv,
+  aclEnv,
+  userAuthEnv,
+  connectorLaunchOptions,
+  controlEndpoint,
+} from "@cotal-ai/connector-core";
+
+const SERVE_SHIM = fileURLToPath(new URL("./serve.js", import.meta.url));
+
+export const agyConnector: Connector = {
+  kind: "connector",
+  name: "agy",
+  requires: ["agy", "script"], // script(1) provides the load-bearing pseudo-TTY wrapper
+  // agy bakes the reasoning level into the model display name ("Gemini 3.1 Pro (High)") —
+  // there is no separate variant/effort flag.
+  supportsModelVariant: false,
+  // v1 fail-loud surface: no resume, no transcript mirror (no transcriptChannel), no tool-sharing.
+  buildLaunch(opts: LaunchOpts): LaunchSpec {
+    if (opts.resume)
+      throw new Error(
+        "agy connector: resuming/forking an existing session (resume) is not implemented (v1) — spawn fresh instead.",
+      );
+    if (opts.mcpServers && Object.keys(opts.mcpServers).length > 0)
+      throw new Error(
+        "agy connector: sharing operator MCP servers with the agent is not implemented (v1).",
+      );
+    if (opts.transcript === true)
+      throw new Error("agy connector: transcript mirroring is not implemented (v1).");
+
+    const env: Record<string, string> = {
+      ...launchEnv({ providerKeys: MODEL_PROVIDER_KEYS }),
+      ...aclEnv(opts),
+      ...userAuthEnv(opts),
+      COTAL_SPACE: opts.space,
+      COTAL_NAME: opts.name,
+    };
+    if (opts.role) env.COTAL_ROLE = opts.role;
+    if (opts.id) env.COTAL_ID = opts.id;
+    if (opts.creds) env.COTAL_CREDS = opts.creds;
+    if (opts.servers) env.COTAL_SERVERS = opts.servers;
+    if (opts.prompt) env.COTAL_AGY_PROMPT = opts.prompt;
+    // Working root for agy turns (stable cwd for every spawned turn). The manager's
+    // workspace by default.
+    env.COTAL_AGY_HOME = opts.workspaceRoot ?? process.cwd();
+
+    let model = opts.model;
+    let variant = opts.variant;
+    if (opts.configPath) {
+      const path = resolve(opts.configPath);
+      env.COTAL_AGENT_FILE = path;
+      const def = loadAgentFile(path);
+      model ??= def.model;
+      variant ??= def.variant;
+    }
+    if (variant)
+      throw new Error(
+        `agy connector: model variants are not supported — the reasoning level is baked into the agy model display name (e.g. "Gemini 3.1 Pro (High)"). Remove "variant: ${variant}" and pick the level via the model name.`,
+      );
+    if (model) env.COTAL_MODEL = model;
+
+    // agy has no config-override surface — fail loud instead of silently dropping options.
+    const unsupported = [...connectorLaunchOptions("agy", opts.launchOptions)];
+    if (unsupported.length)
+      throw new Error(
+        `agy connector: launchOptions are not supported (v1) — got: ${unsupported.map(([k]) => k).join(", ")}`,
+      );
+
+    const control = controlEndpoint(opts.space, opts.name);
+    env.COTAL_CONTROL_SOCKET = control.path;
+    env.COTAL_CONTROL_TOKEN = control.token;
+
+    return {
+      command: process.execPath,
+      args: [SERVE_SHIM],
+      env,
+      control,
+    };
+  },
+};
+
+registry.register(agyConnector);

--- a/extensions/connector-agy/src/serve.ts
+++ b/extensions/connector-agy/src/serve.ts
@@ -1,0 +1,492 @@
+// connector-agy — the serve shim (LaunchSpec.command = node, args = [dist/serve.js]).
+//
+// Owns ONE MeshAgent for the lifetime of the agent and drives the Google Antigravity CLI
+// (`agy`) as a chain of non-interactive turns:
+//
+//   turn 1:  agy -p <persona + orientation [+ initial prompt]>
+//   turn N:  agy -p <formatInjection(drainInbox())> --conversation <conversationId>
+//
+// Every turn runs under a pseudo-TTY (`script -qec … /dev/null`) — LOAD-BEARING: under a
+// non-TTY `agy -p` exits 0 but drops the final response from stdout. The conversation ID is
+// captured from the per-turn agy log file ("Created conversation <uuid>"), and later turns
+// resume it with `--conversation` (state lives in ~/.gemini/antigravity-cli/conversations/).
+//
+// agy has no per-invocation MCP flag, so at startup this shim MERGES a "cotal" entry
+// ({"serverUrl": "http://127.0.0.1:<port>/mcp"}) into the GLOBAL
+// ~/.gemini/config/mcp_config.json and REMOVES it (other entries untouched) on shutdown and
+// on process exit. Consequence: ONE agy mesh worker per machine (v1) — fail loud if a
+// "cotal" entry already exists. The local streamable-HTTP MCP server (this process) exposes
+// the full cotal_* tool surface bound to the ONE MeshAgent, so mesh state (inbox acks,
+// presence, joins) survives across turns. Peer messages that arrive mid-turn queue in the
+// MeshAgent inbox and become the next turn.
+import { spawn, type ChildProcess } from "node:child_process";
+import { createServer as createNetServer } from "node:net";
+import { createServer as createHttpServer, type IncomingMessage } from "node:http";
+import { once } from "node:events";
+import { homedir, tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { loadAgentFile, type PresenceStatus } from "@cotal-ai/core";
+import {
+  configFromEnv,
+  hasIdentity,
+  MeshAgent,
+  registerCotalTools,
+  startControlServer,
+  formatInjection,
+  ORIENTATION_BOOTSTRAP,
+  MESH_FIRST_STEER,
+} from "@cotal-ai/connector-core";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+const DEFAULT_MODEL = "Gemini 3.1 Pro (High)";
+const PRINT_TIMEOUT = process.env.COTAL_AGY_PRINT_TIMEOUT ?? "25m";
+// Hard kill a little after agy's own --print-timeout should have fired.
+const TURN_TIMEOUT_MS = Number(process.env.COTAL_AGY_TURN_TIMEOUT_MS ?? 27 * 60 * 1000);
+// Escape hatch: stateless turns with a rolling digest instead of --conversation resume.
+const STATELESS = process.env.COTAL_AGY_STATELESS === "1";
+const DIGEST_MAX_ENTRIES = 12;
+const DIGEST_MAX_CHARS = 1500;
+const MCP_CONFIG_PATH = join(homedir(), ".gemini", "config", "mcp_config.json");
+
+const log = (msg: string): void => void process.stderr.write(`[cotal-agy] ${msg}\n`);
+const errMsg = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+const shq = (s: string): string => `'${s.replace(/'/g, `'\\''`)}'`;
+const stripAnsi = (s: string): string =>
+  s
+    .replace(/\x1B\][^\x07\x1B]*(?:\x07|\x1B\\)/g, "") // OSC
+    .replace(/\x1B\[[0-9;?]*[A-Za-z]/g, "") // CSI
+    .replace(/\x1B[@-Z\\-_]/g, "") // other escapes
+    .replace(/\r/g, "");
+
+/** The ~/.gemini/config/mcp_config.json shape — only the key this shim merges/removes. */
+interface AgyMcpConfig {
+  mcpServers?: Record<string, unknown>;
+  [k: string]: unknown;
+}
+
+async function freePort(): Promise<number> {
+  const srv = createNetServer();
+  srv.listen(0, "127.0.0.1");
+  await once(srv, "listening");
+  const port = (srv.address() as { port: number }).port;
+  await new Promise<void>((r) => srv.close(() => r()));
+  return port;
+}
+
+function readBody(req: IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => {
+      const raw = Buffer.concat(chunks).toString("utf8");
+      if (!raw) return resolve(undefined);
+      try {
+        resolve(JSON.parse(raw));
+      } catch (e) {
+        reject(e as Error);
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+// ---- global mcp_config.json merge / restore (agy auto-reads it per process launch)
+let cotalEntryInstalled = false;
+
+function installCotalMcpEntry(url: string): void {
+  let cfg: AgyMcpConfig = {};
+  if (existsSync(MCP_CONFIG_PATH)) {
+    try {
+      cfg = JSON.parse(readFileSync(MCP_CONFIG_PATH, "utf8")) as AgyMcpConfig;
+    } catch (e) {
+      throw new Error(
+        `connector-agy: cannot parse ${MCP_CONFIG_PATH} (${errMsg(e)}) — refusing to overwrite it.`,
+      );
+    }
+  }
+  cfg.mcpServers ??= {};
+  if (cfg.mcpServers.cotal)
+    throw new Error(
+      `connector-agy: a "cotal" entry already exists in ${MCP_CONFIG_PATH} — ` +
+        `another agy mesh worker is running (v1 supports ONE agy worker per machine), ` +
+        `or a previous run crashed without cleanup. Stop it / remove the entry and respawn.`,
+    );
+  cfg.mcpServers.cotal = { serverUrl: url };
+  mkdirSync(dirname(MCP_CONFIG_PATH), { recursive: true });
+  writeFileSync(MCP_CONFIG_PATH, JSON.stringify(cfg, null, 2) + "\n");
+  cotalEntryInstalled = true;
+  log(`installed "cotal" MCP entry (${url}) in ${MCP_CONFIG_PATH}`);
+}
+
+function removeCotalMcpEntry(): void {
+  if (!cotalEntryInstalled) return;
+  cotalEntryInstalled = false;
+  try {
+    const cfg = JSON.parse(readFileSync(MCP_CONFIG_PATH, "utf8")) as AgyMcpConfig;
+    if (cfg.mcpServers && "cotal" in cfg.mcpServers) {
+      delete cfg.mcpServers.cotal;
+      writeFileSync(MCP_CONFIG_PATH, JSON.stringify(cfg, null, 2) + "\n");
+      log(`removed "cotal" MCP entry from ${MCP_CONFIG_PATH}`);
+    }
+  } catch (e) {
+    log(`mcp_config cleanup FAILED (remove the "cotal" entry manually): ${errMsg(e)}`);
+  }
+}
+
+async function main(): Promise<void> {
+  if (!hasIdentity())
+    throw new Error(
+      "connector-agy serve: no COTAL_* identity in the environment — this shim is only launched by the cotal manager (not a managed session).",
+    );
+
+  const config = configFromEnv();
+  config.connector = "agy";
+  const workRoot = process.env.COTAL_AGY_HOME?.trim() || process.cwd();
+  const initialPrompt = process.env.COTAL_AGY_PROMPT;
+  const model = process.env.COTAL_MODEL?.trim() || DEFAULT_MODEL;
+
+  // Persona body (markdown after the frontmatter) — configFromEnv reads the frontmatter
+  // (name/role/channels), the body is ours to hand agy as its first turn.
+  let persona: string | undefined;
+  if (process.env.COTAL_AGENT_FILE) {
+    try {
+      persona = loadAgentFile(process.env.COTAL_AGENT_FILE).persona;
+    } catch (e) {
+      throw new Error(
+        `connector-agy: cannot read agent file ${process.env.COTAL_AGENT_FILE}: ${errMsg(e)}`,
+      );
+    }
+  }
+
+  const agent = new MeshAgent(config);
+  agent.on("error", (e) => log(`mesh error: ${errMsg(e)}`));
+  agent.start();
+
+  // ---- cotal MCP over local streamable HTTP (stateless: fresh server per request, one shared agent)
+  const port = await freePort();
+  const mcpUrl = `http://127.0.0.1:${port}/mcp`;
+  const http = createHttpServer(async (req, res) => {
+    if (!req.url?.startsWith("/mcp")) {
+      res.writeHead(404).end();
+      return;
+    }
+    try {
+      const body = await readBody(req);
+      const server = new McpServer(
+        { name: "cotal", version: "0.1.0" },
+        { instructions: `${ORIENTATION_BOOTSTRAP} ${MESH_FIRST_STEER}` },
+      );
+      registerCotalTools(server, agent, config, "agy");
+      const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+      res.on("close", () => {
+        void transport.close();
+        void server.close();
+      });
+      await server.connect(transport);
+      await transport.handleRequest(req, res, body);
+    } catch (e) {
+      log(`mcp request error: ${errMsg(e)}`);
+      if (!res.headersSent) res.writeHead(500).end();
+    }
+  });
+  http.listen(port, "127.0.0.1");
+  await once(http, "listening");
+  log(`cotal MCP for agy on ${mcpUrl}`);
+
+  // agy discovers the cotal MCP server via the GLOBAL config — install now, restore on exit.
+  installCotalMcpEntry(mcpUrl);
+  process.on("exit", removeCotalMcpEntry);
+
+  const tmpRoot = mkdtempSync(join(tmpdir(), "cotal-agy-"));
+  process.on("exit", () => {
+    try {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    } catch {
+      /* best-effort tmp cleanup */
+    }
+  });
+
+  // ---- turn loop state
+  let conversationId: string | undefined; // set from the first turn's agy log ("Created conversation <uuid>")
+  let turnNo = 0;
+  let child: ChildProcess | undefined;
+  let stopping = false;
+  let wakeTimer: NodeJS.Timeout | undefined;
+  const digest: string[] = []; // stateless mode only: rolling window of injections + agy replies
+
+  const agyEnv = (): NodeJS.ProcessEnv => {
+    const env = { ...process.env };
+    for (const k of Object.keys(env)) if (k.startsWith("COTAL_")) delete env[k];
+    const localBin = join(homedir(), ".local", "bin");
+    if (!(env.PATH ?? "").split(":").includes(localBin))
+      env.PATH = `${localBin}:${env.PATH ?? ""}`;
+    if (!env.TERM) env.TERM = "xterm-256color";
+    return env;
+  };
+
+  function pushDigest(label: string, text: string): void {
+    const t = text.trim();
+    if (!t) return;
+    digest.push(`### ${label}\n${t.length > DIGEST_MAX_CHARS ? t.slice(0, DIGEST_MAX_CHARS) + " …[truncated]" : t}`);
+    while (digest.length > DIGEST_MAX_ENTRIES) digest.shift();
+  }
+
+  function agyCommand(promptFile: string, logFile: string): string {
+    // `-p "$(cat '<file>')"` keeps arbitrary prompt text (quotes/newlines/leading dashes)
+    // intact through script(1)'s `sh -c` layer and clear of argv length limits.
+    const parts = [
+      "agy",
+      "-p",
+      `"$(cat ${shq(promptFile)})"`,
+      "--model",
+      shq(model),
+      "--dangerously-skip-permissions",
+      "--print-timeout",
+      shq(PRINT_TIMEOUT),
+      // LOAD-BEARING (benchmark autopsy 2026-07-18): without --add-dir, agy treats
+      // ~/.gemini/antigravity-cli/scratch/ (or $HOME) as its workspace and NEW files land
+      // there instead of the working directory.
+      "--add-dir",
+      shq(workRoot),
+      "--log-file",
+      shq(logFile),
+    ];
+    if (!STATELESS && conversationId) parts.push("--conversation", shq(conversationId));
+    return parts.join(" ");
+  }
+
+  function runTurn(prompt: string): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const n = ++turnNo;
+      const promptFile = join(tmpRoot, `turn-${n}.prompt.txt`);
+      const logFile = join(tmpRoot, `turn-${n}.agy.log`);
+      const resuming = !STATELESS && !!conversationId;
+
+      let fullPrompt = prompt;
+      if (STATELESS && digest.length)
+        fullPrompt = `## Session so far (rolling digest — you are a fresh process; this is your memory)\n\n${digest.join("\n\n")}\n\n---\n\n${prompt}`;
+      writeFileSync(promptFile, fullPrompt);
+
+      // pTTY wrapper is LOAD-BEARING (see header). -e propagates agy's exit code.
+      const proc = spawn("script", ["-qec", agyCommand(promptFile, logFile), "/dev/null"], {
+        cwd: workRoot,
+        env: agyEnv(),
+        stdio: ["ignore", "pipe", "pipe"],
+        detached: true, // own process group — lets the timeout kill agy under script(1)
+      });
+      child = proc;
+
+      let out = "";
+      proc.stdout?.on("data", (d: Buffer) => {
+        out = (out + d.toString()).slice(-200_000);
+      });
+      let errTail = "";
+      proc.stderr?.on("data", (d: Buffer) => {
+        errTail = (errTail + d.toString()).slice(-4000);
+      });
+
+      const killTree = (sig: NodeJS.Signals): void => {
+        try {
+          if (proc.pid === undefined) throw new Error("no pid");
+          process.kill(-proc.pid, sig);
+        } catch {
+          try {
+            proc.kill(sig);
+          } catch {
+            /* already gone */
+          }
+        }
+      };
+      const timer = setTimeout(() => {
+        log(`turn ${n} timed out after ${TURN_TIMEOUT_MS}ms — killing agy`);
+        killTree("SIGKILL");
+      }, TURN_TIMEOUT_MS);
+
+      proc.on("error", (e) => {
+        clearTimeout(timer);
+        child = undefined;
+        reject(new Error(`agy spawn failed (is script(1) installed?): ${e.message}`));
+      });
+      proc.on("close", (code, signal) => {
+        clearTimeout(timer);
+        child = undefined;
+        const text = stripAnsi(out).trim();
+        if (text) log(`agy says: ${text.slice(-400)}`);
+
+        // Conversation bookkeeping from the per-turn agy log.
+        let agyLog = "";
+        try {
+          agyLog = readFileSync(logFile, "utf8");
+        } catch {
+          /* log file may not exist on an early failure */
+        }
+        const created = agyLog.match(/Created conversation ([0-9a-f-]{36})/i)?.[1];
+
+        if (code !== 0)
+          return reject(
+            new Error(
+              `agy turn ${n} exited code=${code} signal=${signal}: ${
+                (errTail.trim() || text).split("\n").slice(-3).join(" | ")
+              }`,
+            ),
+          );
+        if (!STATELESS) {
+          if (resuming && created)
+            return reject(
+              new Error(
+                `agy turn ${n}: asked to resume conversation ${conversationId} but agy CREATED a new one (${created}) — --conversation resume is not working; set COTAL_AGY_STATELESS=1.`,
+              ),
+            );
+          if (!resuming) {
+            if (!created)
+              return reject(
+                new Error(
+                  `agy turn ${n}: no "Created conversation <id>" in the agy log (${logFile}) — cannot chain turns; set COTAL_AGY_STATELESS=1 to run without resume.`,
+                ),
+              );
+            conversationId = created;
+            log(`agy conversation ${conversationId}`);
+          }
+        } else {
+          pushDigest(`Turn ${n} — injected input`, prompt);
+          pushDigest(`Turn ${n} — your final answer`, text);
+        }
+        try {
+          rmSync(promptFile, { force: true });
+        } catch {
+          /* best-effort tmp cleanup */
+        }
+        resolve();
+      });
+    });
+  }
+
+  const setStatusSafe = async (status: PresenceStatus, activity?: string): Promise<void> => {
+    try {
+      await agent.setStatus(status, activity);
+    } catch {
+      /* pre-connect / transient — presence is advisory */
+    }
+  };
+
+  // ---- inbox pump: one turn at a time; messages landing mid-turn queue and become the next turn
+  let pumping = false;
+  async function pump(): Promise<void> {
+    if (pumping || stopping) return;
+    pumping = true;
+    try {
+      for (;;) {
+        if (stopping || agent.pendingWake() === 0) break;
+        const injection = formatInjection(agent.drainInbox(undefined, "automatic"));
+        if (!injection) break;
+        await setStatusSafe("working", "agy turn");
+        try {
+          await runTurn(injection);
+        } catch (e) {
+          log(`turn failed: ${errMsg(e)}`);
+          break; // don't spin — wait for the next wake
+        }
+      }
+    } finally {
+      pumping = false;
+      await setStatusSafe("idle");
+    }
+  }
+  const scheduleWake = (delay = 300): void => {
+    if (stopping) return;
+    clearTimeout(wakeTimer);
+    wakeTimer = setTimeout(() => void pump(), delay);
+  };
+
+  // ---- cooperative shutdown (manager control frame, signals)
+  async function shutdown(code = 0): Promise<void> {
+    if (stopping) return;
+    stopping = true;
+    clearTimeout(wakeTimer);
+    try {
+      if (child?.pid !== undefined) process.kill(-child.pid, "SIGTERM");
+    } catch {
+      try {
+        child?.kill("SIGTERM");
+      } catch {
+        /* already gone */
+      }
+    }
+    removeCotalMcpEntry();
+    try {
+      await agent.stop();
+    } catch {
+      /* best-effort — exiting anyway */
+    }
+    try {
+      http.close();
+    } catch {
+      /* best-effort — exiting anyway */
+    }
+    process.exit(code);
+  }
+  process.on("SIGINT", () => void shutdown(0));
+  process.on("SIGTERM", () => void shutdown(0));
+  const controlPath = process.env.COTAL_CONTROL_SOCKET;
+  const controlToken = process.env.COTAL_CONTROL_TOKEN;
+  if (controlPath && controlToken) {
+    startControlServer(
+      agent,
+      { path: controlPath, token: controlToken },
+      async () => ({}), // agy has no lifecycle hooks — the control plane is shutdown-only
+      { fatalBind: true, onShutdown: () => void shutdown(0) },
+    );
+  }
+
+  // ---- wait for the mesh link, then boot turn: persona + orientation (+ optional launch prompt)
+  const deadline = Date.now() + 60_000;
+  while (!agent.connected && Date.now() < deadline)
+    await new Promise((r) => setTimeout(r, 250));
+  if (!agent.connected)
+    throw new Error(
+      "connector-agy: mesh connection not established within 60s — aborting (is the broker up?)",
+    );
+  log(`joined mesh "${config.space}" as ${config.name} (${agent.id})`);
+
+  const bootParts = [
+    `You are "${config.name}"${config.role ? ` (role: ${config.role})` : ""} — an agent on the Cotal mesh (space "${config.space}"), hosted on the Google Antigravity CLI (agy).`,
+    `Peers reach you via mesh channels and DMs. Use the cotal_* tools (MCP server "cotal") to read and reply: cotal_send for channels, cotal_dm for direct messages. Work delivered to you arrives as "messages from peers" blocks; a turn that ends without sending a reply is INVISIBLE to peers — always report back over the mesh.`,
+    ORIENTATION_BOOTSTRAP,
+    MESH_FIRST_STEER,
+  ];
+  const briefing = agent.channelBriefing();
+  if (briefing) bootParts.push(briefing);
+  if (persona) bootParts.push(`## Your persona\n\n${persona}`);
+  if (initialPrompt) bootParts.push(initialPrompt);
+
+  await setStatusSafe("working", "orienting");
+  try {
+    await runTurn(bootParts.join("\n\n"));
+  } catch (e) {
+    log(`boot turn failed: ${errMsg(e)}`);
+    await shutdown(1);
+    return;
+  }
+  await setStatusSafe("idle");
+  log(`boot turn complete (${STATELESS ? "stateless digest mode" : `conversation ${conversationId}`}) — waiting for peer messages`);
+
+  agent.on("incoming", () => scheduleWake());
+  agent.on("wake", () => scheduleWake(0));
+  agent.on("mention-wake", () => scheduleWake(0));
+  scheduleWake(0); // catch anything buffered during boot
+}
+
+main().catch((e: unknown) => {
+  process.stderr.write(`[cotal-agy] fatal: ${e instanceof Error ? (e.stack ?? e.message) : String(e)}\n`);
+  removeCotalMcpEntry();
+  process.exit(1);
+});

--- a/extensions/connector-agy/tsconfig.json
+++ b/extensions/connector-agy/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,21 @@ importers:
         specifier: ^4.22.4
         version: 4.22.4
 
+  extensions/connector-agy:
+    devDependencies:
+      '@cotal-ai/connector-core':
+        specifier: workspace:*
+        version: link:../connector-core
+      '@cotal-ai/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
+      esbuild:
+        specifier: ^0.28.0
+        version: 0.28.1
+
   extensions/connector-claude-code:
     devDependencies:
       '@cotal-ai/connector-core':


### PR DESCRIPTION
This adds `extensions/connector-agy`, which spawns Google's Antigravity CLI (`agy`) as a
full mesh worker: `cotal spawn worker --agent agy --detach`.

**Design.** A Node shim owns the mesh agent and runs `agy -p` one turn at a time under a
pseudo-TTY (agy drops its final response on a non-TTY stdout while exiting 0). The first
turn's log yields the conversation id; later turns pass `--conversation <id>` so context
persists, and the shim fails loudly if a resume turn unexpectedly creates a fresh
conversation. The `cotal_*` tools are served over a local streamable-HTTP MCP endpoint,
merged into the global `~/.gemini/config/mcp_config.json` for the worker's lifetime and
removed on shutdown and process exit. `--add-dir <workRoot>` is passed on every turn so
artifacts land in the work directory instead of agy's own workspace scratch.

**The shim, in detail.** The process `cotal spawn` keeps alive is a Node supervisor, not
agy: it owns the `MeshAgent` identity and inbox plus a loopback streamable-HTTP MCP
endpoint (ephemeral `127.0.0.1` port, fresh `McpServer` per request — no MCP session
state to lose across respawns). agy has no per-invocation MCP flag, so the shim merges an
`mcpServers.cotal` entry into the global `~/.gemini/config/mcp_config.json` once the
server is listening, and removes it on `shutdown()`, on `process.on("exit")`, and in the
fatal-error path. It refuses to start over an existing `cotal` entry rather than adopt
it — that is the one-worker-per-machine limit, fail-loud by design.

The wake/drain pump is identical to the Codex sibling (#254): event-driven wakes with a
300 ms debounce so bursts coalesce, a single-flight loop that drains the inbox into one
`📨 Cotal — N new message(s)` injection per turn, and mid-turn arrivals buffering until
the child exits. What differs is everything about how a turn runs.

A turn spawns `script -qec '<agy command>' /dev/null` in its own process group
(`detached: true`). The pseudo-TTY wrapper is load-bearing, not cosmetic: on a non-TTY
stdout `agy -p` exits 0 while dropping its final response, so a bare spawn looks like
success with empty output; `script -e` propagates agy's real exit code. The wrapped
command is `agy -p "$(cat '<promptFile>')" --model … --dangerously-skip-permissions
--print-timeout 25m --add-dir <workRoot> --log-file <logFile>`, plus
`--conversation <id>` after the first turn. The prompt travels via a single-quote-escaped
temp file under a `mkdtemp` root (immune to argv limits), and `--add-dir` is what makes
artifacts land in the work directory instead of agy's own workspace scratch. The child
env strips every `COTAL_*` variable, prepends `~/.local/bin` to PATH, and defaults
`TERM=xterm-256color`. Output is plain text — ANSI-stripped, last 200 KB kept.

Continuity rides on agy's server-side conversation state
(`~/.gemini/antigravity-cli/conversations/`): turn 1's log is scanned for
`Created conversation <uuid>`, later turns pass it back, and the shim fails loudly if a
resume turn unexpectedly *creates* a conversation — a silently-broken `--conversation`
was the failure mode we most feared, and `COTAL_AGY_STATELESS=1` exists as a
rolling-digest fallback if a future agy release breaks resume. Failure paths mirror the
process-group reality: a wedged turn hits the 27-minute timeout and gets SIGKILL on the
negative pid — killing only `script` would leave agy alive underneath it — and shutdown
sends the group a SIGTERM. Ack semantics are the same deliberate at-most-once as #254
and worth stating plainly for review: drains ack at drain time, before the spawn, so a
batch whose turn died is not redelivered (replaying a possibly-half-executed turn would
replay its side effects); crash-tolerance instead comes from the conversation itself
surviving — the next wake resumes the same id.

**Code standards.** TypeScript under the shared strict `tsconfig.base.json` (NodeNext,
`verbatimModuleSyntax`), typed against the `Connector` / `LaunchOpts` / `LaunchSpec`
surface. The package contract mirrors the sibling connectors: `types` field + `types`
exports condition, `typecheck` script, declaration emit + esbuild bundles in `build`,
`files` whitelist, `publishConfig`, `prepublishOnly`. `@cotal-ai/connector-agy` is added
to the changesets `fixed` group so it versions in lockstep, and `pnpm-lock.yaml` carries
the new workspace importer (`pnpm install --frozen-lockfile` verified).

**Prior art.** No Antigravity connector has existed in-tree or on npm. The existing
connectors all deliver by pushing into a *live* harness process — hook-injected context at
turn boundaries (Claude Code), API-injected turns (OpenCode), a bridge socket (Hermes),
mid-turn steering (pi) — which requires a cooperation surface the closed `agy` binary
doesn't offer: no lifecycle hooks, no wake-notification channel, no server/host mode, not
even a per-invocation MCP flag. This connector therefore uses the same push-by-respawn
pipeline as the sibling Codex PR (#254): the persistent process is the shim, and each
drained inbox batch becomes a fresh `agy -p --conversation <id>` turn — no idle session
ever needs waking. If agy later ships hooks or a host API, a live-session connector can
layer on without changing the mesh-facing contract.

**Deliberate v1 limits (all fail loudly rather than silently degrade):**
- One agy worker per machine — agy only reads the global MCP config, so the shim refuses
  to start if a `cotal` entry already exists (a stale entry from an unclean shutdown must
  be deleted first).
- `supportsModelVariant: false` — agy bakes the reasoning level into the model display
  name (e.g. "Gemini 3.1 Pro (High)"), selected via `COTAL_MODEL`.
- `COTAL_AGY_STATELESS=1` opts into a rolling-digest fallback (persona + recent
  transcript per turn) if conversation resume misbehaves in a future agy release.

**Testing.** Builds in-tree (`pnpm --filter "@cotal-ai/connector-agy..." run build`),
`pnpm --filter @cotal-ai/connector-agy run typecheck` passes, the esm bundle imports
clean, and `pack --dry-run` ships exactly `dist/` + manifest. Live-verified on a real
mesh with this same shim logic: spawn joins, mcp_config merge preserves existing entries,
DM round-trip publishes to a channel, multi-turn resume holds context, stop removes the
MCP entry cleanly. Also used as a benchmark arm across a 20+ task hermetic suite —
including runs where agy's native harness beat a foreign harness driving the same Gemini
model by ~1.75× at equal quality.


https://claude.ai/code/session_012MLLWMoW1gTp8fft1bWNQv
