### PR TITLE
docs(cli): put the space-parameter note back on the function it documents

### DIFF
--- a/implementations/cli/src/commands/clean.ts
+++ b/implementations/cli/src/commands/clean.ts
@@ -154,10 +154,6 @@ export function liveMeshProcess(root: string, space?: string): string | undefine
   return liveMeshProcesses(root, space)[0];
 }
 
-/** `space` names the tenant whose pidfiles to look at. Pass it whenever the caller already knows
- *  which mesh it means (a registry entry does): re-deriving it from the root can resolve a
- *  DIFFERENT tenant on a multi-space root, and `resolveSpace` throws outright on an unreadable or
- *  ambiguous one — a caller asking a yes/no liveness question should not inherit that failure. */
 /**
  * The live process that makes this root the mesh's HOME, or undefined.
  *
@@ -179,6 +175,10 @@ export function liveMeshOwner(root: string, space?: string): string | undefined 
   return undefined;
 }
 
+/** `space` names the tenant whose pidfiles to look at. Pass it whenever the caller already knows
+ *  which mesh it means (a registry entry does): re-deriving it from the root can resolve a
+ *  DIFFERENT tenant on a multi-space root, and `resolveSpace` throws outright on an unreadable or
+ *  ambiguous one — a caller asking a yes/no liveness question should not inherit that failure. */
 export function liveMeshProcesses(root: string, space?: string): string[] {
   const context: LocalProcessContext = { root, space: space ?? resolveSpace(root) };
   const running: string[] = [];


### PR DESCRIPTION
Follow-up to #331, comment-only.

Inserting `liveMeshOwner` above `liveMeshProcesses` in #331 left that function's JSDoc stranded over the new one, so it described a parameter contract it was not written for. Moved back.

No behaviour change — the diff is four lines of comment relocation in `implementations/cli/src/commands/clean.ts`. No changeset: nothing user-facing to version.

Found by a reviewer on #331; the commit was pushed shortly after that PR merged, so it needs its own.