### PR TITLE
chore: drop the em-dashes from the $SYS rotation change

### DIFF
--- a/.changeset/sys-cred-rotation.md
+++ b/.changeset/sys-cred-rotation.md
@@ -35,7 +35,7 @@ filesystem while enforcing nothing for the tenants actually at risk.
 
 A rotation requires every broker for the root to be stopped, and three checks now say so: this root's
 recorded mesh at the requested address, anything unidentified answering there (which refuses instead
-of relocating to a free port), and the root's own ownership records — a live or unreadable `nats.pid`,
+of relocating to a free port), and the root's own ownership records: a live or unreadable `nats.pid`,
 or any recorded mesh for this root still reachable. Without them a lost registry row, or a
 `nats-server` started by hand against this root's `server.conf`, was enough to bypass the running-mesh
 refusal: `up` found the port busy, picked a free one, rotated, and left the old broker serving the
@@ -68,7 +68,7 @@ registry state written before the rotation reads back through the CLI after it.
 
 Diagnosis now names the cause instead of the symptom. An expired observer cred used to surface as a
 bare "Authorization Violation" in the delivery log and, one layer up, as a `membership-rw` adoption
-refused with "membership feed is not running" — neither of which mentions a credential. The daemon
+refused with "membership feed is not running", neither of which mentions a credential. The daemon
 checks the observer's own expiry before connecting and reports it, carries that reason into the
 adoption reply, and the manager warns on every renewal pass from the 75% point onward rather than
 letting the mesh discover the expiry at the horizon. `cotal doctor auth`, `evictPrincipal`,
@@ -76,5 +76,5 @@ letting the mesh discover the expiry at the horizon. `cotal doctor auth`, `evict
 because its bundle is incomplete rather than expired, the daemon now names the missing files and
 distinguishes the two cases: a missing `$SYS` observer is re-minted by a rotation, while a space
 predating broker-sourced membership is missing the rw cred and the account id as well, which a
-rotation does not write — so it is told the truth rather than sent through a stop/start that cannot
+rotation does not write, so it is told the truth rather than sent through a stop/start that cannot
 help it.

--- a/bin/smoke/flag-inventory.smoke.ts
+++ b/bin/smoke/flag-inventory.smoke.ts
@@ -33,7 +33,7 @@ const GOLDEN: Record<string, { flags: string[]; positionals: boolean; rawArgs?: 
       "channels:string", "detach:boolean", "dry-run:boolean", "file:string:f", "host:string",
       "idp:string", "open:boolean", "runtime:string", "server:string", "space:string",
       "restore:string", "restore-only:string", "accept-missing-source:boolean",
-      // `--rotate-sys` (2026-08): the class-3 renewal — rotate the system account and re-mint the
+      // `--rotate-sys` (2026-08): the class-3 renewal, which rotates the system account and re-mints the
       // two $SYS creds, which nothing re-signs in place (issue #338).
       "rotate-sys:boolean",
       "store-dir:string", "tls-cert:string", "tls-key:string", "user-auth:boolean",

--- a/implementations/cli/smoke/sys-rotation-e2e.smoke.ts
+++ b/implementations/cli/smoke/sys-rotation-e2e.smoke.ts
@@ -1,5 +1,5 @@
 /**
- * `$SYS` ROTATION E2E (issue #338) — the operator's whole recovery cycle, through the packaged
+ * `$SYS` ROTATION E2E (issue #338): the operator's whole recovery cycle, through the packaged
  * binary, against a real broker + a real delivery daemon + a real manager. Nothing here is staged in
  * process: every state transition is a `cotal` subprocess, and every assertion reads what that
  * subprocess left behind.
@@ -12,7 +12,7 @@
  *    feed does not come up, and what it logs is now the credential and the repair rather than a bare
  *    "Authorization Violation";
  *  - the NO-OP that shipped as the fix: `cotal down` + a plain `cotal up` rewrites neither $SYS file
- *    — byte-identical, still expired, doctor still red. This is the regression the branch exists to
+ *    leaves it byte-identical, still expired, doctor still red. This is the regression the branch exists to
  *    kill, so it is a check, not a comment;
  *  - the REPAIR: `cotal up --rotate-sys` clears the symptom in the daemon that reported it;
  *  - the SURVIVAL claim the repair copy makes to the operator. An agent credential minted before the
@@ -22,10 +22,10 @@
  *
  * Elapsed time is the one thing simulated: the $SYS pair is minted with a past `exp`, which is the
  * state a 30-day-old mesh reaches on its own. It is signed by the space's CURRENT system account, so
- * what the daemon and the doctor react to is expiry — not the torn-pair case, which is
+ * what the daemon and the doctor react to is expiry, not the torn-pair case, which is
  * `sys-rotation.smoke.ts` stage 6.
  *
- * NOTE: runs the BUILT dist — `pnpm build` first.
+ * NOTE: runs the BUILT dist, so `pnpm build` first.
  * Run: pnpm smoke:sys-rotation-e2e   (needs `nats-server` on PATH; local-only; ~60s)
  */
 import { randomUUID } from "node:crypto";
@@ -68,13 +68,13 @@ const survivors = (label: string): void => {
   const ps = execFileSync("ps", ["-eo", "pid,command"], { encoding: "utf8" })
     .split("\n")
     .filter((l) => (l.includes(SPACE) || l.includes(`-e2e-${RUN}-`)) && !l.includes("ps -eo"));
-  console.log(`  [debug] after ${label}: ${ps.length} live —\n${ps.map((l) => "      " + l.trim().slice(0, 150)).join("\n")}`);
+  console.log(`  [debug] after ${label}: ${ps.length} live:\n${ps.map((l) => "      " + l.trim().slice(0, 150)).join("\n")}`);
 };
 
 const repoRoot = join(import.meta.dirname, "..", "..", "..");
 const cotalJs = join(repoRoot, "bin", "dist", "cotal.js");
 if (!existsSync(cotalJs)) {
-  console.error(`no built CLI at ${cotalJs} — run \`pnpm build\` first`);
+  console.error(`no built CLI at ${cotalJs}; run \`pnpm build\` first`);
   process.exit(1);
 }
 
@@ -105,12 +105,12 @@ function cotal(args: string[], timeout = 120_000): { code: number | null; out: s
 }
 
 /** The delivery daemon appends across boots, so every read is of ONE boot's tail. Marked in DECODED
- *  characters, not bytes: the log is full of `✓`/`—`/`•`, so a `statSync().size` mark would slice a
+ *  characters, not bytes: the log is full of multibyte glyphs (`✓`, `•`), so a `statSync().size` mark would slice a
  *  UTF-8 string at the wrong place and silently eat the head of the tail. */
 const logSize = (): number => (existsSync(deliveryLog) ? readFileSync(deliveryLog, "utf8").length : 0);
 const logTail = (from: number): string => (existsSync(deliveryLog) ? readFileSync(deliveryLog, "utf8").slice(from) : "");
-/** The daemon starts a beat behind the CLI's exit. Wait for its membership VERDICT — up, degraded,
- *  or unprovisioned — which is the last thing it writes before installing its signal handlers. */
+/** The daemon starts a beat behind the CLI's exit. Wait for its membership VERDICT (up, degraded,
+ *  or unprovisioned), which is the last thing it writes before installing its signal handlers. */
 async function daemonTail(from: number, ms = 25_000): Promise<string> {
   const deadline = Date.now() + ms;
   while (Date.now() < deadline) {
@@ -129,7 +129,7 @@ async function daemonTail(from: number, ms = 25_000): Promise<string> {
  *
  * A daemon SIGTERMed that young never completes the KV delete that releases its single-flight
  * delivery lease: the request does not settle, its own 2s hard-exit fallback fires first, and the
- * lease is left holding a live value for the rest of its 30s TTL — so the NEXT daemon refuses to
+ * lease is left holding a live value for the rest of its 30s TTL, so the NEXT daemon refuses to
  * bind ("a live lease already exists for shard 0") and the mesh comes back without Plane-3 delivery.
  *
  * This is a property of the daemon's shutdown path, not of anything here: it reproduces on an
@@ -144,7 +144,7 @@ async function settleThenDown(opts: { awaitManagerLease?: boolean } = {}): Promi
   // The MANAGER has the same shape of problem on its own lease, and it bites the boot AFTER the one
   // that was stopped. Its instance id is persisted, so a restart re-acquires the SAME per-instance
   // key; a manager whose predecessor did not release it refuses to start ("already serves space … -
-  // stop it first"), `up` still exits 0, and the mesh comes back with no manager at all — no renewal
+  // stop it first"), `up` still exits 0, and the mesh comes back with no manager at all: no renewal
   // pass runs, so `doctor auth` goes on grading a record from before the repair. Waiting out
   // MANAGER_LEASE_TTL_MS (10s) is what makes it deterministic. Also reproducible with no rotation
   // anywhere: three ordinary `up`/`down` cycles refuse on the third, and the same three with 12s
@@ -175,7 +175,7 @@ async function withJsm<T>(creds: string, fn: (jsm: Awaited<ReturnType<typeof jet
 }
 /** The CHAT stream's identity as the operator's data: how many messages, and where the log is. A
  *  stream that was recreated by the rotation would come back at sequence 0. (No role may
- *  `STREAM.MSG.GET` on CHAT — reads there are consumer-scoped by design — so the bytes are proven
+ *  `STREAM.MSG.GET` on CHAT, since reads there are consumer-scoped by design, so the bytes are proven
  *  through the registry instead, below.) */
 const chatState = (creds: string): Promise<{ messages: number; last_seq: number; first_ts: string }> =>
   withJsm(creds, async (jsm) => {
@@ -234,14 +234,14 @@ try {
   check("the message landed on the CHAT stream", chatBefore.messages > 0 && chatBefore.last_seq > 0, chatBefore);
 
   // ── 3) the repair the tooling used to advertise ────────────────────────────────────────────────
-  console.log("\n3) `down` + a plain `up` — the repair that shipped, and did nothing");
+  console.log("\n3) `down` + a plain `up`: the repair that shipped, and did nothing");
   const down1 = await settleThenDown();
   check("`cotal down` exits 0", down1.code === 0, down1.out.slice(-400));
   survivors("down 1");
   mark = logSize();
   const boot2 = cotal(["up", "--detach", "--space", SPACE, "--server", SERVERS]);
   check("a plain `cotal up` comes back", boot2.code === 0, boot2.out.slice(-500));
-  // Wait for THIS boot's daemon before the next `down` — see `settleThenDown` for why a
+  // Wait for THIS boot's daemon before the next `down`; see `settleThenDown` for why a
   // seconds-old daemon must not be stopped here.
   const tail2 = await daemonTail(mark);
   check("the plain re-up's daemon came up", /delivery daemon up/.test(tail2), tail2.slice(-400));
@@ -274,14 +274,14 @@ try {
   check("both are issued by the record's CURRENT system account", credsClaims(newObs).iss === rotated?.sys.pub && credsClaims(newEv).iss === rotated?.sys.pub, `${credsClaims(newObs).iss} / ${credsClaims(newEv).iss} vs ${rotated?.sys.pub}`);
   check("neither is expired any more", inspectCredHealth(newObs).state !== "expired" && inspectCredHealth(newEv).state !== "expired", `${inspectCredHealth(newObs).state} / ${inspectCredHealth(newEv).state}`);
 
-  // The symptom, cleared in the process that reported it — the same reader that said "did NOT start"
+  // The symptom, cleared in the process that reported it: the same reader that said "did NOT start"
   // above, so its silence there was a real reading rather than a broken probe.
   const tail3 = await daemonTail(mark);
   check("the daemon's membership feed IS up after the rotation", /membership feed up/.test(tail3), tail3.slice(-500));
   check("the daemon no longer reports a degraded membership feed", !/! membership:/.test(tail3), tail3.slice(-500));
   // Bounded, and only on the POSITIVE assertion. `doctor auth` also grades the last renewal record,
   // which still holds the pre-rotation adoption failure until the manager's first post-boot pass
-  // rewrites it — so this waits for that pass rather than for the rotation, which has already
+  // rewrites it, so this waits for that pass rather than for the rotation, which has already
   // happened. A red here at the deadline is a real finding: it would mean an operator sees a failed
   // doctor for as long as the record stays stale after a successful repair.
   const started = Date.now();

--- a/implementations/cli/smoke/sys-rotation.smoke.ts
+++ b/implementations/cli/smoke/sys-rotation.smoke.ts
@@ -1,9 +1,9 @@
 /**
- * `$SYS` credential rotation smoke (issue #338) — the class-3 renewal that `renewal.ts` cannot do.
+ * `$SYS` credential rotation smoke (issue #338): the class-3 renewal that `renewal.ts` cannot do.
  *
  * `membership-observer.creds` and `connection-evictor.creds` carry a 30-day expiry and are
  * `rotation-renewed`: no resident process re-signs them. The bug this pins was that the only repair
- * the tooling named — "`cotal down` then a fresh `cotal up`" — did NOTHING: `up` mints the $SYS pair
+ * the tooling named ("`cotal down` then a fresh `cotal up`") did NOTHING: `up` mints the $SYS pair
  * only on the branch that CREATES the trust record, so re-upping an existing space reused the same
  * expired files and reported success, while the delivery daemon's membership feed stayed dead and
  * every `membership-rw` adoption was refused.
@@ -17,8 +17,8 @@
  *     the creds on disk. A writer that persisted the creds from a different (or pre-rotation) bundle
  *     would split them and hand the broker creds it will never honor.
  *  3. Live broker: started from the ROTATED config it REJECTS the pre-rotation observer, ACCEPTS
- *     both rotated $SYS creds, and still accepts a data-account cred minted BEFORE the rotation —
- *     the "your agents survive this" claim the repair copy makes, proven rather than asserted.
+ *     both rotated $SYS creds, and still accepts a data-account cred minted BEFORE the rotation,
+ *     which is the "your agents survive this" claim the repair copy makes, proven rather than asserted.
  *
  * Plus the copy-to-behavior link: `doctor auth`'s repair for an EXPIRED $SYS cred must name
  * `--rotate-sys`. That string regressing back to a bare `up` is the original bug, so it is a check.
@@ -101,7 +101,7 @@ async function accepts(creds: string): Promise<boolean> {
   }
 }
 
-const IDLE_PORT = await pickFreePort(); // nothing ever listens here — keeps `up`'s port-in-use branch out of the way
+const IDLE_PORT = await pickFreePort(); // nothing ever listens here, so `up`'s port-in-use branch stays out of the way
 
 /** Drive `up` and capture how it refused. Several of these refusals `process.exit(1)` rather than
  *  throw, and the default address would otherwise reach whatever broker happens to run on 4222, so
@@ -132,7 +132,7 @@ async function runUp(values: Record<string, unknown>): Promise<string> {
 
 /** Detached meshes this suite started and must tear down, whatever happens to the checks. `up
  *  --detach` leaves THREE processes: the broker (argv carries the root's `server.conf`) and a
- *  delivery daemon + manager, which the CLI re-execs from argv[1] with only `--space`/`--server` —
+ *  delivery daemon + manager, which the CLI re-execs from argv[1] with only `--space`/`--server`,
  *  so the root path alone does not match them and the server URL is what identifies them. */
 const detachedMeshes: Array<{ root: string; server: string }> = [];
 function stopDetached(): void {
@@ -164,7 +164,7 @@ function stopDetached(): void {
 /** Last-resort sweep: kill anything this suite started that is still alive.
  *
  *  It starts several brokers and one detached control plane, and a SIGTERM to a JetStream server is
- *  not always prompt — especially once the temp store has been removed underneath it. Everything this
+ *  not always prompt, especially once the temp store has been removed underneath it. Everything this
  *  suite spawns is identifiable from its own argv: a broker names one of this suite's temp roots, and
  *  the CLI re-execs its daemons from argv[1], which is this file. Both patterns are specific to this
  *  suite, so the sweep cannot reach another lane's broker on the same machine. Without it a failed run
@@ -174,8 +174,8 @@ function sweepSuiteProcesses(): void {
     const ps = execFileSync("ps", ["-eo", "pid,command"], { encoding: "utf8" });
     for (const line of ps.split("\n")) {
       // Two patterns, both specific to this suite. A BROKER names one of its temp roots. A detached
-      // DAEMON names no root at all — the CLI re-execs it from argv[1], so its command line is this
-      // file plus the subcommand — which is why the subcommand has to be part of the match: this
+      // DAEMON names no root at all: the CLI re-execs it from argv[1], so its command line is this
+      // file plus the subcommand, which is why the subcommand has to be part of the match. This
       // file's name ALONE also matches the tsx/pnpm wrappers running the suite, and killing those
       // kills the run itself (observed, twice).
       const isBroker = line.includes("cotal-sysrot-");
@@ -193,7 +193,7 @@ try {
   // ── stage the #338 state: a provisioned space whose $SYS creds are already dead ────────────────
   const auth = await createSpaceAuth(SPACE);
   const store = workspaceSecretStore(root);
-  await putSpaceAuth(store, auth); // strips the $SYS seed at rest — exactly what makes these unremintable
+  await putSpaceAuth(store, auth); // strips the $SYS seed at rest, exactly what makes these unremintable
   const deadAt = Math.floor(Date.now() / 1000) - 60;
   const preObserver = await mintMembershipObserverCreds(auth, newIdentity(), { expiresAt: deadAt });
   writeFileSync(obsPath, preObserver, { mode: 0o600 });
@@ -274,10 +274,10 @@ try {
 
   console.log("\n4b) the blast radius is broker-wide, so a multi-tenant root refuses");
   // A second tenant under the SAME broker operator. The rotation retires the system account for
-  // BOTH, and this root holds one $SYS cred pair pinned to one data account — so it must refuse
+  // BOTH, and this root holds one $SYS cred pair pinned to one data account, so it must refuse
   // rather than silently leave the neighbour unobservable. Guarded in the workspace export, not at
   // the CLI flag, so every caller hits it. (The guard reads the FS account records; that is why the
-  // export takes no SecretStore — an injected store cannot be enumerated, so it could not be
+  // export takes no SecretStore: an injected store cannot be enumerated, so it could not be
   // guarded, only appear to be.)
   const multiRoot = mkdtempSync(join(tmpdir(), "cotal-sysrot-multi-"));
   mkdirSync(join(multiRoot, ".cotal", "auth"), { recursive: true });
@@ -313,7 +313,7 @@ try {
   console.log("\n4e) a maintenance RE-ENTRY refuses, where the explicit --restore guard cannot see");
   // The `--restore` refusal only sees the explicit flag. A restore/resume re-entry arrives with
   // `restore` cleared and an `__*Attempt` set, and those paths can adopt a live listener and RETURN
-  // before `authSetup` — accepting the flag and rotating nothing. Both re-entry keys are checked.
+  // before `authSetup`, accepting the flag and rotating nothing. Both re-entry keys are checked.
   for (const key of ["__restoreAttempt", "__ordinaryResumeAttempt"]) {
     const genBefore = (await getSpaceAuth(store, SPACE))?.gen ?? 0;
     const reentry = await runUp({ "rotate-sys": true, [key]: "attempt-1" });
@@ -324,7 +324,7 @@ try {
   console.log("\n4d) a MANIFEST-open mesh refuses too, not just the --open flag");
   // The flag-level guard cannot see this: openness comes from `broker.auth: false` inside the file,
   // which `upManifest` derives after entry. Left unguarded, `up -f open.yaml --rotate-sys` boots an
-  // open broker and exits 0 having rotated nothing — the silent-success class this change removes.
+  // open broker and exits 0 having rotated nothing: the silent-success class this change removes.
   // `--dry-run` still reaches the guard (it sits before the plan print), so this mutates nothing.
   writeFileSync(
     join(root, "open.yaml"),
@@ -335,7 +335,7 @@ try {
   check("`up -f <open manifest> --rotate-sys` refuses", manifestRefusal.includes("--rotate-sys") && manifestRefusal.includes("broker.auth: false"), manifestRefusal);
   check("the manifest refusal advanced no generation", ((await getSpaceAuth(store, SPACE))?.gen ?? 0) === genBeforeManifest);
 
-  console.log("\n5) live broker on the ROTATED config — the same cred, config the only variable");
+  console.log("\n5) live broker on the ROTATED config: the same cred, config the only variable");
   writeFileSync(confPath, serverConfig(rot.auth, [rot.auth], { transport: { kind: "plaintext" }, storeDir, port: PORT }));
   await startBroker();
   // Bind "came up on the ROTATED config" to IDENTITY, not to a TCP probe: `isReachable` with no
@@ -346,7 +346,7 @@ try {
   check("the ROTATED observer is accepted (so the broker really loaded the successor)", await accepts(obsAfter));
   check("the ROTATED evictor is accepted", await accepts(evAfter));
   // THE retirement check: the SAME healthy cred that connected in stage 1b, now refused. Nothing
-  // about the credential changed between the two connects — only the config the broker loaded.
+  // about the credential changed between the two connects; only the config the broker loaded.
   check("the healthy PRE-rotation observer is now REJECTED (retirement, not expiry)", !(await accepts(livePreObserver)));
   for (const [label, creds] of preRotation)
     check(`a ${label} cred minted BEFORE the rotation still connects (the survival claim, per class)`, await accepts(creds));
@@ -361,7 +361,7 @@ try {
   const goodEv = readFileSync(evPath, "utf8");
   const oldEv = await mintConnectionEvictorCreds(auth, newIdentity()); // healthy, RETIRED issuer
 
-  // (a) crash BEFORE either write: both creds stale, and mutually CONSISTENT — the case a
+  // (a) crash BEFORE either write: both creds stale, and mutually CONSISTENT: the case a
   //     file-vs-file comparison cannot see, which is why the record is the oracle.
   writeFileSync(obsPath, livePreObserver, { mode: 0o600 });
   writeFileSync(evPath, oldEv, { mode: 0o600 });
@@ -400,7 +400,7 @@ try {
 
   console.log("\n5d) a live broker for THIS ROOT blocks rotation, registry row or not");
   // The bypass: with no registry row, a bare `up --rotate-sys` finds the port busy, picks a FREE one
-  // and rotates — leaving the old broker on the retired config and a second one on the successor,
+  // and rotates, leaving the old broker on the retired config and a second one on the successor,
   // both over the same JetStream store. The pid file is the proof the registry cannot supply.
   const genBeforeLive = (await getSpaceAuth(store, SPACE))?.gen ?? 0;
   writeFileSync(join(root, ".cotal", "nats.pid"), String(process.pid)); // alive by construction
@@ -418,7 +418,7 @@ try {
   console.log("\n5e) an UNIDENTIFIED listener refuses the rotation instead of free-porting past it");
   // The out-of-band case: `nats-server -c <root>/.cotal/auth/server.conf` started by hand writes no
   // pidfile and no registry row, so both ownership records are empty and the rotation would step
-  // around it onto a free port — retiring the account that broker is still serving and opening its
+  // around it onto a free port, retiring the account that broker is still serving and opening its
   // JetStream store a second time. Only the fact that SOMETHING unidentified is answering can catch
   // it, so that has to refuse rather than relocate.
   await startBroker(); // stands in for the hand-started broker: reachable, unrecorded
@@ -515,7 +515,7 @@ try {
   };
   // `up --detach` returns once the listener answers, which is earlier than "ready to authenticate a
   // fresh credential" on a loaded machine. Retry the POSITIVE assertion only, and bound it: if the
-  // rotation were broken this cred would never be accepted, so waiting cannot manufacture a pass —
+  // rotation were broken this cred would never be accepted, so waiting cannot manufacture a pass;
   // it only stops the boot's timing from being mistaken for a rotation defect.
   const rotatedObs = readFileSync(join(liveRoot, ".cotal", SYSTEM_CREDS_FILES[0]), "utf8");
   let rotatedAccepted = false;

--- a/implementations/cli/src/commands/doctor.ts
+++ b/implementations/cli/src/commands/doctor.ts
@@ -174,7 +174,7 @@ function report(label: string, kind: CredentialKind, path: string, sysPub?: stri
         // branch that CREATES the trust record, so re-upping an existing space reuses the same
         // expired files and reports success. The rotation must be asked for.
       : `system-account rotation: \`${displayCmd()} down\` then \`${displayCmd()} up --rotate-sys\` re-mints the $SYS material (the space, its agents, its creds and its data are untouched)`;
-  // A $SYS cred is only usable if the system account that SIGNED it is the one the broker loads —
+  // A $SYS cred is only usable if the system account that SIGNED it is the one the broker loads,
   // i.e. the one in this root's trust record. Expiry alone cannot see a RETIRED issuer: a rotation
   // that committed the record and then died leaves a file that is structurally valid and years from
   // expiry, yet broker-dead. Without this the doctor reported `auth: healthy` over exactly that

--- a/implementations/cli/src/commands/up.ts
+++ b/implementations/cli/src/commands/up.ts
@@ -195,7 +195,7 @@ export async function up(args: ParsedArgs): Promise<void> {
       throw new Error("--restore cannot be combined with --file/-f or --channels");
     // A restore REINSTATES a trust root from an artifact; a rotation SUPERSEDES the one on disk.
     // Together they would restore a system account and retire it in the same command, leaving the
-    // operator unable to say which authority the mesh actually came up on — and the artifact's own
+    // operator unable to say which authority the mesh actually came up on, and the artifact's own
     // $SYS creds overwritten by the rotation before anyone verified the restore. Restore, verify,
     // then rotate as its own deliberate step.
     if (values["rotate-sys"])
@@ -232,7 +232,7 @@ export async function up(args: ParsedArgs): Promise<void> {
   // MAINTENANCE RE-ENTRY. `--restore` is refused with `--rotate-sys` above, but that guard only sees
   // the EXPLICIT flag: a restore/resume re-entry arrives with `restore` cleared and an `__*Attempt`
   // set, and an auto-recovered journal reaches the same place with no restore flag ever typed. Both
-  // re-entries then hit adopt-the-live-listener paths that RETURN before `authSetup` — so the flag
+  // re-entries then hit adopt-the-live-listener paths that RETURN before `authSetup`, so the flag
   // would be accepted, nothing would rotate, and the command would exit 0. That is the silent
   // success this whole change exists to remove, so it is refused here, before any attempt state is
   // read. A rotation is a stopped, fresh boot; a half-finished maintenance attempt is neither.
@@ -446,8 +446,8 @@ export async function up(args: ParsedArgs): Promise<void> {
   if (values.idp && !wantUser && !values.file) {
     throw new Error('--idp is for user-auth spaces; pair it with --user-auth, or set broker.auth: "user" in a manifest');
   }
-  // An open mesh has no operator, no system account, and no $SYS creds — there is nothing to rotate,
-  // so the request is a misunderstanding to name, never a silent no-op that reports success.
+  // An open mesh has no operator, no system account, and no $SYS creds, so there is nothing to
+  // rotate; the request is a misunderstanding to name, never a silent no-op that reports success.
   if (values["rotate-sys"] && values.open) {
     throw new Error("--rotate-sys is for auth meshes: an open mesh (--open) has no system account or $SYS credentials to rotate");
   }
@@ -635,7 +635,7 @@ export async function up(args: ParsedArgs): Promise<void> {
       }
       // A rotation retires the system account this LIVE broker was started on, and only a broker
       // (re)started from the rewritten config carries the successor. Rotating under a running mesh
-      // would leave the record and the creds a generation ahead of the broker — every $SYS client
+      // would leave the record and the creds a generation ahead of the broker: every $SYS client
       // denied, with `doctor auth` reporting freshly-minted creds. Refuse with the two-step recipe.
       if (values["rotate-sys"]) {
         console.error(
@@ -759,7 +759,7 @@ export async function up(args: ParsedArgs): Promise<void> {
     // may be a `nats-server -c <root>/.cotal/auth/server.conf` started by hand, holding THIS root's
     // config and JetStream store while writing neither a pidfile nor a registry row. Rotating around
     // it retires the account it is still serving and opens its store a second time. Nothing available
-    // here can identify it — that is what unidentified means — so refuse instead of stepping past it.
+    // here can identify it (that is what unidentified means), so refuse instead of stepping past it.
     if (values["rotate-sys"]) {
       console.error(
         c.red(`✗ ${server} is answering and it is not this root's recorded mesh (${who})`) +
@@ -1657,7 +1657,7 @@ async function upManifest(file: string, opts: UpManifestFlags): Promise<void> {
   // The open-mesh refusal must be RE-STATED here, not only against the CLI `--open` flag: on this
   // path openness comes from the MANIFEST (`broker.auth: false`), which the flag-level guard cannot
   // see. Without it, `cotal up -f open.yaml --rotate-sys` boots an open broker, exits 0 and rotates
-  // nothing — a rotation ask answered with silent success, the exact failure class this change
+  // nothing: a rotation ask answered with silent success, the exact failure class this change
   // exists to remove. Before the dry-run print and before anything boots.
   if (opts.rotateSys && open)
     throw new Error("--rotate-sys is for auth meshes: this manifest sets broker.auth: false (open), so there is no system account or $SYS credentials to rotate");
@@ -2515,7 +2515,7 @@ async function authSetup(
     await putSpaceAuth(store, auth); // strips the $SYS seed at rest, but leaves the in-memory `auth` intact …
     await provisionMembershipCreds(auth, cotalRoot()); // … so the observer can still be minted here (fresh-space only)
     // A fresh space's $SYS material was just minted from the seed that only exists in this branch, so
-    // the ASK is already satisfied — say so rather than rotating a one-second-old account, and never
+    // the ASK is already satisfied, so say so rather than rotating a one-second-old account, and never
     // report a rotation that did not happen.
     if (rotateSys) console.log(c.dim("• --rotate-sys: this space is new, so its $SYS creds were just minted - nothing to rotate"));
   } else if (rotateSys) {
@@ -2524,7 +2524,7 @@ async function authSetup(
     // requested address, and any UNIDENTIFIED listener there (which refuses rather than free-porting
     // around a broker that may be serving this root's own server.conf and store). This one reads the
     // root's ownership records for a broker at an address nobody probed. It reports what those
-    // records say, not what the process table says — see its own comment for the residual — and fails
+    // records say, not what the process table says (see its own comment for the residual), and fails
     // CLOSED, so an ambiguous record refuses exactly like a live one.
     await assertRootBrokerStopped(cotalRoot());
     // Fails loud: a caller that swallowed this would boot the broker on the RETIRED system account
@@ -2537,11 +2537,11 @@ async function authSetup(
     );
     // Say exactly what is true. The retirement is CONFIG-LOAD-BOUND: an old cred dies against any
     // broker that loads the successor config, which is every broker started from this root from here
-    // on — but a stale nats-server still holding the pre-rotation config in memory would keep
+    // on, but a stale nats-server still holding the pre-rotation config in memory would keep
     // honoring it, so "now dead" without that qualifier oversells the guarantee.
     console.log(c.dim("  the data account, every agent cred and the JetStream store are untouched. The OLD $SYS creds are refused by any broker that loads this config; a stale broker still running the previous config would still honor them, so stop those first."));
-    // A full backup binds to the trust chain it was taken against — `rootChainCommitment` hashes the
-    // operator JWT and the system account, both of which just changed — so `cotal up --restore`
+    // A full backup binds to the trust chain it was taken against: `rootChainCommitment` hashes the
+    // operator JWT and the system account, both of which just changed, so `cotal up --restore`
     // refuses every full artifact taken before this moment. That is correct (it is a different trust
     // root), but it is only obvious to someone who has read the fingerprint code, and rotation is
     // now a routine 30-day act rather than a once-per-space event. Say it at the moment it becomes
@@ -2550,7 +2550,7 @@ async function authSetup(
   }
   // The $SYS creds must be signed by the system account THIS boot is about to put in `server.conf`.
   // A rotation that committed the trust record and then died leaves them stale, unexpired, and
-  // broker-dead — and, crash-before-either-write, stale in a way that no comparison between the two
+  // broker-dead and, crash-before-either-write, stale in a way that no comparison between the two
   // FILES can see (they agree with each other; they just disagree with the record). This is the one
   // place holding both, on the one path that renders the config, so it is where the split is caught.
   //
@@ -2646,7 +2646,7 @@ async function assertRootBrokerStopped(root: string): Promise<void> {
       process.kill(pid, 0); // signal 0 is a liveness probe, it signals nothing
       live = true;
     } catch (e) {
-      // EPERM means the process EXISTS and is not ours to signal — alive for this purpose.
+      // EPERM means the process EXISTS and is not ours to signal, i.e. alive for this purpose.
       live = (e as NodeJS.ErrnoException).code === "EPERM";
     }
     if (live)

--- a/implementations/cli/src/lib/restore.ts
+++ b/implementations/cli/src/lib/restore.ts
@@ -339,7 +339,7 @@ async function validateManifest(
     if (!manifest.authority || JSON.stringify(manifest.authority) !== JSON.stringify(currentAuthority)) {
       // Name the LIKELIEST drift instead of leaving a bare hash mismatch. The commitment covers the
       // operator JWT, the system account and the data account; when the DATA account still matches,
-      // what moved is the broker half — and since `cotal up --rotate-sys` re-issues exactly those two
+      // what moved is the broker half, and since `cotal up --rotate-sys` re-issues exactly those two
       // on a 30-day cadence, "you rotated after taking this backup" is the common case, not an exotic
       // one. Without this the operator sees an opaque fingerprint mismatch on the artifact they were
       // counting on during a disaster.

--- a/implementations/delivery/src/delivery.ts
+++ b/implementations/delivery/src/delivery.ts
@@ -241,7 +241,7 @@ export async function runDelivery(args: ParsedArgs, store?: SecretStore): Promis
     ({ handle: membership, down: membershipDown } = await startMembership({ space, server }, store));
   } catch (e) {
     membershipDown = (e as Error).message;
-    console.error(`! membership: failed to start (${membershipDown}) — graph membership degraded, delivery unaffected`);
+    console.error(`! membership: failed to start (${membershipDown}); graph membership degraded, delivery unaffected`);
   }
 
   let stopping = false;

--- a/implementations/delivery/src/evict-exec.ts
+++ b/implementations/delivery/src/evict-exec.ts
@@ -36,11 +36,11 @@ export async function executeEviction(server: string, principal: string): Promis
   const cfgPath = join(dir, "membership.json");
   if (!existsSync(obsPath) || !existsSync(evPath))
     throw new Error(
-      "evictPrincipal: the $SYS observer/evictor creds are not provisioned here (a space created before live eviction) — mint them with `cotal down` then `cotal up --rotate-sys`; until then removal is deny-new-only (durable reauth)",
+      "evictPrincipal: the $SYS observer/evictor creds are not provisioned here (a space created before live eviction); mint them with `cotal down` then `cotal up --rotate-sys`. Until then removal is deny-new-only (durable reauth)",
     );
   if (!existsSync(cfgPath))
     throw new Error(
-      `evictPrincipal: ${cfgPath} is missing, so the account to scan is unknown — until then removal is deny-new-only (durable reauth)`,
+      `evictPrincipal: ${cfgPath} is missing, so the account to scan is unknown; until then removal is deny-new-only (durable reauth)`,
     );
   const accountId = (JSON.parse(readFileSync(cfgPath, "utf8")) as { accountId?: string }).accountId;
   if (!accountId) throw new Error("evictPrincipal: .cotal/membership.json has no accountId");
@@ -73,7 +73,7 @@ export async function executePlaneLiveness(server: string, query: unknown): Prom
   const cfgPath = join(dir, "membership.json");
   if (!existsSync(obsPath))
     throw new Error(
-      "planeConnLiveness: the $SYS observer creds are not provisioned here (a space created before live observation) — mint them with `cotal down` then `cotal up --rotate-sys`",
+      "planeConnLiveness: the $SYS observer creds are not provisioned here (a space created before live observation); mint them with `cotal down` then `cotal up --rotate-sys`",
     );
   if (!existsSync(cfgPath)) throw new Error(`planeConnLiveness: ${cfgPath} is missing, so the account to scan is unknown`);
   const accountId = (JSON.parse(readFileSync(cfgPath, "utf8")) as { accountId?: string }).accountId;

--- a/implementations/delivery/src/membership.ts
+++ b/implementations/delivery/src/membership.ts
@@ -44,7 +44,7 @@ export async function startMembership(opts: { space: string; server: string }, s
   ].filter((f): f is string => f !== undefined);
   if (missing.length) {
     // Name the missing piece AND a repair that reaches it. `cotal up --rotate-sys` re-mints the $SYS
-    // pair — it holds a system-account signing seed for exactly that moment — but it writes neither
+    // pair, since it holds a system-account signing seed for exactly that moment, but it writes neither
     // the DATA-account rw cred nor the account-id config: those are written once, when a space is
     // first provisioned. So a rotation repairs a missing OBSERVER and nothing else, and pointing a
     // pre-feature space at one would send an operator through a stop/start that cannot help it.
@@ -52,28 +52,28 @@ export async function startMembership(opts: { space: string; server: string }, s
       missing.length === 1 && missing[0] === "membership-observer.creds"
         ? "the $SYS observer cred is missing - re-mint it with `cotal down` then `cotal up --rotate-sys`"
         : `the membership bundle is incomplete here (missing ${missing.join(", ")}) - a space created before broker-sourced membership gains the feed only when its auth is regenerated; \`cotal up --rotate-sys\` re-mints the $SYS pair but writes neither the rw cred nor the account id`;
-    console.error(`• membership: ${down} — the graph falls back to traffic-only. Delivery is unaffected.`);
+    console.error(`• membership: ${down}. The graph falls back to traffic-only; delivery is unaffected.`);
     return { down };
   }
 
   const accountId = (JSON.parse(readFileSync(cfgPath, "utf8")) as { accountId?: string }).accountId;
   if (!accountId) {
     const down = ".cotal/membership.json has no accountId";
-    console.error(`• membership: ${down} — membership disabled (delivery unaffected)`);
+    console.error(`• membership: ${down}; membership disabled (delivery unaffected)`);
     return { down };
   }
 
   // Check the OBSERVER's own expiry before connecting. It is `rotation-renewed`, so unlike every
   // renewable cred here nothing re-signs it: at its 30-day horizon the broker simply answers
   // "Authorization Violation", which names neither the credential nor the repair. Reading the JWT
-  // costs nothing and turns the daemon's one loud line into the actual diagnosis — the difference
+  // costs nothing and turns the daemon's one loud line into the actual diagnosis: the difference
   // between an operator finding this in minutes and finding it in a support thread.
   const obsCreds = readFileSync(obsPath, "utf8");
   // A TORN rotation is the other way this cred goes broker-dead without a byte of its own changing:
   // `rotateSystemCreds` commits the trust record, then writes both $SYS creds, so a crash between the
   // two leaves one file on the retired system account. The broker answers the same bare
   // "Authorization Violation" either way. The daemon cannot ask the trust record which account is
-  // current — it deliberately never loads the signer — but it does not need to: the pair is written
+  // current (it deliberately never loads the signer), but it does not need to: the pair is written
   // by one rotation, so two DIFFERENT issuers prove one of them is stale, with no signer read at all.
   // (`doctor auth`, which legitimately holds the record, checks each file against it directly.)
   const evPath = join(dir, "connection-evictor.creds");
@@ -85,7 +85,7 @@ export async function startMembership(opts: { space: string; server: string }, s
     } catch { /* an unreadable file is the health check's case just below */ }
     if (obsIss !== undefined && evIss !== undefined && obsIss !== evIss) {
       const down = `the two $SYS creds are signed by DIFFERENT system accounts (observer ${obsIss.slice(0, 12)}…, evictor ${evIss.slice(0, 12)}…) - a system-account rotation did not finish, so one of them is broker-dead: re-run \`cotal down\` then \`cotal up --rotate-sys\` to land a complete generation`;
-      console.error(`! membership: ${down} — graph membership degraded, delivery unaffected`);
+      console.error(`! membership: ${down}; graph membership degraded, delivery unaffected`);
       return { down };
     }
   }
@@ -95,7 +95,7 @@ export async function startMembership(opts: { space: string; server: string }, s
       obs.state === "expired"
         ? `the $SYS observer cred (${obsPath}) EXPIRED ${new Date((obs.exp ?? 0) * 1000).toISOString()} and the broker denies it - it is rotation-renewed, so nothing re-signs it: run \`cotal down\` then \`cotal up --rotate-sys\` (agents, creds and data are untouched)`
         : `the $SYS observer cred (${obsPath}) is unreadable (${obs.error})`;
-    console.error(`! membership: ${down} — graph membership degraded, delivery unaffected`);
+    console.error(`! membership: ${down}; graph membership degraded, delivery unaffected`);
     return { down };
   }
 

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -1031,7 +1031,7 @@ export class Manager {
    *
    *  The manager is the renewal owner for every credential it CAN re-sign, and these two are the ones
    *  it cannot: they are `rotation-renewed`, so no resident process re-mints them and they simply die
-   *  on their 30-day horizon. Before this, a mesh that never ran `doctor auth` got no signal at all —
+   *  on their 30-day horizon. Before this, a mesh that never ran `doctor auth` got no signal at all,
    *  it discovered the expiry as an "Authorization Violation" in the delivery log and a refused
    *  membership adoption, weeks after the warning would have been actionable (#338). The pass runs
    *  every half-TTL of the 24h class, so this repeats about twice a day for the ~7 days between the

--- a/packages/workspace/src/system-rotation.ts
+++ b/packages/workspace/src/system-rotation.ts
@@ -13,13 +13,13 @@ import { assertSingleSpaceBroker, authDir, getSpaceAuth, putSpaceAuth } from "./
 import { workspaceSecretStore } from "./secret-store-fs.js";
 
 /**
- * The class-3 ($SYS) renewal owner's half — the counterpart to `renewal.ts`, which owns the class-2
+ * The class-3 ($SYS) renewal owner's half, the counterpart to `renewal.ts`, which owns the class-2
  * standing renewal and deliberately EXCLUDES these two files.
  *
  * `membership-observer.creds` and `connection-evictor.creds` are `rotation-renewed`: they are signed
  * by the system-account seed, which is never persisted (`putSpaceAuth` strips it), so no running
  * process can re-sign them for their existing identity the way `remintDaemonCreds` does. Their only
- * renewal is a system-account ROTATION — a fresh $SYS account under the SAME broker operator, fresh
+ * renewal is a system-account ROTATION: a fresh $SYS account under the SAME broker operator, fresh
  * creds minted from its in-memory seed, and a broker that reloads the new operator/system JWTs.
  *
  * That rotation is NOT destructive. `rotateSystemAccount` re-signs the operator JWT with a new
@@ -49,7 +49,7 @@ export const SYSTEM_CREDS_FILES = ["membership-observer.creds", "connection-evic
 export interface SystemRotationResult {
   /** The broker record's new system-account generation (the successor discriminator `putSpaceAuth` guards). */
   gen: number;
-  /** The rotated bundle — the caller MUST render `server.conf` from this, not from its pre-rotation copy. */
+  /** The rotated bundle. The caller MUST render `server.conf` from this, not from its pre-rotation copy. */
   auth: SpaceAuth;
   /** Expiry (epoch sec) of the freshly minted $SYS creds, so the caller can print the next rotation date. */
   expiresAt?: number;
@@ -68,7 +68,7 @@ export interface SystemRotationResult {
  * stale or non-successor write. Then the creds land. What this buys is a single failure direction: a
  * cred file is never overwritten for a system account the record does not already carry, because the
  * inverse order could clobber the last-good creds with creds for an authority the broker will never
- * load — the availability loss `remintDaemonCreds` guards on its own class.
+ * load, which is the availability loss `remintDaemonCreds` guards on its own class.
  *
  * It does NOT make the persistence atomic. `putSpaceAuth` is two puts and the creds are two more, so
  * a crash leaves the record AHEAD of the creds. That state is detected rather than prevented (see
@@ -88,7 +88,7 @@ export async function rotateSystemCreds(root: string, expectedSpace: string): Pr
   // The guard reads the FS account records, and that is exactly why this function takes NO
   // SecretStore. `SecretStore` cannot enumerate, so an injected multi-tenant store paired with an
   // empty local root would sail past this check and retire the system account for every tenant in
-  // it — a guard that looks broker-wide while enforcing nothing. Taking the store away makes the
+  // it: a guard that looks broker-wide while enforcing nothing. Taking the store away makes the
   // mismatch impossible to express rather than merely refused at runtime, and it costs nothing real:
   // the $SYS pair is FS-only anyway (a hosted composition has nowhere in the store to put it), so
   // this operation was never store-composable to begin with. If store enumeration ever exists, this
@@ -108,12 +108,12 @@ export async function rotateSystemCreds(root: string, expectedSpace: string): Pr
   const observer = await mintMembershipObserverCreds(rotated, newIdentity());
   const evictor = await mintConnectionEvictorCreds(rotated, newIdentity());
 
-  // Commit the trust record FIRST — the generation guard lives in this call, and it is what makes the
+  // Commit the trust record FIRST: the generation guard lives in this call, and it is what makes the
   // successor real. Only then the creds that record authorizes.
   //
   // This is NOT one atomic act, and the code must not pretend otherwise: `putSpaceAuth` is itself two
   // puts, and the two cred writes are two more. A crash anywhere in this sequence leaves the record
-  // AHEAD of the creds — both files stale (crash before either write) or one stale (crash between
+  // AHEAD of the creds: both files stale (crash before either write) or one stale (crash between
   // them). The window is not closed here; it is DETECTED, by {@link staleSystemCreds}, which every
   // boot and every `doctor auth` runs against the persisted record. It cannot be repaired in place
   // either: the successor's signing seed is gone the moment it is persisted, so the only repair is
@@ -137,7 +137,7 @@ export interface StaleSystemCred {
 }
 
 /**
- * The $SYS cred files whose issuer is not `sysPub` — the ONE staleness question, asked in one place
+ * The $SYS cred files whose issuer is not `sysPub`: the ONE staleness question, asked in one place
  * so every surface answers it identically.
  *
  * This exists because expiry cannot see the failure. A rotation that committed the trust record and
@@ -145,12 +145,12 @@ export interface StaleSystemCred {
  * broker, because the account that signed them no longer exists as far as the successor config is
  * concerned. Comparing the two files to each other is not enough either: a crash BEFORE either write
  * leaves them stale but mutually consistent. Only the persisted record settles it, which is why this
- * takes `sysPub` and why the callers are the two surfaces that hold it — the boot path, which warns
+ * takes `sysPub` and why the callers are the two surfaces that hold it: the boot path, which warns
  * before it renders a config the files cannot serve, and `cotal doctor auth`, which must never call
  * this state healthy. The delivery daemon is deliberately NOT a caller: it never loads the signer.
  *
  * Absent files are not stale (an unprovisioned space is a different, separately reported state), and
- * an unreadable file is reported with no `iss` rather than throwing — a diagnosis surface must not
+ * an unreadable file is reported with no `iss` rather than throwing, because a diagnosis surface must not
  * crash on the corruption it exists to describe.
  */
 export function staleSystemCreds(root: string, sysPub: string): StaleSystemCred[] {


### PR DESCRIPTION
The `$SYS` rotation change (#364) introduced 81 em-dashed lines: user-facing strings in the
delivery daemon and the eviction executor, its changeset, its comments, and both of its smoke
suites. House style is zero em-dashes in prose, so this rewrites every one of them.

Each line is transformed by role (colon, semicolon, comma, parens, or a sentence split) rather
than by blanket replacement, since a global swap breaks matched-pair parentheticals and leaves
the closing half stranded before a verb.

Prose only. No behaviour, no assertion and no message identity changes:

- the eviction and liveness refusals keep `not provisioned here`, which `smoke:doctor-auth`
  matches on;
- the membership lines keep their `•` / `!` severity markers and their existing wording either
  side of the punctuation;
- the e2e's byte-offset comment explains multibyte glyphs by naming `✓` and `•` instead of
  printing an em-dash as its own example.

Only lines added by #364 are touched. Pre-existing em-dashes elsewhere in the same files are
left as they are.

Verified with `pnpm typecheck`, `pnpm build`, `smoke:sys-rotation` (60/60),
`smoke:sys-rotation-e2e` (36/36), `smoke:doctor-auth` (23/23), `smoke:flag-inventory` and
`smoke:gate-inventory`.

No new changeset: #364's changeset is still unreleased and this edits its text in place, so the
staged bump already covers these packages.
