### PR TITLE
test(manager): guard that a describe/invoke split causes at most one effect

### DIFF
--- a/.changeset/describe-split-effect-guard.md
+++ b/.changeset/describe-split-effect-guard.md
@@ -1,0 +1,6 @@
+---
+---
+
+Test-only: adds a live probe that a describe/invoke class-queue split causes at most one
+effect, and converts it from characterising the duplicate to guarding the fence that closed
+it. No shipped behaviour changes, so no release.

--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -257,3 +257,4 @@ smoke:bind-fence:live
 smoke:claude-launch-model
 smoke:ci-suites
 smoke:membership-feed:auth
+smoke:describe-split-effect

--- a/implementations/manager/smoke/describe-split-duplicate-effect.smoke.ts
+++ b/implementations/manager/smoke/describe-split-duplicate-effect.smoke.ts
@@ -1,39 +1,19 @@
 /**
  * DESCRIBE/INVOKE SPLIT — DUPLICATE EFFECT ON THE CLASS QUEUE (live repro).
  *
- * The mechanism, all of it in core:
- *  1. `invokeService` resolves an endpoint once and CACHES the resolved service, binding the
- *     describe winner's instance (`endpoint.ts` resolve cache).
- *  2. An unpinned invoke routes to the class `one` queue, which picks its own winner — the describe
- *     and the invoke are two independent trips through the same anycast, so in a multi-instance
- *     space they land on different instances on an ordinary, correct request.
- *  3. `describeBound` is handed to `epCall` as its `currentEpoch` hook, and `epCall` calls it
- *     AFTER the reply lands. So when instance B answers a handle resolved against A, B HAS ALREADY
- *     EXECUTED THE COMMAND when the `failed-precondition` is raised.
- *  4. `invokeService` catches exactly that code, drops the cache, re-resolves and re-invokes WITH
- *     THE SAME ARGS. The refusal is never surfaced; the caller sees the second attempt's outcome.
+ * A resolved handle binds the describe winner's instance; an unpinned invoke goes to the class
+ * queue, which picks its own. The currency check runs AFTER the reply lands, so a non-matching
+ * responder has already executed the command when `failed-precondition` is raised, and
+ * `invokeService` re-invokes with the same args — for a write, a duplicate the caller cannot see.
  *
- * For a read this is waste. For a WRITE it is a duplicate effect the caller cannot see, and the
- * manager already registers writes on this rail (`spawn`, `despawn`, `purge`, `launch`, the resume
- * family, and the one used here).
+ * `define-persona`, never `spawn`: a duplicated `spawn` starts a second real agent process.
  *
- * WHY `define-persona` AND NOT `spawn`: a duplicated `spawn` starts a second real agent process.
- * `define-persona` is the most benign write on this surface — it writes one small file and nothing
- * else, a repeat is not destructive, and it rides the SAME `invokeService` path, the same class
- * queue and the same post-reply currency hook. It is admitted by the same `spawn` capability
- * (`SPAWN_SERVICE_COMMANDS`).
- *
- * THE EFFECT IS COUNTED AT THE RESPONDER, NOT AT THE CALLER — the whole defect is that the caller's
- * view is wrong, so the caller cannot be the instrument. Each manager writes personas into its OWN
- * workspace root, so one persona name present in BOTH roots is direct proof the command executed on
- * BOTH instances.
- *
- * This UNDERCOUNTS deliberately: a retry that lands on the same instance executes twice and leaves
- * one file. Every number here is therefore a floor, which is the safe direction for a defect claim.
+ * Effects are counted at the RESPONDERS because the caller's view is what is under test — each
+ * manager writes personas into its own root, so one name in BOTH roots proves it ran twice. This
+ * undercounts (a retry landing on the same instance leaves one file), so every number is a floor.
  *
  * Run: pnpm smoke:describe-split-effect   (needs nats-server on PATH; boots its own broker)
- */
-import { randomUUID } from "node:crypto";
+ */import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createServer, type AddressInfo } from "node:net";
@@ -47,10 +27,8 @@ import { authDir, saveSpaceAuth, recordMesh } from "@cotal-ai/workspace";
 import { Manager } from "../src/manager.js";
 import { MANAGER_ENDPOINT } from "../src/manager-service-contract.js";
 
-// The responder fence's marker, as a LITERAL and deliberately not imported: this harness must run
-// unchanged on tips that predate the fence (where the constant does not exist) so the two can be
-// compared by the same instrument. An import here would make the probe refuse to load on exactly
-// the tip it is the baseline for.
+// A literal, not an import: the constant does not exist on tips predating the fence, and an import
+// would make this probe refuse to load on the very tip it is the baseline for.
 const EP_BIND_REFUSED = "ai.cotal.ep.bind-refused";
 
 const freePort = (): Promise<number> =>
@@ -62,8 +40,7 @@ const freePort = (): Promise<number> =>
 const PORT = await freePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
 
-// FIRST ACTION: scrub inherited live-broker pointers, then verify the scrub held. This probe
-// performs WRITES; it must never be able to reach a real mesh.
+// This probe performs WRITES; it must never be able to reach a real mesh.
 const LIVE_HOST = "broker.cotal.ai";
 for (const k of ["COTAL_SERVERS", "COTAL_SERVER", "COTAL_CREDS", "COTAL_SPACE"]) delete process.env[k];
 for (const [k, v] of Object.entries(process.env))
@@ -121,8 +98,7 @@ try {
     card: { name: "epsplit-caller", owner: DEV_OWNER, actor: id.id, kind: "endpoint" },
   });
   ep.on("error", () => {});
-  // The fence's repair path emits this when it re-resolves and re-issues a bind-refused call. On a
-  // tip that predates the fence the event simply never fires, which keeps one instrument on both.
+  // Emitted by the fence's repair path; never fires on a pre-fence tip, so one instrument grades both.
   let recoveriesThisTrial = 0, recoveriesTotal = 0;
   ep.on("split-recovered", () => { recoveriesThisTrial++; recoveriesTotal++; });
   await ep.start();
@@ -207,17 +183,9 @@ try {
     console.log(`never produced a split at all, and the harness did not reach the condition.`);
   }
 
-  // The claim under test is that a duplicate CAN occur and is invisible. Assert exactly that, and
-  // nothing about a fix: no remedy is adopted, so there is no post-fix state to gate here.
-  // A ZERO IS ONLY EVIDENCE IF A SPLIT ACTUALLY HAPPENED. The three observable signatures of a
-  // split are tip-dependent and this probe must grade both tips with one rule: a duplicate (no
-  // fence, retry crossed instances), a throw (no fence, the second attempt also mismatched), or a
-  // `bind-refused` refusal (fence present, refused before the handler). If ALL THREE are zero the
-  // queue never split during this run and it grades nothing - which is NOT the same as the defect
-  // being absent, and must not be reported as if it were.
-  //
-  // Keyed on the union rather than on the fence marker alone, because the marker cannot exist on a
-  // pre-fence tip: gating on it would label every clean baseline run "unfalsifiable".
+  // A zero is only evidence if a split actually happened, and the signatures differ by tip:
+  // duplicate, throw, or bind-refused. All three zero means the queue never split and this run
+  // grades nothing — which is not the same as the defect being absent.
   const splitSeen = dupes.length + trials.filter((t) => t.callerSaw === "throw").length + bindRefused;
   if (splitSeen === 0) {
     fail++;

--- a/implementations/manager/smoke/describe-split-duplicate-effect.smoke.ts
+++ b/implementations/manager/smoke/describe-split-duplicate-effect.smoke.ts
@@ -1,10 +1,16 @@
 /**
- * DESCRIBE/INVOKE SPLIT — DUPLICATE EFFECT ON THE CLASS QUEUE (live repro).
+ * DESCRIBE/INVOKE SPLIT — NO DUPLICATE EFFECT ON THE CLASS QUEUE (live regression guard).
  *
  * A resolved handle binds the describe winner's instance; an unpinned invoke goes to the class
- * queue, which picks its own. The currency check runs AFTER the reply lands, so a non-matching
- * responder has already executed the command when `failed-precondition` is raised, and
- * `invokeService` re-invokes with the same args — for a write, a duplicate the caller cannot see.
+ * queue, which picks its own. While the currency check ran only AFTER the reply landed, a
+ * non-matching responder had already executed the command when `failed-precondition` was raised,
+ * and `invokeService` re-invoked with the same args — for a write, a duplicate the caller could not
+ * see. This probe first reproduced that; the pre-effect fence closed it, and the probe now holds it
+ * closed. It grades either tip: on an unfenced one the duplicates return and it fails.
+ *
+ * What it asserts is the CALLER-VISIBLE contract, not the mechanism: one request causes at most one
+ * effect, and a request that caused none says so conclusively. A remedy that keeps that promise by
+ * other means passes, which is the point — it is a guard, not a mirror of the implementation.
  *
  * `define-persona`, never `spawn`: a duplicated `spawn` starts a second real agent process.
  *
@@ -110,6 +116,14 @@ try {
     callerSaw: "ok" | "app-error" | "throw";
     detail: string;
     repairs: number;
+    /** The refusal said the command did not run — the marker AND `not-executed` together, because
+     *  the marker is this implementation's vocabulary and the outcome is the spec's, and only the
+     *  outcome licenses a caller to conclude that no effect exists. */
+    refusedBeforeEffect: boolean;
+    /** The failure said whether its effect landed, either way. §13.3 reads an ABSENT outcome as
+     *  `unknown`, so absence is the caller being left unable to tell — which is the condition this
+     *  whole class of defect consists of, duplicate or not. */
+    outcomeStated: boolean;
   };
   const trials: Trial[] = [];
   let bindRefused = 0;
@@ -119,6 +133,8 @@ try {
     const name = `epsplit-${i}`;
     let callerSaw: Trial["callerSaw"] = "ok";
     let detail = "";
+    let refusedBeforeEffect = false;
+    let outcomeStated = true;
     recoveriesThisTrial = 0;
     try {
       const r = await ep.invokeService(MANAGER_ENDPOINT, "define-persona",
@@ -129,20 +145,37 @@ try {
         const err = r.reply.error as { code?: string; outcome?: string; details?: Array<{ kind?: string }> } | undefined;
         const marks = (err?.details ?? []).map((d) => d.kind).filter(Boolean);
         if (marks.includes(EP_BIND_REFUSED)) bindRefused++;
+        refusedBeforeEffect = marks.includes(EP_BIND_REFUSED) && err?.outcome === "not-executed";
+        outcomeStated = err?.outcome !== undefined;
         detail = `${err?.code ?? "?"}|outcome=${err?.outcome ?? "(absent)"}|${marks.join(",") || "(no details)"}`;
       }
     } catch (e) {
       callerSaw = "throw";
-      detail = e instanceof EpEnvelopeError ? e.code : (e as Error).message.slice(0, 40);
+      // The marker arrives on THIS path too: a failed re-issue rethrows the ORIGINAL refusal, so
+      // reading marks only off `ok:false` replies undercounts the fence to zero on exactly the
+      // trials where it fired twice.
+      const marks = (e instanceof EpEnvelopeError ? e.details ?? [] : []).map((d) => d.kind).filter(Boolean);
+      if (marks.includes(EP_BIND_REFUSED)) bindRefused++;
+      refusedBeforeEffect = marks.includes(EP_BIND_REFUSED) && (e as EpEnvelopeError).outcome === "not-executed";
+      outcomeStated = e instanceof EpEnvelopeError && e.outcome !== undefined;
+      detail = e instanceof EpEnvelopeError
+        ? `${e.code}|outcome=${e.outcome ?? "(absent)"}|${marks.join(",") || "(no details)"}`
+        : (e as Error).message.slice(0, 60);
     }
     const inRoot1 = existsSync(agentFilePath(root1, name));
     const inRoot2 = existsSync(agentFilePath(root2, name));
-    trials.push({ i, name, inRoot1, inRoot2, both: inRoot1 && inRoot2, callerSaw, detail, repairs: recoveriesThisTrial });
+    trials.push({ i, name, inRoot1, inRoot2, both: inRoot1 && inRoot2, callerSaw, detail, repairs: recoveriesThisTrial, refusedBeforeEffect, outcomeStated });
   }
 
+  // CONSERVATION, and it replaces "every trial produced an effect somewhere". That older invariant
+  // was true only while the split was unfenced: once a responder can refuse before running, a call
+  // that splits TWICE legitimately produces no effect at all and says so, and demanding an effect
+  // would fail the fixed tip for doing the right thing. What must hold on any correct tip is that
+  // no trial goes unaccounted: exactly one effect, or a refusal that states nothing ran.
   const answered = trials.filter((t) => t.inRoot1 || t.inRoot2);
-  check("every trial produced an effect somewhere (the sample is valid; no silently lost trials)",
-    answered.length === N, { answered: answered.length, N });
+  const accounted = trials.filter((t) => (t.inRoot1 || t.inRoot2) || t.refusedBeforeEffect);
+  check("CONSERVATION: every trial is accounted for — an effect, or a refusal stating it did not run",
+    accounted.length === N, { accounted: accounted.length, effects: answered.length, N });
 
   const dupes = trials.filter((t) => t.both);
   const dupeSilent = dupes.filter((t) => t.callerSaw === "ok");
@@ -160,6 +193,11 @@ try {
   console.log(`                (D = duplicate across both instances, a/b = single effect, - = none)`);
 
   console.log(`     refusals carrying ${EP_BIND_REFUSED}: ${bindRefused}`);
+  // WHICH refusal, not just how many: a count of zero cannot distinguish "the fence never fired"
+  // from "it fired in a shape this probe does not recognise", and those call for opposite work.
+  const byDetail = new Map<string, number>();
+  for (const t of trials) if (t.detail !== "A" && t.detail !== "B") byDetail.set(t.detail, (byDetail.get(t.detail) ?? 0) + 1);
+  for (const [d, n] of [...byDetail].sort((x, y) => y[1] - x[1])) console.log(`       ${n}x ${d}`);
   const repaired = trials.filter((t) => t.repairs > 0);
   const repairedOk = repaired.filter((t) => t.callerSaw === "ok");
   console.log(`\n3. the repair path, measured on a LIVE contended queue (not a constructed re-seed)`);
@@ -171,32 +209,46 @@ try {
 
   console.log(`\n=== FINDING ===`);
   if (dupes.length > 0) {
-    console.log(`REPRODUCED. ${dupes.length}/${N} trials executed the SAME write on BOTH instances.`);
-    console.log(`${dupeSilent.length} of those returned success to the caller, which therefore has no`);
-    console.log(`way to know the write ran twice. The effect count is a FLOOR: a retry landing on the`);
-    console.log(`same instance executes twice and leaves one file, and is not counted here.`);
+    console.log(`REGRESSED. ${dupes.length}/${N} trials executed the SAME write on BOTH instances,`);
+    console.log(`${dupeSilent.length} of them while telling the caller "ok". A responder is not refusing before`);
+    console.log(`the command runs. The count is a FLOOR: a retry landing back on the same instance`);
+    console.log(`executes twice and leaves one file, and is not counted here.`);
   } else {
-    console.log(`NOT REPRODUCED in ${N} trials — no trial wrote to both roots.`);
-    console.log(`This does NOT establish that the mechanism cannot fire. Distinguish the two cases`);
-    console.log(`from the per-trial line above: a healthy mix of a/b means the queue really did split`);
-    console.log(`and the retry still never crossed instances; an all-a or all-b line means this run`);
-    console.log(`never produced a split at all, and the harness did not reach the condition.`);
+    console.log(`HELD. No trial wrote to both roots in ${N} trials, and ${bindRefused} split(s) were refused`);
+    console.log(`before the command ran. The duplicate this probe was written to reproduce does not occur.`);
   }
 
-  // A zero is only evidence if a split actually happened, and the signatures differ by tip:
-  // duplicate, throw, or bind-refused. All three zero means the queue never split and this run
+  // A zero is only evidence if a split actually happened, and the signature differs by tip: on an
+  // unfenced tip a split shows as a duplicate or a throw; on a fenced one as a bind-refused refusal
+  // or a recovery that healed it invisibly. All four zero means the queue never split and this run
   // grades nothing — which is not the same as the defect being absent.
-  const splitSeen = dupes.length + trials.filter((t) => t.callerSaw === "throw").length + bindRefused;
+  const splitSeen = dupes.length + trials.filter((t) => t.callerSaw === "throw").length + bindRefused + recoveriesTotal;
   if (splitSeen === 0) {
     fail++;
     console.log(`  \u2717 FAIL: GRADES NOTHING - no duplicate, no throw, no ${EP_BIND_REFUSED} refusal.`);
     console.log(`     The class queue never split in these ${N} trials, so this run is evidence about`);
     console.log(`     neither the defect nor any remedy. Re-run; do not read it as absence.`);
   }
-  check("DEFECT PRESENT: at least one write executed on both instances for one caller request",
-    dupes.length > 0, { dupes: dupes.length, N });
-  check("DEFECT IS SILENT: at least one duplicated write returned success to the caller",
-    dupeSilent.length > 0, { dupeSilent: dupeSilent.length });
+  check("NO DUPLICATE EFFECT: no caller request executed the same write on both instances",
+    dupes.length === 0, { dupes: dupes.length, N });
+  check("NO SILENT DUPLICATE: no duplicated write was reported to the caller as success",
+    dupeSilent.length === 0, { dupeSilent: dupeSilent.length });
+  // The marker without the outcome is what makes two implementations disagree about whether the
+  // command ran, so a refusal carrying only one of the pair is a defect even with nothing
+  // duplicated. Vacuous when the queue never split — which the grades-nothing guard above forbids.
+  const markedButUnstated = trials.filter((t) => t.detail.includes(EP_BIND_REFUSED) && !t.refusedBeforeEffect);
+  check("REFUSALS ARE CONCLUSIVE: every fence refusal also states `not-executed`",
+    markedButUnstated.length === 0, markedButUnstated.map((t) => t.detail));
+
+  // THE ASSERTION THAT IS SENSITIVE TO THE FENCE ITSELF. Removing the pre-effect refusal does not
+  // bring the duplicate back on its own — the caller-side repair still collapses it — so the two
+  // checks above pass on a tip whose responder never fences. What returns is this: the split is
+  // reported AFTER the command ran, as `failed-precondition` with NO outcome, which §13.3 says a
+  // caller must read as `unknown`. The effect landed and the caller is told only that it failed.
+  // Measured: with the fence neutered, 15/24 failures arrive this way and zero duplicates do.
+  const inconclusive = trials.filter((t) => t.callerSaw !== "ok" && !t.outcomeStated);
+  check("NO INCONCLUSIVE FAILURE: every failed call states whether its effect landed",
+    inconclusive.length === 0, { inconclusive: inconclusive.length, sample: inconclusive[0]?.detail });
 
   console.log(`\n${fail === 0 ? "PASS" : "FAIL"} — ${pass} passed, ${fail} failed`);
 } finally {

--- a/implementations/manager/smoke/describe-split-duplicate-effect.smoke.ts
+++ b/implementations/manager/smoke/describe-split-duplicate-effect.smoke.ts
@@ -121,6 +121,10 @@ try {
     card: { name: "epsplit-caller", owner: DEV_OWNER, actor: id.id, kind: "endpoint" },
   });
   ep.on("error", () => {});
+  // The fence's repair path emits this when it re-resolves and re-issues a bind-refused call. On a
+  // tip that predates the fence the event simply never fires, which keeps one instrument on both.
+  let recoveriesThisTrial = 0, recoveriesTotal = 0;
+  ep.on("split-recovered", () => { recoveriesThisTrial++; recoveriesTotal++; });
   await ep.start();
 
   const N = 24;
@@ -129,6 +133,7 @@ try {
     inRoot1: boolean; inRoot2: boolean; both: boolean;
     callerSaw: "ok" | "app-error" | "throw";
     detail: string;
+    repairs: number;
   };
   const trials: Trial[] = [];
   let bindRefused = 0;
@@ -138,6 +143,7 @@ try {
     const name = `epsplit-${i}`;
     let callerSaw: Trial["callerSaw"] = "ok";
     let detail = "";
+    recoveriesThisTrial = 0;
     try {
       const r = await ep.invokeService(MANAGER_ENDPOINT, "define-persona",
         { name, persona: `probe persona ${i}` }, { deadlineMs: 15_000 });
@@ -155,7 +161,7 @@ try {
     }
     const inRoot1 = existsSync(agentFilePath(root1, name));
     const inRoot2 = existsSync(agentFilePath(root2, name));
-    trials.push({ i, name, inRoot1, inRoot2, both: inRoot1 && inRoot2, callerSaw, detail });
+    trials.push({ i, name, inRoot1, inRoot2, both: inRoot1 && inRoot2, callerSaw, detail, repairs: recoveriesThisTrial });
   }
 
   const answered = trials.filter((t) => t.inRoot1 || t.inRoot2);
@@ -178,6 +184,14 @@ try {
   console.log(`                (D = duplicate across both instances, a/b = single effect, - = none)`);
 
   console.log(`     refusals carrying ${EP_BIND_REFUSED}: ${bindRefused}`);
+  const repaired = trials.filter((t) => t.repairs > 0);
+  const repairedOk = repaired.filter((t) => t.callerSaw === "ok");
+  console.log(`\n3. the repair path, measured on a LIVE contended queue (not a constructed re-seed)`);
+  console.log(`     trials where a re-issue was attempted:  ${repaired.length}`);
+  console.log(`     ...that HEALED into a success:          ${repairedOk.length}`);
+  console.log(`     ...that split AGAIN and surfaced:       ${repaired.length - repairedOk.length}`);
+  console.log(`     self-heal rate: ${repaired.length === 0 ? "n/a (no repair attempted)" : `${((repairedOk.length / repaired.length) * 100).toFixed(0)}%`}`);
+  console.log(`     total recoveries emitted: ${recoveriesTotal}`);
 
   console.log(`\n=== FINDING ===`);
   if (dupes.length > 0) {

--- a/implementations/manager/smoke/describe-split-duplicate-effect.smoke.ts
+++ b/implementations/manager/smoke/describe-split-duplicate-effect.smoke.ts
@@ -47,6 +47,12 @@ import { authDir, saveSpaceAuth, recordMesh } from "@cotal-ai/workspace";
 import { Manager } from "../src/manager.js";
 import { MANAGER_ENDPOINT } from "../src/manager-service-contract.js";
 
+// The responder fence's marker, as a LITERAL and deliberately not imported: this harness must run
+// unchanged on tips that predate the fence (where the constant does not exist) so the two can be
+// compared by the same instrument. An import here would make the probe refuse to load on exactly
+// the tip it is the baseline for.
+const EP_BIND_REFUSED = "ai.cotal.ep.bind-refused";
+
 const freePort = (): Promise<number> =>
   new Promise((res, rej) => {
     const s = createServer();
@@ -125,6 +131,7 @@ try {
     detail: string;
   };
   const trials: Trial[] = [];
+  let bindRefused = 0;
 
   console.log(`\n1. ${N} describe+invoke trials of the write \`define-persona\`, two live managers`);
   for (let i = 0; i < N; i++) {
@@ -135,7 +142,13 @@ try {
       const r = await ep.invokeService(MANAGER_ENDPOINT, "define-persona",
         { name, persona: `probe persona ${i}` }, { deadlineMs: 15_000 });
       if (r.reply.ok === true) { callerSaw = "ok"; detail = r.responder.instanceId === IID1 ? "A" : "B"; }
-      else { callerSaw = "app-error"; detail = r.reply.error?.code ?? "?"; }
+      else {
+        callerSaw = "app-error";
+        const err = r.reply.error as { code?: string; outcome?: string; details?: Array<{ kind?: string }> } | undefined;
+        const marks = (err?.details ?? []).map((d) => d.kind).filter(Boolean);
+        if (marks.includes(EP_BIND_REFUSED)) bindRefused++;
+        detail = `${err?.code ?? "?"}|outcome=${err?.outcome ?? "(absent)"}|${marks.join(",") || "(no details)"}`;
+      }
     } catch (e) {
       callerSaw = "throw";
       detail = e instanceof EpEnvelopeError ? e.code : (e as Error).message.slice(0, 40);
@@ -164,6 +177,8 @@ try {
   console.log(`     per-trial: ${trials.map((t) => (t.both ? "D" : t.inRoot1 ? "a" : t.inRoot2 ? "b" : "-")).join("")}`);
   console.log(`                (D = duplicate across both instances, a/b = single effect, - = none)`);
 
+  console.log(`     refusals carrying ${EP_BIND_REFUSED}: ${bindRefused}`);
+
   console.log(`\n=== FINDING ===`);
   if (dupes.length > 0) {
     console.log(`REPRODUCED. ${dupes.length}/${N} trials executed the SAME write on BOTH instances.`);
@@ -180,6 +195,22 @@ try {
 
   // The claim under test is that a duplicate CAN occur and is invisible. Assert exactly that, and
   // nothing about a fix: no remedy is adopted, so there is no post-fix state to gate here.
+  // A ZERO IS ONLY EVIDENCE IF A SPLIT ACTUALLY HAPPENED. The three observable signatures of a
+  // split are tip-dependent and this probe must grade both tips with one rule: a duplicate (no
+  // fence, retry crossed instances), a throw (no fence, the second attempt also mismatched), or a
+  // `bind-refused` refusal (fence present, refused before the handler). If ALL THREE are zero the
+  // queue never split during this run and it grades nothing - which is NOT the same as the defect
+  // being absent, and must not be reported as if it were.
+  //
+  // Keyed on the union rather than on the fence marker alone, because the marker cannot exist on a
+  // pre-fence tip: gating on it would label every clean baseline run "unfalsifiable".
+  const splitSeen = dupes.length + trials.filter((t) => t.callerSaw === "throw").length + bindRefused;
+  if (splitSeen === 0) {
+    fail++;
+    console.log(`  \u2717 FAIL: GRADES NOTHING - no duplicate, no throw, no ${EP_BIND_REFUSED} refusal.`);
+    console.log(`     The class queue never split in these ${N} trials, so this run is evidence about`);
+    console.log(`     neither the defect nor any remedy. Re-run; do not read it as absence.`);
+  }
   check("DEFECT PRESENT: at least one write executed on both instances for one caller request",
     dupes.length > 0, { dupes: dupes.length, N });
   check("DEFECT IS SILENT: at least one duplicated write returned success to the caller",

--- a/implementations/manager/smoke/describe-split-duplicate-effect.smoke.ts
+++ b/implementations/manager/smoke/describe-split-duplicate-effect.smoke.ts
@@ -177,6 +177,42 @@ try {
   check("CONSERVATION: every trial is accounted for — an effect, or a refusal stating it did not run",
     accounted.length === N, { accounted: accounted.length, effects: answered.length, N });
 
+  // THE SPLIT, FORCED. Everything above waits for the class queue to hand the invoke to someone
+  // other than the describe winner, which is the run's luck and not this fixture's choice — so on
+  // its own this probe can decline to grade, and a suite that declines is not chain-safe.
+  //
+  // Here the bind is made to name an incarnation that CANNOT be serving: the handle's cached
+  // resolve is rewritten to a freshly minted lifecycle id belonging to no manager. Every responder
+  // is then the wrong one, so the pre-effect refusal is not raced for — it is guaranteed. This
+  // needs a valid lifecycle token, not a nonsense string: the responder parses `bind.instanceId`
+  // before comparing it, and a malformed one is refused as bad-request by a different path
+  // entirely, which would prove nothing about the fence.
+  const cache = (ep as unknown as { resolvedServices: Map<string, { responder: { instanceId: string; epoch: number } }> }).resolvedServices;
+  const bound = cache.get(MANAGER_ENDPOINT);
+  check("the caller holds a resolved handle to rewrite (the forced case can be set up at all)",
+    bound !== undefined, { cached: [...cache.keys()] });
+  let forcedRecoveries = 0, forcedEffects = 0, forcedOk = false;
+  if (bound !== undefined) {
+    bound.responder.instanceId = mintLifecycleUid();
+    const forcedName = `epsplit-forced-${randomUUID().slice(0, 6)}`;
+    recoveriesThisTrial = 0;
+    try {
+      const r = await ep.invokeService(MANAGER_ENDPOINT, "define-persona",
+        { name: forcedName, persona: "forced-split probe" }, { deadlineMs: 15_000 });
+      forcedOk = r.reply.ok === true;
+    } catch { forcedOk = false; }
+    forcedRecoveries = recoveriesThisTrial;
+    forcedEffects = [root1, root2].filter((r) => existsSync(agentFilePath(r, forcedName))).length;
+  }
+  console.log(`\n1b. the split FORCED rather than awaited (bind names a non-serving incarnation)`);
+  console.log(`     pre-effect refusals repaired: ${forcedRecoveries}   effects: ${forcedEffects}   caller saw ok: ${forcedOk}`);
+  // A recovery is emitted ONLY on a reply the caller read as refused-before-effect, so counting one
+  // proves the responder produced the marked refusal — this is the fence, observed and not inferred.
+  check("FORCED SPLIT IS FENCED: the wrongly-bound call was refused before it ran, then repaired",
+    forcedRecoveries === 1, { forcedRecoveries });
+  check("FORCED SPLIT LEAVES ONE EFFECT: the repair re-issued once and the write landed exactly once",
+    forcedEffects === 1 && forcedOk, { forcedEffects, forcedOk });
+
   const dupes = trials.filter((t) => t.both);
   const dupeSilent = dupes.filter((t) => t.callerSaw === "ok");
 
@@ -220,8 +256,13 @@ try {
 
   // A zero is only evidence if a split actually happened, and the signature differs by tip: on an
   // unfenced tip a split shows as a duplicate or a throw; on a fenced one as a bind-refused refusal
-  // or a recovery that healed it invisibly. All four zero means the queue never split and this run
-  // grades nothing — which is not the same as the defect being absent.
+  // or a recovery that healed it invisibly. All zero means the queue never split and the natural
+  // sample grades nothing — which is not the same as the defect being absent.
+  //
+  // `recoveriesTotal` includes the FORCED case, which is the point: the forced split does not
+  // depend on the run's luck, so this suite can no longer reach the state where it declines to
+  // answer. The guard stays because it still distinguishes "the natural sample was thin" from
+  // "the fixture is broken" — if even the forced split leaves no trace, nothing here is graded.
   const splitSeen = dupes.length + trials.filter((t) => t.callerSaw === "throw").length + bindRefused + recoveriesTotal;
   if (splitSeen === 0) {
     fail++;

--- a/implementations/manager/smoke/describe-split-duplicate-effect.smoke.ts
+++ b/implementations/manager/smoke/describe-split-duplicate-effect.smoke.ts
@@ -1,0 +1,196 @@
+/**
+ * DESCRIBE/INVOKE SPLIT — DUPLICATE EFFECT ON THE CLASS QUEUE (live repro).
+ *
+ * The mechanism, all of it in core:
+ *  1. `invokeService` resolves an endpoint once and CACHES the resolved service, binding the
+ *     describe winner's instance (`endpoint.ts` resolve cache).
+ *  2. An unpinned invoke routes to the class `one` queue, which picks its own winner — the describe
+ *     and the invoke are two independent trips through the same anycast, so in a multi-instance
+ *     space they land on different instances on an ordinary, correct request.
+ *  3. `describeBound` is handed to `epCall` as its `currentEpoch` hook, and `epCall` calls it
+ *     AFTER the reply lands. So when instance B answers a handle resolved against A, B HAS ALREADY
+ *     EXECUTED THE COMMAND when the `failed-precondition` is raised.
+ *  4. `invokeService` catches exactly that code, drops the cache, re-resolves and re-invokes WITH
+ *     THE SAME ARGS. The refusal is never surfaced; the caller sees the second attempt's outcome.
+ *
+ * For a read this is waste. For a WRITE it is a duplicate effect the caller cannot see, and the
+ * manager already registers writes on this rail (`spawn`, `despawn`, `purge`, `launch`, the resume
+ * family, and the one used here).
+ *
+ * WHY `define-persona` AND NOT `spawn`: a duplicated `spawn` starts a second real agent process.
+ * `define-persona` is the most benign write on this surface — it writes one small file and nothing
+ * else, a repeat is not destructive, and it rides the SAME `invokeService` path, the same class
+ * queue and the same post-reply currency hook. It is admitted by the same `spawn` capability
+ * (`SPAWN_SERVICE_COMMANDS`).
+ *
+ * THE EFFECT IS COUNTED AT THE RESPONDER, NOT AT THE CALLER — the whole defect is that the caller's
+ * view is wrong, so the caller cannot be the instrument. Each manager writes personas into its OWN
+ * workspace root, so one persona name present in BOTH roots is direct proof the command executed on
+ * BOTH instances.
+ *
+ * This UNDERCOUNTS deliberately: a retry that lands on the same instance executes twice and leaves
+ * one file. Every number here is therefore a floor, which is the safe direction for a defect claim.
+ *
+ * Run: pnpm smoke:describe-split-effect   (needs nats-server on PATH; boots its own broker)
+ */
+import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  isReachable, createSpaceAuth, serverConfig, setupSpaceStreams, mintCreds, newIdentity,
+  mintLifecycleUid, DEV_OWNER, agentFilePath, CotalEndpoint, EpEnvelopeError,
+} from "@cotal-ai/core";
+import { authDir, saveSpaceAuth, recordMesh } from "@cotal-ai/workspace";
+import { Manager } from "../src/manager.js";
+import { MANAGER_ENDPOINT } from "../src/manager-service-contract.js";
+
+const freePort = (): Promise<number> =>
+  new Promise((res, rej) => {
+    const s = createServer();
+    s.on("error", rej);
+    s.listen(0, "127.0.0.1", () => { const p = (s.address() as AddressInfo).port; s.close(() => res(p)); });
+  });
+const PORT = await freePort();
+const SERVERS = `nats://127.0.0.1:${PORT}`;
+
+// FIRST ACTION: scrub inherited live-broker pointers, then verify the scrub held. This probe
+// performs WRITES; it must never be able to reach a real mesh.
+const LIVE_HOST = "broker.cotal.ai";
+for (const k of ["COTAL_SERVERS", "COTAL_SERVER", "COTAL_CREDS", "COTAL_SPACE"]) delete process.env[k];
+for (const [k, v] of Object.entries(process.env))
+  if (typeof v === "string" && v.includes(LIVE_HOST)) throw new Error(`refusing to run: ${k} points at the live broker (${v})`);
+if (!/^nats:\/\/127\.0\.0\.1:\d+$/.test(SERVERS)) throw new Error(`this probe only runs against an ephemeral loopback broker; got ${SERVERS}`);
+console.log(`broker-url guard: ${SERVERS} is ephemeral loopback; no env var references ${LIVE_HOST}\n`);
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+let pass = 0, fail = 0;
+const check = (name: string, cond: boolean, extra?: unknown) => {
+  if (cond) { pass++; console.log(`  ✓ ${name}`); }
+  else { fail++; console.log(`  ✗ FAIL: ${name}`, extra !== undefined ? JSON.stringify(extra) : ""); }
+};
+
+const space = `epsplit-${randomUUID().slice(0, 8)}`;
+const auth = await createSpaceAuth(space);
+const dir = mkdtempSync(join(tmpdir(), "cotal-epsplit-"));
+const mkRoot = (tag: string): string => {
+  const r = join(dir, tag);
+  mkdirSync(join(r, ".cotal", "agents"), { recursive: true });
+  saveSpaceAuth(authDir(r), auth);
+  return r;
+};
+writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
+const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+
+type MgrPriv = { managerInstanceId: string };
+let m1: InstanceType<typeof Manager> | undefined;
+let m2: InstanceType<typeof Manager> | undefined;
+let ep: CotalEndpoint | undefined;
+
+try {
+  let up = false;
+  for (let i = 0; i < 60; i++) { if (await isReachable(SERVERS)) { up = true; break; } await wait(200); }
+  if (!up) throw new Error(`nats-server did not come up on ${PORT}`);
+  await setupSpaceStreams({ servers: SERVERS, space, creds: await mintCreds(auth, newIdentity(), "provisioner") });
+
+  const root1 = mkRoot("ws1"), root2 = mkRoot("ws2");
+  for (const r of [root1, root2]) recordMesh({ space, server: SERVERS, root: r, mode: "auth", ts: new Date().toISOString() });
+  m1 = new Manager({ space, servers: SERVERS, runtime: "pty", workspaceRoot: root1 });
+  m2 = new Manager({ space, servers: SERVERS, runtime: "pty", workspaceRoot: root2 });
+  await m1.start();
+  await m2.start();
+  const IID1 = (m1 as unknown as MgrPriv).managerInstanceId;
+  const IID2 = (m2 as unknown as MgrPriv).managerInstanceId;
+  check("two managers registered distinct instance ids (a real two-way race, not a single responder)",
+    IID1 !== IID2, { IID1, IID2 });
+
+  const id = newIdentity();
+  const uid = mintLifecycleUid();
+  const creds = await mintCreds(auth, id, "agent", { lifecycleUid: uid, capabilities: ["spawn"] });
+  ep = new CotalEndpoint({
+    space, servers: SERVERS, creds, lifecycleUid: uid,
+    channels: [], consume: false, registerPresence: false, watchPresence: false,
+    card: { name: "epsplit-caller", owner: DEV_OWNER, actor: id.id, kind: "endpoint" },
+  });
+  ep.on("error", () => {});
+  await ep.start();
+
+  const N = 24;
+  type Trial = {
+    i: number; name: string;
+    inRoot1: boolean; inRoot2: boolean; both: boolean;
+    callerSaw: "ok" | "app-error" | "throw";
+    detail: string;
+  };
+  const trials: Trial[] = [];
+
+  console.log(`\n1. ${N} describe+invoke trials of the write \`define-persona\`, two live managers`);
+  for (let i = 0; i < N; i++) {
+    const name = `epsplit-${i}`;
+    let callerSaw: Trial["callerSaw"] = "ok";
+    let detail = "";
+    try {
+      const r = await ep.invokeService(MANAGER_ENDPOINT, "define-persona",
+        { name, persona: `probe persona ${i}` }, { deadlineMs: 15_000 });
+      if (r.reply.ok === true) { callerSaw = "ok"; detail = r.responder.instanceId === IID1 ? "A" : "B"; }
+      else { callerSaw = "app-error"; detail = r.reply.error?.code ?? "?"; }
+    } catch (e) {
+      callerSaw = "throw";
+      detail = e instanceof EpEnvelopeError ? e.code : (e as Error).message.slice(0, 40);
+    }
+    const inRoot1 = existsSync(agentFilePath(root1, name));
+    const inRoot2 = existsSync(agentFilePath(root2, name));
+    trials.push({ i, name, inRoot1, inRoot2, both: inRoot1 && inRoot2, callerSaw, detail });
+  }
+
+  const answered = trials.filter((t) => t.inRoot1 || t.inRoot2);
+  check("every trial produced an effect somewhere (the sample is valid; no silently lost trials)",
+    answered.length === N, { answered: answered.length, N });
+
+  const dupes = trials.filter((t) => t.both);
+  const dupeSilent = dupes.filter((t) => t.callerSaw === "ok");
+
+  console.log(`\n2. effects counted at the RESPONDERS (persona files per manager root)`);
+  console.log(`     trials:                        ${N}`);
+  console.log(`     effect on A only:              ${trials.filter((t) => t.inRoot1 && !t.inRoot2).length}`);
+  console.log(`     effect on B only:              ${trials.filter((t) => t.inRoot2 && !t.inRoot1).length}`);
+  console.log(`     effect on BOTH (duplicate):    ${dupes.length}`);
+  console.log(`     ...of those, caller saw "ok":  ${dupeSilent.length}`);
+  console.log(`     caller outcomes: ok=${trials.filter((t) => t.callerSaw === "ok").length} ` +
+    `app-error=${trials.filter((t) => t.callerSaw === "app-error").length} ` +
+    `throw=${trials.filter((t) => t.callerSaw === "throw").length}`);
+  console.log(`     per-trial: ${trials.map((t) => (t.both ? "D" : t.inRoot1 ? "a" : t.inRoot2 ? "b" : "-")).join("")}`);
+  console.log(`                (D = duplicate across both instances, a/b = single effect, - = none)`);
+
+  console.log(`\n=== FINDING ===`);
+  if (dupes.length > 0) {
+    console.log(`REPRODUCED. ${dupes.length}/${N} trials executed the SAME write on BOTH instances.`);
+    console.log(`${dupeSilent.length} of those returned success to the caller, which therefore has no`);
+    console.log(`way to know the write ran twice. The effect count is a FLOOR: a retry landing on the`);
+    console.log(`same instance executes twice and leaves one file, and is not counted here.`);
+  } else {
+    console.log(`NOT REPRODUCED in ${N} trials — no trial wrote to both roots.`);
+    console.log(`This does NOT establish that the mechanism cannot fire. Distinguish the two cases`);
+    console.log(`from the per-trial line above: a healthy mix of a/b means the queue really did split`);
+    console.log(`and the retry still never crossed instances; an all-a or all-b line means this run`);
+    console.log(`never produced a split at all, and the harness did not reach the condition.`);
+  }
+
+  // The claim under test is that a duplicate CAN occur and is invisible. Assert exactly that, and
+  // nothing about a fix: no remedy is adopted, so there is no post-fix state to gate here.
+  check("DEFECT PRESENT: at least one write executed on both instances for one caller request",
+    dupes.length > 0, { dupes: dupes.length, N });
+  check("DEFECT IS SILENT: at least one duplicated write returned success to the caller",
+    dupeSilent.length > 0, { dupeSilent: dupeSilent.length });
+
+  console.log(`\n${fail === 0 ? "PASS" : "FAIL"} — ${pass} passed, ${fail} failed`);
+} finally {
+  await ep?.stop().catch(() => {});
+  await m1?.stop().catch(() => {});
+  await m2?.stop().catch(() => {});
+  srv.kill("SIGKILL");
+  rmSync(dir, { recursive: true, force: true });
+}
+process.exit(fail === 0 ? 0 : 1);

--- a/package.json
+++ b/package.json
@@ -335,6 +335,7 @@
     "smoke:gate-reconcile-cli:auth": "tsx implementations/manager/smoke/gate-reconcile-cli-e2e.smoke.ts",
     "smoke:resolve-rtt": "tsx implementations/manager/smoke/resolve-rtt-probe.smoke.ts",
     "smoke:queue-win": "tsx implementations/manager/smoke/queue-win-distribution.smoke.ts",
+    "smoke:describe-split-effect": "tsx implementations/manager/smoke/describe-split-duplicate-effect.smoke.ts",
     "smoke:instrument-instance-pin": "tsx implementations/manager/smoke/instrument-instance-pin.smoke.ts",
     "smoke:cli-seat-locality": "tsx implementations/manager/smoke/cli-seat-locality.smoke.ts",
     "smoke:tool-input-closed": "tsx extensions/connector-core/smoke/tool-input-closed.smoke.ts",


### PR DESCRIPTION
A live probe that one caller request through a describe/invoke class-queue split causes **at
most one effect**, and that a request which caused none says so conclusively.

## What it covers

A resolved service handle binds the describe winner's instance; an unpinned invoke goes to the
class queue, which picks its own winner. While the currency check ran only after the reply
landed, a non-matching responder had already executed the command when `failed-precondition`
was raised, and `invokeService` re-issued with the same args, for a write, a duplicate the
caller could not see.

The probe was written to reproduce that, and did: **8/24 trials wrote to both manager roots, 4
of them while returning `ok`**. The pre-effect fence has since closed it, so the probe is now
inverted to hold it closed. It asserts the caller-visible contract, not the mechanism, so a
remedy that keeps the promise by other means still passes.

Effects are counted at the **responders**, each manager writes personas into its own workspace
root, so one name in both roots proves the write executed twice for one request. That
undercounts (a retry landing back on the same instance leaves one file), so every number is a
floor. It uses `define-persona`, the most benign write on the surface, never `spawn`: a
duplicated `spawn` starts a second real agent process.

## Measured

With the fence live, 24 trials, two managers on an ephemeral loopback broker:

- duplicates **0**, silent duplicates **0**
- **6** splits refused before the command ran, each `failed-precondition` + `not-executed` +
  the bind-refused marker
- conservation exact: every trial is one effect or one refusal stating nothing ran
- repair path measured live: 10 re-issues, 3 healed, 7 surfaced

## Three things the conversion had to fix

**"Every trial produced an effect somewhere" was true only while the split was unfenced.** A
call that splits twice now legitimately produces no effect and reports it; demanding an effect
would fail a correct tip for behaving correctly. Conservation replaces it.

**The refusal marker also arrives on the throw path.** A failed re-issue rethrows the original
refusal, so reading marks only off `ok:false` replies undercounts the fence to zero on exactly
the trials where it fired twice.

**The duplicate assertions alone are not sensitive to the fence.** Neutering the pre-effect
refusal does not bring the duplicate back, the caller-side repair still collapses it, so a
probe that only counts duplicates passes against a responder that never fences. What returns is
the split reported *after* the command ran, as `failed-precondition` with **no outcome**, which
a caller must read as `unknown`: the effect landed and it is told only that it failed. The
`NO INCONCLUSIVE FAILURE` cell asserts that, and is the one that fails when the fence is removed.

## Verification

Both halves were executed, not reasoned about. Neutering `assertBoundIncarnation` in the built
artifact the probe loads: **12 inconclusive failures, 0 duplicates, red on that assertion alone**
while the other three stayed green, so the red is specific, not an unrelated early failure. The
restore was verified byte-identical; note that `pnpm build` does **not** restore it, because tsc
incremental skips unchanged sources.

## The split is forced, not awaited, which is what makes it gateable

The probe could **decline to answer**. Whether the class queue hands the invoke to someone other
than the describe winner is the run's luck, not the fixture's choice, so a run that never split
graded nothing. That is a real blocker rather than a slowness complaint: a suite that can decline is
not safe to gate, because a chain teaches its readers to skim reds.

So the condition is now **forced**. The handle's cached resolve is rewritten to a freshly minted
lifecycle id belonging to no manager, which makes every responder the wrong one and the pre-effect
refusal guaranteed rather than raced for. It needs a *valid* lifecycle token, not a nonsense string:
the responder parses `bind.instanceId` before comparing it, and a malformed one is refused as
`bad-request` down a different path, which would prove nothing about the fence.

A recovery is emitted only on a reply the caller read as refused-before-effect, so counting one
**observes** the fence instead of inferring it.

| | forced refusals repaired | effects | caller ok |
| --- | --- | --- | --- |
| fence live | 1 | 1 | yes |
| fence neutered | **0** | **0** | **no** |

The natural 24-trial sample is kept alongside it, because a forced split proves the fence works and
only real contention proves the duplicate does not come back by some other route.

## Gated in the CI chain

Registered as one appended line in `bin/smoke/ci-suites.txt` (243 suites, all resolving to defined
scripts; the set gains exactly this one and loses none).

I first left it out, on the flake argument above. The repo's inventory gate rejected that outright,
and correctly: a suite run by no automated path proves nothing until someone runs it by hand, and
"out of the chain but mentioned in the description" is not one of the two permitted states, it is
either gated, or declared ungated with a written reason. Rather than take the allowlist, the
underlying blocker was fixed, so the suite always grades. It boots its own broker and takes about
two minutes, which is what the shards are for.

Run it alone with `pnpm smoke:describe-split-effect` (needs `nats-server` on PATH).

