### PR TITLE
docs: remove the nonexistent 'watch' command from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ plus a self-registering `cmux` Runtime and `TerminalLayout` provider.
 plus a self-registering `tmux` Runtime and `TerminalLayout` provider.
 - `**@cotal-ai/orca**` (`extensions/orca`): the Orca integration: a driver over the public Orca
 CLI plus a self-registering `orca` Runtime provider.
-- `**@cotal-ai/cli**` (`implementations/cli`): the mesh CLI: `up`, `join`, `watch`, `console`,
+- `**@cotal-ai/cli**` (`implementations/cli`): the mesh CLI: `up`, `join`, `console`,
 `spawn`, `mint`, `status`, `doctor`, `channels`, `history`, `ext` (operator-installed command extensions).
 - `**@cotal-ai/web**` (`implementations/web`): the browser dashboard as a `cotal ext`-installable
 extension package — it peer-depends on core + workspace (linked to the binary's copies at add


### PR DESCRIPTION
One-line fix: AGENTS.md:103 lists a `watch` CLI command that does not exist (`implementations/cli/src/commands/` has no `watch.ts` and nothing registers one; the real text renderer is `cotal console`). Found when the stale line propagated into six revisions of a design doc — the canonical agent guide poisons every lane that trusts it, so the fix is small and the leverage is not.
