### PR TITLE
fix(cli): re-offer the global install on a repeat `npx cotal-ai setup`

### DIFF
--- a/.changeset/cli-setup-repeat-global-install.md
+++ b/.changeset/cli-setup-repeat-global-install.md
@@ -1,0 +1,13 @@
+---
+"@cotal-ai/cli": patch
+---
+
+fix(cli): re-offer the global install on a repeat `npx cotal-ai setup`
+
+`offerGlobalInstall` only ran on the first-run path (`runFirstRun`). The onboarded marker
+(`~/.cotal/onboarded.json`) is written once, so every later `cotal setup` routed to `runEnsure`,
+which never offered the install. Any machine that had already onboarded — declined or failed the
+install the first time, or onboarded before the offer existed — could re-run `npx cotal-ai setup`
+forever and never get a durable `cotal` on PATH. `runEnsure` now runs the same offer, gated by the
+same `isNpx()` + PATH scan, so it's a no-op for a dev clone or an already-installed `cotal` and only
+fires for the npx-without-`cotal` case it's meant to fix.

--- a/docs/setup-internals.md
+++ b/docs/setup-internals.md
@@ -27,8 +27,10 @@ It is two-tier, gated on a machine marker.
   no longer launches; mode is now `cotal up [--open]`'s concern (an unknown-option error names
   them, no silent no-op).
 
-**Later runs** run `runEnsure`: re-seed the `default` persona if it's missing (announced), then
-print the **status card** (`readyCard`). The card is **read-only probes** (`machineStatus`/`meshStatus`/`webUp`/`managerUp` for NATS, the plugin, the mesh, the web
+**Later runs** run `runEnsure`: re-seed the `default` persona if it's missing (announced),
+re-offer the **global install** (`offerGlobalInstall`, same `isNpx()` + PATH-scan gate as first
+run — so a repeat `npx cotal-ai setup` on a machine that still lacks a durable `cotal` finally
+installs it), then print the **status card** (`readyCard`). The card is **read-only probes** (`machineStatus`/`meshStatus`/`webUp`/`managerUp` for NATS, the plugin, the mesh, the web
 dashboard, and the manager) and for anything down it prints the exact command to start it
 (`cotal up --detach`, `cotal web`, `cotal supervise`). Displaying state never depends on it; setup
 still launches nothing.

--- a/implementations/cli/src/commands/setup.ts
+++ b/implementations/cli/src/commands/setup.ts
@@ -295,6 +295,13 @@ async function runEnsure(demo: boolean): Promise<void> {
   if (demo) seedDemoTeam(); // `cotal setup --demo` on a configured machine: add the team, then card
   ensureSkillsPlugin(); // fail-loud: close the upgrade gap so an onboarded machine re-running setup gets/refreshes (not silently stale) the Claude skills plugin
   seedAgentSkills(); // reconcile the cross-vendor `.agents/skills` drop so an upgrade + re-run isn't stale
+  // A repeat `npx cotal-ai setup` on an onboarded machine that still lacks a durable `cotal` must
+  // ALSO get the global-install offer — the first-run stamp is written once, so without this any
+  // second setup (declined/failed install the first time, or a machine onboarded before the offer
+  // existed) never installs `cotal`. The offer no-ops for a dev clone (`!isNpx()`) or an already
+  // installed `cotal` (`cotalOnPath()`), so only the npx-without-cotal case is affected. Before the
+  // card so its hints render `cotal` rather than `npx cotal-ai`.
+  await offerGlobalInstall(false);
   await readyCard(process.cwd());
 }
 


### PR DESCRIPTION
## Problem

`npx cotal-ai setup` has a global-install offer (`offerGlobalInstall` → `npm i -g cotal-ai`), but it only ran on the **first** run. The onboarded marker (`~/.cotal/onboarded.json`) is written once, so every later `cotal setup` routes to `runEnsure`, which never called it. Any machine that had already onboarded — declined or failed the install the first time, or onboarded before the offer existed — could re-run `npx cotal-ai setup` forever and never get a durable `cotal` on PATH.

## Fix

`runEnsure` now runs the same guarded offer (before the status card). The offer's existing gate (`isNpx()` plus a PATH scan) makes it a no-op for a dev clone (`!isNpx()`) or an already-installed `cotal` (`cotalOnPath()`), so only the npx-without-`cotal` case is affected. The card then renders `cotal` hints instead of `npx cotal-ai`.

## Verification

Reproduced all four states with a fake `npm` recorder (passthrough for real installs, stubs `-g`):

| Scenario | Before | After |
|---|---|---|
| Fresh `npx` setup, no `cotal` | installs | installs |
| Repeat `npx` setup, no `cotal` | never installs | `install -g cotal-ai@…` |
| Non-npx dev clone / smoke | no-op | no-op |
| `cotal` already on PATH | no-op | no-op |

`pnpm --filter @cotal-ai/cli typecheck` clean; `pnpm smoke:setup-pure:live` green (23/23) — the non-npx path stays a no-op, nothing installs globally in the smoke.

Docs (`docs/setup-internals.md`) and a changeset included.