### PR TITLE
fix(cli): land hermetic tmpdir sandbox for spawn/down smokes

### DIFF
--- a/.changeset/spawn-tmpdir-hermetic.md
+++ b/.changeset/spawn-tmpdir-hermetic.md
@@ -1,6 +1,7 @@
 ---
+"@cotal-ai/auth": patch
 "@cotal-ai/cli": patch
 "cotal-ai": patch
 ---
 
-Sandbox the temp root in spawn-from-anywhere and down-target smokes so CI runners with `/tmp/.cotal` no longer fail the ancestry precondition by construction.
+Sandbox the temp root in the smokes that mint a mesh fixture there, so a `.cotal` left above the temp base (`/tmp/.cotal` on Linux CI runners) can no longer capture the fixture and make a suite grade a live mesh. One shared implementation in `bin/smoke/_scratch.ts`, used by `spawn-from-anywhere`, `down-target`, and both `ps` suites. The dead-manager cells now assert that the manager was found, was alive, and is dead, instead of skipping their own kill when the pid file is missing.

--- a/.changeset/spawn-tmpdir-hermetic.md
+++ b/.changeset/spawn-tmpdir-hermetic.md
@@ -1,0 +1,6 @@
+---
+"@cotal-ai/cli": patch
+"cotal-ai": patch
+---
+
+Sandbox the temp root in spawn-from-anywhere and down-target smokes so CI runners with `/tmp/.cotal` no longer fail the ancestry precondition by construction.

--- a/bin/smoke/_scratch.ts
+++ b/bin/smoke/_scratch.ts
@@ -56,6 +56,20 @@ function physical(p: string): string {
   }
 }
 
+/** Scratches this process owns and will sweep at exit unless a caller explicitly claims one. */
+const owned = new Map<string, () => void>();
+
+/**
+ * Take a scratch out of the exit sweep, because the caller has decided to KEEP it.
+ *
+ * The one legitimate reason: a mesh was started and not confirmed stopped, so the scratch's `.cotal`
+ * holds the only pidfiles that can find it. Deleting those turns a recoverable orphan into an
+ * anonymous one, which is worse than the leak.
+ */
+export function preserveScratch(scratch: string): void {
+  owned.delete(scratch);
+}
+
 /** One `findCotalRoot`-shaped walk from `start` up to `/`. */
 function walkUp(start: string): string | null {
   let dir = start;
@@ -148,6 +162,21 @@ export function makeScratch(prefix = "cotal-smoke-"): string {
     process.env.TMPDIR = scratch;
     process.env.TMP = scratch;
     process.env.TEMP = scratch;
+    // OWNERSHIP FROM THE MOMENT IT EXISTS, not from the moment the suite reaches its `try`.
+    //
+    // Every caller does fallible work between this return and its own try/finally — minting dirs,
+    // picking ports, spawning children — and a throw in that window used to escape with the scratch
+    // on disk. Measured on a real entry point: forcing the second `mkdtempSync` to EIO left
+    // `cotal-smoke-*` behind, because the failure preceded the `try` by forty lines. Fixing that per
+    // suite is what produced this finding: the transaction was added to ONE file and the class
+    // declared closed while three more callers kept the same gap.
+    //
+    // Since the fixture anchors a `.cotal` inside the scratch, a leaked one is a capture hazard for
+    // whatever runs under that temp base next — the exact poison this helper exists to remove.
+    // `exit` handlers must be synchronous, which `rmSync` is.
+    const sweep = () => { try { rmSync(scratch, { recursive: true, force: true }); } catch { /* best effort at exit */ } };
+    owned.set(scratch, sweep);
+    process.once("exit", () => { if (owned.has(scratch)) sweep(); });
     return scratch;
   }
   throw new Error(

--- a/bin/smoke/_scratch.ts
+++ b/bin/smoke/_scratch.ts
@@ -56,20 +56,6 @@ function physical(p: string): string {
   }
 }
 
-/** Scratches this process owns and will sweep at exit unless a caller explicitly claims one. */
-const owned = new Map<string, () => void>();
-
-/**
- * Take a scratch out of the exit sweep, because the caller has decided to KEEP it.
- *
- * The one legitimate reason: a mesh was started and not confirmed stopped, so the scratch's `.cotal`
- * holds the only pidfiles that can find it. Deleting those turns a recoverable orphan into an
- * anonymous one, which is worse than the leak.
- */
-export function preserveScratch(scratch: string): void {
-  owned.delete(scratch);
-}
-
 /** One `findCotalRoot`-shaped walk from `start` up to `/`. */
 function walkUp(start: string): string | null {
   let dir = start;
@@ -162,21 +148,6 @@ export function makeScratch(prefix = "cotal-smoke-"): string {
     process.env.TMPDIR = scratch;
     process.env.TMP = scratch;
     process.env.TEMP = scratch;
-    // OWNERSHIP FROM THE MOMENT IT EXISTS, not from the moment the suite reaches its `try`.
-    //
-    // Every caller does fallible work between this return and its own try/finally — minting dirs,
-    // picking ports, spawning children — and a throw in that window used to escape with the scratch
-    // on disk. Measured on a real entry point: forcing the second `mkdtempSync` to EIO left
-    // `cotal-smoke-*` behind, because the failure preceded the `try` by forty lines. Fixing that per
-    // suite is what produced this finding: the transaction was added to ONE file and the class
-    // declared closed while three more callers kept the same gap.
-    //
-    // Since the fixture anchors a `.cotal` inside the scratch, a leaked one is a capture hazard for
-    // whatever runs under that temp base next — the exact poison this helper exists to remove.
-    // `exit` handlers must be synchronous, which `rmSync` is.
-    const sweep = () => { try { rmSync(scratch, { recursive: true, force: true }); } catch { /* best effort at exit */ } };
-    owned.set(scratch, sweep);
-    process.once("exit", () => { if (owned.has(scratch)) sweep(); });
     return scratch;
   }
   throw new Error(

--- a/bin/smoke/_scratch.ts
+++ b/bin/smoke/_scratch.ts
@@ -129,9 +129,21 @@ export function makeScratch(prefix = "cotal-smoke-"): string {
  * working, and it is what makes `dir` the mesh root. Treating it as a capture would red every
  * correct run, which is what the first version of this function did.
  */
+/**
+ * The `.cotal` ABOVE `dir` that would capture it, or null when `dir` still roots itself.
+ *
+ * The predicate form of {@link assertScratchHeld}, for callers that must DECIDE rather than die —
+ * teardown above all. `cotal down` re-resolves its root from cwd, so running it under a captured
+ * root aims it at the ancestor's `.cotal` and it will signal pids the fixture never started. A
+ * cleanup step is exactly the wrong place to throw, and exactly the wrong place to guess.
+ */
+export function scratchCaptor(dir: string): string | null {
+  return cotalRootCaptor(dirname(physical(dir)));
+}
+
 export function assertScratchHeld(dir: string, what = "scratch"): void {
   const self = physical(dir);
-  const captor = cotalRootCaptor(dirname(self));
+  const captor = scratchCaptor(self);
   if (captor) {
     throw new Error(
       `${what} (${self}) is captured by ${join(captor, ".cotal")}: findCotalRoot resolves anything ` +

--- a/bin/smoke/_scratch.ts
+++ b/bin/smoke/_scratch.ts
@@ -50,6 +50,16 @@ export function cotalRootCaptor(start: string): string | null {
  * then `/var/tmp`. A captured base is SKIPPED, not used with a warning — using it is the defect.
  * If every candidate is captured this THROWS, naming each base and why: a suite that cannot be
  * hermetic must fail loudly at its first line, not run and grade.
+ *
+ * KNOWN LIMIT — base DEPTH, not ancestry. Because this repoints `TMPDIR`, anything that later opens
+ * a unix domain socket under it inherits the chosen path, and `sun_path` caps a socket path at 104
+ * bytes on macOS (108 on Linux). A deeply nested base therefore kills the child launcher rather
+ * than the suite: `tsx` dies `listen EINVAL … <base>/tsx-<uid>/<pid>.pipe` before the suite body
+ * runs at all. Measured: 129 bytes under a nested per-tool temp fails; the ordinary
+ * `/var/folders/<…>/T/cotal-*` (~87) and `/var/tmp/cotal-*` are fine, as is CI's `RUNNER_TEMP`.
+ * Selection is deliberately NOT sorted by length — `RUNNER_TEMP` is preferred because CI cleans it
+ * between jobs, and trading that for a shorter path would trade a real guarantee for a rare one.
+ * If you see `listen EINVAL` from a suite that uses this helper, it is path LENGTH, not capture.
  */
 export function makeScratch(prefix = "cotal-smoke-"): string {
   const bases = [process.env.RUNNER_TEMP, process.env.TMPDIR, tmpdir(), "/var/tmp"].filter(

--- a/bin/smoke/_scratch.ts
+++ b/bin/smoke/_scratch.ts
@@ -1,0 +1,148 @@
+/**
+ * A temp root that `findCotalRoot` cannot capture — the one sandbox a smoke cannot get from
+ * `COTAL_HOME`.
+ *
+ * `findCotalRoot` (`packages/workspace/src/auth-paths.ts`) walks to `/` with no boundary, exactly
+ * like git finding `.git`. So ANY `.cotal` in an ancestor of `os.tmpdir()` makes every scratch dir
+ * a suite mints resolve as that ancestor's project root, and `cotalPath()` writes the mesh's
+ * `.cotal/manager.pid`, `manager.log`, `nats/`, and auth material THERE instead of into the
+ * fixture. Sandboxing `COTAL_HOME` does not help: that is the machine home, a different root.
+ *
+ * The damage is not a wrong path, it is a silent disarm. A cell written as
+ * `if (existsSync(pidFile)) kill(...)` skips its own body, the fixture never arms, and the suite
+ * grades a healthy product against a state it failed to create. That is how a captured root
+ * surfaces: not as "file not found", but as a confident, wrong failure somewhere else.
+ *
+ * WHY THIS PASSES LOCALLY AND REDS IN CI. The exposure is not the same on both. On Linux (and so on
+ * CI) `os.tmpdir()` IS `/tmp`, so a `/tmp/.cotal` left behind by any ordinary `cotal` run captures
+ * EVERY suite that mints a fixture there. On macOS the default temp root is `/var/folders/<…>/T`,
+ * whose ancestry is clean, so a `/private/tmp/.cotal` on the same machine captures only suites that
+ * hardcode `/tmp` (or run under a TMPDIR someone pointed there). A suite can therefore be green on
+ * a developer's Mac and red on CI with the product working perfectly in both.
+ *
+ * Call `makeScratch()` FIRST, before importing anything that resolves a root, and tear the returned
+ * directory down in `finally`. Pair it with `assertScratchHeld()` after the fixture exists: the
+ * sandbox is what makes the suite pass, but the assertion is what keeps it honest if the sandbox
+ * ever stops working.
+ */
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+/** The nearest ancestor of `start` (inclusive) holding a `.cotal`, or null if the path is free.
+ *  Deliberately mirrors `findCotalRoot`'s walk — if that changes, this must change with it. */
+export function cotalRootCaptor(start: string): string | null {
+  let dir = resolve(start);
+  for (;;) {
+    if (existsSync(join(dir, ".cotal"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/**
+ * Make a scratch dir under a temp base with NO `.cotal` ancestor and point `TMPDIR`/`TMP`/`TEMP` at
+ * it, so every later `os.tmpdir()` (re-read per call on POSIX) and every child process inheriting
+ * `process.env` lands inside the sandbox.
+ *
+ * Bases are tried in order: the CI runner temp (never `/tmp` on GitHub Actions), the current temp,
+ * then `/var/tmp`. A captured base is SKIPPED, not used with a warning — using it is the defect.
+ * If every candidate is captured this THROWS, naming each base and why: a suite that cannot be
+ * hermetic must fail loudly at its first line, not run and grade.
+ */
+export function makeScratch(prefix = "cotal-smoke-"): string {
+  const bases = [process.env.RUNNER_TEMP, process.env.TMPDIR, tmpdir(), "/var/tmp"].filter(
+    (b): b is string => typeof b === "string" && b.length > 0,
+  );
+  const tried: string[] = [];
+  for (const base of bases) {
+    const captor = cotalRootCaptor(base);
+    if (captor) {
+      tried.push(`${base} (captured by ${join(captor, ".cotal")})`);
+      continue;
+    }
+    let scratch: string;
+    try {
+      scratch = mkdtempSync(join(base, prefix));
+    } catch (e) {
+      tried.push(`${base} (${(e as Error).message})`);
+      continue;
+    }
+    process.env.TMPDIR = scratch;
+    process.env.TMP = scratch;
+    process.env.TEMP = scratch;
+    return scratch;
+  }
+  throw new Error(
+    `no temp base free of a .cotal ancestor, so this suite cannot be hermetic; tried: ${tried.join("; ")}`,
+  );
+}
+
+/**
+ * Witness that nothing ABOVE `dir` captures it — i.e. that `findCotalRoot(dir)` is still `dir`.
+ * Call it AFTER the fixture is built, not only at setup: a `.cotal` can appear above the scratch
+ * mid-run (a concurrent `cotal` command, or the suite's own child rooting somewhere unexpected),
+ * and the failure that causes looks like a product defect.
+ *
+ * Ancestors ONLY. By this point `dir` normally has a `.cotal` of its own — that is `cotal up`
+ * working, and it is what makes `dir` the mesh root. Treating it as a capture would red every
+ * correct run, which is what the first version of this function did.
+ */
+export function assertScratchHeld(dir: string, what = "scratch"): void {
+  const self = resolve(dir);
+  const captor = cotalRootCaptor(dirname(self));
+  if (captor) {
+    throw new Error(
+      `${what} (${self}) is captured by ${join(captor, ".cotal")}: findCotalRoot resolves anything ` +
+        `under it to ${captor}, so this suite's fixture is not where it thinks it is. Remove that ` +
+        `.cotal or point TMPDIR somewhere with no .cotal above it.`,
+    );
+  }
+}
+
+/**
+ * SIGKILL the manager whose pid file sits under `root/.cotal`, and prove every step of it.
+ *
+ * The companion guard to the sandbox above, and the more important half. A suite that writes
+ * `if (existsSync(pidFile)) kill(...)` cannot tell "the manager is dead" from "I never found the
+ * manager": a captured root makes the file absent, the body is skipped, and the next assertion
+ * grades a still-LIVE manager's honest answer as a product defect. Every precondition here throws
+ * with the reason named, so the suite dies at the line that failed to arm rather than at a
+ * downstream cell that was never given the state it asserts on.
+ *
+ * Returns the killed pid. Only ever kills a pid this fixture's own `cotal up` wrote.
+ */
+export async function killManagerAtRoot(root: string): Promise<number> {
+  const pidFile = join(root, ".cotal", "manager.pid");
+  if (!existsSync(pidFile)) {
+    const captor = cotalRootCaptor(dirname(root));
+    throw new Error(
+      `no manager pid at ${pidFile}, so the manager was NOT killed and anything asserted after ` +
+        `this point grades a live mesh` +
+        (captor
+          ? `. The fixture root is captured by ${join(captor, ".cotal")} — cotal wrote its state ` +
+            `there instead. Build the fixture with makeScratch().`
+          : `. The mesh either never started or rooted somewhere unexpected.`),
+    );
+  }
+  const raw = readFileSync(pidFile, "utf8").trim();
+  const pid = Number(raw);
+  if (!Number.isInteger(pid) || pid <= 0) throw new Error(`unparseable manager pid ${JSON.stringify(raw)} at ${pidFile}`);
+  try {
+    process.kill(pid, 0);
+  } catch {
+    throw new Error(`manager pid ${pid} (${pidFile}) was already dead before the kill — the fixture never armed`);
+  }
+  process.kill(pid, "SIGKILL");
+  // Poll rather than sleep a guessed interval: the assertion is "it is gone", not "some time passed".
+  for (let i = 0; i < 100; i++) {
+    await new Promise((r) => setTimeout(r, 50));
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return pid;
+    }
+  }
+  throw new Error(`manager pid ${pid} survived SIGKILL after 5s`);
+}

--- a/bin/smoke/_scratch.ts
+++ b/bin/smoke/_scratch.ts
@@ -25,18 +25,34 @@
  * sandbox is what makes the suite pass, but the assertion is what keeps it honest if the sandbox
  * ever stops working.
  */
-import { existsSync, mkdtempSync, readFileSync, realpathSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { parsePid, probeLiveness } from "../../implementations/cli/src/lib/pid.js";
 
-/** The physical path, symlinks resolved. Falls back to the lexical form for a path that does not
- *  exist yet (a candidate base we are about to reject anyway). */
+/**
+ * The physical path, symlinks resolved.
+ *
+ * FAILS CLOSED. `ENOENT` is the one honest fallback: a candidate base that does not exist yet has no
+ * physical form, and its lexical form is all there is to check. Every other errno — `EACCES`, `EIO`,
+ * `ELOOP` — means we could not PROVE the physical ancestry, and answering with the lexical path
+ * there is a silent downgrade that reopens the exact symlink bypass this function exists to close.
+ * Measured: an injected `EIO` on an existing symlink whose physical parent held a `.cotal` made
+ * {@link cotalRootCaptor} return null, i.e. "clean", for a genuinely captured path.
+ *
+ * A guard that cannot establish its property must say so rather than substitute a weaker one it can.
+ */
 function physical(p: string): string {
   try {
     return realpathSync.native(p);
-  } catch {
-    return resolve(p);
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return resolve(p);
+    throw new Error(
+      `cannot canonicalize ${p} (${code ?? (e as Error).message}) — refusing to fall back to the lexical ` +
+        `path, which cannot see a physical .cotal ancestor`,
+      { cause: e },
+    );
   }
 }
 
@@ -94,19 +110,39 @@ export function makeScratch(prefix = "cotal-smoke-"): string {
   );
   const tried: string[] = [];
   for (const base of bases) {
-    const captor = cotalRootCaptor(base);
+    // A base whose ancestry cannot be PROVEN is unusable, not clean: `cotalRootCaptor` now throws
+    // rather than downgrading to a lexical answer, and "I could not check" must reject the
+    // candidate, never accept it.
+    let captor: string | null;
+    try {
+      captor = cotalRootCaptor(base);
+    } catch (e) {
+      tried.push(`${base} (ancestry unprovable: ${(e as Error).message})`);
+      continue;
+    }
     if (captor) {
       tried.push(`${base} (captured by ${join(captor, ".cotal")})`);
       continue;
     }
     let scratch: string;
+    // Made and canonicalized as two steps, so a canonicalization failure can REMOVE the directory it
+    // just created. Collapsing them leaks a scratch on every rejected base — and since the fixture
+    // anchors a `.cotal` inside it, a leaked scratch is a capture hazard rather than clutter.
+    let made: string;
+    try {
+      made = mkdtempSync(join(base, prefix));
+    } catch (e) {
+      tried.push(`${base} (${(e as Error).message})`);
+      continue;
+    }
     try {
       // Canonical, not lexical. A spawned child's `process.cwd()` is physical on POSIX, so handing
       // out a symlinked path guarantees the suite and the product disagree about where the fixture
       // is. Resolve it once, here, and every later comparison is against the same string.
-      scratch = realpathSync.native(mkdtempSync(join(base, prefix)));
+      scratch = realpathSync.native(made);
     } catch (e) {
-      tried.push(`${base} (${(e as Error).message})`);
+      rmSync(made, { recursive: true, force: true });
+      tried.push(`${base} (created but not canonicalizable, removed: ${(e as Error).message})`);
       continue;
     }
     process.env.TMPDIR = scratch;

--- a/bin/smoke/_scratch.ts
+++ b/bin/smoke/_scratch.ts
@@ -25,20 +25,47 @@
  * sandbox is what makes the suite pass, but the assertion is what keeps it honest if the sandbox
  * ever stops working.
  */
-import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { parsePid, probeLiveness } from "../../implementations/cli/src/lib/pid.js";
 
-/** The nearest ancestor of `start` (inclusive) holding a `.cotal`, or null if the path is free.
- *  Deliberately mirrors `findCotalRoot`'s walk — if that changes, this must change with it. */
-export function cotalRootCaptor(start: string): string | null {
-  let dir = resolve(start);
+/** The physical path, symlinks resolved. Falls back to the lexical form for a path that does not
+ *  exist yet (a candidate base we are about to reject anyway). */
+function physical(p: string): string {
+  try {
+    return realpathSync.native(p);
+  } catch {
+    return resolve(p);
+  }
+}
+
+/** One `findCotalRoot`-shaped walk from `start` up to `/`. */
+function walkUp(start: string): string | null {
+  let dir = start;
   for (;;) {
     if (existsSync(join(dir, ".cotal"))) return dir;
     const parent = dirname(dir);
     if (parent === dir) return null;
     dir = parent;
   }
+}
+
+/**
+ * The nearest ancestor of `start` (inclusive) holding a `.cotal`, or null if the path is free.
+ *
+ * Walks BOTH the lexical and the physical form, and reports a captor found by either. A symlinked
+ * base makes those two different sets of directories: `/var/tmp/alias` walks `/var/tmp` → `/var` →
+ * `/`, while its target walks the real chain, and a `.cotal` on the physical side is invisible to
+ * the lexical walk. That matters because we do not get to choose which walk the product does —
+ * `process.cwd()` is physical on POSIX, so a spawned `cotal` resolves its root physically, while a
+ * path handed to `--root` resolves lexically. Checking one and shipping is how a guard passes while
+ * the thing it guards is captured. Fail closed: either walk finding a `.cotal` is a capture.
+ */
+export function cotalRootCaptor(start: string): string | null {
+  const lex = resolve(start);
+  const phys = physical(start);
+  return walkUp(lex) ?? (phys === lex ? null : walkUp(phys));
 }
 
 /**
@@ -74,7 +101,10 @@ export function makeScratch(prefix = "cotal-smoke-"): string {
     }
     let scratch: string;
     try {
-      scratch = mkdtempSync(join(base, prefix));
+      // Canonical, not lexical. A spawned child's `process.cwd()` is physical on POSIX, so handing
+      // out a symlinked path guarantees the suite and the product disagree about where the fixture
+      // is. Resolve it once, here, and every later comparison is against the same string.
+      scratch = realpathSync.native(mkdtempSync(join(base, prefix)));
     } catch (e) {
       tried.push(`${base} (${(e as Error).message})`);
       continue;
@@ -100,7 +130,7 @@ export function makeScratch(prefix = "cotal-smoke-"): string {
  * correct run, which is what the first version of this function did.
  */
 export function assertScratchHeld(dir: string, what = "scratch"): void {
-  const self = resolve(dir);
+  const self = physical(dir);
   const captor = cotalRootCaptor(dirname(self));
   if (captor) {
     throw new Error(
@@ -137,22 +167,39 @@ export async function killManagerAtRoot(root: string): Promise<number> {
     );
   }
   const raw = readFileSync(pidFile, "utf8").trim();
-  const pid = Number(raw);
-  if (!Number.isInteger(pid) || pid <= 0) throw new Error(`unparseable manager pid ${JSON.stringify(raw)} at ${pidFile}`);
-  try {
-    process.kill(pid, 0);
-  } catch {
+  // The CLI's own parser and tri-state probe, imported rather than re-implemented. That module says
+  // it is "consumed everywhere", and a second copy here would be free to drift from the contract it
+  // is supposed to be enforcing.
+  const pid = parsePid(raw);
+  if (pid === undefined) throw new Error(`unparseable manager pid ${JSON.stringify(raw)} at ${pidFile}`);
+
+  // Only ESRCH proves death. A bare `catch` collapses EPERM (alive, just not ours to signal) and
+  // unknown errnos into "dead" — which would let this helper report a kill it never proved, the
+  // exact false-proof this guard exists to prevent.
+  const before = probeLiveness(pid);
+  if (before === "dead")
     throw new Error(`manager pid ${pid} (${pidFile}) was already dead before the kill — the fixture never armed`);
+  if (before === "unknown")
+    throw new Error(`manager pid ${pid} (${pidFile}) is UNATTRIBUTABLE before the kill — refusing to claim a kill this helper cannot prove`);
+
+  // The signal itself can fail (EPERM on a process that is not ours). Name that as what it is — a
+  // kill this helper could not perform — rather than letting a raw errno escape from a guard whose
+  // whole job is to say precisely why the fixture did not arm.
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch (e) {
+    throw new Error(
+      `SIGKILL of manager pid ${pid} (${pidFile}) failed: ${(e as NodeJS.ErrnoException).code ?? (e as Error).message}` +
+        ` — the mesh is still alive and nothing below this point is grading what it claims`,
+    );
   }
-  process.kill(pid, "SIGKILL");
   // Poll rather than sleep a guessed interval: the assertion is "it is gone", not "some time passed".
   for (let i = 0; i < 100; i++) {
     await new Promise((r) => setTimeout(r, 50));
-    try {
-      process.kill(pid, 0);
-    } catch {
-      return pid;
-    }
+    const after = probeLiveness(pid);
+    if (after === "dead") return pid;
+    if (after === "unknown")
+      throw new Error(`manager pid ${pid} became UNATTRIBUTABLE after SIGKILL — cannot prove the mesh is dead`);
   }
   throw new Error(`manager pid ${pid} survived SIGKILL after 5s`);
 }

--- a/bin/smoke/_scratch.ts
+++ b/bin/smoke/_scratch.ts
@@ -120,34 +120,38 @@ export function makeScratch(prefix = "cotal-smoke-"): string {
 }
 
 /**
- * Witness that nothing ABOVE `dir` captures it — i.e. that `findCotalRoot(dir)` is still `dir`.
- * Call it AFTER the fixture is built, not only at setup: a `.cotal` can appear above the scratch
- * mid-run (a concurrent `cotal` command, or the suite's own child rooting somewhere unexpected),
- * and the failure that causes looks like a product defect.
+ * The root `findCotalRoot` would actually pick for `dir` when that is NOT `dir` itself — a FOREIGN
+ * root capturing the fixture. Null when `dir` roots itself, or when nothing above it roots anything.
  *
- * Ancestors ONLY. By this point `dir` normally has a `.cotal` of its own — that is `cotal up`
- * working, and it is what makes `dir` the mesh root. Treating it as a capture would red every
- * correct run, which is what the first version of this function did.
- */
-/**
- * The `.cotal` ABOVE `dir` that would capture it, or null when `dir` still roots itself.
+ * NEAREST WINS, which is the whole subtlety. `findCotalRoot` walks up and stops at the FIRST
+ * `.cotal`, starting at `dir`. So once `cotal up` has created `root/.cotal`, an ancestor `.cotal`
+ * cannot capture the fixture any more — the fixture outranks it. A predicate that asks "is there
+ * any `.cotal` above me" answers yes and is WRONG after that point: it would call a healthy fixture
+ * captured, and a teardown gated on it would skip a legitimate `cotal down` and leak the mesh.
+ * Before `up`, with no `root/.cotal` yet, the two questions coincide — which is exactly why asking
+ * the wrong one looked correct.
  *
- * The predicate form of {@link assertScratchHeld}, for callers that must DECIDE rather than die —
- * teardown above all. `cotal down` re-resolves its root from cwd, so running it under a captured
- * root aims it at the ancestor's `.cotal` and it will signal pids the fixture never started. A
- * cleanup step is exactly the wrong place to throw, and exactly the wrong place to guess.
+ * The predicate form, for callers that must DECIDE rather than die — teardown above all: `cotal
+ * down` re-resolves from cwd, so under a genuinely foreign root it signals pids the fixture never
+ * started. A cleanup step is the wrong place to throw and the wrong place to guess.
  */
-export function scratchCaptor(dir: string): string | null {
-  return cotalRootCaptor(dirname(physical(dir)));
+export function foreignRootFor(dir: string): string | null {
+  const lex = resolve(dir);
+  const phys = physical(dir);
+  for (const start of phys === lex ? [lex] : [lex, phys]) {
+    const winner = walkUp(start);
+    if (winner !== null && winner !== start) return winner;
+  }
+  return null;
 }
 
 export function assertScratchHeld(dir: string, what = "scratch"): void {
   const self = physical(dir);
-  const captor = scratchCaptor(self);
-  if (captor) {
+  const foreign = foreignRootFor(self);
+  if (foreign) {
     throw new Error(
-      `${what} (${self}) is captured by ${join(captor, ".cotal")}: findCotalRoot resolves anything ` +
-        `under it to ${captor}, so this suite's fixture is not where it thinks it is. Remove that ` +
+      `${what} (${self}) resolves to ${foreign} via ${join(foreign, ".cotal")}: findCotalRoot picks ` +
+        `that root instead, so this suite's fixture is not where it thinks it is. Remove that ` +
         `.cotal or point TMPDIR somewhere with no .cotal above it.`,
     );
   }
@@ -168,7 +172,7 @@ export function assertScratchHeld(dir: string, what = "scratch"): void {
 export async function killManagerAtRoot(root: string): Promise<number> {
   const pidFile = join(root, ".cotal", "manager.pid");
   if (!existsSync(pidFile)) {
-    const captor = cotalRootCaptor(dirname(root));
+    const captor = foreignRootFor(root);
     throw new Error(
       `no manager pid at ${pidFile}, so the manager was NOT killed and anything asserted after ` +
         `this point grades a live mesh` +

--- a/implementations/auth/smoke/ps-operator-path.smoke.ts
+++ b/implementations/auth/smoke/ps-operator-path.smoke.ts
@@ -142,18 +142,22 @@ try {
   console.error("ps-operator-path threw:", e);
   process.exitCode = 1;
 } finally {
-  // Same guard as the user-mode sibling: `cotal down` re-resolves from cwd, so under a captured
-  // root it signals the ANCESTOR's processes — pids this fixture never started. A teardown that
-  // reaches outside its own fixture is worse than no teardown.
-  const teardownCaptor = foreignRootFor(root);
-  if (teardownCaptor === null) {
-    await cotal(["down"], 60_000).catch(() => ({ status: 1, out: "" }));
-  } else {
+  // Steps run INDEPENDENTLY: a throw anywhere in a finalizer aborts the rest, stranding a live
+  // broker and a scratch while the suite still prints its verdict — teardown failing OPEN.
+  const step = async (label: string, fn: () => unknown | Promise<unknown>): Promise<void> => {
+    try { await fn(); } catch (e) { console.error(`  ! teardown step "${label}" failed: ${(e as Error).message} — continuing`); }
+  };
+  // Same guard as the user-mode sibling: `cotal down` re-resolves from cwd, so under a FOREIGN root
+  // it signals that root's processes — pids this fixture never started. A teardown that reaches
+  // outside its own fixture is worse than no teardown.
+  await step("stop the mesh", async () => {
+    const foreign = foreignRootFor(root);
+    if (foreign === null) { await cotal(["down"], 60_000); return; }
     console.error(
-      `  ! SKIPPING \`cotal down\`: the fixture root is captured by ${join(teardownCaptor, ".cotal")}, so down would `
-        + `resolve THAT root and signal processes this suite did not start. Stop any mesh under the captor by hand.`,
+      `  ! SKIPPING \`cotal down\`: ${root} resolves to ${join(foreign, ".cotal")}, so down would target THAT root `
+        + `and signal processes this suite did not start. Stop any mesh under it by hand.`,
     );
-  }
-  rmSync(scratch, { recursive: true, force: true }); // home and root both live under it
+  });
+  await step("remove the scratch", () => rmSync(scratch, { recursive: true, force: true })); // home and root live under it
 }
 if (fail) process.exitCode = 1;

--- a/implementations/auth/smoke/ps-operator-path.smoke.ts
+++ b/implementations/auth/smoke/ps-operator-path.smoke.ts
@@ -18,7 +18,7 @@
  * Mutation-proved: delete that grant row and this suite goes red.
  */
 import { spawn } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { pickFreePort } from "./_free-port.js";
 import { assertScratchHeld, foreignRootFor, killManagerAtRoot, makeScratch } from "../../../bin/smoke/_scratch.js";
@@ -31,14 +31,21 @@ const scratch = makeScratch("cotal-psstatic-");
 const home = mkdtempSync(join(scratch, "home-"));
 process.env.COTAL_HOME = home;
 const root = mkdtempSync(join(scratch, "root-"));
+// ANCHOR THE ROOT BEFORE ANY PRODUCT COMMAND RUNS. `findCotalRoot` stops at the first `.cotal`
+// starting from the directory itself, so owning one here makes every later resolution from this
+// root land on this root - during `up`, during `ps`, and during `down` - no matter what appears
+// above it in between. Ownership then does not depend on the timing of any check, which is the
+// only way to close a race against a child that re-resolves cwd for itself.
+mkdirSync(join(root, ".cotal"), { recursive: true });
 const PORT = await pickFreePort();
 const SERVER = `nats://127.0.0.1:${PORT}`;
 const SPACE = `psstatic-${Math.floor(Math.random() * 1e6)}`;
 const BIN = join(import.meta.dirname, "..", "..", "..", "bin", "cotal.ts");
 
-// Did a mesh ever start? Decides whether an unstopped fixture is an orphan worth preserving
-// evidence for, or simply nothing.
-let meshStarted = false;
+// Was `cotal up` ever INVOKED? Not "did it succeed" — a failed, timed-out or signalled `up` can still
+// have launched detached processes, and those are exactly the ones whose pidfiles must survive.
+// Attribution evidence is earned by the attempt, not by the outcome.
+let upAttempted = false;
 
 let pass = 0, fail = 0;
 const check = (n: string, v: boolean, x?: unknown) => { v ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ FAIL: ${n}`, x ?? "")); };
@@ -92,17 +99,23 @@ function mustHaveRun(r: Run, what: string): void {
 
 try {
   console.log("1) up (STATIC auth — no --user-auth, no IdP, no device login)");
-  // Checked before `up`, because a captured root does not make `up` fail — it makes every later cell
-  // grade a mesh that is not this fixture's.
+  // DIRECT EXISTENCE, not a consequence of it. `foreignRootFor(root) === null` is ALSO true with no
+  // anchor at all under the clean ancestry makeScratch builds, so it cannot tell "anchored" from
+  // "nothing here" on an ordinary run - it would have let CI delete the load-bearing anchor and stay
+  // green. Assert the thing itself; keep the resolution cell beside it as the consequence.
+  check("the fixture root OWNS its .cotal (the anchor exists)", existsSync(join(root, ".cotal")), root);
   const captor = foreignRootFor(root);
-  check("fixture root has no .cotal ancestor (else nothing below can arm)", captor === null, captor);
-  if (captor) { process.exitCode = 1; throw new Error(`FIXTURE FAILURE, not a product defect: the temp root is captured by ${captor}.`); }
+  check("...and therefore outranks any ancestor", captor === null, captor);
+  if (captor) { process.exitCode = 1; throw new Error(`FIXTURE FAILURE, not a product defect: anchor missing, ${root} resolves to ${captor}.`); }
+  upAttempted = true;
   const up = await cotal(["up", "--detach", "--server", SERVER, "--space", SPACE]);
+  // Attribute HOW `up` ended before reading its status: a signalled or timed-out `up` reports
+  // `status: null`, which reads only as "non-zero" and loses why.
+  mustHaveRun(up, "`cotal up`");
   check("`cotal up` exits 0 — checked FIRST so a fixture failure is distinguishable from a product one", up.status === 0, up.out.slice(-700));
   // Also a throw, not an exit: a PARTIALLY started mesh is the case most in need of the teardown
   // that `finally` performs, and `process.exit` here would strand exactly that.
   if (up.status !== 0) { process.exitCode = 1; throw new Error("FIXTURE FAILURE, not a product defect: no mesh came up, so `ps` was never exercised."); }
-  meshStarted = true;
 
   console.log("\n2) cotal ps --space, under the STATIC credential");
   const ps = await cotal(["ps", "--space", SPACE], 20_000);
@@ -164,11 +177,19 @@ try {
   // outside its own fixture is worse than no teardown.
   let meshStopped = false;
   await step("stop the mesh", async () => {
-    const foreign = foreignRootFor(root);
-    if (foreign !== null) {
+    // AN ANCHOR, NOT A GATE — see the user-mode sibling for the full reasoning. `cotal down` is a
+    // child that re-resolves its root from cwd, so a pre-spawn check cannot bind its answer; that
+    // race was measured killing a foreign process. Only `root/.cotal` existing makes the child's
+    // resolution knowable in advance, because nearest-wins means nothing appearing above can outrank
+    // it afterwards.
+    if (!existsSync(join(root, ".cotal"))) {
+      const foreign = foreignRootFor(root);
       throw new Error(
-        `refusing \`cotal down\`: ${root} resolves to ${join(foreign, ".cotal")}, so down would target THAT root `
-          + `and signal processes this suite did not start. Stop any mesh under it by hand.`,
+        `refusing \`cotal down\`: ${root} does not own a .cotal, so the child would resolve to whatever root `
+          + `wins from its cwd and could signal processes this suite never started`
+          + (upAttempted
+            ? `. A mesh may have started under ${foreign ? join(foreign, ".cotal") : "another root"} — stop it by hand.`
+            : `. Nothing was started.`),
       );
     }
     const down = await cotal(["down"], 60_000);
@@ -181,7 +202,7 @@ try {
   await step("remove the scratch", () => {
     // The scratch's `.cotal` holds the pidfiles that are the only way to find a mesh this suite
     // failed to stop. Deleting them turns a recoverable orphan into an anonymous one.
-    if (meshStarted && !meshStopped) {
+    if (upAttempted && !meshStopped) {
       process.exitCode = 1;
       console.error(
         `  ! PRESERVING ${scratch}: the mesh was not confirmed stopped, and its .cotal holds the pidfiles `

--- a/implementations/auth/smoke/ps-operator-path.smoke.ts
+++ b/implementations/auth/smoke/ps-operator-path.smoke.ts
@@ -78,8 +78,12 @@ function mustHaveRun(r: Run, what: string): void {
     : r.status === null ? "ended with neither an exit code nor a signal"
     : null;
   if (why === null) return;
-  console.log(`\n  => FIXTURE FAILURE, not a product defect: ${what} ${why}, which fakes the pass shape.\n`);
-  process.exit(1);
+  // THROW, never `process.exit`. `finally` does not run after `process.exit`, and this suite's
+  // `finally` is what stops the detached mesh and removes the temp root. A fail-loud path that
+  // leaks a live broker and a poisoned scratch is not fail-loud, it is fail-loud-and-dirty — and
+  // the leaked `.cotal` is the exact hazard the rest of this file exists to prevent.
+  process.exitCode = 1;
+  throw new Error(`FIXTURE FAILURE, not a product defect: ${what} ${why}, which fakes the pass shape.`);
 }
 
 try {
@@ -88,10 +92,12 @@ try {
   // grade a mesh that is not this fixture's.
   const captor = cotalRootCaptor(root);
   check("fixture root has no .cotal ancestor (else nothing below can arm)", captor === null, captor);
-  if (captor) { console.log("\n  => FIXTURE FAILURE, not a product defect: the temp root is captured.\n"); process.exit(1); }
+  if (captor) { process.exitCode = 1; throw new Error(`FIXTURE FAILURE, not a product defect: the temp root is captured by ${captor}.`); }
   const up = await cotal(["up", "--detach", "--server", SERVER, "--space", SPACE]);
   check("`cotal up` exits 0 — checked FIRST so a fixture failure is distinguishable from a product one", up.status === 0, up.out.slice(-700));
-  if (up.status !== 0) { console.log("\n  => FIXTURE FAILURE, not a product defect: no mesh came up, so `ps` was never exercised.\n"); process.exit(1); }
+  // Also a throw, not an exit: a PARTIALLY started mesh is the case most in need of the teardown
+  // that `finally` performs, and `process.exit` here would strand exactly that.
+  if (up.status !== 0) { process.exitCode = 1; throw new Error("FIXTURE FAILURE, not a product defect: no mesh came up, so `ps` was never exercised."); }
 
   console.log("\n2) cotal ps --space, under the STATIC credential");
   const ps = await cotal(["ps", "--space", SPACE], 20_000);

--- a/implementations/auth/smoke/ps-operator-path.smoke.ts
+++ b/implementations/auth/smoke/ps-operator-path.smoke.ts
@@ -21,7 +21,7 @@ import { spawn } from "node:child_process";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { pickFreePort } from "./_free-port.js";
-import { assertScratchHeld, cotalRootCaptor, killManagerAtRoot, makeScratch, scratchCaptor } from "../../../bin/smoke/_scratch.js";
+import { assertScratchHeld, foreignRootFor, killManagerAtRoot, makeScratch } from "../../../bin/smoke/_scratch.js";
 
 // Same temp-root sandbox as the user-mode sibling, and for the same reason: `findCotalRoot` walks to
 // `/` unbounded, so a `.cotal` above `tmpdir()` sends this fixture's `manager.pid` into that
@@ -90,7 +90,7 @@ try {
   console.log("1) up (STATIC auth — no --user-auth, no IdP, no device login)");
   // Checked before `up`, because a captured root does not make `up` fail — it makes every later cell
   // grade a mesh that is not this fixture's.
-  const captor = cotalRootCaptor(root);
+  const captor = foreignRootFor(root);
   check("fixture root has no .cotal ancestor (else nothing below can arm)", captor === null, captor);
   if (captor) { process.exitCode = 1; throw new Error(`FIXTURE FAILURE, not a product defect: the temp root is captured by ${captor}.`); }
   const up = await cotal(["up", "--detach", "--server", SERVER, "--space", SPACE]);
@@ -145,7 +145,7 @@ try {
   // Same guard as the user-mode sibling: `cotal down` re-resolves from cwd, so under a captured
   // root it signals the ANCESTOR's processes — pids this fixture never started. A teardown that
   // reaches outside its own fixture is worse than no teardown.
-  const teardownCaptor = scratchCaptor(root);
+  const teardownCaptor = foreignRootFor(root);
   if (teardownCaptor === null) {
     await cotal(["down"], 60_000).catch(() => ({ status: 1, out: "" }));
   } else {

--- a/implementations/auth/smoke/ps-operator-path.smoke.ts
+++ b/implementations/auth/smoke/ps-operator-path.smoke.ts
@@ -56,12 +56,19 @@ const check = (n: string, v: boolean, x?: unknown) => { v ? (pass++, console.log
  * all. Each of those produces the shape step 3's `claimsEmptySuccess` treats as a pass, so a run
  * that proved nothing prints green. A `timedOut` flag alone only knows about OUR timer.
  */
+// How long to keep draining inherited stdio after the direct child exits. Long enough for the tail
+// a detached component flushes (measured ~450ms), short enough that a long-lived one cannot hang
+// the suite. Exceeding it is reported, never absorbed.
+const DRAIN_MS = 2_000;
+
 type Run = {
   status: number | null;
   out: string;
   timedOut: boolean;
   signal: NodeJS.Signals | null;
   launchError?: string;
+  /** Descendants held the inherited pipes past the drain bound: `out` is a PREFIX, not the whole. */
+  stdioTimedOut?: boolean;
 };
 function cotal(args: string[], timeoutMs = 120_000): Promise<Run> {
   return new Promise((res) => {
@@ -69,18 +76,31 @@ function cotal(args: string[], timeoutMs = 120_000): Promise<Run> {
     let out = "";
     let timedOut = false;
     let settled = false;
-    const t = setTimeout(() => { timedOut = true; child.kill("SIGKILL"); }, timeoutMs);
-    // One settle path, so a launch error is not left to the timer and then mislabelled a timeout.
-    const done = (r: Run) => { if (settled) return; settled = true; clearTimeout(t); res(r); };
+    let exited = false;
+    let status: number | null = null;
+    let signal: NodeJS.Signals | null = null;
+    let drain: NodeJS.Timeout | undefined;
+    const done = (r: Run) => { if (settled) return; settled = true; clearTimeout(cmd); clearTimeout(drain); res(r); };
+    // Descendants still hold our pipe ends. Stop waiting, drop them, and SAY the output is partial
+    // rather than grading a prefix silently.
+    const giveUpOnStdio = () => { child.stdout?.destroy(); child.stderr?.destroy(); done({ status, out, timedOut, signal, stdioTimedOut: true }); };
+    const cmd = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+      // A kill cannot close pipes an already-exited child handed to a detached descendant, so the
+      // command timeout has to be able to settle by itself or the wrapper hangs forever.
+      if (exited) giveUpOnStdio(); else drain = setTimeout(giveUpOnStdio, DRAIN_MS);
+    }, timeoutMs);
     child.on("error", (e) => done({ status: null, out, timedOut, signal: null, launchError: e.message }));
     child.stdout!.on("data", (d: Buffer) => { out += d.toString(); });
     child.stderr!.on("data", (d: Buffer) => { out += d.toString(); });
-    // `close`, NOT `exit`. `exit` fires when the direct child dies, but the stdio pipes it handed to
-    // DETACHED descendants stay open and keep writing — and `cotal` spawns detached components
-    // routinely. Settling on `exit` grades a prefix as the whole: measured, `exit` gave `out: ""` at
-    // 26ms where `close` gave `out: "STREAM.INFO"` at 550ms on the same run. The cells below that
-    // read output content, including the empty-success check, would be judging absent text.
-    child.on("close", (status, signal) => done({ status, out, timedOut, signal }));
+    // TWO PHASE. `exit` gives the direct child's outcome; `close` gives the complete output, because
+    // pipes handed to DETACHED descendants keep carrying text after the child dies (measured:
+    // `out: ""` at exit 26ms, `out: "STREAM.INFO"` at close 453ms). But waiting only for `close`
+    // hangs whenever a long-lived detached component holds the pipe — which `cotal` creates on
+    // purpose. So: record the outcome at `exit`, keep draining, and bound that drain.
+    child.on("exit", (s, sg) => { exited = true; status = s; signal = sg; drain = setTimeout(giveUpOnStdio, DRAIN_MS); });
+    child.on("close", (s, sg) => done({ status: s ?? status, out, timedOut, signal: sg ?? signal }));
   });
 }
 
@@ -91,6 +111,7 @@ function mustHaveRun(r: Run, what: string): void {
     r.launchError ? `never launched (${r.launchError})`
     : r.timedOut ? "was SIGKILLed by this suite's timeout"
     : r.signal ? `was killed by ${r.signal} from outside this suite`
+    : r.stdioTimedOut ? "left its output incomplete (detached descendants held the pipes past the drain bound)"
     : r.status === null ? "ended with neither an exit code nor a signal"
     : null;
   if (why === null) return;

--- a/implementations/auth/smoke/ps-operator-path.smoke.ts
+++ b/implementations/auth/smoke/ps-operator-path.smoke.ts
@@ -21,24 +21,29 @@ import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { pickFreePort } from "./_free-port.js";
-import { assertScratchHeld, foreignRootFor, killManagerAtRoot, makeScratch, preserveScratch } from "../../../bin/smoke/_scratch.js";
+import { assertScratchHeld, foreignRootFor, killManagerAtRoot, makeScratch } from "../../../bin/smoke/_scratch.js";
 
 // Same temp-root sandbox as the user-mode sibling, and for the same reason: `findCotalRoot` walks to
 // `/` unbounded, so a `.cotal` above `tmpdir()` sends this fixture's `manager.pid` into that
 // ancestor and step 3's kill silently does nothing. This suite is gated — a red here is read as the
 // shipped operator path being broken — so it must never be able to red for a fixture reason.
 const scratch = makeScratch("cotal-psstatic-");
-const home = mkdtempSync(join(scratch, "home-"));
-process.env.COTAL_HOME = home;
-const root = mkdtempSync(join(scratch, "root-"));
-// ANCHOR THE ROOT BEFORE ANY PRODUCT COMMAND RUNS. `findCotalRoot` stops at the first `.cotal`
-// starting from the directory itself, so owning one here makes every later resolution from this
-// root land on this root - during `up`, during `ps`, and during `down` - no matter what appears
-// above it in between. Ownership then does not depend on the timing of any check, which is the
-// only way to close a race against a child that re-resolves cwd for itself.
-mkdirSync(join(root, ".cotal"), { recursive: true });
-const PORT = await pickFreePort();
-const SERVER = `nats://127.0.0.1:${PORT}`;
+// SETUP TRANSACTION: every line from here to the main body can throw, and a throw used to exit
+// with the scratch — including its anchored `.cotal` — still on disk.
+const cleanScratch = (e: unknown): never => {
+  rmSync(scratch, { recursive: true, force: true });
+  throw new Error(`fixture setup failed (scratch removed): ${(e as Error).message}`, { cause: e });
+};
+let home!: string, root!: string, SERVER!: string;
+try {
+  home = mkdtempSync(join(scratch, "home-"));
+  process.env.COTAL_HOME = home;
+  root = mkdtempSync(join(scratch, "root-"));
+  // ANCHOR THE ROOT BEFORE ANY PRODUCT COMMAND RUNS: `findCotalRoot` stops at the first `.cotal`
+  // from the directory itself, so owning one here pins every later resolution to this root.
+  mkdirSync(join(root, ".cotal"), { recursive: true });
+  SERVER = `nats://127.0.0.1:${await pickFreePort()}`;
+} catch (e) { cleanScratch(e); }
 const SPACE = `psstatic-${Math.floor(Math.random() * 1e6)}`;
 const BIN = join(import.meta.dirname, "..", "..", "..", "bin", "cotal.ts");
 
@@ -240,8 +245,6 @@ try {
     // failed to stop. Deleting them turns a recoverable orphan into an anonymous one.
     if (upAttempted && !meshStopped) {
       process.exitCode = 1;
-      // Claim it out of the exit sweep: the evidence is the whole point of keeping it.
-      preserveScratch(scratch);
       console.error(
         `  ! PRESERVING ${scratch}: the mesh was not confirmed stopped, and its .cotal holds the pidfiles `
           + `needed to find and stop whatever is still running.`,

--- a/implementations/auth/smoke/ps-operator-path.smoke.ts
+++ b/implementations/auth/smoke/ps-operator-path.smoke.ts
@@ -21,7 +21,7 @@ import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { pickFreePort } from "./_free-port.js";
-import { assertScratchHeld, foreignRootFor, killManagerAtRoot, makeScratch } from "../../../bin/smoke/_scratch.js";
+import { assertScratchHeld, foreignRootFor, killManagerAtRoot, makeScratch, preserveScratch } from "../../../bin/smoke/_scratch.js";
 
 // Same temp-root sandbox as the user-mode sibling, and for the same reason: `findCotalRoot` walks to
 // `/` unbounded, so a `.cotal` above `tmpdir()` sends this fixture's `manager.pid` into that
@@ -240,6 +240,8 @@ try {
     // failed to stop. Deleting them turns a recoverable orphan into an anonymous one.
     if (upAttempted && !meshStopped) {
       process.exitCode = 1;
+      // Claim it out of the exit sweep: the evidence is the whole point of keeping it.
+      preserveScratch(scratch);
       console.error(
         `  ! PRESERVING ${scratch}: the mesh was not confirmed stopped, and its .cotal holds the pidfiles `
           + `needed to find and stop whatever is still running.`,

--- a/implementations/auth/smoke/ps-operator-path.smoke.ts
+++ b/implementations/auth/smoke/ps-operator-path.smoke.ts
@@ -104,6 +104,13 @@ try {
   // "nothing here" on an ordinary run - it would have let CI delete the load-bearing anchor and stay
   // green. Assert the thing itself; keep the resolution cell beside it as the consequence.
   check("the fixture root OWNS its .cotal (the anchor exists)", existsSync(join(root, ".cotal")), root);
+  // FATAL HERE, before any product command. A failed `check` alone only increments the tally and
+  // lets `up` run UNANCHORED — the precise state whose race this anchor exists to remove. The suite
+  // would still exit red, but only after starting a mesh that could root anywhere.
+  if (!existsSync(join(root, ".cotal"))) {
+    process.exitCode = 1;
+    throw new Error(`FIXTURE FAILURE: the anchor ${join(root, ".cotal")} is missing, so no product command below can be trusted to root here.`);
+  }
   const captor = foreignRootFor(root);
   check("...and therefore outranks any ancestor", captor === null, captor);
   if (captor) { process.exitCode = 1; throw new Error(`FIXTURE FAILURE, not a product defect: anchor missing, ${root} resolves to ${captor}.`); }

--- a/implementations/auth/smoke/ps-operator-path.smoke.ts
+++ b/implementations/auth/smoke/ps-operator-path.smoke.ts
@@ -36,6 +36,10 @@ const SERVER = `nats://127.0.0.1:${PORT}`;
 const SPACE = `psstatic-${Math.floor(Math.random() * 1e6)}`;
 const BIN = join(import.meta.dirname, "..", "..", "..", "bin", "cotal.ts");
 
+// Did a mesh ever start? Decides whether an unstopped fixture is an orphan worth preserving
+// evidence for, or simply nothing.
+let meshStarted = false;
+
 let pass = 0, fail = 0;
 const check = (n: string, v: boolean, x?: unknown) => { v ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ FAIL: ${n}`, x ?? "")); };
 
@@ -98,6 +102,7 @@ try {
   // Also a throw, not an exit: a PARTIALLY started mesh is the case most in need of the teardown
   // that `finally` performs, and `process.exit` here would strand exactly that.
   if (up.status !== 0) { process.exitCode = 1; throw new Error("FIXTURE FAILURE, not a product defect: no mesh came up, so `ps` was never exercised."); }
+  meshStarted = true;
 
   console.log("\n2) cotal ps --space, under the STATIC credential");
   const ps = await cotal(["ps", "--space", SPACE], 20_000);
@@ -144,20 +149,47 @@ try {
 } finally {
   // Steps run INDEPENDENTLY: a throw anywhere in a finalizer aborts the rest, stranding a live
   // broker and a scratch while the suite still prints its verdict — teardown failing OPEN.
+  // A failing step is RED, not a log line: cleanup that declines and still exits 0 is the same
+  // false-green class as the rest of this branch, moved to the end of the run.
   const step = async (label: string, fn: () => unknown | Promise<unknown>): Promise<void> => {
-    try { await fn(); } catch (e) { console.error(`  ! teardown step "${label}" failed: ${(e as Error).message} — continuing`); }
+    try {
+      await fn();
+    } catch (e) {
+      process.exitCode = 1;
+      console.error(`  ! teardown step "${label}" FAILED: ${(e as Error).message}`);
+    }
   };
   // Same guard as the user-mode sibling: `cotal down` re-resolves from cwd, so under a FOREIGN root
   // it signals that root's processes — pids this fixture never started. A teardown that reaches
   // outside its own fixture is worse than no teardown.
+  let meshStopped = false;
   await step("stop the mesh", async () => {
     const foreign = foreignRootFor(root);
-    if (foreign === null) { await cotal(["down"], 60_000); return; }
-    console.error(
-      `  ! SKIPPING \`cotal down\`: ${root} resolves to ${join(foreign, ".cotal")}, so down would target THAT root `
-        + `and signal processes this suite did not start. Stop any mesh under it by hand.`,
-    );
+    if (foreign !== null) {
+      throw new Error(
+        `refusing \`cotal down\`: ${root} resolves to ${join(foreign, ".cotal")}, so down would target THAT root `
+          + `and signal processes this suite did not start. Stop any mesh under it by hand.`,
+      );
+    }
+    const down = await cotal(["down"], 60_000);
+    // `cotal()` resolves for a timeout, a signal death and a launch failure alike, so an unchecked
+    // `await` would read every one of those as a successful stop.
+    mustHaveRun(down, "`cotal down`");
+    if (down.status !== 0) throw new Error(`\`cotal down\` exited ${down.status}: ${down.out.slice(-300)}`);
+    meshStopped = true;
   });
-  await step("remove the scratch", () => rmSync(scratch, { recursive: true, force: true })); // home and root live under it
+  await step("remove the scratch", () => {
+    // The scratch's `.cotal` holds the pidfiles that are the only way to find a mesh this suite
+    // failed to stop. Deleting them turns a recoverable orphan into an anonymous one.
+    if (meshStarted && !meshStopped) {
+      process.exitCode = 1;
+      console.error(
+        `  ! PRESERVING ${scratch}: the mesh was not confirmed stopped, and its .cotal holds the pidfiles `
+          + `needed to find and stop whatever is still running.`,
+      );
+      return;
+    }
+    rmSync(scratch, { recursive: true, force: true }); // home and root live under it
+  });
 }
 if (fail) process.exitCode = 1;

--- a/implementations/auth/smoke/ps-operator-path.smoke.ts
+++ b/implementations/auth/smoke/ps-operator-path.smoke.ts
@@ -19,13 +19,18 @@
  */
 import { spawn } from "node:child_process";
 import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pickFreePort } from "./_free-port.js";
+import { assertScratchHeld, cotalRootCaptor, killManagerAtRoot, makeScratch } from "../../../bin/smoke/_scratch.js";
 
-const home = mkdtempSync(join(tmpdir(), "cotal-psstatic-home-"));
+// Same temp-root sandbox as the user-mode sibling, and for the same reason: `findCotalRoot` walks to
+// `/` unbounded, so a `.cotal` above `tmpdir()` sends this fixture's `manager.pid` into that
+// ancestor and step 3's kill silently does nothing. This suite is gated — a red here is read as the
+// shipped operator path being broken — so it must never be able to red for a fixture reason.
+const scratch = makeScratch("cotal-psstatic-");
+const home = mkdtempSync(join(scratch, "home-"));
 process.env.COTAL_HOME = home;
-const root = mkdtempSync(join(tmpdir(), "cotal-psstatic-root-"));
+const root = mkdtempSync(join(scratch, "root-"));
 const PORT = await pickFreePort();
 const SERVER = `nats://127.0.0.1:${PORT}`;
 const SPACE = `psstatic-${Math.floor(Math.random() * 1e6)}`;
@@ -47,6 +52,11 @@ function cotal(args: string[], timeoutMs = 120_000): Promise<{ status: number | 
 
 try {
   console.log("1) up (STATIC auth — no --user-auth, no IdP, no device login)");
+  // Checked before `up`, because a captured root does not make `up` fail — it makes every later cell
+  // grade a mesh that is not this fixture's.
+  const captor = cotalRootCaptor(root);
+  check("fixture root has no .cotal ancestor (else nothing below can arm)", captor === null, captor);
+  if (captor) { console.log("\n  => FIXTURE FAILURE, not a product defect: the temp root is captured.\n"); process.exit(1); }
   const up = await cotal(["up", "--detach", "--server", SERVER, "--space", SPACE]);
   check("`cotal up` exits 0 — checked FIRST so a fixture failure is distinguishable from a product one", up.status === 0, up.out.slice(-700));
   if (up.status !== 0) { console.log("\n  => FIXTURE FAILURE, not a product defect: no mesh came up, so `ps` was never exercised.\n"); process.exit(1); }
@@ -68,12 +78,11 @@ try {
   // Completeness honesty: with the manager dead, ps must not print a bare empty list that reads
   // as "no agents". Scatter labels the instance unreachable; a total failure exits non-zero.
   console.log("\n3) manager stopped — ps must not claim a completeness it lacks");
-  const { readFileSync, existsSync } = await import("node:fs");
-  const pidFile = join(root, ".cotal", "manager.pid");
-  if (existsSync(pidFile)) {
-    try { process.kill(Number(readFileSync(pidFile, "utf8").trim()), "SIGKILL"); } catch { /* already gone */ }
-    await new Promise((r) => setTimeout(r, 500));
-  }
+  assertScratchHeld(root, "fixture root");
+  // Fatal, not conditional: a skipped kill leaves the manager ALIVE, and a live manager's honest
+  // "(no managed agents)" trips `claimsEmptySuccess` below — a fixture failure wearing the costume
+  // of the product defect this suite exists to catch.
+  console.log(`   killed manager pid ${await killManagerAtRoot(root)} — the cell below grades a DEAD mesh`);
   const psDead = await cotal(["ps", "--space", SPACE], 20_000);
   console.log(`   dead-manager ps exit=${psDead.status}`);
   console.log(psDead.out.split("\n").map((l) => `   | ${l}`).join("\n").slice(0, 500));
@@ -93,7 +102,6 @@ try {
   process.exitCode = 1;
 } finally {
   await cotal(["down"], 60_000).catch(() => ({ status: 1, out: "" }));
-  rmSync(home, { recursive: true, force: true });
-  rmSync(root, { recursive: true, force: true });
+  rmSync(scratch, { recursive: true, force: true }); // home and root both live under it
 }
 if (fail) process.exitCode = 1;

--- a/implementations/auth/smoke/ps-operator-path.smoke.ts
+++ b/implementations/auth/smoke/ps-operator-path.smoke.ts
@@ -39,15 +39,47 @@ const BIN = join(import.meta.dirname, "..", "..", "..", "bin", "cotal.ts");
 let pass = 0, fail = 0;
 const check = (n: string, v: boolean, x?: unknown) => { v ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ FAIL: ${n}`, x ?? "")); };
 
-function cotal(args: string[], timeoutMs = 120_000): Promise<{ status: number | null; out: string }> {
+/**
+ * How the child ENDED rides in the result. `status: null` covers ANY signal death — this suite's
+ * timeout, an external SIGTERM/SIGKILL, an OOM kill — and a launch failure never fires `exit` at
+ * all. Each of those produces the shape step 3's `claimsEmptySuccess` treats as a pass, so a run
+ * that proved nothing prints green. A `timedOut` flag alone only knows about OUR timer.
+ */
+type Run = {
+  status: number | null;
+  out: string;
+  timedOut: boolean;
+  signal: NodeJS.Signals | null;
+  launchError?: string;
+};
+function cotal(args: string[], timeoutMs = 120_000): Promise<Run> {
   return new Promise((res) => {
     const child = spawn("npx", ["tsx", BIN, ...args], { cwd: root, env: { ...process.env, COTAL_HOME: home }, stdio: ["ignore", "pipe", "pipe"] });
     let out = "";
-    const t = setTimeout(() => child.kill("SIGKILL"), timeoutMs);
+    let timedOut = false;
+    let settled = false;
+    const t = setTimeout(() => { timedOut = true; child.kill("SIGKILL"); }, timeoutMs);
+    // One settle path, so a launch error is not left to the timer and then mislabelled a timeout.
+    const done = (r: Run) => { if (settled) return; settled = true; clearTimeout(t); res(r); };
+    child.on("error", (e) => done({ status: null, out, timedOut, signal: null, launchError: e.message }));
     child.stdout!.on("data", (d: Buffer) => { out += d.toString(); });
     child.stderr!.on("data", (d: Buffer) => { out += d.toString(); });
-    child.on("exit", (status) => { clearTimeout(t); res({ status, out }); });
+    child.on("exit", (status, signal) => done({ status, out, timedOut, signal }));
   });
+}
+
+/** Refuse to grade anything but a self-terminated child with a real exit code: every shape rejected
+ *  here would otherwise SATISFY the cells below. */
+function mustHaveRun(r: Run, what: string): void {
+  const why =
+    r.launchError ? `never launched (${r.launchError})`
+    : r.timedOut ? "was SIGKILLed by this suite's timeout"
+    : r.signal ? `was killed by ${r.signal} from outside this suite`
+    : r.status === null ? "ended with neither an exit code nor a signal"
+    : null;
+  if (why === null) return;
+  console.log(`\n  => FIXTURE FAILURE, not a product defect: ${what} ${why}, which fakes the pass shape.\n`);
+  process.exit(1);
 }
 
 try {
@@ -84,6 +116,9 @@ try {
   // of the product defect this suite exists to catch.
   console.log(`   killed manager pid ${await killManagerAtRoot(root)} — the cell below grades a DEAD mesh`);
   const psDead = await cotal(["ps", "--space", SPACE], 20_000);
+  // Fatal before grading: any of the null-status routes would satisfy `claimsEmptySuccess === false`
+  // on evidence this suite fabricated rather than observed.
+  mustHaveRun(psDead, "the dead-manager `cotal ps`");
   console.log(`   dead-manager ps exit=${psDead.status}`);
   console.log(psDead.out.split("\n").map((l) => `   | ${l}`).join("\n").slice(0, 500));
   const claimsEmptySuccess =

--- a/implementations/auth/smoke/ps-operator-path.smoke.ts
+++ b/implementations/auth/smoke/ps-operator-path.smoke.ts
@@ -21,7 +21,7 @@ import { spawn } from "node:child_process";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { pickFreePort } from "./_free-port.js";
-import { assertScratchHeld, cotalRootCaptor, killManagerAtRoot, makeScratch } from "../../../bin/smoke/_scratch.js";
+import { assertScratchHeld, cotalRootCaptor, killManagerAtRoot, makeScratch, scratchCaptor } from "../../../bin/smoke/_scratch.js";
 
 // Same temp-root sandbox as the user-mode sibling, and for the same reason: `findCotalRoot` walks to
 // `/` unbounded, so a `.cotal` above `tmpdir()` sends this fixture's `manager.pid` into that
@@ -142,7 +142,18 @@ try {
   console.error("ps-operator-path threw:", e);
   process.exitCode = 1;
 } finally {
-  await cotal(["down"], 60_000).catch(() => ({ status: 1, out: "" }));
+  // Same guard as the user-mode sibling: `cotal down` re-resolves from cwd, so under a captured
+  // root it signals the ANCESTOR's processes — pids this fixture never started. A teardown that
+  // reaches outside its own fixture is worse than no teardown.
+  const teardownCaptor = scratchCaptor(root);
+  if (teardownCaptor === null) {
+    await cotal(["down"], 60_000).catch(() => ({ status: 1, out: "" }));
+  } else {
+    console.error(
+      `  ! SKIPPING \`cotal down\`: the fixture root is captured by ${join(teardownCaptor, ".cotal")}, so down would `
+        + `resolve THAT root and signal processes this suite did not start. Stop any mesh under the captor by hand.`,
+    );
+  }
   rmSync(scratch, { recursive: true, force: true }); // home and root both live under it
 }
 if (fail) process.exitCode = 1;

--- a/implementations/auth/smoke/ps-operator-path.smoke.ts
+++ b/implementations/auth/smoke/ps-operator-path.smoke.ts
@@ -75,7 +75,12 @@ function cotal(args: string[], timeoutMs = 120_000): Promise<Run> {
     child.on("error", (e) => done({ status: null, out, timedOut, signal: null, launchError: e.message }));
     child.stdout!.on("data", (d: Buffer) => { out += d.toString(); });
     child.stderr!.on("data", (d: Buffer) => { out += d.toString(); });
-    child.on("exit", (status, signal) => done({ status, out, timedOut, signal }));
+    // `close`, NOT `exit`. `exit` fires when the direct child dies, but the stdio pipes it handed to
+    // DETACHED descendants stay open and keep writing — and `cotal` spawns detached components
+    // routinely. Settling on `exit` grades a prefix as the whole: measured, `exit` gave `out: ""` at
+    // 26ms where `close` gave `out: "STREAM.INFO"` at 550ms on the same run. The cells below that
+    // read output content, including the empty-success check, would be judging absent text.
+    child.on("close", (status, signal) => done({ status, out, timedOut, signal }));
   });
 }
 
@@ -103,11 +108,14 @@ try {
   // anchor at all under the clean ancestry makeScratch builds, so it cannot tell "anchored" from
   // "nothing here" on an ordinary run - it would have let CI delete the load-bearing anchor and stay
   // green. Assert the thing itself; keep the resolution cell beside it as the consequence.
-  check("the fixture root OWNS its .cotal (the anchor exists)", existsSync(join(root, ".cotal")), root);
+  // Read ONCE, so the graded cell and the fatal branch cannot report different things about the
+  // same instant.
+  const anchored = existsSync(join(root, ".cotal"));
+  check("the fixture root OWNS its .cotal (the anchor exists)", anchored, root);
   // FATAL HERE, before any product command. A failed `check` alone only increments the tally and
   // lets `up` run UNANCHORED — the precise state whose race this anchor exists to remove. The suite
   // would still exit red, but only after starting a mesh that could root anywhere.
-  if (!existsSync(join(root, ".cotal"))) {
+  if (!anchored) {
     process.exitCode = 1;
     throw new Error(`FIXTURE FAILURE: the anchor ${join(root, ".cotal")} is missing, so no product command below can be trusted to root here.`);
   }

--- a/implementations/auth/smoke/ps-user-mode.smoke.ts
+++ b/implementations/auth/smoke/ps-user-mode.smoke.ts
@@ -31,7 +31,7 @@ import { deviceAuthorization } from "better-auth/plugins/device-authorization";
 import { bearer } from "better-auth/plugins/bearer";
 import { toNodeHandler } from "better-auth/node";
 import { pickFreePort } from "./_free-port.js";
-import { assertScratchHeld, cotalRootCaptor, killManagerAtRoot, makeScratch, scratchCaptor } from "../../../bin/smoke/_scratch.js";
+import { assertScratchHeld, foreignRootFor, killManagerAtRoot, makeScratch } from "../../../bin/smoke/_scratch.js";
 
 // Sandbox the temp root BEFORE minting the fixture. `findCotalRoot` walks to `/` unbounded, so a
 // `.cotal` above `tmpdir()` makes `cotal up` write `manager.pid` into that ancestor. Step 4 then
@@ -151,7 +151,7 @@ try {
   console.log("1) up --user-auth");
   // Checked FIRST and fatal: with the root captured, `up` still exits 0 and every cell below still
   // "runs" — against a mesh that is not where this suite thinks it is.
-  const captor = cotalRootCaptor(root);
+  const captor = foreignRootFor(root);
   check("fixture root has no .cotal ancestor (else nothing below can arm)", captor === null, captor);
   if (captor) { process.exitCode = 1; throw new Error(`fixture root captured by ${captor}`); }
   const up = await cotal(["up", "--user-auth", "--idp", base, "--detach", "--server", SERVER, "--space", SPACE]);
@@ -205,7 +205,7 @@ try {
   // where the suite has already concluded something is wrong. Cleanup must not be the most
   // dangerous thing the suite does. Skip the CLI teardown when the root is captured and say so
   // loudly, naming what may be left behind; `scratch` is our own mkdtemp either way.
-  const teardownCaptor = scratchCaptor(root);
+  const teardownCaptor = foreignRootFor(root);
   if (teardownCaptor === null) {
     await cotal(["down"], 60_000).catch(() => ({ status: 1, out: "" }));
   } else {

--- a/implementations/auth/smoke/ps-user-mode.smoke.ts
+++ b/implementations/auth/smoke/ps-user-mode.smoke.ts
@@ -209,7 +209,10 @@ try {
 } catch (e) {
   // A listening server keeps the process alive past the throw, and `finally` is not reachable from
   // out here — so both the server and the scratch are this handler's responsibility.
-  try { idpSrv?.close(); } catch { /* never listened */ }
+  // Reported, not swallowed. This is the last catch in the file that could hide something, and a
+  // close that fails leaves a listening server holding the process open — the reader needs to know
+  // that happened even though the scratch removal below must still run.
+  try { idpSrv?.close(); } catch (ce) { console.error(`  ! IdP close failed during setup cleanup: ${(ce as Error).message}`); }
   rmSync(scratch, { recursive: true, force: true });
   throw new Error(`fixture setup failed (scratch removed, IdP closed): ${(e as Error).message}`, { cause: e });
 }

--- a/implementations/auth/smoke/ps-user-mode.smoke.ts
+++ b/implementations/auth/smoke/ps-user-mode.smoke.ts
@@ -200,22 +200,27 @@ try {
   console.error("ps-user-mode threw:", e);
   process.exitCode = 1;
 } finally {
-  // `cotal down` re-resolves its root from cwd, so under a captured root it aims at the ANCESTOR's
+  // Every teardown step runs INDEPENDENTLY. A throw anywhere in a finalizer aborts the rest of it,
+  // so one bad line leaves a live broker and a scratch behind — a teardown that fails OPEN, which is
+  // worse than one that never ran, because the suite still reports its verdict. Measured for real:
+  // an unwired identifier in this block once aborted cleanup mid-flight and stranded a nats-server.
+  const step = async (label: string, fn: () => unknown | Promise<unknown>): Promise<void> => {
+    try { await fn(); } catch (e) { console.error(`  ! teardown step "${label}" failed: ${(e as Error).message} — continuing`); }
+  };
+  // `cotal down` re-resolves its root from cwd, so under a FOREIGN root it aims at that root's
   // `.cotal` and signals pids this fixture never started — another lane's manager, on the one path
   // where the suite has already concluded something is wrong. Cleanup must not be the most
-  // dangerous thing the suite does. Skip the CLI teardown when the root is captured and say so
-  // loudly, naming what may be left behind; `scratch` is our own mkdtemp either way.
-  const teardownCaptor = foreignRootFor(root);
-  if (teardownCaptor === null) {
-    await cotal(["down"], 60_000).catch(() => ({ status: 1, out: "" }));
-  } else {
+  // dangerous thing the suite does.
+  await step("stop the mesh", async () => {
+    const foreign = foreignRootFor(root);
+    if (foreign === null) { await cotal(["down"], 60_000); return; }
     console.error(
-      `  ! SKIPPING \`cotal down\`: the fixture root is captured by ${join(teardownCaptor, ".cotal")}, so down would `
-        + `resolve THAT root and signal processes this suite did not start. Any mesh this run began is under the `
-        + `captor and must be stopped by hand.`,
+      `  ! SKIPPING \`cotal down\`: ${root} resolves to ${join(foreign, ".cotal")}, so down would target THAT `
+        + `root and signal processes this suite did not start. Any mesh this run began is under it and must be `
+        + `stopped by hand.`,
     );
-  }
-  idpSrv.close();
-  rmSync(scratch, { recursive: true, force: true }); // home and root both live under it
+  });
+  await step("close the IdP", () => idpSrv.close());
+  await step("remove the scratch", () => rmSync(scratch, { recursive: true, force: true })); // home and root live under it
 }
 if (fail) process.exitCode = 1;

--- a/implementations/auth/smoke/ps-user-mode.smoke.ts
+++ b/implementations/auth/smoke/ps-user-mode.smoke.ts
@@ -165,6 +165,13 @@ try {
   // "nothing here" on an ordinary run - it would have let CI delete the load-bearing anchor and stay
   // green. Assert the thing itself; keep the resolution cell beside it as the consequence.
   check("the fixture root OWNS its .cotal (the anchor exists)", existsSync(join(root, ".cotal")), root);
+  // FATAL HERE, before any product command. A failed `check` alone only increments the tally and
+  // lets `up` run UNANCHORED — the precise state whose race this anchor exists to remove. The suite
+  // would still exit red, but only after starting a mesh that could root anywhere.
+  if (!existsSync(join(root, ".cotal"))) {
+    process.exitCode = 1;
+    throw new Error(`FIXTURE FAILURE: the anchor ${join(root, ".cotal")} is missing, so no product command below can be trusted to root here.`);
+  }
   const captor = foreignRootFor(root);
   check("...and therefore outranks any ancestor", captor === null, captor);
   if (captor) { process.exitCode = 1; throw new Error(`anchor missing: ${root} resolves to ${captor}`); }

--- a/implementations/auth/smoke/ps-user-mode.smoke.ts
+++ b/implementations/auth/smoke/ps-user-mode.smoke.ts
@@ -31,7 +31,7 @@ import { deviceAuthorization } from "better-auth/plugins/device-authorization";
 import { bearer } from "better-auth/plugins/bearer";
 import { toNodeHandler } from "better-auth/node";
 import { pickFreePort } from "./_free-port.js";
-import { assertScratchHeld, cotalRootCaptor, killManagerAtRoot, makeScratch } from "../../../bin/smoke/_scratch.js";
+import { assertScratchHeld, cotalRootCaptor, killManagerAtRoot, makeScratch, scratchCaptor } from "../../../bin/smoke/_scratch.js";
 
 // Sandbox the temp root BEFORE minting the fixture. `findCotalRoot` walks to `/` unbounded, so a
 // `.cotal` above `tmpdir()` makes `cotal up` write `manager.pid` into that ancestor. Step 4 then
@@ -200,7 +200,21 @@ try {
   console.error("ps-user-mode threw:", e);
   process.exitCode = 1;
 } finally {
-  await cotal(["down"], 60_000).catch(() => ({ status: 1, out: "" }));
+  // `cotal down` re-resolves its root from cwd, so under a captured root it aims at the ANCESTOR's
+  // `.cotal` and signals pids this fixture never started — another lane's manager, on the one path
+  // where the suite has already concluded something is wrong. Cleanup must not be the most
+  // dangerous thing the suite does. Skip the CLI teardown when the root is captured and say so
+  // loudly, naming what may be left behind; `scratch` is our own mkdtemp either way.
+  const teardownCaptor = scratchCaptor(root);
+  if (teardownCaptor === null) {
+    await cotal(["down"], 60_000).catch(() => ({ status: 1, out: "" }));
+  } else {
+    console.error(
+      `  ! SKIPPING \`cotal down\`: the fixture root is captured by ${join(teardownCaptor, ".cotal")}, so down would `
+        + `resolve THAT root and signal processes this suite did not start. Any mesh this run began is under the `
+        + `captor and must be stopped by hand.`,
+    );
+  }
   idpSrv.close();
   rmSync(scratch, { recursive: true, force: true }); // home and root both live under it
 }

--- a/implementations/auth/smoke/ps-user-mode.smoke.ts
+++ b/implementations/auth/smoke/ps-user-mode.smoke.ts
@@ -154,9 +154,30 @@ function mustHaveRun(r: Run, what: string): void {
   );
 }
 
+/**
+ * Everything fallible from here to the main `try` runs under this guard.
+ *
+ * The IdP listen and the Better Auth signup can both throw, and they happen BEFORE the main
+ * try/finally — so a failure there used to escape with the scratch still on disk. That leak matters
+ * more since the anchor landed: the scratch now contains a `.cotal` of its own, so what gets left
+ * behind is not an empty directory but a live capture hazard for whatever runs under that temp base
+ * next. This suite exists to stop exactly that, and was creating it on its own error path.
+ */
+async function setupOrClean<T>(what: string, fn: () => Promise<T> | T): Promise<T> {
+  try {
+    return await fn();
+  } catch (e) {
+    // Close the IdP too: `finally` is not reachable from out here, and a listening server would keep
+    // the process alive after the throw.
+    try { idpSrv.close(); } catch { /* not listening yet */ }
+    rmSync(scratch, { recursive: true, force: true });
+    throw new Error(`fixture setup failed at ${what} (scratch removed): ${(e as Error).message}`, { cause: e });
+  }
+}
+
 let handler: ReturnType<typeof toNodeHandler> | undefined;
 const idpSrv = createServer((req, res) => handler!(req, res));
-await new Promise<void>((r) => idpSrv.listen(0, "127.0.0.1", r));
+await setupOrClean("IdP listen", () => new Promise<void>((r, rej) => { idpSrv.once("error", rej); idpSrv.listen(0, "127.0.0.1", r); }));
 const origin = `http://127.0.0.1:${(idpSrv.address() as AddressInfo).port}`;
 const base = `${origin}/api/auth`;
 const ba = betterAuth({
@@ -171,10 +192,15 @@ const ba = betterAuth({
   ],
 });
 handler = toNodeHandler(ba);
-const signup = await ba.api.signUpEmail({
-  body: { email: "human@example.test", password: "correct-horse-battery", name: "Human 42" },
-  returnHeaders: true,
-});
+// Same guard: a signup failure here would otherwise strand the anchored scratch. Closing the IdP is
+// on the FAILURE path only — the device login below needs it alive on the success path, and the
+// main `finally` owns it from there.
+const signup = await setupOrClean("IdP signup", () =>
+  ba.api.signUpEmail({
+    body: { email: "human@example.test", password: "correct-horse-battery", name: "Human 42" },
+    returnHeaders: true,
+  }),
+);
 const cookie = signup.headers.get("set-cookie")!.split(";")[0];
 async function approve(userCode: string): Promise<void> {
   await fetch(`${base}/device?user_code=${encodeURIComponent(userCode)}`, { headers: { cookie, origin } });

--- a/implementations/auth/smoke/ps-user-mode.smoke.ts
+++ b/implementations/auth/smoke/ps-user-mode.smoke.ts
@@ -11,8 +11,7 @@
 import { spawn } from "node:child_process";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { betterAuth } from "better-auth";
 import { memoryAdapter } from "better-auth/adapters/memory";
@@ -21,10 +20,19 @@ import { deviceAuthorization } from "better-auth/plugins/device-authorization";
 import { bearer } from "better-auth/plugins/bearer";
 import { toNodeHandler } from "better-auth/node";
 import { pickFreePort } from "./_free-port.js";
+import { assertScratchHeld, cotalRootCaptor, killManagerAtRoot, makeScratch } from "../../../bin/smoke/_scratch.js";
 
-const home = mkdtempSync(join(tmpdir(), "cotal-psuser-home-"));
+// Sandbox the temp root BEFORE minting the fixture. `findCotalRoot` walks to `/` unbounded, so a
+// `.cotal` above `tmpdir()` makes `cotal up` write `manager.pid` into that ancestor. Step 4 then
+// finds no pid, skips its kill, and grades a LIVE manager's honest "(no managed agents)" as the
+// empty-success defect it is meant to catch. On Linux/CI `os.tmpdir()` is `/tmp`, so a stray
+// `/tmp/.cotal` there hits this suite every time; on macOS the temp root is `/var/folders/…` and is
+// clean, which is why it stayed green locally. Measured: exit 0 + "(no managed agents)" under a
+// poisoned base, 5/5 under a clean one, at the same commit.
+const scratch = makeScratch("cotal-psuser-");
+const home = mkdtempSync(join(scratch, "home-"));
 process.env.COTAL_HOME = home;
-const root = mkdtempSync(join(tmpdir(), "cotal-psuser-root-"));
+const root = mkdtempSync(join(scratch, "root-"));
 const { establishIdpSession } = await import("../src/index.js");
 type DeviceLoginPrompt = import("../src/index.js").DeviceLoginPrompt;
 
@@ -88,6 +96,11 @@ async function approve(userCode: string): Promise<void> {
 
 try {
   console.log("1) up --user-auth");
+  // Checked FIRST and fatal: with the root captured, `up` still exits 0 and every cell below still
+  // "runs" — against a mesh that is not where this suite thinks it is.
+  const captor = cotalRootCaptor(root);
+  check("fixture root has no .cotal ancestor (else nothing below can arm)", captor === null, captor);
+  if (captor) { process.exitCode = 1; throw new Error(`fixture root captured by ${captor}`); }
   const up = await cotal(["up", "--user-auth", "--idp", base, "--detach", "--server", SERVER, "--space", SPACE]);
   check("up exits 0", up.status === 0, up.out.slice(-600));
   if (up.status !== 0) { process.exitCode = 1; throw new Error("fixture"); }
@@ -109,11 +122,15 @@ try {
     !/STREAM\.INFO/.test(ps.out), ps.out.slice(-200));
 
   console.log("4) kill manager — ps must fail loud, not empty-success");
-  const pidFile = join(root, ".cotal", "manager.pid");
-  if (existsSync(pidFile)) {
-    try { process.kill(Number(readFileSync(pidFile, "utf8").trim()), "SIGKILL"); } catch { /* gone */ }
-    await wait(500);
-  }
+  // The mesh can only root somewhere else if a `.cotal` appeared above the scratch mid-run; witness
+  // it here so that shows up as itself and not as the cell below.
+  assertScratchHeld(root, "fixture root");
+  // Fatal, not conditional. `if (existsSync(pid)) kill()` cannot distinguish "manager dead" from
+  // "manager never found" — and under a captured root it is always the second, which is precisely
+  // how a live manager came to be graded as a bare empty success.
+  // Not a check(): it cannot fail here (the helper throws), and a cell that cannot fail only
+  // inflates the pass count. Log the pid so the transcript shows WHICH process died.
+  console.log(`   killed manager pid ${await killManagerAtRoot(root)} — the cell below grades a DEAD mesh`);
   const psDead = await cotal(["ps", "--space", SPACE], 20_000);
   console.log(`   dead exit=${psDead.status}\n` + psDead.out.split("\n").map((l) => `   | ${l}`).join("\n").slice(0, 500));
   const emptySuccess =
@@ -130,7 +147,6 @@ try {
 } finally {
   await cotal(["down"], 60_000).catch(() => ({ status: 1, out: "" }));
   idpSrv.close();
-  rmSync(home, { recursive: true, force: true });
-  rmSync(root, { recursive: true, force: true });
+  rmSync(scratch, { recursive: true, force: true }); // home and root both live under it
 }
 if (fail) process.exitCode = 1;

--- a/implementations/auth/smoke/ps-user-mode.smoke.ts
+++ b/implementations/auth/smoke/ps-user-mode.smoke.ts
@@ -41,16 +41,13 @@ import { assertScratchHeld, foreignRootFor, killManagerAtRoot, makeScratch } fro
 // clean, which is why it stayed green locally. Measured: exit 0 + "(no managed agents)" under a
 // poisoned base, 5/5 under a clean one, at the same commit.
 const scratch = makeScratch("cotal-psuser-");
-const home = mkdtempSync(join(scratch, "home-"));
-process.env.COTAL_HOME = home;
-const root = mkdtempSync(join(scratch, "root-"));
-// ANCHOR THE ROOT BEFORE ANY PRODUCT COMMAND RUNS. `findCotalRoot` stops at the first `.cotal`
-// starting from the directory itself, so owning one here makes every later resolution from this
-// root land on this root - during `up`, during `ps`, and during `down` - no matter what appears
-// above it in between. Ownership then does not depend on the timing of any check, which is the
-// only way to close a race against a child that re-resolves cwd for itself.
-mkdirSync(join(root, ".cotal"), { recursive: true });
-const { establishIdpSession } = await import("../src/index.js");
+// Assigned inside the ONE setup transaction below. Everything between `makeScratch` and the main
+// body is fallible, and guarding it a line at a time is how the first attempt at this left the
+// cookie read, the auth construction and the port pick outside the guard while a comment claimed
+// otherwise. One transaction or none.
+let home!: string;
+let root!: string;
+let establishIdpSession!: typeof import("../src/index.js").establishIdpSession;
 
 // Was `cotal up` ever INVOKED? Not "did it succeed" — a failed, timed-out or signalled `up` can still
 // have launched detached processes, and those are exactly the ones whose pidfiles must survive.
@@ -64,8 +61,7 @@ const check = (n: string, v: boolean, x?: unknown) => {
 };
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-const PORT = await pickFreePort();
-const SERVER = `nats://127.0.0.1:${PORT}`;
+let SERVER!: string;
 const SPACE = `psuser-${Math.floor(Math.random() * 1e6)}`;
 const CLIENT_ID = "cotal-cli";
 const BIN = join(import.meta.dirname, "..", "..", "..", "bin", "cotal.ts");
@@ -155,53 +151,68 @@ function mustHaveRun(r: Run, what: string): void {
 }
 
 /**
- * Everything fallible from here to the main `try` runs under this guard.
+ * ONE SETUP TRANSACTION. Everything between `makeScratch` and the main body happens in here, and a
+ * throw anywhere in it removes the scratch and closes the IdP before rethrowing.
  *
- * The IdP listen and the Better Auth signup can both throw, and they happen BEFORE the main
- * try/finally — so a failure there used to escape with the scratch still on disk. That leak matters
- * more since the anchor landed: the scratch now contains a `.cotal` of its own, so what gets left
- * behind is not an empty directory but a live capture hazard for whatever runs under that temp base
- * next. This suite exists to stop exactly that, and was creating it on its own error path.
+ * Guarding this a step at a time does not work, and the previous attempt is the proof: it wrapped
+ * the listen and the signup, left the cookie read, the auth construction and the port pick outside,
+ * and carried a comment claiming everything fallible was covered. A forced null `set-cookie` then
+ * threw past it, stranding the scratch AND leaving the IdP listening so the process survived to the
+ * harness's 120s kill. The unit that needs to be atomic is the whole setup, not each fallible line.
+ *
+ * The stakes are higher than tidiness since the anchor landed: a leaked scratch owns a `.cotal`, so
+ * what gets left behind is a live capture hazard for whatever runs under that temp base next — the
+ * exact poison this suite exists to detect, manufactured on its own error path.
  */
-async function setupOrClean<T>(what: string, fn: () => Promise<T> | T): Promise<T> {
-  try {
-    return await fn();
-  } catch (e) {
-    // Close the IdP too: `finally` is not reachable from out here, and a listening server would keep
-    // the process alive after the throw.
-    try { idpSrv.close(); } catch { /* not listening yet */ }
-    rmSync(scratch, { recursive: true, force: true });
-    throw new Error(`fixture setup failed at ${what} (scratch removed): ${(e as Error).message}`, { cause: e });
-  }
-}
-
 let handler: ReturnType<typeof toNodeHandler> | undefined;
-const idpSrv = createServer((req, res) => handler!(req, res));
-await setupOrClean("IdP listen", () => new Promise<void>((r, rej) => { idpSrv.once("error", rej); idpSrv.listen(0, "127.0.0.1", r); }));
-const origin = `http://127.0.0.1:${(idpSrv.address() as AddressInfo).port}`;
-const base = `${origin}/api/auth`;
-const ba = betterAuth({
-  baseURL: origin,
-  secret: "repro-only-better-auth-secret-0123456789",
-  database: memoryAdapter({ user: [], session: [], account: [], verification: [], jwks: [], deviceCode: [] }),
-  emailAndPassword: { enabled: true },
-  plugins: [
-    jwt({ jwt: { issuer: origin, audience: origin } }),
-    deviceAuthorization({ expiresIn: "2m", interval: "1s", validateClient: (id) => id === CLIENT_ID }),
-    bearer(),
-  ],
-});
-handler = toNodeHandler(ba);
-// Same guard: a signup failure here would otherwise strand the anchored scratch. Closing the IdP is
-// on the FAILURE path only — the device login below needs it alive on the success path, and the
-// main `finally` owns it from there.
-const signup = await setupOrClean("IdP signup", () =>
-  ba.api.signUpEmail({
+let idpSrv: ReturnType<typeof createServer> | undefined;
+let base!: string;
+let origin!: string;
+let cookie!: string;
+let ba!: ReturnType<typeof betterAuth>;
+try {
+  home = mkdtempSync(join(scratch, "home-"));
+  process.env.COTAL_HOME = home;
+  root = mkdtempSync(join(scratch, "root-"));
+  // ANCHOR THE ROOT BEFORE ANY PRODUCT COMMAND RUNS. `findCotalRoot` stops at the first `.cotal`
+  // starting from the directory itself, so owning one here makes every later resolution from this
+  // root land on this root - during `up`, during `ps`, and during `down` - no matter what appears
+  // above it in between. Ownership then does not depend on the timing of any check, which is the
+  // only way to close a race against a child that re-resolves cwd for itself.
+  mkdirSync(join(root, ".cotal"), { recursive: true });
+  ({ establishIdpSession } = await import("../src/index.js"));
+  SERVER = `nats://127.0.0.1:${await pickFreePort()}`;
+
+  idpSrv = createServer((req, res) => handler!(req, res));
+  await new Promise<void>((r, rej) => { idpSrv!.once("error", rej); idpSrv!.listen(0, "127.0.0.1", r); });
+  origin = `http://127.0.0.1:${(idpSrv.address() as AddressInfo).port}`;
+  base = `${origin}/api/auth`;
+  ba = betterAuth({
+    baseURL: origin,
+    secret: "repro-only-better-auth-secret-0123456789",
+    database: memoryAdapter({ user: [], session: [], account: [], verification: [], jwks: [], deviceCode: [] }),
+    emailAndPassword: { enabled: true },
+    plugins: [
+      jwt({ jwt: { issuer: origin, audience: origin } }),
+      deviceAuthorization({ expiresIn: "2m", interval: "1s", validateClient: (id) => id === CLIENT_ID }),
+      bearer(),
+    ],
+  });
+  handler = toNodeHandler(ba);
+  const signup = await ba.api.signUpEmail({
     body: { email: "human@example.test", password: "correct-horse-battery", name: "Human 42" },
     returnHeaders: true,
-  }),
-);
-const cookie = signup.headers.get("set-cookie")!.split(";")[0];
+  });
+  const setCookie = signup.headers.get("set-cookie");
+  if (!setCookie) throw new Error("IdP signup returned no set-cookie header");
+  cookie = setCookie.split(";")[0];
+} catch (e) {
+  // A listening server keeps the process alive past the throw, and `finally` is not reachable from
+  // out here — so both the server and the scratch are this handler's responsibility.
+  try { idpSrv?.close(); } catch { /* never listened */ }
+  rmSync(scratch, { recursive: true, force: true });
+  throw new Error(`fixture setup failed (scratch removed, IdP closed): ${(e as Error).message}`, { cause: e });
+}
 async function approve(userCode: string): Promise<void> {
   await fetch(`${base}/device?user_code=${encodeURIComponent(userCode)}`, { headers: { cookie, origin } });
   const res = await fetch(`${base}/device/approve`, {
@@ -328,7 +339,7 @@ try {
     if (down.status !== 0) throw new Error(`\`cotal down\` exited ${down.status}: ${down.out.slice(-300)}`);
     meshStopped = true;
   });
-  await step("close the IdP", () => idpSrv.close());
+  await step("close the IdP", () => idpSrv?.close());
   await step("remove the scratch", () => {
     // Only once nothing is left to find. The scratch's `.cotal` holds the pidfiles that are the only
     // way to locate a mesh this suite failed to stop; deleting them turns a recoverable orphan into

--- a/implementations/auth/smoke/ps-user-mode.smoke.ts
+++ b/implementations/auth/smoke/ps-user-mode.smoke.ts
@@ -7,6 +7,17 @@
  *
  * Spawn-only refusal is asserted in user-spawn.smoke.ts B1e (ungated); not duplicated here.
  * Gated: a RED here is C or the user-mode connect path broken.
+ *
+ * STEP 3 IS DELIBERATELY STRICTER THAN ITS SIBLING, and the difference is not an oversight.
+ * `ps-operator-path.smoke.ts` accepts exit 0 for a dead manager as long as the output says
+ * "unreachable"; this suite demands a non-zero exit. Different rails, different observable
+ * vocabularies: a class scatter can attribute a specific instance and label it unreachable, while
+ * `ep.one` has no such label to print — it either got its one answer or it did not. Asking the
+ * user-mode path for the operator path's wording would be asking for a sentence it cannot say.
+ *
+ * The strictness only ever errs toward RED, and only if user-mode ps deliberately moves to a
+ * label-and-exit-0 shape. That is a product decision to be made on its own evidence; a red here
+ * demanding a human look at it is then the correct behaviour, not a defect in this file.
  */
 import { spawn } from "node:child_process";
 import { createServer } from "node:http";

--- a/implementations/auth/smoke/ps-user-mode.smoke.ts
+++ b/implementations/auth/smoke/ps-user-mode.smoke.ts
@@ -22,7 +22,7 @@
 import { spawn } from "node:child_process";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { betterAuth } from "better-auth";
 import { memoryAdapter } from "better-auth/adapters/memory";
@@ -44,11 +44,18 @@ const scratch = makeScratch("cotal-psuser-");
 const home = mkdtempSync(join(scratch, "home-"));
 process.env.COTAL_HOME = home;
 const root = mkdtempSync(join(scratch, "root-"));
+// ANCHOR THE ROOT BEFORE ANY PRODUCT COMMAND RUNS. `findCotalRoot` stops at the first `.cotal`
+// starting from the directory itself, so owning one here makes every later resolution from this
+// root land on this root - during `up`, during `ps`, and during `down` - no matter what appears
+// above it in between. Ownership then does not depend on the timing of any check, which is the
+// only way to close a race against a child that re-resolves cwd for itself.
+mkdirSync(join(root, ".cotal"), { recursive: true });
 const { establishIdpSession } = await import("../src/index.js");
 
-// Did a mesh ever start? Decides whether an unstopped fixture is an orphan worth preserving
-// evidence for, or simply nothing.
-let meshStarted = false;
+// Was `cotal up` ever INVOKED? Not "did it succeed" — a failed, timed-out or signalled `up` can still
+// have launched detached processes, and those are exactly the ones whose pidfiles must survive.
+// Attribution evidence is earned by the attempt, not by the outcome.
+let upAttempted = false;
 type DeviceLoginPrompt = import("../src/index.js").DeviceLoginPrompt;
 
 let pass = 0, fail = 0;
@@ -153,15 +160,21 @@ async function approve(userCode: string): Promise<void> {
 
 try {
   console.log("1) up --user-auth");
-  // Checked FIRST and fatal: with the root captured, `up` still exits 0 and every cell below still
-  // "runs" — against a mesh that is not where this suite thinks it is.
+  // DIRECT EXISTENCE, not a consequence of it. `foreignRootFor(root) === null` is ALSO true with no
+  // anchor at all under the clean ancestry makeScratch builds, so it cannot tell "anchored" from
+  // "nothing here" on an ordinary run - it would have let CI delete the load-bearing anchor and stay
+  // green. Assert the thing itself; keep the resolution cell beside it as the consequence.
+  check("the fixture root OWNS its .cotal (the anchor exists)", existsSync(join(root, ".cotal")), root);
   const captor = foreignRootFor(root);
-  check("fixture root has no .cotal ancestor (else nothing below can arm)", captor === null, captor);
-  if (captor) { process.exitCode = 1; throw new Error(`fixture root captured by ${captor}`); }
+  check("...and therefore outranks any ancestor", captor === null, captor);
+  if (captor) { process.exitCode = 1; throw new Error(`anchor missing: ${root} resolves to ${captor}`); }
+  upAttempted = true;
   const up = await cotal(["up", "--user-auth", "--idp", base, "--detach", "--server", SERVER, "--space", SPACE]);
+  // Attribute HOW `up` ended before reading its status: a signalled or timed-out `up` reports
+  // `status: null`, which reads only as "non-zero" and loses why.
+  mustHaveRun(up, "`cotal up`");
   check("up exits 0", up.status === 0, up.out.slice(-600));
   if (up.status !== 0) { process.exitCode = 1; throw new Error("fixture"); }
-  meshStarted = true;
   await wait(3000);
 
   console.log("2) device login + admin grant");
@@ -225,11 +238,23 @@ try {
   // dangerous thing the suite does.
   let meshStopped = false;
   await step("stop the mesh", async () => {
-    const foreign = foreignRootFor(root);
-    if (foreign !== null) {
+    // AN ANCHOR, NOT A GATE. `cotal down` is a child that re-resolves its own root from cwd, so no
+    // check performed here can bind what it will decide a moment later — a pre-spawn `foreignRootFor`
+    // returning null then losing to a `.cotal` created before the spawn was measured killing a
+    // foreign process. A time-of-check test cannot win a time-of-use race.
+    //
+    // What CAN close it is a fact that outranks anything appearing afterwards: `findCotalRoot` stops
+    // at the FIRST `.cotal` starting from the directory itself, so once `root/.cotal` exists the
+    // child's resolution IS `root`, permanently, whatever appears above it later. That is the only
+    // condition under which a root-resolving teardown is safe here.
+    if (!existsSync(join(root, ".cotal"))) {
+      const foreign = foreignRootFor(root);
       throw new Error(
-        `refusing \`cotal down\`: ${root} resolves to ${join(foreign, ".cotal")}, so down would target THAT root `
-          + `and signal processes this suite did not start. Any mesh this run began is under it and must be stopped by hand.`,
+        `refusing \`cotal down\`: ${root} does not own a .cotal, so the child would resolve to whatever root `
+          + `wins from its cwd and could signal processes this suite never started`
+          + (upAttempted
+            ? `. A mesh may have started under ${foreign ? join(foreign, ".cotal") : "another root"} — stop it by hand.`
+            : `. Nothing was started.`),
       );
     }
     const down = await cotal(["down"], 60_000);
@@ -244,7 +269,7 @@ try {
     // Only once nothing is left to find. The scratch's `.cotal` holds the pidfiles that are the only
     // way to locate a mesh this suite failed to stop; deleting them turns a recoverable orphan into
     // an anonymous one.
-    if (meshStarted && !meshStopped) {
+    if (upAttempted && !meshStopped) {
       process.exitCode = 1;
       console.error(
         `  ! PRESERVING ${scratch}: the mesh was not confirmed stopped, and its .cotal holds the pidfiles `

--- a/implementations/auth/smoke/ps-user-mode.smoke.ts
+++ b/implementations/auth/smoke/ps-user-mode.smoke.ts
@@ -45,6 +45,10 @@ const home = mkdtempSync(join(scratch, "home-"));
 process.env.COTAL_HOME = home;
 const root = mkdtempSync(join(scratch, "root-"));
 const { establishIdpSession } = await import("../src/index.js");
+
+// Did a mesh ever start? Decides whether an unstopped fixture is an orphan worth preserving
+// evidence for, or simply nothing.
+let meshStarted = false;
 type DeviceLoginPrompt = import("../src/index.js").DeviceLoginPrompt;
 
 let pass = 0, fail = 0;
@@ -157,6 +161,7 @@ try {
   const up = await cotal(["up", "--user-auth", "--idp", base, "--detach", "--server", SERVER, "--space", SPACE]);
   check("up exits 0", up.status === 0, up.out.slice(-600));
   if (up.status !== 0) { process.exitCode = 1; throw new Error("fixture"); }
+  meshStarted = true;
   await wait(3000);
 
   console.log("2) device login + admin grant");
@@ -204,23 +209,50 @@ try {
   // so one bad line leaves a live broker and a scratch behind — a teardown that fails OPEN, which is
   // worse than one that never ran, because the suite still reports its verdict. Measured for real:
   // an unwired identifier in this block once aborted cleanup mid-flight and stranded a nats-server.
+  // A failing step is RED, not a log line. Cleanup that quietly declines and still lets the suite
+  // exit 0 is the same false-green class as everything else on this branch, just moved to the end.
   const step = async (label: string, fn: () => unknown | Promise<unknown>): Promise<void> => {
-    try { await fn(); } catch (e) { console.error(`  ! teardown step "${label}" failed: ${(e as Error).message} — continuing`); }
+    try {
+      await fn();
+    } catch (e) {
+      process.exitCode = 1;
+      console.error(`  ! teardown step "${label}" FAILED: ${(e as Error).message}`);
+    }
   };
   // `cotal down` re-resolves its root from cwd, so under a FOREIGN root it aims at that root's
   // `.cotal` and signals pids this fixture never started — another lane's manager, on the one path
   // where the suite has already concluded something is wrong. Cleanup must not be the most
   // dangerous thing the suite does.
+  let meshStopped = false;
   await step("stop the mesh", async () => {
     const foreign = foreignRootFor(root);
-    if (foreign === null) { await cotal(["down"], 60_000); return; }
-    console.error(
-      `  ! SKIPPING \`cotal down\`: ${root} resolves to ${join(foreign, ".cotal")}, so down would target THAT `
-        + `root and signal processes this suite did not start. Any mesh this run began is under it and must be `
-        + `stopped by hand.`,
-    );
+    if (foreign !== null) {
+      throw new Error(
+        `refusing \`cotal down\`: ${root} resolves to ${join(foreign, ".cotal")}, so down would target THAT root `
+          + `and signal processes this suite did not start. Any mesh this run began is under it and must be stopped by hand.`,
+      );
+    }
+    const down = await cotal(["down"], 60_000);
+    // The same standard the graded cells get: `cotal()` resolves for a timeout, a signal death and a
+    // launch failure alike, so an unchecked `await` treats every one of those as a successful stop.
+    mustHaveRun(down, "`cotal down`");
+    if (down.status !== 0) throw new Error(`\`cotal down\` exited ${down.status}: ${down.out.slice(-300)}`);
+    meshStopped = true;
   });
   await step("close the IdP", () => idpSrv.close());
-  await step("remove the scratch", () => rmSync(scratch, { recursive: true, force: true })); // home and root live under it
+  await step("remove the scratch", () => {
+    // Only once nothing is left to find. The scratch's `.cotal` holds the pidfiles that are the only
+    // way to locate a mesh this suite failed to stop; deleting them turns a recoverable orphan into
+    // an anonymous one.
+    if (meshStarted && !meshStopped) {
+      process.exitCode = 1;
+      console.error(
+        `  ! PRESERVING ${scratch}: the mesh was not confirmed stopped, and its .cotal holds the pidfiles `
+          + `needed to find and stop whatever is still running.`,
+      );
+      return;
+    }
+    rmSync(scratch, { recursive: true, force: true }); // home and root live under it
+  });
 }
 if (fail) process.exitCode = 1;

--- a/implementations/auth/smoke/ps-user-mode.smoke.ts
+++ b/implementations/auth/smoke/ps-user-mode.smoke.ts
@@ -209,12 +209,20 @@ try {
 } catch (e) {
   // A listening server keeps the process alive past the throw, and `finally` is not reachable from
   // out here — so both the server and the scratch are this handler's responsibility.
-  // Reported, not swallowed. This is the last catch in the file that could hide something, and a
-  // close that fails leaves a listening server holding the process open — the reader needs to know
-  // that happened even though the scratch removal below must still run.
-  try { idpSrv?.close(); } catch (ce) { console.error(`  ! IdP close failed during setup cleanup: ${(ce as Error).message}`); }
+  // `Server.close()` reports through its CALLBACK, not by throwing — a `try/catch` around it sees
+  // nothing, so the previous "reporting" version was still blind and the message below still
+  // asserted a close it had not observed. Await the callback and say what actually happened.
+  // `ERR_SERVER_NOT_RUNNING` is the benign case: the failure came before `listen`, so there was
+  // never a server to close.
+  let closed = "not created";
+  if (idpSrv) {
+    const err = await new Promise<NodeJS.ErrnoException | undefined>((r) => idpSrv!.close((x) => r(x ?? undefined)));
+    closed = !err ? "closed"
+      : err.code === "ERR_SERVER_NOT_RUNNING" ? "never listened"
+      : `CLOSE FAILED (${err.code ?? err.message}) — a listening server may still hold this process open`;
+  }
   rmSync(scratch, { recursive: true, force: true });
-  throw new Error(`fixture setup failed (scratch removed, IdP closed): ${(e as Error).message}`, { cause: e });
+  throw new Error(`fixture setup failed (scratch removed, IdP: ${closed}): ${(e as Error).message}`, { cause: e });
 }
 async function approve(userCode: string): Promise<void> {
   await fetch(`${base}/device?user_code=${encodeURIComponent(userCode)}`, { headers: { cookie, origin } });

--- a/implementations/auth/smoke/ps-user-mode.smoke.ts
+++ b/implementations/auth/smoke/ps-user-mode.smoke.ts
@@ -350,7 +350,13 @@ try {
     if (down.status !== 0) throw new Error(`\`cotal down\` exited ${down.status}: ${down.out.slice(-300)}`);
     meshStopped = true;
   });
-  await step("close the IdP", () => idpSrv?.close());
+  // Same callback shape as the setup handler: `close()` never throws, so `step` would have graded
+  // this successful no matter what happened. Reject on a real error so the step goes red; treat
+  // ERR_SERVER_NOT_RUNNING as benign, since it only means the server was already down.
+  await step("close the IdP", () => new Promise<void>((res, rej) => {
+    if (!idpSrv) return res();
+    idpSrv.close((err) => (err && (err as NodeJS.ErrnoException).code !== "ERR_SERVER_NOT_RUNNING" ? rej(err) : res()));
+  }));
   await step("remove the scratch", () => {
     // Only once nothing is left to find. The scratch's `.cotal` holds the pidfiles that are the only
     // way to locate a mesh this suite failed to stop; deleting them turns a recoverable orphan into

--- a/implementations/auth/smoke/ps-user-mode.smoke.ts
+++ b/implementations/auth/smoke/ps-user-mode.smoke.ts
@@ -184,7 +184,21 @@ try {
   SERVER = `nats://127.0.0.1:${await pickFreePort()}`;
 
   idpSrv = createServer((req, res) => handler!(req, res));
-  await new Promise<void>((r, rej) => { idpSrv!.once("error", rej); idpSrv!.listen(0, "127.0.0.1", r); });
+  // The listen-failure listener is REMOVED on success. Left installed, it outlives the Promise it
+  // belongs to: a later server error then invokes an already-settled reject, which is a no-op, so
+  // the error is silently consumed and the run continues on a broken IdP. That is worse than having
+  // no handler at all, since an unhandled `error` on an EventEmitter at least throws.
+  await new Promise<void>((r, rej) => {
+    const onListenError = (e: Error) => rej(e);
+    idpSrv!.once("error", onListenError);
+    idpSrv!.listen(0, "127.0.0.1", () => { idpSrv!.off("error", onListenError); r(); });
+  });
+  // From here the server is live for the rest of the run, so errors get a PERSISTENT handler that
+  // reds the suite rather than either crashing it mid-fixture (losing teardown) or vanishing.
+  idpSrv.on("error", (e) => {
+    process.exitCode = 1;
+    console.error(`  ! IdP server error after listen: ${e.message} — the suite's verdict below cannot be trusted`);
+  });
   origin = `http://127.0.0.1:${(idpSrv.address() as AddressInfo).port}`;
   base = `${origin}/api/auth`;
   ba = betterAuth({

--- a/implementations/auth/smoke/ps-user-mode.smoke.ts
+++ b/implementations/auth/smoke/ps-user-mode.smoke.ts
@@ -31,7 +31,7 @@ import { deviceAuthorization } from "better-auth/plugins/device-authorization";
 import { bearer } from "better-auth/plugins/bearer";
 import { toNodeHandler } from "better-auth/node";
 import { pickFreePort } from "./_free-port.js";
-import { assertScratchHeld, foreignRootFor, killManagerAtRoot, makeScratch } from "../../../bin/smoke/_scratch.js";
+import { assertScratchHeld, foreignRootFor, killManagerAtRoot, makeScratch, preserveScratch } from "../../../bin/smoke/_scratch.js";
 
 // Sandbox the temp root BEFORE minting the fixture. `findCotalRoot` walks to `/` unbounded, so a
 // `.cotal` above `tmpdir()` makes `cotal up` write `manager.pid` into that ancestor. Step 4 then
@@ -377,6 +377,8 @@ try {
     // an anonymous one.
     if (upAttempted && !meshStopped) {
       process.exitCode = 1;
+      // Claim it out of the exit sweep: the evidence is the whole point of keeping it.
+      preserveScratch(scratch);
       console.error(
         `  ! PRESERVING ${scratch}: the mesh was not confirmed stopped, and its .cotal holds the pidfiles `
           + `needed to find and stop whatever is still running.`,

--- a/implementations/auth/smoke/ps-user-mode.smoke.ts
+++ b/implementations/auth/smoke/ps-user-mode.smoke.ts
@@ -60,17 +60,59 @@ const CLIENT_ID = "cotal-cli";
 const BIN = join(import.meta.dirname, "..", "..", "..", "bin", "cotal.ts");
 const TSX = join(import.meta.dirname, "..", "..", "..", "node_modules", ".bin", "tsx");
 
-function cotal(args: string[], timeoutMs = 120_000): Promise<{ status: number | null; out: string }> {
+/**
+ * How the child ENDED is part of the result, not a detail of the wrapper.
+ *
+ * `status: null` is reported for ANY signal death — this suite's own timeout, an external
+ * SIGTERM/SIGKILL, an OOM kill, a supervisor sweep — and a launch failure never fires `exit` at
+ * all. Every one of those yields the exact shape step 4's cell demands (`status !== 0`, no
+ * "(no managed agents)"), so any of them lets a run that proved nothing print PASS. A `timedOut`
+ * flag alone is not enough: it only knows about OUR timer.
+ *
+ * So carry all four routes and let {@link mustHaveRun} insist on the only gradeable outcome —
+ * the child exited by itself, with a real numeric code.
+ */
+type Run = {
+  status: number | null;
+  out: string;
+  timedOut: boolean;
+  signal: NodeJS.Signals | null;
+  launchError?: string;
+};
+function cotal(args: string[], timeoutMs = 120_000): Promise<Run> {
   return new Promise((res) => {
     const child = spawn(TSX, [BIN, ...args], {
       cwd: root, env: { ...process.env, COTAL_HOME: home }, stdio: ["ignore", "pipe", "pipe"],
     });
     let out = "";
-    const t = setTimeout(() => child.kill("SIGKILL"), timeoutMs);
+    let timedOut = false;
+    let settled = false;
+    const t = setTimeout(() => { timedOut = true; child.kill("SIGKILL"); }, timeoutMs);
+    // One settle path. A launch error otherwise leaves this Promise pending until the timer, and the
+    // failure then wears the wrong label — "timed out" for something that never started.
+    const done = (r: Run) => { if (settled) return; settled = true; clearTimeout(t); res(r); };
+    child.on("error", (e) => done({ status: null, out, timedOut, signal: null, launchError: e.message }));
     child.stdout!.on("data", (d: Buffer) => { out += d.toString(); });
     child.stderr!.on("data", (d: Buffer) => { out += d.toString(); });
-    child.on("exit", (status) => { clearTimeout(t); res({ status, out }); });
+    child.on("exit", (status, signal) => done({ status, out, timedOut, signal }));
   });
+}
+
+/** Refuse to grade anything but a self-terminated child with a real exit code. Fatal, because every
+ *  rejected shape here is one that would otherwise SATISFY the cells below. */
+function mustHaveRun(r: Run, what: string): void {
+  const why =
+    r.launchError ? `never launched (${r.launchError})`
+    : r.timedOut ? "was SIGKILLed by this suite's timeout"
+    : r.signal ? `was killed by ${r.signal} from outside this suite`
+    : r.status === null ? "ended with neither an exit code nor a signal"
+    : null;
+  if (why === null) return;
+  process.exitCode = 1;
+  throw new Error(
+    `${what} ${why}: that yields status null and no output, which is exactly the shape the ` +
+      `empty-success cell treats as a pass. Grading it would be a false green.`,
+  );
 }
 
 let handler: ReturnType<typeof toNodeHandler> | undefined;
@@ -144,6 +186,8 @@ try {
   console.log(`   killed manager pid ${await killManagerAtRoot(root)} — the cell below grades a DEAD mesh`);
   const psDead = await cotal(["ps", "--space", SPACE], 20_000);
   console.log(`   dead exit=${psDead.status}\n` + psDead.out.split("\n").map((l) => `   | ${l}`).join("\n").slice(0, 500));
+  // Fatal BEFORE grading, not a cell alongside it.
+  mustHaveRun(psDead, "the dead-manager `cotal ps`");
   const emptySuccess =
     psDead.status === 0 &&
     !/unreachable/i.test(psDead.out) &&

--- a/implementations/auth/smoke/ps-user-mode.smoke.ts
+++ b/implementations/auth/smoke/ps-user-mode.smoke.ts
@@ -31,7 +31,7 @@ import { deviceAuthorization } from "better-auth/plugins/device-authorization";
 import { bearer } from "better-auth/plugins/bearer";
 import { toNodeHandler } from "better-auth/node";
 import { pickFreePort } from "./_free-port.js";
-import { assertScratchHeld, foreignRootFor, killManagerAtRoot, makeScratch, preserveScratch } from "../../../bin/smoke/_scratch.js";
+import { assertScratchHeld, foreignRootFor, killManagerAtRoot, makeScratch } from "../../../bin/smoke/_scratch.js";
 
 // Sandbox the temp root BEFORE minting the fixture. `findCotalRoot` walks to `/` unbounded, so a
 // `.cotal` above `tmpdir()` makes `cotal up` write `manager.pid` into that ancestor. Step 4 then
@@ -377,8 +377,6 @@ try {
     // an anonymous one.
     if (upAttempted && !meshStopped) {
       process.exitCode = 1;
-      // Claim it out of the exit sweep: the evidence is the whole point of keeping it.
-      preserveScratch(scratch);
       console.error(
         `  ! PRESERVING ${scratch}: the mesh was not confirmed stopped, and its .cotal holds the pidfiles `
           + `needed to find and stop whatever is still running.`,

--- a/implementations/auth/smoke/ps-user-mode.smoke.ts
+++ b/implementations/auth/smoke/ps-user-mode.smoke.ts
@@ -105,7 +105,13 @@ function cotal(args: string[], timeoutMs = 120_000): Promise<Run> {
     child.on("error", (e) => done({ status: null, out, timedOut, signal: null, launchError: e.message }));
     child.stdout!.on("data", (d: Buffer) => { out += d.toString(); });
     child.stderr!.on("data", (d: Buffer) => { out += d.toString(); });
-    child.on("exit", (status, signal) => done({ status, out, timedOut, signal }));
+    // `close`, NOT `exit`. `exit` fires when the direct child dies; the stdio pipes it handed to
+    // DETACHED descendants stay open and keep writing after that, and `cotal` commands spawn
+    // detached components as a matter of course. Settling on `exit` therefore captures a prefix of
+    // the output and grades it as the whole: measured, `exit` gave `out: ""` at 26ms where `close`
+    // gave `out: "STREAM.INFO"` at 550ms on the same run. Every assertion below that reads output
+    // CONTENT — the empty-success cell most of all — would be judging text that had not arrived.
+    child.on("close", (status, signal) => done({ status, out, timedOut, signal }));
   });
 }
 
@@ -164,11 +170,14 @@ try {
   // anchor at all under the clean ancestry makeScratch builds, so it cannot tell "anchored" from
   // "nothing here" on an ordinary run - it would have let CI delete the load-bearing anchor and stay
   // green. Assert the thing itself; keep the resolution cell beside it as the consequence.
-  check("the fixture root OWNS its .cotal (the anchor exists)", existsSync(join(root, ".cotal")), root);
+  // Read ONCE, so the graded cell and the fatal branch cannot report different things about the
+  // same instant.
+  const anchored = existsSync(join(root, ".cotal"));
+  check("the fixture root OWNS its .cotal (the anchor exists)", anchored, root);
   // FATAL HERE, before any product command. A failed `check` alone only increments the tally and
   // lets `up` run UNANCHORED — the precise state whose race this anchor exists to remove. The suite
   // would still exit red, but only after starting a mesh that could root anywhere.
-  if (!existsSync(join(root, ".cotal"))) {
+  if (!anchored) {
     process.exitCode = 1;
     throw new Error(`FIXTURE FAILURE: the anchor ${join(root, ".cotal")} is missing, so no product command below can be trusted to root here.`);
   }

--- a/implementations/auth/smoke/ps-user-mode.smoke.ts
+++ b/implementations/auth/smoke/ps-user-mode.smoke.ts
@@ -83,12 +83,19 @@ const TSX = join(import.meta.dirname, "..", "..", "..", "node_modules", ".bin", 
  * So carry all four routes and let {@link mustHaveRun} insist on the only gradeable outcome —
  * the child exited by itself, with a real numeric code.
  */
+// How long to keep draining inherited stdio after the direct child exits. Long enough for the tail
+// a detached component flushes (measured ~450ms), short enough that a long-lived one cannot hang
+// the suite. Exceeding it is reported, never absorbed.
+const DRAIN_MS = 2_000;
+
 type Run = {
   status: number | null;
   out: string;
   timedOut: boolean;
   signal: NodeJS.Signals | null;
   launchError?: string;
+  /** Descendants held the inherited pipes past the drain bound: `out` is a PREFIX, not the whole. */
+  stdioTimedOut?: boolean;
 };
 function cotal(args: string[], timeoutMs = 120_000): Promise<Run> {
   return new Promise((res) => {
@@ -98,20 +105,34 @@ function cotal(args: string[], timeoutMs = 120_000): Promise<Run> {
     let out = "";
     let timedOut = false;
     let settled = false;
-    const t = setTimeout(() => { timedOut = true; child.kill("SIGKILL"); }, timeoutMs);
+    let exited = false;
+    let status: number | null = null;
+    let signal: NodeJS.Signals | null = null;
+    let drain: NodeJS.Timeout | undefined;
     // One settle path. A launch error otherwise leaves this Promise pending until the timer, and the
     // failure then wears the wrong label — "timed out" for something that never started.
-    const done = (r: Run) => { if (settled) return; settled = true; clearTimeout(t); res(r); };
+    const done = (r: Run) => { if (settled) return; settled = true; clearTimeout(cmd); clearTimeout(drain); res(r); };
+    // Descendants still hold our pipe ends. Stop waiting, drop them, and SAY the output is partial
+    // rather than grading a prefix silently.
+    const giveUpOnStdio = () => { child.stdout?.destroy(); child.stderr?.destroy(); done({ status, out, timedOut, signal, stdioTimedOut: true }); };
+    const cmd = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+      // A kill cannot close pipes an already-exited child handed to a detached descendant, so the
+      // command timeout has to be able to settle by itself or this wrapper hangs forever.
+      if (exited) giveUpOnStdio(); else drain = setTimeout(giveUpOnStdio, DRAIN_MS);
+    }, timeoutMs);
     child.on("error", (e) => done({ status: null, out, timedOut, signal: null, launchError: e.message }));
     child.stdout!.on("data", (d: Buffer) => { out += d.toString(); });
     child.stderr!.on("data", (d: Buffer) => { out += d.toString(); });
-    // `close`, NOT `exit`. `exit` fires when the direct child dies; the stdio pipes it handed to
-    // DETACHED descendants stay open and keep writing after that, and `cotal` commands spawn
-    // detached components as a matter of course. Settling on `exit` therefore captures a prefix of
-    // the output and grades it as the whole: measured, `exit` gave `out: ""` at 26ms where `close`
-    // gave `out: "STREAM.INFO"` at 550ms on the same run. Every assertion below that reads output
-    // CONTENT — the empty-success cell most of all — would be judging text that had not arrived.
-    child.on("close", (status, signal) => done({ status, out, timedOut, signal }));
+    // TWO PHASE. `exit` gives the direct child's outcome; `close` gives the COMPLETE output, because
+    // pipes handed to DETACHED descendants keep carrying text after the child dies (measured:
+    // `out: ""` at exit 26ms, `out: "STREAM.INFO"` at close 453ms) and every cell below that reads
+    // output content would otherwise judge text that had not arrived. But waiting only for `close`
+    // hangs whenever a long-lived detached component holds the pipe — which `cotal` creates on
+    // purpose. So: record the outcome at `exit`, keep draining, and bound that drain.
+    child.on("exit", (s, sg) => { exited = true; status = s; signal = sg; drain = setTimeout(giveUpOnStdio, DRAIN_MS); });
+    child.on("close", (s, sg) => done({ status: s ?? status, out, timedOut, signal: sg ?? signal }));
   });
 }
 
@@ -122,6 +143,7 @@ function mustHaveRun(r: Run, what: string): void {
     r.launchError ? `never launched (${r.launchError})`
     : r.timedOut ? "was SIGKILLed by this suite's timeout"
     : r.signal ? `was killed by ${r.signal} from outside this suite`
+    : r.stdioTimedOut ? "left its output incomplete (detached descendants held the pipes past the drain bound)"
     : r.status === null ? "ended with neither an exit code nor a signal"
     : null;
   if (why === null) return;

--- a/implementations/cli/smoke/down-target.smoke.ts
+++ b/implementations/cli/smoke/down-target.smoke.ts
@@ -13,43 +13,13 @@ import { strict as assert } from "node:assert";
 import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { join } from "node:path";
+import { makeScratch } from "../../../bin/smoke/_scratch.js";
 
 // Isolate BOTH the machine-home AND the temp root. `findCotalRoot` walks to `/` with no boundary,
-// so a `.cotal` above the temp base (observed: `/tmp/.cotal` on GHA; a home-dir `.cotal` when the
-// scratch sat under the monorepo) captures every "neutral" dir. Pick a base with no `.cotal`
-// ancestor, point TMPDIR at a scratch under it.
-function hasCotalAncestor(start: string): boolean {
-  let dir = resolve(start);
-  for (;;) {
-    if (existsSync(join(dir, ".cotal"))) return true;
-    const parent = dirname(dir);
-    if (parent === dir) return false;
-    dir = parent;
-  }
-}
-function makeScratch(): string {
-  const bases = [process.env.RUNNER_TEMP, process.env.TMPDIR, tmpdir(), "/var/tmp"].filter(
-    (b): b is string => typeof b === "string" && b.length > 0,
-  );
-  const tried: string[] = [];
-  for (const base of bases) {
-    if (hasCotalAncestor(base)) {
-      tried.push(`${base} (has .cotal ancestor)`);
-      continue;
-    }
-    try {
-      return mkdtempSync(join(base, "cotal-smoke-"));
-    } catch (e) {
-      tried.push(`${base} (${(e as Error).message})`);
-    }
-  }
-  throw new Error(`no temp base free of a .cotal ancestor; tried: ${tried.join("; ")}`);
-}
+// so a `.cotal` above the temp base (observed: `/tmp/.cotal` on CI; a home-dir `.cotal` when the
+// scratch sat under the monorepo) captures every "neutral" dir.
 const scratch = makeScratch();
-process.env.TMPDIR = scratch;
-process.env.TMP = scratch;
-process.env.TEMP = scratch;
 const home = mkdtempSync(join(scratch, "home-"));
 process.env.COTAL_HOME = home;
 

--- a/implementations/cli/smoke/down-target.smoke.ts
+++ b/implementations/cli/smoke/down-target.smoke.ts
@@ -150,24 +150,34 @@ try {
   // Only the ones that were actually created — a throw partway through leaves the rest undefined,
   // and `finally` has to cope with a half-built fixture rather than assume a complete one.
   let stranded = 0;
+  const survivors: number[] = [];
   for (const child of spawnedChildren) {
-    const m = { child };
-    if (!m.child.pid) continue;
-    if (!alive(m.child.pid)) continue;
+    if (!child.pid) continue;
+    if (!alive(child.pid)) continue;
     try {
-      process.kill(m.child.pid, "SIGKILL");
+      process.kill(child.pid, "SIGKILL");
     } catch (e) {
       stranded++;
-      console.error(`  ! could not kill dashboard child ${m.child.pid} (${(e as Error).message}) — it is still running`);
+      survivors.push(child.pid);
+      console.error(`  ! could not kill dashboard child ${child.pid} (${(e as Error).message})`);
     }
   }
-  // The scratch goes ONLY if nothing of ours is still alive in it. Its `.cotal/web.pid` is the sole
-  // record that could identify a survivor, and deleting that makes a recoverable orphan anonymous.
+  // EVIDENCE MUST EXIST, not merely be preserved. On partial construction the pidfile write is
+  // exactly what threw, so "the scratch holds the pidfiles" was false in the one case that needs
+  // them. Write the survivors down where they can be found, and if even that fails, put the PIDs on
+  // stderr — an operator can act on a printed PID, but not on a claim that a file exists.
   if (stranded > 0) {
     process.exitCode = 1;
-    console.error(`  ! PRESERVING ${scratch}: ${stranded} child(ren) still alive; its web.pid files are the only way to find them.`);
+    const record = join(scratch, "STRANDED-PIDS.txt");
+    try {
+      writeFileSync(record, survivors.join("\n") + "\n", { mode: 0o600 });
+      console.error(`  ! PRESERVING ${scratch}: ${stranded} child(ren) still alive; PIDs recorded in ${record}`);
+    } catch (e) {
+      console.error(`  ! ${stranded} child(ren) still alive and the record could not be written (${(e as Error).message}). PIDs: ${survivors.join(", ")}`);
+    }
   } else {
     rmSync(scratch, { recursive: true, force: true });
   }
 }
+
 // No `process.exit(0)`: it overrode the exitCode a stranded child sets, turning a leak green.

--- a/implementations/cli/smoke/down-target.smoke.ts
+++ b/implementations/cli/smoke/down-target.smoke.ts
@@ -5,19 +5,52 @@
  * `cotal web` (target-resolved) claimed `<mesh-root>/.cotal/web.pid` but `cotal down web` only
  * looked under the folder it ran in and reported "Nothing running for web".
  *
- * Hermetic (no broker): COTAL_HOME is sandboxed, meshes are recorded straight into the registry,
- * and the dashboard is a real SIGTERM-able child whose pid sits in the mesh root's web.pid.
- * Run: pnpm smoke:down-target
+ * Hermetic (no broker): COTAL_HOME and the temp root are sandboxed, meshes are recorded straight
+ * into the registry, and the dashboard is a real SIGTERM-able child whose pid sits in the mesh
+ * root's web.pid. Run: pnpm smoke:down-target
  */
 import { strict as assert } from "node:assert";
 import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
-// Sandbox the machine-home BEFORE touching the registry — homeCotalDir() reads COTAL_HOME per call,
-// so the real ~/.cotal is never touched.
-const home = mkdtempSync(join(tmpdir(), "cotal-home-"));
+// Isolate BOTH the machine-home AND the temp root. `findCotalRoot` walks to `/` with no boundary,
+// so a `.cotal` above the temp base (observed: `/tmp/.cotal` on GHA; a home-dir `.cotal` when the
+// scratch sat under the monorepo) captures every "neutral" dir. Pick a base with no `.cotal`
+// ancestor, point TMPDIR at a scratch under it.
+function hasCotalAncestor(start: string): boolean {
+  let dir = resolve(start);
+  for (;;) {
+    if (existsSync(join(dir, ".cotal"))) return true;
+    const parent = dirname(dir);
+    if (parent === dir) return false;
+    dir = parent;
+  }
+}
+function makeScratch(): string {
+  const bases = [process.env.RUNNER_TEMP, process.env.TMPDIR, tmpdir(), "/var/tmp"].filter(
+    (b): b is string => typeof b === "string" && b.length > 0,
+  );
+  const tried: string[] = [];
+  for (const base of bases) {
+    if (hasCotalAncestor(base)) {
+      tried.push(`${base} (has .cotal ancestor)`);
+      continue;
+    }
+    try {
+      return mkdtempSync(join(base, "cotal-smoke-"));
+    } catch (e) {
+      tried.push(`${base} (${(e as Error).message})`);
+    }
+  }
+  throw new Error(`no temp base free of a .cotal ancestor; tried: ${tried.join("; ")}`);
+}
+const scratch = makeScratch();
+process.env.TMPDIR = scratch;
+process.env.TMP = scratch;
+process.env.TEMP = scratch;
+const home = mkdtempSync(join(scratch, "home-"));
 process.env.COTAL_HOME = home;
 
 const { registry } = await import("@cotal-ai/core");
@@ -55,24 +88,13 @@ const run = (positionals: string[], values: Record<string, string | boolean> = {
 const entry = (space: string, root: string) =>
   ({ space, server: "nats://127.0.0.1:4222", root, mode: "open" as const, ts: "2026-07-27T00:00:00.000Z" });
 
-const neutral = mkdtempSync(join(tmpdir(), "cotal-neutral-")); // no .cotal up-tree, not a mesh root
+const neutral = mkdtempSync(join(tmpdir(), "cotal-neutral-")); // no .cotal up-tree (enforced by scratch)
 const prevCwd = process.cwd();
 const meshA = meshWithDashboard("meshA");
 const meshB = meshWithDashboard("meshB");
 
 try {
-  // PRECONDITION this suite cannot sandbox. COTAL_HOME is isolated, but `findCotalRoot` walks to
-  // `/` with no boundary, so ANY `.cotal` in an ANCESTOR of `tmpdir()` makes `neutral` resolve as
-  // a local project and the not-a-mesh-root cells stop testing what they name. Measured: this file
-  // fails on a machine whose tmp parent holds a `.cotal` and passes 11/11 under clean ancestry, at
-  // the same commit. Name the directory rather than failing later and opaquely.
-  const neutralRoot = findCotalRoot(neutral);
-  assert.equal(
-    neutralRoot,
-    neutral,
-    `this smoke needs a tmp dir with NO .cotal ancestor, but found one at ${join(neutralRoot, ".cotal")} `
-      + `(tmpdir is ${tmpdir()}). Point TMPDIR at a directory whose ancestors hold no .cotal, or remove that one.`,
-  );
+  check("scratch has no .cotal ancestor", findCotalRoot(neutral) === neutral, findCotalRoot(neutral));
 
   // The real web descriptor must declare target rooting, and down must see it on the surface.
   check('web descriptor declares rootedAt: "target"', webProcess.rootedAt === "target");
@@ -123,9 +145,7 @@ try {
     if (m.child.pid && alive(m.child.pid)) {
       try { process.kill(m.child.pid, "SIGKILL"); } catch { /* gone */ }
     }
-    rmSync(m.root, { recursive: true, force: true });
   }
-  rmSync(neutral, { recursive: true, force: true });
-  rmSync(home, { recursive: true, force: true });
+  rmSync(scratch, { recursive: true, force: true });
 }
 process.exit(0);

--- a/implementations/cli/smoke/down-target.smoke.ts
+++ b/implementations/cli/smoke/down-target.smoke.ts
@@ -14,7 +14,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { makeScratch } from "../../../bin/smoke/_scratch.js";
+import { makeScratch, preserveScratch } from "../../../bin/smoke/_scratch.js";
 
 // Isolate BOTH the machine-home AND the temp root. `findCotalRoot` walks to `/` with no boundary,
 // so a `.cotal` above the temp base (observed: `/tmp/.cotal` on CI; a home-dir `.cotal` when the
@@ -58,12 +58,20 @@ const run = (positionals: string[], values: Record<string, string | boolean> = {
 const entry = (space: string, root: string) =>
   ({ space, server: "nats://127.0.0.1:4222", root, mode: "open" as const, ts: "2026-07-27T00:00:00.000Z" });
 
-const neutral = mkdtempSync(join(tmpdir(), "cotal-neutral-")); // no .cotal up-tree (enforced by scratch)
 const prevCwd = process.cwd();
-const meshA = meshWithDashboard("meshA");
-const meshB = meshWithDashboard("meshB");
+// Declared here, CREATED inside the try. Spawning detached children before the try meant a throw in
+// between — the second mkdtemp, the neutral dir, the second mesh — exited with them still running
+// and no `finally` to reach them. An exit-time scratch sweep is NOT a fix for that: it deletes
+// `.cotal/web.pid`, which is the only thing that could have identified the orphan, turning a
+// recoverable leak into an anonymous one. Cleanup has to own the children, not just their directory.
+let neutral: string | undefined;
+let meshA: { root: string; child: ChildProcess; pidPath: string } | undefined;
+let meshB: { root: string; child: ChildProcess; pidPath: string } | undefined;
 
 try {
+  neutral = mkdtempSync(join(tmpdir(), "cotal-neutral-")); // no .cotal up-tree (enforced by scratch)
+  meshA = meshWithDashboard("meshA");
+  meshB = meshWithDashboard("meshB");
   check("scratch has no .cotal ancestor", findCotalRoot(neutral) === neutral, findCotalRoot(neutral));
 
   // The real web descriptor must declare target rooting, and down must see it on the surface.
@@ -111,11 +119,27 @@ try {
   console.log(`\ndown target-addressed smoke: ${pass} checks passed`);
 } finally {
   process.chdir(prevCwd);
+  // Only the ones that were actually created — a throw partway through leaves the rest undefined,
+  // and `finally` has to cope with a half-built fixture rather than assume a complete one.
+  let stranded = 0;
   for (const m of [meshA, meshB]) {
-    if (m.child.pid && alive(m.child.pid)) {
-      try { process.kill(m.child.pid, "SIGKILL"); } catch { /* gone */ }
+    if (!m?.child.pid) continue;
+    if (!alive(m.child.pid)) continue;
+    try {
+      process.kill(m.child.pid, "SIGKILL");
+    } catch (e) {
+      stranded++;
+      console.error(`  ! could not kill dashboard child ${m.child.pid} (${(e as Error).message}) — it is still running`);
     }
   }
-  rmSync(scratch, { recursive: true, force: true });
+  // The scratch goes ONLY if nothing of ours is still alive in it. Its `.cotal/web.pid` is the sole
+  // record that could identify a survivor, and deleting that makes a recoverable orphan anonymous.
+  if (stranded > 0) {
+    process.exitCode = 1;
+    preserveScratch(scratch);
+    console.error(`  ! PRESERVING ${scratch}: ${stranded} child(ren) still alive; its web.pid files are the only way to find them.`);
+  } else {
+    rmSync(scratch, { recursive: true, force: true });
+  }
 }
 process.exit(0);

--- a/implementations/cli/smoke/down-target.smoke.ts
+++ b/implementations/cli/smoke/down-target.smoke.ts
@@ -14,7 +14,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { makeScratch, preserveScratch } from "../../../bin/smoke/_scratch.js";
+import { makeScratch } from "../../../bin/smoke/_scratch.js";
 
 // Isolate BOTH the machine-home AND the temp root. `findCotalRoot` walks to `/` with no boundary,
 // so a `.cotal` above the temp base (observed: `/tmp/.cotal` on CI; a home-dir `.cotal` when the
@@ -47,9 +47,22 @@ function meshWithDashboard(label: string): { root: string; child: ChildProcess; 
   mkdirSync(join(root, ".cotal"), { recursive: true });
   const child = spawn(process.execPath, ["-e", "setInterval(()=>{}, 1000);"], { detached: true, stdio: "ignore" });
   child.unref();
-  const pidPath = join(root, ".cotal", "web.pid");
-  writeFileSync(pidPath, String(child.pid), { mode: 0o600 });
-  return { root, child, pidPath };
+  // TRANSACTIONAL FROM THE SPAWN, because ownership cannot be published by a `return` that never
+  // happens. Moving the call inside the caller's `try` was not enough: a throw between the spawn and
+  // the return — the pidfile write — leaves the assignment undefined, so the caller's `finally` has
+  // no record to clean and the child survives with PPID 1. Measured exactly that way: PID alive,
+  // reparented, and its pid evidence gone.
+  try {
+    const pidPath = join(root, ".cotal", "web.pid");
+    writeFileSync(pidPath, String(child.pid), { mode: 0o600 });
+    return { root, child, pidPath };
+  } catch (e) {
+    if (child.pid) {
+      try { process.kill(child.pid, "SIGKILL"); }
+      catch (ke) { console.error(`  ! ${label}: spawned ${child.pid} then failed, and could not kill it: ${(ke as Error).message}`); }
+    }
+    throw e;
+  }
 }
 
 const run = (positionals: string[], values: Record<string, string | boolean> = {}) =>
@@ -136,7 +149,6 @@ try {
   // record that could identify a survivor, and deleting that makes a recoverable orphan anonymous.
   if (stranded > 0) {
     process.exitCode = 1;
-    preserveScratch(scratch);
     console.error(`  ! PRESERVING ${scratch}: ${stranded} child(ren) still alive; its web.pid files are the only way to find them.`);
   } else {
     rmSync(scratch, { recursive: true, force: true });

--- a/implementations/cli/smoke/down-target.smoke.ts
+++ b/implementations/cli/smoke/down-target.smoke.ts
@@ -15,18 +15,35 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { makeScratch } from "../../../bin/smoke/_scratch.js";
+import { probeLiveness } from "../src/lib/pid.js";
 
 // Isolate BOTH the machine-home AND the temp root. `findCotalRoot` walks to `/` with no boundary,
 // so a `.cotal` above the temp base (observed: `/tmp/.cotal` on CI; a home-dir `.cotal` when the
 // scratch sat under the monorepo) captures every "neutral" dir.
 const scratch = makeScratch();
-const home = mkdtempSync(join(scratch, "home-"));
-process.env.COTAL_HOME = home;
-
-const { registry } = await import("@cotal-ai/core");
-const { cacheLocalProcess, extensionLocalProcesses, findCotalRoot, recordMesh, setCurrent } = await import("@cotal-ai/workspace");
-const { down } = await import("../src/commands/down.js");
-const { webProcess } = await import("../../web/src/web.js");
+// SETUP TRANSACTION covering the WHOLE post-scratch window: the home mkdtemp and every dynamic
+// import. An import failure here used to exit with the scratch on disk just as a failed mkdtemp did.
+const cleanScratch = (e: unknown): never => {
+  rmSync(scratch, { recursive: true, force: true });
+  throw new Error(`fixture setup failed (scratch removed): ${(e as Error).message}`, { cause: e });
+};
+let home!: string;
+let registry!: typeof import("@cotal-ai/core").registry;
+let cacheLocalProcess!: typeof import("@cotal-ai/workspace").cacheLocalProcess;
+let extensionLocalProcesses!: typeof import("@cotal-ai/workspace").extensionLocalProcesses;
+let findCotalRoot!: typeof import("@cotal-ai/workspace").findCotalRoot;
+let recordMesh!: typeof import("@cotal-ai/workspace").recordMesh;
+let setCurrent!: typeof import("@cotal-ai/workspace").setCurrent;
+let down!: typeof import("../src/commands/down.js").down;
+let webProcess!: typeof import("../../web/src/web.js").webProcess;
+try {
+  home = mkdtempSync(join(scratch, "home-"));
+  process.env.COTAL_HOME = home;
+  ({ registry } = await import("@cotal-ai/core"));
+  ({ cacheLocalProcess, extensionLocalProcesses, findCotalRoot, recordMesh, setCurrent } = await import("@cotal-ai/workspace"));
+  ({ down } = await import("../src/commands/down.js"));
+  ({ webProcess } = await import("../../web/src/web.js"));
+} catch (e) { cleanScratch(e); }
 
 let pass = 0;
 const check = (name: string, cond: boolean, extra?: unknown) => {
@@ -35,10 +52,15 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
   console.log(`  ✓ ${name}`);
 };
 
-const alive = (pid: number): boolean => {
-  try { process.kill(pid, 0); return true; }
-  catch (e) { return (e as NodeJS.ErrnoException).code === "EPERM"; }
-};
+// Only ESRCH proves death. The previous two-state form mapped ANY other errno - EPERM, EIO,
+// unknown - to "dead", which let cleanup skip a live child and then delete its pid evidence.
+const alive = (pid: number): boolean => probeLiveness(pid) !== "dead";
+
+// OWNERSHIP IS PUBLISHED AT THE SPAWN, not by a `return` that may never happen. Every child goes in
+// here the instant it exists, so a throw between the spawn and the return still leaves `finally` a
+// reference to something alive. The caller cannot own a resource whose creating function threw
+// before returning; only the spawner can.
+const spawnedChildren: ChildProcess[] = [];
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /** A registered mesh root with a live "dashboard" child recorded in its web.pid. */
@@ -46,23 +68,16 @@ function meshWithDashboard(label: string): { root: string; child: ChildProcess; 
   const root = mkdtempSync(join(tmpdir(), `cotal-${label}-`));
   mkdirSync(join(root, ".cotal"), { recursive: true });
   const child = spawn(process.execPath, ["-e", "setInterval(()=>{}, 1000);"], { detached: true, stdio: "ignore" });
+  spawnedChildren.push(child);   // <- before ANY fallible work below
   child.unref();
   // TRANSACTIONAL FROM THE SPAWN, because ownership cannot be published by a `return` that never
   // happens. Moving the call inside the caller's `try` was not enough: a throw between the spawn and
   // the return — the pidfile write — leaves the assignment undefined, so the caller's `finally` has
   // no record to clean and the child survives with PPID 1. Measured exactly that way: PID alive,
   // reparented, and its pid evidence gone.
-  try {
-    const pidPath = join(root, ".cotal", "web.pid");
-    writeFileSync(pidPath, String(child.pid), { mode: 0o600 });
-    return { root, child, pidPath };
-  } catch (e) {
-    if (child.pid) {
-      try { process.kill(child.pid, "SIGKILL"); }
-      catch (ke) { console.error(`  ! ${label}: spawned ${child.pid} then failed, and could not kill it: ${(ke as Error).message}`); }
-    }
-    throw e;
-  }
+  const pidPath = join(root, ".cotal", "web.pid");
+  writeFileSync(pidPath, String(child.pid), { mode: 0o600 });
+  return { root, child, pidPath };
 }
 
 const run = (positionals: string[], values: Record<string, string | boolean> = {}) =>
@@ -135,8 +150,9 @@ try {
   // Only the ones that were actually created — a throw partway through leaves the rest undefined,
   // and `finally` has to cope with a half-built fixture rather than assume a complete one.
   let stranded = 0;
-  for (const m of [meshA, meshB]) {
-    if (!m?.child.pid) continue;
+  for (const child of spawnedChildren) {
+    const m = { child };
+    if (!m.child.pid) continue;
     if (!alive(m.child.pid)) continue;
     try {
       process.kill(m.child.pid, "SIGKILL");
@@ -154,4 +170,4 @@ try {
     rmSync(scratch, { recursive: true, force: true });
   }
 }
-process.exit(0);
+// No `process.exit(0)`: it overrode the exitCode a stranded child sets, turning a leak green.

--- a/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
+++ b/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
@@ -1,8 +1,8 @@
 /**
  * `cotal spawn` from any directory — the mesh registry + resolver + offline completion + the
- * connect preflight's stale-detection. Hermetic (no broker needed): COTAL_HOME is sandboxed to a
- * temp dir, "meshes" are recorded straight into the registry, and reachability is probed against a
- * closed port. Run: pnpm smoke:spawn-from-anywhere
+ * connect preflight's stale-detection. Hermetic (no broker needed): COTAL_HOME and the temp root
+ * are sandboxed, "meshes" are recorded straight into the registry, and reachability is probed
+ * against a closed port. Run: pnpm smoke:spawn-from-anywhere
  *
  * Covers every `resolveMeshTarget` source branch (0 / 1 / N+current / --space / local-project),
  * that completion lists the RESOLVED mesh's personas (not the cwd's) without opening the network,
@@ -10,13 +10,49 @@
  * and is pruned.
  */
 import { strict as assert } from "node:assert";
-import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
-// Sandbox the machine-home BEFORE touching the registry — homeCotalDir() reads COTAL_HOME per call,
-// so the real ~/.cotal is never touched.
-const home = mkdtempSync(join(tmpdir(), "cotal-home-"));
+// Isolate BOTH the machine-home AND the temp root before anything else. `findCotalRoot` walks to
+// `/` with no boundary, so a `.cotal` above the temp base (observed: `/tmp/.cotal` on GHA;
+// `/Users/<you>/.cotal` when the suite's scratch sat under the home directory) captures every
+// "neutral" dir and the 0-mesh cell resolves as a local project instead of throwing. Pick a temp
+// base with NO `.cotal` ancestor, point TMPDIR at a scratch under it, tear it down in `finally`.
+function hasCotalAncestor(start: string): boolean {
+  let dir = resolve(start);
+  for (;;) {
+    if (existsSync(join(dir, ".cotal"))) return true;
+    const parent = dirname(dir);
+    if (parent === dir) return false;
+    dir = parent;
+  }
+}
+function makeScratch(): string {
+  // Prefer the CI runner temp (never /tmp on GHA), then the process temp, then /var/tmp. Skip any
+  // base that already has a `.cotal` above it — that is the whole defect this sandbox exists to dodge.
+  const bases = [process.env.RUNNER_TEMP, process.env.TMPDIR, tmpdir(), "/var/tmp"].filter(
+    (b): b is string => typeof b === "string" && b.length > 0,
+  );
+  const tried: string[] = [];
+  for (const base of bases) {
+    if (hasCotalAncestor(base)) {
+      tried.push(`${base} (has .cotal ancestor)`);
+      continue;
+    }
+    try {
+      return mkdtempSync(join(base, "cotal-smoke-"));
+    } catch (e) {
+      tried.push(`${base} (${(e as Error).message})`);
+    }
+  }
+  throw new Error(`no temp base free of a .cotal ancestor; tried: ${tried.join("; ")}`);
+}
+const scratch = makeScratch();
+process.env.TMPDIR = scratch;
+process.env.TMP = scratch;
+process.env.TEMP = scratch;
+const home = mkdtempSync(join(scratch, "home-"));
 process.env.COTAL_HOME = home;
 
 const { probeConnect, createSpaceAuth } = await import("@cotal-ai/core");
@@ -55,27 +91,16 @@ function project(label: string, personas: string[]): string {
 
 const projA = project("projA", ["reviewer", "researcher"]);
 const projB = project("projB", ["builder"]);
-const neutral = mkdtempSync(join(tmpdir(), "cotal-neutral-")); // no .cotal up-tree
+const neutral = mkdtempSync(join(tmpdir(), "cotal-neutral-")); // no .cotal up-tree (enforced by scratch)
 const SERVER = "nats://127.0.0.1:4222";
 const DEAD = "nats://127.0.0.1:1"; // nothing listens here
 const entry = (space: string, root: string, server = SERVER) =>
   ({ space, server, root, mode: "open" as const, ts: "2026-06-22T00:00:00.000Z" });
 
 try {
-  // PRECONDITION, stated because this suite cannot enforce it. It calls itself hermetic and is —
-  // for COTAL_HOME. But `findCotalRoot` walks to `/` with no boundary, so ANY `.cotal` in an
-  // ANCESTOR of `tmpdir()` captures `neutral`: resolution takes the local-project branch and
-  // returns a `local-space` target rather than throwing, and the 0-mesh assertion below fails as
-  // a bare "Missing expected exception" that names neither the cause nor the cure. Observed for
-  // real: a machine with `/tmp/.cotal` fails every run while the identical tree passes under a tmp
-  // root with clean ancestry. Fail here instead, naming the directory and the fix.
-  const neutralRoot = findCotalRoot(neutral);
-  assert.equal(
-    neutralRoot,
-    neutral,
-    `this smoke needs a tmp dir with NO .cotal ancestor, but found one at ${join(neutralRoot, ".cotal")} `
-      + `(tmpdir is ${tmpdir()}). Point TMPDIR at a directory whose ancestors hold no .cotal, or remove that one.`,
-  );
+  // The sandbox is the fix; this check is the witness that it held (not a precondition operators
+  // have to satisfy). A poisoned os.tmpdir() must not reach here.
+  check("scratch has no .cotal ancestor", findCotalRoot(neutral) === neutral, findCotalRoot(neutral));
 
   // 0 meshes → a bare resolve fails with one sentence, not a crash.
   assert.throws(() => resolveMeshTarget(neutral), /no mesh running/);
@@ -253,6 +278,6 @@ try {
 
   console.log(`\nspawn-from-anywhere smoke: ${pass} checks passed`);
 } finally {
-  for (const d of [home, projA, projB, neutral]) rmSync(d, { recursive: true, force: true });
+  rmSync(scratch, { recursive: true, force: true });
 }
 process.exit(0);

--- a/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
+++ b/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
@@ -10,48 +10,16 @@
  * and is pruned.
  */
 import { strict as assert } from "node:assert";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { join } from "node:path";
+import { makeScratch } from "../../../bin/smoke/_scratch.js";
 
 // Isolate BOTH the machine-home AND the temp root before anything else. `findCotalRoot` walks to
-// `/` with no boundary, so a `.cotal` above the temp base (observed: `/tmp/.cotal` on GHA;
+// `/` with no boundary, so a `.cotal` above the temp base (observed: `/tmp/.cotal` on CI;
 // `/Users/<you>/.cotal` when the suite's scratch sat under the home directory) captures every
-// "neutral" dir and the 0-mesh cell resolves as a local project instead of throwing. Pick a temp
-// base with NO `.cotal` ancestor, point TMPDIR at a scratch under it, tear it down in `finally`.
-function hasCotalAncestor(start: string): boolean {
-  let dir = resolve(start);
-  for (;;) {
-    if (existsSync(join(dir, ".cotal"))) return true;
-    const parent = dirname(dir);
-    if (parent === dir) return false;
-    dir = parent;
-  }
-}
-function makeScratch(): string {
-  // Prefer the CI runner temp (never /tmp on GHA), then the process temp, then /var/tmp. Skip any
-  // base that already has a `.cotal` above it — that is the whole defect this sandbox exists to dodge.
-  const bases = [process.env.RUNNER_TEMP, process.env.TMPDIR, tmpdir(), "/var/tmp"].filter(
-    (b): b is string => typeof b === "string" && b.length > 0,
-  );
-  const tried: string[] = [];
-  for (const base of bases) {
-    if (hasCotalAncestor(base)) {
-      tried.push(`${base} (has .cotal ancestor)`);
-      continue;
-    }
-    try {
-      return mkdtempSync(join(base, "cotal-smoke-"));
-    } catch (e) {
-      tried.push(`${base} (${(e as Error).message})`);
-    }
-  }
-  throw new Error(`no temp base free of a .cotal ancestor; tried: ${tried.join("; ")}`);
-}
+// "neutral" dir and the 0-mesh cell resolves as a local project instead of throwing.
 const scratch = makeScratch();
-process.env.TMPDIR = scratch;
-process.env.TMP = scratch;
-process.env.TEMP = scratch;
 const home = mkdtempSync(join(scratch, "home-"));
 process.env.COTAL_HOME = home;
 

--- a/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
+++ b/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
@@ -35,7 +35,25 @@ try {
 } catch (e) { cleanScratch(e); }
 process.env.COTAL_HOME = home;
 
-let probeConnect!: any, createSpaceAuth!: any, authDir!: any, findCotalRoot!: any, clearCurrent!: any, isWorkspaceTargetError!: any, loadMeshes!: any, meshesDir!: any, recordMesh!: any, removeMesh!: any, resolveMeshTarget!: any, saveSpaceAuth!: any, setCurrent!: any, spawnComplete!: any, spawnPersonaRef!: any, listPersonas!: any, pruneStaleMeshes!: any;
+// Typed against the modules they come from — `any` here would have bought cleanup by giving up
+// the compile-time checking this smoke exists to exercise.
+let probeConnect!: typeof import("@cotal-ai/core").probeConnect;
+let createSpaceAuth!: typeof import("@cotal-ai/core").createSpaceAuth;
+let authDir!: typeof import("@cotal-ai/workspace").authDir;
+let findCotalRoot!: typeof import("@cotal-ai/workspace").findCotalRoot;
+let clearCurrent!: typeof import("@cotal-ai/workspace").clearCurrent;
+let isWorkspaceTargetError!: typeof import("@cotal-ai/workspace").isWorkspaceTargetError;
+let loadMeshes!: typeof import("@cotal-ai/workspace").loadMeshes;
+let meshesDir!: typeof import("@cotal-ai/workspace").meshesDir;
+let recordMesh!: typeof import("@cotal-ai/workspace").recordMesh;
+let removeMesh!: typeof import("@cotal-ai/workspace").removeMesh;
+let resolveMeshTarget!: typeof import("@cotal-ai/workspace").resolveMeshTarget;
+let saveSpaceAuth!: typeof import("@cotal-ai/workspace").saveSpaceAuth;
+let setCurrent!: typeof import("@cotal-ai/workspace").setCurrent;
+let spawnComplete!: typeof import("../src/commands/spawn.js").spawnComplete;
+let spawnPersonaRef!: typeof import("../src/commands/spawn.js").spawnPersonaRef;
+let listPersonas!: typeof import("../src/lib/personas.js").listPersonas;
+let pruneStaleMeshes!: typeof import("../src/lib/meshes.js").pruneStaleMeshes;
 try {
   ({ probeConnect, createSpaceAuth } = await import("@cotal-ai/core"));
   ({

--- a/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
+++ b/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
@@ -20,7 +20,19 @@ import { makeScratch } from "../../../bin/smoke/_scratch.js";
 // `/Users/<you>/.cotal` when the suite's scratch sat under the home directory) captures every
 // "neutral" dir and the 0-mesh cell resolves as a local project instead of throwing.
 const scratch = makeScratch();
-const home = mkdtempSync(join(scratch, "home-"));
+// SETUP TRANSACTION. Everything from here to the main body is fallible — a second mkdtemp, the
+// dynamic imports, the project fixtures — and a throw in that window used to exit with the scratch
+// still on disk (measured: forcing the second `mkdtempSync` to EIO left `cotal-smoke-*` behind).
+// Guarding it per statement is what left three sibling suites exposed after the first attempt, so
+// this is one transaction covering the whole window.
+const cleanScratch = (e: unknown): never => {
+  rmSync(scratch, { recursive: true, force: true });
+  throw new Error(`fixture setup failed (scratch removed): ${(e as Error).message}`, { cause: e });
+};
+let home!: string;
+try {
+  home = mkdtempSync(join(scratch, "home-"));
+} catch (e) { cleanScratch(e); }
 process.env.COTAL_HOME = home;
 
 const { probeConnect, createSpaceAuth } = await import("@cotal-ai/core");
@@ -57,9 +69,13 @@ function project(label: string, personas: string[]): string {
   return root;
 }
 
-const projA = project("projA", ["reviewer", "researcher"]);
-const projB = project("projB", ["builder"]);
-const neutral = mkdtempSync(join(tmpdir(), "cotal-neutral-")); // no .cotal up-tree (enforced by scratch)
+// Same transaction: these mint more directories under the scratch and each can throw.
+let projA!: string, projB!: string, neutral!: string;
+try {
+  projA = project("projA", ["reviewer", "researcher"]);
+  projB = project("projB", ["builder"]);
+  neutral = mkdtempSync(join(tmpdir(), "cotal-neutral-")); // no .cotal up-tree (enforced by scratch)
+} catch (e) { cleanScratch(e); }
 const SERVER = "nats://127.0.0.1:4222";
 const DEAD = "nats://127.0.0.1:1"; // nothing listens here
 const entry = (space: string, root: string, server = SERVER) =>

--- a/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
+++ b/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
@@ -35,23 +35,26 @@ try {
 } catch (e) { cleanScratch(e); }
 process.env.COTAL_HOME = home;
 
-const { probeConnect, createSpaceAuth } = await import("@cotal-ai/core");
-const {
-  authDir,
-  findCotalRoot,
-  clearCurrent,
-  isWorkspaceTargetError,
-  loadMeshes,
-  meshesDir,
-  recordMesh,
-  removeMesh,
-  resolveMeshTarget,
-  saveSpaceAuth,
-  setCurrent,
-} = await import("@cotal-ai/workspace");
-const { spawnComplete, spawnPersonaRef } = await import("../src/commands/spawn.js");
-const { listPersonas } = await import("../src/lib/personas.js");
-const { pruneStaleMeshes } = await import("../src/lib/meshes.js");
+let probeConnect!: any, createSpaceAuth!: any, authDir!: any, findCotalRoot!: any, clearCurrent!: any, isWorkspaceTargetError!: any, loadMeshes!: any, meshesDir!: any, recordMesh!: any, removeMesh!: any, resolveMeshTarget!: any, saveSpaceAuth!: any, setCurrent!: any, spawnComplete!: any, spawnPersonaRef!: any, listPersonas!: any, pruneStaleMeshes!: any;
+try {
+  ({ probeConnect, createSpaceAuth } = await import("@cotal-ai/core"));
+  ({
+    authDir,
+    findCotalRoot,
+    clearCurrent,
+    isWorkspaceTargetError,
+    loadMeshes,
+    meshesDir,
+    recordMesh,
+    removeMesh,
+    resolveMeshTarget,
+    saveSpaceAuth,
+    setCurrent,
+  } = await import("@cotal-ai/workspace"));
+  ({ spawnComplete, spawnPersonaRef } = await import("../src/commands/spawn.js"));
+  ({ listPersonas } = await import("../src/lib/personas.js"));
+  ({ pruneStaleMeshes } = await import("../src/lib/meshes.js"));
+} catch (e) { cleanScratch(e); }
 
 let pass = 0;
 const check = (name: string, cond: boolean, extra?: unknown) => {

--- a/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
+++ b/implementations/cli/smoke/spawn-from-anywhere.smoke.ts
@@ -20,11 +20,11 @@ import { makeScratch } from "../../../bin/smoke/_scratch.js";
 // `/Users/<you>/.cotal` when the suite's scratch sat under the home directory) captures every
 // "neutral" dir and the 0-mesh cell resolves as a local project instead of throwing.
 const scratch = makeScratch();
-// SETUP TRANSACTION. Everything from here to the main body is fallible — a second mkdtemp, the
-// dynamic imports, the project fixtures — and a throw in that window used to exit with the scratch
-// still on disk (measured: forcing the second `mkdtempSync` to EIO left `cotal-smoke-*` behind).
-// Guarding it per statement is what left three sibling suites exposed after the first attempt, so
-// this is one transaction covering the whole window.
+// SETUP OWNERSHIP, in THREE guarded windows — home, the dynamic imports, the project fixtures.
+// Not one transaction: an earlier version of this comment said so and the code never did, which is
+// the false-claim class this branch keeps tripping over. What matters is coverage, and every one of
+// the three removes the scratch on failure, so no window can exit with it on disk. Measured: the
+// 2nd `mkdtempSync` at EIO and a thrown first dynamic import both leave nothing behind.
 const cleanScratch = (e: unknown): never => {
   rmSync(scratch, { recursive: true, force: true });
   throw new Error(`fixture setup failed (scratch removed): ${(e as Error).message}`, { cause: e });
@@ -285,4 +285,5 @@ try {
 } finally {
   rmSync(scratch, { recursive: true, force: true });
 }
-process.exit(0);
+// No `process.exit(0)`: it overrides any non-zero exitCode a cleanup path sets, so a leak or a
+// failed teardown would report green. Let the process exit on its own code.


### PR DESCRIPTION
## Summary

Main CI is red on `smoke:spawn-from-anywhere` (shard 3/4):

```
AssertionError: this smoke needs a tmp dir with NO .cotal ancestor, but found one at /tmp/.cotal
+ actual: '/tmp'
- expected: '/tmp/cotal-neutral-…'
at spawn-from-anywhere.smoke.ts:73
```

`findCotalRoot` walks to `/` with no boundary. On GHA, `/tmp/.cotal` captures every "neutral" temp dir, so the 0-mesh cell resolves as a local project instead of throwing. PR #341 fixed this (sandbox temp root, point TMPDIR at a clean base) but its merge commit never landed on main's first-parent tip — main still has the "name the precondition and fail" version from #339-era.

This cherry-picks `db5bcfc3` onto current main and adds a changeset.

## What the fix does

- Prefer `RUNNER_TEMP` / clean `tmpdir()` / `/var/tmp` bases with no `.cotal` ancestor
- Point `TMPDIR`/`TMP`/`TEMP` at a scratch under that base before any `mkdtempSync`
- Same treatment for `down-target.smoke.ts`
- Hermeticity goal of #341 preserved; no wholesale revert

## Evidence

```
pnpm smoke:spawn-from-anywhere  →  35/35
pnpm smoke:down-target          →  12/12
same under poisoned TMPDIR parent (ancestor has .cotal)  →  35/35
```

## Test plan

- [x] spawn-from-anywhere 35/35
- [x] down-target 12/12
- [x] poisoned-parent TMPDIR still green
- [ ] CI green on this PR (the actual GHA `/tmp/.cotal` case)