### PR TITLE
test: pick broker ports via pickFreePort instead of a random range

### DIFF
--- a/implementations/auth/smoke/admission-mediator.smoke.ts
+++ b/implementations/auth/smoke/admission-mediator.smoke.ts
@@ -33,6 +33,7 @@ import { openLifecycleRegistry, activateLifecycle } from "../src/lifecycle-regis
 import { registryStores } from "../src/lifecycle-registry.js";
 import { makeRecordsScannerOverConnection } from "../src/records-scanner.js";
 import type { CommitValue } from "../src/admission-mediator.js";
+import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -71,7 +72,7 @@ const CALLER = { owner: "local", actor: "caller", uid: "u".repeat(26) };
 const mkReq = (cc: { owner: string; actor: string; uid: string }): MediatedRequest =>
   mediatedRequestFromSubject(`cotal.${SPACE}.epj.${EP}.admit.${cc.owner}.${cc.actor}.${cc.uid}`);
 
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const sd = mkdtempSync(join(tmpdir(), "cotal-medsmoke-"));
 writeFileSync(join(sd, "server.conf"), `
 port: ${PORT}

--- a/implementations/auth/smoke/auth-admin.smoke.ts
+++ b/implementations/auth/smoke/auth-admin.smoke.ts
@@ -37,8 +37,9 @@ import { openAuthorityClient } from "../src/authority-client.js";
 import { ensureRootCredential } from "../src/root-credential.js";
 import { openLifecycleRegistry, readLifecycleHeadForOperation } from "../src/lifecycle-registry.js";
 import type { EvictPrincipal } from "../src/credential-ledger.js";
+import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
 
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 let pass = 0, fail = 0;

--- a/implementations/auth/smoke/barrier-plane.smoke.ts
+++ b/implementations/auth/smoke/barrier-plane.smoke.ts
@@ -37,8 +37,9 @@ import { observeGate, openLifecycleRegistry, readLifecycleHeadForOperation, regi
 import { credRowKey, enumerateOperationIntents, parseLedgerRow, runAgentTakeoverBarrier, type EvictPrincipal } from "../src/credential-ledger.js";
 import { runAgentRetirementBarrier, type RetirementDeps } from "../src/retirement-barrier.js";
 import { makeLedgerScannerOverConnection } from "../src/ledger-scanner.js";
+import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
 
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 const awaitExit = (proc: ReturnType<typeof spawn>, timeoutMs = 3000): Promise<void> =>

--- a/implementations/auth/smoke/connect-reader-acl.smoke.ts
+++ b/implementations/auth/smoke/connect-reader-acl.smoke.ts
@@ -26,8 +26,9 @@ import { ensureRootCredential } from "../src/root-credential.js";
 import { openLifecycleRegistry, registryStores } from "../src/lifecycle-registry.js";
 import { credRowKey, parseLedgerRow } from "../src/credential-ledger.js";
 import type { ValidatedUserToken } from "../src/token.js";
+import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
 
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 const awaitExit = (proc: ReturnType<typeof spawn>, timeoutMs = 3000): Promise<void> =>

--- a/implementations/auth/smoke/credential-ledger.smoke.ts
+++ b/implementations/auth/smoke/credential-ledger.smoke.ts
@@ -46,6 +46,7 @@ import {
   credRowKey, srcgateKey, stageIntentKey,
   type EvictPrincipal, type ReconcileSessionPair,
 } from "../src/credential-ledger.js";
+import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -68,7 +69,7 @@ const EVICT_OPTS = { maxWaitMs: 1500, settleMs: 200, maxVerifyRounds: 3 } as con
 const enc = new TextEncoder();
 const dec = new TextDecoder();
 
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const sd = mkdtempSync(join(tmpdir(), "cotal-credledger-"));
 // A conf broker with a REAL system account (CONNZ + KICK live) and an APP account holding the
 // trusted-auth user plus two victim users whose usernames are principal NAME-forms — CONNZ

--- a/implementations/auth/smoke/deny-new.smoke.ts
+++ b/implementations/auth/smoke/deny-new.smoke.ts
@@ -34,8 +34,9 @@ import { openLifecycleRegistry, registryStores } from "../src/lifecycle-registry
 import { credRowKey, finalizeAgentMint, markLedgerRowRevoked, stageAgentMint } from "../src/credential-ledger.js";
 import { authorityWriterGrants, openAuthorityClient } from "../src/authority-client.js";
 import { ROOT_CREDENTIAL_TTL_MS } from "../src/root-credential.js";
+import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
 
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
 const enc = (s: string) => new TextEncoder().encode(s);
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));

--- a/implementations/auth/smoke/descendant-deny.smoke.ts
+++ b/implementations/auth/smoke/descendant-deny.smoke.ts
@@ -33,8 +33,9 @@ import {
 } from "../src/credential-ledger.js";
 import { openAuthorityClient } from "../src/authority-client.js";
 import { ROOT_CREDENTIAL_TTL_MS } from "../src/root-credential.js";
+import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
 
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
 const enc = (s: string) => new TextEncoder().encode(s);
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));

--- a/implementations/auth/smoke/drain-repair.smoke.ts
+++ b/implementations/auth/smoke/drain-repair.smoke.ts
@@ -27,8 +27,9 @@ import { Kvm } from "@nats-io/kv";
 import { contractDigest, createSpaceAuth, ensureAuthorityStores, epfStreamName, isReachable, parseEffectFact, publishFactCreateOnly, readLastFact, recordsBucket, serverConfig, spacePrefix, createEndpointStreams, effectFactOf, effectCancelledFactOf, type AcceptanceFact } from "@cotal-ai/core";
 import { openAuthorityClient } from "../src/authority-client.js";
 import { assertAppliableCommitKey, assertEffectsCancelSubject, assertPoolRepairSubject, drainApplierGrants, drainCancellerGrants, drainReconcilerGrants, makeDrainRepairers } from "../src/drain-repair.js";
+import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
 
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 let pass = 0, fail = 0;

--- a/implementations/auth/smoke/freeslot-respawn-barrier.smoke.ts
+++ b/implementations/auth/smoke/freeslot-respawn-barrier.smoke.ts
@@ -148,7 +148,8 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 const SELF = process.argv[1];
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const { pickFreePort } = await import("../../../packages/core/smoke/_free-port.js");
+const PORT = await pickFreePort();
 const SERVER = `nats://127.0.0.1:${PORT}`;
 const SPACE = `fsb-${Math.floor(Math.random() * 1e6)}`;
 const CLIENT_ID = "cotal-cli";

--- a/implementations/auth/smoke/int2-revoke-hold.smoke.ts
+++ b/implementations/auth/smoke/int2-revoke-hold.smoke.ts
@@ -137,7 +137,8 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 const SELF = process.argv[1];
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const { pickFreePort } = await import("../../../packages/core/smoke/_free-port.js");
+const PORT = await pickFreePort();
 const SERVER = `nats://127.0.0.1:${PORT}`;
 const SPACE = `fsb-${Math.floor(Math.random() * 1e6)}`;
 const CLIENT_ID = "cotal-cli";

--- a/implementations/auth/smoke/lifecycle-registry.smoke.ts
+++ b/implementations/auth/smoke/lifecycle-registry.smoke.ts
@@ -39,6 +39,7 @@ import {
   tryReserveUid, reserveLifecycleUid, activateLifecycle, resumeActivation,
   observeGate, createGateFrozen, freezeGate, reopenGate, retireGate,
 } from "../src/lifecycle-registry.js";
+import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -55,7 +56,7 @@ const enc = new TextEncoder();
 const headKey = (o: string, a: string) => recordAtomicKey(LIFECYCLE_HEAD, [o, a]);
 const uidKey = (u: string) => recordAtomicKey(UID_RESERVATION, [u]);
 
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const sd = mkdtempSync(join(tmpdir(), "cotal-lifereg-"));
 // A conf broker with a full ADMIN user, a SCOPED mapping-reader user (records leader read +
 // the bind-time STREAM.INFO shape proof, §13.9; a CONNECTION-scoped inbox, never the

--- a/implementations/auth/smoke/mediator-confinement.smoke.ts
+++ b/implementations/auth/smoke/mediator-confinement.smoke.ts
@@ -39,6 +39,7 @@ import {
 import { makeRecordsScannerOverConnection } from "../src/records-scanner.js";
 import { openLifecycleRegistry, activateLifecycle } from "../src/lifecycle-registry.js";
 import { runExactPoolCleaner } from "../src/retirement-barrier.js";
+import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -73,7 +74,7 @@ const D = contractDigest({ s: 1 });
 const fp = (tag: string): string => contractDigest({ fp: tag });
 const enc = new TextEncoder();
 
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const sd = mkdtempSync(join(tmpdir(), "cotal-confine-"));
 // The connection-scoped inbox nonces (SPEC 13.9: never the account-wide `_INBOX.>` default). The
 // mediator holds NO records-stream consumer grant (site 3): its drain enumerates through the sealed

--- a/implementations/auth/smoke/plane-claim.smoke.ts
+++ b/implementations/auth/smoke/plane-claim.smoke.ts
@@ -35,8 +35,9 @@ import { openRecordsScannerCandidate } from "../src/records-scanner.js";
 import { acquirePlaneClaim, parsePlaneClaimRow, scannerDeathCopy, PLANE_CLAIM_KEY, type PlaneLivenessOracle } from "../src/plane-claim.js";
 import { openAuthAuthorityPlane } from "../src/service.js";
 import type { EvictPrincipal } from "../src/credential-ledger.js";
+import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
 
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 let pass = 0, fail = 0;

--- a/implementations/auth/smoke/retirement-barrier.smoke.ts
+++ b/implementations/auth/smoke/retirement-barrier.smoke.ts
@@ -33,6 +33,7 @@ import { makeRecordsScannerOverConnection } from "../src/records-scanner.js";
 import { runAgentRetirementBarrier, resumeAgentRetirement, settlementForIntent, type RetirementDeps, type PoolCleanerBind, type RetirementExecutorBind } from "../src/retirement-barrier.js";
 import { drainRepairPrincipals } from "../src/drain-repair.js";
 import { workPoolContext } from "@cotal-ai/core";
+import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -63,7 +64,7 @@ const EVICT_OPTS = { maxWaitMs: 1500, settleMs: 200, maxVerifyRounds: 3 } as con
 const enc = new TextEncoder();
 const dec = new TextDecoder();
 
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 // #4 repro: the applier principal of scenario H's op, surfaced as a static-conf user whose CONNZ
 // `authorized_user` name maps back to `local.epapl_<hash>` (principalFromName splits the first
 // dash). A live connection under it models a repair bearer still connected when the barrier is

--- a/implementations/auth/smoke/retirement-cleaner-confinement.smoke.ts
+++ b/implementations/auth/smoke/retirement-cleaner-confinement.smoke.ts
@@ -33,6 +33,7 @@ import { settlementForIntent } from "../src/retirement-barrier.js";
 import { openAuthorityClient } from "../src/authority-client.js";
 import { jetstream } from "@nats-io/jetstream";
 import type { NatsConnection } from "@nats-io/transport-node";
+import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; console.log(`  ✓ ${n}`); } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -44,7 +45,7 @@ const reaches = async (nc: NatsConnection, subject: string, body?: Uint8Array): 
   catch { return "denied"; }
 };
 
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
 const SPACE = `rclean-${randomUUID().slice(0, 8)}`;
 const EP = "jobsrv", EP2 = "mgrjob", POOL_A = "pa", POOL_B = "pb";

--- a/implementations/auth/smoke/session-ledger.smoke.ts
+++ b/implementations/auth/smoke/session-ledger.smoke.ts
@@ -42,6 +42,7 @@ import { writeEndpointGate, epgateKey, reconcileSessionForTakeover, kvServeIssua
 import { makeLedgerScannerOverConnection } from "../src/ledger-scanner.js";
 import { parseLedgerRow } from "../src/credential-ledger.js";
 import { tryReserveUid, createGateFrozen, reopenGate } from "../src/lifecycle-registry.js";
+import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -89,7 +90,7 @@ const mkGrant = (sessionId: string, over: Partial<SessionGrant> = {}): SessionGr
 const PRESENTER = { id: HOLDER_ID, lifecycleUid: HOLDER_UID };
 const sid = (n: number) => `${"q".repeat(20)}${String(n).padStart(4, "0")}`;
 
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const sd = mkdtempSync(join(tmpdir(), "cotal-sessadapter-"));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
 

--- a/implementations/auth/smoke/shape-supervisor.smoke.ts
+++ b/implementations/auth/smoke/shape-supervisor.smoke.ts
@@ -26,8 +26,9 @@ import { createSpaceAuth, ensureAuthorityStores, epAuthBucket, isReachable, serv
 import { Kvm } from "@nats-io/kv";
 import { assertAuthorityStreamShape, type AuthorityStreamCfg } from "../src/lifecycle-registry.js";
 import { openAuthorityClient, openSupervisedConnectReader } from "../src/authority-client.js";
+import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
 
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 const awaitExit = (proc: ReturnType<typeof spawn>, timeoutMs = 3000): Promise<void> =>

--- a/implementations/auth/smoke/storage-authority-confinement.smoke.ts
+++ b/implementations/auth/smoke/storage-authority-confinement.smoke.ts
@@ -42,6 +42,7 @@ import {
   RECORD_KINDS, poolDurable, effectsDurable, canonDurable,
   type EpCapability,
 } from "@cotal-ai/core";
+import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -89,7 +90,7 @@ const serveRows = {
 const cap: EpCapability = { endpoint: EP, command: "spawn", target: { mode: "owner", tOwner: "u_abc" }, journal: true };
 const callerRows = epCallerGrantRows(S, [cap], { owner: "u_abc", actor: "cli", uid: UID });
 
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const sd = mkdtempSync(join(tmpdir(), "cotal-stauth-"));
 writeFileSync(join(sd, "server.conf"), [
   `port: ${PORT}`,

--- a/packages/core/smoke/acl-cas.smoke.ts
+++ b/packages/core/smoke/acl-cas.smoke.ts
@@ -17,6 +17,7 @@ import { join } from "node:path";
 import { connect } from "@nats-io/transport-node";
 import type { KV } from "@nats-io/kv";
 import { isReachable, openAclRegistry, readAcl, commitAcl, reissueAcl, deleteAcl, aclKey } from "../src/index.js";
+import { pickFreePort } from "./_free-port.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => {
@@ -29,7 +30,7 @@ const U1 = "owner1aaaaaaaaaaaaaaaaaaaaa"; // 26 chars, [a-z0-9]
 const UG = "garbledbbbbbbbbbbbbbbbbbbbb";
 const UW = "wedgedcccccccccccccccccccc";
 
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const sd = mkdtempSync(join(tmpdir(), "cotal-aclcas-"));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
 

--- a/packages/core/smoke/endpoint-action.smoke.ts
+++ b/packages/core/smoke/endpoint-action.smoke.ts
@@ -32,6 +32,7 @@ import {
   type EpCaller, type GoalRef, type ParsedEpRequest, type GoalResultFact, type ActionContext,
   type Receipt, type ReceiptEmissionWiring, type ReceiptStoreContext,
 } from "../src/index.js";
+import { pickFreePort } from "./_free-port.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -68,7 +69,7 @@ c("the per-goal progress topic carries the caller identity for mint-time read co
   epeSubject(SPACE, "manager", "i".repeat(26), 1, goalProgressTopic(ref("g1")))
     .endsWith(`.goal.u_abc.worker.${UID}.g1.progress`));
 
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const sd = mkdtempSync(join(tmpdir(), "cotal-epact-"));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
 

--- a/packages/core/smoke/endpoint-binding.smoke.ts
+++ b/packages/core/smoke/endpoint-binding.smoke.ts
@@ -42,6 +42,7 @@ import {
   EP_ERROR_CODES, RESERVED_COMMANDS,
   type EpCaller, type RecordKindDef,
 } from "../src/index.js";
+import { pickFreePort } from "./_free-port.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -378,7 +379,7 @@ throws("a branded config with a post-mint deliver_subject refuses (family consum
   });
 
 // ── the resources + live behaviors (real broker) ──
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const sd = mkdtempSync(join(tmpdir(), "cotal-epbind-"));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
 
@@ -542,7 +543,7 @@ try {
   // not a handler, must let the canonicalizer enqueue + leader-read while denying everyone else
   // the body-selected EPW read.
   {
-    const SPORT = 20000 + Math.floor(Math.random() * 40000);
+    const SPORT = await pickFreePort();
     const sd2 = mkdtempSync(join(tmpdir(), "cotal-epbind-auth-"));
     const canonRows = canonicalizerWorkGrants(SPACE, "manager");
     writeFileSync(join(sd2, "server.conf"), [

--- a/packages/core/smoke/endpoint-checkpoint.smoke.ts
+++ b/packages/core/smoke/endpoint-checkpoint.smoke.ts
@@ -31,6 +31,7 @@ import {
   timerWriterContext, checkpointSettleSubject, epfStreamName,
   type CheckpointRef,
 } from "../src/index.js";
+import { pickFreePort } from "./_free-port.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -49,7 +50,7 @@ const ref = (token: string): CheckpointRef => ({ endpoint: "manager", token });
 const holderA = { id: "u_abc.worker", lifecycleUid: "u".repeat(26) };
 const holderB = { id: "u_abc.other", lifecycleUid: "v".repeat(26) };
 
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const sd = mkdtempSync(join(tmpdir(), "cotal-epcp-"));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
 

--- a/packages/core/smoke/endpoint-contract-store.smoke.ts
+++ b/packages/core/smoke/endpoint-contract-store.smoke.ts
@@ -26,6 +26,7 @@ import {
   CONTRACT_ARTIFACT_MAX_BYTES, CONTRACT_CLOSURE_MAX_ARTIFACTS,
   type ContractStoreContext,
 } from "../src/index.js";
+import { pickFreePort } from "./_free-port.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -58,7 +59,7 @@ await rejects("non-JSON bytes are never an artifact",
 await rejects("invalid UTF-8 bytes are never an artifact",
   () => assertCanonicalArtifactBytes(new Uint8Array([0x7b, 0xff, 0x7d]), "probe"), "contract-invalid");
 
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const sd = mkdtempSync(join(tmpdir(), "cotal-epstore-"));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
 try {

--- a/packages/core/smoke/endpoint-guard.smoke.ts
+++ b/packages/core/smoke/endpoint-guard.smoke.ts
@@ -26,6 +26,7 @@ import {
   ownerCommitProof, claimGuardClearanceMint, resumeCheckpoint, expireCheckpoint, readCheckpointSpec,
   type EpCaller, type GoalRef, type SignerAnchor, type AnchorResolver, type GuardCallSeam, type ActionContext,
 } from "../src/index.js";
+import { pickFreePort } from "./_free-port.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -124,7 +125,7 @@ await rejects("the guard call and obligation verification share ONE gate budget 
 }
 
 // ── the hold wiring over the checkpoint pause primitive (real broker) ──
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const sd = mkdtempSync(join(tmpdir(), "cotal-epguard-"));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
 try {

--- a/packages/core/smoke/endpoint-journal.smoke.ts
+++ b/packages/core/smoke/endpoint-journal.smoke.ts
@@ -21,6 +21,7 @@ import {
   epjSubject, epRequestSubject, parseEpSubject,
   type AcceptanceFact, type RejectionFact, type QuarantineFact, type ParsedEpRequest, type EpCaller,
 } from "../src/index.js";
+import { pickFreePort } from "./_free-port.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -156,7 +157,7 @@ c("size preflight passes a bounded fact", assertFactFits(rej, 1024 * 1024).lengt
 throws("size preflight refuses an acceptance that cannot fit", () => assertFactFits(acc, 64));
 
 // ── the decision CAS + plain appends (real broker) ──
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const sd = mkdtempSync(join(tmpdir(), "cotal-epjrn-"));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
 

--- a/packages/core/smoke/endpoint-receipt.smoke.ts
+++ b/packages/core/smoke/endpoint-receipt.smoke.ts
@@ -26,6 +26,7 @@ import {
   receiptSubject, receiptStoreContext,
   type EpCaller, type ReceiptRef, type Receipt, type ReceiptStoreContext, type SignerAnchor, type AnchorResolver,
 } from "../src/index.js";
+import { pickFreePort } from "./_free-port.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -222,7 +223,7 @@ await rejects("a non-positive verifyBudgetMs refuses",
 }
 
 // ── create-only publication through the space-bonded context: one execution, one receipt ──
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const sd = mkdtempSync(join(tmpdir(), "cotal-eprcpt-"));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
 try {

--- a/packages/core/smoke/endpoint-records.smoke.ts
+++ b/packages/core/smoke/endpoint-records.smoke.ts
@@ -19,6 +19,7 @@ import {
   readRecord, readAtomicRecord, watchRecord, openRecordsBucket,
   type MergedRecord,
 } from "../src/index.js";
+import { pickFreePort } from "./_free-port.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -158,7 +159,7 @@ const tK = recordStatusKey(RECORD_KINDS.svc, svcQ);
 }
 
 // ── the live half: CAS, merged read, head, watch ──
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const sd = mkdtempSync(join(tmpdir(), "cotal-eprec-"));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
 

--- a/packages/core/smoke/endpoint-serve-gate.smoke.ts
+++ b/packages/core/smoke/endpoint-serve-gate.smoke.ts
@@ -47,6 +47,7 @@ import {
   type EpServeLedgerRow,
 } from "../src/index.js";
 import type { KV } from "@nats-io/kv";
+import { pickFreePort } from "./_free-port.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -70,7 +71,7 @@ const mkServeRow = (credentialId: string): EpServeLedgerRow => ({
   generation: 0, processEpoch: 0, registrationRevision: 0, nameAuthorityRevision: 0,
 });
 
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const sd = mkdtempSync(join(tmpdir(), "cotal-epservegate-"));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
 

--- a/packages/core/smoke/endpoint-serve.smoke.ts
+++ b/packages/core/smoke/endpoint-serve.smoke.ts
@@ -39,6 +39,7 @@ import {
   type EpIssuanceBarrier, type EpVerbOp,
 } from "../src/index.js";
 import type { KV } from "@nats-io/kv";
+import { pickFreePort } from "./_free-port.js";
 
 /** READING THIS SUITE'S OUTPUT — the reporting is INVERTED and the inversion is a trap.
  *
@@ -263,7 +264,7 @@ const freezeErr = async (jsmStub: unknown): Promise<{ code?: string; message: st
 }
 
 // ── live broker ──
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const sd = mkdtempSync(join(tmpdir(), "cotal-epserve-"));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
 

--- a/packages/core/smoke/endpoint-session.smoke.ts
+++ b/packages/core/smoke/endpoint-session.smoke.ts
@@ -47,6 +47,7 @@ import {
   type SessionGrant, type SessionLedger, type SessionLedgerRow, type SessionRedemptionHooks,
   type SignerAnchor, type AnchorResolver,
 } from "../src/index.js";
+import { pickFreePort } from "./_free-port.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; console.log(`  ✓ ${n}`); } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -458,7 +459,7 @@ console.log("D. no standing EPS grant in any grant builder");
 
 // ---------- C. the rails over a real broker ----------
 console.log("C. rails: duplex windowed frames over a live broker");
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const sd = mkdtempSync(join(tmpdir(), "cotal-epsession-"));
 const broker = spawn("nats-server", ["-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
 try {

--- a/packages/core/smoke/endpoint-traits.smoke.ts
+++ b/packages/core/smoke/endpoint-traits.smoke.ts
@@ -42,6 +42,7 @@ import {
   type ServiceSpec, type ServiceNameAuthority, type EpCaller, type EndpointReply,
   type EpCommandDef, type EpServeGrant, type EpIssuanceBarrier, type EpServeContext,
 } from "../src/index.js";
+import { pickFreePort } from "./_free-port.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -280,7 +281,7 @@ await rejects("an exotic container in a signed artifact (Map) refuses instead of
   });
 
 // ── live broker: registration → serve grant → governed surface → the pre-effect gate ──
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const sd = mkdtempSync(join(tmpdir(), "cotal-eptraits-"));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
 

--- a/packages/core/smoke/endpoint-verbs.smoke.ts
+++ b/packages/core/smoke/endpoint-verbs.smoke.ts
@@ -27,6 +27,7 @@ import {
   type EpCaller, type EpVerbOp, type ParsedEpRequest, type FrozenInstance, type EpAttributedEvent,
   type EpRegistrationState,
 } from "../src/index.js";
+import { pickFreePort } from "./_free-port.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -76,7 +77,7 @@ function respond(nc: NatsConnection, filter: string, batch: (req: ParsedEpReques
 }
 
 // ── live broker ──
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const sd = mkdtempSync(join(tmpdir(), "cotal-epverbs-"));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
 

--- a/packages/core/smoke/endpoint-virtual.smoke.ts
+++ b/packages/core/smoke/endpoint-virtual.smoke.ts
@@ -42,6 +42,7 @@ import {
   type EpCaller, type WorkItemRef, type WorkPoolContext, type ServiceStatus,
   type ActivatorContext, type RestartHistoryEntry,
 } from "../src/index.js";
+import { pickFreePort } from "./_free-port.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -64,7 +65,7 @@ const ref = (id: string, pool: string): WorkItemRef => ({ endpoint: "manager", p
 const enc = (s: string) => new TextEncoder().encode(s);
 const td = new TextDecoder();
 
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const sd = mkdtempSync(join(tmpdir(), "cotal-epvirtual-"));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
 

--- a/packages/core/smoke/endpoint-work.smoke.ts
+++ b/packages/core/smoke/endpoint-work.smoke.ts
@@ -29,6 +29,7 @@ import {
   workItemSubject, workTerminalSubject, openRecordsBucket,
   type EpCaller, type WorkItemRef, type WorkWorker, type WorkPoolContext,
 } from "../src/index.js";
+import { pickFreePort } from "./_free-port.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -48,7 +49,7 @@ const workerB: WorkWorker = { kind: "agent", owner: "u_wrk", actor: "beta", life
 const epWorker = (epoch: number): WorkWorker => ({ kind: "endpoint", owner: "u_wrk", actor: "svc", lifecycleUid: "e".repeat(26), epoch });
 const enc = (s: string) => new TextEncoder().encode(s);
 
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const sd = mkdtempSync(join(tmpdir(), "cotal-epwork-"));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
 

--- a/packages/core/smoke/goal-epoch-fence.smoke.ts
+++ b/packages/core/smoke/goal-epoch-fence.smoke.ts
@@ -59,6 +59,7 @@ import {
   projectGoalTerminal, goalResultSubject, goalRefOf, readLastFact, epfStreamName,
   type EpCaller, type GoalRef, type ParsedEpRequest, type ActionContext,
 } from "../src/index.js";
+import { pickFreePort } from "./_free-port.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -87,7 +88,7 @@ c("a goal's terminal subject is the ONE flat SPEC:1394 form, with no epoch token
   goalResultSubject(SPACE, ref("g1")).endsWith(".g1.result")
   && !/\.result\.\d+$/.test(goalResultSubject(SPACE, ref("g1"))));
 
-const PORT = 20000 + Math.floor(Math.random() * 40000);
+const PORT = await pickFreePort();
 const sd = mkdtempSync(join(tmpdir(), "cotal-epfence-"));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
 


### PR DESCRIPTION
Closes the cause behind an unattributable class of CI red.

35 smoke suites drew their broker port from `20000 + Math.random() * 40000` and
spawned `nats-server` with `stdio: "ignore"`. A bind failure was therefore
**silent by construction**: the only symptom was `ConnectionError: connection
refused` after the readiness poll expired, with nothing anywhere saying why.

The repo had already diagnosed this and written the fix. `_free-port.ts` says so
in its own doc comment, and 60 suites already used it. These 35 never adopted it.

## What it cost

A full `smoke:ci` died at `smoke:acl-cas` with connection refused. The same suite
run alone, same commit, same environment, passed 12/12.

That is not a chain-order defect. Run alone, nearly every port in the range is
free. Run after ~45 suites have each started and stopped a broker, a population
of recently-used ports sits in `TIME_WAIT` and the same draw has materially worse
odds. Same dice, worse odds, no shared state required.

The consequence worth naming: **a re-run does not discriminate.** Green on retry
means the dice landed differently, not that anything was fixed. Every one of
these was a standing chance of an unattributable red on any branch, and the cost
lands on whoever happens to be gating that day.

## The change

36 declarations across 35 files, including one indented inside a block. 33 take
the static import; 2 that deliberately avoid static imports (they sandbox the
environment before importing) use the dynamic form already present in the tree.

## Verification

```
install 0   build 0   typecheck 0   smoke:ci 0
179 invocations, 0 failures
last invocation = packages/lang/smoke/options.smoke.ts = the chain's LAST declared entry
HEAD unchanged, tree clean both ends, TMPDIR ancestry clean before AND after
host: Linux, nats-server 2.12.12 (the repo's declared floor), 23 min
```

Validated by **execution**, not typecheck. The tsconfigs include only `src`, so
smoke files are never typechecked and a syntax error here compiles nowhere and
fails only at run time.

That matters concretely: a first pass at this change inserted the import after
the last line *beginning* with `import`, which lands inside a multi-line import
block and split 17 files into garbage. Running the suites caught it immediately.
Reading the diff did not, and a green typecheck would not have either.

## Not fixed here, deliberately

`stdio: "ignore"` is unchanged. Reducing collisions removes most of these
failures; capturing broker output is what would make the remainder diagnosable
instead of mute. That is a larger change to error surfaces and belongs on its
own, but it is the reason a rare bind failure will still present as an
unexplained connection error.

## Adjacent finding, not addressed here

`smoke:int2-revoke:live` and `smoke:freeslot-barrier:live` both fail with
`TypeError: Cannot read properties of undefined (reading 'get')`, and are in
neither `smoke:ci` nor CI's `live` job, so nothing runs them.
`freeslot-respawn-barrier.smoke.ts` documents itself as expected-red until the P2
alias reservation lands; `int2-revoke-hold` carries no such note and fails
identically. Confirmed to predate this change by reverting only those two files
and reproducing the identical exit and error.

Refs #359
