### PR TITLE
chore(changeset): downgrade the web-bundling bump to patch

### DIFF
--- a/.changeset/web-ships-with-umbrella.md
+++ b/.changeset/web-ships-with-umbrella.md
@@ -1,8 +1,8 @@
 ---
-"cotal-ai": minor
-"@cotal-ai/web": minor
-"@cotal-ai/cli": minor
-"@cotal-ai/workspace": minor
+"cotal-ai": patch
+"@cotal-ai/web": patch
+"@cotal-ai/cli": patch
+"@cotal-ai/workspace": patch
 ---
 
 The web dashboard now ships and versions with the `cotal-ai` binary. Previously `@cotal-ai/web` was fetched separately on its own version line, so upgrading the CLI (`npm i -g cotal-ai@new`) left the dashboard stale, and the documented `cotal ext add @cotal-ai/web` could not cross the 0.x caret to reach the new release, leaving customers on an old dashboard with no clean way forward.


### PR DESCRIPTION
The bundled-web change (#271) is a non-breaking behavior change, so it should take a **patch**, not a minor.

The other pending changeset (`lean-connector-docs`) is already patch, so with this edit the `fixed` group releases **0.13.1 → 0.13.2** instead of 0.14.0. `changeset status` confirms: all packages patch, none minor/major.

Changeset-only edit; no code change.