### PR TITLE
fix(scripts): the mutation allowlist rejected keys a sibling tool reads

### DIFF
--- a/scripts/mutation-proof.mjs
+++ b/scripts/mutation-proof.mjs
@@ -120,7 +120,21 @@ const progressCount = (output, pattern) => {
 /** Keys a mutation may carry. An unknown key is an ERROR, not a shrug: this tool exists because
  *  every step of the experiment has a way to lie, and "the field I set was quietly ignored" is one
  *  of them — a mis-spelled `expectRed` turns a graded proof into an ungraded red. */
-const MUTATION_KEYS = new Set(["name", "file", "find", "replace", "expectRed", "command", "allowMultiple", "afterRestore"]);
+const MUTATION_KEYS = new Set([
+  "name", "file", "find", "replace", "expectRed", "command", "allowMultiple", "afterRestore",
+  // Read by `mutation-coverage.mjs`: the allowlist covers the toolchain, not this one file.
+  "cell", "note", "cellTemplate",
+]);
+
+/** Top-level config keys, checked for the same reason the mutation keys are. */
+const CONFIG_KEYS = new Set([
+  // Read here.
+  "command", "mutations", "progressPattern", "minTicks",
+  // Read by `mutation-coverage.mjs`.
+  "suite", "guard", "grades", "kind", "unkillable", "why", "proveWith",
+  // Read by nothing: prose for the next reader, listed so that is a stated property.
+  "completionMarker", "_note", "resolved", "redundant", "ungradable",
+]);
 
 function proveOne(m, opts) {
   const cwd = opts.cwd;
@@ -317,6 +331,8 @@ if (a.config) {
   // `resolve`, not `join`: an ABSOLUTE --config path joined to cwd becomes a nonexistent path under
   // the repo, and the tool dies on ENOENT with the two paths glued together.
   const cfg = JSON.parse(readFileSync(resolve(cwd, a.config), "utf8"));
+  const unknownCfg = Object.keys(cfg).filter((k) => !CONFIG_KEYS.has(k));
+  if (unknownCfg.length) usage(`config has unknown top-level key(s): ${unknownCfg.join(", ")}`);
   mutations = cfg.mutations ?? usage("config has no `mutations` array");
   opts = { ...opts, command: cfg.command ?? opts.command, progressPattern: cfg.progressPattern ?? opts.progressPattern, minTicks: cfg.minTicks ?? opts.minTicks };
 } else if (a.file && a.find !== undefined && a.replace !== undefined) {

--- a/scripts/mutation-proof.selftest.mjs
+++ b/scripts/mutation-proof.selftest.mjs
@@ -241,6 +241,23 @@ writeFileSync(
     mutations: [{ label: "typo: the key is `name`", file: "src/impl.js", find: "if (n > 10)", replace: "if (false)", expectRed: "oversized values are refused" }],
   }),
 );
+// A key a sibling tool reads is not an unknown key.
+writeFileSync(
+  join(root, "sibling-keys.json"),
+  JSON.stringify({
+    command: `${process.execPath} suite.mjs`,
+    mutations: [{ name: "carries the keys the coverage pass reads", file: "src/impl.js", find: "if (n > 10)", replace: "if (false)", expectRed: "the guard refuses an oversized value", cell: "the guard refuses an oversized value", note: "prose for the next reader" }],
+  }),
+);
+// ...and the control, because a widened allowlist that refuses nothing is a removal, not a fix.
+writeFileSync(
+  join(root, "unknown-top-key.json"),
+  JSON.stringify({
+    command: `${process.execPath} suite.mjs`,
+    complitionMarker: "a real typo of a real key",
+    mutations: [{ name: "fine", file: "src/impl.js", find: "if (n > 10)", replace: "if (false)", expectRed: "the guard refuses an oversized value" }],
+  }),
+);
 writeFileSync(
   join(root, "no-expect.json"),
   JSON.stringify({
@@ -483,6 +500,19 @@ check("afterRestore regenerates derived output from the RESTORED source",
 r = runTool(["--config", "unknown-key.json"]);
 check("an unknown mutation key is an ERROR, not a shrug",
   r.status !== 0 && r.stdout.includes("ERROR") && r.stdout.includes("unknown mutation key"), r.stdout.slice(-300));
+
+// The claim is exactly "these keys no longer make a mutation ungradable", so that is what this
+// asserts: no ERROR, and a real verdict reached. Which verdict depends on where in this file the
+// fixture sits and is not the property under test — asserting KILLED here would pin the fixture's
+// position rather than the allowlist.
+r = runTool(["--config", "sibling-keys.json"]);
+check("...but a key a SIBLING tool reads is not unknown, and the mutation is GRADED rather than refused",
+  !r.stdout.includes("unknown mutation key") && !r.stdout.includes("ERROR")
+    && /KILLED|SURVIVED|WRONG-RED|INCONCLUSIVE|UNGRADABLE/.test(r.stdout), r.stdout.slice(-300));
+
+r = runTool(["--config", "unknown-top-key.json"]);
+check("...and a mis-spelled TOP-LEVEL key is refused, at the level the silent ignore actually lived at",
+  r.status !== 0 && r.stdout.includes("complitionMarker"), r.stdout.slice(-300));
 
 // 7g. Mandatory since the first version's header, unenforced until now.
 r = runTool(["--config", "no-expect.json"]);

--- a/scripts/mutations/key-allowlist.json
+++ b/scripts/mutations/key-allowlist.json
@@ -1,0 +1,26 @@
+{
+  "grades": "tool",
+  "guard": "the allowlist admits the keys a sibling tool reads, and still refuses a mis-spelled one at BOTH levels",
+  "command": "node scripts/mutation-proof.selftest.mjs",
+  "progressPattern": "✓",
+  "why": "A widened allowlist that no longer refuses anything is a removal wearing a fix's commit message. Each mutation removes one half of the pair, and the cell it reddens is the half that would have gone silently missing.",
+  "mutations": [
+    {
+      "name": "the sibling tool's keys are rejected again",
+      "file": "scripts/mutation-proof.mjs",
+      "find": "  \"cell\", \"note\", \"cellTemplate\",\n",
+      "replace": "",
+      "expectRed": "...but a key a SIBLING tool reads is not unknown, and the mutation is GRADED rather than refused",
+      "cell": "...but a key a SIBLING tool reads is not unknown, and the mutation is GRADED rather than refused",
+      "note": "Restores the state this change fixes: configs carrying the coverage pass's keys grade ERROR instead of being graded."
+    },
+    {
+      "name": "the top-level check is dropped, leaving only the level that was never wrong",
+      "file": "scripts/mutation-proof.mjs",
+      "find": "  if (unknownCfg.length) usage(`config has unknown top-level key(s): ${unknownCfg.join(\", \")}`);\n",
+      "replace": "",
+      "expectRed": "...and a mis-spelled TOP-LEVEL key is refused, at the level the silent ignore actually lived at",
+      "cell": "...and a mis-spelled TOP-LEVEL key is refused, at the level the silent ignore actually lived at"
+    }
+  ]
+}


### PR DESCRIPTION
`mutation-proof.mjs` treats an unknown mutation key as an `ERROR` rather than ignoring it, because
"the field I set was quietly dropped" is one of the ways a mutation experiment lies: a mis-spelled
`expectRed` turns a graded proof into an ungraded red. The allowlist behind that check omitted
`cell`, `note` and `cellTemplate`, and all three are read by `mutation-coverage.mjs`, which grades
the same configs from the other side.

**14 of this repository's 30 mutations grade `ERROR` on `main` today**, every mutation in two of
the seven configs. Reproduced with a control: two configs identical but for those two fields, the
one carrying them errors, the one without reaches a graded verdict.

The reason it went unnoticed is worth stating, because it is the same shape as the defect. `ERROR`
is neither `KILLED` nor `SURVIVED`, so anything scanning the output for failures found none. A
grading tool that could not grade reported as nothing to report.

## The second half, which is the part that preserves the intent

Widening the allowlist alone would fix the symptom and remove the check's reason for existing. So
top-level config keys are now validated against their own allowlist too, and that is the level the
silent ignore was actually at: `completionMarker` is set by two configs in this repo and has never
been read by any version of this tool. The existing validation was watching the level where nothing
was wrong and skipping the one where a field really had been ignored since the day it was written.

Keys that no tool reads are listed as such, with a comment saying so, so "nothing reads this" is a
stated property rather than something you find out when setting it changes nothing.

## Proof

A widened allowlist that no longer refuses anything is a removal wearing a fix's commit message, so
the cells pin both directions:

- an unknown *mutation* key is still an `ERROR`, and still named
- a key a *sibling tool* reads is graded rather than refused
- a mis-spelled *top-level* key is refused, and the message names the key

Both new guards carry a predicted mutation in `scripts/mutations/key-allowlist.json`, and each
removes one half of the pair. Both are killed; the self-test is 29 checks, green.

The `sibling-keys` cell asserts "no `ERROR`, and a verdict was reached" rather than asserting a
particular verdict. Which verdict that fixture produces depends on where in the self-test it sits,
and that is not the property under test, pinning it would pin the fixture's position instead of
the allowlist.

## One gap this does not close

`mutation-proof:selftest` is a script but is not listed in `bin/smoke/ci-suites.txt`, so it does not
run in CI. None of these cells, nor the ones added to that file recently, are protected against
regression yet. Left out of this change deliberately: this PR's job is to unbreak the tool, and a
separate branch already adds a chain entry for it.

