### PR TITLE
feat(manifest): per-agent kickoff prompt auto-submitted at spawn

### DIFF
--- a/.changeset/tall-hats-teach.md
+++ b/.changeset/tall-hats-teach.md
@@ -1,0 +1,7 @@
+---
+"@cotal-ai/core": patch
+"@cotal-ai/cli": patch
+"@cotal-ai/manager": patch
+---
+
+Per-agent `prompt:` in the mesh manifest — a kickoff message auto-submitted once the session is up, the declarative form of `cotal spawn --prompt`. Submitted on first boot and on stale-restart (hash-covered, so changing it marks a running agent stale); a reclaim of a still-live session does not re-submit. Imperative `--prompt` alongside a manifest launch is still rejected (one source). `topology view` marks agents that carry one.

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -43,16 +43,24 @@ agents:
     role: lead
     capabilities: [spawn]               # may spawn helpers
     instructions: Coordinate the team.
+    prompt: Introduce yourself in #general and assign the first task.
 ```
 
 Per-agent keys: `persona`, `agent` (harness override), `model`, `variant`, `role`,
-`description`, `instructions`, `capabilities` (`spawn`,
+`description`, `instructions`, `prompt`, `capabilities` (`spawn`,
 [what it grants](identity-and-auth.md); on a per-user-auth mesh also `role:<r>`, so the
 agent may delegate that role when spawning; `admin` is never accepted from a manifest),
 `personaPermissions` (override the top-level policy). Model strings and variants pass to
 the harness as-is: for Claude use the short form (`opus`, `sonnet`) or the full id; for
 OpenCode use `provider/model` plus an optional variant (`cotal models --agent opencode`
 lists both). Persona file format: [agent files](agent-files.md).
+
+`instructions` and `prompt` differ in kind: `instructions` become the session's **system
+prompt** (who the agent is), while `prompt` is a **kickoff message** auto-submitted once
+the session is up (what to do right now) — the declarative form of `cotal spawn --prompt`.
+It is submitted on first boot and again on a stale-restart (it is part of the launch form,
+so changing it marks a running agent `stale` like any other launch field); a manager
+reclaiming a still-live session does not re-submit it.
 
 ## `channels:` (the three access verbs)
 

--- a/implementations/cli/src/lib/manifest/apply.ts
+++ b/implementations/cli/src/lib/manifest/apply.ts
@@ -30,6 +30,9 @@ export function hashAgent(a: PreparedAgent): string {
     launchOptions: a.launchOptions ? Object.fromEntries(Object.entries(a.launchOptions).sort(([x], [y]) => (x < y ? -1 : x > y ? 1 : 0))) : null,
     role: a.role ?? null,
     body: a.body ?? null,
+    // Only when set: a prompt-less agent must keep its pre-`prompt:` hash, or upgrading flips
+    // every already-deployed manifest agent to stale.
+    ...(a.prompt !== undefined ? { prompt: a.prompt } : {}),
     capabilities: [...a.capabilities].sort(),
     subscribe: [...a.policy.subscribe].sort(),
     allowSubscribe: [...a.policy.allowSubscribe].sort(),
@@ -49,6 +52,7 @@ function toLaunchAgent(a: PreparedAgent): MeshLaunchAgent {
     launchOptions: a.launchOptions,
     description: a.description,
     body: a.body,
+    prompt: a.prompt,
     capabilities: a.capabilities.length ? a.capabilities : undefined,
     subscribe: a.policy.subscribe,
     allowSubscribe: a.policy.allowSubscribe,

--- a/implementations/cli/src/lib/manifest/model.ts
+++ b/implementations/cli/src/lib/manifest/model.ts
@@ -53,6 +53,8 @@ export interface ResolvedAgent {
   description?: string;
   /** Manifest persona body (REPLACES the file body when set; the sole body for inline). */
   instructions?: string;
+  /** Kickoff prompt auto-submitted at session start (manifest-only; personas carry none). */
+  prompt?: string;
   /** Manifest capabilities — win over the persona's when present. */
   capabilities?: string[];
   /** Effective policy for THIS agent: per-agent override ?? top-level ?? "reject". */

--- a/implementations/cli/src/lib/manifest/prepare.ts
+++ b/implementations/cli/src/lib/manifest/prepare.ts
@@ -45,6 +45,8 @@ export interface PreparedAgent {
   description?: string;
   /** Effective persona body (manifest `instructions` REPLACES the file body; sole body for inline). */
   body?: string;
+  /** Kickoff prompt auto-submitted at session start (manifest-only; personas carry none). */
+  prompt?: string;
   /** Effective merged capabilities. */
   capabilities: string[];
   capabilitySource: "manifest" | "persona" | "none";
@@ -143,6 +145,7 @@ export function prepareAgent(agent: ResolvedAgent, persona: AgentDef | undefined
       role,
       description,
       body,
+      prompt: agent.prompt,
       capabilities,
       capabilitySource,
       policy,

--- a/implementations/cli/src/lib/manifest/render.ts
+++ b/implementations/cli/src/lib/manifest/render.ts
@@ -41,7 +41,7 @@ export function renderTopology(p: PreparedManifest): string {
   out.push("", c.bold(`Agents (${p.agents.length})`));
   for (const a of p.agents) {
     const src = a.persona ? `persona ${a.persona}` : "inline";
-    const meta = [a.agentType, a.model ? `model ${a.model}` : undefined, a.role ? `role ${a.role}` : undefined]
+    const meta = [a.agentType, a.model ? `model ${a.model}` : undefined, a.role ? `role ${a.role}` : undefined, a.prompt ? "kickoff prompt" : undefined]
       .filter(Boolean)
       .join(" · ");
     out.push(`  ${c.bold(a.name)}  ${c.dim(meta + " · " + src)}`);

--- a/implementations/cli/src/lib/manifest/resolve.ts
+++ b/implementations/cli/src/lib/manifest/resolve.ts
@@ -170,6 +170,7 @@ function resolveAgents(
     role: entry.role,
     description: entry.description,
     instructions: entry.instructions,
+    prompt: entry.prompt,
     capabilities: entry.capabilities,
     personaPermissions: entry.personaPermissions ?? topPolicy,
     policy: invertPolicy(name, channels),

--- a/implementations/cli/src/lib/manifest/schema.ts
+++ b/implementations/cli/src/lib/manifest/schema.ts
@@ -28,6 +28,8 @@ const AgentEntryObject = z
     role: z.string().min(1).optional(),
     description: z.string().optional(),
     instructions: z.string().optional(),
+    /** Kickoff prompt auto-submitted once the session is up (the declarative `--prompt`). */
+    prompt: z.string().min(1).optional(),
     capabilities: z.array(z.string().min(1)).optional(),
     /** Per-agent override of the top-level `personaPermissions` policy. */
     personaPermissions: PersonaPermissions.optional(),

--- a/implementations/manager/smoke/manifest-launch.smoke.ts
+++ b/implementations/manager/smoke/manifest-launch.smoke.ts
@@ -52,6 +52,7 @@ const resolved: MeshLaunchAgent = {
   launchOptions: { temperature: "0.2" },
   description: "Quick web researcher.",
   body: "Research the web; report in 3 bullets.",
+  prompt: "Kick off: post your research plan in #general.",
   capabilities: ["spawn"],
   subscribe: ["general", "ops"],
   allowSubscribe: ["general", "ops", "review"],
@@ -92,6 +93,7 @@ const fakeHandle = (name: string): AgentHandle => ({ name, kind: "fake", status:
 };
 let seenVariant: string | undefined;
 let seenLaunchOptions: Record<string, unknown> | undefined;
+let seenPrompt: string | undefined;
 const recCon: Connector = {
   kind: "connector",
   name: "smoke-launch",
@@ -100,6 +102,7 @@ const recCon: Connector = {
   buildLaunch: (opts) => {
     seenVariant = opts.variant;
     seenLaunchOptions = opts.launchOptions;
+    seenPrompt = opts.prompt;
     return { command: "true", args: [], env: {} };
   },
 };
@@ -117,6 +120,10 @@ registry.register(recCon);
   check("identity is the resolved name", reply.ok && reply.data?.name === "scout", reply.ok && reply.data?.name);
   check("variant is forwarded to the connector", seenVariant === "high", seenVariant);
   check("launchOptions forwarded to the connector (via resolved)", JSON.stringify(seenLaunchOptions) === JSON.stringify({ temperature: "0.2" }), seenLaunchOptions);
+  check("manifest kickoff prompt forwarded to the connector (via resolved)", seenPrompt === "Kick off: post your research plan in #general.", seenPrompt);
+  // One source: an imperative --prompt alongside a resolved launch is a caller contract error.
+  const rej = await mgr.startAgent({ ...launchAgentToStartOpts(resolved, personaPath), prompt: "imperative override" });
+  check("imperative prompt alongside resolved is rejected", rej.ok === false && /prompt/.test(rej.error ?? ""), JSON.stringify(rej));
 
   const acl = credAcl(join(root, ".cotal", "auth", "creds", "scout.creds"));
   check("read ACL = resolved allowSubscribe (general+ops+review)", ["general", "ops", "review"].every((ch) => acl.sub.some((s) => s.endsWith("." + ch))), acl.sub);
@@ -151,6 +158,8 @@ function writeSpec(name: string, body: unknown): string {
   throws("unsafe capability token rejected", () => loadLaunchSpec(writeSpec("a3.json", agent1({ capabilities: ["spawn x"] }))));
   throws("non-alphanumeric hash rejected", () => loadLaunchSpec(writeSpec("a4.json", agent1({ hash: "../../etc" }))));
   throws("empty variant rejected", () => loadLaunchSpec(writeSpec("a5.json", agent1({ variant: "" }))));
+  throws("empty prompt rejected", () => loadLaunchSpec(writeSpec("a6.json", agent1({ prompt: "" }))));
+  check("kickoff prompt loads through the strict schema", loadLaunchSpec(writeSpec("a7.json", agent1({ prompt: "go" }))).agents[0].prompt === "go");
   // Policy re-validation at the manager boundary — --launch must not be a looser manifest format.
   throws("wildcard scope in launch policy rejected", () => loadLaunchSpec(writeSpec("p1.json", agent1({ subscribe: ["team.>"], allowSubscribe: ["team.>"] }))));
   throws("subscribe ⊄ allowSubscribe rejected", () => loadLaunchSpec(writeSpec("p2.json", agent1({ subscribe: ["general"], allowSubscribe: [] }))));

--- a/implementations/manager/src/launch.ts
+++ b/implementations/manager/src/launch.ts
@@ -28,6 +28,7 @@ const LaunchAgentSchema = z.strictObject({
   launchOptions: z.record(z.string(), z.unknown()).optional(),
   description: z.string().optional(),
   body: z.string().optional(),
+  prompt: z.string().min(1).optional(),
   capabilities: z.array(z.string().regex(/^[A-Za-z0-9_-]+(?::[A-Za-z0-9_-]+)?$/, "capability must be a safe token, optionally role-namespaced (role:<r>)")).optional(),
   subscribe: z.array(z.string()),
   allowSubscribe: z.array(z.string()),

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -284,7 +284,8 @@ export interface StartAgentOpts {
    *  `--transcript` flag) opts in. */
   transcript?: boolean;
   /** Initial prompt auto-submitted at session start (the `--prompt` flag), forwarded verbatim to
-   *  the connector. Imperative-only: never set from `resolved` (a manifest carries no prompt). */
+   *  the connector. Imperative launches only — a manifest launch carries its own `resolved.prompt`
+   *  and rejects this flag alongside it (one source, no merge). */
   prompt?: string;
   /** Access-policy overrides (the `--subscribe` / `--allow-subscribe` / `--allow-publish` flags):
    *  win over the persona file exactly as in foreground `cotal spawn`, and are minted into the
@@ -2173,6 +2174,7 @@ export class Manager {
     let model = opts.model;
     let variant = opts.variant;
     let launchOptions = opts.launchOptions;
+    let prompt = opts.prompt;
     if (opts.resolved) {
       // A manifest launch is the access + identity authority: imperative overrides arriving
       // alongside `resolved` are a caller contract error, not something to merge (no fallbacks).
@@ -2188,6 +2190,8 @@ export class Manager {
       model = opts.model ?? r.model;
       variant = opts.variant ?? r.variant;
       launchOptions = mergeLaunchOptions(r.launchOptions, opts.launchOptions);
+      prompt = r.prompt; // the guard above rejected an imperative prompt — one source
+
     } else {
       let def: AgentDef;
       try {
@@ -2353,8 +2357,8 @@ export class Manager {
         // control arg), never from `opts.resolved` — so the manifest launch path carries no resume by
         // construction. An unsupported connector throws here before any process is spawned.
         resume: opts.resume,
-        // Initial prompt (imperative-only; the resolved guard above keeps manifests prompt-free).
-        prompt: opts.prompt,
+        // Initial prompt: the `--prompt` flag, or the manifest entry's `prompt:` on a resolved launch.
+        prompt,
         // The SAME access set the creds were minted from (above) — forwarded so the session's
         // runtime read/post set matches its credentials. Without this a manifest-spawned agent
         // (materialized persona has no access frontmatter) falls back to `["general"]`, which its

--- a/packages/core/src/launch.ts
+++ b/packages/core/src/launch.ts
@@ -22,6 +22,10 @@ export interface MeshLaunchAgent {
   description?: string;
   /** Persona body — materialized to a transient, non-authoritative file the connector reads. */
   body?: string;
+  /** Kickoff prompt auto-submitted at session start (the manifest's `prompt:`), forwarded to the
+   *  connector exactly like the imperative `--prompt`. Part of the launch form: re-submitted on
+   *  every (re)start under this entry, and hash-covered so a change marks a running agent stale. */
+  prompt?: string;
   capabilities?: string[];
   /** Effective merged read set — the sole creds authority (not re-read from any file). */
   subscribe: string[];


### PR DESCRIPTION
## What

A per-agent `prompt:` key in the mesh manifest (`cotal.yaml`) — a kickoff message auto-submitted once the session is up, the declarative form of `cotal spawn --prompt`. A team deployed with `up -f` / `spawn -f` can now start working immediately, without a post-deploy nudge.

```yaml
agents:
  planner:
    instructions: You plan.            # system prompt (who the agent is)
    prompt: Post the first plan in #dev.   # kickoff (what to do right now)
```

## Semantics

- `instructions` remain the session's system prompt; `prompt` is a one-shot first message, forwarded to the connector exactly like the imperative `--prompt`.
- The prompt is part of the launch form: submitted on first boot and again on a stale-restart. It participates in the drift hash, so changing it marks a running agent `stale` like any other launch field. A manager reclaim of a still-live session does not re-submit it.
- Prompt-less agents hash exactly as before (the field is only hashed when set), so upgrading does not flip already-deployed manifest agents to stale.
- The manager still rejects an imperative `--prompt` alongside a manifest launch (one source, no merge), and the strict launch-spec schema accepts the new field (empty string rejected).
- `topology view` / dry-run mark agents that carry a kickoff prompt.

## Plumbing

`schema.ts` → `resolve.ts` → `prepare.ts` → `apply.ts` (hash + launch spec) in the CLI manifest pipeline; `MeshLaunchAgent.prompt` in core; strict-schema acceptance + resolved-launch forwarding in the manager.

## Verification

- `pnpm typecheck` and `pnpm build` green.
- `smoke:manifest-launch` extended: kickoff prompt forwarded to the connector via `resolved`, imperative prompt alongside `resolved` rejected, empty prompt rejected by the strict schema, non-empty accepted. Green, plus `smoke:launch-parity`, `smoke:flag-inventory`, `smoke:cli-kernel`.
- Live end-to-end: booted a fresh auth mesh from a manifest whose single Claude agent carried only `prompt: Post exactly "kickoff-received" in #dev`; the durable CHAT stream then contained that exact post from the agent with zero human interaction. Hash behavior verified live: adding a prompt or editing its text changes the agent hash; absent prompt reproduces the pre-change hash.

Docs: `docs/manifest.md` (per-agent keys + instructions-vs-prompt semantics). Changeset included (patch across the fixed group).