### PR TITLE
test(smoke): make the ambient-broker suites name the broker they resolved

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,12 @@ jobs:
         run: pnpm smoke:view
       - name: Verify Claude connector package
         run: pnpm --filter @cotal-ai/connector-claude-code pack --dry-run
+      # Grades the convention, not one suite: every file that defaults COTAL_SERVERS with `||=`
+      # must also print what it resolved. Pure — reads sources, spawns nothing, dials nothing.
+      # Placed here rather than in the smoke:ci chain so the chain migration lands without a
+      # rebase; `gate-inventory` counts a suite named in a workflow as reached.
+      - name: Broker disclosure
+        run: pnpm smoke:broker-disclosure
 
   smoke:
     name: smoke (shard ${{ matrix.shard }}/4)

--- a/bin/smoke/broker-disclosure.smoke.ts
+++ b/bin/smoke/broker-disclosure.smoke.ts
@@ -60,19 +60,54 @@ check(
   { defaulters },
 );
 
-// 2 — the disclosure itself, per file.
-for (const f of defaulters) {
-  const text = readFileSync(join(repoRoot, f), "utf8");
-  check(`${f} prints the broker it resolved`, PRINTS.test(text));
-  // The inherited/defaulted distinction is the forensically useful half, and it is only knowable
-  // BEFORE the `||=` runs. Capturing it afterwards reads the value the suite just wrote.
+/** What the guard asks of one file. Extracted so it can be aimed at a fixture as well as at the
+ *  repo: with every real file compliant, dropping a requirement here changes no real verdict, and
+ *  a check nothing exercises is a check nobody can prove. */
+function evaluate(text: string): { prints: boolean; ordered: boolean } {
   const capture = text.search(CAPTURES);
   const assign = text.search(DEFAULTS);
+  // The inherited/defaulted distinction is the forensically useful half, and it is only knowable
+  // BEFORE the `||=` runs — afterwards the variable is set either way, so a capture below the
+  // assignment reads the value the suite just wrote and reports every run as inherited.
+  return { prints: PRINTS.test(text), ordered: capture !== -1 && capture < assign };
+}
+
+// 2 — the census spans more than one top-level directory. Every cell below is generated per
+// discovered file, so a census that narrows does not FAIL cells, it stops emitting them — and a
+// suite with fewer cells still exits 0. The pattern living outside `extensions/` is the whole
+// reason the first count of these files was wrong, so a census that cannot see outside one
+// directory is the failure this cell is here to catch, not an incidental property.
+{
+  const tops = new Set(defaulters.map((f) => f.split("/")[0]));
   check(
-    `${f} records whether the value was inherited, before \`||=\` overwrites the evidence`,
-    capture !== -1 && capture < assign,
-    { captureAt: capture, assignAt: assign },
+    "the census spans more than one top-level directory, so it is keyed on content and not on location",
+    tops.size > 1,
+    { tops: [...tops] },
   );
+}
+
+// 3 — the checker rejects a file that discloses in the wrong ORDER. Aimed at a fixture rather than
+// at the repo, because every real file is compliant: without a negative control, removing the
+// ordering requirement would pass and the requirement would be unprovable.
+{
+  const GOOD = 'const brokerFromEnv = process.env.COTAL_SERVERS !== undefined;\n'
+    + 'process.env.COTAL_SERVERS ||= "nats://127.0.0.1:4222";\n'
+    + 'console.log(`• broker: ${process.env.COTAL_SERVERS} (${brokerFromEnv ? "INHERITED" : "default"})`);\n';
+  const SWAPPED = 'process.env.COTAL_SERVERS ||= "nats://127.0.0.1:4222";\n'
+    + 'const brokerFromEnv = process.env.COTAL_SERVERS !== undefined;\n'
+    + 'console.log(`• broker: ${process.env.COTAL_SERVERS} (${brokerFromEnv ? "INHERITED" : "default"})`);\n';
+  const MUTE = 'const brokerFromEnv = process.env.COTAL_SERVERS !== undefined;\n'
+    + 'process.env.COTAL_SERVERS ||= "nats://127.0.0.1:4222";\nvoid brokerFromEnv;\n';
+  check("fixture: a compliant file passes both requirements", evaluate(GOOD).prints && evaluate(GOOD).ordered);
+  check("fixture: a file that captures AFTER the `||=` is rejected on order", !evaluate(SWAPPED).ordered);
+  check("fixture: a file that never prints the broker is rejected on disclosure", !evaluate(MUTE).prints);
+}
+
+// 4 — the disclosure itself, per real file.
+for (const f of defaulters) {
+  const { prints, ordered } = evaluate(readFileSync(join(repoRoot, f), "utf8"));
+  check(`${f} prints the broker it resolved`, prints);
+  check(`${f} records whether the value was inherited, before \`||=\` overwrites the evidence`, ordered);
 }
 
 console.log(`\nBROKER-DISCLOSURE SMOKE ${fail === 0 ? "OK ✅" : "FAILED ❌"}  (${pass} passed, ${fail} failed)`);

--- a/bin/smoke/broker-disclosure.smoke.ts
+++ b/bin/smoke/broker-disclosure.smoke.ts
@@ -31,9 +31,29 @@ function* sources(dir: string): Generator<string> {
   }
 }
 
-const DEFAULTS = /process\.env\.COTAL_SERVERS\s*\|\|=/;
-const CAPTURES = /process\.env\.COTAL_SERVERS\s*!==\s*undefined/;
-const PRINTS = /console\.log\([^\n]*broker:[^\n]*process\.env\.COTAL_SERVERS/;
+/** The variable, written either way people write it. Dot access is what the tree uses today and a
+ *  bracket read is the same assignment, so a census that knew only the first would MISS a file
+ *  silently: it would never enter the census, and every per-file cell is generated from the census.
+ *  `??=` is admitted for the same reason. A shape this does not know fails the safe direction only
+ *  if it is still SEEN, and the shapes it cannot see are the ones worth widening for. */
+const VAR = String.raw`process\.env(?:\.COTAL_SERVERS|\[["']COTAL_SERVERS["']\])`;
+const DEFAULTS = new RegExp(String.raw`${VAR}\s*(?:\|\||\?\?)=`);
+const CAPTURES = new RegExp(String.raw`${VAR}\s*!==?\s*(?:undefined|null)`);
+/**
+ * The disclosure line, and it requires the INTERPOLATION rather than the name.
+ *
+ * The earlier pattern asked only that the name appear on the line, and a guard that asserts a NAME
+ * where the behaviour depends on a VALUE is one character from present-and-inert. Deleting the `$`
+ * from `${process.env.COTAL_SERVERS}` left every cell green and printed the literal text
+ * `{process.env.COTAL_SERVERS}` at runtime, which is the disclosure saying nothing at all. So did a
+ * line that hardcoded the address and mentioned the variable in a trailing comment. Both are
+ * reproduced as fixtures below rather than argued about here.
+ *
+ * SINGLE LINE, on purpose and stated so it is a rule rather than an accident: a disclosure wrapped
+ * across lines by a formatter will not match and its file will go RED. That is the loud direction,
+ * and the fix is to keep the line whole.
+ */
+const PRINTS = new RegExp(String.raw`console\.log\([^\n]*broker:[^\n]*\$\{\s*${VAR}\s*\}`);
 
 let pass = 0;
 let fail = 0;
@@ -42,10 +62,22 @@ const check = (name: string, ok: boolean, extra?: unknown): void => {
   else { fail++; console.log(`  ✗ FAIL: ${name}`, extra !== undefined ? JSON.stringify(extra) : ""); }
 };
 
+// THIS FILE, and only this file, is left out of its own census. A census keyed on TEXT cannot tell
+// a call site from a fixture, and the one file guaranteed to contain fixtures is the one that
+// carries them. Without this it reported eight files defaulting the variable when seven do, and
+// graded its own negative controls as if they were real suites. The exclusion is computed from
+// `import.meta.url` rather than written as a path, so it can only ever name this file: a carve-out
+// that could grow is the shape that later hides something, and this one cannot grow.
+const self = relative(repoRoot, fileURLToPath(import.meta.url));
+
 const defaulters: string[] = [];
+let excluded = 0;
 for (const file of sources(repoRoot)) {
   const text = readFileSync(file, "utf8");
-  if (DEFAULTS.test(text)) defaulters.push(relative(repoRoot, file));
+  if (!DEFAULTS.test(text)) continue;
+  const rel = relative(repoRoot, file);
+  if (rel === self) { excluded += 1; continue; }
+  defaulters.push(rel);
 }
 defaulters.sort();
 
@@ -58,6 +90,15 @@ check(
   "at least one file defaults COTAL_SERVERS, so this guard is grading a non-empty set",
   defaulters.length > 0,
   { defaulters },
+);
+
+// 1b — and the exclusion is exactly this file, still matching. If the fixtures below ever stop
+// carrying the pattern the exclusion has quietly become dead, which is the same shape as an
+// allowlist entry nobody notices has stopped matching anything.
+check(
+  "exactly one file is excluded from the census, and it is this file's own fixtures",
+  excluded === 1,
+  { excluded, self },
 );
 
 /** What the guard asks of one file. Extracted so it can be aimed at a fixture as well as at the
@@ -98,9 +139,31 @@ function evaluate(text: string): { prints: boolean; ordered: boolean } {
     + 'console.log(`• broker: ${process.env.COTAL_SERVERS} (${brokerFromEnv ? "INHERITED" : "default"})`);\n';
   const MUTE = 'const brokerFromEnv = process.env.COTAL_SERVERS !== undefined;\n'
     + 'process.env.COTAL_SERVERS ||= "nats://127.0.0.1:4222";\nvoid brokerFromEnv;\n';
+  // The NAME is present in all three of these and the VALUE is not, which is the whole family. A
+  // guard that asks only whether `process.env.COTAL_SERVERS` appears on the line is one character
+  // from present-and-inert, and the first of these is that one character: `${…}` with the `$`
+  // deleted prints the literal text `{process.env.COTAL_SERVERS}` and every cell stays green.
+  const DOLLARLESS = 'const brokerFromEnv = process.env.COTAL_SERVERS !== undefined;\n'
+    + 'process.env.COTAL_SERVERS ||= "nats://127.0.0.1:4222";\n'
+    + 'console.log(`• broker: {process.env.COTAL_SERVERS} (${brokerFromEnv ? "INHERITED" : "default"})`);\n';
+  const HARDCODED = 'const brokerFromEnv = process.env.COTAL_SERVERS !== undefined;\n'
+    + 'process.env.COTAL_SERVERS ||= "nats://127.0.0.1:4222";\n'
+    + 'console.log(`• broker: nats://127.0.0.1:4222`); // was process.env.COTAL_SERVERS\n'
+    + 'void brokerFromEnv;\n';
+  // The census direction. A file this cannot SEE is not rejected, it is absent, and every per-file
+  // cell is generated from the census -- so a shape it does not know costs cells rather than reds.
+  const BRACKET = 'const brokerFromEnv = process.env["COTAL_SERVERS"] !== undefined;\n'
+    + 'process.env["COTAL_SERVERS"] ??= "nats://127.0.0.1:4222";\n'
+    + 'console.log(`• broker: ${process.env["COTAL_SERVERS"]} (${brokerFromEnv ? "INHERITED" : "default"})`);\n';
   check("fixture: a compliant file passes both requirements", evaluate(GOOD).prints && evaluate(GOOD).ordered);
   check("fixture: a file that captures AFTER the `||=` is rejected on order", !evaluate(SWAPPED).ordered);
   check("fixture: a file that never prints the broker is rejected on disclosure", !evaluate(MUTE).prints);
+  check("fixture: a line carrying the NAME without the interpolation is rejected: `${` is the value",
+    !evaluate(DOLLARLESS).prints);
+  check("fixture: a hardcoded address with the variable in a trailing comment is rejected",
+    !evaluate(HARDCODED).prints);
+  check("fixture: the same assignment under bracket access is SEEN, so it can be judged at all",
+    DEFAULTS.test(BRACKET) && evaluate(BRACKET).prints && evaluate(BRACKET).ordered);
 }
 
 // 4 — the disclosure itself, per real file.

--- a/bin/smoke/broker-disclosure.smoke.ts
+++ b/bin/smoke/broker-disclosure.smoke.ts
@@ -60,6 +60,14 @@ const CAPTURES = new RegExp(String.raw`${VAR}\s*!==?\s*(?:undefined|null)`);
  * plausible careless edit in this family, because it is what somebody leaves behind after pinning
  * an address to debug something.
  *
+ * AND THE STRING MUST BE A TEMPLATE, which is the same requirement one level down. `${…}` inside a
+ * quoted string is not an interpolation, it is six characters of text: a line reading
+ * `console.log("• broker: ${process.env.COTAL_SERVERS}")` prints that literally on every run with
+ * the real address sitting in the environment, unread. Ran both forms with the variable set to
+ * confirm it rather than reasoning about it. This is the plausible careless edit, not sabotage:
+ * somebody converts ticks to quotes, or rewrites toward concatenation and leaves a `${}` behind
+ * inside the quotes. So the pattern requires the opening backtick.
+ *
  * WHAT READING SOURCE CANNOT DO, named rather than implied, because a boundary nobody wrote down
  * gets mistaken for coverage. This checks that the line is SHAPED like a disclosure. It cannot
  * follow evaluation, so a line that builds the value and then discards it stays accepted: a
@@ -69,7 +77,7 @@ const CAPTURES = new RegExp(String.raw`${VAR}\s*!==?\s*(?:undefined|null)`);
  * repository source inside a guard, which buys less than it costs. Measured and left open, not
  * overlooked.
  */
-const PRINTS = new RegExp(String.raw`console\.log\([^\n]*broker:\s*\$\{\s*${VAR}\s*\}`);
+const PRINTS = new RegExp(String.raw`console\.log\(\`[^\n\`]*broker:\s*\$\{\s*${VAR}\s*\}`);
 
 let pass = 0;
 let fail = 0;
@@ -178,6 +186,13 @@ function evaluate(text: string): { prints: boolean; ordered: boolean } {
     + 'process.env.COTAL_SERVERS ||= "nats://127.0.0.1:4222";\n'
     + 'console.log(`• broker: nats://127.0.0.1:4222`); // ${process.env.COTAL_SERVERS}\n'
     + 'void brokerFromEnv;\n';
+  // Same family, one level down: the interpolation is exactly where it belongs and the string is
+  // QUOTED, so JS never interpolates it and the line prints `${process.env.COTAL_SERVERS}` as text.
+  // Ran it with the variable set before writing this. Careless rather than sabotage: it is what a
+  // tick-to-quote conversion leaves behind.
+  const QUOTED = 'const brokerFromEnv = process.env.COTAL_SERVERS !== undefined;\n'
+    + 'process.env.COTAL_SERVERS ||= "nats://127.0.0.1:4222";\n'
+    + 'console.log("• broker: ${process.env.COTAL_SERVERS} (x)");\nvoid brokerFromEnv;\n';
   // The census direction. A file this cannot SEE is not rejected, it is absent, and every per-file
   // cell is generated from the census -- so a shape it does not know costs cells rather than reds.
   const BRACKET = 'const brokerFromEnv = process.env["COTAL_SERVERS"] !== undefined;\n'
@@ -192,6 +207,8 @@ function evaluate(text: string): { prints: boolean; ordered: boolean } {
     !evaluate(HARDCODED).prints);
   check("fixture: the INTERPOLATION parked in a trailing comment is rejected too",
     !evaluate(COMMENTED_INTERP).prints);
+  check("fixture: the interpolation inside a QUOTED string is rejected: it prints as text, not a value",
+    !evaluate(QUOTED).prints);
   check("fixture: the same assignment under bracket access is SEEN, so it can be judged at all",
     DEFAULTS.test(BRACKET) && evaluate(BRACKET).prints && evaluate(BRACKET).ordered);
 }

--- a/bin/smoke/broker-disclosure.smoke.ts
+++ b/bin/smoke/broker-disclosure.smoke.ts
@@ -52,8 +52,24 @@ const CAPTURES = new RegExp(String.raw`${VAR}\s*!==?\s*(?:undefined|null)`);
  * SINGLE LINE, on purpose and stated so it is a rule rather than an accident: a disclosure wrapped
  * across lines by a formatter will not match and its file will go RED. That is the loud direction,
  * and the fix is to keep the line whole.
+ *
+ * THE INTERPOLATION MUST BE WHAT FOLLOWS `broker:`, not merely something later on the line. Review
+ * found the next member of the family once the first was closed: park the interpolation in a
+ * TRAILING COMMENT, hardcode the address in the template, and a pattern that accepted `${…}`
+ * anywhere after `broker:` was satisfied by a line that printed a literal every run. That is the
+ * plausible careless edit in this family, because it is what somebody leaves behind after pinning
+ * an address to debug something.
+ *
+ * WHAT READING SOURCE CANNOT DO, named rather than implied, because a boundary nobody wrote down
+ * gets mistaken for coverage. This checks that the line is SHAPED like a disclosure. It cannot
+ * follow evaluation, so a line that builds the value and then discards it stays accepted: a
+ * disclosing template with a `.replace` chained onto it that overwrites the whole string, and the
+ * comma-expression form that evaluates the disclosing template and hands `console.log` something
+ * else. Both are deliberate sabotage rather than a careless edit, and closing them means executing
+ * repository source inside a guard, which buys less than it costs. Measured and left open, not
+ * overlooked.
  */
-const PRINTS = new RegExp(String.raw`console\.log\([^\n]*broker:[^\n]*\$\{\s*${VAR}\s*\}`);
+const PRINTS = new RegExp(String.raw`console\.log\([^\n]*broker:\s*\$\{\s*${VAR}\s*\}`);
 
 let pass = 0;
 let fail = 0;
@@ -71,12 +87,12 @@ const check = (name: string, ok: boolean, extra?: unknown): void => {
 const self = relative(repoRoot, fileURLToPath(import.meta.url));
 
 const defaulters: string[] = [];
-let excluded = 0;
+const excludedPaths: string[] = [];
 for (const file of sources(repoRoot)) {
   const text = readFileSync(file, "utf8");
   if (!DEFAULTS.test(text)) continue;
   const rel = relative(repoRoot, file);
-  if (rel === self) { excluded += 1; continue; }
+  if (rel === self) { excludedPaths.push(rel); continue; }
   defaulters.push(rel);
 }
 defaulters.sort();
@@ -95,10 +111,14 @@ check(
 // 1b — and the exclusion is exactly this file, still matching. If the fixtures below ever stop
 // carrying the pattern the exclusion has quietly become dead, which is the same shape as an
 // allowlist entry nobody notices has stopped matching anything.
+// The path is named as a LITERAL and not re-derived from `self`, which would make the cell a
+// tautology. Cardinality alone leaves the carve-out free to point somewhere else: rewriting `self`
+// to a real suite keeps the count at one, keeps the census size unchanged, and silently stops
+// grading that suite while this file walks in through its own compliant fixture.
 check(
   "exactly one file is excluded from the census, and it is this file's own fixtures",
-  excluded === 1,
-  { excluded, self },
+  excludedPaths.length === 1 && excludedPaths[0]!.endsWith("bin/smoke/broker-disclosure.smoke.ts"),
+  { excludedPaths, self },
 );
 
 /** What the guard asks of one file. Extracted so it can be aimed at a fixture as well as at the
@@ -150,6 +170,14 @@ function evaluate(text: string): { prints: boolean; ordered: boolean } {
     + 'process.env.COTAL_SERVERS ||= "nats://127.0.0.1:4222";\n'
     + 'console.log(`• broker: nats://127.0.0.1:4222`); // was process.env.COTAL_SERVERS\n'
     + 'void brokerFromEnv;\n';
+  // The next member of the family, found by review once the first was closed: the interpolation is
+  // present and correct and is INSIDE A COMMENT, while the template prints a literal. A pattern that
+  // took `${…}` anywhere after `broker:` accepted it, which is why the interpolation now has to be
+  // the thing that FOLLOWS `broker:` rather than merely something later on the line.
+  const COMMENTED_INTERP = 'const brokerFromEnv = process.env.COTAL_SERVERS !== undefined;\n'
+    + 'process.env.COTAL_SERVERS ||= "nats://127.0.0.1:4222";\n'
+    + 'console.log(`• broker: nats://127.0.0.1:4222`); // ${process.env.COTAL_SERVERS}\n'
+    + 'void brokerFromEnv;\n';
   // The census direction. A file this cannot SEE is not rejected, it is absent, and every per-file
   // cell is generated from the census -- so a shape it does not know costs cells rather than reds.
   const BRACKET = 'const brokerFromEnv = process.env["COTAL_SERVERS"] !== undefined;\n'
@@ -162,6 +190,8 @@ function evaluate(text: string): { prints: boolean; ordered: boolean } {
     !evaluate(DOLLARLESS).prints);
   check("fixture: a hardcoded address with the variable in a trailing comment is rejected",
     !evaluate(HARDCODED).prints);
+  check("fixture: the INTERPOLATION parked in a trailing comment is rejected too",
+    !evaluate(COMMENTED_INTERP).prints);
   check("fixture: the same assignment under bracket access is SEEN, so it can be judged at all",
     DEFAULTS.test(BRACKET) && evaluate(BRACKET).prints && evaluate(BRACKET).ordered);
 }

--- a/bin/smoke/broker-disclosure.smoke.ts
+++ b/bin/smoke/broker-disclosure.smoke.ts
@@ -70,12 +70,16 @@ const CAPTURES = new RegExp(String.raw`${VAR}\s*!==?\s*(?:undefined|null)`);
  *
  * WHAT READING SOURCE CANNOT DO, named rather than implied, because a boundary nobody wrote down
  * gets mistaken for coverage. This checks that the line is SHAPED like a disclosure. It cannot
- * follow evaluation, so a line that builds the value and then discards it stays accepted: a
- * disclosing template with a `.replace` chained onto it that overwrites the whole string, and the
- * comma-expression form that evaluates the disclosing template and hands `console.log` something
- * else. Both are deliberate sabotage rather than a careless edit, and closing them means executing
- * repository source inside a guard, which buys less than it costs. Measured and left open, not
- * overlooked.
+ * follow evaluation, so ONE line that builds the value and then discards it stays accepted: a
+ * disclosing template with a `.replace` chained onto it that overwrites the whole string. That is
+ * deliberate sabotage rather than a careless edit, and closing it means executing repository source
+ * inside a guard, which buys less than it costs. Measured and left open, not overlooked.
+ *
+ * The comma-expression form, which evaluates the disclosing template and hands `console.log`
+ * something else, USED to be the second one. Requiring the backtick immediately after the `(` closed
+ * it as a side effect, since the comma form opens with a parenthesis. It is recorded here rather
+ * than quietly enjoyed: a boundary that has moved and still reads as open is the same misreading as
+ * one nobody wrote down. It fails in the loud direction and stays closed.
  */
 const PRINTS = new RegExp(String.raw`console\.log\(\`[^\n\`]*broker:\s*\$\{\s*${VAR}\s*\}`);
 

--- a/bin/smoke/broker-disclosure.smoke.ts
+++ b/bin/smoke/broker-disclosure.smoke.ts
@@ -1,0 +1,79 @@
+/**
+ * Smoke for the ambient-broker disclosure — pure (no broker, no network, no spawning).
+ *
+ * A handful of suites default `COTAL_SERVERS` with `||=`, which KEEPS an already-set value. That
+ * makes them loopback only where nothing exported the variable; in an agent's or an operator's
+ * shell they resolve to whatever that shell holds. Each of them names what it resolved, so an
+ * archived run can be audited after the fact.
+ *
+ * This grades the convention rather than any one suite: every file that sets the default must also
+ * print it, and must capture whether it was inherited BEFORE the `||=` overwrites the evidence.
+ * Without this, the disclosure is a habit, and a habit is one careless edit from gone — with
+ * nothing red, which is the same failure the disclosure exists to prevent.
+ *
+ * Run: `pnpm smoke:broker-disclosure`
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const SKIP = new Set(["node_modules", "dist", ".git", ".pnpm-store", "coverage", "reserved"]);
+
+/** Every tracked source file, so the census is keyed on CONTENT and not on a directory. A sweep of
+ *  `extensions/` misses `bin/smoke/launch-parity.smoke.ts`, which carries the same default. */
+function* sources(dir: string): Generator<string> {
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    if (e.name.startsWith(".") || SKIP.has(e.name)) continue;
+    const p = join(dir, e.name);
+    if (e.isDirectory()) yield* sources(p);
+    else if (/\.(ts|mts|cts|mjs|js)$/.test(e.name) && statSync(p).size < 2_000_000) yield p;
+  }
+}
+
+const DEFAULTS = /process\.env\.COTAL_SERVERS\s*\|\|=/;
+const CAPTURES = /process\.env\.COTAL_SERVERS\s*!==\s*undefined/;
+const PRINTS = /console\.log\([^\n]*broker:[^\n]*process\.env\.COTAL_SERVERS/;
+
+let pass = 0;
+let fail = 0;
+const check = (name: string, ok: boolean, extra?: unknown): void => {
+  if (ok) { pass++; console.log(`  ✓ ${name}`); }
+  else { fail++; console.log(`  ✗ FAIL: ${name}`, extra !== undefined ? JSON.stringify(extra) : ""); }
+};
+
+const defaulters: string[] = [];
+for (const file of sources(repoRoot)) {
+  const text = readFileSync(file, "utf8");
+  if (DEFAULTS.test(text)) defaulters.push(relative(repoRoot, file));
+}
+defaulters.sort();
+
+console.log(`• ${defaulters.length} file(s) default COTAL_SERVERS with \`||=\``);
+for (const f of defaulters) console.log(`    ${f}`);
+
+// 1 — the census is not empty. A guard over an empty set passes forever and grades nothing, which
+// is the exact shape of an allowlist entry nobody notices has stopped matching anything.
+check(
+  "at least one file defaults COTAL_SERVERS, so this guard is grading a non-empty set",
+  defaulters.length > 0,
+  { defaulters },
+);
+
+// 2 — the disclosure itself, per file.
+for (const f of defaulters) {
+  const text = readFileSync(join(repoRoot, f), "utf8");
+  check(`${f} prints the broker it resolved`, PRINTS.test(text));
+  // The inherited/defaulted distinction is the forensically useful half, and it is only knowable
+  // BEFORE the `||=` runs. Capturing it afterwards reads the value the suite just wrote.
+  const capture = text.search(CAPTURES);
+  const assign = text.search(DEFAULTS);
+  check(
+    `${f} records whether the value was inherited, before \`||=\` overwrites the evidence`,
+    capture !== -1 && capture < assign,
+    { captureAt: capture, assignAt: assign },
+  );
+}
+
+console.log(`\nBROKER-DISCLOSURE SMOKE ${fail === 0 ? "OK ✅" : "FAILED ❌"}  (${pass} passed, ${fail} failed)`);
+process.exit(fail === 0 ? 0 : 1);

--- a/bin/smoke/launch-parity.smoke.ts
+++ b/bin/smoke/launch-parity.smoke.ts
@@ -22,7 +22,16 @@ import type { CotalEndpoint } from "@cotal-ai/core";
 // cotalToolSpecs is capability-gated: cotal_spawn only renders for a spawn-capable agent.
 process.env.COTAL_SPACE ||= "parity";
 process.env.COTAL_NAME ||= "parity-1";
+// `||=` KEEPS an already-set value, so this suite is loopback only where nothing set the
+// variable. In any shell that already exports COTAL_SERVERS — an agent's, an operator's — it
+// resolves to that instead, and an archived run gave no way to tell which. It names its target
+// now: a suite that names its target cannot silently change it. Measured, and true today: this
+// suite opens no TCP connection to the value at all (verified against a listener that counted
+// zero accepts), so the line discloses a CONFIG input, not traffic. If that ever stops being
+// true, this line is already where a reader would look.
+const brokerFromEnv = process.env.COTAL_SERVERS !== undefined;
 process.env.COTAL_SERVERS ||= "nats://127.0.0.1:4222";
+console.log(`• broker: ${process.env.COTAL_SERVERS} (${brokerFromEnv ? "INHERITED from the environment" : "suite default"})`);
 process.env.COTAL_CAPABILITIES = "spawn";
 
 /** The manager `start` op's argument vocabulary (StartAgentOpts, minus the internal `resolved`).

--- a/bin/smoke/mutations/broker-disclosure.json
+++ b/bin/smoke/mutations/broker-disclosure.json
@@ -84,6 +84,33 @@
       "expectRed": "extensions/connector-core/smoke/tool-input-closed.smoke.ts records whether the value was inherited, before `||=` overwrites the evidence",
       "cell": "extensions/connector-core/smoke/tool-input-closed.smoke.ts records whether the value was inherited, before `||=` overwrites the evidence",
       "note": "The defect wearing a healthy shape: two lines swapped, everything still compiles, the line still prints, and it is wrong every single run. This is the pair that makes mutation 3 mean something -- one shows the guard would stop looking, the other shows what it is looking at."
+    },
+    {
+      "name": "the disclosure requirement drops back to the NAME, so `${` deleted is accepted",
+      "file": "bin/smoke/broker-disclosure.smoke.ts",
+      "find": "const PRINTS = new RegExp(String.raw`console\\.log\\([^\\n]*broker:[^\\n]*\\$\\{\\s*${VAR}\\s*\\}`);",
+      "replace": "const PRINTS = new RegExp(String.raw`console\\.log\\([^\\n]*broker:[^\\n]*${VAR}`);",
+      "expectRed": "fixture: a line carrying the NAME without the interpolation is rejected",
+      "cell": "fixture: a line carrying the NAME without the interpolation is rejected: `${` is the value",
+      "note": "THE SHIPPED STATE BEFORE THIS ROUND, and it is the whole name-versus-value family in one character. A reviewer reproduced it against the suite's own `evaluate`: delete the `$` from `${process.env.COTAL_SERVERS}` and every cell stays green while the line prints the literal text `{process.env.COTAL_SERVERS}` at runtime. The cell was called \"prints the broker it resolved\" and never looked at whether anything was resolved. The corpus cannot prove this either way -- every real file is compliant -- so the fixtures are the only thing that can, which is the same argument mutation 3 already carries one level up."
+    },
+    {
+      "name": "the self-exclusion is removed, so the guard counts its own fixtures as real suites",
+      "file": "bin/smoke/broker-disclosure.smoke.ts",
+      "find": "  if (rel === self) { excluded += 1; continue; }",
+      "replace": "  if (false) { excluded += 1; continue; }",
+      "expectRed": "exactly one file is excluded from the census, and it is this file's own fixtures",
+      "cell": "exactly one file is excluded from the census, and it is this file's own fixtures",
+      "note": "A census keyed on TEXT cannot tell a call site from a fixture, and this file is the one guaranteed to hold fixtures: without the exclusion it reported EIGHT files defaulting the variable when seven do, and graded its own negative controls as though they were suites. The published count was wrong by one and nothing said so. The exclusion is computed from `import.meta.url` rather than written as a path, so it cannot grow into an allowlist, and this cell is what stops it going dead if the fixtures ever stop matching."
+    },
+    {
+      "name": "the census narrows back to dot access, so the same assignment under brackets is INVISIBLE",
+      "file": "bin/smoke/broker-disclosure.smoke.ts",
+      "find": "const VAR = String.raw`process\\.env(?:\\.COTAL_SERVERS|\\[[\"']COTAL_SERVERS[\"']\\])`;",
+      "replace": "const VAR = String.raw`process\\.env\\.COTAL_SERVERS`;",
+      "expectRed": "fixture: the same assignment under bracket access is SEEN, so it can be judged at all",
+      "cell": "fixture: the same assignment under bracket access is SEEN, so it can be judged at all",
+      "note": "The dangerous direction, because it is SILENT. `process.env[\"COTAL_SERVERS\"] ||=` is the same assignment, and a census that cannot see it does not reject that file, it never enumerates it -- and every per-file cell is generated from the census, so the guard loses cells rather than going red. That is the same shape as scoping the sweep to `extensions/` (mutation 2), one level lower: there the census missed a DIRECTORY, here it misses a SPELLING. No file in the tree writes it this way today, which is exactly why only a fixture can hold the line."
     }
   ]
 }

--- a/bin/smoke/mutations/broker-disclosure.json
+++ b/bin/smoke/mutations/broker-disclosure.json
@@ -70,8 +70,8 @@
     {
       "name": "the inherited-capture is allowed to sit AFTER the assignment that destroys the evidence",
       "file": "bin/smoke/broker-disclosure.smoke.ts",
-      "find": "    capture !== -1 && capture < assign,",
-      "replace": "    capture !== -1,",
+      "find": "  return { prints: PRINTS.test(text), ordered: capture !== -1 && capture < assign };",
+      "replace": "  return { prints: PRINTS.test(text), ordered: capture !== -1 };",
       "expectRed": "fixture: a file that captures AFTER the `||=` is rejected on order",
       "cell": "fixture: a file that captures AFTER the `||=` is rejected on order",
       "note": "Presence-not-position: the resulting checker accepts a disclosure that reports EVERY run as inherited. It first SURVIVED, and correctly -- every real file is compliant, so dropping the requirement changed no real verdict. A requirement that no input exercises cannot be proved by the corpus, so the suite now carries its own negative control and this mutation is aimed at that fixture. Paired with mutation 4, which puts the same defect in a real file: the fixture proves the checker still looks, mutation 4 proves it is looking at the repo."

--- a/bin/smoke/mutations/broker-disclosure.json
+++ b/bin/smoke/mutations/broker-disclosure.json
@@ -88,11 +88,11 @@
     {
       "name": "the disclosure requirement drops back to the NAME, so `${` deleted is accepted",
       "file": "bin/smoke/broker-disclosure.smoke.ts",
-      "find": "const PRINTS = new RegExp(String.raw`console\\.log\\([^\\n]*broker:\\s*\\$\\{\\s*${VAR}\\s*\\}`);",
+      "find": "const PRINTS = new RegExp(String.raw`console\\.log\\(\\`[^\\n\\`]*broker:\\s*\\$\\{\\s*${VAR}\\s*\\}`);",
       "replace": "const PRINTS = new RegExp(String.raw`console\\.log\\([^\\n]*broker:[^\\n]*${VAR}`);",
       "expectRed": "fixture: a line carrying the NAME without the interpolation is rejected",
       "cell": "fixture: a line carrying the NAME without the interpolation is rejected: `${` is the value",
-      "note": "THE SHIPPED STATE BEFORE THIS ROUND, and it is the whole name-versus-value family in one character. A reviewer reproduced it against the suite's own `evaluate`: delete the `$` from `${process.env.COTAL_SERVERS}` and every cell stays green while the line prints the literal text `{process.env.COTAL_SERVERS}` at runtime. The cell was called \"prints the broker it resolved\" and never looked at whether anything was resolved. The corpus cannot prove this either way -- every real file is compliant -- so the fixtures are the only thing that can, which is the same argument mutation 3 already carries one level up. RE-ANCHORED after the same regex was tightened again a round later: an anchor that has moved reports ERROR rather than a verdict, which is the tool being honest, and is the reason a kill set is re-run rather than inherited when the guard it grades changes."
+      "note": "THE SHIPPED STATE BEFORE THIS ROUND, and it is the whole name-versus-value family in one character. A reviewer reproduced it against the suite's own `evaluate`: delete the `$` from `${process.env.COTAL_SERVERS}` and every cell stays green while the line prints the literal text `{process.env.COTAL_SERVERS}` at runtime. The cell was called \"prints the broker it resolved\" and never looked at whether anything was resolved. The corpus cannot prove this either way -- every real file is compliant -- so the fixtures are the only thing that can, which is the same argument mutation 3 already carries one level up. RE-ANCHORED TWICE, the second time after the backtick requirement landed on the same line: an anchor that has moved reports ERROR rather than a verdict, which is the tool being honest, and is the reason a kill set is re-run rather than inherited when the guard it grades changes."
     },
     {
       "name": "the self-exclusion is removed, so the guard counts its own fixtures as real suites",
@@ -129,6 +129,15 @@
       "expectRed": "fixture: the same assignment under bracket access is SEEN, so it can be judged at all",
       "cell": "fixture: the same assignment under bracket access is SEEN, so it can be judged at all",
       "note": "The dangerous direction, because it is SILENT. `process.env[\"COTAL_SERVERS\"] ||=` is the same assignment, and a census that cannot see it does not reject that file, it never enumerates it -- and every per-file cell is generated from the census, so the guard loses cells rather than going red. That is the same shape as scoping the sweep to `extensions/` (mutation 2), one level lower: there the census missed a DIRECTORY, here it misses a SPELLING. No file in the tree writes it this way today, which is exactly why only a fixture can hold the line."
+    },
+    {
+      "name": "the template requirement is dropped, so `${...}` inside a QUOTED string is accepted",
+      "file": "bin/smoke/broker-disclosure.smoke.ts",
+      "find": "const PRINTS = new RegExp(String.raw`console\\.log\\(\\`[^\\n\\`]*broker:\\s*\\$\\{\\s*${VAR}\\s*\\}`);",
+      "replace": "const PRINTS = new RegExp(String.raw`console\\.log\\([^\\n]*broker:\\s*\\$\\{\\s*${VAR}\\s*\\}`);",
+      "expectRed": "fixture: the interpolation inside a QUOTED string is rejected",
+      "cell": "fixture: the interpolation inside a QUOTED string is rejected: it prints as text, not a value",
+      "note": "THE SHIPPED STATE BEFORE THIS ROUND, and the same name-versus-value family one level down. The interpolation is present, spelled correctly, and sits exactly where the pattern wants it, and the string is quoted, so JS never interpolates: the line prints `${process.env.COTAL_SERVERS}` as six characters of text with the real address sitting unread in the environment. Ran both forms with the variable set rather than reasoning about it. This is a careless edit and not sabotage, which is why it belongs closed: a tick-to-quote conversion, or a rewrite toward concatenation that leaves a `${}` behind inside the quotes. Every real file uses a template today, so only a fixture can hold this."
     }
   ]
 }

--- a/bin/smoke/mutations/broker-disclosure.json
+++ b/bin/smoke/mutations/broker-disclosure.json
@@ -104,6 +104,24 @@
       "note": "A census keyed on TEXT cannot tell a call site from a fixture, and this file is the one guaranteed to hold fixtures: without the exclusion it reported EIGHT files defaulting the variable when seven do, and graded its own negative controls as though they were suites. The published count was wrong by one and nothing said so. The exclusion is computed from `import.meta.url` rather than written as a path, so it cannot grow into an allowlist, and this cell is what stops it going dead if the fixtures ever stop matching."
     },
     {
+      "name": "the interpolation may sit ANYWHERE after `broker:`, so a commented one satisfies a literal line",
+      "file": "bin/smoke/broker-disclosure.smoke.ts",
+      "find": "const PRINTS = new RegExp(String.raw`console\\.log\\([^\\n]*broker:\\s*\\$\\{\\s*${VAR}\\s*\\}`);",
+      "replace": "const PRINTS = new RegExp(String.raw`console\\.log\\([^\\n]*broker:[^\\n]*\\$\\{\\s*${VAR}\\s*\\}`);",
+      "expectRed": "fixture: the INTERPOLATION parked in a trailing comment is rejected too",
+      "cell": "fixture: the INTERPOLATION parked in a trailing comment is rejected too",
+      "note": "THE NEXT MEMBER OF THE FAMILY, found by review after the first was closed, and the lesson is that closing the members you were shown is not closing the family. Requiring the interpolation was right and requiring it ANYWHERE ON THE LINE was not: park it in a trailing comment, hardcode the address in the template, and the line prints a literal every run while the check is satisfied. It is also the plausible careless edit rather than a contrived one, because it is what somebody leaves behind after pinning an address to debug something."
+    },
+    {
+      "name": "the self-exclusion is repointed at a real suite, which stops grading it and lets this file in",
+      "file": "bin/smoke/broker-disclosure.smoke.ts",
+      "find": "const self = relative(repoRoot, fileURLToPath(import.meta.url));",
+      "replace": "const self = \"bin/smoke/launch-parity.smoke.ts\";",
+      "expectRed": "exactly one file is excluded from the census, and it is this file's own fixtures",
+      "cell": "exactly one file is excluded from the census, and it is this file's own fixtures",
+      "note": "CARDINALITY IS NOT IDENTITY, and a cell that counts a carve-out without naming it leaves the carve-out free to point elsewhere. Raised by review: repointing `self` keeps `excluded` at one, keeps the census the same size, keeps the span-directories cell green, and silently stops grading a real suite while this file walks into the census through its own compliant fixture. The cell now names the path as a LITERAL rather than re-deriving it from `self`, which would have made it a tautology that this mutation passes."
+    },
+    {
       "name": "the census narrows back to dot access, so the same assignment under brackets is INVISIBLE",
       "file": "bin/smoke/broker-disclosure.smoke.ts",
       "find": "const VAR = String.raw`process\\.env(?:\\.COTAL_SERVERS|\\[[\"']COTAL_SERVERS[\"']\\])`;",

--- a/bin/smoke/mutations/broker-disclosure.json
+++ b/bin/smoke/mutations/broker-disclosure.json
@@ -88,20 +88,20 @@
     {
       "name": "the disclosure requirement drops back to the NAME, so `${` deleted is accepted",
       "file": "bin/smoke/broker-disclosure.smoke.ts",
-      "find": "const PRINTS = new RegExp(String.raw`console\\.log\\([^\\n]*broker:[^\\n]*\\$\\{\\s*${VAR}\\s*\\}`);",
+      "find": "const PRINTS = new RegExp(String.raw`console\\.log\\([^\\n]*broker:\\s*\\$\\{\\s*${VAR}\\s*\\}`);",
       "replace": "const PRINTS = new RegExp(String.raw`console\\.log\\([^\\n]*broker:[^\\n]*${VAR}`);",
       "expectRed": "fixture: a line carrying the NAME without the interpolation is rejected",
       "cell": "fixture: a line carrying the NAME without the interpolation is rejected: `${` is the value",
-      "note": "THE SHIPPED STATE BEFORE THIS ROUND, and it is the whole name-versus-value family in one character. A reviewer reproduced it against the suite's own `evaluate`: delete the `$` from `${process.env.COTAL_SERVERS}` and every cell stays green while the line prints the literal text `{process.env.COTAL_SERVERS}` at runtime. The cell was called \"prints the broker it resolved\" and never looked at whether anything was resolved. The corpus cannot prove this either way -- every real file is compliant -- so the fixtures are the only thing that can, which is the same argument mutation 3 already carries one level up."
+      "note": "THE SHIPPED STATE BEFORE THIS ROUND, and it is the whole name-versus-value family in one character. A reviewer reproduced it against the suite's own `evaluate`: delete the `$` from `${process.env.COTAL_SERVERS}` and every cell stays green while the line prints the literal text `{process.env.COTAL_SERVERS}` at runtime. The cell was called \"prints the broker it resolved\" and never looked at whether anything was resolved. The corpus cannot prove this either way -- every real file is compliant -- so the fixtures are the only thing that can, which is the same argument mutation 3 already carries one level up. RE-ANCHORED after the same regex was tightened again a round later: an anchor that has moved reports ERROR rather than a verdict, which is the tool being honest, and is the reason a kill set is re-run rather than inherited when the guard it grades changes."
     },
     {
       "name": "the self-exclusion is removed, so the guard counts its own fixtures as real suites",
       "file": "bin/smoke/broker-disclosure.smoke.ts",
-      "find": "  if (rel === self) { excluded += 1; continue; }",
-      "replace": "  if (false) { excluded += 1; continue; }",
+      "find": "  if (rel === self) { excludedPaths.push(rel); continue; }",
+      "replace": "  if (false) { excludedPaths.push(rel); continue; }",
       "expectRed": "exactly one file is excluded from the census, and it is this file's own fixtures",
       "cell": "exactly one file is excluded from the census, and it is this file's own fixtures",
-      "note": "A census keyed on TEXT cannot tell a call site from a fixture, and this file is the one guaranteed to hold fixtures: without the exclusion it reported EIGHT files defaulting the variable when seven do, and graded its own negative controls as though they were suites. The published count was wrong by one and nothing said so. The exclusion is computed from `import.meta.url` rather than written as a path, so it cannot grow into an allowlist, and this cell is what stops it going dead if the fixtures ever stop matching."
+      "note": "A census keyed on TEXT cannot tell a call site from a fixture, and this file is the one guaranteed to hold fixtures: without the exclusion it reported EIGHT files defaulting the variable when seven do, and graded its own negative controls as though they were suites. The published count was wrong by one and nothing said so. The exclusion is computed from `import.meta.url` rather than written as a path, so it cannot grow into an allowlist, and this cell is what stops it going dead if the fixtures ever stop matching. RE-ANCHORED when the exclusion started recording the PATH rather than a count, so identity could be asserted rather than cardinality alone."
     },
     {
       "name": "the interpolation may sit ANYWHERE after `broker:`, so a commented one satisfies a literal line",

--- a/bin/smoke/mutations/broker-disclosure.json
+++ b/bin/smoke/mutations/broker-disclosure.json
@@ -106,11 +106,11 @@
     {
       "name": "the interpolation may sit ANYWHERE after `broker:`, so a commented one satisfies a literal line",
       "file": "bin/smoke/broker-disclosure.smoke.ts",
-      "find": "const PRINTS = new RegExp(String.raw`console\\.log\\([^\\n]*broker:\\s*\\$\\{\\s*${VAR}\\s*\\}`);",
-      "replace": "const PRINTS = new RegExp(String.raw`console\\.log\\([^\\n]*broker:[^\\n]*\\$\\{\\s*${VAR}\\s*\\}`);",
+      "find": "const PRINTS = new RegExp(String.raw`console\\.log\\(\\`[^\\n\\`]*broker:\\s*\\$\\{\\s*${VAR}\\s*\\}`);",
+      "replace": "const PRINTS = new RegExp(String.raw`console\\.log\\(\\`[^\\n\\`]*broker:[^\\n]*\\$\\{\\s*${VAR}\\s*\\}`);",
       "expectRed": "fixture: the INTERPOLATION parked in a trailing comment is rejected too",
       "cell": "fixture: the INTERPOLATION parked in a trailing comment is rejected too",
-      "note": "THE NEXT MEMBER OF THE FAMILY, found by review after the first was closed, and the lesson is that closing the members you were shown is not closing the family. Requiring the interpolation was right and requiring it ANYWHERE ON THE LINE was not: park it in a trailing comment, hardcode the address in the template, and the line prints a literal every run while the check is satisfied. It is also the plausible careless edit rather than a contrived one, because it is what somebody leaves behind after pinning an address to debug something."
+      "note": "THE NEXT MEMBER OF THE FAMILY, found by review after the first was closed, and the lesson is that closing the members you were shown is not closing the family. Requiring the interpolation was right and requiring it ANYWHERE ON THE LINE was not: park it in a trailing comment, hardcode the address in the template, and the line prints a literal every run while the check is satisfied. It is also the plausible careless edit rather than a contrived one, because it is what somebody leaves behind after pinning an address to debug something. RE-ANCHORED after the backtick requirement landed on the same line: it kept the shape it grades and moved to the line as it stands, because an anchor that has moved reports ERROR rather than a verdict, and a set is re-run rather than inherited when the guard it grades changes."
     },
     {
       "name": "the self-exclusion is repointed at a real suite, which stops grading it and lets this file in",

--- a/bin/smoke/mutations/broker-disclosure.json
+++ b/bin/smoke/mutations/broker-disclosure.json
@@ -1,0 +1,80 @@
+{
+  "suite": "bin/smoke/broker-disclosure.smoke.ts",
+  "guard": "every file that defaults COTAL_SERVERS with `||=` also prints what it resolved, and records whether it was inherited before the assignment destroys that evidence",
+  "command": "pnpm smoke:broker-disclosure",
+  "completionMarker": "file(s) default COTAL_SERVERS",
+  "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/broker-disclosure.json",
+  "why": [
+    "The disclosure itself adds output, not a guard: nothing stopped a future edit from deleting a",
+    "line, and its absence is silent in exactly the way the disclosure exists to prevent. This",
+    "grades the CONVENTION rather than any one suite, so a new file that picks up the `||=` habit",
+    "is caught the day it lands rather than the day someone audits.",
+    "",
+    "THE CENSUS IS KEYED ON CONTENT, NOT ON A DIRECTORY, and that is the whole reason it finds",
+    "seven. A sweep of `extensions/` -- the obvious heuristic, and the one an earlier count used --",
+    "misses `bin/smoke/launch-parity.smoke.ts`, which carries the same default and lives elsewhere.",
+    "A census keyed on where a thing usually lives cannot see the one that lives somewhere else.",
+    "",
+    "THE ORDERING CELL IS NOT DECORATION. `||=` destroys the evidence it is being asked about: once",
+    "it has run, `process.env.COTAL_SERVERS` is set either way and nothing downstream can tell an",
+    "inherited value from the default. A capture placed after the assignment reads the value the",
+    "suite just wrote and reports every run as inherited -- output present, disclosure worthless.",
+    "So the guard checks POSITION, not merely presence, and mutation 3 is that exact regression.",
+    "",
+    "THE EMPTY-SET CELL IS THE ONE MOST LIKELY TO BE CALLED PARANOID AND IS NOT. Every other cell",
+    "in this suite is generated per discovered file, so if the census ever matches nothing -- a",
+    "regex drifting against a reformat, a directory added to SKIP -- the suite passes with zero",
+    "assertions and reports OK. That is a guard over an empty set: green forever, grading nothing.",
+    "It is the same shape as an allowlist entry that has quietly stopped matching anything.",
+    "",
+    "NOT GRADED, and named rather than implied: that the seven suites do not DIAL the address. That",
+    "was measured live -- a listener on the configured port counted zero accepts for all seven, and",
+    "each passes pointed at a blackhole -- and it is a fact about what those suites do at runtime,",
+    "which a source-reading guard cannot see. It is written in the comment above each line rather",
+    "than asserted here, because a check that cannot observe a connection must not claim there was",
+    "none.",
+    "",
+    "SPECIFIER BOUNDARY: not applicable, and checked rather than assumed. This suite imports no",
+    "workspace package at all -- only `node:fs`, `node:path`, `node:url` -- and reads the mutated",
+    "files as TEXT from disk. There is no `dist` in the path and no build in the command, so the",
+    "bytes mutated are the bytes graded."
+  ],
+  "mutations": [
+    {
+      "name": "one file's disclosure is deleted, which is the regression this guard exists for",
+      "file": "extensions/pi/smoke/tool-input-closed.smoke.ts",
+      "find": "console.log(`• broker: ${process.env.COTAL_SERVERS} (${brokerFromEnv ? \"INHERITED from the environment\" : \"suite default\"})`);",
+      "replace": "void brokerFromEnv;",
+      "expectRed": "extensions/pi/smoke/tool-input-closed.smoke.ts prints the broker it resolved",
+      "cell": "extensions/pi/smoke/tool-input-closed.smoke.ts prints the broker it resolved",
+      "note": "A careless edit, not a malicious one: the line is dropped and the capture kept, which still typechecks and leaves that suite passing. Before this guard the whole repo stayed green."
+    },
+    {
+      "name": "the census is scoped to `extensions/`, the heuristic that produced a count of six",
+      "file": "bin/smoke/broker-disclosure.smoke.ts",
+      "find": "for (const file of sources(repoRoot)) {",
+      "replace": "for (const file of sources(join(repoRoot, \"extensions\"))) {",
+      "expectRed": "bin/smoke/launch-parity.smoke.ts prints the broker it resolved",
+      "cell": "bin/smoke/launch-parity.smoke.ts prints the broker it resolved",
+      "note": "The mutation is a real person's first instinct, and it is why the original report said six. The cell it kills is named for the file that lives outside the directory -- so the kill is the census proving it is not keyed on location."
+    },
+    {
+      "name": "the inherited-capture is allowed to sit AFTER the assignment that destroys the evidence",
+      "file": "bin/smoke/broker-disclosure.smoke.ts",
+      "find": "    capture !== -1 && capture < assign,",
+      "replace": "    capture !== -1,",
+      "expectRed": "records whether the value was inherited, before `||=` overwrites the evidence",
+      "cell": "records whether the value was inherited, before `||=` overwrites the evidence",
+      "note": "Presence-not-position, and the resulting suite would accept a disclosure that reports EVERY run as inherited. Paired with mutation 4, which moves a real capture below its assignment: mutation 3 proves the check would stop noticing, mutation 4 proves it notices today."
+    },
+    {
+      "name": "PAIRED: a real file captures the flag after its own `||=`, so the disclosure always says inherited",
+      "file": "extensions/connector-core/smoke/tool-input-closed.smoke.ts",
+      "find": "const brokerFromEnv = process.env.COTAL_SERVERS !== undefined;\nprocess.env.COTAL_SERVERS ||= \"nats://127.0.0.1:4222\";",
+      "replace": "process.env.COTAL_SERVERS ||= \"nats://127.0.0.1:4222\";\nconst brokerFromEnv = process.env.COTAL_SERVERS !== undefined;",
+      "expectRed": "extensions/connector-core/smoke/tool-input-closed.smoke.ts records whether the value was inherited, before `||=` overwrites the evidence",
+      "cell": "extensions/connector-core/smoke/tool-input-closed.smoke.ts records whether the value was inherited, before `||=` overwrites the evidence",
+      "note": "The defect wearing a healthy shape: two lines swapped, everything still compiles, the line still prints, and it is wrong every single run. This is the pair that makes mutation 3 mean something -- one shows the guard would stop looking, the other shows what it is looking at."
+    }
+  ]
+}

--- a/bin/smoke/mutations/broker-disclosure.json
+++ b/bin/smoke/mutations/broker-disclosure.json
@@ -37,7 +37,16 @@
     "SPECIFIER BOUNDARY: not applicable, and checked rather than assumed. This suite imports no",
     "workspace package at all -- only `node:fs`, `node:path`, `node:url` -- and reads the mutated",
     "files as TEXT from disk. There is no `dist` in the path and no build in the command, so the",
-    "bytes mutated are the bytes graded."
+    "bytes mutated are the bytes graded.",
+    "",
+    "TWO MUTATIONS SURVIVED THE FIRST RUN AND BOTH SURVIVALS WERE THE SUITE'S FAULT, fixed on the",
+    "test side rather than by re-aiming. (1) Scoping the census to `extensions/` did not redden any",
+    "cell -- it DELETED two, because every per-file cell is generated from the census, and a suite",
+    "with fewer cells still exits 0. A guard whose coverage shrinks silently with its input is the",
+    "same shape as the allowlist entry that stops matching anything. (2) Dropping the ordering",
+    "requirement changed no verdict, because every real file is compliant -- a requirement no input",
+    "exercises cannot be proved by the corpus, however many files the corpus has. The first is now a",
+    "cell about the census itself, the second a negative fixture. Neither mutation was weakened."
   ],
   "mutations": [
     {
@@ -54,18 +63,18 @@
       "file": "bin/smoke/broker-disclosure.smoke.ts",
       "find": "for (const file of sources(repoRoot)) {",
       "replace": "for (const file of sources(join(repoRoot, \"extensions\"))) {",
-      "expectRed": "bin/smoke/launch-parity.smoke.ts prints the broker it resolved",
-      "cell": "bin/smoke/launch-parity.smoke.ts prints the broker it resolved",
-      "note": "The mutation is a real person's first instinct, and it is why the original report said six. The cell it kills is named for the file that lives outside the directory -- so the kill is the census proving it is not keyed on location."
+      "expectRed": "the census spans more than one top-level directory, so it is keyed on content and not on location",
+      "cell": "the census spans more than one top-level directory, so it is keyed on content and not on location",
+      "note": "The mutation is a real person's first instinct, and it is why the original count of these files was six. It first SURVIVED: narrowing the census does not FAIL the per-file cells, it stops emitting them, and a suite with two fewer cells still exits 0. That is a guard whose strength shrinks with its input and reports nothing -- so the suite gained a cell that asserts the census SPANS more than one top-level directory, which is the property the finding was actually about."
     },
     {
       "name": "the inherited-capture is allowed to sit AFTER the assignment that destroys the evidence",
       "file": "bin/smoke/broker-disclosure.smoke.ts",
       "find": "    capture !== -1 && capture < assign,",
       "replace": "    capture !== -1,",
-      "expectRed": "records whether the value was inherited, before `||=` overwrites the evidence",
-      "cell": "records whether the value was inherited, before `||=` overwrites the evidence",
-      "note": "Presence-not-position, and the resulting suite would accept a disclosure that reports EVERY run as inherited. Paired with mutation 4, which moves a real capture below its assignment: mutation 3 proves the check would stop noticing, mutation 4 proves it notices today."
+      "expectRed": "fixture: a file that captures AFTER the `||=` is rejected on order",
+      "cell": "fixture: a file that captures AFTER the `||=` is rejected on order",
+      "note": "Presence-not-position: the resulting checker accepts a disclosure that reports EVERY run as inherited. It first SURVIVED, and correctly -- every real file is compliant, so dropping the requirement changed no real verdict. A requirement that no input exercises cannot be proved by the corpus, so the suite now carries its own negative control and this mutation is aimed at that fixture. Paired with mutation 4, which puts the same defect in a real file: the fixture proves the checker still looks, mutation 4 proves it is looking at the repo."
     },
     {
       "name": "PAIRED: a real file captures the flag after its own `||=`, so the disclosure always says inherited",

--- a/extensions/connector-codex/smoke/tool-input-closed.smoke.ts
+++ b/extensions/connector-codex/smoke/tool-input-closed.smoke.ts
@@ -22,7 +22,16 @@ import { startCotalMcp } from "../src/mcp.js";
 
 process.env.COTAL_SPACE ||= "toolclosed";
 process.env.COTAL_NAME ||= "codex-1";
+// `||=` KEEPS an already-set value, so this suite is loopback only where nothing set the
+// variable. In any shell that already exports COTAL_SERVERS — an agent's, an operator's — it
+// resolves to that instead, and an archived run gave no way to tell which. It names its target
+// now: a suite that names its target cannot silently change it. Measured, and true today: this
+// suite opens no TCP connection to the value at all (verified against a listener that counted
+// zero accepts), so the line discloses a CONFIG input, not traffic. If that ever stops being
+// true, this line is already where a reader would look.
+const brokerFromEnv = process.env.COTAL_SERVERS !== undefined;
 process.env.COTAL_SERVERS ||= "nats://127.0.0.1:4222";
+console.log(`• broker: ${process.env.COTAL_SERVERS} (${brokerFromEnv ? "INHERITED from the environment" : "suite default"})`);
 
 let failures = 0;
 const check = (label: string, ok: boolean, extra?: unknown): void => {

--- a/extensions/connector-core/smoke/tool-input-closed.smoke.ts
+++ b/extensions/connector-core/smoke/tool-input-closed.smoke.ts
@@ -47,7 +47,16 @@ import type { MeshAgent } from "../src/agent.js";
 
 process.env.COTAL_SPACE ||= "toolclosed";
 process.env.COTAL_NAME ||= "closed-1";
+// `||=` KEEPS an already-set value, so this suite is loopback only where nothing set the
+// variable. In any shell that already exports COTAL_SERVERS — an agent's, an operator's — it
+// resolves to that instead, and an archived run gave no way to tell which. It names its target
+// now: a suite that names its target cannot silently change it. Measured, and true today: this
+// suite opens no TCP connection to the value at all (verified against a listener that counted
+// zero accepts), so the line discloses a CONFIG input, not traffic. If that ever stops being
+// true, this line is already where a reader would look.
+const brokerFromEnv = process.env.COTAL_SERVERS !== undefined;
 process.env.COTAL_SERVERS ||= "nats://127.0.0.1:4222";
+console.log(`• broker: ${process.env.COTAL_SERVERS} (${brokerFromEnv ? "INHERITED from the environment" : "suite default"})`);
 
 let failures = 0;
 const check = (label: string, ok: boolean, extra?: unknown): void => {

--- a/extensions/connector-hermes/smoke/tool-input-closed.smoke.ts
+++ b/extensions/connector-hermes/smoke/tool-input-closed.smoke.ts
@@ -43,7 +43,16 @@ const check = (label: string, ok: boolean, extra?: unknown): void => {
 
 process.env.COTAL_SPACE ||= "toolclosed";
 process.env.COTAL_NAME ||= "hermes-1";
+// `||=` KEEPS an already-set value, so this suite is loopback only where nothing set the
+// variable. In any shell that already exports COTAL_SERVERS — an agent's, an operator's — it
+// resolves to that instead, and an archived run gave no way to tell which. It names its target
+// now: a suite that names its target cannot silently change it. Measured, and true today: this
+// suite opens no TCP connection to the value at all (verified against a listener that counted
+// zero accepts), so the line discloses a CONFIG input, not traffic. If that ever stops being
+// true, this line is already where a reader would look.
+const brokerFromEnv = process.env.COTAL_SERVERS !== undefined;
 process.env.COTAL_SERVERS ||= "nats://127.0.0.1:4222";
+console.log(`• broker: ${process.env.COTAL_SERVERS} (${brokerFromEnv ? "INHERITED from the environment" : "suite default"})`);
 const config = configFromEnv();
 
 // ── 1-2. what the sidecar is handed ──

--- a/extensions/connector-hermes/smoke/tool-parity.smoke.ts
+++ b/extensions/connector-hermes/smoke/tool-parity.smoke.ts
@@ -15,7 +15,16 @@ import { hermesToolDescriptors } from "../src/tool-schema.js";
 
 process.env.COTAL_SPACE ||= "parity";
 process.env.COTAL_NAME ||= "hermes-1";
+// `||=` KEEPS an already-set value, so this suite is loopback only where nothing set the
+// variable. In any shell that already exports COTAL_SERVERS — an agent's, an operator's — it
+// resolves to that instead, and an archived run gave no way to tell which. It names its target
+// now: a suite that names its target cannot silently change it. Measured, and true today: this
+// suite opens no TCP connection to the value at all (verified against a listener that counted
+// zero accepts), so the line discloses a CONFIG input, not traffic. If that ever stops being
+// true, this line is already where a reader would look.
+const brokerFromEnv = process.env.COTAL_SERVERS !== undefined;
 process.env.COTAL_SERVERS ||= "nats://127.0.0.1:4222";
+console.log(`• broker: ${process.env.COTAL_SERVERS} (${brokerFromEnv ? "INHERITED from the environment" : "suite default"})`);
 
 const config = configFromEnv();
 const specNames = cotalToolSpecs(config, "hermes").map((s) => s.name);

--- a/extensions/connector-hermes/smoke/tool-parity.smoke.ts
+++ b/extensions/connector-hermes/smoke/tool-parity.smoke.ts
@@ -22,6 +22,11 @@ process.env.COTAL_NAME ||= "hermes-1";
 // suite opens no TCP connection to the value at all (verified against a listener that counted
 // zero accepts), so the line discloses a CONFIG input, not traffic. If that ever stops being
 // true, this line is already where a reader would look.
+// This file reaches CI by a DIFFERENT ROAD from its six siblings: it is not a `smoke:*` script
+// and no root script names it, so an audit that sweeps the `smoke:ci` chain concludes it is
+// unreachable. It runs through this package's own `test` script, which `pnpm -r --if-present
+// test` picks up — the repo's `test` root, invoked by `check` and by CI's unit job. Gated, just
+// not by the chain. Do not delete this pattern here on the grounds that the file looks dead.
 const brokerFromEnv = process.env.COTAL_SERVERS !== undefined;
 process.env.COTAL_SERVERS ||= "nats://127.0.0.1:4222";
 console.log(`• broker: ${process.env.COTAL_SERVERS} (${brokerFromEnv ? "INHERITED from the environment" : "suite default"})`);

--- a/extensions/connector-opencode/smoke/tool-input-closed.smoke.ts
+++ b/extensions/connector-opencode/smoke/tool-input-closed.smoke.ts
@@ -40,7 +40,16 @@ import { buildCotalTools } from "../src/tools.js";
 
 process.env.COTAL_SPACE ||= "toolclosed";
 process.env.COTAL_NAME ||= "oc-1";
+// `||=` KEEPS an already-set value, so this suite is loopback only where nothing set the
+// variable. In any shell that already exports COTAL_SERVERS — an agent's, an operator's — it
+// resolves to that instead, and an archived run gave no way to tell which. It names its target
+// now: a suite that names its target cannot silently change it. Measured, and true today: this
+// suite opens no TCP connection to the value at all (verified against a listener that counted
+// zero accepts), so the line discloses a CONFIG input, not traffic. If that ever stops being
+// true, this line is already where a reader would look.
+const brokerFromEnv = process.env.COTAL_SERVERS !== undefined;
 process.env.COTAL_SERVERS ||= "nats://127.0.0.1:4222";
+console.log(`• broker: ${process.env.COTAL_SERVERS} (${brokerFromEnv ? "INHERITED from the environment" : "suite default"})`);
 
 let failures = 0;
 const check = (label: string, ok: boolean, extra?: unknown): void => {

--- a/extensions/pi/smoke/tool-input-closed.smoke.ts
+++ b/extensions/pi/smoke/tool-input-closed.smoke.ts
@@ -30,7 +30,16 @@ import { registerCotalTools } from "../src/tools.js";
 
 process.env.COTAL_SPACE ||= "toolclosed";
 process.env.COTAL_NAME ||= "pi-1";
+// `||=` KEEPS an already-set value, so this suite is loopback only where nothing set the
+// variable. In any shell that already exports COTAL_SERVERS — an agent's, an operator's — it
+// resolves to that instead, and an archived run gave no way to tell which. It names its target
+// now: a suite that names its target cannot silently change it. Measured, and true today: this
+// suite opens no TCP connection to the value at all (verified against a listener that counted
+// zero accepts), so the line discloses a CONFIG input, not traffic. If that ever stops being
+// true, this line is already where a reader would look.
+const brokerFromEnv = process.env.COTAL_SERVERS !== undefined;
 process.env.COTAL_SERVERS ||= "nats://127.0.0.1:4222";
+console.log(`• broker: ${process.env.COTAL_SERVERS} (${brokerFromEnv ? "INHERITED from the environment" : "suite default"})`);
 
 let failures = 0;
 const check = (label: string, ok: boolean, extra?: unknown): void => {

--- a/package.json
+++ b/package.json
@@ -270,6 +270,7 @@
     "smoke:flag-inventory": "tsx bin/smoke/flag-inventory.smoke.ts",
     "smoke:start-overrides": "tsx implementations/manager/smoke/start-overrides.smoke.ts",
     "smoke:launch-parity": "tsx bin/smoke/launch-parity.smoke.ts",
+    "smoke:broker-disclosure": "tsx bin/smoke/broker-disclosure.smoke.ts",
     "smoke:spawn-detach:live": "tsx bin/smoke/spawn-detach-live.smoke.ts",
     "smoke:readiness:live": "tsx bin/smoke/readiness-window-live.smoke.ts",
     "smoke:setup-pure:live": "pnpm --filter @cotal-ai/workspace... build && tsx bin/smoke/setup-pure-live.smoke.ts",


### PR DESCRIPTION
Seven smokes carry `process.env.COTAL_SERVERS ||= "nats://127.0.0.1:4222"`. `||=` keeps an
already-set value, so they are loopback only where nothing exported the variable; in any shell
that already exports it, they resolve to whatever that shell holds. None of them printed it, and a
full run produced zero occurrences of `nats://`, `127.0.0.1:4222` or any host name, so an archived
run gave no way to say afterwards which broker it had been configured against.

They name it now, and say whether the value was inherited or defaulted:

```
• broker: nats://127.0.0.1:4222 (suite default)
• broker: nats://broker.example:4222 (INHERITED from the environment)
```

A suite that names its target cannot silently change it.

## Two things measured while doing it, both of which narrow the claim

**None of the seven dials the value.** Every one passes pointed at a blackhole address, and, in
the decisive form, a listener on the configured port counted zero TCP accepts for every suite.
`COTAL_SERVERS` here is a config input that `configFromEnv` requires to be set, not a broker these
suites connect to. So the printed line discloses configuration rather than traffic, and the
comment above it says exactly that instead of letting a reader infer connections that did not
happen. If that ever stops being true, the line is already where someone would look.

**It is seven files, not six**, and the seventh is interesting rather than merely missed.
`bin/smoke/launch-parity.smoke.ts` carries the same default and is not under `extensions/`, so a
census scoped to extension directories cannot see it.

## Two roads into CI, and the second one is worth stating

Six of the seven are `smoke:*` entries in the `smoke:ci` chain, one entry each.
`extensions/connector-hermes/smoke/tool-parity.smoke.ts` is not a `smoke:*` script at all, and no
root script names it. It runs through its own package's `test` script, which
`pnpm -r --if-present test` picks up: the repo's `test` root, invoked by `check` and by CI's unit
job. It is gated, just not by the chain, so an audit that sweeps `smoke:ci` concludes it is dead
code. That is now written above the line in the file itself, so nobody deletes the pattern from a
file they think nothing runs.

## One suite is not in this family, contrary to how it was first flagged

`implementations/manager/smoke/spawn-action.smoke.ts` does pass `servers:` into a `CotalEndpoint`
it spawns, which is a create rather than a connect, but the value is not ambient: it boots its own
`nats-server` on a free loopback port (`spawn-action.smoke.ts:55-56`, `:142`) and hands the child
`o.servers ?? SERVER` (`:86`). It never reads an inherited `COTAL_SERVERS`. Left alone.

## The disclosure is gated, so a deleted line is not silent

`bin/smoke/broker-disclosure.smoke.ts` (25 cells) grades the convention rather than any one suite:
every file that defaults `COTAL_SERVERS` with `||=` must also print what it resolved, and must
capture whether the value was inherited *before* the assignment destroys that evidence. It finds
the files by content rather than by directory, which is the only reason it finds seven. It is
wired to the unit job rather than the `smoke:ci` chain so that an in-flight change to the chain
lands without a rebase; `gate-inventory` counts a suite named in a workflow as reached.

`bin/smoke/mutations/broker-disclosure.json`, 10 of 10 killed, after two of them survived the
first run. Both survivals were the test's fault and were fixed there rather than by re-aiming:

* Scoping the census to `extensions/` reddened nothing. It *deleted* two cells. Every per-file
  cell is generated from the census, so a census that narrows produces a smaller suite that still
  exits 0. A guard whose coverage shrinks silently with its input is the same shape as an
  allowlist entry that has quietly stopped matching anything. The suite now asserts that the
  census spans more than one top-level directory, which is the property this finding was actually
  about.
* Dropping the ordering requirement changed no result, and correctly so: every real file is
  compliant, so nothing exercised it. A requirement that no input exercises cannot be proved by
  the corpus however large the corpus is. The suite now carries its own negative control, paired
  with a mutation that puts the same defect in a real file, so that the fixture proves the checker
  still looks and the pair proves it is looking at the repo.

## The check asked for the variable's name where the behaviour depends on its value

Found in review, reproduced against the suite's own checker, and closed here. The disclosure test
asked only that `process.env.COTAL_SERVERS` appear on the same line as `broker:`, which is one
character from present and inert: delete the `$` from `${process.env.COTAL_SERVERS}` and every cell
stays green while the line prints the literal text `{process.env.COTAL_SERVERS}` at runtime. A
hardcoded address with the variable left in a trailing comment passed the same way, and so did a
comma expression that names the variable and yields something else. The check now requires the
interpolation, and both accepted shapes are fixtures rather than an argument.

The census had the mirror of the same problem. Keyed on dot access alone it could not see
`process.env["COTAL_SERVERS"] ||=` or `??=`, which are the same assignment. A shape the census
cannot see is not rejected, it is never enumerated, and every per-file cell is generated from the
census, so the guard would lose cells rather than go red. That is the silent direction and it is
now closed; the loud direction is left alone on purpose, because a compliant file written in a
shape the check does not know goes red and says so.

It also counted itself. A census keyed on text cannot tell a call site from a fixture, and this
file is the one guaranteed to hold fixtures, so it published eight files defaulting the variable
where seven do and graded its own negative controls as though they were suites. The exclusion is
computed from the module's own URL rather than written as a path, so it cannot grow into an
allowlist, and a cell holds it to exactly one file, named.

Closing the members a review shows is not closing the family, and the second round proved it. With
the interpolation required anywhere on the line, parking it in a trailing comment and hardcoding
the address in the template still passed, and that is the plausible careless edit rather than a
contrived one: it is what somebody leaves behind after pinning an address to debug something. The
interpolation now has to be what follows `broker:`. In the same round the exclusion cell stopped
counting and started naming, because cardinality is not identity: repointing the carve-out at a
real suite kept the count at one, kept the census the same size, and silently stopped grading that
suite while this file walked in through its own compliant fixture.

A third round found the same family one level further down, and it is the cheapest of the three to
make by accident. The interpolation can be spelled correctly, sit exactly where the check wants it,
and print nothing, because the string around it is quoted rather than a template: `${...}` inside
`"..."` is six characters of text, so the line prints `${process.env.COTAL_SERVERS}` on every run
with the real address sitting unread in the environment. Both forms were run with the variable set
rather than reasoned about. Nobody sabotages a suite this way; it is what a tick-to-quote
conversion, or a rewrite toward concatenation, leaves behind. The check now requires the opening
backtick, a fixture holds the quoted form, and the predicted change that drops the requirement is
in the set.

What reading source cannot do is written down rather than implied, since a boundary nobody records
gets mistaken for coverage. This checks that the line is shaped like a disclosure; it cannot follow
evaluation, so a template that builds the value and then discards it stays accepted: a disclosing
template with a `.replace` chained onto it that overwrites the whole string. That one is deliberate
rather than careless, and closing it would mean executing repository source inside a guard. The
comma-expression form was the other, and requiring the backtick immediately after the `(` closed it
as a side effect, since that form opens with a parenthesis. It is recorded rather than quietly
enjoyed: a boundary that has moved and still reads as open is the same misreading as one nobody
wrote down.

## Still not included

Whether these suites should *refuse* a non-loopback host is a separate question this change
deliberately does not answer. The guard reads source, so it cannot observe a connection and does
not assert the measured result that none of them dials.




