### PR TITLE
fix(workspace): confirm a preflight failure before deleting a registry entry

### DIFF
--- a/.changeset/preflight-prune-confirm.md
+++ b/.changeset/preflight-prune-confirm.md
@@ -1,0 +1,21 @@
+---
+"@cotal-ai/workspace": patch
+---
+
+Stop a slow link from deleting a live mesh's registry entry on connect.
+
+0.14.3 made the registry *sweep* (`pruneStaleMeshes`) confirm a failure before removing an entry.
+The connect-time path was left with the original behavior, and that is the one that actually bites:
+`preflightTarget` probes with `probeConnect`, whose default budget is one second, and passes no
+override. That probe completes a full auth handshake — TCP, INFO, then the JWT exchange, several
+round trips — which a perfectly healthy broker across a slow or jittery link (a relayed overlay VPN,
+a loaded host) cannot finish in a second.
+
+The verdict is destructive: a registry-sourced failure deletes the entry and reports "no mesh running
+(stale registry entry - removed)". Both halves of that are wrong when the cause was latency, and for
+a mesh this machine did not start it is unrecoverable, since only `cotal up` writes registry records.
+Observed repeatedly against a reachable remote mesh whose broker was up the whole time.
+
+A first probe failure now only makes the target a candidate: it is re-probed with a budget that fits
+a real network before anything is classified or removed. A genuinely dead or genuinely
+credential-rejected mesh reaches the same verdict as before, one extra probe later.

--- a/packages/workspace/src/preflight.ts
+++ b/packages/workspace/src/preflight.ts
@@ -70,7 +70,18 @@ export async function preflightTarget(
     throw new Error("preflightTarget: a user-mode target cannot be credless-probed - the caller owns the user connect (see preflightOrExit's user branch)");
   const creds =
     probeCreds ?? (target.auth ? await mintCreds(target.auth, newIdentity(), "probe") : undefined);
-  const probe = await probeConnect(target.server, creds ? { creds } : {});
+  const auth = creds ? { creds } : {};
+  let probe = await probeConnect(target.server, auth);
+  if (probe.ok) return { ok: true };
+  // CONFIRM BEFORE CONDEMNING. `probeConnect`'s default budget is 1s, and this is a CREDENTIALED
+  // connect: TCP, INFO, then the JWT exchange — several round trips. A perfectly healthy broker
+  // across a slow or jittery link (a relayed overlay VPN, a loaded host) misses that routinely, and
+  // the verdict here is destructive: a registry-sourced failure DELETES the entry, and for a mesh
+  // this machine did not start that is unrecoverable, since only `cotal up` writes registry records.
+  // The observed failure mode was exactly this — a live, reachable mesh reported as "no mesh
+  // running (stale registry entry - removed)" because the handshake needed more than a second.
+  // So a first failure only makes it a candidate; re-probe with a budget that fits a real network.
+  probe = await probeConnect(target.server, { ...auth, timeoutMs: PREFLIGHT_CONFIRM_TIMEOUT_MS });
   if (probe.ok) return { ok: true };
   const { prune, kind } = classifyPreflightFailure(target.source, probe.reason, Boolean(target.auth));
   return { ok: false, kind, prune };
@@ -96,6 +107,10 @@ export async function preflightTarget(
  * sweep, one extra probe later.
  */
 const PRUNE_CONFIRM_TIMEOUT_MS = 5_000;
+
+/** The confirming budget for a single target's preflight. Larger than {@link PRUNE_CONFIRM_TIMEOUT_MS}
+ *  because this probe completes an AUTH HANDSHAKE, not just a TCP+INFO liveness check. */
+const PREFLIGHT_CONFIRM_TIMEOUT_MS = 8_000;
 
 export async function pruneStaleMeshes(): Promise<void> {
   await Promise.all(


### PR DESCRIPTION
Completes the prune fix from 0.14.3, which hardened the wrong path.

## The bug

There are two places that can delete a mesh registry entry. 0.14.3 gave the **sweep** (`pruneStaleMeshes`) a confirming probe. The **connect-time** path was left alone, and that is the one that actually fires: `preflightTarget` calls `probeConnect`, whose default budget is **one second** (`packages/core/src/endpoint.ts:3641`), and passes no override.

That probe is not a liveness ping. It completes a full auth handshake — TCP, INFO, then the JWT exchange — several round trips. A perfectly healthy broker across a slow or jittery link cannot finish that in a second.

The verdict is destructive. A registry-sourced failure deletes the entry and reports:

```
✗ no mesh running at nats://<host>:4222 (stale registry entry - removed) - run `cotal up`
```

Both halves are wrong when the cause was latency: the mesh is running, and the entry was not stale. For a mesh this machine did not start it is also unrecoverable, since only `cotal up` writes registry records.

## Reproduced on a real link

Against a remote mesh over a relayed overlay VPN (~450ms RTT), broker up and reachable throughout:

- credless `isReachable` → `true`
- `probeConnect` with properly minted creds and a realistic budget → `{ok: true}`
- released binary → pruned the entry and refused, repeatedly and deterministically
- patched binary → `cotal ps` worked, `spawn --detach` worked, `attach` streamed the remote terminal, entry intact

## The fix

A first probe failure only makes the target a candidate. It is re-probed with a budget that fits a real network before anything is classified or removed. A genuinely dead or genuinely credential-rejected mesh reaches the same verdict as before, one probe later.

Verified: `smoke:preflight`, `smoke:spawn-from-anywhere`, `smoke:connect`, `smoke:multi-space`, `pnpm typecheck`.