### PR TITLE
feat(manifest): deploy spawn -f to a remote manager over the control plane

### DIFF
--- a/.changeset/shiny-taxis-repeat.md
+++ b/.changeset/shiny-taxis-repeat.md
@@ -1,0 +1,6 @@
+---
+"@cotal-ai/cli": patch
+"@cotal-ai/manager": patch
+---
+
+`cotal spawn -f` now deploys to a remote manager: when the mesh's serving manager lives in another checkout or on another host, the resolved launch spec rides the `launch` control op inline — the manager validates it with the same untrusted-input contract as the file path and persists it under its own `.cotal/run/` (stale-restart and retained resume read one source either way). The ledger stays with the deploying checkout, so `down -f` works from there too. Also fixes a pre-existing re-apply edge: the transient persona file is now written atomic-replace instead of exclusive-create, so re-launching an agent after a partial deploy failure no longer dies on EEXIST.

--- a/docs/define-a-team.md
+++ b/docs/define-a-team.md
@@ -121,6 +121,15 @@ declared item against the live mesh:
 > `spawn -f` prints a warning: an isolation conflict on a shared mesh. It is an explicit *lower
 > bound* (presence plus the broker membership feed), not a guarantee that no other access exists.
 
+**Deploying to a remote manager.** The mesh's manager may live on another machine (or another
+checkout): `spawn -f` detects that from the manager lease and pushes the resolved launch spec
+inline over the control plane — the manager validates it as untrusted input and persists it under
+its own `.cotal/run/` before launching, so nothing changes downstream. Run the deploy from the
+checkout the mesh is **registered** to on your machine (that's where the ledger lands), and run
+`down -f` from that same checkout; it stops remote agents over the control plane and treats a
+locally-absent cred file as proven-absent. One residual: the agents' cred files minted on the
+manager's host stay there until the mesh's own cleanup, exactly as after a crash.
+
 ## Operating a manifest mesh
 
 Every mesh-touching command resolves the broker from the mesh registry, so `--space <name>` is

--- a/implementations/cli/src/commands/spawn-manifest.ts
+++ b/implementations/cli/src/commands/spawn-manifest.ts
@@ -4,8 +4,10 @@
  *
  *  - classifies channels (new → seed + own · existing → `exists-unmanaged`, card untouched) and
  *    agents (will-create · already-owned · stale) against the live mesh + any prior ledger;
- *  - boots agents through the workspace-local manager's admin `launch` op (it reads the run spec by
- *    id and mints from the resolved policy — the control wire carries no authority);
+ *  - boots agents through the serving manager's admin `launch` op — a manager in THIS checkout
+ *    reads the run spec by id; a manager in another checkout/host gets the resolved spec pushed
+ *    inline over the control plane (it validates + persists it itself, and mints from the resolved
+ *    policy — the control wire carries no authority, and never a path);
  *  - records exactly what it created in a `cotal-ledger/v1` ledger so `down -f` removes only that;
  *  - flags unmanaged actors on declared channels as a SECURITY warning (an explicit lower bound).
  *
@@ -90,17 +92,17 @@ export async function spawnManifest(file: string, flags: SpawnManifestFlags): Pr
   const tier = user ? CONTROL_PRIVILEGED : CONTROL_ADMIN;
 
   const root = cotalRoot();
-  // Same-checkout invariant (security/UX): the launch spec, the ledger, and the manager `spawn -f`
-  // drives all live under THIS checkout's `.cotal`. Deploying onto a mesh recorded by a different
-  // checkout would decouple those local artifacts from that mesh's root/manager. Refuse unless the
-  // resolved mesh is registered to this root; a raw off-registry target (no recorded root) isn't
-  // supported for a manifest deploy.
+  // Deploy-home invariant (UX): the ledger and any locally-minted creds live under THIS checkout's
+  // `.cotal`, and `down -f` later resolves them from here — so the deploy must run from the
+  // checkout the mesh is REGISTERED to on this machine. (The serving MANAGER may live elsewhere;
+  // that's the remote path below.) A raw off-registry target (no recorded root) isn't supported
+  // for a manifest deploy.
   if (!connection.root) {
     console.error(c.red(`✗ spawn -f needs a mesh registered to this checkout - a raw off-registry target (--server/--space) isn't supported for a manifest deploy`));
     process.exit(1);
   }
   if (resolve(connection.root) !== resolve(root)) {
-    console.error(c.red(`✗ mesh "${space}" belongs to a different checkout (${connection.root}) - \`spawn -f\` / \`down -f\` are same-checkout; run them from ${connection.root}`));
+    console.error(c.red(`✗ mesh "${space}" is registered to another checkout on this machine (${connection.root}) - run \`spawn -f\` / \`down -f\` from there (the deploy's ledger lives with the registration)`));
     process.exit(1);
   }
   const manifestHash = hashManifestSource(readFileSync(abs, "utf8"));
@@ -176,8 +178,8 @@ export async function spawnManifest(file: string, flags: SpawnManifestFlags): Pr
     const held = agentPlan.willCreate.length ? await ep.readManagerLease() : undefined;
     const heldReady = Boolean(held && await waitManagerReady(ep, MANAGER_PROBE_MS, tier));
     if (heldReady && held) {
-      if (resolve(held.root) !== resolve(root))
-        throw new Error(`a manager from a different checkout serves "${space}" (root ${held.root}) - stop it, or run spawn -f from there`);
+      // A manager in another checkout (or on another host) is fine — the deploy goes REMOTE below,
+      // pushing the resolved spec over the control plane. Only a runtime mismatch is unresolvable.
       if (held.runtime !== runtime)
         throw new Error(`a ${held.runtime} manager already serves "${space}" but runtime ${runtime} was requested - stop it, or match it with --runtime ${held.runtime}`);
     } else if (agentPlan.willCreate.length) {
@@ -206,10 +208,12 @@ export async function spawnManifest(file: string, flags: SpawnManifestFlags): Pr
     const agents: LedgerAgent[] = [...(prior?.created.agents ?? [])];
     const launchedNow: string[] = [];
     if (agentPlan.willCreate.length) {
-      // The manager reads the run spec by runId on each `launch`. USER MODE stamps the deploy's
-      // owner (the login's derived owner, read from the deployer-view bearer) into the spec — the
-      // manager launches the agents under it AND enforces it equals the launch caller's owner.
-      writeLaunchSpec(root, buildLaunchSpec(eff, runId, user?.owner), { update: Boolean(prior) });
+      // The manager reads the run spec by runId on each `launch` (a remote manager gets it pushed
+      // inline instead, below). USER MODE stamps the deploy's owner (the login's derived owner,
+      // read from the deployer-view bearer) into the spec — the manager launches the agents under
+      // it AND enforces it equals the launch caller's owner.
+      const spec = buildLaunchSpec(eff, runId, user?.owner);
+      writeLaunchSpec(root, spec, { update: Boolean(prior) });
       // Ensure a manager is SERVING this space, then validate it's ours — the lease is the authoritative
       // owner record. A held lease alone is not proof a manager is alive (a crashed holder's key lingers
       // until the bucket TTL, MANAGER_LEASE_TTL_MS), so read it (fast) and, when one exists, PROBE control to tell
@@ -249,16 +253,24 @@ export async function spawnManifest(file: string, flags: SpawnManifestFlags): Pr
         console.error(c.red(`✗ "${space}" has no manager lease after the manager became ready - re-run \`cotal spawn -f\``));
         process.exit(1);
       }
-      if (resolve(live.root) !== resolve(root)) {
-        console.error(c.red(`✗ a manager from a different checkout serves "${space}" (root ${live.root}) - stop it, or run spawn -f from there`));
-        process.exit(1);
-      }
       if (live.runtime !== runtime) {
         console.error(c.red(`✗ a ${live.runtime} manager already serves "${space}" but runtime ${runtime} was requested - stop it, or match it with --runtime ${live.runtime}`));
         process.exit(1);
       }
+      // A manager from another checkout/host serves the space → REMOTE deploy: each `launch` call
+      // carries the resolved spec inline (the manager validates it as untrusted input and persists
+      // it under ITS OWN run tree). The ledger — and so `down -f` — stays with THIS checkout.
+      const remote = resolve(live.root) !== resolve(root);
+      if (remote) {
+        const wireBytes = Buffer.byteLength(JSON.stringify(spec));
+        if (wireBytes > 512 * 1024) {
+          console.error(c.red(`✗ launch spec too large to push over the control plane (${Math.round(wireBytes / 1024)}KB > 512KB) - deploy from the manager's checkout (${live.root})`));
+          process.exit(1);
+        }
+        console.log(c.dim(`  ~ remote manager serves "${space}" (root ${live.root}) - pushing the launch spec over the control plane`));
+      }
       for (const e of agentPlan.willCreate) {
-        const reply: ControlReply = await launchAgent(ep, runId, e.agent.name, tier);
+        const reply: ControlReply = await launchAgent(ep, runId, e.agent.name, tier, remote ? spec : undefined);
         if (!reply.ok) {
           console.error(c.red(`✗ ${e.agent.name}: ${reply.error ?? "launch failed"}`));
           continue;

--- a/implementations/cli/src/lib/manifest/live.ts
+++ b/implementations/cli/src/lib/manifest/live.ts
@@ -5,7 +5,7 @@
  * deployer-view deploy (the manager's owner-equality authorization governs there). (Channel-registry
  * reads use `readChannelRegistry`, which connects itself.)
  */
-import { CotalEndpoint, CONTROL_ADMIN, type ControlReply, type ControlTier, type Presence } from "@cotal-ai/core";
+import { CotalEndpoint, CONTROL_ADMIN, type ControlReply, type ControlTier, type MeshLaunchSpec, type Presence } from "@cotal-ai/core";
 import { START_TIMEOUT_MS } from "../control.js";
 
 export interface MeshConn {
@@ -89,9 +89,11 @@ export async function waitLeaseGone(ep: CotalEndpoint, timeoutMs: number): Promi
  *  a static operator deploy (the `launch` op is operator-only there; a spawn-capable agent must
  *  not reach it), on the PRIVILEGED tier for a user-mode deployer-view deploy (the manager
  *  enforces spec-owner === caller-owner). The manager derives `.cotal/run/<runId>.json` itself;
- *  we pass the runId, never a path. */
-export async function launchAgent(ep: CotalEndpoint, runId: string, name: string, tier: ControlTier = CONTROL_ADMIN): Promise<ControlReply> {
+ *  we pass the runId, never a path. When the serving manager lives in ANOTHER checkout/host, pass
+ *  `spec` and the resolved spec rides the control plane inline — the manager validates it as
+ *  untrusted input and persists it under its own run tree before launching. */
+export async function launchAgent(ep: CotalEndpoint, runId: string, name: string, tier: ControlTier = CONTROL_ADMIN, spec?: MeshLaunchSpec): Promise<ControlReply> {
   // #159 B1: `launch` funnels into the same startAgent readiness wait as `start` — the manager
   // replies only on a real outcome (join / exit / ~30s backstop), so the request must outlive it.
-  return ep.requestControl(tier, { op: "launch", args: { runId, name } }, START_TIMEOUT_MS);
+  return ep.requestControl(tier, { op: "launch", args: { runId, name, ...(spec ? { spec } : {}) } }, START_TIMEOUT_MS);
 }

--- a/implementations/manager/smoke/manifest-launch.smoke.ts
+++ b/implementations/manager/smoke/manifest-launch.smoke.ts
@@ -229,6 +229,28 @@ function writeSpec(name: string, body: unknown): string {
   }
   const bad = await op({ runId: runId2, name: "ghost" });
   check("opLaunch rejects an unknown agent name", bad.ok === false);
+
+  // --- INLINE spec: the remote-deploy path (spec pushed over the control plane, no shared disk) --
+  const runId3 = "cafebabe03";
+  const spec3: MeshLaunchSpec = {
+    apiVersion: "cotal-launch/v1",
+    space: "demo",
+    runId: runId3,
+    agents: [{
+      name: "pusher", agent: "smoke-launch", role: "researcher", model: "opus", body: "Inline persona.",
+      subscribe: ["general"], allowSubscribe: ["general"], allowPublish: ["general"], personaPath: undefined, hash: "def456",
+    }],
+  };
+  const inline = await op({ runId: runId3, name: "pusher", spec: spec3 });
+  check("opLaunch boots from an INLINE spec (no pre-shared run file)", inline.ok === true, inline.error);
+  check("inline spec persisted under the MANAGER's own run tree", existsSync(join(root, ".cotal", "run", `${runId3}.json`)));
+  check("persisted spec round-trips through launchSpecForRun", launchSpecForRun(root, runId3).agents[0].name === "pusher");
+  const mism = await op({ runId: "aaaaaaaa04", name: "pusher", spec: spec3 });
+  check("inline spec runId mismatch rejected", mism.ok === false && /does not match/.test(mism.error ?? ""), mism.error);
+  const evil = await op({ runId: runId3, name: "pusher", spec: { ...spec3, agents: [{ ...spec3.agents[0], name: "../evil" }] } });
+  check("invalid inline spec rejected (unsafe agent name)", evil.ok === false);
+  const again = await op({ runId: runId3, name: "pusher", spec: spec3 });
+  check("re-push of the same inline spec is idempotent (collision-numbered spawn)", again.ok === true && (again.data as { name?: string })?.name === "pusher-2", JSON.stringify(again));
 }
 
 // --- symlinked parent dir refused (writes can't escape the run tree) ----------------------------

--- a/implementations/manager/src/launch.ts
+++ b/implementations/manager/src/launch.ts
@@ -1,4 +1,5 @@
-import { readFileSync, writeFileSync, lstatSync } from "node:fs";
+import { readFileSync, writeFileSync, lstatSync, renameSync } from "node:fs";
+import { randomBytes } from "node:crypto";
 import { dirname, join, resolve } from "node:path";
 import { z } from "zod";
 import { assertDerivedOwnerToken, assertValidChannel, assertValidName, ensureDirNoSymlink, isConcreteChannel, realDirNoSymlink, type MeshLaunchAgent, type MeshLaunchSpec } from "@cotal-ai/core";
@@ -53,8 +54,21 @@ const LaunchSpecSchema = z.strictObject({
   agents: z.array(LaunchAgentSchema),
 });
 
-/** Parse + strictly validate a launch spec file. Throws on any deviation (it's untrusted, local
- *  though it is) — including an agent name that isn't a safe mesh/file token (no path traversal). */
+/** Parse + strictly validate a launch spec from untrusted JSON (a file OR an inline control-op
+ *  payload). Throws on any deviation — including an agent name that isn't a safe mesh/file token
+ *  (no path traversal). */
+export function parseLaunchSpec(json: unknown, label: string): MeshLaunchSpec {
+  const r = LaunchSpecSchema.safeParse(json);
+  if (!r.success)
+    throw new Error(`${label}: ${r.error.issues.map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`).join("; ")}`);
+  for (const a of r.data.agents) {
+    assertValidName(a.name); // names the transient file → must be safe
+    validateLaunchPolicy(a); // don't let --launch be a looser second manifest format
+  }
+  return r.data;
+}
+
+/** Parse + strictly validate a launch spec file ({@link parseLaunchSpec} on its contents). */
 export function loadLaunchSpec(path: string): MeshLaunchSpec {
   let json: unknown;
   try {
@@ -62,14 +76,22 @@ export function loadLaunchSpec(path: string): MeshLaunchSpec {
   } catch (e) {
     throw new Error(`launch spec ${path}: ${(e as Error).message}`);
   }
-  const r = LaunchSpecSchema.safeParse(json);
-  if (!r.success)
-    throw new Error(`launch spec ${path}: ${r.error.issues.map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`).join("; ")}`);
-  for (const a of r.data.agents) {
-    assertValidName(a.name); // names the transient file → must be safe
-    validateLaunchPolicy(a); // don't let --launch be a looser second manifest format
-  }
-  return r.data;
+  return parseLaunchSpec(json, `launch spec ${path}`);
+}
+
+/** Persist a PUSHED (inline) launch spec under this manager's own `.cotal/run/<runId>.json`, so a
+ *  remote deploy leaves the same on-disk source the file path would: stale-restart and retained
+ *  resume ({@link launchSpecForRun}) read one place either way. Atomic temp-then-rename (exclusive
+ *  temp, never follows a pre-planted symlink), replacing any prior content for the runId — the
+ *  deploying CLI owns runId reuse semantics, the manager just holds the current spec. Callers pass
+ *  an already-validated spec, so `runId` is a safe token. */
+export function persistLaunchSpec(root: string, spec: MeshLaunchSpec): string {
+  const dir = ensureDirNoSymlink(root, ".cotal", "run");
+  const path = join(dir, `${spec.runId}.json`);
+  const tmp = join(dir, `.${spec.runId}.${randomBytes(4).toString("hex")}.tmp`);
+  writeFileSync(tmp, JSON.stringify(spec, null, 2), { mode: 0o600, flag: "wx" });
+  renameSync(tmp, path);
+  return path;
 }
 
 /** Resolve + load the launch spec for a run id, deriving the path from a known root rather than
@@ -142,8 +164,13 @@ export function materializePersona(root: string, runId: string, a: MeshLaunchAge
   const src = a.personaPath ?? "the manifest";
   const header = `<!-- Generated runtime artifact from a cotal mesh manifest (run ${runId}). Do NOT edit - regenerated on each launch and deleted by \`cotal down\`. Edit ${src} instead. This file is not a reusable persona and carries no access authority. -->`;
   const body = a.body ? `${a.body.trim()}\n` : "";
-  // `wx`: exclusive create — fails rather than following a symlink pre-planted at the path.
-  writeFileSync(path, `${fm.join("\n")}${header}\n\n${body}`, { mode: 0o600, flag: "wx" });
+  // Atomic replace via an exclusive temp (never follows a symlink pre-planted at either path): the
+  // file is a derived artifact of the spec, so regenerating is always correct — a plain `wx` here
+  // made RE-launching an agent in the same run (a re-apply after a partial deploy failure, or a
+  // re-pushed remote spec) fail EEXIST on a leftover from the first attempt.
+  const tmp = resolve(dir, `.${a.name}.${randomBytes(4).toString("hex")}.tmp`);
+  writeFileSync(tmp, `${fm.join("\n")}${header}\n\n${body}`, { mode: 0o600, flag: "wx" });
+  renameSync(tmp, path);
   return path;
 }
 

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -46,7 +46,7 @@ import {
   type RuntimeMode,
 } from "./runtime/index.js";
 import { AttachEndpoint, attachHost } from "./attach-endpoint.js";
-import { launchSpecForRun, materializePersona, launchAgentToStartOpts } from "./launch.js";
+import { launchSpecForRun, materializePersona, launchAgentToStartOpts, parseLaunchSpec, persistLaunchSpec } from "./launch.js";
 import { authorizeLaunch, authorizeNamedControl } from "./authorize.js";
 import { controlShutdown } from "./control-shutdown.js";
 import { parseResumeCommitArgs, parseResumeControlArgs, parseResumeFinalizeArgs } from "./resume.js";
@@ -2037,7 +2037,9 @@ export class Manager {
   }
 
   /** Boot one resolved agent from a mesh-manifest launch spec, for `cotal spawn -f` onto a RUNNING
-   *  manager. The request carries a `{ runId, name }`, NEVER a path: the manager derives + validates
+   *  manager. The request carries `{ runId, name }` — plus, for a deploy from another checkout or
+   *  host, the resolved `spec` itself inline (validated as untrusted input and persisted under THIS
+   *  manager's `.cotal/run/` first) — NEVER a path: the manager derives + validates
    *  `.cotal/run/<runId>.json` itself ({@link launchSpecForRun} — token-safe id, no-follow,
    *  `loadLaunchSpec`'s untrusted-input + `validateLaunchPolicy` contract), materializes the named
    *  agent's transient persona, and spawns via the same `startAgent({ resolved })` path as
@@ -2050,10 +2052,26 @@ export class Manager {
     const name = String(args.name ?? "").trim();
     if (!runId || !name) return { ok: false, error: "launch requires runId + name" };
     let spec;
-    try {
-      spec = launchSpecForRun(this.workspaceRoot, runId);
-    } catch (e) {
-      return { ok: false, error: (e as Error).message };
+    if (args.spec !== undefined) {
+      // REMOTE deploy: the caller pushes the resolved spec inline over the control plane instead of
+      // sharing this checkout's disk. Same untrusted-input contract as the file path (strict schema,
+      // safe names, policy re-validation), then persisted under OUR `.cotal/run/<runId>.json` so
+      // stale-restart and retained resume read the same on-disk source either way. Still never a
+      // path: the payload is the spec itself, and where it lands is derived here.
+      try {
+        spec = parseLaunchSpec(args.spec, `inline launch spec (run ${runId})`);
+        if (spec.runId !== runId)
+          return { ok: false, error: `inline launch spec runId "${spec.runId}" does not match requested "${runId}"` };
+        persistLaunchSpec(this.workspaceRoot, spec);
+      } catch (e) {
+        return { ok: false, error: (e as Error).message };
+      }
+    } else {
+      try {
+        spec = launchSpecForRun(this.workspaceRoot, runId);
+      } catch (e) {
+        return { ok: false, error: (e as Error).message };
+      }
     }
     const la = spec.agents.find((a) => a.name === name);
     if (!la) return { ok: false, error: `no agent "${name}" in launch spec for run ${runId}` };


### PR DESCRIPTION
## What

`cotal spawn -f` can now deploy onto a mesh whose **manager lives in another checkout or on another host** — the standard operator story of running the broker+manager on a server and operating it from a laptop. Previously this failed with `a manager from a different checkout serves "<space>" - stop it, or run spawn -f from there`.

## How

- **Manager**: the admin/privileged `launch` op accepts the resolved launch spec **inline** as an alternative to the runId-only file reference. The pushed spec goes through exactly the untrusted-input contract the file path has (strict schema, token-safe names, `validateLaunchPolicy`), must match the requested runId, and is **persisted under the manager's own `.cotal/run/<runId>.json`** (atomic temp-then-rename) before launching — stale-restart and retained-resume machinery read the same on-disk source either way. The wire still never carries a path.
- **CLI**: `spawn -f` compares the serving manager's lease root against the local checkout; on mismatch it pushes the spec on each `launch` call (size-guarded at 512KB) and says so in the output. The creation ledger stays with the deploying checkout, so `down -f` keeps working from where the deploy ran (it already stops agents over the control plane and treats a locally-absent cred file as proven-absent).
- The runtime-mismatch refusal stays; the "registered to another checkout on this machine" gate stays (the ledger lives with the registration).

## Also fixed

The new smoke caught a pre-existing re-apply edge: `materializePersona` wrote the transient persona exclusive-create (`wx`), so re-launching an agent in the same run — a re-apply after a partial deploy failure, or a re-pushed remote spec — failed `EEXIST` on the first attempt's leftover. Now an atomic replace via exclusive temp + rename, preserving the no-symlink-follow property.

## Residual

Cred files the manager mints for launched agents live on the manager's host; a remote `down -f` stops the agents and removes owned channels but leaves those files, exactly as after a crash. Noted in `docs/define-a-team.md`.

## Verification

- `pnpm typecheck`, `pnpm build` green.
- `smoke:manifest-launch` extended and green: inline-spec boot with no pre-shared run file, persistence under the manager's run tree + round-trip through `launchSpecForRun`, runId-mismatch rejection, unsafe-inline-spec rejection, and idempotent re-push (collision-numbered spawn). `smoke:launch-parity` green.

Docs: `docs/define-a-team.md` gains a "Deploying to a remote manager" section. Changeset included (patch).

Closes #316.