### PR TITLE
docs: correct the remaining Node 20 claims to the real Node 22 floor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ pnpm typecheck     # tsc --noEmit across all packages
 pnpm build         # tsc build across all packages
 ```
 
-ESM only (`"type": "module"`); run TS directly with `tsx`, no build step for dev. Node &gt;= 20.
+ESM only (`"type": "module"`); run TS directly with `tsx`, no build step for dev. Node &gt;= 22.
 
 ## Repository map
 

--- a/extensions/pi/README.md
+++ b/extensions/pi/README.md
@@ -5,8 +5,9 @@ The package does not bundle Pi.
 
 ## Requirements
 
-- Cotal and this package: Node 20 or newer.
-- The Pi host: exactly `@earendil-works/pi-coding-agent@0.79.10` for this release.
+- Cotal (`cotal-ai`): Node 22 or newer.
+- The Pi host: exactly `@earendil-works/pi-coding-agent@0.79.10` for this release, which needs
+  Node 22.19 or newer.
 - `pi` on `PATH` for managed spawning.
 
 ## Use

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "packageManager": "pnpm@11.1.2",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "scripts": {
     "typecheck": "pnpm build && pnpm -r typecheck",


### PR DESCRIPTION
`cotal-ai` requires Node 22: the published package declares `engines.node >= 22`, and
`bin/cotal.ts` runs a preflight that hard-exits below that. The reason is in that file —
the bundled `nats-server` broker needs Node 22, and npm *silently skips* an optional
dependency whose `engines` the running Node does not satisfy, so installing on Node 20
yields a Cotal with no broker and a confusing crash later.

Most user-facing docs were corrected when the floor moved. Three claims were missed and
still told readers Node 20 was enough.

## Changes

- **`AGENTS.md`** — said `Node >= 20`. It is written with an HTML entity (`&gt;`), which is
  why a plain grep for `Node >= 20` did not surface it.
- **`extensions/pi/README.md`** — claimed "Cotal and this package: Node 20 or newer". The
  Cotal half is wrong. Also now states the Pi host's own Node 22.19 floor, which
  `docs/connect-pi.md` already documents but this README omitted.
- **`package.json`** (dev root, private) — declared `engines.node >= 20` while every CI job
  in `ci.yml`, `windows.yml`, `changesets.yml` and `docs.yml` runs Node 22, and `pnpm build`
  builds a binary that will not start below 22.

## Deliberately not changed

`extensions/pi/package.json` keeps `engines.node >= 20`. That floor is intentional
install-compat for the package standing alone, gated by a pack-and-install-under-Node-20
exit criterion, and it is not a statement about what Cotal requires. The README wording was
adjusted to stop conflating the two.

## Scope

Documentation and one private dev-root engine field. No runtime code, no published package
behavior, so no changeset.