### PR TITLE
docs(readme): lead on pub/sub, the thing no other agent standard has

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <img src="assets/cotal-wordmark-light.png" width="210" alt="Cotal">
 </picture>
 
-**The first open standard to bring pub/sub to AI agents.**
+**The first open standard to bring pub/sub to AI agents, and still the most powerful.**
 
 MCP gave agents tools. A2A gave them one-to-one calls. Cotal gives them a live shared
 space: many agents at once, each seeing who else is there, each able to reach a whole

--- a/README.md
+++ b/README.md
@@ -7,19 +7,10 @@
 
 **The first and most powerful pub/sub standard for AI agents.**
 
-One agent is easy. A team of them is a distributed systems problem: they cannot see each
-other, work is lost the moment one is busy or crashes, and the shape of the team is
-hardcoded by whatever framework you picked.
-
-Cotal is the wire that solves it. MCP gave agents tools, A2A gave them one-to-one calls;
-Cotal gives them a live shared space and three ways to address it: a whole channel, one
-named peer, or whoever is free. Compose those into any topology you want, across machines
-and frameworks, and change it by editing config instead of rewriting code. The addressing
-modes are the instruction set; the topology is the program.
-
 <img src="assets/cotal-demo.webp" width="760" alt="Cotal: any agent, any topology. Claude Code, OpenCode, Hermes and Codex across peer-to-peer, supervised, hierarchical and hybrid topologies">
 
-<sub>One protocol, any topology: peer-to-peer, supervised, hierarchical, or any mix.</sub>
+<sub>One agent is easy. A team of them is a distributed systems problem.<br>
+Any topology you can draw, you can deploy: peer-to-peer, supervised, hierarchical, or any mix.</sub>
 
 <p>
 <a href="https://docs.cotal.ai"><img src="assets/button-docs.svg" width="270" alt="Read the docs at docs.cotal.ai"></a>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@
 <img src="assets/cotal-wordmark-light.png" width="210" alt="Cotal">
 </picture>
 
-**The open standard for agent coordination.**
+**The first and most powerful open standard for multi-agent coordination.**
+
+MCP gave agents tools. A2A gave them one-to-one calls. **Cotal gives them pub/sub:**
+many agents in one live space, each seeing who else is there, each able to reach a
+whole channel, one named peer, or whoever is free.
 
 <img src="assets/cotal-demo.webp" width="760" alt="Cotal: any agent, any topology. Claude Code, OpenCode, Hermes and Codex across peer-to-peer, supervised, hierarchical and hybrid topologies">
 
@@ -120,8 +124,9 @@ them.
 - **[MCP](https://modelcontextprotocol.io)** connects an agent to its tools.
 - **[A2A](https://a2a-protocol.org)** connects two agents in a pairwise
   request/response.
-- **Cotal** connects *many* agents coordinating live in a shared space: presence,
-  channels, durable delivery, and the three addressing modes as one model.
+- **Cotal** brings pub/sub to agents: *many* of them coordinating live in one shared
+  space, with presence, channels, durable delivery, and the three addressing modes as
+  one model.
 
 Cotal reuses A2A's data shapes to stay interoperable: identity is an A2A `AgentCard`
 (its `role` is the addressable service that anycast resolves to), and wire messages

--- a/README.md
+++ b/README.md
@@ -44,11 +44,12 @@ with no shared space at all. With Cotal it is configuration: who delegates to wh
 whether anyone is in charge, is something you set, so the same standard runs a **flat team
 of peers**, a **manager with workers**, a **chain of command**, or **any mix**.
 
-And you are not limited to one. Every `cotal up` registers its own mesh, so several run
-side by side on one machine, each with its own agents, channels and broker. `cotal meshes`
-lists them, `cotal use <space>` picks your default, and every command takes
-`--space <name>`, so a client project and a research team run in parallel and never see
-each other.
+And a mesh is not tied to one project or one machine. Several run side by side on the same
+box, each with its own agents, channels and broker: `cotal meshes` lists them,
+`cotal use <space>` picks your default, and every command takes `--space <name>`, so a
+client project and a research team run in parallel and never see each other. The broker can
+equally sit on a server you reach over the internet, so a laptop, a workstation and a
+container in the cloud all join the same space.
 
 Because the standard is open, you extend it the same way: bring your own agents, or
 connect anything that speaks the contract. It runs on [NATS and JetStream](https://nats.io),

--- a/README.md
+++ b/README.md
@@ -7,9 +7,15 @@
 
 **The first and most powerful pub/sub standard for AI agents.**
 
-MCP gave agents tools. A2A gave them one-to-one calls. Cotal gives them a live shared
-space: many agents at once, each seeing who else is there, each able to reach a whole
-channel, one named peer, or whoever is free.
+One agent is easy. A team of them is a distributed systems problem: they cannot see each
+other, work is lost the moment one is busy or crashes, and the shape of the team is
+hardcoded by whatever framework you picked.
+
+Cotal is the wire that solves it. MCP gave agents tools, A2A gave them one-to-one calls;
+Cotal gives them a live shared space and three ways to address it: a whole channel, one
+named peer, or whoever is free. Compose those into any topology you want, across machines
+and frameworks, and change it by editing config instead of rewriting code. The addressing
+modes are the instruction set; the topology is the program.
 
 <img src="assets/cotal-demo.webp" width="760" alt="Cotal: any agent, any topology. Claude Code, OpenCode, Hermes and Codex across peer-to-peer, supervised, hierarchical and hybrid topologies">
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 <img src="assets/cotal-demo.webp" width="760" alt="Cotal: any agent, any topology. Claude Code, OpenCode, Hermes and Codex across peer-to-peer, supervised, hierarchical and hybrid topologies">
 
-<sub>Deploy distributed agent topologies: peer-to-peer, supervised, hierarchical, or any mix.<br>
+<sub>Deploy distributed agent topologies: DAGs, graphs, swarms, supervisor trees, pipelines, or any shape you can draw.<br>
 A programming language for agency.</sub>
 
 <p>

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ with no shared space at all. With Cotal it is configuration: who delegates to wh
 whether anyone is in charge, is something you set, so the same standard runs a **flat team
 of peers**, a **manager with workers**, a **chain of command**, or **any mix**.
 
+And you are not limited to one. Every `cotal up` registers its own mesh, so several run
+side by side on one machine, each with its own agents, channels and broker. `cotal meshes`
+lists them, `cotal use <space>` picks your default, and every command takes
+`--space <name>`, so a client project and a research team run in parallel and never see
+each other.
+
 Because the standard is open, you extend it the same way: bring your own agents, or
 connect anything that speaks the contract. It runs on [NATS and JetStream](https://nats.io),
 messaging infrastructure proven in production for years; the reference implementation is

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 <img src="assets/cotal-demo.webp" width="760" alt="Cotal: any agent, any topology. Claude Code, OpenCode, Hermes and Codex across peer-to-peer, supervised, hierarchical and hybrid topologies">
 
-<sub>One agent is easy. A team of them is a distributed systems problem.<br>
-Any topology you can draw, you can deploy: peer-to-peer, supervised, hierarchical, or any mix.</sub>
+<sub>Deploy distributed agent topologies: peer-to-peer, supervised, hierarchical, or any mix.<br>
+A programming language for agency.</sub>
 
 <p>
 <a href="https://docs.cotal.ai"><img src="assets/button-docs.svg" width="270" alt="Read the docs at docs.cotal.ai"></a>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <img src="assets/cotal-wordmark-light.png" width="210" alt="Cotal">
 </picture>
 
-**The first open standard to bring pub/sub to AI agents, and still the most powerful.**
+**The first and most powerful pub/sub standard for AI agents.**
 
 MCP gave agents tools. A2A gave them one-to-one calls. Cotal gives them a live shared
 space: many agents at once, each seeing who else is there, each able to reach a whole

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 <img src="assets/cotal-demo.webp" width="760" alt="Cotal: any agent, any topology. Claude Code, OpenCode, Hermes and Codex across peer-to-peer, supervised, hierarchical and hybrid topologies">
 
-<sub>Deploy distributed agent topologies: DAGs, graphs, swarms, supervisor trees, pipelines, or any shape you can draw.<br>
-A programming language for agency.</sub>
+<sub>Deploy any agent topology: DAGs, graphs, swarms, supervisor trees, pipelines, or any shape you can draw.<br>
+Distributed programming for agents.</sub>
 
 <p>
 <a href="https://docs.cotal.ai"><img src="assets/button-docs.svg" width="270" alt="Read the docs at docs.cotal.ai"></a>

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 <img src="assets/cotal-wordmark-light.png" width="210" alt="Cotal">
 </picture>
 
-**The first and most powerful open standard for multi-agent coordination.**
+**The first open standard to bring pub/sub to AI agents.**
 
-MCP gave agents tools. A2A gave them one-to-one calls. **Cotal gives them pub/sub:**
-many agents in one live space, each seeing who else is there, each able to reach a
-whole channel, one named peer, or whoever is free.
+MCP gave agents tools. A2A gave them one-to-one calls. Cotal gives them a live shared
+space: many agents at once, each seeing who else is there, each able to reach a whole
+channel, one named peer, or whoever is free.
 
 <img src="assets/cotal-demo.webp" width="760" alt="Cotal: any agent, any topology. Claude Code, OpenCode, Hermes and Codex across peer-to-peer, supervised, hierarchical and hybrid topologies">
 


### PR DESCRIPTION
## What

The tagline was "The open standard for agent coordination", which names the category
without saying what Cotal does that the category does not. The header now reads:

> **The first open standard to bring pub/sub to AI agents, and still the most powerful.**
>
> MCP gave agents tools. A2A gave them one-to-one calls. Cotal gives them a live shared
> space: many agents at once, each seeing who else is there, each able to reach a whole
> channel, one named peer, or whoever is free.

The claim is scoped to pub/sub on purpose. Broader framings are answerable by AutoGen,
CrewAI and LangGraph, and by FIPA-era work before them; this one is not, and it is the
difference that actually matters to someone choosing a protocol. Others have shipped in
this space since, so "still the most powerful" says both halves at once.

The "Why a protocol?" bullet now names pub/sub too, so the top of the file and the
section below it say the same thing rather than two different things.

## Verified

Rendered from the pushed branch on GitHub: the tagline sits on one line, centered under
the wordmark, ahead of the demo image and the buttons.

## Note

The repo's GitHub **About** description still reads "The open standard for agent
coordination". That is a repo setting, not part of this diff, and it sits in the
sidebar right next to the README.