### PR TITLE
fix(scripts): keep the original mtime when a mutation is rolled back

### DIFF
--- a/scripts/mutation-proof.mjs
+++ b/scripts/mutation-proof.mjs
@@ -38,7 +38,7 @@
  * Every mutation must name the assertion it expects to redden (`expectRed`). "It went red" and "it
  * went red for my reason" are the same exit code until you say which.
  */
-import { readFileSync, writeFileSync, copyFileSync, existsSync, rmSync } from "node:fs";
+import { readFileSync, writeFileSync, copyFileSync, existsSync, rmSync, statSync, utimesSync } from "node:fs";
 import { execSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
@@ -167,6 +167,7 @@ function proveOne(m, opts) {
   const backup = join(tmpdir(), `mutation-proof-${createHash("sha1").update(path).digest("hex").slice(0, 12)}.bak`);
   copyFileSync(path, backup);
   const shaBefore = sha(path);
+  const { atime: atimeBefore, mtime: mtimeBefore } = statSync(path);
 
   // Restoring the FILE is not restoring the TREE when the command under test compiles it. The sha
   // check below proves the source is byte-identical again; it says nothing about a `dist/` the run
@@ -176,6 +177,16 @@ function proveOne(m, opts) {
   const restore = () => {
     copyFileSync(backup, path);
     const ok = sha(path) === shaBefore;
+    // Restore the TIMESTAMP as well as the bytes. `copyFileSync` is a write, so the file's mtime
+    // becomes now even though the line above proves the content is what it was. Anything that
+    // compares source mtimes against a build then reports a stale artefact for a file nobody
+    // edited: `smoke:dist-freshness` does exactly that, and after a graded run it named
+    // `packages/core` stale and refused the 261-suite chain at its first entry.
+    //
+    // Only when the content is verified identical. If `ok` is false the file is NOT what it was,
+    // and back-dating it would hide a failed restore from the tools that compare timestamps —
+    // the one case where a bumped mtime is telling the truth.
+    if (ok) utimesSync(path, atimeBefore, mtimeBefore);
     rmSync(backup, { force: true });
     if (ok && m.afterRestore) {
       const rr = run(m.afterRestore, cwd, opts.timeoutMs);

--- a/scripts/mutation-proof.selftest.mjs
+++ b/scripts/mutation-proof.selftest.mjs
@@ -12,7 +12,7 @@
  *
  * Run: node scripts/mutation-proof.selftest.mjs
  */
-import { mkdtempSync, writeFileSync, rmSync, readFileSync, mkdirSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync, readFileSync, mkdirSync, statSync } from "node:fs";
 import { execSync, spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
@@ -537,6 +537,37 @@ check("an anchored progress pattern counts per LINE, not once per transcript",
 const after = execSync("git status --porcelain", { cwd: root, encoding: "utf8" }).trim();
 check("every run restored the tree", after === "", { after });
 check("...and the guard is byte-intact", readFileSync(join(root, "src/impl.js"), "utf8").includes("if (n > 10)"));
+
+// 9. Restoring the BYTES is not restoring the FILE. `copyFileSync` is a write, so a restored file
+// carries a fresh mtime while its content is provably unchanged — and every tool that compares a
+// source against a build reads exactly that. After a real graded run, `smoke:dist-freshness` named
+// `packages/core` stale and refused the 261-suite chain at its first entry, for a file nobody had
+// edited. The sha checks above stay green through all of it, which is why this asserts the TIME.
+//
+// Back-date first: without it a fast restore lands in the same millisecond as the original and the
+// check passes whether or not the timestamp was preserved.
+const timed = join(root, "src/impl.js");
+const OLD_MS = Date.now() - 3600_000;
+execSync(`touch -d ${JSON.stringify(new Date(OLD_MS).toISOString())} ${JSON.stringify(timed)}`);
+const mtimeBefore = statSync(timed).mtimeMs;
+const startedMs = Date.now();
+r = runTool([
+  "--command", `${process.execPath} suite.mjs`,
+  "--file", "src/impl.js",
+  "--find", "if (n > 10)\n    return false;",
+  "--replace", "if (false)\n    return false;",
+  "--expect-red", "oversized values are refused",
+]);
+const mtimeAfter = statSync(timed).mtimeMs;
+// Not an equality test. `statSync` surfaces a nanosecond timestamp as a millisecond Date and
+// `utimesSync` can only write that precision back, so a faithful restore still lands up to 1ms
+// off. The defect is not imprecision, it is the mtime becoming NOW — so the discriminating
+// question is whether the restored time predates the run that touched it.
+check("a restored file keeps its original mtime, not the time of the restore",
+  verdictIs(r.stdout, "KILLED") && mtimeAfter < startedMs && Math.abs(mtimeAfter - mtimeBefore) <= 1,
+  { mtimeBefore, mtimeAfter, startedMs, movedMs: mtimeAfter - mtimeBefore });
+check("...and the content is unchanged too, so the time was not preserved by skipping the restore",
+  readFileSync(timed, "utf8").includes("if (n > 10)"));
 
 rmSync(root, { recursive: true, force: true });
 console.log(`\nMUTATION-PROOF SELF-TEST PASSED ✅  (${pass} checks)`);

--- a/scripts/mutations/restore-mtime.json
+++ b/scripts/mutations/restore-mtime.json
@@ -1,0 +1,45 @@
+{
+  "suite": "scripts/mutation-proof.selftest.mjs",
+  "guard": "restore() puts the original mtime back, not the time of the restore",
+  "command": "node scripts/mutation-proof.selftest.mjs",
+  "proveWith": "node scripts/mutation-proof.mjs --config scripts/mutations/restore-mtime.json",
+  "why": [
+    "`copyFileSync` is a write, so restoring the BYTES gives the file a fresh mtime while its",
+    "content is provably unchanged. Every tool that compares a source against a build reads exactly",
+    "that: after a graded run of 94 mutations, `smoke:dist-freshness` named `packages/core` stale",
+    "and refused the 261-suite chain at its first entry, for a file nobody had edited.",
+    "",
+    "The existing sha assertions stay green through the whole defect, which is why the cell these",
+    "mutations redden asserts the TIME. Two mutations rather than one because 'the call is gone'",
+    "and 'the call is there with the wrong value' are different failures, and a cell that only",
+    "notices an absent call would pass a restore that faithfully wrote the wrong timestamp.",
+    "",
+    "NO top-level `completionMarker`. This suite is fail-fast, so its success banner is not printed",
+    "on a red run; pointing a completion marker at it turns every genuine kill INCONCLUSIVE.",
+    "",
+    "NOT ASSERTED, and recorded rather than implied: the `if (ok)` condition on the restore. It",
+    "exists so that a FAILED restore is not back-dated -- that is the one case where a bumped mtime",
+    "is telling the truth, and hiding it would conceal a corrupted tree from the tools that compare",
+    "timestamps. No cell drives it, because reaching it needs the backup itself to be wrong after",
+    "`copyFileSync` succeeds, and the harness offers no seam for that. Making the call unconditional",
+    "would therefore SURVIVE. It is a real unasserted guard, left in place with its reason stated."
+  ],
+  "mutations": [
+    {
+      "name": "the restore does not put the timestamp back at all",
+      "file": "scripts/mutation-proof.mjs",
+      "find": "    if (ok) utimesSync(path, atimeBefore, mtimeBefore);\n",
+      "replace": "",
+      "expectRed": "a restored file keeps its original mtime, not the time of the restore",
+      "cell": "a restored file keeps its original mtime, not the time of the restore"
+    },
+    {
+      "name": "the restore writes the CURRENT time instead of the original",
+      "file": "scripts/mutation-proof.mjs",
+      "find": "    if (ok) utimesSync(path, atimeBefore, mtimeBefore);",
+      "replace": "    if (ok) utimesSync(path, new Date(), new Date());",
+      "expectRed": "a restored file keeps its original mtime, not the time of the restore",
+      "cell": "a restored file keeps its original mtime, not the time of the restore"
+    }
+  ]
+}


### PR DESCRIPTION
`mutation-proof` restores a mutated file by copying its backup back. `copyFileSync` is a write, so
the file ends the run with a fresh mtime, while the sha check on the very next line proves the
content is exactly what it was. Grading a set of mutations therefore leaves every file it touched
looking newer than the build made from it, with no content difference anywhere.

That is not theoretical. After grading 94 mutations across 18 configs, `smoke:dist-freshness`
reported

```
✗ FAIL: packages/core dist/ is 1007s OLDER than src/.
    newest src:  packages/core/src/run-migration.ts
```

and the 261-suite `smoke:ci` chain refused at its **first** entry. The tree was clean, nothing had
been edited, and the file it named is the one two mutation configs target. The diagnosis pointed
away from the cause.

## The change

Capture the timestamps beside the sha, and put them back when the content is verified identical:

```js
const { atime: atimeBefore, mtime: mtimeBefore } = statSync(path);
...
if (ok) utimesSync(path, atimeBefore, mtimeBefore);
```

`if (ok)` is the part worth reviewing rather than the call. If the restore **failed**, the file is
not what it was, and back-dating it would hide that from every tool that compares timestamps: the
one case where a bumped mtime is telling the truth. The fix deliberately does not extend to the
failure path.

## Proved both ways

One direction alone is worth nothing here: "the freshness suite passes after a graded run" is
satisfiable by breaking the suite's ability to detect anything at all. So both were run against the
real suite, on the same file that caused the refusal above:

| | result |
| --- | --- |
| after grading 7 mutations on `packages/core/src/run-migration.ts` | `rc=0`, and it reports the *same* margin as before the run |
| that file `touch`ed directly, outside the tool | `rc=1`, and real staleness is still caught |
| tree afterwards | clean, guard byte-intact, no mutant left behind |

The mtime went `…491013589` to `…490999000` across the graded run. That is preserved, not exact:
`statSync` surfaces a nanosecond timestamp as a millisecond `Date` and `utimesSync` can only write
that precision back, so a faithful restore still lands under a millisecond off. The defect was never
imprecision. It was the mtime becoming *now*, so the new cell asks whether the restored time
predates the run rather than whether it is bit-identical. An equality assertion would have passed
for the wrong reason on a fast restore and failed for the wrong reason on a slow one.

## Predicted changes

Two, in `scripts/mutations/restore-mtime.json`, because a missing call and a call given the wrong
value are different failures and a cell that only notices an absent call would accept a restore that
faithfully wrote the wrong timestamp. Deleting the restore, and having it write the current time
instead of the original: both are caught, each on the named cell, and the mark counts place the
failure at that cell rather than an earlier one (baseline 31, mutant 29).

The config carries no top-level `completionMarker`. The self-test is fail-fast, so its success
banner is not printed on a red run, and pointing a completion marker at it turns every genuine kill
inconclusive.

## How much this is worth, and how much it is not

Bounded, so the defect is not read as bigger than it is: `packages/core/dist` is **gitignored**, so
CI builds its own from source and a local mtime cannot structurally reach a PR verdict. This costs a
local chain refusing at its first suite with a diagnosis pointing at the wrong thing. It could not
have produced a false green on a pull request.

## Not asserted, and recorded rather than implied

The `if (ok)` condition has no cell. Driving it requires the backup to be wrong *after* a successful
copy, and the harness offers no seam for that, so making the call unconditional would survive. It is
a real unasserted guard; it is left in place with its reason stated in the config's `why`, rather
than removed for being untestable or quietly counted as covered.
