### PR TITLE
docs(core): re-attach the ACL write doc to the function that performs it

### DIFF
--- a/packages/core/src/acls.ts
+++ b/packages/core/src/acls.ts
@@ -138,13 +138,6 @@ async function enumerateLiveAclRows(
 }
 
 /**
- * Record (set) an owner's read ACL — a single ATOMIC CAS put of the full value, never
- * create-then-populate, so a present record is always complete and `[]` always means "no-read", never
- * "not yet written". Bumps `revision`. Retries a revision conflict by re-reading. Idempotent in
- * effect: writing the same `allowSubscribe` is harmless. Use `allowSubscribe: []` to revoke all reads
- * (the reader then DROPS the owner's entries) — distinct from {@link deleteAcl}, which removes the row.
- */
-/**
  * Raise the mint-time history ceiling (`issuedAllowSubscribe`) to match `allowSubscribe`.
  *
  * CALL PATH: only {@link provisionAgent} (and tests of that path). Ordinary registry writers use
@@ -182,6 +175,16 @@ export async function commitAcl(
   return writeAcl(kv, owner, lifecycleUid, allowSubscribe, { reissue: false });
 }
 
+/**
+ * Record (set) an owner's read ACL — a single ATOMIC CAS put of the full value, never
+ * create-then-populate, so a present record is always complete and `[]` always means "no-read", never
+ * "not yet written". Bumps `revision`. Retries a revision conflict by re-reading. Idempotent in
+ * effect: writing the same `allowSubscribe` is harmless. Use `allowSubscribe: []` to revoke all reads
+ * (the reader then DROPS the owner's entries) — distinct from {@link deleteAcl}, which removes the row.
+ *
+ * The shared write both {@link commitAcl} and {@link reissueAcl} delegate to; they differ only in
+ * whether the mint-time ceiling may rise, which is `opts.reissue`.
+ */
 async function writeAcl(
   kv: KV,
   owner: string,


### PR DESCRIPTION
`packages/core/src/acls.ts` carried **two docblocks back to back with no declaration between
them**. TypeScript attaches every leading block to the same node, so the parser bound both to
`reissueAcl`, which meant `reissueAcl` wore a doc about something it does not do, and `writeAcl`,
which does do it, carried no doc at all.

### Which function it belongs to, from history rather than inference

The stray describes "a single ATOMIC CAS put of the full value… Bumps `revision`. Retries a
revision conflict by re-reading." That is `writeAcl`'s retry loop.

`git log -L` on the block shows it arrived with the file and documented **`commitAcl`**, which at
the time was one function containing that loop. A later change split it into `commitAcl` +
`reissueAcl` over a shared private `writeAcl`, wrote `commitAcl` a **new** doc about the mint-time
ceiling, and left the original block sitting where it had always been, now above `reissueAcl`,
whose own doc is about raising that ceiling and is unrelated to it.

So this is not a judgement call about which function the prose suits best. The mechanism it
describes moved into `writeAcl`, and the doc is being moved to follow it.

### Moved, not deleted

Measured with the parser, before and after:

| | documented declarations | multi-block holders | `writeAcl` |
| --- | --- | --- | --- |
| before | 9 | 1 (`reissueAcl`, 2 blocks) | **no doc** |
| after | 10 | **0** | 1 block |

The block count is conserved and simply lands on a declaration that had none. Two added sentences
name the two public wrappers that delegate to `writeAcl` and the one flag they differ on, so the
private function's doc says who calls it.

**Comment lines only**, verified by filtering the diff for any changed line that is not a comment,
which returns nothing. No behaviour, no signatures, no exports.

### How it was found

A multiplicity query over the tree, `node.jsDoc.length > 1`, which finds a declaration wearing
documentation that is not its own, at any distance. Adjacency is not the property: TypeScript binds
a docblock across blank lines, so this is invisible to reading and invisible to a search for
comments that look detached.

