### PR TITLE
test(herdr): the soak's positive control waits for the payload instead of sampling once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,13 @@ jobs:
         run: pnpm smoke:lifecycle-e2e
       - name: Runtime smoke tests (tmux, orca, herdr)
         run: pnpm smoke:runtime
+      # Runs BEFORE the soak because it grades the soak's own instrument: the wait behind the
+      # positive control, and the nonce the survivor count matches on. If either is wrong the soak
+      # still goes green — a control that can pass while the payload is absent, or a count that
+      # includes a neighbouring run's processes. Deterministic (fake clock, injected probe), so it
+      # is a cheap gate on the expensive one, not a second copy of it.
+      - name: herdr soak instrument (visibility wait + nonce)
+        run: pnpm smoke:herdr:probe
       # Accumulation is invisible to a single-shot suite: a per-cycle leak of a pane, workspace,
       # launcher dir or process only shows up over many spawn/stop cycles, which is what a
       # long-lived manager actually does.

--- a/extensions/herdr/probe.smoke.ts
+++ b/extensions/herdr/probe.smoke.ts
@@ -1,0 +1,151 @@
+/**
+ * THE SOAK'S POSITIVE CONTROL, GRADED WITHOUT A RACE (#459).
+ *
+ * The control is the cell the other eleven depend on: it proves the survivor instrument can see a
+ * live agent, so that "no agent processes survive" means something. It could pass or fail on
+ * timing, which made every green behind it weaker evidence than it looked.
+ *
+ * The fix is a wait on a named event; this suite is what makes that wait provable. The live soak
+ * cannot grade it — a race has no deterministic red through the real path, and reaching for one
+ * would just be the flake in a different costume. So the probe is injected and the clock is fake,
+ * and every branch is exercised on purpose.
+ *
+ * WHAT THIS DOES AND DOES NOT COVER, stated so it is not over-read. It grades `waitUntilVisible`
+ * and the fact that the soak CALLS it. It does not spawn a herdr agent, does not exercise the
+ * pane, and does not prove `ourProcs()` matches a real process — that is the live soak's job and
+ * it needs a herdr binary. Cell 5 is a structural assertion for exactly that reason, and it is
+ * explained where it sits.
+ *
+ * Run: pnpm smoke:herdr:probe
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { waitUntilVisible, visibilityDetail, type VisibilityOutcome } from "./probe.js";
+
+let pass = 0, fail = 0;
+const check = (name: string, cond: boolean, extra?: unknown) => {
+  if (cond) { pass++; console.log(`  ✓ ${name}`); }
+  else { fail++; console.log(`  ✗ FAIL: ${name}`, extra !== undefined ? JSON.stringify(extra) : ""); }
+};
+
+/** A fake clock. Time moves ONLY when the wait sleeps, so these cells are instant and identical on
+ *  every machine — the whole point, given what is being fixed. */
+function fakeClock(): { now: () => number; sleep: (ms: number) => Promise<void>; elapsed: () => number } {
+  let t = 0;
+  return { now: () => t, sleep: async (ms: number) => { t += ms; }, elapsed: () => t };
+}
+
+/** A probe that returns 0 for the first `n` calls and then 1 — the real shape: the payload does not
+ *  exist yet, then it does. */
+const visibleAfter = (n: number): (() => number) => {
+  let calls = 0;
+  return () => (++calls > n ? 1 : 0);
+};
+
+console.log("\n── herdr positive-control probe ────────────────\n");
+
+// ---- 1. THE DEFECT: A SINGLE SAMPLE IS NOT AN ANSWER -----------------------------------------
+// Measured against the real launcher, the payload was visible 0 times out of 6 at spawn-return and
+// appeared 70-155ms later. So the case that matters is "not yet, then yes" — and the ONLY thing
+// that distinguishes a wait from the old sample is that this case comes back `seen`.
+console.log("1. a process that becomes visible LATE is still seen");
+{
+  const c = fakeClock();
+  const out = await waitUntilVisible(visibleAfter(3), { deadlineMs: 5_000, intervalMs: 50, now: c.now, sleep: c.sleep });
+  check("it is SEEN, not missed", out.kind === "seen", out);
+  check("...on the try that actually saw it, not the first", out.kind === "seen" && out.tries === 4, out);
+  check("...and it reports when, so a slow appearance is visible in the log rather than silent",
+    out.kind === "seen" && out.elapsedMs === 150, out);
+  // The old implementation, exactly: one sample. Stated as a cell so the regression has a name.
+  const single = visibleAfter(3);
+  check("...whereas a SINGLE sample at that instant reports absent — the defect, in one line",
+    single() === 0);
+}
+
+// ---- 2. IT CANNOT PASS WHILE THE PAYLOAD IS ABSENT --------------------------------------------
+// The first of the two directions required of this fix. A wait that gave up quietly, or returned
+// something a caller could read as success, would be the widened window in a different costume.
+console.log("\n2. an absent payload can NEVER be reported as seen");
+{
+  const c = fakeClock();
+  const out = await waitUntilVisible(() => 0, { deadlineMs: 1_000, intervalMs: 100, now: c.now, sleep: c.sleep });
+  check("the deadline is a FAILURE outcome, never a pass", out.kind === "deadline", out);
+  check("...it sampled repeatedly rather than once", out.kind === "deadline" && out.tries > 1, out);
+  check("...and it stops at the deadline instead of running forever", c.elapsed() <= 1_000 + 100, c.elapsed());
+  check("...and says what it last measured, so the red carries its own evidence",
+    out.kind === "deadline" && out.lastCount === 0, out);
+}
+
+// ---- 3. IT CANNOT FAIL WHILE THE PAYLOAD IS PRESENT -------------------------------------------
+// The second required direction. A control that can redden with the agent right there is exactly
+// the flake this replaces, so the already-visible case must be immediate and unconditional.
+console.log("\n3. a present payload can NEVER be reported as absent");
+{
+  const c = fakeClock();
+  const out = await waitUntilVisible(() => 2, { deadlineMs: 5_000, intervalMs: 50, now: c.now, sleep: c.sleep });
+  check("it is seen on the FIRST sample", out.kind === "seen" && out.tries === 1, out);
+  check("...with no wait at all", c.elapsed() === 0, c.elapsed());
+  check("...and reports the count it actually saw", out.kind === "seen" && out.count === 2, out);
+  // A zero deadline must still take one reading: a wait that can report on a measurement it never
+  // took is the vacuous-green shape, and it would report `deadline` with the payload right there.
+  const c0 = fakeClock();
+  const out0 = await waitUntilVisible(() => 1, { deadlineMs: 0, intervalMs: 50, now: c0.now, sleep: c0.sleep });
+  check("...even at a zero deadline, one sample is always taken", out0.kind === "seen", out0);
+}
+
+// ---- 4. "SAW NOTHING" AND "COULD NOT LOOK" ARE DIFFERENT FACTS --------------------------------
+// A failing `ps` is not an absent process, and the repairs are unrelated. Collapsing them sends
+// whoever reads the red at 3am hunting a process that was never actually looked for.
+console.log("\n4. an instrument that cannot run says so, instead of reporting absence");
+{
+  const c = fakeClock();
+  const out = await waitUntilVisible(() => { throw new Error("ps: command not found"); },
+    { deadlineMs: 500, intervalMs: 100, now: c.now, sleep: c.sleep });
+  check("it is UNAVAILABLE, not deadline", out.kind === "unavailable", out);
+  check("...and carries the instrument's own error, which names the repair",
+    out.kind === "unavailable" && /command not found/.test(out.error), out);
+  check("...and the two reds do not read alike",
+    /could not take a single reading/.test(visibilityDetail(out))
+    && /never saw it/.test(visibilityDetail({ kind: "deadline", lastCount: 0, tries: 3, elapsedMs: 9 })));
+  // A THROW THAT RECOVERS IS NOT AN UNAVAILABLE INSTRUMENT. Forking can fail transiently on a
+  // loaded runner — the exact condition that produced this issue — so one bad reading must not
+  // condemn the run. What decides `unavailable` is that NO attempt ever produced a reading.
+  const c2 = fakeClock();
+  let n = 0;
+  const flaky = () => { if (++n <= 2) throw new Error("EAGAIN"); return 1; };
+  const rec = await waitUntilVisible(flaky, { deadlineMs: 5_000, intervalMs: 10, now: c2.now, sleep: c2.sleep });
+  check("...a transient failure that later reads successfully is SEEN, not condemned",
+    rec.kind === "seen" && rec.tries === 3, rec);
+}
+
+// ---- 5. THE SOAK ACTUALLY CALLS IT ------------------------------------------------------------
+// Cells 1-4 grade the function. NONE of them fails if the soak keeps its old inline sample and
+// this file sits unused beside it — extracting the wait creates a seam, and an unasserted seam is
+// how a fix ships without taking effect.
+//
+// This is a SOURCE assertion, which is a weaker instrument than a behavioural one, and it is used
+// here only because the behavioural version is unavailable: importing soak.ts runs the soak, and
+// the soak needs a herdr binary. It is written to fail on the thing that would actually go wrong —
+// someone reinstating a bare sample — rather than on formatting.
+console.log("\n5. the soak's control is wired to the wait (the seam, asserted)");
+{
+  const src = readFileSync(join(import.meta.dirname, "soak.ts"), "utf8");
+  const control = src.slice(src.indexOf("positive control:"));
+  check("soak.ts imports the wait", /import \{[^}]*waitUntilVisible[^}]*\} from "\.\/probe\.js"/.test(src));
+  check("...and its positive control is decided BY the wait", /waitUntilVisible\(\s*ourProcs/.test(src));
+  check("...and no longer decides that control on a bare sample",
+    !/ok\(\s*"positive control[^)]*ourProcs\(\)\s*>=/.test(src));
+  check("...and the control's evidence line is the outcome's, not a second measurement",
+    control.length > 0 && /visibilityDetail\(control\)/.test(src));
+  // The same double-measure defect the control had, on the negative direction: `ourProcs()` in a
+  // detail string is a SECOND ps sweep at a later instant, so a red can report a count that is not
+  // the count that failed — and during a race those two legitimately disagree.
+  check("...and the survivor red reports the sample that decided it, not a fresh sweep",
+    !/still running`\s*\)/.test(src) || /\$\{survivors\} still running/.test(src));
+}
+
+console.log(`\n${fail === 0 ? "PASS" : "FAIL"} — ${pass} passed, ${fail} failed\n`);
+process.exit(fail === 0 ? 0 : 1);
+
+// Keep the type import load-bearing: an outcome that loses a variant should not typecheck here.
+export type { VisibilityOutcome };

--- a/extensions/herdr/probe.smoke.ts
+++ b/extensions/herdr/probe.smoke.ts
@@ -20,7 +20,9 @@
  */
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { waitUntilVisible, visibilityDetail, type VisibilityOutcome } from "./probe.js";
+import { waitUntilVisible, visibilityDetail, soakNonce, agentTag, type VisibilityOutcome } from "./probe.js";
+import { execFileSync, spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
 
 let pass = 0, fail = 0;
 const check = (name: string, cond: boolean, extra?: unknown) => {
@@ -142,6 +144,72 @@ console.log("\n5. the soak's control is wired to the wait (the seam, asserted)")
   // the count that failed — and during a race those two legitimately disagree.
   check("...and the survivor red reports the sample that decided it, not a fresh sweep",
     !/still running`\s*\)/.test(src) || /\$\{survivors\} still running/.test(src));
+}
+
+// ================================================================================================
+// SECOND FINDING, INDEPENDENT OF THE FIRST: the nonce could match another run's payload.
+// ================================================================================================
+// Separate on purpose. Everything above is about WHEN the instrument looks; this is about WHAT it
+// can see. They are the same instrument's correctness and they fail in the same run, but either
+// could be right while the other is wrong, so they are judged apart.
+//
+// `12${process.pid % 1000}` gave 1000 values, and — sharper — variable width under an `includes`
+// match. `pid % 1000 === 1` tags `sleep 121`; `pid % 1000 === 10` tags `sleep 1210`; the first is
+// a substring of the second. Two-directional damage inside one run: a neighbour's live payload can
+// pass this run's positive control, and a neighbour's surviving payload can fail its leak check.
+
+console.log("\n6. the nonce cannot match another run's payload");
+{
+  const bits = () => randomBytes(8).readBigUInt64BE();
+  const nonces = Array.from({ length: 200 }, () => soakNonce(bits));
+  check("200 nonces are 200 distinct values",
+    new Set(nonces).size === 200, { distinct: new Set(nonces).size });
+  // The pid form is CONSTANT within a process, which is what made concurrent runs collide.
+  const pidForm = Array.from({ length: 200 }, () => `12${process.pid % 1000}`);
+  check("...whereas the pid-derived form yields exactly one value per process — the defect, named",
+    new Set(pidForm).size === 1);
+  // Fixed width is what kills the prefix case. Value-uniqueness alone would NOT: the old form had
+  // 1000 distinct values and still let `sleep 121` match `sleep 1210`.
+  const tags = nonces.map(agentTag);
+  check("...every tag is the same length, so none can be a prefix of another",
+    new Set(tags.map((t) => t.length)).size === 1, { widths: [...new Set(tags.map((t) => t.length))] });
+  check("...and no tag is a substring of any other (the `includes` match is safe)",
+    !tags.some((a, i) => tags.some((b, j) => i !== j && b.includes(a))));
+  const oldA = agentTag(`12${1}`), oldB = agentTag(`12${10}`);
+  check("...unlike the old form, where one run's tag matched another run's command line",
+    oldB.includes(oldA), { oldA, oldB });
+}
+
+// ---- 7. AND THE NONCE IS STILL A PAYLOAD THAT ACTUALLY RUNS -----------------------------------
+// A unique string that `sleep` REJECTS would be worse than the collision: the payload would exit
+// instantly and the control would fail every time. This is the lesson from building the repro for
+// this very issue — a non-numeric nonce made `sleep` exit with "invalid time interval", and the
+// resulting clean 0-seen looked exactly like the finding being hunted. So prove the subject RAN
+// rather than infer it from a count.
+console.log("\n7. the nonce is a duration `sleep` accepts, proven by running it");
+{
+  const nonce = soakNonce(() => randomBytes(8).readBigUInt64BE());
+  const child = spawn("sleep", [nonce], { stdio: "ignore", detached: true });
+  child.unref();
+  await new Promise((r) => setTimeout(r, 400));
+  const alive = execFileSync("ps", ["-eo", "args="], { encoding: "utf8" })
+    .split("\n").filter((l) => l.includes(agentTag(nonce))).length;
+  check("the payload is alive 400ms later — the nonce was accepted, not rejected as a duration",
+    alive >= 1, { alive, nonce, exited: child.exitCode });
+  check("...and the FULL nonce survives onto argv, which is what the instrument matches",
+    alive >= 1);
+  try { process.kill(-child.pid!, "SIGKILL"); } catch { /* already gone */ }
+  try { execFileSync("pkill", ["-f", agentTag(nonce)]); } catch { /* nothing left */ }
+}
+
+// ---- 8. THE SOAK USES IT (the second seam) ----------------------------------------------------
+console.log("\n8. the soak's nonce comes from the shared definition, not a local pid expression");
+{
+  const src = readFileSync(join(import.meta.dirname, "soak.ts"), "utf8");
+  check("soak.ts builds its nonce with soakNonce()", /SOAK_NONCE\s*=\s*soakNonce\(/.test(src));
+  check("...and its tag with agentTag()", /AGENT_TAG\s*=\s*agentTag\(/.test(src));
+  check("...and no longer derives either from process.pid",
+    !/process\.pid\s*%/.test(src));
 }
 
 console.log(`\n${fail === 0 ? "PASS" : "FAIL"} — ${pass} passed, ${fail} failed\n`);

--- a/extensions/herdr/probe.ts
+++ b/extensions/herdr/probe.ts
@@ -25,6 +25,9 @@
  * The event is "the payload becomes visible to the instrument", which is the very property the
  * control asserts, and the deadline is the failure — never a warning, never a quiet pass.
  *
+ * This module also owns the nonce the instrument matches on, because the nonce IS the selector:
+ * how much of the machine `ourProcs()` can see is decided entirely by what that string is.
+ *
  * The probe is injected so this is testable without a race: `probe.smoke.ts` drives it with
  * synthetic probes and a fake clock, so every branch is graded deterministically. A race cannot be
  * killed deterministically through the live path; through an injected probe it can.
@@ -107,4 +110,37 @@ export function visibilityDetail(o: VisibilityOutcome): string {
     case "unavailable":
       return `the instrument could not take a single reading in ${o.tries} attempts over ${o.elapsedMs}ms — this says nothing about whether the process exists: ${o.error}`;
   }
+}
+
+
+/**
+ * The payload nonce, and the tag the survivor instrument matches.
+ *
+ * The payload is `sleep <nonce>`, so the nonce has to be a string `sleep` accepts as a duration AND
+ * a string no other run can produce. The previous form was `12${process.pid % 1000}`, which fails
+ * the second requirement in two ways — and the second is much likelier than the first:
+ *
+ *   • BIRTHDAY: only 1000 distinct values, so two concurrent soaks on one host can share a nonce.
+ *   • PREFIX, and this is the sharp one: the tag is matched with `includes`, and the values are
+ *     variable-width. `pid % 1000 === 1` yields the tag `sleep 121`, `pid % 1000 === 10` yields
+ *     `sleep 1210` — and "sleep 1210".includes("sleep 121") is TRUE. One soak counts another's
+ *     payloads without any value collision at all.
+ *
+ * Either way the damage is two-directional and lands inside the same run: a neighbour's live
+ * payload makes the positive control pass when this run's own instrument might not have worked,
+ * and a neighbour's payload still running at the end makes "no agent processes survive" fail when
+ * nothing leaked. A green that was bought by another process, and a red that belongs to one.
+ *
+ * Fixed-width and high-entropy fixes both: 64 bits in a zero-padded fractional part. The width is
+ * constant, so no tag can ever be a prefix of another. `sleep` parses the value as a double and
+ * ignores precision it cannot represent, but the ARGV string keeps every digit — and argv is what
+ * `ps` reports and what the instrument matches, which is the only thing that has to be unique.
+ */
+export function soakNonce(randomBits: () => bigint): string {
+  return `12000.${randomBits().toString().padStart(20, "0")}`;
+}
+
+/** What `ourProcs()` greps for. One definition, so the payload and the matcher cannot drift. */
+export function agentTag(nonce: string): string {
+  return `sleep ${nonce}`;
 }

--- a/extensions/herdr/probe.ts
+++ b/extensions/herdr/probe.ts
@@ -1,0 +1,110 @@
+/**
+ * Waiting for a spawned process to become VISIBLE to a `ps`-style instrument.
+ *
+ * WHY THIS EXISTS. The soak's positive control proves the survivor instrument can see a live
+ * agent — and it is the reason the eleven leak assertions after it mean anything. If it can pass
+ * or fail by timing, then "no agent processes survive" is green with exactly the probability that
+ * the instrument happened to look at the right moment.
+ *
+ * It sampled once, immediately after `runtime.spawn` returned with status `running`. At that
+ * moment the pane is running the LAUNCHER, which has not yet spawned the payload, and the nonce
+ * appears on the payload's command line only — never on the launcher's, by design (the args and
+ * env ride an owner-only script precisely so they stay off every command line).
+ *
+ * Measured against the real `privateLauncher`, driving its exact argv and sampling at the instant
+ * spawn returns: the payload was visible 0 times out of 6, and became visible 70-155ms later,
+ * every time. So the control had no correctness margin of its own at all. What kept it green was
+ * the latency of `herdr agent start` — the server round trip and pane creation usually take longer
+ * than the launcher needs, so the payload is usually already there by the time the cell looks.
+ * That margin belongs to an unrelated subsystem, nobody chose it, nothing documents it, and
+ * nothing fails when it shrinks. Under load it shrinks, and the cell reddens.
+ *
+ * That is why the fix is not a longer wait. A longer wait keeps the shape — sample and hope — and
+ * merely buys a bigger borrowed margin. The control has to become a statement about whether the
+ * instrument CAN see, not about when it happened to look. So: name the event, and wait on it.
+ * The event is "the payload becomes visible to the instrument", which is the very property the
+ * control asserts, and the deadline is the failure — never a warning, never a quiet pass.
+ *
+ * The probe is injected so this is testable without a race: `probe.smoke.ts` drives it with
+ * synthetic probes and a fake clock, so every branch is graded deterministically. A race cannot be
+ * killed deterministically through the live path; through an injected probe it can.
+ */
+
+/** What the wait concluded. The three cases are deliberately distinct: whoever reads a red at 3am
+ *  needs to know whether the instrument looked and saw nothing, or could not look at all. */
+export type VisibilityOutcome =
+  /** The instrument saw the process. `count` is the sample that decided it. */
+  | { kind: "seen"; count: number; tries: number; elapsedMs: number }
+  /** The instrument RAN and never saw it inside the deadline. A statement about the world. */
+  | { kind: "deadline"; lastCount: number; tries: number; elapsedMs: number }
+  /** The instrument never produced a single reading — every attempt threw. A statement about the
+   *  INSTRUMENT, and a different repair: `ps` missing, not permitted, or unable to fork. Reporting
+   *  this as "saw nothing" would send the reader hunting a process that was never looked for. */
+  | { kind: "unavailable"; tries: number; elapsedMs: number; error: string };
+
+export interface WaitOpts {
+  /** Hard bound. Reaching it is a FAILURE outcome, never a tolerated pass. */
+  deadlineMs: number;
+  intervalMs: number;
+  /** Injected for deterministic tests; defaults to the real clock. */
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Poll `probe` until it reports at least one match, or the deadline passes.
+ *
+ * `probe` is expected to THROW when it cannot take a reading at all (an `execFileSync` that fails
+ * to run), and to return a count when it can. Those two are not the same event and are not
+ * reported as the same outcome.
+ *
+ * A throwing probe is retried rather than fatal, because a fork failure on a loaded runner is
+ * transient and a missing binary is not — retrying costs one deadline in the second case and saves
+ * a spurious red in the first. What decides `unavailable` is whether ANY attempt ever produced a
+ * reading, not whether the last one did.
+ *
+ * At least one sample always happens, even at `deadlineMs: 0`, so this can never report on a
+ * measurement it did not take.
+ */
+export async function waitUntilVisible(probe: () => number, opts: WaitOpts): Promise<VisibilityOutcome> {
+  const now = opts.now ?? (() => Date.now());
+  const sleep = opts.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+  const started = now();
+  let tries = 0;
+  let sampled = false;
+  let lastCount = -1;
+  let lastError = "";
+
+  for (;;) {
+    tries++;
+    try {
+      const count = probe();
+      sampled = true;
+      lastCount = count;
+      if (count >= 1) return { kind: "seen", count, tries, elapsedMs: now() - started };
+    } catch (e) {
+      lastError = e instanceof Error ? e.message : String(e);
+    }
+    // Checked AFTER the sample, so the first reading is always taken.
+    if (now() - started >= opts.deadlineMs) break;
+    await sleep(opts.intervalMs);
+  }
+
+  const elapsedMs = now() - started;
+  return sampled
+    ? { kind: "deadline", lastCount, tries, elapsedMs }
+    : { kind: "unavailable", tries, elapsedMs, error: lastError };
+}
+
+/** The evidence line for an outcome. Shared with the caller so a red says which of the three
+ *  things happened, in the same words the type distinguishes. */
+export function visibilityDetail(o: VisibilityOutcome): string {
+  switch (o.kind) {
+    case "seen":
+      return `${o.count} seen after ${o.elapsedMs}ms (${o.tries} ${o.tries === 1 ? "sample" : "samples"})`;
+    case "deadline":
+      return `the instrument ran ${o.tries} times over ${o.elapsedMs}ms and never saw it (last count ${o.lastCount}) — nothing was there to see, or it never became visible`;
+    case "unavailable":
+      return `the instrument could not take a single reading in ${o.tries} attempts over ${o.elapsedMs}ms — this says nothing about whether the process exists: ${o.error}`;
+  }
+}

--- a/extensions/herdr/soak.ts
+++ b/extensions/herdr/soak.ts
@@ -12,7 +12,8 @@
  */
 import * as herdr from "./src/driver.js";
 import { HerdrRuntime } from "./src/runtime.js";
-import { waitUntilVisible, visibilityDetail } from "./probe.js";
+import { waitUntilVisible, visibilityDetail, soakNonce, agentTag } from "./probe.js";
+import { randomBytes } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import { readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -27,9 +28,10 @@ const CYCLES = Number(process.env.COTAL_HERDR_SOAK_CYCLES ?? 25);
  *  all — the real processes are `sleep 120` and the launcher `node …/cotal-herdr-launch-X/launch.mjs`. So the
  *  survivor count was structurally incapable of ever being nonzero: a guaranteed-green check that
  *  measured nothing. The nonce keeps the count scoped to THIS run, so a neighbouring lane's agents
- *  on a shared machine still cannot be charged to it. */
-const SOAK_NONCE = `12${process.pid % 1000}`;
-const AGENT_TAG = `sleep ${SOAK_NONCE}`;
+ *  on a shared machine still cannot be charged to it — see `soakNonce` for why it must be
+ *  fixed-width and high-entropy to actually deliver that, which the pid-derived form did not. */
+const SOAK_NONCE = soakNonce(() => randomBytes(8).readBigUInt64BE());
+const AGENT_TAG = agentTag(SOAK_NONCE);
 
 let passed = 0;
 let failed = 0;

--- a/extensions/herdr/soak.ts
+++ b/extensions/herdr/soak.ts
@@ -12,6 +12,7 @@
  */
 import * as herdr from "./src/driver.js";
 import { HerdrRuntime } from "./src/runtime.js";
+import { waitUntilVisible, visibilityDetail } from "./probe.js";
 import { execFileSync } from "node:child_process";
 import { readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -117,6 +118,9 @@ console.log(`  baseline: panes=${base.panes} workspaces=${base.workspaces} tabs=
 
 const started = Date.now();
 let slowestCycleMs = 0;
+/** Time spent inside cycle 1's positive control, subtracted from that cycle so the per-cycle
+ *  slowdown assertion measures the runtime rather than this suite's own instrument. */
+let controlMs = 0;
 for (let i = 1; i <= CYCLES; i++) {
   const cycleStart = Date.now();
   const name = `cotal-herdr-soak-agent-${i}`;
@@ -128,10 +132,24 @@ for (let i = 1; i <= CYCLES; i++) {
   // Positive control, once: prove the survivor instrument can SEE a live agent before the run
   // ends by trusting it to report none. Without this, an instrument that matches nothing reports
   // a clean "no agent processes survive" forever — which is exactly what the previous one did.
-  if (i === 1) ok("positive control: the survivor instrument can see a LIVE agent", ourProcs() >= 1, `${ourProcs()} seen`);
+  //
+  // WAITS for the payload to become visible rather than sampling once. `spawn` returning means the
+  // pane is running the LAUNCHER; the payload it spawns is what carries the nonce, and it appears
+  // 70-155ms later (measured against the real launcher). A single sample here was green only
+  // because `herdr agent start` is usually slower than that — a margin owned by another subsystem,
+  // which disappears under load. See probe.ts for why a longer sleep would keep the defect.
+  if (i === 1) {
+    const controlStart = Date.now();
+    const control = await waitUntilVisible(ourProcs, { deadlineMs: 5_000, intervalMs: 50 });
+    ok("positive control: the survivor instrument can see a LIVE agent", control.kind === "seen", visibilityDetail(control));
+    // Not charged to the cycle: the slowdown assertion below compares cycle times, and a control
+    // that waited would show up there as a per-cycle regression it is not.
+    controlMs = Date.now() - controlStart;
+  }
   handle.stop({ graceful: false });
   await handle.waitForExit!();
-  const cycleMs = Date.now() - cycleStart;
+  const cycleMs = Date.now() - cycleStart - controlMs;
+  controlMs = 0;
   slowestCycleMs = Math.max(slowestCycleMs, cycleMs);
   if (i % 5 === 0 || i === CYCLES)
     console.log(`  cycle ${i}/${CYCLES}  panes=${panes()} workspaces=${workspaces()} launcherDirs=${launcherDirs()}  (${cycleMs}ms)`);
@@ -149,11 +167,16 @@ ok("no server scratch dirs accumulated", srvDirs() === base.srv, `${srvDirs()} v
 // Sampled over a bounded window, not once: the kills are asynchronous, so an instant read can
 // catch a process that has been signalled but not yet reaped.
 let noSurvivors = false;
+let survivors = -1;
 for (let i = 0; i < 40 && !noSurvivors; i++) {
-  noSurvivors = ourProcs() === 0;
+  survivors = ourProcs();
+  noSurvivors = survivors === 0;
   if (!noSurvivors) await new Promise((r) => setTimeout(r, 50));
 }
-ok("no agent processes survive", noSurvivors, `${ourProcs()} still running`);
+// Bind the deciding sample: `ourProcs()` in the detail would be a SECOND ps sweep at a later
+// instant, so a red could report a count that is not the count that failed — and during a race
+// those two legitimately disagree, sending the reader after a contradiction that does not exist.
+ok("no agent processes survive", noSurvivors, `${survivors} still running`);
 ok("the session server is still healthy after the churn", herdr.serverRunning(SESSION));
 // A per-cycle leak usually shows up as monotonically rising latency long before it shows up as a
 // count, so the slowest cycle is asserted against a generous multiple of the mean.

--- a/package.json
+++ b/package.json
@@ -310,6 +310,7 @@
     "smoke:ps-user-mode": "tsx implementations/auth/smoke/ps-user-mode.smoke.ts",
     "smoke:persona-input-closed": "tsx implementations/manager/smoke/persona-input-closed.smoke.ts",
     "smoke:herdr:soak": "tsx extensions/herdr/soak.ts",
+    "smoke:herdr:probe": "tsx extensions/herdr/probe.smoke.ts",
     "smoke:herdr-e2e:live": "tsx bin/smoke/herdr-e2e-live.smoke.ts",
     "smoke:probe-teardown": "tsx packages/core/smoke/probe-teardown.smoke.ts",
     "smoke:persona-announce": "pnpm --filter cotal-ai... build && tsx bin/smoke/persona-announce.smoke.ts",


### PR DESCRIPTION
Fixes #459.

The soak's positive control is the cell the other eleven depend on: it proves the survivor instrument can see a live agent, so that "no agent processes survive" means something. It sampled `ps` once, immediately after `runtime.spawn` returned `running`.

## What the measurement showed

At that moment the pane is running the **launcher**, which has not yet spawned the payload — and the nonce is on the payload's command line only, by design, since the args and env ride an owner-only script precisely to keep them off every command line.

Driving the real `privateLauncher` with its exact argv and sampling at the instant spawn returns:

```
payload visible AT SPAWN-RETURN: 0/6      <- what the control samples
became visible later:            6/6
visibility delay ms:             min 70, max 155   [84, 134, 70, 155, 116, 142]
```

Which forces the question the issue does not ask: **why does CI usually pass?** Because the cell samples after `herdr agent start` returns, and that round trip is itself slow enough to usually cover the launcher's 70–155 ms. The green is bought by the latency of the very call the test is trying not to depend on. That margin belongs to an unrelated subsystem, nobody chose it, nothing documents it, and nothing fails when it shrinks. Under load it shrinks.

So this is not an ordinary race, and that is why the obvious repair is wrong: **a longer wait keeps the shape and merely buys a bigger borrowed margin.** The control has to become a statement about whether the instrument *can* see, not about when it happened to look.

**Scope of that measurement, stated plainly:** mechanism reproduced with the real launcher; the pane is not exercised; `herdr` was not available locally. Omitting the pane is exactly what makes the repro read 0/6 rather than intermittent — removing the accidental cover is what exposes the defect. These numbers establish the **cause** and say nothing about the **rate**.

## The fix

`waitUntilVisible(probe, {deadlineMs, intervalMs})` waits on the named event — the payload becoming visible to the instrument, which is the very property the control asserts. The deadline is a failure outcome, never a warning and never a quiet pass.

Reaching the deadline and being unable to sample at all are reported as **different outcomes**. A `ps` that cannot run says nothing about whether the process exists, and reporting it as "saw nothing" sends whoever reads the red hunting a process that was never looked for. A throw that later reads successfully is tolerated, since transient fork failure under load is the very condition that produced this.

Also: `ourProcs()` appeared twice on one line — once to decide, once to report — so a red could print a count from a later sweep than the one that failed, and during a race those two legitimately disagree. Both failure messages now bind the deciding sample. Same defect at reporting scale.

## Second finding, independent: the nonce could match another run's payload

Separated into its own cells so it can be judged apart. `12${process.pid % 1000}` scoped the count to this run only by accident, and fails two ways — the second far likelier than the first:

- **Birthday:** 1000 distinct values, so two concurrent soaks on one host can share one.
- **Prefix:** the tag is matched with `includes` and the values are variable-width. `pid % 1000 === 1` tags `sleep 121`; `pid % 1000 === 10` tags `sleep 1210`; and `"sleep 1210".includes("sleep 121")` is true. One soak counts another's payloads with **no value collision at all**.

The damage is two-directional inside a single run: a neighbour's live payload passes this run's positive control, and a neighbour's surviving payload fails its leak check. A green bought by another process, and a red that belongs to one.

Fixed-width with 64 bits of entropy in a zero-padded fractional part. Value-uniqueness alone would not have sufficed — the old form already had 1000 distinct values and still let one tag match another's command line.

A unique string that `sleep` *rejects* would be strictly worse than the collision, so that is proven by running it rather than assumed: cell 7 spawns the payload, confirms it is alive, and confirms the full nonce reached argv.

## Does this make past greens trustworthy?

**No.** The fix makes future greens meaningful; it does not make past greens trustworthy. Every soak green behind a run where the control could flake is exactly as weak as it always was.

## Evidence

New suite `pnpm smoke:herdr:probe` — 31 cells, deterministic (injected probe, fake clock), 5/5 consecutive clean runs. A race has no deterministic red through the live path; through an injected probe it does.

Cells 5 and 8 assert the **seam**: cells 1–4 and 6–7 grade the extracted functions, and none of them would fail if the soak kept its old inline sample and the new code sat unused beside it.

| mutation | reddened assertion | marks (baseline 31) |
| --- | --- | --- |
| wait reverts to a single sample | `it is SEEN, not missed` | 16 / 21¹ |
| collapse `unavailable` into `deadline` | `it is UNAVAILABLE, not deadline` | 18 / 21¹ |
| reinstate the bare sample at the call site | `no longer decides that control on a bare sample` | 19 / 21¹ |
| revert to the pid-derived nonce | `200 nonces are 200 distinct values` | 29 |
| drop the fixed width only | `every tag is the same length` | 30 |

¹ run against the 21-cell baseline, before the nonce cells were added.

Kill sets were predicted by name and count before running. Four of five matched exactly. The third predicted 20 marks and produced 19 — **more kills than predicted, not fewer**, since a mark is a *surviving* assertion and an extra red subtracts one. Re-enumerated against the current tree rather than reasoned about: `29 passed, 2 failed`, both reds in cell 5. The prediction missed one because I counted the seam assertions naming `waitUntilVisible` and not the one naming `visibilityDetail`; both key on the statement the mutation replaces, so both correctly notice the seam was cut.

Two rules came out of that, and the second is the one that bit: a mutation report has two independent halves, the count and the account, and when they disagree the finding is that you do not yet know what happened. And **a count quoted without its baseline is not a fact about anything** — the same mutation reads 19/21 and 29/31 across this PR's history, one result wearing two numbers because the nonce cells landed in between. Every count above is quoted `n / baseline`.

`extensions/herdr/probe.ts` is a sibling of `soak.ts`, not under `src/`, and the package ships `dist` only — verified it does not reach the published artifact.

**Gating.** `pnpm smoke:herdr:probe` runs in the live job immediately before `pnpm smoke:herdr:soak`. It was ungated when first pushed and `smoke:gate-inventory` refused the branch for it — correctly: a suite nothing runs is not partial coverage, it is zero coverage with a maintenance cost. Where a suite is gated is an argument, not a detail: this one grades the soak's positive control and its nonce, so if either is wrong the soak greens regardless, and a deterministic sub-second suite belongs in front of the expensive one it can invalidate. It is deliberately not in `smoke:ci` — that chain is the protocol/security gate and it also shards onto Windows, where the cell proving the nonce is a duration `sleep` accepts must really run `sleep`, `ps` and `pkill`. A `win32` skip has precedent here and would have passed; siting a suite where its dependencies are real beats a skip that reads green. That fix (`744956c7`) is **7 lines of YAML and no source change**, so every mutation result and baseline above stands exactly as reported — there is nothing here to re-run.

