### PR TITLE
ci: let a superseded pull-request run be cancelled, not left holding the group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,19 @@ on:
     branches:
       - main
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+# A new push to a PR supersedes the run already going; a merge to main does not.
+#
+# The group expression is unchanged — only what happens to the run holding it. Without
+# `cancel-in-progress` the superseded run keeps the group and its replacement is created with
+# ZERO JOBS and sits pending, which reads as "queued and about to start" rather than "starved".
+#
+# Deliberately not unconditional: a main commit's CI result is the record for that commit, not a
+# preview of the next, and a cancelled run leaves a merge ungradable — neither red nor green.
+# Superseding is only right where the earlier answer has stopped being interesting, which is true
+# of a PR revision and false of a merge.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Same coverage as before, fanned across parallel jobs so wall-clock is the slowest job, not the sum:
 #   • unit  — typecheck + build + unit tests + the broker-free view/pack checks (fast).

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,7 +28,11 @@ on:
     branches:
       - main
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+# Same rule as ci.yml, and for the same reason: a superseded PR run holds the group and starves
+# the run that replaced it, while a merge to main must keep its own verdict. See the note there.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # REQUIRED lane — Windows-specific + broker-free, so a red is a real Windows regression.


### PR DESCRIPTION
A new push to a PR creates a run in the same concurrency group as the one already in flight.
Without `cancel-in-progress` the old run keeps the group and the new run is created with **zero
jobs**, then sits pending indefinitely.

That state is the problem, more than the delay. The checks list shows a run that looks queued and
about to start; nothing anywhere reports that it is starved. It happened three times in one night
on a single PR, and each time it was cleared by cancelling the superseded run by hand.

## Why conditional rather than unconditional

`github.ref` differs between a PR and `main`, so the two never share a group and `main` was never
at risk from a PR. The risk is a rapid sequence of merges: unconditionally, each would cancel the
last, and **a main commit's CI result is the record for that commit, not a preview of the next.**

Superseding is only correct where the earlier answer has stopped being interesting. That is true
of a PR revision and false of a merge.

## The habit this is really fixing

Clearing the pending state by hand teaches "cancel a run to unblock the queue", and that has
already been aimed at a merge: `c35c4c6a` on `main` has **CI and Windows both cancelled**, so that
commit has no CI verdict of its own.

Stated precisely, because the weaker claim is the true one: **`main`'s verified line has no hole.**
The next commit, `a671d7f7`, is a superset tree and reports **zero non-success checks** (19/19), as
do `50e5557c` and `39f821a0` (19/19) and `de81d16a` and `b6d6d799` (18/18). What was lost is one commit's *own* verdict, an artifact that is
neither red nor green and cannot be recovered without a re-run.

## Scope

`ci.yml` and `windows.yml` only, the two that produced the pathology. `installer.yml` and
`changesets.yml` keep the shorthand form deliberately: changesets performs releases, where
cancelling a run in flight is a worse failure than queueing behind one.

The group expression is byte-identical to before. Only what happens to the run holding it changes.

## Verification

**Arm 1, observed.** A second commit pushed while the first run was in flight: at 50s the old runs
were still queued and the new ones pending at zero jobs; at 140s the superseded `CI` and `Windows`
runs were `completed/cancelled` and the new runs had gone from **0 jobs to 6**. `CodeQL` was *not*
cancelled, correctly, it is the default-setup workflow configured outside the repo, so this
change cannot reach it.

**A real limitation, observed twice.** Superseding by **force-push** does not cancel: the old run
stays queued indefinitely and the new tip sits at zero jobs behind it. Seen on a rewind to an
earlier sha and again on an amend, both times released by hand; a normal push cancels as expected.
Congestion would not select for force-push, so this is not queue saturation. Mechanism unknown.

Practically: this fixes the common case, pushing a new commit to a PR, and does **not** fix the
amend/rebase case, which is a large share of real usage. It is never worse than the status quo,
but it does less than the title suggests.

**Arm 2, inferred and not claimed as observed.** A push to `main` is not cancelled, because
`github.event_name` is `push` there. That cannot be produced without pushing to `main`. What *is*
observed: every recent `main` run carries `event=push`, and arm 1 proves the expression is
evaluated rather than treated as a literal.




