### PR TITLE
docs(readme): add prominent docs and quick start buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@
 
 <sub>One protocol, any topology: peer-to-peer, supervised, hierarchical, or any mix.</sub>
 
+<p>
+<a href="https://docs.cotal.ai"><img src="assets/button-docs.svg" width="270" alt="Read the docs at docs.cotal.ai"></a>
+&nbsp;
+<a href="#quick-start"><picture>
+<source media="(prefers-color-scheme: dark)" srcset="assets/button-quickstart-dark.svg">
+<img src="assets/button-quickstart-light.svg" width="270" alt="Quick start">
+</picture></a>
+</p>
+
 [![CI](https://github.com/Cotal-AI/Cotal/actions/workflows/ci.yml/badge.svg)](https://github.com/Cotal-AI/Cotal/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@cotal-ai/core?label=%40cotal-ai%2Fcore)](https://www.npmjs.com/package/@cotal-ai/core)
 [![Docs](https://img.shields.io/badge/docs-docs.cotal.ai-e9c46a)](https://docs.cotal.ai)
@@ -18,7 +27,7 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%E2%89%A522-brightgreen)](https://nodejs.org)
 
-**[Quick start](#quick-start)** · [Docs](https://docs.cotal.ai) · [Examples](#examples) · [FAQ](#faq)
+[Examples](#examples) · [Supported agents](#supported-agents) · [FAQ](#faq)
 
 </div>
 

--- a/assets/button-docs.svg
+++ b/assets/button-docs.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="58" viewBox="0 0 300 58" role="img" aria-label="Read the docs">
+  <title>Read the docs</title>
+  <rect width="300" height="58" rx="12" fill="#E9C46A"/>
+  <text x="150" y="37" text-anchor="middle" fill="#141414" font-size="19" font-weight="600" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">Read the docs  &#8594;</text>
+</svg>

--- a/assets/button-quickstart-dark.svg
+++ b/assets/button-quickstart-dark.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="58" viewBox="0 0 300 58" role="img" aria-label="Quick start">
+  <title>Quick start</title>
+  <rect x="0.75" y="0.75" width="298.5" height="56.5" rx="11.25" fill="none" stroke="#4d5157" stroke-width="1.5"/>
+  <text x="150" y="37" text-anchor="middle" fill="#e6e6e3" font-size="19" font-weight="600" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">Quick start  &#8594;</text>
+</svg>

--- a/assets/button-quickstart-light.svg
+++ b/assets/button-quickstart-light.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="58" viewBox="0 0 300 58" role="img" aria-label="Quick start">
+  <title>Quick start</title>
+  <rect x="0.75" y="0.75" width="298.5" height="56.5" rx="11.25" fill="none" stroke="#c9ccd1" stroke-width="1.5"/>
+  <text x="150" y="37" text-anchor="middle" fill="#1f2328" font-size="19" font-weight="600" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">Quick start  &#8594;</text>
+</svg>


### PR DESCRIPTION
## What

The docs site was reachable from the README only through a small shields badge and a
text nav line, so most visitors never left GitHub. This adds two full-size buttons
directly under the demo image, where the eye lands first.

- **Read the docs** (solid gold) links to <https://docs.cotal.ai>. Gold reads on both
  GitHub themes, so it needs no variant.
- **Quick start** (outlined) jumps to `#quick-start`. It ships light and dark cuts
  behind `<picture>`, matching how the wordmark at the top already switches.

Three new assets in `assets/`: `button-docs.svg`, `button-quickstart-dark.svg`,
`button-quickstart-light.svg`. Hand-written SVG, no external service, so the buttons
cannot break when a badge host does.

The old text nav line dropped its now-duplicated Quick start and Docs entries and keeps
`Examples · Supported agents · FAQ`.

## Verified

Rendered on GitHub from the pushed branch: both buttons load, the dark cut is picked in
dark mode, `Read the docs` resolves to `https://docs.cotal.ai` and `Quick start` to the
`#quick-start` anchor. Light and dark cuts checked side by side against `#ffffff` and
GitHub's `#0d1117`.

No package touches the root README (`cotal-ai` publishes `bin/README.md`), so no
changeset.