### PR TITLE
test(manager): grade the forced split on the contract, not on which member the queue picks

### DIFF
--- a/.changeset/split-probe-contract-grade.md
+++ b/.changeset/split-probe-contract-grade.md
@@ -1,0 +1,7 @@
+---
+---
+
+Test-only: the forced-split arm of the describe/invoke probe now grades the caller-visible
+contract instead of which class-queue member happens to answer, so a repair that is split a
+second time, which is a correct and conclusive outcome, no longer reads as a failure. No
+shipped behaviour changes, so no release.

--- a/.changeset/split-probe-contract-grade.md
+++ b/.changeset/split-probe-contract-grade.md
@@ -1,7 +1,31 @@
 ---
+"@cotal-ai/core": patch
 ---
 
-Test-only: the forced-split arm of the describe/invoke probe now grades the caller-visible
-contract instead of which class-queue member happens to answer, so a repair that is split a
-second time, which is a correct and conclusive outcome, no longer reads as a failure. No
-shipped behaviour changes, so no release.
+Report which bind went stale when a class-queue split is recovered, and grade the describe/invoke
+probe's forced arm on the caller-visible contract.
+
+`split-recovered` carried `servedBy`, the incarnation that answered, without `boundTo`, the one the
+handle thought it was addressing. A listener could therefore see that a split had been recovered but
+not which bind went stale, which is the difference between one handle to drop and a class that is
+churning. Both halves of the fact are now on the event.
+
+The probe's forced arm previously required the repair to land, which asserts a coin comes up heads:
+core repairs a bind refusal exactly once and lets a second refusal surface, while in a two-manager
+space roughly half of all class-queue calls split, so the re-issue goes back through the same queue
+and is split again about half the time. That second refusal is a correct and conclusive outcome, and
+grading it as a failure reddened the suite on runs where the property it exists to protect held
+completely. The arm now accepts either face: the repair landed exactly once, or it was refused again
+and stated that nothing ran.
+
+Accepting an absence of effects requires proving the arm could have produced one, so a positive
+control on the arming runs before any question about the outcome. The forcing writes a bind naming no
+live incarnation; the control reads it back through a fresh cache lookup, proving the entry the
+client sends from was mutated rather than a copy, and requires the first refusal to name that bind.
+
+Without it the ambient system supplied the signal. The probe's space splits naturally about half the
+time, so a run that forced nothing still saw a refusal, a repair, and a second refusal naming a
+different instance: every symptom of the case under test, produced by the ordinary race. Measured
+with the forcing removed, the arm passed 4 of 6 runs. With the control it is caught 6 of 6. Reading
+the first refusal's bind is what required it on the event, because once the repair re-issues, the
+error the caller ends up holding names the second refusal and not the first.

--- a/implementations/manager/smoke/describe-split-duplicate-effect.smoke.ts
+++ b/implementations/manager/smoke/describe-split-duplicate-effect.smoke.ts
@@ -106,7 +106,15 @@ try {
   ep.on("error", () => {});
   // Emitted by the fence's repair path; never fires on a pre-fence tip, so one instrument grades both.
   let recoveriesThisTrial = 0, recoveriesTotal = 0;
-  ep.on("split-recovered", () => { recoveriesThisTrial++; recoveriesTotal++; });
+  // The FIRST refusal's bind, which the final error cannot supply: once the repair re-issues, the
+  // error the caller ends up holding names the SECOND refusal's bind. Only this event sees the one
+  // that was actually fenced, and the forced arm's positive control is that it names the uid the
+  // probe installed.
+  let firstBoundTo = "";
+  ep.on("split-recovered", (e: { boundTo?: { instanceId: string } }) => {
+    if (recoveriesThisTrial === 0) firstBoundTo = e.boundTo?.instanceId ?? "";
+    recoveriesThisTrial++; recoveriesTotal++;
+  });
   await ep.start();
 
   const N = 24;
@@ -198,11 +206,17 @@ try {
   // queue and is split again about half the time. Asserting that the repair always lands is
   // asserting a coin comes up heads.
   let forcedRefusedBeforeEffect = false, forcedDetail = "", forcedUid = "", forcedBoundTo = "";
+  let forcedInstalled = false;
   if (bound !== undefined) {
     forcedUid = mintLifecycleUid();
     bound.responder.instanceId = forcedUid;
+    // Read back through a FRESH cache lookup, not the local alias: this is what proves the probe
+    // mutated the entry the client will actually send from, rather than a copy handed out by
+    // `get`. If this is ever false the arm below is measuring an unforced call.
+    forcedInstalled = cache.get(MANAGER_ENDPOINT)?.responder.instanceId === forcedUid;
     const forcedName = `epsplit-forced-${randomUUID().slice(0, 6)}`;
     recoveriesThisTrial = 0;
+    firstBoundTo = "";
     try {
       const r = await ep.invokeService(MANAGER_ENDPOINT, "define-persona",
         { name: forcedName, persona: "forced-split probe" }, { deadlineMs: 15_000 });
@@ -241,6 +255,16 @@ try {
   console.log(`     pre-effect refusals repaired: ${forcedRecoveries}   effects: ${forcedEffects}   caller saw ok: ${forcedOk}`);
   if (!forcedOk) console.log(`     the re-issue was refused too: ${forcedDetail}`);
   if (!forcedOk) console.log(`     forced bind: ${forcedUid}   the refusal names: ${forcedBoundTo || "(none)"}`);
+  console.log(`     armed: installed=${forcedInstalled}  first refusal named: ${firstBoundTo || "(none)"}`);
+  // POSITIVE CONTROL ON THE ARMING, and it must come before any question about the outcome. This
+  // suite's space splits naturally about half the time, so a probe that failed to force anything
+  // still sees a refusal, a repair and a differing bind — every symptom of the case under test,
+  // produced by the ordinary race instead. Measured: with the forcing removed, the cells below
+  // passed on 4 of 6 runs. An absence of effects is only evidence if the arm could have produced
+  // one, and that is what this states: the bind went in, and the refusal that came back is the
+  // one it provoked.
+  check("THE FORCED SPLIT WAS ACTUALLY FORCED: the probe's bind was installed on the live handle, and the refusal that came back names THAT bind and not a natural one",
+    forcedInstalled && firstBoundTo === forcedUid, { forcedInstalled, forcedUid, firstBoundTo });
   // A recovery is emitted ONLY on a reply the caller read as refused-before-effect, so counting one
   // proves the responder produced the marked refusal — this is the fence, observed and not inferred.
   check("FORCED SPLIT IS FENCED: the wrongly-bound call was refused before it ran, then repaired",

--- a/implementations/manager/smoke/describe-split-duplicate-effect.smoke.ts
+++ b/implementations/manager/smoke/describe-split-duplicate-effect.smoke.ts
@@ -192,26 +192,72 @@ try {
   check("the caller holds a resolved handle to rewrite (the forced case can be set up at all)",
     bound !== undefined, { cached: [...cache.keys()] });
   let forcedRecoveries = 0, forcedEffects = 0, forcedOk = false;
+  // THE REPAIR IS NOT GUARANTEED TO LAND, BY DESIGN. Core repairs a bind refusal exactly once and
+  // lets a second refusal surface, while in a two-manager space roughly half of all class-queue
+  // calls split (both stated in `endpoint.ts`). The re-issue therefore goes back through the same
+  // queue and is split again about half the time. Asserting that the repair always lands is
+  // asserting a coin comes up heads.
+  let forcedRefusedBeforeEffect = false, forcedDetail = "", forcedUid = "", forcedBoundTo = "";
   if (bound !== undefined) {
-    bound.responder.instanceId = mintLifecycleUid();
+    forcedUid = mintLifecycleUid();
+    bound.responder.instanceId = forcedUid;
     const forcedName = `epsplit-forced-${randomUUID().slice(0, 6)}`;
     recoveriesThisTrial = 0;
     try {
       const r = await ep.invokeService(MANAGER_ENDPOINT, "define-persona",
         { name: forcedName, persona: "forced-split probe" }, { deadlineMs: 15_000 });
       forcedOk = r.reply.ok === true;
-    } catch { forcedOk = false; }
+      if (!forcedOk) {
+        const err = r.reply.error as { code?: string; outcome?: string; details?: Array<{ kind?: string; boundTo?: { instanceId?: string } }> } | undefined;
+        const marks = (err?.details ?? []).map((d) => d.kind).filter(Boolean);
+        forcedRefusedBeforeEffect = marks.includes(EP_BIND_REFUSED) && err?.outcome === "not-executed";
+        // WHICH bind the refusal names is what proves the re-issue actually went out: the first
+        // attempt is bound to the uid this probe forced in, so a second refusal still naming it
+        // would mean nothing was re-resolved and re-sent.
+        forcedBoundTo = (err?.details ?? []).find((d) => d.kind === EP_BIND_REFUSED)?.boundTo?.instanceId ?? "";
+        forcedDetail = `${err?.code ?? "?"}|outcome=${err?.outcome ?? "(absent)"}|${marks.join(",") || "(no details)"}`;
+      }
+    } catch (e) {
+      // RECORDED, NEVER DISCARDED. This arm previously wrote `catch { forcedOk = false; }`, which
+      // gave a timeout and a second fence refusal the same two numbers and no way to tell them
+      // apart — in a suite whose own subject is that a failure must state what it did. Diagnosing
+      // the flake it caused required adding this line first.
+      const thrown = (e instanceof EpEnvelopeError ? e.details ?? [] : []) as Array<{ kind?: string; boundTo?: { instanceId?: string } }>;
+      const marks = thrown.map((d) => d.kind).filter(Boolean);
+      forcedRefusedBeforeEffect = marks.includes(EP_BIND_REFUSED) && (e as EpEnvelopeError).outcome === "not-executed";
+      // Read here too, so this face is legible rather than blank. A resolve failure rethrows the
+      // ORIGINAL refusal, whose bind is the one forced in, so the guard below correctly rejects it:
+      // no re-issue went out. Left unassigned it stayed "", which is indistinguishable in the output
+      // from a detail that was absent, and telling those apart is this suite's whole subject.
+      forcedBoundTo = thrown.find((d) => d.kind === EP_BIND_REFUSED)?.boundTo?.instanceId ?? "";
+      forcedDetail = e instanceof EpEnvelopeError
+        ? `${e.code}|outcome=${e.outcome ?? "(absent)"}|${marks.join(",") || "(no details)"}`
+        : `${(e as Error).name}: ${(e as Error).message.slice(0, 80)}`;
+    }
     forcedRecoveries = recoveriesThisTrial;
     forcedEffects = [root1, root2].filter((r) => existsSync(agentFilePath(r, forcedName))).length;
   }
   console.log(`\n1b. the split FORCED rather than awaited (bind names a non-serving incarnation)`);
   console.log(`     pre-effect refusals repaired: ${forcedRecoveries}   effects: ${forcedEffects}   caller saw ok: ${forcedOk}`);
+  if (!forcedOk) console.log(`     the re-issue was refused too: ${forcedDetail}`);
+  if (!forcedOk) console.log(`     forced bind: ${forcedUid}   the refusal names: ${forcedBoundTo || "(none)"}`);
   // A recovery is emitted ONLY on a reply the caller read as refused-before-effect, so counting one
   // proves the responder produced the marked refusal — this is the fence, observed and not inferred.
   check("FORCED SPLIT IS FENCED: the wrongly-bound call was refused before it ran, then repaired",
     forcedRecoveries === 1, { forcedRecoveries });
-  check("FORCED SPLIT LEAVES ONE EFFECT: the repair re-issued once and the write landed exactly once",
-    forcedEffects === 1 && forcedOk, { forcedEffects, forcedOk });
+  // BOTH OUTCOMES ARE CORRECT, so both pass: the repair either landed (one effect, caller told ok)
+  // or was split again and refused (no effect, and the refusal states conclusively that nothing
+  // ran). Grading the first alone reddened this suite on runs where the property it exists to
+  // protect — at most one effect, and a conclusive answer when there was none — held completely.
+  // What must never happen is two effects, or none with nothing conclusive said about it.
+  const forcedLanded = forcedEffects === 1 && forcedOk;
+  // The refusal must name a DIFFERENT bind than the one forced in. Without this the arm would
+  // accept a client that counts the refusal, drops the handle and never re-issues at all: that
+  // also yields zero effects and a conclusive refusal, and would otherwise read as the good face.
+  const forcedRefusedAgain = forcedEffects === 0 && !forcedOk && forcedRefusedBeforeEffect
+    && forcedBoundTo !== "" && forcedBoundTo !== forcedUid;
+  check("FORCED SPLIT CAUSES AT MOST ONE EFFECT AND SAYS SO: the repair either landed exactly once, or was refused again and stated that nothing ran",
+    forcedLanded || forcedRefusedAgain, { forcedEffects, forcedOk, forcedRefusedBeforeEffect, forcedDetail, forcedUid, forcedBoundTo });
 
   const dupes = trials.filter((t) => t.both);
   const dupeSilent = dupes.filter((t) => t.callerSaw === "ok");

--- a/implementations/manager/smoke/fixtures/bind-recovery.mutations.json
+++ b/implementations/manager/smoke/fixtures/bind-recovery.mutations.json
@@ -4,8 +4,8 @@
     {
       "name": "a long-lived client stops recovering from a bind refusal (the stale bind strands it)",
       "file": "packages/core/src/endpoint.ts",
-      "find": "        if (r.reply.ok === false && replyRefusedBeforeEffect(r.reply.error)) {\n          // Counted before it is repaired, and emitted for anyone watching: see {@link splitsRecovered}.\n          // A recovery that leaves no trace takes the split rate with it.\n          this.splitsRecovered++;\n          this.emit(\"split-recovered\", {\n            endpoint, command, servedBy: r.responder, splitsRecovered: this.splitsRecovered,\n          });\n          this.resolvedServices.delete(endpoint);\n          return await invokeCommand(nc, this.space, await resolve(), command, args, invokeOpts);\n        }\n",
-      "replace": "",
+      "find": "        if (r.reply.ok === false && replyRefusedBeforeEffect(r.reply.error)) {\n",
+      "replace": "        if (false && r.reply.ok === false && replyRefusedBeforeEffect(r.reply.error)) {\n",
       "expectRed": "the stale (epoch 0) bind was replaced by the successor's"
     },
     {
@@ -18,8 +18,8 @@
     {
       "name": "the recovery stops announcing itself",
       "file": "packages/core/src/endpoint.ts",
-      "find": "          this.emit(\"split-recovered\", {\n            endpoint, command, servedBy: r.responder, splitsRecovered: this.splitsRecovered,\n          });\n",
-      "replace": "",
+      "find": "          this.emit(\"split-recovered\", {\n",
+      "replace": "          this.emit(\"split-recovered-MUTANT-NOT-ANNOUNCED\", {\n",
       "expectRed": "it was announced to anyone listening"
     }
   ]

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -18,7 +18,7 @@ import {
 import { credsClaims, credsFingerprint, credsRenewalDelayMs, idFromCreds } from "./identity.js";
 import { inspectCredHealth } from "./provision.js";
 import { resolveService, invokeCommand, submitAndFollowGoal, type ResolvedService } from "./endpoint-invoke.js";
-import { EpEnvelopeError, respondedButUnbound, replyRefusedBeforeEffect } from "./endpoint-envelope.js";
+import { EpEnvelopeError, respondedButUnbound, replyRefusedBeforeEffect, EP_BIND_REFUSED, type EpBindRefusedDetail } from "./endpoint-envelope.js";
 import { isRepeatSafeCommand } from "./endpoint-grants.js";
 import type { EpCaller } from "./endpoint-subjects.js";
 import type { EpVerbTarget, EpAttributedReply } from "./endpoint-verbs.js";
@@ -1418,8 +1418,16 @@ export class CotalEndpoint extends EventEmitter {
         if (r.reply.ok === false && replyRefusedBeforeEffect(r.reply.error)) {
           // Counted before it is repaired: a recovery that leaves no trace takes the split rate with it.
           this.splitsRecovered++;
+          // `boundTo` is the other half of `servedBy`: who the handle THOUGHT it was talking to,
+          // against who actually answered. Without it a listener sees that a split was recovered
+          // but not which bind went stale, so it cannot tell one handle's repeated staleness from
+          // splits spread across many — and that is the difference between a handle to drop and a
+          // class that is churning.
           this.emit("split-recovered", {
             endpoint, command, servedBy: r.responder, splitsRecovered: this.splitsRecovered,
+            boundTo: (r.reply.error?.details ?? []).find(
+              (d): d is EpBindRefusedDetail => d.kind === EP_BIND_REFUSED,
+            )?.boundTo,
           });
           this.resolvedServices.delete(endpoint);
           // A FAILED RE-ISSUE RETHROWS THE ORIGINAL REFUSAL, not the resolve error: if the endpoint


### PR DESCRIPTION
`smoke:describe-split-effect` fails roughly half the time. It is entry 244 in the CI chain, so it
runs on shard 3 of every run on `main` and every PR, and the failure it reports is not a defect.

## The assertion cannot hold

The forced arm asserted that the repair always lands:

```ts
check("FORCED SPLIT LEAVES ONE EFFECT: the repair re-issued once and the write landed exactly once",
  forcedEffects === 1 && forcedOk, ...)
```

Two facts, both already stated in `endpoint.ts`, make that a coin flip:

> *"Exactly once; a second refusal surfaces."*

> *"in a two-manager space roughly half of all class-queue calls split"*

The fence refuses the wrongly-bound call, the client repairs it exactly once, and the re-issue goes
back through the same class queue, which splits it again about half the time. The second refusal
surfaces to the caller, and the arm calls that a failure.

## The failing runs are correct

The probe's own docblock states what it grades: *"one request causes at most one effect, and a
request that caused none says so conclusively."* A failing run:

```
code: failed-precondition
details: [{ kind: "ai.cotal.ep.bind-refused", boundTo: …, servedBy: … }]
outcome: "not-executed"
effects: 0
```

At most one effect held. The caller was told conclusively that nothing ran. **The suite went red on
a run where the property it exists to protect was fully satisfied**, which is worse than a red on
an ambiguous result, because a red on correct behaviour survives investigation rather than inviting
it.

Measured on a live two-manager mesh before the change: **15 runs, 8 red**, across three different
commits, with the same numbers every time. The same second-refusal face also reaches ordinary
operator commands; it is not an artifact of the forced fixture.

## What changed

Both legitimate outcomes now pass and a duplicate still fails: the repair either landed exactly
once, or it was refused again and said so conclusively.

The relaxation would otherwise be vacuous, so it is bounded: **the second refusal must name a
different bind than the one forced in.** A client that counted the refusal, dropped the handle and
never re-issued produces the same zero effects and the same conclusive answer, and would read as
the good face. That case is now a failure.

## The catch discarded its own error

`catch { forcedOk = false; }` gave a timeout and a second fence refusal identical numbers, in a
suite whose own subject is that a failure must state what it did. This was not cosmetic: the flake
could not be diagnosed until that line was added, and the first hypothesis, a 15s deadline expiring
under load, was refuted only by observing that the error never printed at all, because the second
refusal arrives as an `ok:false` reply and never enters the catch.

No deadline was changed. Widening 15s would have bought quiet and kept the defect.

## Verification

- **12 consecutive runs, zero failures**, with both faces exercised (repair landed, and repair
  refused again). Under the previous assertion the refused-again runs were failures.
- **Mutation-proved, 2 of 2 killed**, each red on its own named assertion:
  - the client never re-issues (`return r`), red on `FORCED SPLIT CAUSES AT MOST ONE EFFECT AND
    SAYS SO`. This is the face the relaxed assertion could have accepted, and is why the bind check
    exists.
  - the responder's pre-effect fence removed, red on `FORCED SPLIT IS FENCED`.
  - Both mutations live in `packages/core/src`, which the suite reaches through `dist`, so the
    fixture builds core before each run and rebuilds after restore.
- `pnpm typecheck` clean; `pnpm changeset status` clean.

## This PR contains a core change, and it is a dependency of the control above

**`packages/core/src/endpoint.ts`: the `split-recovered` event now carries `boundTo` alongside
`servedBy`.** Ten lines, additive, declared `@cotal-ai/core: patch`. Calling it out here because a
`test(manager):` headline over a `packages/core` hunk is how a shipped change reaches a reviewer who
was not looking for one.

It is required by the arming control, not bundled with it: **after the repair re-issues, the error
the caller ends up holding names the SECOND refusal's bind.** The first one, the only one that
proves the fixture armed, is observable nowhere else.

It also stands on its own. The event reported who answered without reporting who the handle thought
it was addressing, so a listener could see that a split had been recovered but not which bind went
stale, and that is the difference between one handle to drop and a class that is churning.

## The arm was not testing what it claimed

The bound above requires the second refusal to name a different bind than the one forced in, and the
argument for it was that a fixture which never armed could not produce a differing bind. **That
argument is wrong, and the demonstration killed it.**

The probe's space splits naturally about half the time. A run that forced nothing still gets a
refusal, still gets a repair, and its second refusal still names a different instance: every symptom
of the case under test, supplied by the ordinary race. The bound asked whether a different bind came
back, and the queue answers yes unaided.

**Measured, with the bind write removed: the arm passed 4 of 6 runs.** The 2 catches were the runs
where no natural split happened to occur. So the arm was not testing the forcing; it was testing
that a split of some kind had happened.

**A control whose signal the ambient system also produces is not a control.**

## The positive control

Before any question about the outcome: the forced bind was installed on the live handle, **read back
through a fresh cache lookup** so it proves the entry the client actually sends from was mutated
rather than a copy, **and the first refusal names that bind.**

**Same never-armed mutant, with the control in: caught 6 of 6.** Two of those reds show
`installed=false` with the refusal naming a real instance, which is the natural-split impostor
failing where it used to pass.

An absence of effects is only evidence if the arm could have produced one. This PR accepts an
absence of effects, so it now proves the precondition rather than assuming it.




## The widened assertion still rejects something

Widening is the direction that can silently accept everything, so the relaxation is proved rather
than asserted. **Break `define-persona` to report success without writing**, which produces
`effects: 0` with `ok: true`, the one shape neither arm covers: it is not the repair landing once,
and it is not a conclusive refusal.

**KILLED, red on `FORCED SPLIT CAUSES AT MOST ONE EFFECT AND SAYS SO`, 8 marks against a baseline
of 10.** A duplicate or a silent failure satisfies neither arm, which is the property the arm is
really asserting: **the caller is never lied to.** Landed exactly once and reported so, or landed
nowhere with the marker and an explicit `not-executed`.

Independent corroboration from a second lane that wrote the same disjunction before learning this PR
existed, and closed its own as the duplicate: **8 local runs, 8 of 8 green, two of them landing on
the surfaced ending that the old cell graded FAIL**, a 25 percent false-red in that sample.

Per-run heal rates across those eight runs: **47, 44, 75, 78, 40, 50, 27, 57.** The mechanism is not
stable enough for any single-coin assertion at any threshold, which is why the answer is not to retry
the suite or to raise a bar.

## A guard this PR would otherwise have killed

`implementations/manager/smoke/fixtures/bind-recovery.mutations.json` mutation 2, "the recovery stops
announcing itself", matched the **whole emit block**. Adding `boundTo` to that payload stops it
applying, so it would have graded ERROR rather than KILLED. Nothing in CI runs `mutation-coverage` or
validates fixtures, so it would have merged green and rotted until someone ran it by hand.

**The guard on the announce path lapsing in the same commit that extends the announce path** is the
defect class the tool exists to prevent, so it is fixed here rather than filed.

Both it and mutation 0 now anchor on a line that does not depend on the block's contents: the emit
call line, renamed so no listener hears it, and the branch condition, disabled so the recovery never
runs. Growing the payload again cannot rot either one.

**Mutation 0 was already stale on `main` before this PR** and has been grading ERROR for some time:
its `find` carried a comment that no longer exists, matching neither `main` nor this head. Repaired
here because it is the same defect in the same file. **All three now killed, each red on its own
named assertion**, at 14, 21 and 21 marks against a baseline of 22.
