### PR TITLE
docs(manager): move three docblocks back onto the declarations they describe

### DIFF
--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -481,12 +481,6 @@ interface ManagedAgent {
   terminalizing?: boolean;
 }
 
-/**
- * The agent supervisor: a long-lived mesh node that owns agent process lifecycle.
- * It serves control requests on the "manager" service and spawns/kills agents
- * through a pluggable {@link Runtime} (pty by default). It does NOT proxy agent
- * mesh traffic — terminal I/O streams over its own attach endpoint instead.
- */
 
 /** Runtime hooks the spawn-as-action serve path (P2 item 2) injects into {@link Manager.startAgent}.
  *  Roster boot and the blocking callers pass none (unchanged behavior). */
@@ -570,6 +564,12 @@ export async function epAwaitReply(
   }
 }
 
+/**
+ * The agent supervisor: a long-lived mesh node that owns agent process lifecycle.
+ * It serves control requests on the "manager" service and spawns/kills agents
+ * through a pluggable {@link Runtime} (pty by default). It does NOT proxy agent
+ * mesh traffic — terminal I/O streams over its own attach endpoint instead.
+ */
 export class Manager {
   private readonly space: string;
   private readonly servers: string | undefined;
@@ -2512,16 +2512,6 @@ export class Manager {
       : `unsafe name ${JSON.stringify(name)} (allowed: letters, digits, _ -)`;
   }
 
-  /** First free name in the series `base`, `base-2`, `base-3`, … — checked against live slots,
-   *  in-flight (reserved) slots, names held pending retirement, AND the live mesh roster. The
-   *  roster check covers occupants this manager does not manage (a foreground `cotal spawn`, a
-   *  connector session, another manager's agent): allocating their name would mint a sibling the
-   *  broker/auth then refuses to admit, surfacing as a 30s launch-uncertain black hole instead of
-   *  the auto-number the join path gives. Presence is ADVISORY (SPEC §6) — this is an availability
-   *  choice at allocation, never an authority check (the broker still enforces): a stale
-   *  still-live-looking row only costs a numbered suffix, and a missed freshly-joined occupant is
-   *  still refused downstream exactly as before. Offline rows do NOT occupy — a properly retired
-   *  name stays reusable. */
   /** The roster's LIVE occupant names (status !== offline) — occupants this manager may NOT manage
    *  (a foreground `cotal spawn`, a connector session, ANOTHER manager's agent). Allocating over any
    *  of them mints a sibling the broker/auth then refuses to admit, surfacing as the 30s launch-
@@ -2540,6 +2530,16 @@ export class Manager {
     return this.agents.has(name) || this.reserved.has(name) || this.retiring.has(name) || live.has(name);
   }
 
+  /** First free name in the series `base`, `base-2`, `base-3`, … — checked against live slots,
+   *  in-flight (reserved) slots, names held pending retirement, AND the live mesh roster. The
+   *  roster check covers occupants this manager does not manage (a foreground `cotal spawn`, a
+   *  connector session, another manager's agent): allocating their name would mint a sibling the
+   *  broker/auth then refuses to admit, surfacing as a 30s launch-uncertain black hole instead of
+   *  the auto-number the join path gives. Presence is ADVISORY (SPEC §6) — this is an availability
+   *  choice at allocation, never an authority check (the broker still enforces): a stale
+   *  still-live-looking row only costs a numbered suffix, and a missed freshly-joined occupant is
+   *  still refused downstream exactly as before. Offline rows do NOT occupy — a properly retired
+   *  name stays reusable. */
   private uniqueName(base: string): string {
     const live = this.liveRosterNames();
     return firstFreeName(base, (n) => this.nameInUse(n, live));
@@ -3882,11 +3882,6 @@ export class Manager {
     return undefined;
   }
 
-  /** Open a short-lived PROVISIONER connection, run the onboarding ops on it, and drain it (closure (ii),
-   *  residual 2). The DM/DLV consumer-create surface — the irreducible onboarding power — lives only for
-   *  this window, never as a standing grant on the long-lived supervisor. A provision-only endpoint
-   *  (no presence/consume/channel-watch) connected with memory-only `provisioner` creds; it sets its own
-   *  `inboxPrefix` so JS-API replies land on the `_INBOX_<id>.>` the provisioner cred subscribes. */
   /** Run one static §13.1 lifecycle OPERATION over an ephemeral, key-pinned `lifecycle-executor`
    *  connection (Unit B): the credential's grants name exactly ONE incarnation's head/uid/gate/
    *  cred-family/slot keys, so the write authority exists only for this operation's window and
@@ -5009,6 +5004,11 @@ export class Manager {
     return undefined;
   }
 
+  /** Open a short-lived PROVISIONER connection, run the onboarding ops on it, and drain it (closure (ii),
+   *  residual 2). The DM/DLV consumer-create surface — the irreducible onboarding power — lives only for
+   *  this window, never as a standing grant on the long-lived supervisor. A provision-only endpoint
+   *  (no presence/consume/channel-watch) connected with memory-only `provisioner` creds; it sets its own
+   *  `inboxPrefix` so JS-API replies land on the `_INBOX_<id>.>` the provisioner cred subscribes. */
   private async withProvisioner<T>(fn: (prov: CotalEndpoint) => Promise<T>): Promise<T> {
     if (!this.auth) throw new Error("withProvisioner: no space auth (an open mesh has no scoped creds)");
     const identity = newIdentity();


### PR DESCRIPTION
## What this fixes

Three declarations in `manager.ts` had no documentation, and the blocks written for them were sitting
on other declarations:

| documented nothing | the block describing it sat on |
| --- | --- |
| `class Manager` | `SpawnHooks` |
| `uniqueName` | `liveRosterNames` |
| `withProvisioner` | `withLifecycleExecutor` |

TypeScript attaches **every** preceding JSDoc block to the following declaration, not the nearest
one. So each of those three carried two blocks: its own, and one about something else. Hovering
`SpawnHooks` showed a paragraph about the agent supervisor; `class Manager`, the central class of the
file, appeared to be one nobody had bothered to document.

Nothing is deleted and nothing is rewritten. **21 lines moved, 21 removed.**

## How each subject was established

Not by proximity, and not by reading the prose, since both are unreliable here, and prose is especially so
because good documentation describes behaviour rather than naming symbols. Each block's subject comes
from the commit that introduced it:

- the supervisor block arrived in `feat(manager): agent supervisor + control plane`
- the name-series block in `feat(manager): auto-number spawn names on collision`, i.e. `uniqueName`
- the provisioner block was introduced **directly above `private async withProvisioner<T>`**, in the
  same hunk

That last one is the case nothing local could settle: its documentation sits **1,118 lines** away from
it, so neither adjacency nor distance is evidence either way.

## Verification

Post-conditions were fixed before the change was made, and checked by the parser rather than by eye:

```
BEFORE  documented=170  multi-block holders=4   (Manager, uniqueName, withProvisioner each 0 blocks)
AFTER   documented=173  multi-block holders=1   (each of the three now 1 block)
```

The count of documented declarations rising by exactly three is what separates a move from a
deletion: dropping the blocks would have left it at 170. The per-symbol check alone would not, because it
passes on a move that also disturbs something out of view.

The one remaining multi-block holder is `list`, whose two blocks both describe `list`. That is
legitimate and is left alone.

`pnpm typecheck` rc=0. Suites: `manager-split` 135, `manager-spawn-action` 35, `manager-service` 25,
`journal-model-b` 9, `journal-declaration` 6, `manager-name-claim` 4, giving **214 cells, 0 failed**, each
rc=0. The diff is 42 lines, **0 of them non-comment**.

