### PR TITLE
feat(scripts): mutation-proof — a test that cannot fail cannot pass as one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,13 @@ endpoint methods; those go into `core`, generalized.
 - **Never fix an issue you could not reproduce.** Reproduce the failure (live, not just in
 reasoning or a unit simulation) before writing a fix; the repro is also the only proof the
 fix works. If you can't reproduce it, report that and stop, don't ship a guess.
+- **A test that passes with the fix reverted proves nothing — so prove it doesn't.** `pnpm
+mutation-proof` breaks the implementation on purpose and requires the suite to go red **on the
+assertion you name**. It refuses an absent or ambiguous target, refuses a dirty tree (git must be
+your recovery, not the tool), refuses an already-red suite, verifies its own restore, and reports
+`SURVIVED` rather than a pass when the suite fails to notice. Red alone is not proof: an unrelated
+early failure is also red. And a killed mutation shows the test *depends* on that code — not that a
+real entry point *reaches* it; if the test builds its inputs by hand, prove that part separately.
 - **Keep the code clean and minimal.** No bloat, no overcomplication.
 - **Do only what is asked**, not more, not less. Do not add features or abstractions that are
 not explicitly requested or clearly needed.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "gen:schema": "node scripts/generate-cotal-schema.mjs",
     "gen:tooldocs": "tsx scripts/generate-tool-docs.mjs",
     "gen:docsbundle": "node scripts/generate-docs-bundle.mjs",
+    "mutation-proof": "node scripts/mutation-proof.mjs",
+    "mutation-proof:selftest": "node scripts/mutation-proof.selftest.mjs",
     "check:docsbundle": "pnpm gen:tooldocs && pnpm gen:docsbundle && git diff --exit-code -- docs/mcp-tools.md extensions/connector-core/src/docs-bundle.generated.ts",
     "test": "pnpm -r --if-present test",
     "check": "pnpm typecheck && pnpm check:docsbundle && pnpm test && pnpm smoke:docs && pnpm smoke:orientation && pnpm smoke:view && pnpm smoke:spawn-from-anywhere && pnpm smoke:spawn-from-anywhere:live && pnpm smoke:connect && pnpm smoke:core-boundary && pnpm smoke:preflight && pnpm smoke:update-concurrency && pnpm smoke:ci && pnpm smoke:spawn-detach:live && pnpm smoke:readiness:live && pnpm smoke:setup-pure:live && pnpm smoke:up-stack:live && pnpm smoke:up-manifest:live && pnpm smoke:ext:live && pnpm smoke:dogfood:live && pnpm smoke:freeslot-barrier:live && pnpm smoke:int2-revoke:live && pnpm smoke:backup-perms:live && pnpm smoke:backup-restore:live && pnpm smoke:backup-conservation:live && pnpm smoke:backup-usermode:live && pnpm smoke:backup-faults:live && pnpm smoke:down-manifest-usermode:live",

--- a/scripts/mutation-proof.mjs
+++ b/scripts/mutation-proof.mjs
@@ -39,11 +39,20 @@ function usage(msg) {
   process.exit(2);
 }
 
+/** Pairs `--k v`, but a flag whose next token is another flag (or nothing) is a boolean. Pairing
+ *  unconditionally made `--allow-dirty` unusable: alone it parsed as `undefined`, and followed by
+ *  another flag it swallowed it. A documented escape hatch that cannot be typed is not an escape. */
 function parseArgs(argv) {
   const a = {};
-  for (let i = 0; i < argv.length; i += 2) {
+  for (let i = 0; i < argv.length; i++) {
     if (!argv[i].startsWith("--")) usage(`unexpected argument: ${argv[i]}`);
-    a[argv[i].slice(2)] = argv[i + 1];
+    const key = argv[i].slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith("--")) a[key] = true;
+    else {
+      a[key] = next;
+      i++;
+    }
   }
   return a;
 }
@@ -154,11 +163,16 @@ function proveOne(m, opts) {
         ticks,
       };
     }
-    if (opts.minTicks !== undefined && ticks < opts.minTicks) {
+    // The tick floor is a HEURISTIC for "did it get far enough to be about my check", and it must
+    // never overrule direct evidence. A matched `expectRed` IS that evidence: the suite printed the
+    // assertion we named. Letting the heuristic win graded a correct proof as WRONG-RED whenever the
+    // mutation targeted the suite's FIRST assertion — a false negative on a working test, which is
+    // the expensive direction, because the fix someone reaches for is to weaken the test.
+    if (!m.expectRed && opts.minTicks !== undefined && ticks < opts.minTicks) {
       return {
         label,
         verdict: "WRONG-RED",
-        why: `died after only ${ticks} progress marks (expected ≥ ${opts.minTicks}) — it failed before reaching the check`,
+        why: `died after only ${ticks} progress marks (expected ≥ ${opts.minTicks}) and no expectRed was given, so there is nothing to tie this red to your check`,
         ticks,
       };
     }

--- a/scripts/mutation-proof.mjs
+++ b/scripts/mutation-proof.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+/**
+ * mutation-proof — prove a suite would actually catch the bug it claims to guard.
+ *
+ * A suite that passes with the change reverted proves nothing (AGENTS.md). The way to know is to
+ * break the implementation on purpose and watch the suite go red **on its own line**. Doing that by
+ * hand is a destructive experiment on a working tree, and every step of it has a way to lie:
+ *
+ *   - the mutation silently does not apply       → "unmutated" and "mutated" are the same run, and
+ *                                                  the verdict is an accusation about nothing
+ *   - the target string appears more than once   → you mutated something else as well
+ *   - the suite dies EARLY for an unrelated reason → red, but not the red you claimed
+ *   - the run never reached the new check at all → green that never executed the test
+ *   - the restore silently fails                 → the next person inherits a broken tree
+ *
+ * Each of those has happened. This runs the experiment so that none of them can pass as a result.
+ *
+ * Usage:
+ *   node scripts/mutation-proof.mjs --config mutations.json
+ *   node scripts/mutation-proof.mjs --file <path> --find <str> --replace <str> \
+ *        --command "pnpm smoke:x" --expect-red "<substring of the failing assertion>"
+ *
+ * Every mutation must name the assertion it expects to redden (`expectRed`). "It went red" and "it
+ * went red for my reason" are the same exit code until you say which.
+ */
+import { readFileSync, writeFileSync, copyFileSync, existsSync, rmSync } from "node:fs";
+import { execSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const C = { red: "\x1b[31m", green: "\x1b[32m", yellow: "\x1b[33m", dim: "\x1b[2m", off: "\x1b[0m" };
+const say = (s = "") => process.stdout.write(`${s}\n`);
+const sha = (p) => createHash("sha256").update(readFileSync(p)).digest("hex");
+
+function usage(msg) {
+  say(`${C.red}${msg}${C.off}\n`);
+  say(readFileSync(new URL(import.meta.url)).toString().split("\n").slice(2, 27).join("\n").replace(/^ \* ?/gm, ""));
+  process.exit(2);
+}
+
+function parseArgs(argv) {
+  const a = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    if (!argv[i].startsWith("--")) usage(`unexpected argument: ${argv[i]}`);
+    a[argv[i].slice(2)] = argv[i + 1];
+  }
+  return a;
+}
+
+/**
+ * Count occurrences of a literal. Deliberately literal, not a regex: a regex target is how a
+ * mutation silently matches nothing (an unescaped `.` or `(` is easy), and how it silently matches
+ * something else as well. If you need a multi-line target, pass one — literals span lines fine,
+ * which a line-oriented matcher does not. A compiled body puts `if (…)` and its statement on
+ * separate lines, so a single-line pattern misses exactly the guards worth proving.
+ */
+const countOccurrences = (hay, needle) => hay.split(needle).length - 1;
+
+/** The tree must be recoverable WITHOUT this tool before a destructive experiment starts. */
+function assertCleanTree(cwd, allowDirty) {
+  const out = execSync("git status --porcelain", { cwd, encoding: "utf8" }).trim();
+  if (!out) return;
+  if (allowDirty) {
+    say(`${C.yellow}! tree is dirty and --allow-dirty was passed; git cannot be your recovery${C.off}`);
+    return;
+  }
+  say(`${C.red}REFUSING: working tree is dirty.${C.off}`);
+  say("Commit before you mutate — the tree has to be recoverable independently of this tool.");
+  say(`${out.split("\n").slice(0, 10).join("\n")}`);
+  process.exit(3);
+}
+
+/** Run a command, capture combined output, never let a pipe eat the status. */
+function run(command, cwd, timeoutMs) {
+  const r = spawnSync(command, { cwd, shell: true, encoding: "utf8", timeout: timeoutMs, maxBuffer: 64 * 1024 * 1024 });
+  const output = `${r.stdout ?? ""}${r.stderr ?? ""}`;
+  // A timeout kills the child and leaves status null; that is not a red, it is an unknown.
+  return { status: r.status, timedOut: r.error?.code === "ETIMEDOUT" || r.signal === "SIGTERM", output };
+}
+
+/**
+ * How far into the suite did the run get? Counting a suite's own progress markers separates
+ * "failed at my assertion" from "died before reaching it" and from "ran an older copy of the file".
+ * Convention-bound by nature, so it is advisory unless the caller supplies `progressPattern`.
+ */
+const progressCount = (output, pattern) => {
+  const re = new RegExp(pattern ?? "✓", "g");
+  return (output.match(re) ?? []).length;
+};
+
+function proveOne(m, opts) {
+  const cwd = opts.cwd;
+  const path = join(cwd, m.file);
+  const label = m.name ?? `${m.file}: ${m.find.slice(0, 48).replace(/\n/g, "⏎")}`;
+  say(`\n${C.dim}────────────────────────────────────────────────────────${C.off}`);
+  say(`${label}`);
+
+  if (!existsSync(path)) return { label, verdict: "ERROR", why: `target file not found: ${m.file}` };
+
+  const before = readFileSync(path, "utf8");
+  const hits = countOccurrences(before, m.find);
+  // Assert the target is present AND unambiguous BEFORE grading anything. Zero means the mutation
+  // would be a no-op and the verdict would be an accusation about nothing; more than one means the
+  // experiment changed something you did not name.
+  if (hits === 0) return { label, verdict: "ERROR", why: `target string not found in ${m.file} — nothing would have been mutated` };
+  if (hits > 1 && !m.allowMultiple) {
+    return { label, verdict: "ERROR", why: `target appears ${hits}× in ${m.file}; pass allowMultiple to mutate them all, or narrow it` };
+  }
+
+  const backup = join(tmpdir(), `mutation-proof-${createHash("sha1").update(path).digest("hex").slice(0, 12)}.bak`);
+  copyFileSync(path, backup);
+  const shaBefore = sha(path);
+
+  const restore = () => {
+    copyFileSync(backup, path);
+    const ok = sha(path) === shaBefore;
+    rmSync(backup, { force: true });
+    return ok;
+  };
+
+  try {
+    writeFileSync(path, before.split(m.find).join(m.replace));
+    // Assert the mutation APPLIED. A no-op mutation makes a green uninterpretable and leaves a red
+    // sound only by accident.
+    if (sha(path) === shaBefore) {
+      restore();
+      return { label, verdict: "ERROR", why: "mutation produced an identical file — it did not apply" };
+    }
+    say(`${C.dim}  mutated ${hits}× · running: ${m.command ?? opts.command}${C.off}`);
+
+    const r = run(m.command ?? opts.command, cwd, opts.timeoutMs);
+    const ticks = progressCount(r.output, opts.progressPattern);
+
+    const restored = restore();
+    if (!restored) return { label, verdict: "ERROR", why: `RESTORE FAILED for ${m.file} — backup at ${backup}`, ticks };
+
+    if (r.timedOut) return { label, verdict: "INCONCLUSIVE", why: `run timed out; a hang is not a red`, ticks };
+    if (r.status === 0) {
+      return {
+        label,
+        verdict: "SURVIVED",
+        why: "the suite PASSED with the implementation broken — it does not test this",
+        ticks,
+      };
+    }
+    // Red is necessary but not sufficient: it has to be red for the reason claimed, or an unrelated
+    // early failure reads as proof.
+    if (m.expectRed && !r.output.includes(m.expectRed)) {
+      return {
+        label,
+        verdict: "WRONG-RED",
+        why: `exited ${r.status} but never printed the expected failure: ${JSON.stringify(m.expectRed)}`,
+        ticks,
+      };
+    }
+    if (opts.minTicks !== undefined && ticks < opts.minTicks) {
+      return {
+        label,
+        verdict: "WRONG-RED",
+        why: `died after only ${ticks} progress marks (expected ≥ ${opts.minTicks}) — it failed before reaching the check`,
+        ticks,
+      };
+    }
+    return { label, verdict: "KILLED", why: m.expectRed ? `red, and named: ${m.expectRed}` : `red (exit ${r.status})`, ticks };
+  } catch (e) {
+    restore();
+    return { label, verdict: "ERROR", why: `harness threw: ${e.message}` };
+  }
+}
+
+// ---- entry ------------------------------------------------------------------------------------
+const a = parseArgs(process.argv.slice(2));
+const cwd = a.cwd ?? process.cwd();
+let mutations;
+let opts = {
+  cwd,
+  command: a.command,
+  timeoutMs: Number(a.timeout ?? 900_000),
+  progressPattern: a["progress-pattern"],
+  minTicks: a["min-ticks"] === undefined ? undefined : Number(a["min-ticks"]),
+};
+
+if (a.config) {
+  const cfg = JSON.parse(readFileSync(join(cwd, a.config), "utf8"));
+  mutations = cfg.mutations ?? usage("config has no `mutations` array");
+  opts = { ...opts, command: cfg.command ?? opts.command, progressPattern: cfg.progressPattern ?? opts.progressPattern, minTicks: cfg.minTicks ?? opts.minTicks };
+} else if (a.file && a.find !== undefined && a.replace !== undefined) {
+  mutations = [{ file: a.file, find: a.find, replace: a.replace, expectRed: a["expect-red"] }];
+} else {
+  usage("need --config <file>, or --file/--find/--replace");
+}
+if (!opts.command) usage("no --command given (and none in the config)");
+
+assertCleanTree(cwd, a["allow-dirty"] !== undefined);
+
+// A baseline is not optional: a suite that is ALREADY red grades every mutation as KILLED.
+say(`${C.dim}baseline: ${opts.command}${C.off}`);
+const base = run(opts.command, cwd, opts.timeoutMs);
+const baseTicks = progressCount(base.output, opts.progressPattern);
+if (base.status !== 0) {
+  say(`${C.red}REFUSING: the suite is red BEFORE any mutation (exit ${base.status}).${C.off}`);
+  say("Every mutation would grade as KILLED for a reason that has nothing to do with the mutation.");
+  process.exit(4);
+}
+say(`${C.green}baseline green${C.off} (${baseTicks} progress marks)`);
+if (opts.minTicks === undefined && baseTicks > 0) {
+  // Default the floor just under the baseline: a mutated run that dies much earlier failed for
+  // some other reason, and a run that never reaches the check is not evidence about it.
+  opts.minTicks = 1;
+}
+
+const results = [];
+for (const m of mutations) results.push(proveOne(m, opts));
+
+say(`\n${C.dim}════════════════════════════════════════════════════════${C.off}`);
+let bad = 0;
+for (const r of results) {
+  const good = r.verdict === "KILLED";
+  if (!good) bad++;
+  const colour = good ? C.green : r.verdict === "SURVIVED" ? C.red : C.yellow;
+  say(`${colour}${r.verdict.padEnd(12)}${C.off} ${r.label}`);
+  say(`  ${C.dim}${r.why}${r.ticks !== undefined ? ` · ${r.ticks} marks (baseline ${baseTicks})` : ""}${C.off}`);
+}
+say("");
+if (bad === 0) {
+  say(`${C.green}All ${results.length} mutation(s) killed. The suite discriminates.${C.off}`);
+  say(`${C.dim}Scope: this proves the suite DEPENDS on the mutated code. It does not prove a real entry`);
+  say(`point reaches that code — if the test builds its inputs by hand, prove that separately.${C.off}`);
+} else {
+  say(`${C.red}${bad} of ${results.length} mutation(s) did not produce a clean, named red.${C.off}`);
+}
+process.exit(bad === 0 ? 0 : 1);

--- a/scripts/mutation-proof.selftest.mjs
+++ b/scripts/mutation-proof.selftest.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * Self-test for `mutation-proof.mjs`.
+ *
+ * The tool exists because a check that cannot fail is indistinguishable, in every log, from a check
+ * that passed. That applies to the tool. **A mutation harness that can never report SURVIVED is the
+ * undiscriminating instrument it was built to detect**, so this drives it against a throwaway fixture
+ * where the right answer is known in advance, including the answers that are supposed to be bad.
+ *
+ * Fast on purpose: a temp git repo, a two-line "implementation", and a "suite" that is a shell exit
+ * code. Seconds, not the minutes a real smoke costs — so there is no reason to skip it.
+ *
+ * Run: node scripts/mutation-proof.selftest.mjs
+ */
+import { mkdtempSync, writeFileSync, rmSync, readFileSync, mkdirSync } from "node:fs";
+import { execSync, spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const TOOL = join(dirname(fileURLToPath(import.meta.url)), "mutation-proof.mjs");
+const root = mkdtempSync(join(tmpdir(), "mutation-selftest-"));
+let pass = 0;
+const check = (name, cond, extra) => {
+  if (!cond) {
+    console.error(`\n  ✗ ${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
+    rmSync(root, { recursive: true, force: true });
+    process.exit(1);
+  }
+  pass++;
+  console.log(`  ✓ ${name}`);
+};
+
+// ---- a fixture repo: one guard, one suite that depends on it, one that does not ----------------
+mkdirSync(join(root, "src"), { recursive: true });
+writeFileSync(
+  join(root, "src/impl.js"),
+  [
+    "export function admit(n) {",
+    "  // the guard under test; the compiled shape puts the statement on its own line",
+    "  if (n > 10)",
+    "    return false;",
+    "  return true;",
+    "}",
+    "export const unrelated = () => 'untouched';",
+    "",
+  ].join("\n"),
+);
+// A "suite": prints progress marks, exits non-zero with a named assertion when the guard is gone.
+writeFileSync(
+  join(root, "suite.mjs"),
+  [
+    "import { admit } from './src/impl.js';",
+    "console.log('  ✓ admits a small value');",
+    "if (admit(5) !== true) { console.error('AssertionError: small values are admitted'); process.exit(1); }",
+    "console.log('  ✓ the guard refuses an oversized value');",
+    "if (admit(50) !== false) { console.error('AssertionError: oversized values are refused'); process.exit(1); }",
+    "console.log('  ✓ done');",
+    "",
+  ].join("\n"),
+);
+execSync("git init -q && git add -A && git -c user.email=a@b -c user.name=c commit -qm fixture", { cwd: root });
+
+const runTool = (args) =>
+  spawnSync(process.execPath, [TOOL, ...args], { cwd: root, encoding: "utf8", timeout: 120_000 });
+
+// 1. A mutation the suite DOES catch, named. The everyday case.
+let r = runTool([
+  "--command", `${process.execPath} suite.mjs`,
+  "--file", "src/impl.js",
+  "--find", "if (n > 10)\n    return false;",
+  "--replace", "if (false)\n    return false;",
+  "--expect-red", "oversized values are refused",
+]);
+check("a killed mutation exits 0 and reports KILLED", r.status === 0 && r.stdout.includes("KILLED"), r.stdout.slice(-300));
+check("...and a multi-line target matches (the compiled shape of a guard)", !r.stdout.includes("not found"));
+
+// 2. THE ONE THAT MATTERS: a mutation the suite does NOT catch must be reported, not passed.
+r = runTool([
+  "--command", `${process.execPath} suite.mjs`,
+  "--file", "src/impl.js",
+  "--find", "'untouched'",
+  "--replace", "'mutated'",
+  "--expect-red", "never printed",
+]);
+check("a SURVIVED mutation is reported and exits non-zero", r.status !== 0 && r.stdout.includes("SURVIVED"), r.stdout.slice(-300));
+
+// 3. A target that does not exist must ERROR, never silently grade.
+r = runTool([
+  "--command", `${process.execPath} suite.mjs`,
+  "--file", "src/impl.js",
+  "--find", "this string is not in the file",
+  "--replace", "x",
+]);
+check("an absent target is an ERROR, not a verdict", r.status !== 0 && r.stdout.includes("ERROR") && r.stdout.includes("not found"));
+
+// 4. An ambiguous target must ERROR: the experiment must change only what was named.
+r = runTool([
+  "--command", `${process.execPath} suite.mjs`,
+  "--file", "src/impl.js",
+  "--find", "return",
+  "--replace", "return",
+]);
+check("an ambiguous target is refused", r.status !== 0 && r.stdout.includes("appears"), r.stdout.slice(-200));
+
+// 5. Red for the WRONG reason must not read as proof.
+r = runTool([
+  "--command", `${process.execPath} suite.mjs`,
+  "--file", "src/impl.js",
+  "--find", "if (n > 10)\n    return false;",
+  "--replace", "throw new Error('unrelated explosion');",
+  "--expect-red", "oversized values are refused",
+]);
+check("red for an unnamed reason is WRONG-RED, not KILLED", r.status !== 0 && r.stdout.includes("WRONG-RED"), r.stdout.slice(-300));
+
+// 6. A dirty tree is refused: git must be the recovery, not this tool.
+writeFileSync(join(root, "src/impl.js"), readFileSync(join(root, "src/impl.js"), "utf8") + "\n// dirty\n");
+r = runTool([
+  "--command", `${process.execPath} suite.mjs`,
+  "--file", "src/impl.js",
+  "--find", "if (n > 10)",
+  "--replace", "if (false)",
+]);
+check("a dirty tree is refused before anything is mutated", r.status !== 0 && r.stdout.includes("dirty"), r.stdout.slice(-200));
+execSync("git checkout -- .", { cwd: root });
+
+// 7. An already-red suite is refused: it would grade every mutation as KILLED.
+writeFileSync(join(root, "broken.mjs"), "console.error('AssertionError: pre-existing'); process.exit(1);\n");
+execSync("git add -A && git -c user.email=a@b -c user.name=c commit -qm broken", { cwd: root });
+r = runTool([
+  "--command", `${process.execPath} broken.mjs`,
+  "--file", "src/impl.js",
+  "--find", "if (n > 10)",
+  "--replace", "if (false)",
+]);
+check("a suite that is already red is refused", r.status !== 0 && r.stdout.includes("red BEFORE any mutation"), r.stdout.slice(-200));
+
+// 8. The tree is left exactly as found, after all of that.
+const after = execSync("git status --porcelain", { cwd: root, encoding: "utf8" }).trim();
+check("every run restored the tree", after === "", { after });
+check("...and the guard is byte-intact", readFileSync(join(root, "src/impl.js"), "utf8").includes("if (n > 10)"));
+
+rmSync(root, { recursive: true, force: true });
+console.log(`\nMUTATION-PROOF SELF-TEST PASSED ✅  (${pass} checks)`);

--- a/scripts/mutation-proof.selftest.mjs
+++ b/scripts/mutation-proof.selftest.mjs
@@ -135,6 +135,41 @@ r = runTool([
 ]);
 check("a suite that is already red is refused", r.status !== 0 && r.stdout.includes("red BEFORE any mutation"), r.stdout.slice(-200));
 
+// 7b. A boolean flag must be typeable. `--allow-dirty` paired with the next token, so alone it
+// parsed as undefined and the guard never saw it: a documented escape hatch that could not be used.
+writeFileSync(join(root, "src/impl.js"), readFileSync(join(root, "src/impl.js"), "utf8") + "\n// dirty\n");
+r = runTool([
+  "--command", `${process.execPath} suite.mjs`,
+  "--file", "src/impl.js",
+  "--find", "if (n > 10)\n    return false;",
+  "--replace", "if (false)\n    return false;",
+  "--expect-red", "oversized values are refused",
+  "--allow-dirty",
+]);
+check("bare --allow-dirty is honoured, not swallowed as a value", r.stdout.includes("KILLED") && !r.stdout.includes("REFUSING"), r.stdout.slice(-260));
+execSync("git checkout -- .", { cwd: root });
+
+// 7c. A mutation at the suite's FIRST assertion has zero preceding progress marks. The tick floor is
+// a heuristic; a matched expectRed is direct evidence, and the heuristic must not overrule it.
+writeFileSync(
+  join(root, "first.mjs"),
+  [
+    "import { admit } from './src/impl.js';",
+    "if (admit(50) !== false) { console.error('AssertionError: oversized values are refused'); process.exit(1); }",
+    "console.log('  ✓ the guard refuses an oversized value');",
+    "",
+  ].join("\n"),
+);
+execSync("git add -A && git -c user.email=a@b -c user.name=c commit -qm first", { cwd: root });
+r = runTool([
+  "--command", `${process.execPath} first.mjs`,
+  "--file", "src/impl.js",
+  "--find", "if (n > 10)\n    return false;",
+  "--replace", "if (false)\n    return false;",
+  "--expect-red", "oversized values are refused",
+]);
+check("a named red at the FIRST assertion is KILLED, not WRONG-RED", r.status === 0 && r.stdout.includes("KILLED"), r.stdout.slice(-300));
+
 // 8. The tree is left exactly as found, after all of that.
 const after = execSync("git status --porcelain", { cwd: root, encoding: "utf8" }).trim();
 check("every run restored the tree", after === "", { after });


### PR DESCRIPTION
## What

`scripts/mutation-proof.mjs`: mutate a claimed guard, run the suite that claims to cover it, and require exactly that suite to go red. A check that cannot fail is indistinguishable in every log from a check that passed — this makes that class of test detectable mechanically.

- 12-check self-test (the tool proves itself the same way it proves suites)
- `--allow-dirty` for worktree use; evidence beats heuristics on dirty-tree detection

## Why

Every real bug caught in the foreman-platform wave was a failure presenting as a valid result — including bugs in tests themselves (hardcoded `ok(..., true)` smokes, asserts that crash-skip later assertions). Mutation testing found more real bugs than any read-through. This packages that discipline as a tool the fm-* lanes run routinely.

## Verification

- Self-test: 12/12 green at `aaaf7e08`
- Reviewed and approved by the orchestrator (default_agent) against the artifact: mutations verified to redden exactly their claiming check
