### PR TITLE
fix(cli): mint a lifecycle uid for the agent profile

### DIFF
--- a/.changeset/mint-agent-lifecycle.md
+++ b/.changeset/mint-agent-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/cli": patch
+---
+
+`cotal mint --profile agent` now mints the lifecycle uid the agent profile requires, instead of failing on every invocation. The agent arm of `permissionsFor` builds lifecycle-keyed dm/dlv/chathist grants and threw without one, so the default profile could never be used and the only reachable profiles were observer and admin, neither of which can publish to a channel.

--- a/implementations/cli/src/commands/mint.ts
+++ b/implementations/cli/src/commands/mint.ts
@@ -4,6 +4,7 @@ import {
   agentFilePath,
   loadAgentFile,
   mintCreds,
+  mintLifecycleUid,
   mkSecretDir,
   newIdentity,
   stripSpaceAuth,
@@ -84,15 +85,25 @@ export async function mint(args: ParsedArgs): Promise<void> {
   let allowSubscribe: string[] | undefined;
   let allowPublish: string[] | undefined;
   let role: string | undefined;
+  // The agent profile's dm/dlv/chathist grants are lifecycle-keyed exact names (SPEC 13.1), so
+  // `permissionsFor("agent")` REQUIRES a lifecycleUid and throws without one. This command never
+  // supplied it, which made `cotal mint <name> --profile agent` — the default profile, and the one
+  // its own usage line advertises first — fail on every space with:
+  //   permissionsFor(agent): a lifecycleUid is required
+  // Minting one HERE is the correct owner: a lifecycle uid identifies an incarnation, and an
+  // out-of-band mint IS the first incarnation of that identity. The alternative (accept one as a
+  // flag) would let a caller collide with a live agent's broker footprint by passing its uid.
+  let lifecycleUid: string | undefined;
   if (profile === "agent") {
     const f = agentFilePath(cotalRoot(), name);
     const def = existsSync(f) ? loadAgentFile(f) : undefined;
     allowSubscribe = splitList(values["allow-subscribe"]) ?? def?.allowSubscribe ?? def?.subscribe;
     allowPublish = splitList(values["allow-publish"]) ?? def?.allowPublish;
     role = def?.role;
+    lifecycleUid = mintLifecycleUid();
   }
   const identity = newIdentity();
-  const creds = await mintCreds(auth, identity, profile, { allowSubscribe, allowPublish, role });
+  const creds = await mintCreds(auth, identity, profile, { allowSubscribe, allowPublish, role, lifecycleUid });
   let out: string;
   if (values.out) {
     // An operator-directed EXPORT to an explicit path — outside the canonical kind location,


### PR DESCRIPTION
## What was broken

`cotal mint <name> --profile agent` could never succeed. The agent arm of `permissionsFor` builds the dm/dlv/chathist grants from lifecycle-keyed exact names (SPEC 13.1) and throws when no `lifecycleUid` is supplied. `mint` never supplied one, so every invocation died with:

```
✗ permissionsFor(agent): a lifecycleUid is required - the agent's dm/dlv/chathist grants are lifecycle-keyed exact names (SPEC 13.1)
```

`agent` is the **default** profile and the first one the command's own usage line advertises, so in practice the only reachable profiles were `observer` and `admin`.

## Why that mattered

Neither reachable profile can publish to a channel. `admin` is a read-everything audit shape whose publish grants are JetStream API calls only — on a live space its credential has 29 publish grants and every one of them is `$JS.*`, with nothing on the chat subject tree.

So there was no way to mint an out-of-band identity with a post ACL at all. The only route to a publishing identity was `cotal spawn`, which also starts a process — which is not what you want when the thing that needs to publish is a long-running service rather than an agent seat.

## The change

Mint the uid in `mint` rather than accepting it as a flag. A lifecycle uid names an incarnation, and an out-of-band mint is that identity's first incarnation. Taking one from the caller would let a mint collide with a live agent's broker footprint by passing its uid.

Unchanged: this still mints creds only. The bind-only chat/DM/TASK durables are pre-created by a privileged provisioner, exactly as the note above the arm already says. A credential minted here can publish within its post ACL immediately, and needs that provisioning before it binds a reader.

## Verification

Against a live auth space, with both controls:

- **Before:** `cotal mint fm-asks --profile agent --allow-publish 'ask.>'` → `permissionsFor(agent): a lifecycleUid is required`.
- **After:** the same command mints. The credential's only non-JetStream chat grant is `cotal.main.chat.<owner>.<actor>.ask.>` — scoped to the requested channels and nothing else.
- **Positive control:** publishing to `ask.<id>` with that credential succeeds.
- **Negative control:** publishing to `general` with the same credential is refused by the broker with a permissions violation, so the scoping is enforced at the broker rather than merely declared in the JWT.

`pnpm typecheck` passes across all packages.