### PR TITLE
fix(cli): make setup's plugin update actually fire on upgrade

### DIFF
--- a/.changeset/setup-plugin-update-fires.md
+++ b/.changeset/setup-plugin-update-fires.md
@@ -1,0 +1,14 @@
+---
+"@cotal-ai/cli": patch
+---
+
+Fix `cotal setup` failing on every upgrade with `plugin <name>@cotal-mesh is at version <old>,
+expected <new> (the update did not take)`. `installOrUpdatePlugin` ran `claude plugin update`
+only inside the install-failed branch, but `claude plugin install` reports "is already
+installed" and exits **zero**, so on an upgrade the update never fired, the Claude plugin cache
+kept the old version, and the verification step then threw. The update is now triggered by what
+`plugin install` reports rather than by an exit status that never comes, which is what closes
+the upgrade path for the `cotal` connector plugin and the `cotal-skills` plugin alike.
+
+Also correct setup's own Node preflight, which still checked for Node 20 and told the user
+"Cotal needs Node 20 or newer" while `cotal-ai` declares and enforces a Node 22 floor.

--- a/implementations/cli/src/commands/setup.ts
+++ b/implementations/cli/src/commands/setup.ts
@@ -68,11 +68,11 @@ async function runFirstRun(yes: boolean, demo: boolean): Promise<void> {
     {
       name: "node-version",
       title: "Check Node.js",
-      explain: "Cotal needs Node 20 or newer.",
+      explain: "Cotal needs Node 22 or newer.",
       context: [README_URL],
       async run() {
         const major = Number(process.versions.node.split(".")[0]);
-        if (major < 20) throw new Error(`Node ${process.versions.node} is too old; Cotal needs Node >= 20`);
+        if (major < 22) throw new Error(`Node ${process.versions.node} is too old; Cotal needs Node >= 22`);
         return `Node ${process.versions.node}`;
       },
     },
@@ -469,8 +469,13 @@ function registerMarketplace(): void {
 function installOrUpdatePlugin(name: string, scope: string, expectedVersion?: string): void {
   registerMarketplace();
   const install = claude("plugin", "install", `${name}@cotal-mesh`, "--scope", scope);
-  if (install.status !== 0) {
-    if (!/already installed/i.test(install.output)) throw new Error(`plugin install failed (${name}):\n${install.output}`);
+  // Trigger the update on what `plugin install` SAYS, not on its exit status: when the plugin is
+  // already installed it reports that and exits ZERO. Gating the update on a non-zero status meant
+  // it never ran on an upgrade, so the cache kept the old version and verifyPluginLoaded below
+  // threw "the update did not take" at every customer who upgraded.
+  const already = /already installed/i.test(install.output);
+  if (install.status !== 0 && !already) throw new Error(`plugin install failed (${name}):\n${install.output}`);
+  if (already) {
     const update = claude("plugin", "update", `${name}@cotal-mesh`, "--scope", scope);
     if (update.status !== 0) throw new Error(`plugin update failed (${name}):\n${update.output}`);
   }


### PR DESCRIPTION
`cotal setup` fails for **every upgrading customer** with:

```
✗ plugin cotal-skills@cotal-mesh is at version 0.14.0, expected 0.14.10 (the update did not take)
```

## Cause

`installOrUpdatePlugin` gated the update on the install *failing*:

```ts
const install = claude("plugin", "install", `${name}@cotal-mesh`, "--scope", scope);
if (install.status !== 0) {                 // never true
  if (!/already installed/i.test(install.output)) throw ...
  const update = claude("plugin", "update", ...)   // never runs
}
verifyPluginLoaded(name, scope, expectedVersion); // throws
```

The doc comment above it assumed a bare re-install fails when the plugin is already there. It
does not. Measured:

```
$ claude plugin install cotal-skills@cotal-mesh --scope user
✔ Plugin "cotal-skills@cotal-mesh" is already installed (scope: user)
$ echo $?
0
```

Exit **0**, so the branch is unreachable on an upgrade. No update runs, the Claude plugin cache
keeps the old version, and `verifyPluginLoaded` then throws. The verification is doing its job;
the update simply never happened.

## Fix

Trigger on what install *reports* rather than on an exit status that never comes, and keep
failing loud when the install genuinely fails.

## Verification

Restored the exact failing state (plugin cache pinned back to `0.14.0`, confirmed via
`claude plugin list --json`) and drove the real `skillsPluginStep()` both ways from the same
starting point:

| code | result |
| --- | --- |
| before | `THREW -> plugin cotal-skills@cotal-mesh is at version 0.14.0, expected 0.0.0 (the update did not take)` |
| after | `OK -> cotal-skills@cotal-mesh (user scope)`, cache advanced |

(`expected 0.0.0` is a dev-clone artifact of `cliVersion()`; it does not affect the branch under
test.) `smoke:setup-failloud` and `smoke:agent-skills` both pass, and the CLI typechecks.

## Also

Setup's own Node preflight still checked `major < 20` and told the user "Cotal needs Node 20 or
newer", while `cotal-ai` declares and enforces a Node 22 floor. It is unreachable in the
published binary (`bin/cotal.ts` refuses below 22 first) but wrong in a dev clone and wrong on
screen. Corrected to 22, finishing the sweep from #322.