### PR TITLE
chore(release): version @cotal-ai/lang with the rest of the workspace

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,7 @@
       "cotal-ai",
       "@cotal-ai/core",
       "@cotal-ai/workspace",
+      "@cotal-ai/lang",
       "@cotal-ai/cli",
       "@cotal-ai/manager",
       "@cotal-ai/delivery",

--- a/.changeset/lang-joins-release-group.md
+++ b/.changeset/lang-joins-release-group.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/lang": minor
+---
+
+Version `@cotal-ai/lang` with the rest of the workspace. It is a public package (`packages/lang`, alongside `core` and `workspace`) but was missing from the `fixed` group, so Changesets never bumped it: it stayed pinned at 0.15.0 while every other package moved, and `pnpm publish -r` would have pushed a version permanently out of lockstep with the release it shipped in. Joining the group means it versions and publishes with everything else.


### PR DESCRIPTION
`@cotal-ai/lang` is a public package (`packages/lang`, alongside `core` and `workspace`, both of which are in the group) but it is missing from the `fixed` group in `.changeset/config.json`.

The consequence is not cosmetic. Changesets never bumps it, so it stayed pinned at `0.15.0` while the rest of the workspace moved to `0.17.0`. Since it is not private, `pnpm publish -r` still tries to publish it — pushing a version permanently out of lockstep with the release that shipped it, and then silently publishing nothing at all once its version stops changing.

It also had no package on npm until it was bootstrapped just now, which is why the mismatch never surfaced as a failed release.

Adding it to the group. Verified with a local `changeset version` against the pending changesets: all 19 packages land on `0.18.0` together, `lang` and `herdr` included, with nothing left off the group version.