### PR TITLE
chore: add changeset for the `cotal -v`/`--version` feature (#267)

### DIFF
--- a/.changeset/cli-version-flag.md
+++ b/.changeset/cli-version-flag.md
@@ -1,0 +1,6 @@
+---
+"@cotal-ai/cli": patch
+"@cotal-ai/connector-core": patch
+---
+
+Add `cotal -v` / `cotal --version`: print the binary version plus each installed extension's, then exit. `cotal status` gains the same report — the Machine section leads with the `cotal-ai` version, and a new Extensions section lists each installed extension with its pinned version, so version skew across the seeded connectors is visible at a glance.


### PR DESCRIPTION
Follow-up to #267. That PR merged without its changeset (it was force-pushed onto the branch a moment after the merge landed), so main has the feature but no changeset to bump/publish it.

This adds the missing **patch** changeset for `@cotal-ai/cli` + `@cotal-ai/connector-core` (the `fixed` group bumps every package to 0.13.1 in lockstep). Merging it lets the next Version Packages PR release the feature.

Changeset-only — no code change.