### PR TITLE
fix(connector-hermes): installed-ext launch crash and hermes provider-key forwarding

### DIFF
--- a/.changeset/hermes-ext-bundle-and-provider-keys.md
+++ b/.changeset/hermes-ext-bundle-and-provider-keys.md
@@ -6,7 +6,8 @@ Fix the Hermes connector when it runs as an installed extension: `dist/launch.js
 carries a `createRequire` banner (the esbuild ESM bundle crashed at import with `Dynamic
 require of "crypto"` on every installed-ext launch; dev runs via tsx masked it), and the
 launch-env filter now forwards Hermes' own model-provider API keys (`OPENCODE_GO_API_KEY`,
-`OPENCODE_ZEN_API_KEY`, and the other dedicated key names in the hermes 0.16 provider
-registry) so a managed or containerized Hermes can authenticate any of its providers from
-the operator's environment. Generic cross-tool credentials (`GH_TOKEN`,
-`CLAUDE_CODE_OAUTH_TOKEN`, …) stay excluded from the forward list.
+`OPENCODE_ZEN_API_KEY`, `NOVITA_API_KEY`, and the other dedicated key names in the hermes
+0.16 provider registry, bundled model-provider plugins included) so a managed or
+containerized Hermes can authenticate any of its providers from the operator's
+environment. Generic cross-tool and cloud-wide credentials (`GH_TOKEN`,
+`CLAUDE_CODE_OAUTH_TOKEN`, `GOOGLE_API_KEY`, …) stay excluded from the forward list.

--- a/.changeset/hermes-ext-bundle-and-provider-keys.md
+++ b/.changeset/hermes-ext-bundle-and-provider-keys.md
@@ -1,0 +1,12 @@
+---
+"@cotal-ai/connector-hermes": patch
+---
+
+Fix the Hermes connector when it runs as an installed extension: `dist/launch.js` now
+carries a `createRequire` banner (the esbuild ESM bundle crashed at import with `Dynamic
+require of "crypto"` on every installed-ext launch; dev runs via tsx masked it), and the
+launch-env filter now forwards Hermes' own model-provider API keys (`OPENCODE_GO_API_KEY`,
+`OPENCODE_ZEN_API_KEY`, and the other dedicated key names in the hermes 0.16 provider
+registry) so a managed or containerized Hermes can authenticate any of its providers from
+the operator's environment. Generic cross-tool credentials (`GH_TOKEN`,
+`CLAUDE_CODE_OAUTH_TOKEN`, …) stay excluded from the forward list.

--- a/extensions/connector-hermes/package.json
+++ b/extensions/connector-hermes/package.json
@@ -22,9 +22,9 @@
   },
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "tsx smoke/tool-parity.smoke.ts && tsx smoke/bridge-quiet.smoke.ts",
+    "test": "tsx smoke/tool-parity.smoke.ts && tsx smoke/bridge-quiet.smoke.ts && tsx smoke/launch-env.smoke.ts && tsx smoke/bundle-import.smoke.ts",
     "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json --emitDeclarationOnly && pnpm run bundle",
-    "bundle": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/index.js --external:@cotal-ai/core && esbuild src/launch.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/launch.js && esbuild src/standalone.ts --bundle --platform=node --format=cjs --target=node20 --outfile=plugin/cotal/_sidecar/standalone.cjs",
+    "bundle": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/index.js --external:@cotal-ai/core && esbuild src/launch.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/launch.js --banner:js=\"import { createRequire as __cotalCreateRequire } from 'node:module'; const require = __cotalCreateRequire(import.meta.url);\" && esbuild src/standalone.ts --bundle --platform=node --format=cjs --target=node20 --outfile=plugin/cotal/_sidecar/standalone.cjs",
     "prepublishOnly": "pnpm run build"
   },
   "peerDependencies": {

--- a/extensions/connector-hermes/smoke/bundle-import.smoke.ts
+++ b/extensions/connector-hermes/smoke/bundle-import.smoke.ts
@@ -1,0 +1,43 @@
+/**
+ * Bundle import (no test runner) — the SHIPPED dist/launch.js must be importable by plain
+ * node. The launcher bundle inlines CJS deps (tweetnacl via @nats-io/nkeys) that
+ * `require()` node builtins at import time; esbuild's ESM output only supports that
+ * through the createRequire banner in the package's `bundle` script. An installed ext runs
+ * exactly this file with node (FROM_BUILD), while dev runs src via tsx — so only this
+ * smoke, not any dev flow, catches a banner regression.
+ *
+ * Rebuilds the bundle with the real `bundle` script (single source of truth), then imports
+ * it with an identity-free env: expected outcome is a clean exit 0 with the launcher's
+ * "not a managed session" notice, not an import-time crash.
+ * Run: pnpm --filter @cotal-ai/connector-hermes test
+ */
+import { strict as assert } from "node:assert";
+import { execFileSync, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+
+if (process.platform === "win32") {
+  console.log("✓ bundle-import smoke skipped on Windows (the Hermes connector is Unix-only; execFileSync(\"pnpm\") cannot spawn a .cmd)");
+  process.exit(0);
+}
+
+const pkgDir = fileURLToPath(new URL("..", import.meta.url));
+
+execFileSync("pnpm", ["run", "bundle"], { cwd: pkgDir, stdio: "pipe" });
+
+const res = spawnSync(process.execPath, [join(pkgDir, "dist", "launch.js")], {
+  // Identity-free, minimal env: hasIdentity() is false, so a healthy bundle imports, logs
+  // the not-a-managed-session notice, and exits 0 before touching uv or any socket.
+  env: { PATH: process.env.PATH ?? "", HOME: process.env.HOME ?? "" },
+  encoding: "utf8",
+  timeout: 30_000,
+});
+
+assert.equal(
+  res.status,
+  0,
+  `dist/launch.js did not import cleanly (exit ${res.status}):\n${res.stderr}`,
+);
+assert.match(res.stderr, /not a managed session/, "expected the launcher's identity-free notice");
+
+console.log("bundle-import smoke: dist/launch.js imports cleanly under plain node");

--- a/extensions/connector-hermes/smoke/launch-env.smoke.ts
+++ b/extensions/connector-hermes/smoke/launch-env.smoke.ts
@@ -14,6 +14,46 @@ if (process.platform === "win32") {
   process.exit(0);
 }
 
+/** Independent snapshot of the complete allow-list (shared MODEL_PROVIDER_KEYS + the
+ *  hermes 0.16 registry's dedicated key names). Deliberately NOT derived from the
+ *  production export: set-equality against it below is what catches a key silently
+ *  dropped from (or smuggled into) HERMES_PROVIDER_KEYS — the exact escape path of the
+ *  original NOVITA_API_KEY regression. A legitimate list change edits both places. */
+const EXPECTED_KEYS = [
+  // shared MODEL_PROVIDER_KEYS
+  "OPENCODE_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "OPENROUTER_API_KEY",
+  "NOUS_API_KEY",
+  // hermes-registry dedicated keys
+  "OPENCODE_GO_API_KEY",
+  "OPENCODE_ZEN_API_KEY",
+  "XAI_API_KEY",
+  "GEMINI_API_KEY",
+  "NOVITA_API_KEY",
+  "DEEPSEEK_API_KEY",
+  "GLM_API_KEY",
+  "ZAI_API_KEY",
+  "Z_AI_API_KEY",
+  "KIMI_API_KEY",
+  "KIMI_CODING_API_KEY",
+  "KIMI_CN_API_KEY",
+  "MINIMAX_API_KEY",
+  "MINIMAX_CN_API_KEY",
+  "DASHSCOPE_API_KEY",
+  "ALIBABA_CODING_PLAN_API_KEY",
+  "STEPFUN_API_KEY",
+  "ARCEEAI_API_KEY",
+  "GMI_API_KEY",
+  "NVIDIA_API_KEY",
+  "KILOCODE_API_KEY",
+  "XIAOMI_API_KEY",
+  "TOKENHUB_API_KEY",
+  "OLLAMA_API_KEY",
+  "AZURE_FOUNDRY_API_KEY",
+] as const;
+
 /** The full exclusion boundary the extension documents — names Hermes can read but the
  *  connector must NOT forward. Keep in sync with the HERMES_PROVIDER_KEYS doc comment. */
 const EXCLUDED = [
@@ -28,15 +68,22 @@ const EXCLUDED = [
   "QWEN_API_KEY",
 ] as const;
 
-for (const key of HERMES_PROVIDER_KEYS) process.env[key] = `smoke-${key}`;
+// The production list must match the snapshot exactly — both directions.
+assert.deepEqual(
+  [...HERMES_PROVIDER_KEYS].sort(),
+  [...EXPECTED_KEYS].sort(),
+  "HERMES_PROVIDER_KEYS drifted from the smoke's expected-key snapshot — a dropped or added key must be a deliberate two-place change",
+);
+
+for (const key of EXPECTED_KEYS) process.env[key] = `smoke-${key}`;
 for (const key of EXCLUDED) process.env[key] = `smoke-${key}`;
 process.env.SOME_UNRELATED_SECRET = "smoke-unrelated";
 
 const spec = hermesConnector.buildLaunch({ space: "smoke", name: "hermes-1" });
 const env = spec.env ?? {};
 
-// Every allow-listed provider key flows — completeness, not samples.
-for (const key of HERMES_PROVIDER_KEYS)
+// Every expected provider key flows — completeness against the snapshot, not samples.
+for (const key of EXPECTED_KEYS)
   assert.equal(env[key], `smoke-${key}`, `${key} was stripped from the launch env`);
 
 // The P3 boundary holds: the whole exclusion set and unrelated secrets stay out.

--- a/extensions/connector-hermes/smoke/launch-env.smoke.ts
+++ b/extensions/connector-hermes/smoke/launch-env.smoke.ts
@@ -1,0 +1,34 @@
+/**
+ * Launch-env key forwarding (no test runner) — the connector must forward every
+ * Hermes-readable model-provider key (HERMES_PROVIDER_KEYS) into the launcher env, and
+ * ONLY named keys (P3): a generic cross-tool credential or unrelated secret in the
+ * operator's env must never reach the gateway child.
+ * Run: pnpm --filter @cotal-ai/connector-hermes test
+ */
+import { strict as assert } from "node:assert";
+import { hermesConnector } from "../src/extension.js";
+
+if (process.platform === "win32") {
+  console.log("✓ launch-env smoke skipped on Windows (the Hermes connector is Unix-only; buildLaunch throws)");
+  process.exit(0);
+}
+
+process.env.OPENCODE_GO_API_KEY = "smoke-opencode-go";
+process.env.OPENROUTER_API_KEY = "smoke-openrouter";
+process.env.GH_TOKEN = "smoke-generic-vcs-token";
+process.env.CLAUDE_CODE_OAUTH_TOKEN = "smoke-claude-session";
+process.env.SOME_UNRELATED_SECRET = "smoke-unrelated";
+
+const spec = hermesConnector.buildLaunch({ space: "smoke", name: "hermes-1" });
+const env = spec.env ?? {};
+
+// Hermes-specific provider key (the opencode-go regression) and a shared one both flow.
+assert.equal(env.OPENCODE_GO_API_KEY, "smoke-opencode-go", "OPENCODE_GO_API_KEY was stripped from the launch env");
+assert.equal(env.OPENROUTER_API_KEY, "smoke-openrouter", "OPENROUTER_API_KEY was stripped from the launch env");
+
+// The P3 boundary holds: nothing outside the named allow-list leaks.
+assert.ok(!("GH_TOKEN" in env), "GH_TOKEN (generic VCS credential) must not be forwarded");
+assert.ok(!("CLAUDE_CODE_OAUTH_TOKEN" in env), "CLAUDE_CODE_OAUTH_TOKEN (Claude session) must not be forwarded");
+assert.ok(!("SOME_UNRELATED_SECRET" in env), "unrelated env secrets must not be forwarded");
+
+console.log("launch-env smoke: hermes provider keys forwarded, P3 boundary holds");

--- a/extensions/connector-hermes/smoke/launch-env.smoke.ts
+++ b/extensions/connector-hermes/smoke/launch-env.smoke.ts
@@ -1,34 +1,53 @@
 /**
- * Launch-env key forwarding (no test runner) — the connector must forward every
- * Hermes-readable model-provider key (HERMES_PROVIDER_KEYS) into the launcher env, and
- * ONLY named keys (P3): a generic cross-tool credential or unrelated secret in the
- * operator's env must never reach the gateway child.
+ * Launch-env key forwarding (no test runner) — the connector must forward EVERY key in
+ * HERMES_PROVIDER_KEYS into the launcher env (a single missing name silently locks a
+ * provider out of managed/containerized spawns), and ONLY named keys (P3): the full
+ * documented exclusion set — generic cross-tool credentials, cloud-wide keys, and unused
+ * profile metadata — must never reach the gateway child.
  * Run: pnpm --filter @cotal-ai/connector-hermes test
  */
 import { strict as assert } from "node:assert";
-import { hermesConnector } from "../src/extension.js";
+import { hermesConnector, HERMES_PROVIDER_KEYS } from "../src/extension.js";
 
 if (process.platform === "win32") {
   console.log("✓ launch-env smoke skipped on Windows (the Hermes connector is Unix-only; buildLaunch throws)");
   process.exit(0);
 }
 
-process.env.OPENCODE_GO_API_KEY = "smoke-opencode-go";
-process.env.OPENROUTER_API_KEY = "smoke-openrouter";
-process.env.GH_TOKEN = "smoke-generic-vcs-token";
-process.env.CLAUDE_CODE_OAUTH_TOKEN = "smoke-claude-session";
+/** The full exclusion boundary the extension documents — names Hermes can read but the
+ *  connector must NOT forward. Keep in sync with the HERMES_PROVIDER_KEYS doc comment. */
+const EXCLUDED = [
+  "GH_TOKEN",
+  "GITHUB_TOKEN",
+  "COPILOT_GITHUB_TOKEN",
+  "HF_TOKEN",
+  "ANTHROPIC_TOKEN",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "GOOGLE_API_KEY",
+  "LM_API_KEY",
+  "QWEN_API_KEY",
+] as const;
+
+for (const key of HERMES_PROVIDER_KEYS) process.env[key] = `smoke-${key}`;
+for (const key of EXCLUDED) process.env[key] = `smoke-${key}`;
 process.env.SOME_UNRELATED_SECRET = "smoke-unrelated";
 
 const spec = hermesConnector.buildLaunch({ space: "smoke", name: "hermes-1" });
 const env = spec.env ?? {};
 
-// Hermes-specific provider key (the opencode-go regression) and a shared one both flow.
-assert.equal(env.OPENCODE_GO_API_KEY, "smoke-opencode-go", "OPENCODE_GO_API_KEY was stripped from the launch env");
-assert.equal(env.OPENROUTER_API_KEY, "smoke-openrouter", "OPENROUTER_API_KEY was stripped from the launch env");
+// Every allow-listed provider key flows — completeness, not samples.
+for (const key of HERMES_PROVIDER_KEYS)
+  assert.equal(env[key], `smoke-${key}`, `${key} was stripped from the launch env`);
 
-// The P3 boundary holds: nothing outside the named allow-list leaks.
-assert.ok(!("GH_TOKEN" in env), "GH_TOKEN (generic VCS credential) must not be forwarded");
-assert.ok(!("CLAUDE_CODE_OAUTH_TOKEN" in env), "CLAUDE_CODE_OAUTH_TOKEN (Claude session) must not be forwarded");
+// The P3 boundary holds: the whole exclusion set and unrelated secrets stay out.
+for (const key of EXCLUDED)
+  assert.ok(!(key in env), `${key} must not be forwarded to the gateway`);
 assert.ok(!("SOME_UNRELATED_SECRET" in env), "unrelated env secrets must not be forwarded");
 
-console.log("launch-env smoke: hermes provider keys forwarded, P3 boundary holds");
+// An exclusion appearing on the allow-list is a policy contradiction, not coverage.
+for (const key of EXCLUDED)
+  assert.ok(!HERMES_PROVIDER_KEYS.includes(key), `${key} is both allow-listed and excluded`);
+
+console.log(
+  `launch-env smoke: ${HERMES_PROVIDER_KEYS.length} provider keys forwarded, ${EXCLUDED.length} exclusions held, P3 boundary intact`,
+);

--- a/extensions/connector-hermes/src/extension.ts
+++ b/extensions/connector-hermes/src/extension.ts
@@ -23,17 +23,20 @@ const LAUNCH_COMMAND = FROM_BUILD
  *
  * Deliberately excluded: generic cross-tool credentials Hermes also accepts
  * (`GH_TOKEN`/`GITHUB_TOKEN`/`COPILOT_GITHUB_TOKEN`, `HF_TOKEN`, `ANTHROPIC_TOKEN`,
- * `CLAUDE_CODE_OAUTH_TOKEN`) — auto-forwarding an operator's VCS or Claude session
- * credential into every gateway would silently widen its blast radius — and `LM_API_KEY`
- * (LM Studio is a localhost server a managed gateway cannot reach anyway).
+ * `CLAUDE_CODE_OAUTH_TOKEN`, and `GOOGLE_API_KEY` — a generic Google Cloud API key, not a
+ * Gemini-only credential) — auto-forwarding an operator's VCS, Claude-session, or
+ * cloud-wide credential into every gateway would silently widen its blast radius —
+ * `LM_API_KEY` (LM Studio is a localhost server a managed gateway cannot reach anyway),
+ * and `QWEN_API_KEY` (Hermes 0.16 Qwen auth is OAuth-only; that profile metadata is never
+ * read as a key). Exported for the launch-env smoke, which pins both sets.
  */
-const HERMES_PROVIDER_KEYS: readonly string[] = [
+export const HERMES_PROVIDER_KEYS: readonly string[] = [
   ...MODEL_PROVIDER_KEYS,
   "OPENCODE_GO_API_KEY",
   "OPENCODE_ZEN_API_KEY",
   "XAI_API_KEY",
   "GEMINI_API_KEY",
-  "GOOGLE_API_KEY",
+  "NOVITA_API_KEY",
   "DEEPSEEK_API_KEY",
   "GLM_API_KEY",
   "ZAI_API_KEY",

--- a/extensions/connector-hermes/src/extension.ts
+++ b/extensions/connector-hermes/src/extension.ts
@@ -13,6 +13,50 @@ const LAUNCH_COMMAND = FROM_BUILD
   : fileURLToPath(new URL("../node_modules/.bin/tsx", import.meta.url));
 
 /**
+ * Every model-provider API key Hermes itself can read, beyond the shared
+ * {@link MODEL_PROVIDER_KEYS}. Hermes is model-agnostic across its own provider registry
+ * (hermes_cli, pinned 0.16 line), and each of these names is that registry's dedicated
+ * `api_key_env_vars` entry for one model provider — without them the P3 filter strips the
+ * key before it reaches the gateway, so e.g. the opencode-go provider could never
+ * authenticate in a managed or containerized spawn. Still forwarded BY NAME, never
+ * `...process.env`.
+ *
+ * Deliberately excluded: generic cross-tool credentials Hermes also accepts
+ * (`GH_TOKEN`/`GITHUB_TOKEN`/`COPILOT_GITHUB_TOKEN`, `HF_TOKEN`, `ANTHROPIC_TOKEN`,
+ * `CLAUDE_CODE_OAUTH_TOKEN`) — auto-forwarding an operator's VCS or Claude session
+ * credential into every gateway would silently widen its blast radius — and `LM_API_KEY`
+ * (LM Studio is a localhost server a managed gateway cannot reach anyway).
+ */
+const HERMES_PROVIDER_KEYS: readonly string[] = [
+  ...MODEL_PROVIDER_KEYS,
+  "OPENCODE_GO_API_KEY",
+  "OPENCODE_ZEN_API_KEY",
+  "XAI_API_KEY",
+  "GEMINI_API_KEY",
+  "GOOGLE_API_KEY",
+  "DEEPSEEK_API_KEY",
+  "GLM_API_KEY",
+  "ZAI_API_KEY",
+  "Z_AI_API_KEY",
+  "KIMI_API_KEY",
+  "KIMI_CODING_API_KEY",
+  "KIMI_CN_API_KEY",
+  "MINIMAX_API_KEY",
+  "MINIMAX_CN_API_KEY",
+  "DASHSCOPE_API_KEY",
+  "ALIBABA_CODING_PLAN_API_KEY",
+  "STEPFUN_API_KEY",
+  "ARCEEAI_API_KEY",
+  "GMI_API_KEY",
+  "NVIDIA_API_KEY",
+  "KILOCODE_API_KEY",
+  "XIAOMI_API_KEY",
+  "TOKENHUB_API_KEY",
+  "OLLAMA_API_KEY",
+  "AZURE_FOUNDRY_API_KEY",
+];
+
+/**
  * The Hermes (Nous Research) connector. Unlike Claude Code / Codex — where the harness *is* the
  * process and an MCP server rides inside it — Hermes runs as a long-lived **gateway daemon** that
  * spins up a fresh `AIAgent` per inbound message. So the mesh endpoint can't live inside a
@@ -42,11 +86,11 @@ export const hermesConnector: Connector = {
     // rendering arbitrary options to env would silently drop them. Fail loud rather than pretend.
     if (opts.launchOptions && Object.keys(opts.launchOptions).length)
       throw new Error("the Hermes connector does not support launch options (--opt / launchOptions)");
-    // OS allow-list + the named model-provider key (Hermes is model-agnostic; any one unlocks a
+    // OS allow-list + the named model-provider keys (Hermes is model-agnostic; any one unlocks a
     // provider), forwarded BY NAME — never `...process.env` — so the operator's unrelated secrets
     // don't reach the gateway child (P3).
     const env: Record<string, string> = {
-      ...launchEnv({ providerKeys: MODEL_PROVIDER_KEYS }),
+      ...launchEnv({ providerKeys: HERMES_PROVIDER_KEYS }),
       ...aclEnv(opts),
       ...userAuthEnv(opts),
       COTAL_SPACE: opts.space,


### PR DESCRIPTION
## Scope

Two fixes that make the Hermes connector actually work when it runs as an installed extension (the path every real deployment uses), plus regression smokes for both.

### 1. `dist/launch.js` crashed at import on every installed-ext launch

The installed extension runs `dist/launch.js` with plain node (`FROM_BUILD`), and that esbuild ESM bundle inlines CJS deps (tweetnacl via `@nats-io/nkeys`) that `require()` node builtins at import time. esbuild's ESM output only supports that via a `createRequire` banner, so every installed-ext launch died with `Dynamic require of "crypto" is not supported` before the launcher ran a line. Dev runs go through tsx on `src/` and never hit it, which is why the bug stayed invisible. The bundle script now prepends the same banner the pi extension already ships on its standalone bundle.

### 2. Hermes' own provider keys were stripped by the P3 launch-env filter

`buildLaunch` forwarded only the shared `MODEL_PROVIDER_KEYS`, but Hermes resolves providers against its own registry with its own dedicated key names (`OPENCODE_GO_API_KEY`, `OPENCODE_ZEN_API_KEY`, `XAI_API_KEY`, `GEMINI_API_KEY`, …). None of those providers could ever authenticate in a managed or containerized spawn: the filter dropped the key before the gateway saw it. The connector now forwards the dedicated `api_key_env_vars` names from the hermes 0.16 provider registry via a connector-local `HERMES_PROVIDER_KEYS` list (the shared list is untouched, so other connectors' env exposure is unchanged). Generic cross-tool credentials Hermes also accepts (`GH_TOKEN`/`GITHUB_TOKEN`/`COPILOT_GITHUB_TOKEN`, `HF_TOKEN`, `ANTHROPIC_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`) and the localhost-only `LM_API_KEY` stay deliberately excluded.

### Tests

- `smoke/bundle-import.smoke.ts`: re-bundles via the real `bundle` script, then imports `dist/launch.js` identity-free under plain node — fails on any banner regression, exactly how an installed ext runs it.
- `smoke/launch-env.smoke.ts`: asserts the hermes provider keys flow through `buildLaunch` and that the P3 boundary still holds (generic tokens and unrelated secrets do not).
- Both skip on Windows like the existing bridge smoke (the connector is Unix-only).
- Verified end-to-end in a containerized deployment: with these fixes and no workarounds, a dockerized `spawn --agent hermes` joins a mesh and answers over DM.

One changeset (patch; the fixed group versions in lockstep).