### PR TITLE
chore: give the published packages searchable keywords

### DIFF
--- a/bin/package.json
+++ b/bin/package.json
@@ -6,11 +6,18 @@
   "keywords": [
     "cotal",
     "agents",
+    "ai-agents",
     "multi-agent",
+    "agent-communication",
+    "agent-coordination",
+    "agent-orchestration",
+    "swarm",
+    "pubsub",
+    "protocol",
     "nats",
     "jetstream",
-    "pubsub",
-    "mcp"
+    "mcp",
+    "a2a"
   ],
   "homepage": "https://github.com/Cotal-AI/Cotal#readme",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,22 @@
   "description": "The Cotal protocol: endpoint, subjects, message types, the NATS client layer, and the extension contracts.",
   "version": "0.14.11",
   "license": "Apache-2.0",
+  "keywords": [
+    "cotal",
+    "agents",
+    "ai-agents",
+    "multi-agent",
+    "agent-communication",
+    "agent-coordination",
+    "agent-orchestration",
+    "swarm",
+    "pubsub",
+    "protocol",
+    "nats",
+    "jetstream",
+    "mcp",
+    "a2a"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/Cotal-AI/Cotal.git",


### PR DESCRIPTION
## What

`@cotal-ai/core` shipped with **no** `keywords` field at all, and `cotal-ai` was missing
the terms people actually search for: `agent-communication`, `agent-coordination`,
`agent-orchestration`, `swarm`, `protocol`, `a2a`, `ai-agents`.

Both now carry the same fourteen. The other packages are left alone on purpose: nobody
searches npm hoping to land on `@cotal-ai/tmux`, they arrive as a dependency.

## Why it matters

npm search, and the tooling that scrapes it, is where most "best multi-agent framework"
write-ups get their candidate list. Empty metadata means Cotal is invisible to that whole
pipeline no matter how good the README is.

The repo's GitHub topics were extended to match in the same pass (`multi-agent`, `pubsub`,
`nats`, `a2a`, `swarm`, `agent-communication`), which needed no code change.

## Release

Keywords reach the registry at the next publish. No changeset here, so this rides along
with the next real release rather than forcing a lockstep bump of every package for
metadata.