### PR TITLE
fix(cli,delivery): heal the membership bundle's data half on any up

### DIFF
--- a/.changeset/membership-selfheal.md
+++ b/.changeset/membership-selfheal.md
@@ -1,0 +1,6 @@
+---
+"@cotal-ai/cli": patch
+"@cotal-ai/delivery": patch
+---
+
+`cotal up` now provisions the data-account half of the membership bundle on every run, not only when a space is first created, so a space provisioned before broker-sourced membership gains the graph feed without regenerating its auth. The delivery daemon's incomplete-bundle message now names the repair that matches the missing piece instead of always pointing at a system-account rotation.

--- a/implementations/cli/src/commands/up.ts
+++ b/implementations/cli/src/commands/up.ts
@@ -2594,6 +2594,8 @@ async function authSetup(
     // true, not in a doc the operator reads after the restore has already failed.
     console.log(c.dim("  NOTE: full backups taken before this rotation can no longer be restored (they are bound to the retired trust chain) - take a fresh `cotal backup` once the mesh is up."));
   }
+  // The DATA half of the membership bundle, on EVERY path — see healMembershipDataCreds.
+  await healMembershipDataCreds(auth, cotalRoot());
   // The $SYS creds must be signed by the system account THIS boot is about to put in `server.conf`.
   // A rotation that committed the trust record and then died leaves them stale, unexpired, and
   // broker-dead and, crash-before-either-write, stale in a way that no comparison between the two
@@ -2723,6 +2725,47 @@ async function assertRootBrokerStopped(root: string): Promise<void> {
  *  its write/read/delete all go through the {@link SecretStore} seam (here, the feed reader, and clean),
  *  so the renewal owner can re-sign it into a hosted store. The observer / evictor / config stay on the
  *  raw FS (static $SYS creds + non-secret config, not renewable kinds). */
+/** Provision the DATA-account half of the membership bundle, on EVERY `up` rather than only a fresh
+ *  space. Idempotent: it writes only what is absent and is silent when both are present.
+ *
+ *  WHY THIS IS SEPARATE FROM {@link provisionMembershipCreds}. That function mints the whole bundle
+ *  in the fresh-space branch because the `$SYS` signing seed exists only there and is never
+ *  persisted — true of `membership-observer.creds` and `connection-evictor.creds`, and the reason
+ *  they can only be re-minted by a system-account rotation. It is NOT true of the other two.
+ *  `membership-rw.creds` is signed by the DATA account, whose signing seed IS persisted, and
+ *  `membership.json` is just that account's public id. Neither needs the `$SYS` window, so binding
+ *  them to it left every space provisioned before the feature permanently without the feed.
+ *
+ *  That gap was not theoretical. A space with a complete `$SYS` pair, missing only the rw cred,
+ *  reported `the membership bundle is incomplete here (missing membership-rw.creds)` on every
+ *  delivery-daemon start and served a traffic-only graph, and the documented remedy did not work:
+ *  `--rotate-sys` re-mints the `$SYS` pair and never calls the provisioner, so it wrote neither the
+ *  rw cred nor the account id. `mintMembershipObserverCreds` even names that rotation as the fix in
+ *  its own error text — advice that could not succeed. Healing here fixes both spellings at once:
+ *  the ordinary `up` repairs the data half with no rotation at all, and a rotation now repairs it
+ *  too, because this runs after both branches converge. */
+async function healMembershipDataCreds(auth: SpaceAuth, root: string): Promise<void> {
+  try {
+    const store = workspaceSecretStore(root);
+    const wrote: string[] = [];
+    if ((await store.get(MEMBERSHIP_RW_CREDS_KEY)) === undefined) {
+      await store.put(MEMBERSHIP_RW_CREDS_KEY, await mintCreds(auth, newIdentity(), "membership-rw"));
+      wrote.push(MEMBERSHIP_RW_CREDS_KEY);
+    }
+    if (!existsSync(cotalPath("membership.json"))) {
+      mkSecretDir(cotalPath()); // harden .cotal/ before the file lands, as the fresh path does
+      writeSecretFile(cotalPath("membership.json"), JSON.stringify({ accountId: auth.account.pub }));
+      wrote.push("membership.json");
+    }
+    if (wrote.length)
+      console.log(c.dim(`• membership: provisioned ${wrote.join(" + ")} - the data-account half needs no system-account rotation`));
+  } catch (e) {
+    // Best-effort, exactly like the fresh-space provisioner: a failure here leaves the graph on
+    // traffic-only and leaves delivery untouched. It must never keep the mesh from starting.
+    console.error(c.dim(`• broker-sourced membership not repaired: ${(e as Error).message}`));
+  }
+}
+
 async function provisionMembershipCreds(auth: SpaceAuth, root: string): Promise<void> {
   try {
     const observer = await mintMembershipObserverCreds(auth, newIdentity());

--- a/implementations/delivery/src/membership.ts
+++ b/implementations/delivery/src/membership.ts
@@ -43,15 +43,26 @@ export async function startMembership(opts: { space: string; server: string }, s
     existsSync(cfgPath) ? undefined : "membership.json",
   ].filter((f): f is string => f !== undefined);
   if (missing.length) {
-    // Name the missing piece AND a repair that reaches it. `cotal up --rotate-sys` re-mints the $SYS
-    // pair, since it holds a system-account signing seed for exactly that moment, but it writes neither
-    // the DATA-account rw cred nor the account-id config: those are written once, when a space is
-    // first provisioned. So a rotation repairs a missing OBSERVER and nothing else, and pointing a
-    // pre-feature space at one would send an operator through a stop/start that cannot help it.
+    // Name the missing piece AND a repair that reaches it. The bundle has two halves with two
+    // different repairs, and naming the wrong one costs an operator a full mesh stop for nothing.
+    // The $SYS-signed half (observer, evictor) can only be minted while the never-persisted system
+    // signing seed is in memory, so it takes a rotation. The DATA half (rw cred, account id) is
+    // signed by the data account, whose seed IS persisted, so a plain `cotal up` heals it — that is
+    // what `healMembershipDataCreds` in `up` does, on every path rather than only a fresh space.
     const down =
       missing.length === 1 && missing[0] === "membership-observer.creds"
         ? "the $SYS observer cred is missing - re-mint it with `cotal down` then `cotal up --rotate-sys`"
-        : `the membership bundle is incomplete here (missing ${missing.join(", ")}) - a space created before broker-sourced membership gains the feed only when its auth is regenerated; \`cotal up --rotate-sys\` re-mints the $SYS pair but writes neither the rw cred nor the account id`;
+        // Name the remedy that matches the MISSING piece, because the two halves are repaired by
+        // different acts. The data half (`membership-rw.creds`, `membership.json`) is signed by the
+        // data account, whose seed is persisted, so a plain `cotal up` mints it. The $SYS half
+        // (observer, evictor) can only be re-minted while the never-persisted $SYS seed is in
+        // memory, which is a system-account rotation. Telling an operator to rotate when a plain
+        // `up` would do it sends them through a full mesh stop for nothing.
+        : `the membership bundle is incomplete here (missing ${missing.join(", ")}) - ${
+            missing.every((m) => m === MEMBERSHIP_RW_CREDS_KEY || m === "membership.json")
+              ? "run `cotal up` to provision the data-account half (no rotation needed)"
+              : "the $SYS-signed creds can only be re-minted while the system account is being provisioned: `cotal down` then `cotal up --rotate-sys`"
+          }`;
     console.error(`• membership: ${down}. The graph falls back to traffic-only; delivery is unaffected.`);
     return { down };
   }


### PR DESCRIPTION
## What was broken

A space provisioned before broker-sourced membership could never gain the graph feed, and the documented remedy could not give it one.

`provisionMembershipCreds` runs only in `up`'s fresh-space branch, because the `$SYS` signing seed exists only there and is never persisted. That is the correct constraint for two of the four pieces it writes — `membership-observer.creds` and `connection-evictor.creds` are `$SYS`-signed, so a rotation really is the only way to re-mint them.

It is not the constraint for the other two. `membership-rw.creds` is signed by the **data** account, whose signing seed **is** persisted, and `membership.json` is just that account's public id. Binding those to the `$SYS` window is what left pre-feature spaces stuck on a traffic-only graph forever.

The advice was wrong too. `--rotate-sys` re-mints the `$SYS` pair and never calls the provisioner, so it writes neither the rw cred nor the account id — and `mintMembershipObserverCreds` names that same rotation as the fix in its own error text. For a missing rw cred, following it costs a full mesh stop and changes nothing.

## The change

`healMembershipDataCreds` runs after both branches of `up` converge. It writes only what is absent and says nothing when both are present, so:

- an ordinary `cotal up` repairs a missing data half, with no rotation and no mesh stop
- a rotation repairs it too, because this is downstream of the branch

The `$SYS` half still requires a rotation. That constraint is real and is unchanged.

The delivery daemon's incomplete-bundle message now branches on **which** piece is missing instead of always naming a rotation.

## Verification

Measured against a live space whose observer, evictor and `membership.json` were all present and whose `membership-rw.creds` was absent:

- **Before:** every delivery-daemon start logged `the membership bundle is incomplete here (missing membership-rw.creds)` and the graph served traffic-only.
- **After** minting the rw cred through the same `SecretStore` seam this heals with, and restarting the daemon: the warning is gone and the daemon starts clean.

The rw cred was confirmed readable at the same root the daemon resolves via `findCotalRoot()`, so the store write and the daemon read agree on location rather than merely both succeeding.

`pnpm typecheck` passes across all packages.