### PR TITLE
docs: anchor SPEC citations to sections instead of line numbers

### DIFF
--- a/implementations/auth/smoke/d32-matrix.smoke.ts
+++ b/implementations/auth/smoke/d32-matrix.smoke.ts
@@ -20,10 +20,10 @@
  * overlap the commit principal's five fact families; per-kind record writers stay disjoint).
  *
  * KNOWN RECORDED GAPS (not failures): the CANONICALIZER principal holds neither of the two
- * authorities SPEC gives it — the `epf.<e>.dec.>`/`.quar.>` fact publish (SPEC:1658-1663: the
+ * authorities SPEC gives it — the `epf.<e>.dec.>`/`.quar.>` fact publish (SPEC §13.4: the
  * canonicalizer publishes the decision or quarantine fact and terminally acks only after it
  * durably exists) nor the leader-served `STREAM.MSG.GET.EPF_<space>` of the row titled
- * "Canonicalizer CAS-winner + terminal read" (SPEC:2907, which it needs to read the winning fact
+ * "Canonicalizer CAS-winner + terminal read" (SPEC §13.9, which it needs to read the winning fact
  * on redelivery). Its builders emit its EPJ consumer rows plus the EPW work publish, and the
  * holder-set fixture below asserts that absence POSITIVELY by listing `canonicalizer:EPW_<space>`
  * and no `canonicalizer:EPF_<space>`. That is correct today — no production path mints a
@@ -376,7 +376,7 @@ const FIXTURE: Record<string, { publish: string[]; subscribe: string[] }> = {
   // P2 item 6: the manager's per-session SERVING credential — the EXACT mirror of `session-caller`
   // with the rail directions swapped, for ONE session. It replaces a STANDING writer that held
   // `eps.manager.*.<epoch>.{in,out}` and so reached every live session's bytes at its epoch, against
-  // SPEC:2753 ("no standing EPS grant exists on either side", §13.6 session credentials). No KV and no JS-API at all: the
+  // SPEC §13.9 ("no standing EPS grant exists on either side", §13.6 session credentials). No KV and no JS-API at all: the
   // serving side drives bytes, and the ledger belongs to the standing credential below.
   "session-serving": { publish: [
     `cotal.d32m.eps.manager.${SC_SID}.3.out`,
@@ -566,7 +566,7 @@ for (const [principal, v] of Object.entries(gen)) for (const row of [...v.publis
     holders.size === expected.size && [...holders].every((h) => expected.has(h)), [...holders].sort());
 }
 
-// (2b') EXACTLY ONE principal may hold BOTH sides of the goal fact chain. SPEC:2906 splits the
+// (2b') EXACTLY ONE principal may hold BOTH sides of the goal fact chain. SPEC §13.9 splits the
 // `.bind` leaf from the commit principal's `.result` and says so in the row itself ("no writer
 // overlap"); the self-mediated goal-writer (P2 item 2) unions them ON PURPOSE, because a Model-B
 // endpoint accepts and commits on one connection. That union is safe only while it is UNIQUE and
@@ -609,7 +609,7 @@ for (const [principal, v] of Object.entries(gen)) for (const row of [...v.publis
   // WHAT THIS COMPARES TODAY, said exactly, because the label used to name three families the set
   // does not contain. `canonSubjects` resolves to ONE row — `cotal.<space>.epw.<e>.>` — since the
   // canonicalizer's builders emit its EPJ consumer rows plus the EPW work publish and nothing else.
-  // The dec/quar/bind publish SPEC:1658-1663 gives the canonicalizer is not in any builder yet (see
+  // The dec/quar/bind publish SPEC §13.4 gives the canonicalizer is not in any builder yet (see
   // the recorded gap in this file's header), so it cannot be on either side of this intersection.
   // The cell still earns its place — a builder broadened to an ancestor that SUBSUMES a foreign
   // family fails here, which is its stated purpose — but it is a subsumption guard over the rows

--- a/implementations/manager/smoke/journal-declaration.smoke.ts
+++ b/implementations/manager/smoke/journal-declaration.smoke.ts
@@ -3,7 +3,7 @@
  * quietly — and pinned at the invariant the flip must NOT break.
  *
  * WHY THIS SUITE IS GREEN WHILE THE DEFECT IS UNFIXED, said first because it looks backwards.
- * The defect is that spawn/launch ship as Model B — `class: "ephemeral"` — where SPEC:1465 makes
+ * The defect is that spawn/launch ship as Model B — `class: "ephemeral"` — where SPEC §13.3 makes
  * the class a MUST that matches the command's contract and §13.6 makes these action commands, whose
  * submissions are journal. The obvious instrument is a cell that fails today and passes when
  * the flip lands. It was asked for, and it is the wrong instrument HERE, for a mechanical reason:

--- a/implementations/manager/smoke/journal-model-b.smoke.ts
+++ b/implementations/manager/smoke/journal-model-b.smoke.ts
@@ -62,7 +62,7 @@ c("WRONG-TODAY: the boot sweep skips goals via `goalAcceptances`, an IN-MEMORY m
 pending("the CANONICALIZER writes goalidx create-only BEFORE the bind (step 4a), so the index no longer depends on a live manager's memory");
 
 console.log("\n── THE MECHANISM THAT MUST LIVE — read this before deleting anything ──");
-// SPEC:2391 REQUIRES a provisioner sweep over `goalidx`. J2 replaces the IMPLEMENTATION and never
+// SPEC §13.7 REQUIRES a provisioner sweep over `goalidx`. J2 replaces the IMPLEMENTATION and never
 // the MECHANISM. Three orphan classes exist that the effects durable structurally cannot see — the
 // worst being a crash after `goalidx` and before the bind, where no decision message will ever
 // exist, so the occupancy row leaks FOREVER if the sweep is gone.

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -4641,7 +4641,7 @@ export class Manager {
     // caller cannot publish it). TWO COMPOSED FENCES (defense in depth): must-5 (a) reads THIS
     // incarnation's OWN gate epoch and REFUSES a superseded commit (the currency belt), and (b)
     // barrier-revoke evicts this connection on takeover. The terminal lands on the ONE subject
-    // SPEC:1433 (§13.2 reserved subjects) reserves; first-terminal-fact-wins is global, so a committed outcome is visible
+    // SPEC §13.2 (reserved subjects) reserves; first-terminal-fact-wins is global, so a committed outcome is visible
     // to every reader in every incarnation. On success the reconcile-index entry is cleared.
     //
     // Named rather than inlined into the hooks below so the H1 post-accept fallback drives THIS

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -3707,7 +3707,7 @@ export class Manager {
     // resolve "uncertain"; caught by the lifecycle e2e).
     const wanted = this.managedPrincipal(a);
     // READINESS LIFECYCLE FENCE (SPEC 13.1): match the exact principal AND the exact lifecycle uid
-    // the manager minted for THIS spawn (presence carries it, §6/:315). The endpoint's own
+    // the manager minted for THIS spawn (presence carries it, §6). The endpoint's own
     // register-only broker proof is gated on the CLIENT-authored `card.kind`, which a managed child
     // holding a valid agent credential could set to "endpoint" to skip - so it is defense-in-depth,
     // NOT the authority boundary. This equality is: the manager (not the child) owns the expected

--- a/packages/core/smoke/deprovision-agent-auth.smoke.ts
+++ b/packages/core/smoke/deprovision-agent-auth.smoke.ts
@@ -167,7 +167,7 @@ try {
   // ---- THE D15 BARRIERS (SPEC 13.1): a same-name SUCCESSOR is untouchable by the retired
   // lifecycle's teardown — by NAME DISJOINTNESS (the replay names only A's uid) and by the
   // BROKER (A's cred is denied on B's exact names). ----
-  // FRONTIER PROBE setup (SPEC :467 / 13.1): a DM published to the ALIAS while no successor
+  // FRONTIER PROBE setup (SPEC §8 / §13.1): a DM published to the ALIAS while no successor
   // exists (between A's retirement and B's provisioning) must NOT flow to B — B's dm durable
   // starts at the activation frontier captured at ITS provisioning. Publish DM1 now, DM2 after.
   const insp = await (async () => {

--- a/packages/core/smoke/endpoint-binding.smoke.ts
+++ b/packages/core/smoke/endpoint-binding.smoke.ts
@@ -571,7 +571,7 @@ try {
     epj.duplicate_window === nanos(EPJ_DUPLICATE_WINDOW_MS));
   const epf = await cfg(epfStreamName(SPACE));
   c("EPF serves Direct Get (the last-by-subject fact reads)", epf.allow_direct === true);
-  // THE RETENTION FLOOR IS THE AGE TERM ONLY, AND THE RULE IS WIDER THAN THE AGE TERM. SPEC:3189-3195
+  // THE RETENTION FLOOR IS THE AGE TERM ONLY, AND THE RULE IS WIDER THAN THE AGE TERM. SPEC §13.12
   // forbids "not only age eviction below the horizon but every conforming alternative that erases it
   // while `MaxAge` still passes": a finite MaxMsgs/MaxBytes/MaxMsgsPerSubject with DiscardOld, a
   // per-message TTL, rollup/compaction, or a retention-policy change. The floor validator checks the

--- a/packages/core/smoke/endpoint-guard.smoke.ts
+++ b/packages/core/smoke/endpoint-guard.smoke.ts
@@ -308,7 +308,7 @@ try {
       && heldSpec?.holder.id === guardResponder.id && heldSpec.holder.lifecycleUid === guardResponder.lifecycleUid);
 
     // HIGH 1 (distsys, fact-confirmed): a HOLD's VERIFIED obligations must SURVIVE the pause
-    // (SPEC :1628-1630 MUST-apply, :2311 reusable within the goal) - persisted on the hold's
+    // (SPEC §13.6: obligations are MUST-apply and reusable within the goal) - persisted on the hold's
     // immutable record at mint, returned identically from release and reconcile.
     const go = goalOf("g-gate-obl");
     await createGoal(ctx, go, gspec("sha256:go"));

--- a/packages/core/smoke/endpoint-journal.smoke.ts
+++ b/packages/core/smoke/endpoint-journal.smoke.ts
@@ -228,7 +228,7 @@ admits("c8 a string spelling out a name is CONTENT, never structure", { id: "r",
 admits("c8 quoted braces and a trailing backslash are content too",
   { id: "req-1", args: { a: '{"a":1}', b: "x\\", c: [{ k: 1 }, { k: 2 }], d: { k: 3 } } });
 
-// c10 — OUT-OF-RANGE NUMBERS, the fourth I-JSON condition SPEC:1654-1655 names and the last one
+// c10 — OUT-OF-RANGE NUMBERS, the fourth I-JSON condition SPEC §13.4 names and the last one
 // this module did not enforce. Found the same way c8 was and NOT the way the rest of this file was:
 // by reading what the SPEC names against what the code can produce. No mutant could have found it,
 // and that is a property of the class rather than of the effort — the evidence is destroyed by

--- a/packages/core/smoke/endpoint-session.smoke.ts
+++ b/packages/core/smoke/endpoint-session.smoke.ts
@@ -28,7 +28,7 @@
  *      peer-close teardown (no remotely triggerable subscription/timer leak); the in-band
  *      close is advisory.
  *   D. NO STANDING EPS GRANT: the caller/serve grant builders emit no `eps.` row (§13.9
- *      :2068-2070 — both sides hold only redemption-minted per-session credentials).
+ *      SPEC §13.9 — both sides hold only redemption-minted per-session credentials).
  *
  * Run: pnpm smoke:ep-session   (needs nats-server on PATH; part of smoke:ci)
  */

--- a/packages/core/smoke/eps-grant-sweep.smoke.ts
+++ b/packages/core/smoke/eps-grant-sweep.smoke.ts
@@ -1,6 +1,6 @@
 /**
  * EPS GRANT SWEEP (control-surface v0.4, Lane B finding 1) — the STRUCTURAL guard behind
- * SPEC.md:2526: "both sides of a session hold only redemption-minted per-session credentials
+ * SPEC §13.9: "both sides of a session hold only redemption-minted per-session credentials
  * (§13.6); no standing EPS grant exists on either side", and the §13.9 matrix rows at 2695-2698
  * which require the EXACT `eps.<endpoint>.<sessionId>.<epoch>.{in,out}` subject on all four legs.
  *

--- a/packages/core/smoke/goal-epoch-fence.smoke.ts
+++ b/packages/core/smoke/goal-epoch-fence.smoke.ts
@@ -4,7 +4,7 @@
  * WHAT THIS SUITE USED TO ASSERT, and why it was replaced. It encoded the epoch-scoped terminal
  * subject `…result.<execEpoch>`: one create-only subject per executor epoch, so a superseded
  * manager's terminal landed where no current reader looked. That mechanism was BOTH
- * non-conformant (SPEC:1433 (§13.2 reserved subjects) reserves the flat `goal.<cOwner>.<cActor>.<cUid>.<goalId>.result`
+ * non-conformant (SPEC §13.2 (reserved subjects) reserves the flat `goal.<cOwner>.<cActor>.<cUid>.<goalId>.result`
  * with no epoch token) AND actively wrong. It conflated two different jobs:
  *   - as a READ fence it produced WRONG ANSWERS. The window is "commit the terminal, then die
  *     before projecting it", where the pre-restart fact is the LEGITIMATE outcome, not a corpse's

--- a/packages/core/src/endpoint-action.ts
+++ b/packages/core/src/endpoint-action.ts
@@ -166,7 +166,7 @@ export function goalRefOf(request: ParsedEpRequest, goalId: string): GoalRef {
   return { endpoint: request.endpoint, caller: { owner: c.owner, actor: c.actor, uid: c.uid }, goalId: assertIdToken(goalId, "goalId") };
 }
 
-/** The goal's terminal-result fact subject — the ONE subject SPEC:1433 reserves (§13.2 reserved subjects, `goal.<cOwner>.<cActor>.<cUid>.<goalId>.result`),
+/** The goal's terminal-result fact subject — the ONE subject SPEC §13.2 reserves (reserved subjects, `goal.<cOwner>.<cActor>.<cUid>.<goalId>.result`),
  *  `epf.<e>.goal.<cOwner>.<cActor>.<cUid>.<goalId>.result`, with NO epoch token.
  *
  *  An earlier revision epoch-scoped this (`…result.<execEpoch>`) to fence a live-superseded

--- a/packages/core/src/endpoint-binding.ts
+++ b/packages/core/src/endpoint-binding.ts
@@ -143,12 +143,12 @@ export interface EndpointStreamOptions {
 /**
  * The §13.12 RETENTION FLOOR on decision facts, enforced at the only site that exists.
  *
- * SPEC:3203-3205 requires EPF retention ≥ max(idempotency horizon, result retention, receipt retention), and §13.12 states it by OUTCOME: no
+ * SPEC §13.12 requires EPF retention ≥ max(idempotency horizon, result retention, receipt retention), and §13.12 states it by OUTCOME: no
  * removal cause may drop a protected fact early. The §13.4 idempotency horizon is realized BY that
  * retention and never by a clock — the create-only CAS returns the recorded decision for exactly as
  * long as the fact exists. So a fact age below the horizon does not shorten a guarantee, it deletes
  * the mechanism: once the decision fact is evicted, a redelivered submission finds no winner to
- * read and is accepted as NEW WORK, which is the failure SPEC:1718 names in as many words.
+ * read and is accepted as NEW WORK, which is the failure SPEC §13.8 names in as many words.
  *
  * WHY THIS IS A THROW AND NOT A CLAMP. The field's own contract was that horizons are "enforced by
  * policy above the broker, never by silently losing facts under a horizon" — and nothing was above
@@ -188,7 +188,7 @@ export function assertFactRetentionFloor(
       `factMaxAgeMs ${factMaxAgeMs} is below the declared ${binding} ${floor}: EPF facts would be evicted `
       + `while that promise still stands — a redelivered submission whose decision fact has gone is accepted `
       + `as NEW WORK rather than resolved to its recorded decision, and a receipt whose acceptance fact has `
-      + `gone can no longer be reconstructed (SPEC:3203-3205, §13.12 "Streams and retention")`,
+      + `gone can no longer be reconstructed (SPEC §13.12)`,
     );
 }
 

--- a/packages/core/src/endpoint-journal.ts
+++ b/packages/core/src/endpoint-journal.ts
@@ -217,7 +217,7 @@ function decimalValueKey(literal: string): string {
 }
 
 /**
- * Out-of-range numbers in the RAW bytes — the fourth I-JSON condition SPEC:1654-1655 names
+ * Out-of-range numbers in the RAW bytes — the fourth I-JSON condition SPEC §13.4 names
  * ("unparseable, duplicate object names, lone surrogate, out-of-range number") and the only one
  * this module did not enforce.
  *

--- a/packages/core/src/endpoint-verbs.ts
+++ b/packages/core/src/endpoint-verbs.ts
@@ -229,7 +229,7 @@ function parseAttributedReply(space: string, subject: string, data: Uint8Array, 
   const parsed = parseEpSubject(subject);
   if (!parsed || parsed.plane !== "reply")
     throw new EpEnvelopeError("internal", `a message on the caller's reply rail does not parse as a reply subject: ${subject}`);
-  // §13.2 (:1173-1189): ACCEPTANCE binds the subject-borne attribution to the INVOKED identity.
+  // SPEC §13.2: ACCEPTANCE binds the subject-borne attribution to the INVOKED identity.
   // Reading the endpoint/instance/epoch off the subject is not the same as checking them against the
   // invocation: a truthfully-attributed reply from a DIFFERENT endpoint (or a stale/other instance)
   // is not the requested responder, and nonce possession is addressing, not authorization. A stale

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -2168,7 +2168,7 @@ export class CotalEndpoint extends EventEmitter {
   }
 
   /** Idempotent-PER-LIFECYCLE create of a `dm_<o>-<a>-<uid>` durable with its ACTIVATION FRONTIER
-   *  (SPEC :467). Info-first: an existing durable (a manager-restart re-provision of the SAME uid, or
+   *  (SPEC §8). Info-first: an existing durable (a manager-restart re-provision of the SAME uid, or
    *  the same lifecycle's own restart) is kept as-is, preserving the ORIGINAL frontier — the
    *  activation moment never moves. A fresh lifecycle captures the DM stream's current `last_seq` and
    *  starts delivery at frontier+1, so a same-alias successor inherits none of the predecessor's
@@ -3765,7 +3765,7 @@ export class CotalEndpoint extends EventEmitter {
     if (!this.doRegister || !this.kv) return; // observers watch but never publish their own record
     const p: Presence = {
       card: this.card,
-      // SPEC §6/:315: presence carries the incarnation's lifecycle UID (MUST in auth mode from v0.4);
+      // SPEC §6: presence carries the incarnation's lifecycle UID (MUST in auth mode from v0.4);
       // omitted only where the endpoint has none (a pure operator/daemon connection never registers).
       ...(this.ownLifecycleUid !== undefined ? { lifecycleUid: this.ownLifecycleUid } : {}),
       status: this.status,

--- a/packages/core/src/provision.ts
+++ b/packages/core/src/provision.ts
@@ -650,7 +650,7 @@ export interface ProvisionOpts extends MintOpts {
 export interface DurableProvisioner {
   /** Pre-create the lifecycle's bind-only DM durable (`dm_<owner>-<actor>-<uid>`). The implementation
    *  captures the DM stream's ACTIVATION FRONTIER (its `last_seq` at first creation) and starts
-   *  delivery at frontier+1 (SPEC :467) — a same-alias successor inherits no predecessor DMs.
+   *  delivery at frontier+1 (SPEC §8) — a same-alias successor inherits no predecessor DMs.
    *  Idempotent PER LIFECYCLE: a re-provision of the same uid keeps the existing durable (and so the
    *  ORIGINAL frontier — the activation moment does not move on manager restart). */
   provisionDmInbox(owner: string, actor: string, lifecycleUid: string): Promise<void>;

--- a/packages/core/src/streams.ts
+++ b/packages/core/src/streams.ts
@@ -229,7 +229,7 @@ export function dmDurableConfig(
   // lifecycle scoping lives in the consumer: the NAME carries the uid (exact-name deprovision) and
   // delivery starts at the ACTIVATION FRONTIER — the DM stream sequence captured when this lifecycle
   // was provisioned — so a same-alias successor inherits none of the predecessor's pending DMs
-  // (SPEC :467). `activationFrontier` = that captured `last_seq`; delivery begins at frontier+1.
+  // (SPEC §8). `activationFrontier` = that captured `last_seq`; delivery begins at frontier+1.
   // Callers that provision a genuinely fresh lifecycle pass the sequence they captured; 0 = from the
   // stream start (an explicit choice, e.g. a stream created after the lifecycle in tests).
   const frontier = opts.activationFrontier ?? 0;


### PR DESCRIPTION
## What this fixes

Twenty-six comments cited `SPEC.md` by line number. **Resolved against the current document, not one
of them points at what its comment claims.** A line number is a derived value that nothing
re-derives, so it rots the moment the document is edited, and it rots *silently*, because the stale
reference still resolves to real, authoritative-looking prose.

That is the part worth stating plainly: an unresolvable reference fails loudly the first time someone
follows it. A stale one that still resolves hands the reader a coherent paragraph about a different
feature and gives them no signal at all that they have been misdirected.

Representative cases:

| cited | comment claims | the line actually holds |
| --- | --- | --- |
| `:467` (×4) | the activation frontier | **a blank line** |
| `:315` (×2) | presence carrying the lifecycle UID | **a blank line** |
| `:1433` (×3) | reserves the goal terminal-result subject | timer `.schedule` requests |
| `:1465` | the `class` MUST | token grammar `[A-Za-z0-9_-]{1,64}` |
| `:2526` | quoted, on session credentials | idempotency-retry prose, in a different section |
| `:2907` | a row titled "Canonicalizer CAS-winner + terminal read" | that row is 16 lines away |

Two are wrong in a way that needs no comparison with the document at all: `endpoint-verbs.ts` named
**§13.2** while citing a range lying wholly inside **§13.1**, so the comment contradicted itself; and
`endpoint-binding.ts` cited a section heading, **"Streams and retention"**, that does not appear
anywhere in `SPEC.md`.

## Why sections

A section is the coordinate that has to be right, and the only one that does. Sections are renamed
far less often than lines move, so replacing a line number with a section removes the decaying
coordinate instead of adding a second one beside it.

It also resolves a case a line range cannot. One comment makes two claims, an EPF retention formula
and an outcome clause, that live 15 lines apart. Any single line range is wrong for at least one of
them; the section covers both.

## Scope

Assertion labels keep their line numbers. There the cited text is the thing under test, and rewriting
it would change what a suite proves rather than how it reads.

The one exception is a **thrown** error string, not an assertion: it named the section that does not
exist. Nothing in the tree matches on that message, so rewriting it changes no cell.

## Verification

- 40 changed lines. **38 are comments; the 2 remaining are the one error string**, asserted
  mechanically, not by eye.
- Every substitution refused unless its target occurred **exactly once** in the file. This caught two
  real collisions where the same citation appears in both a comment and a `c(...)` label, which a
  naive replace would have rewritten silently.
- Validation of all edits runs before any of them is written, so a refusal cannot leave the tree
  half-edited.
- `pnpm typecheck` rc=0.
- Eight affected suites: `ep-binding` 165, `ep-guard` 71, `ep-journal` 115, `goal-epoch-fence` 20,
  `journal-model-b` 9, `journal-declaration` 6, `eps-grant-sweep` 11, `ep-session` 113, giving **510 cells,
  0 failed**, each rc=0.

