### PR TITLE
fix(cli): accept npm's array-form version output in cotal update

### DIFF
--- a/.changeset/cli-update-npm-array.md
+++ b/.changeset/cli-update-npm-array.md
@@ -1,0 +1,7 @@
+---
+"@cotal-ai/cli": patch
+---
+
+fix(cli): accept npm's array-form version output in `cotal update`
+
+`cotal update`'s "is a newer binary available" check parsed `npm view cotal-ai@latest version --json` as a bare JSON string. Real npm only returns a bare string while the registry holds a single published version; once more than one version exists it wraps the field in a JSON array (`["0.13.2"]`) even for the `@latest` tag. The strict string check then failed with `npm returned an invalid cotal-ai version`, so the whole command errored at the final step on every real install. The parser now accepts both the string and array forms and takes the highest valid semver, and still rejects empty/garbage output loudly.

--- a/implementations/cli/smoke/command-kernel.smoke.ts
+++ b/implementations/cli/smoke/command-kernel.smoke.ts
@@ -239,7 +239,14 @@ async function completionOut(positionals: string[]): Promise<string> {
   assert.ok(compareSemver("0.13.2", "0.13.2-rc.1") > 0);
   assert.equal(parseNpmVersion('"0.13.2-rc.1"'), "0.13.2-rc.1");
   assert.throws(() => parseNpmVersion('"0.13"'), /invalid cotal-ai version/);
-  assert.throws(() => parseNpmVersion('["0.13.1","0.13.2"]'), /invalid cotal-ai version/);
+  // Real npm wraps `view cotal-ai@latest version --json` in a JSON array once the registry holds more
+  // than one published version — a bare string only appears with a single version. Accept the array
+  // form (the production shape) and take the highest valid semver; reject empty/garbage arrays loudly.
+  assert.equal(parseNpmVersion('["0.13.2"]'), "0.13.2");
+  assert.equal(parseNpmVersion('["0.13.1","0.13.2"]'), "0.13.2");
+  assert.equal(parseNpmVersion('["0.13.2","0.13.10"]'), "0.13.10");
+  assert.throws(() => parseNpmVersion("[]"), /invalid cotal-ai version/);
+  assert.throws(() => parseNpmVersion('["0.13","not-a-version"]'), /invalid cotal-ai version/);
 
   const { rt, events } = updateRuntime({
     extensions: [

--- a/implementations/cli/src/commands/update.ts
+++ b/implementations/cli/src/commands/update.ts
@@ -304,10 +304,16 @@ function childBinding(rt: UpdateRuntime):
 
 export function parseNpmVersion(output: string): string {
   const parsed: unknown = JSON.parse(output.trim());
-  if (typeof parsed !== "string" || !STRICT_SEMVER.test(parsed))
+  // `npm view cotal-ai@latest version --json` returns a bare string ("0.13.2") only while the
+  // registry holds a single published version; once more than one exists npm wraps the field query
+  // in a JSON array (["0.13.2"]) even for the @latest tag. Accept both, and take the highest valid
+  // semver — the @latest query resolves the array to a single element, and the max is the right
+  // answer whether npm hands back one element or the whole version list.
+  const candidates = typeof parsed === "string" ? [parsed] : Array.isArray(parsed) ? parsed : [];
+  const versions = candidates.filter((v): v is string => typeof v === "string" && STRICT_SEMVER.test(v));
+  if (versions.length === 0)
     throw new Error(`npm returned an invalid cotal-ai version: ${JSON.stringify(parsed)}`);
-  compareSemver(parsed, parsed);
-  return parsed;
+  return versions.reduce((max, v) => (compareSemver(v, max) > 0 ? v : max));
 }
 
 const PRE = "(?:0|[1-9]\\d*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)";


### PR DESCRIPTION
## Problem

`cotal update` failed at its final step on every real install:

```
✗ cotal-ai version check failed: npm returned an invalid cotal-ai version: ["0.13.2"] ??
```

The "is a newer binary available" check parses `npm view cotal-ai@latest version --json`. That command returns a bare JSON string (`"0.13.2"`) **only while the registry holds a single published version**. Once more than one version exists, npm wraps the field in a JSON array (`["0.13.2"]`) even for the `@latest` tag. The parser required `typeof parsed === "string"`, so it rejected the array and errored out. Everything before it (built-in connector + web reconcile, operator-ext reconcile) had already succeeded; only the version check broke.

This slipped through the original e2e because the local verdaccio registry held a single version and returned the bare-string form, so the array branch was never exercised. A prior unit assertion even codified the wrong assumption (`parseNpmVersion('["0.13.1","0.13.2"]')` was asserted to throw).

## Fix

`parseNpmVersion` now accepts both the bare-string and array forms and takes the highest valid semver (for the `@latest` query the array resolves to a single element; the max is correct whether npm returns one element or the whole list). Empty and non-semver output still throw loudly.

## Verification

- **Reproduced live** against real npm: `npm view cotal-ai@latest version --json` returns `["0.13.2"]`; the shipped 0.13.2 binary errors on it.
- **Fixed end-to-end**: `cotal update` from the patched build now completes with `✓ cotal-ai 0.13.2 is up to date`.
- **Unit coverage** in `command-kernel` flips the array assertion and adds the single-element (the exact production shape), full-list, empty-array, and garbage cases.
- Green locally: `typecheck`, `build`, `smoke:cli-kernel`, `smoke:update-concurrency`, `smoke:flag-inventory`.