### PR TITLE
fix(core): say the command did not run in the field, not only in the message

### DIFF
--- a/.changeset/reissue-resolve-outcome.md
+++ b/.changeset/reissue-resolve-outcome.md
@@ -1,0 +1,8 @@
+---
+"@cotal-ai/core": minor
+---
+
+State the effect outcome structurally when a bind refusal's re-issue cannot be resolved. The
+error's message asserted the command had not run while its `outcome` field was absent, and an
+omitted outcome must be read as `unknown` (SPEC 13.3), so the prose and the field a caller keys
+on disagreed on the one path whose purpose is to be conclusive.

--- a/packages/core/smoke/unfenced-responder.smoke.ts
+++ b/packages/core/smoke/unfenced-responder.smoke.ts
@@ -60,7 +60,7 @@ const c = (name: string, cond: boolean, extra?: unknown) => {
 /** Declared, not implied: a live suite can end in ways that redden no line, and `fail === 0` reads
  *  as PASS in every one of them. Measured by this lane's own crash controls — a mid-run exit prints
  *  nothing at all, and an import-time throw does not even reach this handler. */
-const EXPECTED_CELLS = 33;
+const EXPECTED_CELLS = 34;
 process.on("exit", () => {
   const ran = pass + fail;
   if (ran !== EXPECTED_CELLS) {
@@ -325,6 +325,13 @@ try {
   c("...and still carries the bind-refused marker, so a caller keys on the same fact either way",
     replyRefusedBeforeEffect(goneThrew instanceof EpEnvelopeError ? goneThrew.toEpError() : undefined),
     goneThrew instanceof EpEnvelopeError ? goneThrew.details : goneThrew);
+  // §13.3: `WAS NOT RUN` in the message is prose; `outcome` is the field a caller keys on, and an
+  // omitted one MUST be read as `unknown`. Every cell above is satisfied by prose plus the marker,
+  // so a rethrow that dropped the outcome told a reader one thing and a machine the opposite, on
+  // the one path whose entire purpose is to be conclusive.
+  c("...and says so STRUCTURALLY, not only in prose (an omitted outcome reads as `unknown`)",
+    (goneThrew instanceof EpEnvelopeError ? goneThrew.outcome : undefined) === "not-executed",
+    { outcome: goneThrew instanceof EpEnvelopeError ? goneThrew.outcome ?? "(absent)" : "(not an EpEnvelopeError)" });
   c("...and nothing ran on the way to saying so", executions === exec4, { exec4, executions });
 
   // ---- 5. THE REFUSAL MUST BE DERIVABLE, NOT MERELY PRESENT ------------------------------------

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -1452,6 +1452,11 @@ export class CotalEndpoint extends EventEmitter {
               refusalCode,
               `${endpoint}.${command} WAS NOT RUN - the incarnation that received it refused it before any effect, and the re-issue could not be resolved: ${reissue instanceof Error ? reissue.message : String(reissue)}. Re-resolve and re-issue when the endpoint is reachable (SPEC 13.2)`,
               r.reply.error?.details,
+              // §13.3: the message asserts the command did not run, so the FIELD a caller keys on
+              // must assert it too. Omitted, it MUST be read as `unknown`, which is the opposite of
+              // what this path knows: the responder fenced the call before any effect and the
+              // re-issue never went out. Prose is for the reader; this is for the machine.
+              "not-executed",
             );
           }
           return await invokeCommand(nc, this.space, reissueTarget, command, args, invokeOpts);


### PR DESCRIPTION
When a bind refusal's re-issue cannot be resolved, `invokeService` rethrows an error whose message
asserts the command did not run:

```
manager.define-persona WAS NOT RUN - the incarnation that received it refused it before any
effect, and the re-issue could not be resolved: … (SPEC 13.2)
```

It passed three arguments to a four-argument constructor:

```ts
constructor(readonly code: EpErrorCode, message: string, readonly details?: EpErrorDetail[],
            readonly outcome?: EpEffectOutcome)
```

So `outcome` was absent. `endpoint-error.ts` states the rule forty lines above:

> *"An omitted `outcome` MUST be read as `unknown`, so absence is never evidence of
> non-execution."*

**The prose told a reader the command did not run, and the structured field told a machine it was
unknown, on the one path whose entire purpose is to be conclusive.** The spec makes the field win,
so a correct caller had to treat a definite answer as indefinite, and the safe response to
`unknown` for a mutating command is to not retry, which is the opposite of what this path is
telling it to do.

## Why the existing cells could not catch it

`unfenced-responder` already covers this path, with four cells. They assert the message matches
`WAS NOT RUN`, that the resolve failure is named as the reason, that the bind-refused marker is
carried, and that nothing ran. The marker check goes through `replyRefusedBeforeEffect`, which
tests only for the marker:

```ts
export function replyRefusedBeforeEffect(e: EpError | undefined): boolean {
  return (e?.details ?? []).some((d) => d.kind === EP_BIND_REFUSED);
}
```

**Prose and marker were both satisfied while the field was missing.** Every cell passed, and the
one fact a machine consumes was absent.

## Reproduced before it was fixed

The cell was written first and run against the unfixed tree:

```
✗ FAIL: ...and says so STRUCTURALLY, not only in prose (an omitted outcome reads as `unknown`)
        { outcome: '(absent)' }
```

33 passed, 1 failed: the new cell was the only one that moved.

Then the one-argument fix, and the same suite passes 34 of 34.

The suite's `EXPECTED_CELLS` guard is advanced from 33 to 34 in the same change, since it refuses
a run whose cell count does not match and a partial run is not a pass. That guard fired during
this work and is the reason the count moved rather than drifting.

## Verification

- **Mutation-proved, 1 of 1 killed**: dropping the `"not-executed"` argument again reddens
  `...and says so STRUCTURALLY, not only in prose`, the cell named for it. The suite reads
  `../src/index.js` through tsx rather than the built `dist`, so no build is prepended, verified
  by reading its imports rather than assumed.
- Adjacent suites unaffected: `smoke:bind-fence` 20/0, `smoke:ep-envelope` 70/0.
- `pnpm typecheck` clean, `pnpm build` clean.
