### PR TITLE
fix(cli): require Node >= 22 and fail fast on older Node

### DIFF
--- a/.changeset/node22-preflight.md
+++ b/.changeset/node22-preflight.md
@@ -1,0 +1,20 @@
+---
+"cotal-ai": patch
+"@cotal-ai/cli": patch
+---
+
+Require Node >= 22 and fail fast with a clear message on older Node.
+
+The bundled `nats-server` broker (`@eplightning/nats-server-*`) declares `engines.node >= 22`, and
+npm silently skips an optional dependency whose engine the running Node doesn't satisfy — so on any
+Node older than 22 the broker binary was never installed, surfacing later as a misleading
+"nats-server not found". Older Node also crashed the CLI outright on a Node-20+ regex in a transitive
+dependency, and only a non-fatal engine warning was emitted rather than a hard stop.
+
+The executable entry is now a thin Node-version preflight (`bin/cotal.ts`) that checks the running
+Node before any heavy import is parsed and hands off to the real composition root (`bin/run.ts`) only
+when it passes; on Node < 22 it prints an actionable message (upgrade Node; clear the npx cache if a
+stale install is being reused) and exits non-zero. The declared `engines.node` floor is corrected from
+`>=20` to `>=22` to match the broker's real requirement (Node 20/21 satisfied the old floor but
+never got the bundled broker), and the `nats-server` resolution error now names the root cause and
+the fix instead of a generic PATH hint.

--- a/bin/cotal.ts
+++ b/bin/cotal.ts
@@ -1,38 +1,32 @@
 #!/usr/bin/env node
 /**
- * Composition root for the `cotal` operator CLI, published as `cotal-ai`. Importing an
- * implementation self-registers its commands into the shared registry — base mesh commands
- * plus `spawn`/`console` (@cotal-ai/cli) and the manager's control plane + daemon runners
- * (@cotal-ai/manager). The root just picks which surfaces to pull in; `runCli` resolves
- * whatever registered. A new surface (another connector, a control client …) is one more import line.
+ * Executable entry for the `cotal` CLI (published as `cotal-ai`): a Node-version preflight, then a
+ * hand-off to the real composition root (./run.js) via dynamic import.
+ *
+ * Why this file exists separately: the CLI's UI stack (ink, @clack/prompts, string-width) and the
+ * bundled `nats-server` optional dependency (@eplightning/nats-server-*) all require Node >= 22 —
+ * and npm SILENTLY SKIPS an optional dependency whose `engines` the running Node doesn't satisfy,
+ * so on an older Node the bundled broker is never installed at all. On top of that, string-width
+ * uses a Node-20+ regex flag that is a hard parse error on older Node. An ESM entry parses its whole
+ * static-import graph before its own body runs, so a version check inside ./run.ts would come too
+ * late — it would crash while parsing string-width. This shim therefore keeps ZERO static imports
+ * of that chain: the check runs first, and ./run.js is only pulled in (dynamically) once it passes.
  */
-// NOTE: registration order across these imports is NOT guaranteed (tsx's entry interop can
-// evaluate the smaller daemon graphs first) — display order is a non-goal here; `help` ranks
-// its groups explicitly (GROUP_ORDER in @cotal-ai/cli).
-import { runCli } from "@cotal-ai/cli"; // self-registers the base surface incl. spawn (foreground + --detach) / stop / ps / attach
-import "@cotal-ai/manager"; // self-registers `supervise` — the agent-supervisor daemon
-import "@cotal-ai/delivery"; // self-registers `deliver` — the server-side Plane-3 delivery daemon
-import "@cotal-ai/auth"; // self-registers login / logout — per-user IdP sessions (device-code sign-in)
-import { registry } from "@cotal-ai/core";
+const MIN_NODE_MAJOR = 22;
+const nodeMajor = Number.parseInt(process.versions.node.split(".")[0] ?? "", 10);
 
-// A CLI must exit quietly when its stdout is closed early — piped to `head`, a pager that quits,
-// or a shell's process substitution (`source <(cotal completion bash)`). Node otherwise turns the
-// closed-pipe write into a fatal unhandled 'error' event with a stack trace. Mirror SIGPIPE: exit
-// 0. Registered before any command can write.
-process.stdout.on("error", (e: NodeJS.ErrnoException) => {
-  if (e.code === "EPIPE") process.exit(0);
-  throw e;
-});
+if (!Number.isInteger(nodeMajor) || nodeMajor < MIN_NODE_MAJOR) {
+  process.stderr.write(
+    `\ncotal-ai requires Node.js >= ${MIN_NODE_MAJOR}, but this is ${process.version}.\n` +
+      `The bundled nats-server broker (and the CLI's UI stack) need Node >= ${MIN_NODE_MAJOR}; on an\n` +
+      `older Node, npm silently skips the broker binary and the CLI cannot start.\n\n` +
+      `Install a newer Node (https://nodejs.org). With nvm:\n` +
+      `  nvm install ${MIN_NODE_MAJOR} && nvm use ${MIN_NODE_MAJOR}\n\n` +
+      `If you already ran cotal once under the old Node, also clear the npx cache so the bundled\n` +
+      `nats-server is fetched cleanly, then retry:\n` +
+      `  rm -rf ~/.npm/_npx        # or: npx clear-npx-cache\n\n`,
+  );
+  process.exit(1);
+}
 
-// The four agent connectors (claude/opencode/hermes/pi) are NOT imported here: they are removable,
-// install-seeded `cotal ext` plugins loaded through the manifest, exactly like a third-party
-// connector (and like the `@cotal-ai/orca` runtime already is). `runCli` seeds them on first run and
-// materializes each lazily when a command resolves it; the default agent is `COTAL_DEFAULT_AGENT`
-// (else claude), resolved manager-side. The old `"cotal"` default-agent alias is gone with them.
-//
-// Bare `cotal` prints help; explicit `cotal setup` runs guided setup. The published binary is
-// the ONE composition root that loads operator-installed extensions (`cotal ext add …`) — commands,
-// runtimes, connectors, and local process components all self-register from those packages. Library
-// roots keep the explicit-import model.
-const argv = process.argv.slice(2);
-await runCli(registry, argv, { extensions: true });
+await import("./run.js");

--- a/bin/package.json
+++ b/bin/package.json
@@ -23,7 +23,7 @@
     "cotal": "./dist/cotal.js"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/bin/run.ts
+++ b/bin/run.ts
@@ -1,0 +1,41 @@
+/**
+ * Composition root for the `cotal` operator CLI, published as `cotal-ai`. Importing an
+ * implementation self-registers its commands into the shared registry — base mesh commands
+ * plus `spawn`/`console` (@cotal-ai/cli) and the manager's control plane + daemon runners
+ * (@cotal-ai/manager). The root just picks which surfaces to pull in; `runCli` resolves
+ * whatever registered. A new surface (another connector, a control client …) is one more import line.
+ *
+ * Reached only via ./cotal.ts, which runs the Node-version preflight first: everything imported
+ * here requires Node >= 22 (the UI stack and the bundled nats-server optional dep), so this module
+ * must never be the executable entry — importing it on an old Node crashes at parse time.
+ */
+// NOTE: registration order across these imports is NOT guaranteed (tsx's entry interop can
+// evaluate the smaller daemon graphs first) — display order is a non-goal here; `help` ranks
+// its groups explicitly (GROUP_ORDER in @cotal-ai/cli).
+import { runCli } from "@cotal-ai/cli"; // self-registers the base surface incl. spawn (foreground + --detach) / stop / ps / attach
+import "@cotal-ai/manager"; // self-registers `supervise` — the agent-supervisor daemon
+import "@cotal-ai/delivery"; // self-registers `deliver` — the server-side Plane-3 delivery daemon
+import "@cotal-ai/auth"; // self-registers login / logout — per-user IdP sessions (device-code sign-in)
+import { registry } from "@cotal-ai/core";
+
+// A CLI must exit quietly when its stdout is closed early — piped to `head`, a pager that quits,
+// or a shell's process substitution (`source <(cotal completion bash)`). Node otherwise turns the
+// closed-pipe write into a fatal unhandled 'error' event with a stack trace. Mirror SIGPIPE: exit
+// 0. Registered before any command can write.
+process.stdout.on("error", (e: NodeJS.ErrnoException) => {
+  if (e.code === "EPIPE") process.exit(0);
+  throw e;
+});
+
+// The four agent connectors (claude/opencode/hermes/pi) are NOT imported here: they are removable,
+// install-seeded `cotal ext` plugins loaded through the manifest, exactly like a third-party
+// connector (and like the `@cotal-ai/orca` runtime already is). `runCli` seeds them on first run and
+// materializes each lazily when a command resolves it; the default agent is `COTAL_DEFAULT_AGENT`
+// (else claude), resolved manager-side. The old `"cotal"` default-agent alias is gone with them.
+//
+// Bare `cotal` prints help; explicit `cotal setup` runs guided setup. The published binary is
+// the ONE composition root that loads operator-installed extensions (`cotal ext add …`) — commands,
+// runtimes, connectors, and local process components all self-register from those packages. Library
+// roots keep the explicit-import model.
+const argv = process.argv.slice(2);
+await runCli(registry, argv, { extensions: true });

--- a/bin/tsconfig.json
+++ b/bin/tsconfig.json
@@ -7,5 +7,5 @@
     "declarationMap": false,
     "sourceMap": false
   },
-  "include": ["cotal.ts"]
+  "include": ["cotal.ts", "run.ts"]
 }

--- a/implementations/cli/src/lib/nats-bin.ts
+++ b/implementations/cli/src/lib/nats-bin.ts
@@ -15,9 +15,19 @@ export async function resolveNatsServer(): Promise<{ bin: string; source: "path"
     const mod = (await import(pkg)) as { getBinaryPath(): string };
     return { bin: mod.getBinaryPath(), source: "bundled" };
   } catch {
+    // The bundled binary requires Node >= 22; npm silently skips an optional dependency whose
+    // engine the running Node doesn't satisfy, so an install done under an older Node lacks it —
+    // and npx reuses that binary-less tree even after Node is upgraded. Name the likely cause.
+    const nodeMajor = Number.parseInt(process.versions.node.split(".")[0] ?? "", 10);
+    const staleInstallHint = Number.isInteger(nodeMajor) && nodeMajor < 22
+      ? `This is Node ${process.version}; the bundled broker needs Node >= 22. Upgrade Node, then reinstall.\n`
+      : `This usually means cotal was first installed under Node < 22 (npm skips the broker binary\nthere) and the stale install is being reused. Reinstall under Node >= 22.\n`;
     throw new Error(
-      `nats-server not found on PATH and no bundled binary for ${process.platform}/${process.arch} (${pkg}). ` +
-        "Install nats-server (https://github.com/nats-io/nats-server/releases) and put it on PATH.",
+      `nats-server not found on PATH, and the bundled binary for ${process.platform}/${process.arch} (${pkg}) is not installed.\n` +
+        staleInstallHint +
+        `  npm i -g cotal-ai         # global install\n` +
+        `  rm -rf ~/.npm/_npx        # if you use npx, clear its cache first, then re-run\n` +
+        `Or install nats-server yourself (https://github.com/nats-io/nats-server/releases) and put it on PATH.`,
     );
   }
 }


### PR DESCRIPTION
## Problem

`npx cotal-ai setup` fails on machines whose default Node is older than 22 (e.g. Ubuntu 24.04 ships Node 18) in a confusing, cascading way:

- **Bundled broker silently skipped.** The bundled `nats-server` (`@eplightning/nats-server-*`) declares `engines.node >= 22`. npm silently **skips an optional dependency** whose engine the running Node doesn't satisfy, so on older Node the broker binary is never installed — surfacing later as a misleading *"nats-server not found on PATH and no bundled binary"*.
- **Cryptic crash + only a warning.** On Node < 20 the CLI additionally crashes at parse time on a Node-20+ regex flag in a transitive dependency (`string-width`), yet cotal only emits npm's non-fatal engine warning instead of stopping.
- **Stale npx cache.** npx caches the binary-less install and reuses it even after Node is upgraded, so the failure persists across a Node bump.

There's also a floor mismatch: cotal-ai declared `>=20`, but the broker needs `>=22`, so a user on **Node 20/21** passed cotal's own engine check yet still got no bundled broker.

## Fix

- The executable entry (`bin/cotal.ts`) becomes a thin **Node-version preflight** that runs before any heavy import is parsed (an ESM entry parses its whole static-import graph before its body runs, so a check inside the composition root would crash first). It hands off to the real composition root (`bin/run.ts`) via dynamic import only when the check passes; on Node < 22 it prints an actionable message and exits non-zero.
- Corrects the declared `engines.node` floor from `>=20` to `>=22` to match the broker's real requirement.
- Rewrites the `nats-server` resolution error to name the root cause (older Node skipped the binary / stale reused install) and the fix, instead of a generic PATH hint.

## Compatibility

Corrects the declared `engines.node` floor (`>=20` → `>=22`). Node 20/21 satisfied the old floor but never received the bundled broker, so this only makes the contract honest — released as a **patch**.

## Verification (live)

On the exact binary-less install that previously crashed:
- **Node 18** — now prints the guard message and exits 1 (was: `SyntaxError: Invalid regular expression flags`).
- **Node 22** — hands off to `run.js` and runs normally (`--version` prints, exit 0).

`pnpm build` and `pnpm typecheck` are green across all packages.