### PR TITLE
examples: quorum code review (resample-and-vote over v0.4 endpoints)

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -16,6 +16,7 @@ README.
 | [02: Self-improving Console](../examples/02-self-improving-console/README.md) | A swarm of Claude Code agents (with an OpenCode/GPT agent reviewing their work) ships a live activity-pulse sparkline into Cotal's own console, settling the data↔UI contract peer-to-peer over the mesh. Agents improving the system that coordinates them. |
 | [03: Personas](../examples/03-personas/README.md) | Ten character personas join one space and talk in real time: the same primitives (presence, channels, DMs) as the worker examples, but the peers are personalities, not roles. Research drops and derived personas are gitignored; only the READMEs and the template are committed. |
 | [04: Frontier Faces](../examples/04-frontier-faces/README.md) | Panelist personas as animated 32×32 pixel-art OpenCode agents: each thinks, lip-syncs its streamed reply, and steers its own expression. Two front-ends onto the *same* live mesh (a browser studio and a tmux wall), both spawning real agents that coordinate as lateral peers. |
+| [05: Quorum Code Review](../examples/05-quorum-code-review/README.md) | Resample-and-vote code review over the v0.4 endpoint surface: a reviewer service with N instances, three persona commands, and an orchestrator that `scatter`s a PR to every instance, groups the schema-clean replies by instance into runs, and keeps only findings that appear in ≥ k runs. The `scatter` verb gives isolation, attribution, and partial-result handling; the k-of-N vote stays application code. |
 
 Example 02 running, a Claude Code swarm with the live console beside it:
 

--- a/examples/05-quorum-code-review/.gitignore
+++ b/examples/05-quorum-code-review/.gitignore
@@ -1,2 +1,1 @@
 dist/
-.runs/

--- a/examples/05-quorum-code-review/.gitignore
+++ b/examples/05-quorum-code-review/.gitignore
@@ -1,0 +1,2 @@
+dist/
+.runs/

--- a/examples/05-quorum-code-review/README.md
+++ b/examples/05-quorum-code-review/README.md
@@ -65,7 +65,9 @@ minted by the auth layer for a secured space, and is out of scope here.
 - Node ≥ 20, pnpm, and `nats-server` on PATH (macOS: `brew install nats-server`).
 - Build core once, from the repo root: `pnpm install && pnpm -r build`.
 - For a **real** run (not `--mock`): `opencode` on PATH with a configured model
-  (`COTAL_REVIEW_MODEL`, default `openai/gpt-5.5`); `GITHUB_TOKEN` is optional (lifts the rate limit).
+  (`COTAL_REVIEW_MODEL`, default `openai/gpt-5.5`); `GITHUB_TOKEN` is optional (lifts the rate limit);
+  `COTAL_REVIEW_TIMEOUT_MS` caps each model call (default 600000). A real run starts with a model
+  canary — one tiny call — so a missing CLI or an exhausted quota fails fast instead of hanging.
 
 ## Run it
 

--- a/examples/05-quorum-code-review/README.md
+++ b/examples/05-quorum-code-review/README.md
@@ -1,0 +1,105 @@
+# Example 05 — Quorum Code Review
+
+Point it at a public GitHub PR and it runs a resample-and-vote review **live on Cotal**: one
+three-persona team, run **N times in strict isolation**, keeping only the findings that show up in
+**≥ k of N** runs. The transport is the v0.4 endpoint surface — a `scatter` fans one request to
+every instance of a service and gathers one schema-clean, attributed reply each.
+
+```
+(cd examples/05-quorum-code-review && pnpm run review -- --mock)
+```
+
+```
+[mock] reviewing https://github.com/example/repo/pull/1
+  3 instances, keep findings in >= 3 of 3 runs
+
+scatters:
+  bughunter  complete=true runs=3 missing=0 churn=0 duplicate=0
+  keeper     complete=true runs=3 missing=0 churn=0 duplicate=0
+  sweeper    complete=true runs=3 missing=0 churn=0 duplicate=0
+
+survived the 3-of-3 vote: 2 finding(s)
+  [HIGH] src/auth.ts:42  (support 3/3)
+    off-by-one on the token loop bound also trips the boundary test, which can no longer fail
+  [MED] src/cache.ts:17  (support 3/3)
+    cache entry written before the DB commit; a rollback leaves a stale read
+```
+
+## What it demonstrates
+
+- **N instances ARE the N runs.** One reviewer endpoint (`ai.cotal.reviewer`) with N instances;
+  each serves three persona commands (`review-bughunter` / `review-keeper` / `review-sweeper`).
+  Two instances reviewing the same PR with the same persona are two independent samples.
+- **Isolation is structural, not prompt-enforced.** The `scatter` verb fans one request to every
+  instance and gathers one reply each; replies ride the caller's own nonce-scoped rail, and there
+  is no shared channel. No instance is on the path of another instance's reply.
+- **Schema-clean replies, no repair pass.** Findings are ajv-validated at the serving boundary and
+  again caller-side by the scatter, so the orchestrator never sees a malformed finding.
+- **Broker-derived attribution.** Every reply's `(instanceId, epoch)` comes from the reply subject,
+  so grouping by `instanceId` reconstructs the runs — an instance can't be misattributed.
+- **Deadlines and partial results for free.** A quota-hung instance becomes a reported `missing`
+  run, not a silent hang; `churn` / `duplicate` are classified, not guessed.
+- **The vote stays application code.** Cotal has no quorum / k-of-N / clustering primitive; it hands
+  you N isolated, attributed samples and the "kept if in ≥ k runs" filter is yours (`vote.ts`).
+
+## Why isolation matters
+
+The isolation is the whole game: if the runs can see each other, their findings correlate and the
+k-of-N filter stops removing noise. Putting reviewers in one shared channel with endorsements leaks
+exactly that correlation, and a prompt line ("you do not see other reviewers' output") is a request,
+not a guarantee. On the endpoint surface the guarantee is structural — the scatter delivers the same
+request to each instance independently and each reply is addressed to the caller alone.
+
+### Isolation fidelity (honest note)
+
+This example runs on a **single local broker** and enforces each instance's command surface **in
+code** — through its authorized serve grant — exactly as `@cotal-ai/core`'s own smoke tests do. That
+gives real structural isolation: no shared channel, per-caller nonce-scoped reply rails, and
+broker-derived attribution; the smoke asserts that a *foreign* caller sees none of the
+orchestrator's replies. The stronger wire-level default-deny — a *malicious* instance provably
+**cannot** subscribe to another instance's rail even if it tries — is a credential-scoping property
+minted by the auth layer for a secured space, and is out of scope here.
+
+## Prerequisites
+
+- Node ≥ 20, pnpm, and `nats-server` on PATH (macOS: `brew install nats-server`).
+- Build core once, from the repo root: `pnpm install && pnpm -r build`.
+- For a **real** run (not `--mock`): `opencode` on PATH with a configured model
+  (`COTAL_REVIEW_MODEL`, default `openai/gpt-5.5`); `GITHUB_TOKEN` is optional (lifts the rate limit).
+
+## Run it
+
+```bash
+# mock — canned findings, no model quota, no network
+(cd examples/05-quorum-code-review && pnpm run review -- --mock)
+
+# real — a live model on a public PR
+(cd examples/05-quorum-code-review && pnpm run review -- https://github.com/OWNER/REPO/pull/N)
+```
+
+Options: `--instances N` (default 3) and `--k K` (default 3, i.e. unanimity). For the demo the
+reviewer daemon and the orchestrator run in one process against one local broker; in a real
+deployment the daemon is long-lived and separately provisioned, and the orchestrator is a plain
+core-client that connects, freezes the live instance set, and scatters.
+
+## How it works
+
+1. Start a local broker and provision the `ai.cotal.reviewer` service (its two-digest contract
+   closure is pinned, so every instance registers the identical contract).
+2. The reviewer daemon registers N instances and serves the three persona commands; each handler is
+   a fresh, stateless model call (serialized per instance for OpenCode's SQLite lock).
+3. The orchestrator builds the PR packet, `freezeExpectedSet` → the run set, then **three scatters**
+   (one per persona) against that frozen set.
+4. Group replies by `instanceId` into runs → merge the three personas within each run → cluster the
+   findings across runs → keep the clusters with support ≥ k.
+
+## Self-test
+
+```
+(cd examples/05-quorum-code-review && pnpm run smoke)
+```
+
+A mock end-to-end check: broker up, the reviewer daemon with three instances, the orchestrator on a
+fixture PR. It asserts three complete scatters over three attributed instances, that the runs
+reconstruct, that the k-of-N vote keeps the shared findings and votes out the per-instance noise, and
+that a foreign caller's reply rail receives nothing.

--- a/examples/05-quorum-code-review/package.json
+++ b/examples/05-quorum-code-review/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@cotal-ai/example-05-quorum-code-review",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "review": "tsx src/main.ts",
+    "smoke": "tsx src/smoke.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@cotal-ai/core": "workspace:*",
+    "@nats-io/jetstream": "^3.4.0",
+    "@nats-io/kv": "^3.4.0",
+    "@nats-io/transport-node": "^3.4.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.22.4"
+  }
+}

--- a/examples/05-quorum-code-review/src/contracts.ts
+++ b/examples/05-quorum-code-review/src/contracts.ts
@@ -1,0 +1,118 @@
+// The review cluster's contracts (SPEC §13.7). Two JSON Schema 2020-12 documents — the PR-packet
+// input and the findings output — compiled to provenance-branded validators, plus a cluster
+// document whose commands pin those schemas by closure digest. Every reviewer instance registers
+// the SAME clusterDigest, so a run that served a different contract is structurally excluded from
+// the vote (§13.5 registrationRevision freeze). Replies are ajv-validated at the serving boundary
+// AND caller-side by the scatter, so the orchestrator never sees a malformed finding.
+import {
+  compileContract,
+  contractDigest,
+  buildContractClosureManifest,
+  type CompiledContract,
+} from "@cotal-ai/core";
+
+/** The endpoint (reverse-DNS; wire token `ai_cotal_reviewer`) and its cluster URN (§13.7). */
+export const REVIEW_ENDPOINT = "ai.cotal.reviewer";
+export const REVIEW_CLUSTER_URN = "ai.cotal.review";
+export const REVIEW_OWNER = "u_cotal";
+
+/** One command per persona; each is untargeted, ephemeral, scattered on the `all` rail. */
+export const PERSONAS = ["bughunter", "keeper", "sweeper"] as const;
+export type Persona = (typeof PERSONAS)[number];
+export const commandFor = (persona: Persona): string => `review-${persona}`;
+
+/** The PR packet a reviewer sees. The patch rides `args` (the body), never the subject (§13.4). */
+export interface PrPacket {
+  prUrl: string;
+  title: string;
+  body?: string;
+  patch: string;
+  context?: string;
+  maxFindings?: number;
+}
+
+export interface Finding {
+  path: string | null;
+  line: number | null;
+  severity: "HIGH" | "MED" | "LOW";
+  body: string;
+}
+
+export interface ReviewFindings {
+  findings: Finding[];
+}
+
+// Input (PR packet) — the patch is bounded by max_payload, not the 1 KiB subject bound (§13.2).
+const INPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["prUrl", "title", "patch"],
+  properties: {
+    prUrl: { type: "string", maxLength: 512 },
+    title: { type: "string", maxLength: 1024 },
+    body: { type: "string", maxLength: 8192 },
+    patch: { type: "string", maxLength: 400000 },
+    context: { type: "string", maxLength: 400000 },
+    maxFindings: { type: "integer", minimum: 1, maximum: 32 },
+  },
+} as const;
+
+// Output (findings) — the win that replaces the JSON-repair pass on the wire.
+const OUTPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["findings"],
+  properties: {
+    findings: {
+      type: "array",
+      maxItems: 32,
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["body", "severity"],
+        properties: {
+          path: { type: ["string", "null"], maxLength: 512 },
+          line: { type: ["integer", "null"], minimum: 0 },
+          severity: { enum: ["HIGH", "MED", "LOW"] },
+          body: { type: "string", maxLength: 4096 },
+        },
+      },
+    },
+  },
+} as const;
+
+export const inputContract: CompiledContract = compileContract({ root: INPUT_SCHEMA });
+export const outputContract: CompiledContract = compileContract({ root: OUTPUT_SCHEMA });
+
+// The §13.7 cluster document: the content-addressed authority for every command's served shape.
+// Its commands pin the input/output schemas by their compiled closure digests.
+const clusterDocument = {
+  urn: REVIEW_CLUSTER_URN,
+  revision: 1,
+  attributes: [],
+  events: [],
+  commands: PERSONAS.map((persona) => ({
+    name: commandFor(persona),
+    class: "ephemeral",
+    targeted: false,
+    capability: "manager.call",
+    inputDigest: inputContract.closureDigest,
+    outputDigest: outputContract.closureDigest,
+  })),
+};
+
+// A minimal content-addressed contract store (SPEC §13.7 two-digest addressing): the cluster
+// DOCUMENT lives at its artifact digest; a single-member closure MANIFEST `{v,root,members}` lives
+// at the CLOSURE digest, which is what instances register and callers pin. This mirrors the proven
+// register/serve path exactly; a KV-backed store (publishContractArtifact) is the production form.
+const rootDigest = contractDigest(clusterDocument);
+const closureManifest = buildContractClosureManifest(rootDigest, []);
+export const clusterDigest = contractDigest(closureManifest);
+
+const store = new Map<string, unknown>([
+  [rootDigest, clusterDocument],
+  [clusterDigest, closureManifest],
+]);
+
+/** The §13.7 content-store reader the register/serve seams resolve cluster digests through. */
+export const readClusterArtifact = (digest: string): unknown => store.get(digest);

--- a/examples/05-quorum-code-review/src/fixtures/sample-pr.ts
+++ b/examples/05-quorum-code-review/src/fixtures/sample-pr.ts
@@ -1,0 +1,25 @@
+// A tiny fixture PR used by `--mock` runs and the smoke test, so neither needs network or model
+// quota. The planted defects line up with the canned mock findings (src/auth.ts:42, src/cache.ts:17).
+import type { PrPacket } from "../contracts.js";
+
+export const SAMPLE_PR: PrPacket = {
+  prUrl: "https://github.com/example/repo/pull/1",
+  title: "Add token rotation and a write-through cache",
+  body: "Rotates auth tokens on refresh and caches the lookup. Follow-up to #0.",
+  patch: `diff --git a/src/auth.ts b/src/auth.ts
+@@ -38,6 +38,9 @@ export function rotate(tokens: string[]) {
+-  for (let i = 0; i < tokens.length; i++) {
++  for (let i = 0; i <= tokens.length; i++) {
+     tokens[i] = mint(tokens[i]);
+   }
+diff --git a/src/cache.ts b/src/cache.ts
+@@ -14,5 +14,7 @@ export async function lookup(id: string) {
++  cache.set(id, row);
++  await db.commit();
+   return row;
+diff --git a/src/util.ts b/src/util.ts
+@@ -1,3 +1,4 @@
++export const noop = () => {};
+`,
+  maxFindings: 8,
+};

--- a/examples/05-quorum-code-review/src/github.ts
+++ b/examples/05-quorum-code-review/src/github.ts
@@ -1,0 +1,50 @@
+// Build the PR packet from a public GitHub PR URL (ported and simplified from the benchmark
+// harness). GITHUB_TOKEN is used when present to lift the rate limit, but public PRs work without.
+import type { PrPacket } from "./contracts.js";
+
+function parseGithubPr(url: string): { owner: string; repo: string; number: number } {
+  const m = url.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+  if (!m) throw new Error(`not a GitHub PR URL: ${url}`);
+  return { owner: m[1], repo: m[2], number: Number(m[3]) };
+}
+
+async function withRetry<T>(label: string, fn: () => Promise<T>, attempts = 3): Promise<T> {
+  let last: unknown;
+  for (let i = 1; i <= attempts; i++) {
+    try {
+      return await fn();
+    } catch (e) {
+      last = e;
+      if (i === attempts) break;
+      await new Promise((r) => setTimeout(r, 1000 * 2 ** (i - 1)));
+    }
+  }
+  throw last;
+}
+
+const authHeader = (): Record<string, string> =>
+  process.env.GITHUB_TOKEN ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` } : {};
+
+/** Fetch PR metadata + the unified patch, capped to the input contract's bounds. */
+export async function fetchPrPacket(url: string, maxFindings = 8): Promise<PrPacket> {
+  const { owner, repo, number } = parseGithubPr(url);
+  const meta = await withRetry(`meta ${url}`, async () => {
+    const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/pulls/${number}`, {
+      headers: { Accept: "application/vnd.github+json", ...authHeader() },
+    });
+    if (!res.ok) throw new Error(`GitHub ${res.status} for ${url}`);
+    return (await res.json()) as { title?: string; body?: string };
+  });
+  const patch = await withRetry(`patch ${url}`, async () => {
+    const res = await fetch(`${url}.patch`, { headers: authHeader() });
+    if (!res.ok) throw new Error(`GitHub ${res.status} for ${url}.patch`);
+    return res.text();
+  });
+  return {
+    prUrl: url,
+    title: (meta.title || "").slice(0, 1024),
+    body: (meta.body || "").slice(0, 8192),
+    patch: patch.slice(0, 400_000),
+    maxFindings,
+  };
+}

--- a/examples/05-quorum-code-review/src/main.ts
+++ b/examples/05-quorum-code-review/src/main.ts
@@ -1,0 +1,68 @@
+// CLI: point at a public GitHub PR and run the benchmark-winning recipe live on Cotal.
+//
+//   pnpm run review -- <pr-url> [--instances N] [--k K] [--mock]
+//
+// Starts a local broker, brings up the reviewer daemon (N instances), fetches the PR, runs the
+// orchestrator (freeze -> 3 scatters -> group -> merge -> k-of-N vote), prints the survivors, and
+// tears everything down. `--mock` returns canned findings (no model quota, no network needed).
+import { mintLifecycleUid } from "@cotal-ai/core";
+import { fetchPrPacket } from "./github.js";
+import { startBroker } from "./space.js";
+import { startReviewer } from "./reviewer.js";
+import { reviewPr } from "./orchestrator.js";
+import { SAMPLE_PR } from "./fixtures/sample-pr.js";
+
+function parseArgs(argv: string[]) {
+  let url: string | undefined;
+  let instances = 3;
+  let k = 3;
+  let mock = false;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--mock") mock = true;
+    else if (a === "--instances") instances = Number(argv[++i]);
+    else if (a === "--k") k = Number(argv[++i]);
+    else if (!a.startsWith("--")) url = a;
+  }
+  return { url, instances, k, mock };
+}
+
+async function main() {
+  const { url, instances, k, mock } = parseArgs(process.argv.slice(2));
+  if (!url && !mock) {
+    console.error("usage: pnpm run review -- <github-pr-url> [--instances N] [--k K] [--mock]");
+    process.exit(2);
+  }
+  const space = "review";
+  const packet = url ? await fetchPrPacket(url) : SAMPLE_PR;
+  const reviewTimeoutMs = Number(process.env.COTAL_REVIEW_TIMEOUT_MS || 600_000);
+  const deadlineMs = mock ? 8_000 : reviewTimeoutMs + 60_000;
+
+  console.log(`${mock ? "[mock] " : ""}reviewing ${packet.prUrl}`);
+  console.log(`  ${instances} instances, keep findings in >= ${k} of ${instances} runs`);
+
+  const broker = await startBroker();
+  const instanceIds = Array.from({ length: instances }, () => mintLifecycleUid());
+  const reviewer = await startReviewer({ url: broker.url, space, instanceIds, mock });
+  try {
+    const result = await reviewPr({ url: broker.url, space, packet, k, deadlineMs, mock });
+
+    console.log("\nscatters:");
+    for (const s of result.stats) {
+      console.log(`  ${s.persona.padEnd(10)} complete=${s.complete} runs=${s.responders.length} missing=${s.missing} churn=${s.churn} duplicate=${s.duplicate}`);
+    }
+    console.log(`\nsurvived the ${k}-of-${instances} vote: ${result.voted.length} finding(s)`);
+    for (const f of result.voted) {
+      const at = f.path ? `${f.path}${f.line !== null ? `:${f.line}` : ""}` : "(no location)";
+      console.log(`  [${f.severity}] ${at}  (support ${f.support}/${instances})\n    ${f.body}`);
+    }
+  } finally {
+    await reviewer.stop();
+    broker.stop();
+  }
+}
+
+main().catch((e) => {
+  console.error(e instanceof Error ? e.stack : e);
+  process.exit(1);
+});

--- a/examples/05-quorum-code-review/src/main.ts
+++ b/examples/05-quorum-code-review/src/main.ts
@@ -7,6 +7,7 @@
 // tears everything down. `--mock` returns canned findings (no model quota, no network needed).
 import { mintLifecycleUid } from "@cotal-ai/core";
 import { fetchPrPacket } from "./github.js";
+import { canaryModel } from "./personas.js";
 import { startBroker } from "./space.js";
 import { startReviewer } from "./reviewer.js";
 import { reviewPr } from "./orchestrator.js";
@@ -32,6 +33,11 @@ async function main() {
   if (!url && !mock) {
     console.error("usage: pnpm run review -- <github-pr-url> [--instances N] [--k K] [--mock]");
     process.exit(2);
+  }
+  if (!mock) {
+    process.stdout.write("model canary... ");
+    await canaryModel();
+    console.log("ok");
   }
   const space = "review";
   const packet = url ? await fetchPrPacket(url) : SAMPLE_PR;

--- a/examples/05-quorum-code-review/src/orchestrator.ts
+++ b/examples/05-quorum-code-review/src/orchestrator.ts
@@ -1,0 +1,102 @@
+// The orchestrator: a core-client (NOT an agent). It holds a caller credential and drives the run
+// with `freezeExpectedSet` + `epScatter` — three scatters, one per persona, against a single frozen
+// set. Grouping replies by instanceId reconstructs the runs; the deadline/partial-result bookkeeping
+// (missing / churn / duplicate) comes from the scatter for free.
+import {
+  freezeExpectedSet,
+  epScatter,
+  registrationReconciler,
+  mintLifecycleUid,
+  type EpCaller,
+  type EpScatterResult,
+} from "@cotal-ai/core";
+import { REVIEW_ENDPOINT, REVIEW_OWNER, PERSONAS, commandFor, inputContract, outputContract, type Finding, type PrPacket } from "./contracts.js";
+import { connectNats, openSpaceKv, openJsm } from "./space.js";
+import { mergeRun, clusterAndVote, type VotedFinding } from "./vote.js";
+
+export interface ScatterStat {
+  persona: string;
+  complete: boolean;
+  responders: string[];
+  missing: number;
+  churn: number;
+  duplicate: number;
+  unexpected: number;
+  invalid: number;
+}
+
+export interface ReviewResult {
+  caller: EpCaller;
+  runIds: string[];
+  runs: { instanceId: string; findings: Finding[] }[];
+  voted: VotedFinding[];
+  stats: ScatterStat[];
+}
+
+function findingsOf(res: EpScatterResult, instanceId: string): Finding[] {
+  const att = res.replies.get(instanceId);
+  if (!att || !att.reply.ok) return [];
+  const data = att.reply.data as { findings?: Finding[] };
+  return Array.isArray(data.findings) ? data.findings : [];
+}
+
+/** Review one PR: freeze -> 3 scatters -> group by run -> per-run merge -> cross-run k-of-N vote. */
+export async function reviewPr(opts: {
+  url: string;
+  space: string;
+  packet: PrPacket;
+  k: number;
+  deadlineMs: number;
+  mock: boolean;
+}): Promise<ReviewResult> {
+  const nc = await connectNats(opts.url);
+  try {
+    const kv = await openSpaceKv(nc, opts.space);
+    const jsm = await openJsm(nc);
+    const caller: EpCaller = { owner: REVIEW_OWNER, actor: "orchestrator", uid: mintLifecycleUid() };
+
+    // The run set: every live, READY instance at its frozen (registrationRevision, epoch).
+    const frozen = await freezeExpectedSet(jsm, kv, opts.space, REVIEW_ENDPOINT);
+    const runIds = frozen.map((f) => f.instanceId);
+
+    const byPersona = new Map<string, EpScatterResult>();
+    const stats: ScatterStat[] = [];
+    for (const persona of PERSONAS) {
+      const op = {
+        endpoint: REVIEW_ENDPOINT,
+        command: commandFor(persona),
+        contract: { input: inputContract, output: outputContract },
+        caller,
+        args: opts.packet as unknown as Record<string, unknown>,
+      };
+      const res = await epScatter(nc, opts.space, op, {
+        deadlineMs: opts.deadlineMs,
+        expected: frozen,
+        reconcileRegistration: registrationReconciler(jsm, opts.space, REVIEW_ENDPOINT, frozen),
+      });
+      byPersona.set(persona, res);
+      stats.push({
+        persona,
+        complete: res.complete,
+        responders: [...res.replies.keys()],
+        missing: res.missing.length,
+        churn: res.churn.length,
+        duplicate: res.duplicate.length,
+        unexpected: res.unexpected.length,
+        invalid: res.invalid.length,
+      });
+    }
+
+    // Group by run: run r is instance r's bughunter + keeper + sweeper replies, merged across the
+    // 3 personas. A run missing a persona still contributes its other findings (a partial run).
+    const runs = runIds.map((instanceId) => {
+      const perPersona = PERSONAS.flatMap((persona) => findingsOf(byPersona.get(persona)!, instanceId));
+      return { instanceId, findings: mergeRun(perPersona) };
+    });
+
+    const voted = await clusterAndVote(runs.map((r) => r.findings), opts.k, opts.mock);
+    return { caller, runIds, runs, voted, stats };
+  } finally {
+    await nc.close();
+  }
+}

--- a/examples/05-quorum-code-review/src/personas.ts
+++ b/examples/05-quorum-code-review/src/personas.ts
@@ -1,0 +1,162 @@
+// The three reviewer personas and the shared prompt frame, ported from the benchmark harness that
+// won this recipe (its data-derived trio: generalists first, tilt second). Each persona is one
+// served command; a handler is a fresh, stateless model call — no cross-command or cross-PR memory,
+// so two instances reviewing the same PR with the same persona are two independent samples.
+import { spawn } from "node:child_process";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Finding, Persona, PrPacket } from "./contracts.js";
+
+const MODEL = process.env.COTAL_REVIEW_MODEL || "openai/gpt-5.5";
+const REVIEW_TIMEOUT_MS = Number(process.env.COTAL_REVIEW_TIMEOUT_MS || 600_000);
+const MAX_PATCH_CHARS = 180_000;
+
+/** The persona tilt text — a tiebreaker for where to dig, never a filter on what counts. */
+export const PERSONA_FOCUS: Record<Persona, string> = {
+  bughunter:
+    "logic and correctness: behavior contradicting intent, broken control flow, subtle single-line defects",
+  keeper:
+    "data integrity and API misuse: partial writes, cache invalidation, stale reads, lost updates, misused framework APIs, misleading code",
+  sweeper:
+    "minor but real defects a thorough reviewer still notes: dead or unreachable code, tests that cannot fail or no-op, stale docstrings/comments that contradict behavior, invalid or misspelled properties/identifiers/metric tags, truthiness checks that break on 0/empty/None, unawaited async calls, wrong-variable and copy-paste slips. LOW severity findings are expected and welcome",
+};
+
+/** The shared prompt frame. The in-prompt isolation rules are now redundant (the transport makes
+ *  isolation structural) but harmless, so they stay verbatim from the reference harness. */
+export function promptFor(persona: Persona, packet: PrPacket): string {
+  const patch =
+    packet.patch.length > MAX_PATCH_CHARS
+      ? `${packet.patch.slice(0, MAX_PATCH_CHARS)}\n\n[PATCH TRUNCATED TO ${MAX_PATCH_CHARS} CHARS]`
+      : packet.patch;
+  const maxFindings = packet.maxFindings ?? 8;
+  const contextSection = packet.context
+    ? `Full changed files (read these for context; the diff below marks what THIS PR changed):\n${packet.context}\n\n`
+    : "";
+  return `You are a senior code reviewer on a small review team.
+
+Reviewer: ${persona}
+Tilt: ${PERSONA_FOCUS[persona]}
+
+Task: Review this pull request patch and report what is actually WRONG. A real defect of any category outranks an on-theme observation; your tilt is only a tiebreaker when choosing where to dig deeper. Check each changed line for subtle errors: wrong operators or comparisons, invalid syntax, falsy vs null confusion, off-by-one mistakes, misused APIs, regex mistakes.
+
+Only report findings a senior maintainer would block the PR over. Never flag missing tests, style preferences, or speculative "could theoretically" issues. Report at most ${maxFindings} findings, ranked by severity.
+
+Isolation rules:
+- You do not see other reviewers' output.
+- Do not browse the web.
+- Output only JSON.
+
+Return shape:
+{
+  "findings": [
+    {"path": "relative/file", "line": 123, "severity": "HIGH|MED|LOW", "body": "specific issue and why it matters"}
+  ]
+}
+
+PR URL: ${packet.prUrl}
+PR Title: ${packet.title}
+PR Body:
+${packet.body || ""}
+
+${contextSection}Patch:
+${patch}
+`;
+}
+
+const SEVERITIES = new Set(["HIGH", "MED", "LOW"]);
+
+/** Coerce one raw model finding to the exact output-schema shape, or drop it. The daemon does this
+ *  BEFORE replying, so the wire stays schema-clean (the serving boundary re-validates either way). */
+export function normalizeFinding(raw: unknown): Finding | null {
+  if (raw === null || typeof raw !== "object") return null;
+  const f = raw as Record<string, unknown>;
+  const body = typeof f.body === "string" ? f.body.trim() : "";
+  if (!body) return null;
+  const sev = typeof f.severity === "string" ? f.severity.toUpperCase() : "";
+  return {
+    path: typeof f.path === "string" && f.path.trim() ? f.path.trim().slice(0, 512) : null,
+    line: typeof f.line === "number" && Number.isInteger(f.line) && f.line >= 0 ? f.line : null,
+    severity: SEVERITIES.has(sev) ? (sev as Finding["severity"]) : "LOW",
+    body: body.slice(0, 4096),
+  };
+}
+
+function extractFindings(stdout: string, maxFindings: number): Finding[] {
+  const fenced = stdout.match(/```(?:json)?\s*([\s\S]*?)```/);
+  const candidate = fenced ? fenced[1] : stdout.slice(stdout.indexOf("{"), stdout.lastIndexOf("}") + 1);
+  const parsed = JSON.parse(candidate.trim()) as { findings?: unknown };
+  const raw = Array.isArray(parsed.findings) ? parsed.findings : [];
+  return raw
+    .map((r) => normalizeFinding(r))
+    .filter((f): f is Finding => f !== null)
+    .slice(0, maxFindings);
+}
+
+function runOpencode(promptPath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      "opencode",
+      ["run", "Review this PR. JSON only.", "--model", MODEL, "--file", promptPath, "--format", "default"],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+    let stdout = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      reject(new Error(`opencode timed out after ${REVIEW_TIMEOUT_MS}ms`));
+    }, REVIEW_TIMEOUT_MS);
+    child.stdout.on("data", (c) => (stdout += c.toString()));
+    child.on("close", () => {
+      clearTimeout(timer);
+      resolve(stdout);
+    });
+    child.on("error", (e) => {
+      clearTimeout(timer);
+      reject(e);
+    });
+  });
+}
+
+/** One persona review through the OpenCode CLI. Parse failure degrades to zero findings (a partial
+ *  run), never a malformed reply — the wire schema would reject one anyway. */
+export async function runReview(persona: Persona, packet: PrPacket): Promise<Finding[]> {
+  const maxFindings = packet.maxFindings ?? 8;
+  const dir = await mkdtemp(join(tmpdir(), "cotal-review-"));
+  const promptPath = join(dir, `${persona}-prompt.md`);
+  try {
+    await writeFile(promptPath, promptFor(persona, packet));
+    const stdout = await runOpencode(promptPath);
+    try {
+      return extractFindings(stdout, maxFindings);
+    } catch (e) {
+      console.warn(`  [${persona}] unparseable model output (${(e as Error).message}); contributing zero findings`);
+      return [];
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+/** Deterministic canned findings for `--mock`: real defects the fixture plants (identical across
+ *  instances, so they survive the vote) plus one instance-specific hallucination (support 1, so the
+ *  k-of-N filter removes it). Exercises the whole transport + vote without model quota. */
+export function mockReview(persona: Persona, packet: PrPacket, instanceId: string): Finding[] {
+  const real: Record<Persona, Finding[]> = {
+    bughunter: [
+      { path: "src/auth.ts", line: 42, severity: "HIGH", body: "off-by-one: loop uses <= so it reads one past the end of the token array" },
+    ],
+    keeper: [
+      { path: "src/cache.ts", line: 17, severity: "MED", body: "cache entry written before the DB commit; a rollback leaves a stale read" },
+    ],
+    sweeper: [
+      { path: "src/auth.ts", line: 42, severity: "LOW", body: "off-by-one on the token loop bound also trips the boundary test, which can no longer fail" },
+    ],
+  };
+  const noise: Finding = {
+    path: "src/util.ts",
+    line: 3,
+    severity: "LOW",
+    body: `speculative: helper on instance ${instanceId.slice(0, 6)} might not handle an empty input`,
+  };
+  return [...real[persona], noise].slice(0, packet.maxFindings ?? 8);
+}

--- a/examples/05-quorum-code-review/src/personas.ts
+++ b/examples/05-quorum-code-review/src/personas.ts
@@ -117,6 +117,29 @@ function runOpencode(promptPath: string): Promise<string> {
   });
 }
 
+/** Fail-fast preflight: one tiny model call so a missing CLI or an unconfigured model surfaces as a
+ *  single clear error before the broker and daemon come up. */
+export function canaryModel(timeoutMs = 120_000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("opencode", ["run", "Reply with exactly: OK", "--model", MODEL, "--format", "default"], { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      reject(new Error(`model canary timed out after ${timeoutMs}ms (model ${MODEL}); exhausted quotas make opencode hang silently`));
+    }, timeoutMs);
+    child.stdout.on("data", (c) => (stdout += c.toString()));
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (code === 0 && stdout.trim().length) resolve();
+      else reject(new Error(`model canary failed (exit ${code}, model ${MODEL}); is opencode authenticated for this provider?`));
+    });
+    child.on("error", (e) => {
+      clearTimeout(timer);
+      reject(new Error(`could not run the opencode CLI (${e.message}); install it and configure ${MODEL}, or use --mock`));
+    });
+  });
+}
+
 /** One persona review through the OpenCode CLI. Parse failure degrades to zero findings (a partial
  *  run), never a malformed reply — the wire schema would reject one anyway. */
 export async function runReview(persona: Persona, packet: PrPacket): Promise<Finding[]> {
@@ -125,7 +148,13 @@ export async function runReview(persona: Persona, packet: PrPacket): Promise<Fin
   const promptPath = join(dir, `${persona}-prompt.md`);
   try {
     await writeFile(promptPath, promptFor(persona, packet));
-    const stdout = await runOpencode(promptPath);
+    let stdout: string;
+    try {
+      stdout = await runOpencode(promptPath);
+    } catch (e) {
+      console.warn(`  [${persona}] opencode call failed (${(e as Error).message}); contributing zero findings`);
+      return [];
+    }
     try {
       return extractFindings(stdout, maxFindings);
     } catch (e) {

--- a/examples/05-quorum-code-review/src/reviewer.ts
+++ b/examples/05-quorum-code-review/src/reviewer.ts
@@ -1,0 +1,66 @@
+// The reviewer endpoint daemon (`ai.cotal.reviewer`). N instances ARE the N runs: each is a
+// stateless client on its OWN connection, registered and serving the three persona commands. A
+// handler is a fresh model call per delivery; nothing is shared across commands, instances, or PRs.
+import { serveEndpoint, type EpServeContext, type EpServeHandle } from "@cotal-ai/core";
+import type { NatsConnection } from "@nats-io/transport-node";
+import { PERSONAS, commandFor, inputContract, outputContract, type PrPacket } from "./contracts.js";
+import { runReview, mockReview } from "./personas.js";
+import { connectNats, openSpaceKv, provisionInstance } from "./space.js";
+
+export interface Reviewer {
+  instanceIds: string[];
+  stop: () => Promise<void>;
+}
+
+/** Serialize the model calls of ONE instance: OpenCode's local SQLite state collides under
+ *  concurrent CLI runs, and an instance can receive all three persona deliveries at once. */
+function makeSerializer(): (fn: () => Promise<void>) => Promise<void> {
+  let tail = Promise.resolve();
+  return (fn) => {
+    const next = tail.then(fn, fn);
+    tail = next.catch(() => {});
+    return next;
+  };
+}
+
+/** Bring up N reviewer instances on the given broker + space. Returns the live instance ids and a
+ *  stop() that drains every serve table and closes every connection. */
+export async function startReviewer(opts: {
+  url: string;
+  space: string;
+  instanceIds: string[];
+  mock: boolean;
+}): Promise<Reviewer> {
+  const provisionerNc = await connectNats(opts.url);
+  const kv = await openSpaceKv(provisionerNc, opts.space);
+  const instances: { nc: NatsConnection; serve: EpServeHandle }[] = [];
+
+  for (const instanceId of opts.instanceIds) {
+    const grant = await provisionInstance(kv, opts.space, instanceId);
+    const serveNc = await connectNats(opts.url);
+    const serialize = makeSerializer();
+    const defs = PERSONAS.map((persona) => ({
+      command: commandFor(persona),
+      contract: { input: inputContract, output: outputContract },
+      handler: async (ctx: EpServeContext) => {
+        const packet = ctx.request.args as unknown as PrPacket;
+        if (opts.mock) return { findings: mockReview(persona, packet, instanceId) };
+        let findings: Awaited<ReturnType<typeof runReview>> = [];
+        await serialize(async () => { findings = await runReview(persona, packet); });
+        return { findings };
+      },
+    }));
+    const serve = serveEndpoint(serveNc, opts.space, grant, defs, { public: true });
+    await serveNc.flush();
+    instances.push({ nc: serveNc, serve });
+  }
+
+  return {
+    instanceIds: [...opts.instanceIds],
+    stop: async () => {
+      await Promise.all(instances.map((i) => i.serve.stop()));
+      await Promise.all(instances.map((i) => i.nc.close()));
+      await provisionerNc.close();
+    },
+  };
+}

--- a/examples/05-quorum-code-review/src/smoke.ts
+++ b/examples/05-quorum-code-review/src/smoke.ts
@@ -1,0 +1,71 @@
+// Mock end-to-end smoke: broker up, reviewer daemon with 3 instances, orchestrator on the fixture
+// PR. Proves the transport + vote without model quota, and checks the isolation the mechanism needs.
+// Run: pnpm --filter @cotal-ai/example-05-quorum-code-review smoke  (needs nats-server on PATH)
+import { mintLifecycleUid, epCallerReplyFilter, type EpCaller } from "@cotal-ai/core";
+import { startBroker, connectNats } from "./space.js";
+import { startReviewer } from "./reviewer.js";
+import { reviewPr } from "./orchestrator.js";
+import { SAMPLE_PR } from "./fixtures/sample-pr.js";
+
+let ok = 0;
+let fail = 0;
+const check = (name: string, cond: boolean, extra?: unknown) => {
+  if (cond) ok++;
+  else { fail++; console.log("  x FAIL:", name, extra ?? ""); }
+};
+
+async function main() {
+  const space = "review";
+  const k = 3;
+  const broker = await startBroker();
+  const instanceIds = Array.from({ length: 3 }, () => mintLifecycleUid());
+  const reviewer = await startReviewer({ url: broker.url, space, instanceIds, mock: true });
+
+  // An eavesdropper on a DIFFERENT caller's reply rail: replies are addressed to the orchestrator's
+  // caller (nonce-scoped, §13.9), so a foreign caller subscribed to its own rail must see nothing.
+  const evil: EpCaller = { owner: "u_evil", actor: "spy", uid: mintLifecycleUid() };
+  const spyNc = await connectNats(broker.url);
+  let spied = 0;
+  spyNc.subscribe(epCallerReplyFilter(space, evil), { callback: () => { spied++; } });
+  await spyNc.flush();
+
+  try {
+    const result = await reviewPr({ url: broker.url, space, packet: SAMPLE_PR, k, deadlineMs: 8_000, mock: true });
+
+    // Fan-out + broker-derived attribution: every persona scatter draws one reply per instance.
+    for (const s of result.stats) {
+      check(`${s.persona}: complete scatter over 3 attributed instances`,
+        s.complete && s.responders.length === 3 && new Set(s.responders).size === 3, JSON.stringify(s));
+      check(`${s.persona}: no anomalies (missing/churn/duplicate/unexpected/invalid all 0)`,
+        s.missing + s.churn + s.duplicate + s.unexpected + s.invalid === 0, JSON.stringify(s));
+    }
+
+    // The 3 scatters cover the SAME instance set, so runs reconstruct cleanly.
+    const responderSets = result.stats.map((s) => [...s.responders].sort().join(","));
+    check("the 3 persona scatters cover the same instance set (runs pair up)",
+      new Set(responderSets).size === 1, responderSets);
+    check("3 runs reconstructed", result.runs.length === 3);
+
+    // The vote: shared findings (in all 3 runs) survive; per-instance noise (1 run) is filtered.
+    check("k-of-N kept exactly the 2 shared findings", result.voted.length === 2, result.voted);
+    check("every survivor has full 3/3 support", result.voted.every((f) => f.support === 3), result.voted);
+    check("the HIGH off-by-one on src/auth.ts:42 survived",
+      result.voted.some((f) => f.path === "src/auth.ts" && f.line === 42 && f.severity === "HIGH"));
+    check("the cache-before-commit finding on src/cache.ts survived",
+      result.voted.some((f) => f.path === "src/cache.ts"));
+    check("the per-instance noise on src/util.ts was voted out (support 1 < 3)",
+      !result.voted.some((f) => f.path === "src/util.ts"), result.voted);
+
+    // Isolation: a foreign caller never saw the orchestrator's replies.
+    check("a foreign caller's reply rail received 0 replies (per-caller nonce-scoped rails)", spied === 0, { spied });
+  } finally {
+    await spyNc.close();
+    await reviewer.stop();
+    broker.stop();
+  }
+
+  console.log(`\nQUORUM REVIEW SMOKE ${fail === 0 ? "OK" : "FAILED"}  (${ok} passed, ${fail} failed)`);
+  if (fail > 0) process.exit(1);
+}
+
+main().catch((e) => { console.error(e instanceof Error ? e.stack : e); process.exit(1); });

--- a/examples/05-quorum-code-review/src/smoke.ts
+++ b/examples/05-quorum-code-review/src/smoke.ts
@@ -1,6 +1,6 @@
 // Mock end-to-end smoke: broker up, reviewer daemon with 3 instances, orchestrator on the fixture
 // PR. Proves the transport + vote without model quota, and checks the isolation the mechanism needs.
-// Run: pnpm --filter @cotal-ai/example-05-quorum-code-review smoke  (needs nats-server on PATH)
+// Run: pnpm run smoke  (needs nats-server on PATH)
 import { mintLifecycleUid, epCallerReplyFilter, type EpCaller } from "@cotal-ai/core";
 import { startBroker, connectNats } from "./space.js";
 import { startReviewer } from "./reviewer.js";

--- a/examples/05-quorum-code-review/src/space.ts
+++ b/examples/05-quorum-code-review/src/space.ts
@@ -2,7 +2,7 @@
 // registry needs — a name authority, a per-instance issuance gate (§13.1), and the content-store
 // reader — wired to the review contracts. These are the reference stub implementations the core
 // smoke tests use; a production space provisions them through the auth/delivery layer instead.
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn } from "node:child_process";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -39,8 +39,11 @@ export async function startBroker(): Promise<Broker> {
     [`port: ${port}`, `host: "127.0.0.1"`, `max_control_line: 65536`, `max_payload: 8388608`, `jetstream { store_dir: "${join(dir, "js")}" }`, ""].join("\n"),
   );
   const child = spawn("nats-server", ["-c", conf], { stdio: "ignore" });
+  let spawnError: Error | undefined;
+  child.on("error", (e) => (spawnError = e));
   const url = `nats://127.0.0.1:${port}`;
   for (let i = 0; i < 100; i++) {
+    if (spawnError) throw new Error(`could not start nats-server (${spawnError.message}); install it: brew install nats-server`);
     if (await isReachable(url)) return { url, stop: () => child.kill("SIGKILL") };
     await new Promise((r) => setTimeout(r, 100));
   }

--- a/examples/05-quorum-code-review/src/space.ts
+++ b/examples/05-quorum-code-review/src/space.ts
@@ -1,0 +1,125 @@
+// Local space provisioning: a NATS/JetStream broker plus the three protocol seams the endpoint
+// registry needs — a name authority, a per-instance issuance gate (§13.1), and the content-store
+// reader — wired to the review contracts. These are the reference stub implementations the core
+// smoke tests use; a production space provisions them through the auth/delivery layer instead.
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { connect, type NatsConnection } from "@nats-io/transport-node";
+import { jetstreamManager, type JetStreamManager } from "@nats-io/jetstream";
+import type { KV } from "@nats-io/kv";
+import {
+  isReachable,
+  openRecordsBucket,
+  registerServiceInstance,
+  writeServiceStatus,
+  authorizeServeGrant,
+  SERVICE_READY,
+  type ServiceNameAuthority,
+  type EpIssuanceBarrier,
+  type EpServeGrant,
+} from "@cotal-ai/core";
+import { REVIEW_ENDPOINT, REVIEW_OWNER, clusterDigest, readClusterArtifact } from "./contracts.js";
+
+const EPOCH = 1;
+
+export interface Broker {
+  url: string;
+  stop: () => void;
+}
+
+/** Start a local nats-server with a big `max_payload` (a full patch rides the request body). */
+export async function startBroker(): Promise<Broker> {
+  const dir = mkdtempSync(join(tmpdir(), "cotal-review-broker-"));
+  const port = 20000 + Math.floor(Math.random() * 40000);
+  const conf = join(dir, "nats.conf");
+  writeFileSync(
+    conf,
+    [`port: ${port}`, `host: "127.0.0.1"`, `max_control_line: 65536`, `max_payload: 8388608`, `jetstream { store_dir: "${join(dir, "js")}" }`, ""].join("\n"),
+  );
+  const child = spawn("nats-server", ["-c", conf], { stdio: "ignore" });
+  const url = `nats://127.0.0.1:${port}`;
+  for (let i = 0; i < 100; i++) {
+    if (await isReachable(url)) return { url, stop: () => child.kill("SIGKILL") };
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  child.kill("SIGKILL");
+  throw new Error(`nats-server did not come up at ${url}`);
+}
+
+export async function connectNats(url: string): Promise<NatsConnection> {
+  return connect({ servers: url });
+}
+
+/** The name authority: `ai.cotal.reviewer` is authorized only for the review owner (§13.9). */
+export const reviewAuthority: ServiceNameAuthority = {
+  authorize: (name, owner) => ({ authorized: name === REVIEW_ENDPOINT && owner === REVIEW_OWNER, revision: 0 }),
+};
+
+// Per-instance §13.1 issuance gate: a faithful freeze -> (spec write) -> reopen writer. Every
+// registration serializes on its own (endpoint, instanceId) gate.
+const gates = new Map<string, { state: "open" | "frozen" | "retired"; revision: number; generation: number; processEpoch: number; registrationRevision: number; nameAuthorityRevision: number }>();
+function barrierFor(space: string, endpoint: string, instanceId: string): EpIssuanceBarrier {
+  const key = `${space}/${endpoint}/${instanceId}`;
+  if (!gates.has(key)) gates.set(key, { state: "open", revision: 1, generation: 0, processEpoch: 0, registrationRevision: 0, nameAuthorityRevision: 0 });
+  const g = gates.get(key)!;
+  return {
+    observe: () => ({ space, endpoint, lifecycleUid: instanceId, principal: `${REVIEW_OWNER}.reviewer`, ...g }),
+    freeze: (rev) => { if (g.state !== "open" || g.revision !== rev) return null; g.state = "frozen"; g.revision++; return g.revision; },
+    enumerate: () => [],
+    revoke: () => {},
+    evict: () => true,
+    reopen: (token, succ) => {
+      if (g.state !== "frozen" || g.revision !== token) return false;
+      g.state = "open";
+      g.generation = succ.generation;
+      g.processEpoch = succ.processEpoch;
+      g.registrationRevision = succ.registrationRevision;
+      g.nameAuthorityRevision = succ.nameAuthorityRevision;
+      g.revision++;
+      return true;
+    },
+  };
+}
+
+/** Register one reviewer instance, mark it READY, and authorize its serve grant (§13.2/13.7/13.9).
+ *  The returned grant is the ONLY door to serving — it binds the space, owner, epoch, and the full
+ *  verified command surface. */
+export async function provisionInstance(kv: KV, space: string, instanceId: string): Promise<EpServeGrant> {
+  const spec = { endpoint: REVIEW_ENDPOINT, owner: REVIEW_OWNER, clusterDigests: [clusterDigest], protocol: { v: 1 as const } };
+  const reg = await registerServiceInstance(kv, {
+    space,
+    spec,
+    instanceId,
+    registrant: { owner: REVIEW_OWNER },
+    authority: reviewAuthority,
+    barrier: barrierFor(space, REVIEW_ENDPOINT, instanceId),
+    readClusterArtifact,
+  });
+  await writeServiceStatus(kv, {
+    endpoint: REVIEW_ENDPOINT,
+    instanceId,
+    epoch: EPOCH,
+    readProcessEpoch: () => EPOCH,
+    status: { epoch: EPOCH, state: SERVICE_READY, observedSpecRevision: reg.registrationRevision },
+  });
+  return authorizeServeGrant(kv, {
+    space,
+    endpoint: REVIEW_ENDPOINT,
+    instanceId,
+    epoch: EPOCH,
+    holder: { owner: REVIEW_OWNER },
+    authority: reviewAuthority,
+    readProcessEpoch: () => EPOCH,
+    readClusterArtifact,
+  });
+}
+
+export async function openSpaceKv(nc: NatsConnection, space: string): Promise<KV> {
+  return openRecordsBucket(nc, space, { create: true });
+}
+
+export async function openJsm(nc: NatsConnection): Promise<JetStreamManager> {
+  return jetstreamManager(nc);
+}

--- a/examples/05-quorum-code-review/src/vote.ts
+++ b/examples/05-quorum-code-review/src/vote.ts
@@ -1,0 +1,162 @@
+// The vote — the one piece Cotal does NOT give us (there is no quorum/k-of-N/clustering primitive,
+// §13.5/13.6/13.8). Cotal hands us N isolated, schema-clean, attributed samples; keeping only what
+// appears in >= k runs stays application logic, ported from the benchmark harness (majority.ts).
+import { spawn } from "node:child_process";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Finding } from "./contracts.js";
+
+const MODEL = process.env.COTAL_REVIEW_MODEL || "openai/gpt-5.5";
+const CLUSTER_TIMEOUT_MS = Number(process.env.COTAL_REVIEW_TIMEOUT_MS || 600_000);
+
+export interface VotedFinding extends Finding {
+  /** How many distinct runs reported this issue. Kept only when support >= k. */
+  support: number;
+}
+
+const tokens = (text: string): Set<string> =>
+  new Set(text.toLowerCase().replace(/[^a-z0-9]+/g, " ").split(" ").filter((w) => w.length > 2));
+
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (!a.size || !b.size) return 0;
+  let hit = 0;
+  for (const t of a) if (b.has(t)) hit++;
+  return hit / (a.size + b.size - hit);
+}
+
+const SEV_RANK: Record<string, number> = { HIGH: 3, MED: 2, LOW: 1 };
+
+// The text threshold scales with how precisely the locations agree (same reference-harness heuristic):
+// same line +-3 needs only 0.12 overlap, nearby lines 0.35, findings without a line keep 0.5.
+function requiredOverlap(a: number | null, b: number | null): number | null {
+  if (a !== null && b !== null) {
+    if (Math.abs(a - b) <= 3) return 0.12;
+    if (Math.abs(a - b) <= 15) return 0.35;
+    return null;
+  }
+  return 0.5;
+}
+
+/** Cross-PERSONA merge within one run: the 3 personas often flag one defect in different words, so
+ *  collapse those into a single candidate before the cross-run vote. */
+export function mergeRun(perPersona: Finding[]): Finding[] {
+  const merged: Array<Finding & { tok: Set<string> }> = [];
+  for (const f of perPersona) {
+    const tok = tokens(f.body);
+    const hit = merged.find((m) => {
+      if ((m.path || "") !== (f.path || "")) return false;
+      const threshold = requiredOverlap(m.line, f.line);
+      return threshold !== null && jaccard(m.tok, tok) >= threshold;
+    });
+    if (hit) {
+      if (f.body.length > hit.body.length) hit.body = f.body;
+      if ((SEV_RANK[f.severity] || 0) > (SEV_RANK[hit.severity] || 0)) hit.severity = f.severity;
+      if (hit.line === null && f.line !== null) hit.line = f.line;
+      for (const t of tok) hit.tok.add(t);
+    } else {
+      merged.push({ ...f, tok });
+    }
+  }
+  return merged.map(({ tok: _t, ...f }) => f);
+}
+
+type Tagged = Finding & { run: number };
+
+function representative(members: Tagged[]): VotedFinding {
+  const support = new Set(members.map((m) => m.run)).size;
+  // Prefer a member with a line anchor, then the highest severity, then the longest body.
+  const rep = [...members].sort(
+    (a, b) =>
+      (b.line !== null ? 1 : 0) - (a.line !== null ? 1 : 0) ||
+      (SEV_RANK[b.severity] || 0) - (SEV_RANK[a.severity] || 0) ||
+      b.body.length - a.body.length,
+  )[0];
+  return { path: rep.path, line: rep.line, severity: rep.severity, body: rep.body, support };
+}
+
+/** Deterministic cross-run clustering: bucket by path + line + normalized text. Same-issue findings
+ *  reported identically across runs land in one bucket; per-run noise stays a singleton. Used for
+ *  `--mock` (no model) and as the fallback when the clustering model call fails. */
+function clusterDeterministic(all: Tagged[]): Tagged[][] {
+  const buckets = new Map<string, Tagged[]>();
+  for (const f of all) {
+    const key = `${f.path ?? ""}|${f.line ?? ""}|${[...tokens(f.body)].sort().join(" ")}`;
+    (buckets.get(key) ?? buckets.set(key, []).get(key)!).push(f);
+  }
+  return [...buckets.values()];
+}
+
+async function clusterWithModel(all: Tagged[]): Promise<Tagged[][]> {
+  const items = all.map((f, index) => ({ index, run: f.run, path: f.path, line: f.line, finding: f.body }));
+  const prompt = `Below are code-review findings on one pull request from independent review runs (the "run" field). Group findings that report the SAME underlying issue (same defect/root cause), across runs.
+
+Rules:
+- Same group only if fixing one defect resolves all members.
+- Different facets or call sites are different groups.
+- Singletons are groups of one.
+- Every index appears in exactly one group.
+
+Output only JSON: { "groups": [[0,3,7],[1],[2]] }
+
+Findings:
+${JSON.stringify(items, null, 2)}
+`;
+  const dir = await mkdtemp(join(tmpdir(), "cotal-cluster-"));
+  const promptPath = join(dir, "cluster-prompt.md");
+  try {
+    await writeFile(promptPath, prompt);
+    const stdout = await new Promise<string>((resolve, reject) => {
+      const child = spawn(
+        "opencode",
+        ["run", "Group duplicate review findings across runs. JSON only.", "--model", MODEL, "--file", promptPath, "--format", "default"],
+        { stdio: ["ignore", "pipe", "pipe"] },
+      );
+      let out = "";
+      const timer = setTimeout(() => { child.kill("SIGTERM"); reject(new Error("cluster timed out")); }, CLUSTER_TIMEOUT_MS);
+      child.stdout.on("data", (c) => (out += c.toString()));
+      child.on("close", () => { clearTimeout(timer); resolve(out); });
+      child.on("error", (e) => { clearTimeout(timer); reject(e); });
+    });
+    const fenced = stdout.match(/```(?:json)?\s*([\s\S]*?)```/);
+    const body = fenced ? fenced[1] : stdout.slice(stdout.indexOf("{"), stdout.lastIndexOf("}") + 1);
+    const parsed = JSON.parse(body.trim()) as { groups?: unknown };
+    const groups = Array.isArray(parsed.groups)
+      ? parsed.groups.filter((g): g is number[] => Array.isArray(g) && g.every((i) => Number.isInteger(i)))
+      : [];
+    const seen = new Set<number>();
+    const clusters: Tagged[][] = [];
+    for (const g of groups) {
+      const members = g.filter((i) => i >= 0 && i < all.length && !seen.has(i));
+      if (!members.length) continue;
+      members.forEach((i) => seen.add(i));
+      clusters.push(members.map((i) => all[i]));
+    }
+    all.forEach((f, i) => { if (!seen.has(i)) clusters.push([f]); }); // unplaced -> singletons (fail-open)
+    return clusters;
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+/** Cross-run cluster + k-of-N vote. `runs[r]` is run r's per-run candidate list. Keeps only clusters
+ *  spanning >= k distinct runs (solution 8 = k=3, N=3), sorted by support then severity. */
+export async function clusterAndVote(runs: Finding[][], k: number, mock: boolean): Promise<VotedFinding[]> {
+  const all: Tagged[] = runs.flatMap((run, r) => run.map((f) => ({ ...f, run: r })));
+  if (!all.length) return [];
+  let clusters: Tagged[][];
+  if (mock) {
+    clusters = clusterDeterministic(all);
+  } else {
+    try {
+      clusters = await clusterWithModel(all);
+    } catch (e) {
+      console.warn(`  clustering model call failed (${(e as Error).message}); falling back to deterministic bucketing`);
+      clusters = clusterDeterministic(all);
+    }
+  }
+  return clusters
+    .map(representative)
+    .filter((v) => v.support >= k)
+    .sort((a, b) => b.support - a.support || (SEV_RANK[b.severity] || 0) - (SEV_RANK[a.severity] || 0));
+}

--- a/examples/05-quorum-code-review/tsconfig.json
+++ b/examples/05-quorum-code-review/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,25 @@ importers:
         specifier: ^2.9.0
         version: 2.9.0
 
+  examples/05-quorum-code-review:
+    dependencies:
+      '@cotal-ai/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@nats-io/jetstream':
+        specifier: ^3.4.0
+        version: 3.4.0
+      '@nats-io/kv':
+        specifier: ^3.4.0
+        version: 3.4.0
+      '@nats-io/transport-node':
+        specifier: ^3.4.0
+        version: 3.4.0
+    devDependencies:
+      tsx:
+        specifier: ^4.22.4
+        version: 4.23.0
+
   extensions/cmux:
     devDependencies:
       '@cotal-ai/core':


### PR DESCRIPTION
## Summary

A new self-contained example (`examples/05-quorum-code-review`) that runs a resample-and-vote code
review live on the v0.4 endpoint surface: one three-persona reviewer team, run **N times in strict
isolation** on a PR, keeping only the findings that appear in **≥ k of N** runs.

Point it at a public GitHub PR:

```
(cd examples/05-quorum-code-review && pnpm run review -- https://github.com/OWNER/REPO/pull/N)
```

The transport is the endpoint surface end to end: a reviewer service (`ai.cotal.reviewer`) with N
instances each serving three persona commands, and an orchestrator (a plain core-client) that
`freezeExpectedSet` → `scatter`s each persona command to every instance → groups the schema-clean,
attributed replies by `instanceId` into runs → merges the three personas per run → clusters findings
across runs → keeps support ≥ k. The k-of-N vote is application code; Cotal has no quorum primitive.

## What it demonstrates

- **N instances ARE the N runs.** One endpoint, N instances, three persona commands scattered on the
  `all` rail. Two instances with the same persona are two independent samples.
- **Structural isolation.** `scatter` fans one request to each instance and gathers one reply each;
  replies ride the caller's own nonce-scoped rail — no shared channel, so no run can condition on
  another run's output (which is what keeps the vote valid).
- **Schema-clean replies** (ajv at the serving boundary + caller-side), so the orchestrator never
  sees a malformed finding — no JSON-repair pass on the wire.
- **Broker-derived attribution** — every reply's `(instanceId, epoch)` comes from the reply subject.
- **Deadlines / partial results for free** — `missing` / `churn` / `duplicate` from the scatter.
- A **`--mock`** mode returns canned findings, so the whole transport + vote runs with no model
  quota and no network.

## How to run / smoke evidence

```
$ (cd examples/05-quorum-code-review && pnpm run smoke)
QUORUM REVIEW SMOKE OK  (14 passed, 0 failed)
```

The smoke brings up a broker, the reviewer daemon with three instances, and the orchestrator on a
fixture PR, and asserts: each of the three persona scatters is complete over three attributed
instances (0 missing / churn / duplicate / unexpected / invalid), the runs reconstruct, the 3-of-3
vote keeps the two shared findings and votes out the per-instance noise (support 1), and a foreign
caller's reply rail receives nothing.

```
$ (cd examples/05-quorum-code-review && pnpm run review -- --mock)
scatters:
  bughunter  complete=true runs=3 missing=0 churn=0 duplicate=0
  keeper     complete=true runs=3 missing=0 churn=0 duplicate=0
  sweeper    complete=true runs=3 missing=0 churn=0 duplicate=0

survived the 3-of-3 vote: 2 finding(s)
  [HIGH] src/auth.ts:42  (support 3/3)  off-by-one on the token loop bound ...
  [MED]  src/cache.ts:17 (support 3/3)  cache entry written before the DB commit ...
```

`pnpm --filter @cotal-ai/example-05-quorum-code-review typecheck` and `build` both pass. The GitHub
fetch path is verified against a real public PR; a real model run is wired but needs `opencode` + a
configured model, so it is not exercised in CI.

## Isolation fidelity (called out honestly)

The example runs on a **single local broker** and enforces each instance's command surface **in
code** — through its authorized serve grant — exactly as `@cotal-ai/core`'s own endpoint smoke tests
do. That gives real structural isolation (no shared channel, per-caller nonce-scoped reply rails,
broker-derived attribution). The stronger wire-level default-deny — a *malicious* instance provably
cannot subscribe to another instance's rail — is a credential-scoping property minted by the auth
layer for a secured space, and is deliberately out of scope for a self-contained example. Both the
README and the smoke are explicit about which property is demonstrated.

## Scope

In: reviewer daemon (register N instances, serve the three persona commands, serialize model calls
per instance for OpenCode's SQLite lock), the two JSON-Schema-2020-12 contracts with closure-digest
pinning, the orchestrator (freeze → 3 scatters → group → merge → cluster → k-of-N vote), a `--mock`
path, the GitHub fetch, a README, and a mock smoke.

Out: the Martian benchmark harness / judge / F1 scoring, the durable 50-PR work-pool queue, and any
quorum composite in core — none of that is here. The only core touch is importing existing exports.

One deviation worth noting: the contracts use an in-memory content-addressed store (a map keyed by
`contractDigest`, as the core smoke tests do) rather than the KV-backed EPC store, because the
digest-pinning guarantee is identical and it avoids provisioning an EPC stream the runnable path does
not otherwise need.


## Real e2e evidence (2026-07-23)

`pnpm run review -- https://github.com/Cotal-AI/Cotal/pull/282` — 3 instances, k=3, model `openai/gpt-5.5`, wall clock 1m37s:

- model canary ok; all three persona scatters **complete** over 3 instances (`missing`/`churn`/`duplicate` = 0)
- 2 of 9 review calls returned unparseable model output and degraded to zero findings with a warning (the designed partial-run path); the vote still converged
- the 3-of-3 vote kept exactly **one** finding, a real defect in the reviewed PR:

> [MED] `implementations/cli/src/commands/update.ts:122` (support 3/3)
> The new array parser silently drops invalid entries as long as at least one valid semver remains. That contradicts the existing loud-failure contract for malformed npm output: `["0.13.2","not-a-version"]` now returns `0.13.2` instead of throwing.

Follow-up hardening in the second commit: fail-fast model canary before broker start, clean error for a missing `nats-server` binary, an opencode-failure guard in the reviewer path, and README documents `COTAL_REVIEW_TIMEOUT_MS`.
