### PR TITLE
fix(cli,workspace): name the actual repair on target and raw-probe failures

### DIFF
--- a/implementations/cli/src/commands/status.ts
+++ b/implementations/cli/src/commands/status.ts
@@ -10,7 +10,7 @@ import {
   type ParsedArgs,
   type UserAuthStatus,
 } from "@cotal-ai/core";
-import { CLI_USER_ACTOR, accountInventory, authDir, extensionsDir, findCotalRoot, getCurrent, hasUserAuthState, isWorkspaceTargetError, loadExtensionsManifest, loadMeshes, loadSoleSpaceAuth, loadSpaceAuth, localProcessPath, localProcessVisible, preflightTarget, resolveMeshTarget, serverFlag, spaceFlag, type LocalProcess, type LocalProcessContext, userAuthStateDir, workspaceSecretStore } from "@cotal-ai/workspace";
+import { CLI_USER_ACTOR, accountInventory, authDir, extensionsDir, findCotalRoot, getCurrent, hasUserAuthState, isWorkspaceTargetError, loadExtensionsManifest, loadMeshes, loadSoleSpaceAuth, loadSpaceAuth, localProcessPath, localProcessVisible, preflightTarget, renderWorkspaceError, resolveMeshTarget, serverFlag, spaceFlag, type LocalProcess, type LocalProcessContext, userAuthStateDir, workspaceSecretStore } from "@cotal-ai/workspace";
 import { localProcessSurface } from "../ext-loader.js";
 import { cliVersion, extensionVersions } from "../lib/version.js";
 import { agentSkillsSkew } from "../lib/agent-skills.js";
@@ -215,7 +215,11 @@ async function printTarget(
   } catch (e) {
     if (isWorkspaceTargetError(e)) {
       row("target", c.red(e.code));
-      row("hint", `${cmd} up --detach`);
+      // The canonical renderer names the ACTUAL repair per code (`cotal meshes rm`, `--space
+      // <name>`, `cotal up --user-auth`, …). The fixed `up --detach` hint that used to sit here was
+      // right for at most one of the seven codes and pointed the other six at a command that does
+      // not fix them — worse than no hint, because it reads as a diagnosis.
+      row("hint", renderWorkspaceError({ kind: "target", error: e }).replace(/^✗ /, ""));
       return;
     }
     throw e;

--- a/packages/workspace/smoke/preflight.smoke.ts
+++ b/packages/workspace/smoke/preflight.smoke.ts
@@ -98,9 +98,24 @@ check("stale-auth preflight copy names `cotal doctor auth` (the repair surface)"
   return msg.includes("doctor auth") && msg.includes("EXPIRED");
 })());
 check("stale-auth raw-probe copy names `cotal doctor auth`", (() => {
-  const msg = renderWorkspaceError({ kind: "reachable", reason: "stale-auth", server: "nats://x:1" });
+  const msg = renderWorkspaceError({ kind: "reachable", reason: "stale-auth", server: "nats://x:1", hasAuth: true });
   return msg.includes("doctor auth") && msg.includes("EXPIRED");
 })());
+
+// `auth-required` on the RAW probe splits the same way the registry path splits it. Both cells are
+// load-bearing in one direction each: collapsing them back tells a caller who sent nothing that its
+// credentials were refused, and the reverse tells a caller holding a bad cred to go get one.
+const rawAuthRequired = (hasAuth: boolean) =>
+  renderWorkspaceError({ kind: "reachable", reason: "auth-required", server: "nats://x:1", hasAuth });
+check("raw auth-required WITH creds says they were rejected", (() => {
+  const msg = rawAuthRequired(true);
+  return msg.includes("credentials rejected") && !msg.includes("no credentials were supplied");
+})());
+check("raw auth-required WITHOUT creds says none were supplied, and does not claim rejection", (() => {
+  const msg = rawAuthRequired(false);
+  return msg.includes("no credentials were supplied") && msg.includes("--creds") && !msg.includes("credentials rejected");
+})());
+check("the two raw auth-required sentences actually differ", rawAuthRequired(true) !== rawAuthRequired(false));
 
 // The invariant, exhaustively: a non-registry source is NEVER pruned — whatever the reason/auth.
 for (const s of NON_REGISTRY)

--- a/packages/workspace/src/connect.ts
+++ b/packages/workspace/src/connect.ts
@@ -370,7 +370,10 @@ async function userConnectOrExit(target: MeshTarget): Promise<Connection> {
 export async function reachableOrExit(server: string, auth: RawAuth = {}): Promise<void> {
   const probe = await probeConnect(server, auth);
   if (probe.ok) return;
-  console.error(c.red(renderWorkspaceError({ kind: "reachable", reason: probe.reason, server })));
+  // Whether the caller actually presented anything to be rejected. `tls` is deliberately not part
+  // of this: it is transport, not identity, and a TLS-only connection presents no credential.
+  const hasAuth = Boolean(auth.creds ?? auth.token ?? (auth.user && auth.pass));
+  console.error(c.red(renderWorkspaceError({ kind: "reachable", reason: probe.reason, server, hasAuth })));
   process.exit(1);
 }
 

--- a/packages/workspace/src/render.ts
+++ b/packages/workspace/src/render.ts
@@ -15,7 +15,7 @@ import type { PreflightFailure } from "./preflight.js";
 export type WorkspaceError =
   | { kind: "target"; error: MeshTargetError }
   | { kind: "preflight"; failure: PreflightFailure; target: MeshTarget; pruned: boolean }
-  | { kind: "reachable"; reason: "auth-required" | "stale-auth" | "unreachable"; server: string };
+  | { kind: "reachable"; reason: "auth-required" | "stale-auth" | "unreachable"; server: string; hasAuth: boolean };
 
 /** Render a workspace failure as the canonical one-line `cotal …` sentence. */
 export function renderWorkspaceError(e: WorkspaceError): string {
@@ -25,7 +25,7 @@ export function renderWorkspaceError(e: WorkspaceError): string {
     case "preflight":
       return renderPreflightFailure(e.failure, e.target, e.pruned);
     case "reachable":
-      return renderReachable(e.reason, e.server);
+      return renderReachable(e.reason, e.server, e.hasAuth);
   }
 }
 
@@ -88,10 +88,20 @@ function renderPreflightFailure(kind: PreflightFailure, t: MeshTarget, pruned: b
 
 /** Plain reachability for a RAW (off-registry) probe — the `--creds` / `--server`+unregistered-`--space`
  *  escape hatch, which never touches the registry (no prune, no stale-entry wording). */
-function renderReachable(reason: "auth-required" | "stale-auth" | "unreachable", server: string): string {
+function renderReachable(
+  reason: "auth-required" | "stale-auth" | "unreachable",
+  server: string,
+  hasAuth: boolean,
+): string {
   if (reason === "stale-auth")
     return `✗ credential EXPIRED at ${server} - bounded lifetime reached (credential death); run \`cotal doctor auth\` where the mesh runs, or re-mint the credential`;
-  return reason === "auth-required"
+  if (reason === "unreachable") return `✗ can't reach a broker at ${server} - is it running? (\`cotal up\`)`;
+  // `auth-required` is two different user situations with two different repairs, and this path used
+  // to collapse them. The registry path never did: `classifyPreflightFailure` branches on the same
+  // bit into `creds-rejected` vs `open-wants-auth`. Told "credentials rejected" after sending NO
+  // credentials, a caller goes looking for what is wrong with creds they never had, when the actual
+  // next step is to obtain some.
+  return hasAuth
     ? `✗ credentials rejected at ${server} - check your creds, or the broker wants different auth`
-    : `✗ can't reach a broker at ${server} - is it running? (\`cotal up\`)`;
+    : `✗ broker at ${server} requires auth, but no credentials were supplied - pass \`--creds <file>\`, or \`cotal join\` with a link/token`;
 }


### PR DESCRIPTION
Two message defects that pointed users at the wrong command.

**`cotal status` printed a machine code and a fixed hint.** On any target
resolution failure it rendered the raw `MeshTargetError` code plus
`cotal up --detach`, for all seven codes. That hint repairs at most one of them:
`ambiguous-target` needs `--space`, `stale-auth-root` needs
`cotal meshes add`/`rm`, `user-auth-unrecorded` needs `cotal up --user-auth`,
`default-occupied` needs `--space <the other one>`. A wrong hint is worse than
none, because it reads as a diagnosis. The canonical renderer already had
correct copy for every code, so status now uses it.

**The raw probe claimed rejection when nothing was sent.** `renderReachable`
collapsed both halves of `auth-required` into "credentials rejected". On the
off-registry path (`--creds`, or `--server` with an unregistered `--space`) the
caller may have presented nothing at all, and being told its credentials were
refused sends it to inspect creds it never had instead of obtaining some. The
registry path never had this bug: `classifyPreflightFailure` splits the same bit
into `creds-rejected` vs `open-wants-auth`. The `reachable` variant now carries
`hasAuth` and splits to match.

Three cells added, covering both branches and their difference.

**Mutation-proofed, with a stated limit.** Collapsing the split back kills
exactly 2 of the 3 new cells and leaves the with-creds cell passing, matching
the prediction. Worth recording: the suite loads the built `dist`, so the same
mutation applied to `src` without a rebuild leaves it fully green. A run without
a preceding build certifies stale code.

The limit: these cells exercise the renderer directly, not the caller wiring. A
second mutation making `reachableOrExit` always pass `hasAuth: true` kills
nothing, because the only suite touching that function probes a live open broker
and never reaches the render branch. The derivation is typechecked but not
covered, and closing that needs a subprocess against an auth-requiring broker.
