### PR TITLE
test(cli): sandbox server-resolution:live's fixtures, and witness the sandbox

### DIFF
--- a/.changeset/live-fixture-sandbox.md
+++ b/.changeset/live-fixture-sandbox.md
@@ -1,0 +1,20 @@
+---
+"@cotal-ai/cli": patch
+---
+
+Sandbox `server-resolution:live`'s fixtures so a stray `.cotal` above the temp base cannot capture them.
+
+`findCotalRoot` walks to `/` with no boundary, so one `.cotal` anywhere above the temp base captures
+every fixture a suite mints there. This suite is unusually exposed: the whole premise of its `cwd`
+fixture is that it has NO `.cotal` up-tree, so bare resolution falls through to the registry. Under a
+captured base that premise is simply false.
+
+Measured, both arms, against a deliberately poisoned base: unconverted, the suite resolved against a
+foreign registry and dialled the shared local demo broker instead of its own fixture. Converted, it
+rejects the captured base, mints under a clean one, and passes its 18 checks. The scratch is
+witnessed with `assertScratchHeld` rather than assumed, which is the half that makes it evidence.
+
+Only this one entry is converted. The other live entries mint raw too, but minting raw is not the
+same as being captured: tested by artifact, two of four write into a captured root and two never
+touch it. A sweep would have "fixed" suites that were never broken, so the rest want the
+poisoned-base arm run per suite first (tracked on #360).

--- a/implementations/cli/smoke/server-resolution-live.smoke.ts
+++ b/implementations/cli/smoke/server-resolution-live.smoke.ts
@@ -15,6 +15,7 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { once } from "node:events";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { makeScratch, assertScratchHeld } from "../../../bin/smoke/_scratch.js";
 import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -31,12 +32,23 @@ const freePort = (): Promise<number> =>
   });
 
 // Sandbox the registry BEFORE importing workspace — homeCotalDir() reads COTAL_HOME per call.
-const home = mkdtempSync(join(tmpdir(), "cotal-ps-resolve-home-"));
-const cwd = mkdtempSync(join(tmpdir(), "cotal-ps-resolve-cwd-"));
-const projectRoot = mkdtempSync(join(tmpdir(), "cotal-ps-resolve-root-"));
+//
+// The fixtures go under a scratch base with PROVEN-clean `.cotal` ancestry, not under a bare
+// `tmpdir()`. `findCotalRoot` walks to `/` with no boundary, so a single `.cotal` anywhere above the
+// temp base captures every dir minted here. This suite is unusually exposed to that: the whole point
+// of `cwd` below is that it has no `.cotal` up-tree, so bare resolution falls through to the
+// registry. Under a captured base that premise is simply false, and the cells still pass, having
+// exercised a different code path than the one they name.
+const scratch = makeScratch("cotal-ps-resolve-");
+const home = mkdtempSync(join(scratch, "home-"));
+const cwd = mkdtempSync(join(scratch, "cwd-"));
+const projectRoot = mkdtempSync(join(scratch, "root-"));
 // Created out here with its siblings so the `finally` sweep removes it on every exit path — a
 // dir made inside the `try` leaks one OS temp directory per run when a cell throws.
-const mismatchRoot = mkdtempSync(join(tmpdir(), "cotal-ps-resolve-mismatch-"));
+const mismatchRoot = mkdtempSync(join(scratch, "mismatch-"));
+// Witnessed, not assumed. A scratch base that is silently captured would leave every assertion
+// below testing the captured-root path while reading as green.
+assertScratchHeld(cwd, "server-resolution fixtures");
 process.env.COTAL_HOME = home;
 const startCwd = process.cwd(); // restored before cleanup so Windows can rmdir `cwd` (it locks a live process's cwd)
 process.chdir(cwd); // a dir with no `.cotal` up-tree, so bare resolution falls through to the registry


### PR DESCRIPTION
Partial fix for #360, deliberately one entry rather than a sweep.

## The exposure

`findCotalRoot` walks to `/` with no boundary, so one `.cotal` anywhere above the temp base captures
every fixture a suite mints there. This suite is the clearest case in the live job, because its own
comment states the premise that capture falsifies:

```ts
process.chdir(cwd); // a dir with no `.cotal` up-tree, so bare resolution falls through to the registry
```

## Both arms, against a deliberately poisoned base

| | exit | what it did |
|---|---|---|
| unconverted | 1 | resolved against a foreign registry and dialled the **shared local demo broker** instead of its own fixture |
| converted | 0 | rejected the captured base, minted under a clean one, 18 checks |

The scratch is **witnessed** (`assertScratchHeld`), not assumed, which is the half that turns it from
hope into evidence.

Verified that the helper does the work and not luck: probed directly, `cotalRootCaptor` identifies the
captor over the poisoned `TMPDIR` and `makeScratch` falls through to a clean base whose own captor is
`null`.

## Why only one entry

My own earlier enumeration on the issue said 10 of 11 live entries mint fixtures raw. That count is
right, and I let it imply those 10 are exposed. **Tested by artifact, they are not:**

| entry | files written into a captured `.cotal` | reached by capture? |
|---|---|---|
| `server-resolution:live` | (dialled the wrong broker) | yes |
| `setup-pure:live` | 2 | yes |
| `spawn-detach:live` | 0 | no |
| `readiness:live` | 0 | no |

Two of four are immune to this vector despite minting raw. A mechanical sweep would have changed
suites that were never broken and claimed credit for it. The grep finds candidates; only the artifact
test finds the exposed set, so the remaining entries want the poisoned-base arm run per suite.

`setup-pure:live` is the other confirmed-exposed one and is a good next PR; it is not in this one
because each live entry drives `cotal up` differently and deserves its own arms rather than a shared
assumption.

## Not claimed

I have still not produced an instance of a suite passing **silently** under capture. Both exposed
suites failed loudly. The silent class is the real motivation for #360 and it remains unevidenced;
this PR does not supply it.