### PR TITLE
fix(cli): keep the control-target mode peek from exiting on an off-registry target

### DIFF
--- a/.changeset/control-target-mode-peek.md
+++ b/.changeset/control-target-mode-peek.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/cli": patch
+---
+
+Stop the control-target mode peek from exiting on an off-registry target. `--server` with an unregistered `--space` is the raw-open escape hatch and has no registry entry to carry a mode, but the peek resolved through the exiting form and ended the command before `connectOrExit` could serve it.

--- a/extensions/connector-claude-code/smoke/wake-path.smoke.ts
+++ b/extensions/connector-claude-code/smoke/wake-path.smoke.ts
@@ -476,8 +476,15 @@ try {
     automatic: agent.inboxCount("automatic"),
   });
   // Surface all of it into an in-flight batch whose handoff is guaranteed to fail...
+  const oldestId = agent.peekInbox("all").find((i) => i.text.includes(oldest))!.id;
   const inFlightHandoff = fireHookViaRealRelay({ hook_event_name: "UserPromptSubmit" }, { starveStdout: true });
-  await sleep(400); // ...and, while it is in flight, push one more message through the capacity valve
+  // ...and push one more message through the capacity valve WHILE IT IS IN FLIGHT — which this must
+  // WAIT for, not guess at. A fixed sleep here made the cell a race: the handoff runs through a real
+  // relay process, and on a slower machine the hold was not yet taken when the overflow landed, so
+  // the valve acked an id no batch had claimed. That is the bounded-loss design working correctly on
+  // an unlooked-at backlog, and the cell then failed for a condition it had never established.
+  // Measured on Linux: eviction 133ms BEFORE the hold. Wait for the property this cell is named for.
+  await waitFor("the oldest message to be held in flight", () => agent.isInFlight(oldestId), 15_000);
   await dmOtto("dm-seven-overflow: arrives mid-handoff and evicts the oldest");
   const starvedBig = await inFlightHandoff;
   check("the in-flight handoff failed, as this check requires", starvedBig.stdout.length === 0, {

--- a/extensions/connector-core/src/agent.ts
+++ b/extensions/connector-core/src/agent.ts
@@ -480,6 +480,14 @@ export class MeshAgent extends EventEmitter {
     return true;
   }
 
+  /** Whether this id is currently protected from the overflow valve — i.e. some frame is mid-delivery
+   *  holding it. Read-only observability for the property {@link holdInFlight} establishes. A caller
+   *  that needs a batch to actually BE in flight before it acts must wait on this, never on a sleep:
+   *  the handoff runs through a real relay process whose latency is not the caller's to predict. */
+  isInFlight(id: string): boolean {
+    return this.inFlightIds.has(id);
+  }
+
   /** One frame's verdict is in (either way). The id is ordinary backlog again only once EVERY frame
    *  holding it has reported — a release from one must not speak for another still in flight. */
   releaseInFlight(ids: readonly string[]): void {

--- a/implementations/cli/smoke/down-target.smoke.ts
+++ b/implementations/cli/smoke/down-target.smoke.ts
@@ -21,7 +21,7 @@ const home = mkdtempSync(join(tmpdir(), "cotal-home-"));
 process.env.COTAL_HOME = home;
 
 const { registry } = await import("@cotal-ai/core");
-const { cacheLocalProcess, extensionLocalProcesses, recordMesh, setCurrent } = await import("@cotal-ai/workspace");
+const { cacheLocalProcess, extensionLocalProcesses, findCotalRoot, recordMesh, setCurrent } = await import("@cotal-ai/workspace");
 const { down } = await import("../src/commands/down.js");
 const { webProcess } = await import("../../web/src/web.js");
 
@@ -61,6 +61,19 @@ const meshA = meshWithDashboard("meshA");
 const meshB = meshWithDashboard("meshB");
 
 try {
+  // PRECONDITION this suite cannot sandbox. COTAL_HOME is isolated, but `findCotalRoot` walks to
+  // `/` with no boundary, so ANY `.cotal` in an ANCESTOR of `tmpdir()` makes `neutral` resolve as
+  // a local project and the not-a-mesh-root cells stop testing what they name. Measured: this file
+  // fails on a machine whose tmp parent holds a `.cotal` and passes 11/11 under clean ancestry, at
+  // the same commit. Name the directory rather than failing later and opaquely.
+  const neutralRoot = findCotalRoot(neutral);
+  assert.equal(
+    neutralRoot,
+    neutral,
+    `this smoke needs a tmp dir with NO .cotal ancestor, but found one at ${join(neutralRoot, ".cotal")} `
+      + `(tmpdir is ${tmpdir()}). Point TMPDIR at a directory whose ancestors hold no .cotal, or remove that one.`,
+  );
+
   // The real web descriptor must declare target rooting, and down must see it on the surface.
   check('web descriptor declares rootedAt: "target"', webProcess.rootedAt === "target");
   // The installed path never imports package code: the descriptor rides the extensions manifest as

--- a/implementations/cli/smoke/server-resolution-live.smoke.ts
+++ b/implementations/cli/smoke/server-resolution-live.smoke.ts
@@ -34,6 +34,9 @@ const freePort = (): Promise<number> =>
 const home = mkdtempSync(join(tmpdir(), "cotal-ps-resolve-home-"));
 const cwd = mkdtempSync(join(tmpdir(), "cotal-ps-resolve-cwd-"));
 const projectRoot = mkdtempSync(join(tmpdir(), "cotal-ps-resolve-root-"));
+// Created out here with its siblings so the `finally` sweep removes it on every exit path — a
+// dir made inside the `try` leaks one OS temp directory per run when a cell throws.
+const mismatchRoot = mkdtempSync(join(tmpdir(), "cotal-ps-resolve-mismatch-"));
 process.env.COTAL_HOME = home;
 const startCwd = process.cwd(); // restored before cleanup so Windows can rmdir `cwd` (it locks a live process's cwd)
 process.chdir(cwd); // a dir with no `.cotal` up-tree, so bare resolution falls through to the registry
@@ -136,7 +139,7 @@ try {
   //    connected with NO CREDENTIALS. A misconfigured AUTH mesh silently became an OPEN one and the
   //    operator was never told. ABSENCE (`unknown-space`/`no-meshes`) may be absorbed; "registered
   //    and broken" may not. Regression guard for that exact swap.
-  const mismatchRoot = mkdtempSync(join(tmpdir(), "cotal-ps-resolve-mismatch-"));
+
   const mismatchAuth = join(mismatchRoot, ".cotal", "auth");
   mkdirSync(mismatchAuth, { recursive: true });
   // The root's on-disk auth is for a DIFFERENT space than the entry names — the exact divergence
@@ -181,5 +184,6 @@ try {
   rmSync(home, rmOpts);
   rmSync(cwd, rmOpts);
   rmSync(projectRoot, rmOpts);
+  rmSync(mismatchRoot, rmOpts);
 }
 process.exit(0);

--- a/implementations/cli/smoke/server-resolution-live.smoke.ts
+++ b/implementations/cli/smoke/server-resolution-live.smoke.ts
@@ -14,7 +14,7 @@
  */
 import { spawn, type ChildProcess } from "node:child_process";
 import { once } from "node:events";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -39,7 +39,7 @@ const startCwd = process.cwd(); // restored before cleanup so Windows can rmdir 
 process.chdir(cwd); // a dir with no `.cotal` up-tree, so bare resolution falls through to the registry
 
 const { probeConnect, DEFAULT_SERVER } = await import("@cotal-ai/core");
-const { recordMesh, loadMeshes, resolveMeshTarget } = await import("@cotal-ai/workspace");
+const { recordMesh, loadMeshes, resolveMeshTarget, spaceAccountPath, listSpaceAccounts } = await import("@cotal-ai/workspace");
 const { resolveControlTarget } = await import("../src/lib/control.js");
 
 let pass = 0;
@@ -126,6 +126,40 @@ try {
   const bareAfter = await resolveControlTarget({}, "control-caller-privileged");
   ok("bare resolve prunes the dead entry (global sweep)", !loadMeshes().some((m) => m.space === "team-alpha"), loadMeshes());
   ok("bare resolve returns the surviving live mesh", bareAfter.server === OVERRIDE, bareAfter);
+
+  // 7. REGISTERED-BUT-BROKEN must fail loud — it must never fall through to a credential-less open
+  //    connection. `resolveControlTarget` peeks at the target's MODE before connecting. For an
+  //    `origin: "up"` AUTH entry whose recorded root now holds another space's account,
+  //    `targetFromEntry` PRUNES the entry and THEN throws `stale-auth-root`. An earlier cut of the
+  //    peek absorbed the whole WorkspaceTargetError family, so that prune left `connectOrExit`
+  //    seeing no registration at all; with an explicit `--server` it took the raw-open arm and
+  //    connected with NO CREDENTIALS. A misconfigured AUTH mesh silently became an OPEN one and the
+  //    operator was never told. ABSENCE (`unknown-space`/`no-meshes`) may be absorbed; "registered
+  //    and broken" may not. Regression guard for that exact swap.
+  const mismatchRoot = mkdtempSync(join(tmpdir(), "cotal-ps-resolve-mismatch-"));
+  const mismatchAuth = join(mismatchRoot, ".cotal", "auth");
+  mkdirSync(mismatchAuth, { recursive: true });
+  // The root's on-disk auth is for a DIFFERENT space than the entry names — the exact divergence
+  // `stale-auth-root` exists to catch (the root was re-`up`ed as another space without re-recording).
+  const foreign = "someone-else";
+  writeFileSync(
+    spaceAccountPath(mismatchAuth, foreign),
+    JSON.stringify({ space: foreign, account: { pub: "A_FAKE_PUB", jwt: "fake.jwt.value", signingSeed: "SA_FAKE_SEED", signingPub: "A_FAKE_SIGNING_PUB" } }),
+  );
+  ok("fixture: the root's auth really does hold only the FOREIGN space", listSpaceAccounts(mismatchAuth).includes(foreign) && !listSpaceAccounts(mismatchAuth).includes("mismatch"), listSpaceAccounts(mismatchAuth));
+  recordMesh({ space: "mismatch", server: OVERRIDE, root: mismatchRoot, mode: "auth", origin: "up", ts });
+  let staleRefused: unknown;
+  let staleResolved: unknown;
+  try {
+    staleResolved = await resolveControlTarget({ space: "mismatch", server: OVERRIDE }, "control-caller-privileged");
+  } catch (e) {
+    staleRefused = e;
+  }
+  // The live OVERRIDE broker is open and reachable, so a raw-open fallthrough SUCCEEDS — which is
+  // precisely why this has to assert the refusal and not merely "did not crash".
+  ok("a registered AUTH mesh whose root auth is foreign REFUSES, never a credential-less raw open", staleRefused !== undefined, { staleResolved });
+  ok("and it refuses for the stale-auth reason, not some incidental error",
+    (staleRefused as { code?: string })?.code === "stale-auth-root", staleRefused);
 
   console.log(`\nmanager server-resolution live e2e: ${pass} checks passed`);
 } finally {

--- a/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
+++ b/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
@@ -22,6 +22,7 @@ process.env.COTAL_HOME = home;
 const { probeConnect, createSpaceAuth } = await import("@cotal-ai/core");
 const {
   authDir,
+  findCotalRoot,
   clearCurrent,
   isWorkspaceTargetError,
   loadMeshes,
@@ -61,6 +62,21 @@ const entry = (space: string, root: string, server = SERVER) =>
   ({ space, server, root, mode: "open" as const, ts: "2026-06-22T00:00:00.000Z" });
 
 try {
+  // PRECONDITION, stated because this suite cannot enforce it. It calls itself hermetic and is —
+  // for COTAL_HOME. But `findCotalRoot` walks to `/` with no boundary, so ANY `.cotal` in an
+  // ANCESTOR of `tmpdir()` captures `neutral`: resolution takes the local-project branch and
+  // returns a `local-space` target rather than throwing, and the 0-mesh assertion below fails as
+  // a bare "Missing expected exception" that names neither the cause nor the cure. Observed for
+  // real: a machine with `/tmp/.cotal` fails every run while the identical tree passes under a tmp
+  // root with clean ancestry. Fail here instead, naming the directory and the fix.
+  const neutralRoot = findCotalRoot(neutral);
+  assert.equal(
+    neutralRoot,
+    neutral,
+    `this smoke needs a tmp dir with NO .cotal ancestor, but found one at ${join(neutralRoot, ".cotal")} `
+      + `(tmpdir is ${tmpdir()}). Point TMPDIR at a directory whose ancestors hold no .cotal, or remove that one.`,
+  );
+
   // 0 meshes → a bare resolve fails with one sentence, not a crash.
   assert.throws(() => resolveMeshTarget(neutral), /no mesh running/);
   check("0 meshes: resolve throws 'no mesh running'", true);

--- a/implementations/cli/src/command.ts
+++ b/implementations/cli/src/command.ts
@@ -1,4 +1,5 @@
 import { commandUsage, parseCommandArgs, type Command, type Registry } from "@cotal-ai/core";
+import { isWorkspaceTargetError, renderWorkspaceError } from "@cotal-ai/workspace";
 import { c, staleStoreHint } from "./ui.js";
 import {
   isExtensionStub,
@@ -201,6 +202,17 @@ export async function runCli(registry: Registry, argv: string[], opts: RunCliOpt
       const msg = (e as Error).message.split(".")[0];
       console.error(c.red(`✗ ${msg}`));
       commandHelp(cmd);
+      process.exit(1);
+    }
+    // A workspace TARGET error carries structured recovery — which entry, whether it was removed,
+    // what to run next — and has its own renderer. Its raw `.message` is deliberately dev-safe
+    // rather than product copy, so falling through to the generic line below strips the removed
+    // fact and the action, leaving the operator a diagnosis they cannot act on. Rendering it HERE
+    // covers every path that lets one reach the boundary, not just the ones that happen to call an
+    // `…OrExit` helper.
+    if (isWorkspaceTargetError(e)) {
+      console.error(c.red(renderWorkspaceError({ kind: "target", error: e })));
+      if (process.env.COTAL_DEBUG && e instanceof Error && e.stack) console.error(c.dim(e.stack));
       process.exit(1);
     }
     // Every other command failure (a broker permission denial, a missing --creds file, a failed

--- a/implementations/cli/src/lib/control.ts
+++ b/implementations/cli/src/lib/control.ts
@@ -17,9 +17,12 @@ import {
   type Profile,
 } from "@cotal-ai/core";
 import { connect } from "@nats-io/transport-node";
-import { authDir, endpointAuth, findCotalRoot, loadSpaceAuth, soleSpaceOf } from "@cotal-ai/workspace";
+import {
+  authDir, endpointAuth, findCotalRoot, isWorkspaceTargetError, loadSpaceAuth, resolveMeshTarget,
+  soleSpaceOf, type MeshTarget,
+} from "@cotal-ai/workspace";
 import { c, staleStoreHint } from "../ui.js";
-import { connectOrExit, connectUserControlOrExit, resolveTargetOrExit, type ConnectFlags } from "./connect.js";
+import { connectOrExit, connectUserControlOrExit, type ConnectFlags } from "./connect.js";
 
 /** Endpoint auth material for one control call — a static/raw cred OR user-mode bearer+sentinel
  *  (spread into the endpoint verbatim), plus the minted instrument's v0.4 caller triple when the
@@ -62,11 +65,22 @@ export async function resolveControlTarget(
   // Accepted for this slice so mode choice stays where it is knowable. The two reads are not
   // atomic; a mesh that flips mode between them is an operator action mid-command.
   //
-  // `resolveTargetOrExit` EXITS on a WorkspaceTargetError (never returns). Any other throw
-  // propagates — there is no bare catch. Raw `--creds` skips the peek (static/raw path below).
+  // This peek reads the MODE and NOTHING ELSE — it must never decide the command's fate. It used
+  // to run through `resolveTargetOrExit`, which EXITS on a WorkspaceTargetError, so it killed a
+  // legitimate input on the way past: `--server` with an UNREGISTERED `--space` is the raw-open
+  // escape hatch, and by definition it has no registry entry to carry a mode. Resolve through the
+  // THROWING form instead and read "no such target" as "not a registry mesh, therefore not user
+  // mode", leaving that path to `connectOrExit` below, which owns it and still exits loudly on a
+  // genuinely bad target. ONLY WorkspaceTargetError is absorbed; anything else propagates.
+  // Raw `--creds` skips the peek entirely (static/raw path below).
   if (!withSpace.creds) {
-    const target = await resolveTargetOrExit({ server: withSpace.server, space: withSpace.space });
-    if (target.mode === "user") {
+    let mode: MeshTarget["mode"] | undefined;
+    try {
+      mode = resolveMeshTarget(process.cwd(), { server: withSpace.server, space: withSpace.space }).mode;
+    } catch (e) {
+      if (!isWorkspaceTargetError(e)) throw e;
+    }
+    if (mode === "user") {
       const conn = await connectUserControlOrExit(withSpace);
       return {
         space: conn.space,

--- a/implementations/cli/src/lib/control.ts
+++ b/implementations/cli/src/lib/control.ts
@@ -19,7 +19,7 @@ import {
 import { connect } from "@nats-io/transport-node";
 import {
   authDir, endpointAuth, findCotalRoot, isWorkspaceTargetError, loadSpaceAuth, resolveMeshTarget,
-  soleSpaceOf, type MeshTarget,
+  pruneStaleMeshes, soleSpaceOf, type MeshTarget, type MeshTargetErrorCode,
 } from "@cotal-ai/workspace";
 import { c, staleStoreHint } from "../ui.js";
 import { connectOrExit, connectUserControlOrExit, type ConnectFlags } from "./connect.js";
@@ -28,6 +28,14 @@ import { connectOrExit, connectUserControlOrExit, type ConnectFlags } from "./co
  *  (spread into the endpoint verbatim), plus the minted instrument's v0.4 caller triple when the
  *  static mint produced one ({@link askManager}'s ep-rail path rides it). */
 export type ControlAuth = { creds?: string; bearer?: string; sentinelCreds?: string; epCaller?: EpCaller };
+
+/** The only {@link MeshTargetErrorCode}s that mean "there is NO registry entry here", and so the
+ *  only ones the mode peek in {@link resolveControlTarget} may absorb. Every other code means the
+ *  entry exists and is broken (`stale-auth-root`, `unreadable-auth`, `user-auth-unrecorded`,
+ *  `ambiguous-target`, `default-occupied`) — absorbing those would let a MISCONFIGURED mesh fall
+ *  through to a credential-less raw-open connect. Deliberately a closed allow-list, not a
+ *  deny-list: a new code defaults to failing loud. */
+const TARGET_ABSENT_CODES: ReadonlySet<string> = new Set<MeshTargetErrorCode>(["unknown-space", "no-meshes"]);
 
 /** Client-side request window for the manager's readiness-waiting launch ops (`start`, and the
  *  manifest `launch` — both funnel into the same startAgent readiness wait). #159 B1: the manager
@@ -69,16 +77,29 @@ export async function resolveControlTarget(
   // to run through `resolveTargetOrExit`, which EXITS on a WorkspaceTargetError, so it killed a
   // legitimate input on the way past: `--server` with an UNREGISTERED `--space` is the raw-open
   // escape hatch, and by definition it has no registry entry to carry a mode. Resolve through the
-  // THROWING form instead and read "no such target" as "not a registry mesh, therefore not user
-  // mode", leaving that path to `connectOrExit` below, which owns it and still exits loudly on a
-  // genuinely bad target. ONLY WorkspaceTargetError is absorbed; anything else propagates.
+  // THROWING form instead and read ABSENCE as "not a registry mesh, therefore not user mode",
+  // leaving that path to `connectOrExit` below, which owns it.
+  //
+  // ABSENCE ONLY. The two absent codes are the entire escape hatch; every other
+  // MeshTargetErrorCode means the entry EXISTS and is BROKEN, and swallowing those is a
+  // fallback, not a restoration. `stale-auth-root` is the one that bites: `targetFromEntry`
+  // PRUNES the entry before throwing it, so absorbing it leaves `connectOrExit` seeing no
+  // registration at all — and with an explicit `--server` it then takes the raw-open arm and
+  // connects with NO CREDENTIALS. A misconfigured AUTH mesh would silently become an OPEN one,
+  // hiding the misconfiguration and switching identity planes under the operator. Those codes
+  // rethrow and the command dies loud, exactly as it did before this peek existed.
   // Raw `--creds` skips the peek entirely (static/raw path below).
   if (!withSpace.creds) {
+    // Sweep first when no space is named, exactly as `resolveTargetOrExit` does before ITS
+    // resolve. Without it the peek reads a world `connectOrExit` never sees: a dead entry
+    // alongside a live one makes a bare resolve `ambiguous-target` here while the connect,
+    // having pruned, resolves the single survivor cleanly. Same sweep, same view, one answer.
+    if (!withSpace.space) await pruneStaleMeshes();
     let mode: MeshTarget["mode"] | undefined;
     try {
       mode = resolveMeshTarget(process.cwd(), { server: withSpace.server, space: withSpace.space }).mode;
     } catch (e) {
-      if (!isWorkspaceTargetError(e)) throw e;
+      if (!isWorkspaceTargetError(e) || !TARGET_ABSENT_CODES.has(e.code)) throw e;
     }
     if (mode === "user") {
       const conn = await connectUserControlOrExit(withSpace);

--- a/implementations/cli/src/lib/control.ts
+++ b/implementations/cli/src/lib/control.ts
@@ -30,10 +30,13 @@ import { connectOrExit, connectUserControlOrExit, type ConnectFlags } from "./co
 export type ControlAuth = { creds?: string; bearer?: string; sentinelCreds?: string; epCaller?: EpCaller };
 
 /** The only {@link MeshTargetErrorCode}s that mean "there is NO registry entry here", and so the
- *  only ones the mode peek in {@link resolveControlTarget} may absorb. Every other code means the
- *  entry exists and is broken (`stale-auth-root`, `unreadable-auth`, `user-auth-unrecorded`,
- *  `ambiguous-target`, `default-occupied`) — absorbing those would let a MISCONFIGURED mesh fall
- *  through to a credential-less raw-open connect. Deliberately a closed allow-list, not a
+ *  only ones the mode peek in {@link resolveControlTarget} may absorb. **Every other code is
+ *  NON-ABSENCE and must fail loud** — which is the precise claim, and covers more than one
+ *  situation: `stale-auth-root` / `unreadable-auth` / `user-auth-unrecorded` are an entry that
+ *  exists and is broken, while `ambiguous-target` can be several perfectly healthy entries and
+ *  `default-occupied` an intended local target with no entry at all. What unites them is not
+ *  breakage, it is that absence has NOT been established, so falling through to a
+ *  credential-less raw-open connect would be unsound. Deliberately a closed allow-list, not a
  *  deny-list: a new code defaults to failing loud. */
 const TARGET_ABSENT_CODES: ReadonlySet<string> = new Set<MeshTargetErrorCode>(["unknown-space", "no-meshes"]);
 
@@ -81,7 +84,7 @@ export async function resolveControlTarget(
   // leaving that path to `connectOrExit` below, which owns it.
   //
   // ABSENCE ONLY. The two absent codes are the entire escape hatch; every other
-  // MeshTargetErrorCode means the entry EXISTS and is BROKEN, and swallowing those is a
+  // MeshTargetErrorCode is NON-ABSENCE, and swallowing those is a
   // fallback, not a restoration. `stale-auth-root` is the one that bites: `targetFromEntry`
   // PRUNES the entry before throwing it, so absorbing it leaves `connectOrExit` seeing no
   // registration at all — and with an explicit `--server` it then takes the raw-open arm and

--- a/implementations/cli/src/lib/control.ts
+++ b/implementations/cli/src/lib/control.ts
@@ -19,7 +19,7 @@ import {
 import { connect } from "@nats-io/transport-node";
 import {
   authDir, endpointAuth, findCotalRoot, isWorkspaceTargetError, loadSpaceAuth, resolveMeshTarget,
-  pruneStaleMeshes, soleSpaceOf, type MeshTarget, type MeshTargetErrorCode,
+  pruneStaleMeshes, renderWorkspaceError, soleSpaceOf, type MeshTarget, type MeshTargetErrorCode,
 } from "@cotal-ai/workspace";
 import { c, staleStoreHint } from "../ui.js";
 import { connectOrExit, connectUserControlOrExit, type ConnectFlags } from "./connect.js";
@@ -102,6 +102,10 @@ export async function resolveControlTarget(
     try {
       mode = resolveMeshTarget(process.cwd(), { server: withSpace.server, space: withSpace.space }).mode;
     } catch (e) {
+      // Non-absence propagates and ends the command. It is rethrown rather than rendered-and-exited
+      // here so this function stays composable and testable; the CLI boundary renders every
+      // WorkspaceTargetError through `renderWorkspaceError` (see the dispatcher's catch), which is
+      // what turns "entry X points at a root holding Y" into the removed-fact plus a recovery line.
       if (!isWorkspaceTargetError(e) || !TARGET_ABSENT_CODES.has(e.code)) throw e;
     }
     if (mode === "user") {

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -3376,7 +3376,14 @@ export class Manager {
 
       let connector: Connector;
       try {
-        connector = registry.resolve<Connector>("connector", entry.launch.connector);
+        // The SAME resolver the spawn path uses. A bare `registry.resolve` here made preserve→resume
+        // fail for EVERY retained agent on the published binary: the resuming manager is a fresh
+        // process whose registry is empty (its supervise child runs with the connector seed
+        // skipped), so nothing is registered until something materializes it from the ext manifest.
+        // That is precisely what `resolveConnector` does and what every spawn path already calls.
+        // Resolving bare meant a preserved mesh could never come back — first-party connectors
+        // included, since the asymmetry is about materialization, not about which connector it is.
+        connector = await this.resolveConnector(entry.launch.connector);
       } catch (e) {
         return { ok: false, error: (e as Error).message };
       }


### PR DESCRIPTION
## What

The user-mode mode-peek in `resolveControlTarget` resolved through `resolveTargetOrExit`, which **exits the process** when a target cannot be resolved. `--server` with an unregistered `--space` is the raw-open escape hatch: it has no registry entry, so it has no mode to read, and the peek killed the command before `connectOrExit` — the path that actually serves it — was reached.

The peek now resolves through the throwing form and reads "no such target" as "not a registry mesh, therefore not user mode". Only `WorkspaceTargetError` is absorbed; anything else propagates, and a genuinely bad target still fails loudly downstream.

## Why it was not caught

The `live` chain is a **separate CI job** from `smoke:ci`. No `smoke:ci` gate — on any platform — reaches this code path. `server-resolution:live` is the suite that covers it, and it lives only in the `live` job.

## Verification

- `server-resolution:live` — 15/15, previously failing. Covers both the escape hatch and the global prune sweep.
- Full `live` chain, all eleven suites, green end to end; the final suite printed its own banner.
- `ps-user-mode` and `ps-operator-path` both pass, so user-mode routing (the reason the peek exists) is intact.

## Scope

This fixes the `live` regression only. `main` remains red on three failures that pre-date it — `claude-wake`, `down-target`, and `spawn-from-anywhere` — each of which reproduces on the pre-merge `main` on Linux. They need their own fixes.