### PR TITLE
fix(smoke): settle endpoint-action broker teardown on already-exited

### DIFF
--- a/packages/core/smoke/endpoint-action.smoke.ts
+++ b/packages/core/smoke/endpoint-action.smoke.ts
@@ -474,7 +474,18 @@ try {
   await nc.close();
 } finally {
   broker.kill("SIGKILL");
-  await new Promise<void>((resolve) => { broker.once("exit", () => resolve()); broker.once("error", () => resolve()); });
+  // Settle on every path the broker can take, including ALREADY-EXITED. Attaching once("exit")
+  // only after kill races: under load the child can fully exit before the listener is armed, the
+  // promise never settles, and tsx exits 13 with "Detected unsettled top-level await" after every
+  // assertion has already passed (reproduced: forced already-exited path → exit 13 + same warning).
+  await new Promise<void>((resolve) => {
+    if (broker.exitCode !== null || broker.signalCode !== null) return resolve();
+    const done = () => resolve();
+    broker.once("exit", done);
+    broker.once("error", done);
+    // Re-check after arming: exit may have fired between the null test and once().
+    if (broker.exitCode !== null || broker.signalCode !== null) resolve();
+  });
   rmSync(sd, { recursive: true, force: true });
 }
 


### PR DESCRIPTION
`packages/core/smoke/endpoint-action.smoke.ts` intermittently failed `smoke:ci`
with `[ELIFECYCLE] Command failed with exit code 13` and the warning
`Detected unsettled top-level await`, after every one of its 83 assertions had
already passed.

The teardown killed the broker and only then armed `once("exit")` /
`once("error")`. Under load the child can fully exit before the listeners are
attached, so neither event ever fires, the promise never settles, and the
process dies at the end of a run that had actually succeeded. It reds any
branch, and because a bare re-run clears it, it reads as noise.

The settle now covers every path the child can be on: check `exitCode` /
`signalCode` first, arm, then re-check to close the window between the null test
and `once()`.

Verified with a controlled pair rather than a re-run. Forcing the
already-exited path and changing nothing else: the old pattern exits 13 and
emits the unsettled-await warning; the new pattern exits 0 with 83 passed. Plus
12 sequential unforced runs, all green.

Landing this alone and first, so branches inherit the fix instead of the flake.
