### PR TITLE
docs: remove references a public reader cannot resolve

### DIFF
--- a/implementations/auth/src/drain-repair.ts
+++ b/implementations/auth/src/drain-repair.ts
@@ -83,7 +83,7 @@ function opActor(prefix: "epapl" | "eprec" | "epcan", opId: string): string {
  * post-frontier applier write would be an OBSERVABLE overwrite/DEL — unlike the reconciler/canceller
  * epw/epf appends, which land past the interval and are excluded by the interval reader.
  *
- * NAMED RESIDUAL (SPEC 13.9, cs-rev-sec-ruled ACCEPTED, seed-dominated): the fence is a POINT-IN-TIME
+ * NAMED RESIDUAL (SPEC 13.9, ruled ACCEPTED in security review, seed-dominated): the fence is a POINT-IN-TIME
  * scan, not a deny-new, so a holder of a still-unexpired repair JWT+seed could open a FRESH connection
  * AFTER the verify — the reconnect vector the `noReconnect` mint removes for the plane's OWN
  * connections, but not for an exfiltrated bearer. It is confined by the exact ONE-coordinate grant

--- a/implementations/cli/smoke/mesh-target-rebind.smoke.ts
+++ b/implementations/cli/smoke/mesh-target-rebind.smoke.ts
@@ -81,7 +81,7 @@
  *
  *      A NO-OP MUTANT AND AN EQUIVALENT ONE ARE INDISTINGUISHABLE FROM A GREEN SUITE — both
  *      survive, both leave every cell green, both produce identical artifacts. Cotal #424
- *      (measured by fm-webconsole, credit theirs) is the live version of that hazard: in a
+ *      (measured elsewhere, credit theirs) is the live version of that hazard: in a
  *      worktree, `node_modules` resolves to the SHARED checkout, so a cross-package mutation can
  *      edit one copy while the suite loads another and the code under test never changes.
  *      "M2 is equivalent" is the strictly stronger of the two explanations, so it needs its own
@@ -91,7 +91,7 @@
  *           so `node_modules` is not consulted for it at all and #424 cannot apply.
  *        3. Directly measured: M2 re-run with an added marker printing `import.meta.url` from the
  *           mutated module. It printed
- *           `file:///…/cotal-worktrees/fm-rebind/packages/workspace/src/mesh-target.ts` — this
+ *           `file:///…/<this-worktree>/packages/workspace/src/mesh-target.ts` — this
  *           worktree, not the shared checkout — with the mutant proven non-identical by `git diff`
  *           first, and the suite still 22/22. The mutation WAS loaded and it still changed nothing.
  *      A no-op would have shown up as a MISSING MARKER rather than as a survival.

--- a/implementations/delivery/smoke/adoption-swap-strand.smoke.ts
+++ b/implementations/delivery/smoke/adoption-swap-strand.smoke.ts
@@ -12,7 +12,7 @@
  * succeeded. The fix moves `scheduleResidentSwap()` to AFTER `Promise.all` settles in
  * `handleDeliveryAdmin`, immediately before the reply is returned+responded.
  *
- * This isolates that exact timing with REAL nats connections (the shape ss-rev-engineer used to prove
+ * This isolates that exact timing with REAL nats connections (the shape review used to prove
  * the strand): a responder receives a request and either arms `nc.reconnect()` BEFORE responding (the
  * pre-fix pattern) or responds first and arms it AFTER (the fix), with a slow "other proof" window in
  * between. The requester uses the manager's 15s bound.

--- a/packages/core/smoke/inst-route-enforce.smoke.ts
+++ b/packages/core/smoke/inst-route-enforce.smoke.ts
@@ -11,8 +11,8 @@
  * confound the pin with everything else that differs between them; comparing one profile against
  * itself isolates the thing C actually changed.
  *
- * THE SHAPE IS BORROWED AND SO IS THE CLASSIFIER, from a probe cs-lane-session executed and then
- * published a defect in. Both are load-bearing:
+ * THE SHAPE IS BORROWED AND SO IS THE CLASSIFIER, from an earlier probe that was run and had a
+ * defect published in it. Both are load-bearing:
  *
  *   - Take a REAL row out of `permissionsFor` for this principal, substitute only the trailing nonce
  *     wildcard, and publish it as the CONTROL. Then rewrite ONLY the route segment and publish that.


### PR DESCRIPTION
## What this removes

Five comments named a source a reader outside this repository cannot look up: internal reviewer
identifiers, one local worktree path, and an internal probe.

| file | was |
| --- | --- |
| `implementations/auth/src/drain-repair.ts` | a reviewer identifier inside a `NAMED RESIDUAL` note |
| `implementations/cli/smoke/mesh-target-rebind.smoke.ts` | who measured a related hazard, and a local worktree path in a `file://` URL |
| `implementations/delivery/smoke/adoption-swap-strand.smoke.ts` | who first proved the timing this suite isolates |
| `packages/core/smoke/inst-route-enforce.smoke.ts` | the probe the shape and classifier were borrowed from |

None of it is secret. All of it is **unresolvable**, which is the problem: a reference a reader cannot
follow is worse than no reference at all, because it reads as sourced. It invites someone to go and
check a citation that has nothing behind it.

**The claims are kept; only the pointers go.** What a finding says is useful to a reader. Who found it
is not, and the `NAMED RESIDUAL`, the `#424` hazard, the borrowed shape and the strand timing all
survive intact, still explaining why the code and the suites are written the way they are. The
`file://` URL keeps its point (the mutant loaded from *this* worktree, not the shared checkout), with
the machine-specific path replaced by `<this-worktree>`.

## What this does not do

**It mitigates for future readers; it does not erase.** All five strings remain in `main`'s history,
and they are in this PR's own diff on the `-` lines permanently. Removing a string in a commit does
not remove it from the repository, and merging this should not be remembered as making the tree clean
in the stronger sense.

It is still worth doing: the working tree is what people read, and a `file://` path pointing at a
developer's machine sitting in a live comment is worth removing even though the commit that removes it
preserves it.

**And this is five identified sites, not a clean tree.** The search that found them was a prefix list,
which is exactly the instrument that cannot find what its author forgot to list. A shape-based scan was
tried and drowned: `/Users/x/repo` and `/home/r/.config` are *inputs to path-parsing suites*, and a
fixture and a leak have the same shape. They differ only in whether the string is being tested or being
cited, which is a semantic property, not a syntactic one. The rule for next time is about a **named
actor credited as the source of a claim**, and no instrument here reliably finds the sixth one.

## Verification

- `pnpm typecheck` rc=0.
- The three suites whose files changed all pass: `inst-route-enforce` 6/6, `adoption-swap-strand` 3/3,
  `mesh-target-rebind` 22/22.
- **6 lines changed across 4 files, and 0 non-comment lines.** Every `+`/`−` line with comment markers
  stripped leaves nothing but prose.

## Why it is worth a PR rather than a drive-by

These were found by a rule, not by reading. The first version of the search was a list of known
prefixes, and it missed sites whose prefix was not on the list: a scope check built from a list you
wrote cannot find what you forgot to list. The durable form of the rule is about the **shape** of a
reference, meaning a named actor in a comment that a public reader cannot resolve, whatever it is
called.
