### PR TITLE
fix(web): stop hiding hubs from a membership snapshot the page cannot re-read

### DIFF
--- a/.changeset/web-unreadable-not-authoritative.md
+++ b/.changeset/web-unreadable-not-authoritative.md
@@ -1,0 +1,9 @@
+---
+"@cotal-ai/web": minor
+---
+
+The membership pill said "unreadable" while the layout kept acting on the snapshot it had just
+disowned: `hide empty` was gated on `feed.available`, which an unreadable feed leaves true, so a hub
+was still collapsed as empty on the strength of a reading the page could no longer make. Hiding now
+requires the feed to be authoritative, meaning available and readable. The snapshot itself is kept:
+`asOf` still records when the feed was last read successfully, which is true and worth showing.

--- a/implementations/web/smoke/membership-refusal.smoke.ts
+++ b/implementations/web/smoke/membership-refusal.smoke.ts
@@ -373,4 +373,53 @@ check("graph.js registers a listener for the refusal event", Boolean(listened), 
 check("the listener's event name IS the server's exported constant (a restated literal can drift)",
   listened === MEMBERSHIP_READ_FAILED, { listened, exported: MEMBERSHIP_READ_FAILED });
 
+// ── The page stops ACTING on a reading it has just disowned ─────────────────────────────────────
+// The pill telling the truth was only half of it. `hide empty` collapses a hub with no visible
+// member, and it was gated on `feed.available`, which an unreadable feed leaves TRUE — so the pill
+// read "unreadable" while the layout went on asserting a hub is empty NOW, from a snapshot the page
+// had just said it could no longer read. Internally inconsistent with one honest half is a strict
+// improvement on consistently false, and a bad place to stop.
+const feedAuth = liftStmt(graphJs, "const feedAuthoritative", ";");
+const isHiddenSrc = liftStmt(graphJs, "const isHidden", ";");
+check("the feed-authority predicate was lifted out of graph.js", feedAuth !== null);
+check("the isHidden expression was lifted out of graph.js", isHiddenSrc !== null);
+
+/** Drive the SHIPPED `isHidden` over a hub that is empty, under a given feed state. */
+const hubHidden = (f: Record<string, unknown>): boolean => {
+  const ctx: Record<string, unknown> = {
+    feed: { asOf: undefined, available: false, unreadable: false, ...f },
+    filter: { hideEmpty: true, hideOffline: false },
+    isOffline: () => false,
+    out: undefined,
+  };
+  runInContext(`${feedAuth}\n${isHiddenSrc}\nout = isHidden({ kind: "hub", empty: true });`,
+    createContext(ctx), { filename: "graph.js (isHidden)" });
+  return ctx.out as boolean;
+};
+
+check("CONTROL: an authoritative feed still hides an empty hub (the toggle is not collateral damage)",
+  hubHidden({ available: true, asOf: 1700000000000 }) === true);
+check("CONTROL: with no feed at all an empty hub is still not hidden (traffic-only is unchanged)",
+  hubHidden({ available: false }) === false);
+// THE DEFECT, STATED DIRECTLY. A stale snapshot is what we last KNEW, never what IS, and `hide empty`
+// is a claim about now. This is the cell a revert reddens.
+check("AN UNREADABLE FEED IS NOT AUTHORITATIVE: an empty hub is not hidden while the feed cannot be read",
+  hubHidden({ available: true, asOf: 1700000000000, unreadable: true }) === false);
+
+// The over-correction this could invite is discarding the snapshot, which would throw away a true
+// fact: `asOf` means "when we last read successfully", and that is exactly what it should keep
+// meaning. The same trap the read path already passes, one layer up.
+const unreadableFn = lift(graphJs, "function membershipUnreadable()");
+check("the unreadable transition was lifted out of graph.js", unreadableFn !== null);
+const afterUnreadable = (): Record<string, unknown> => {
+  const feed: Record<string, unknown> = { asOf: 1700000000000, available: true, unreadable: false };
+  runInContext(`${unreadableFn}\nmembershipUnreadable();`,
+    createContext({ feed, setFeed: () => undefined }), { filename: "graph.js (unreadable)" });
+  return feed;
+};
+check("an unreadable feed still records WHEN it was last read successfully (asOf is not discarded)",
+  afterUnreadable().asOf === 1700000000000, afterUnreadable());
+check("...and it does say it is unreadable, so the state is marked rather than erased",
+  afterUnreadable().unreadable === true);
+
 console.log(`\nMEMBERSHIP REFUSAL SMOKE OK ✅  (${pass} passed, 0 failed)`);

--- a/implementations/web/src/web/graph.js
+++ b/implementations/web/src/web/graph.js
@@ -62,7 +62,10 @@
   const particles = [];
   const blooms = [];
   const recent = [];
-  const feed = { asOf: undefined, available: false }; // membership-feed freshness
+  // `available` is "there is a feed and it said something"; `unreadable` is "the last attempt to read
+  // it failed". They are independent, and `unreadable` is declared here rather than sprung into
+  // existence on first failure so the shape of the state is readable in one place.
+  const feed = { asOf: undefined, available: false, unreadable: false }; // membership-feed freshness
   const cam = { x: 0, y: 0, scale: 1, ready: false, user: false };
   const filter = { chat: true, unicast: true, anycast: true, window: 30, paused: false, hideOffline: true, hideEmpty: true };
   let W = 0, H = 0, DPR = 1, hover = null, sel = null, lastT = 0, alpha = 1;
@@ -339,13 +342,24 @@
   // default) collapses a HUB with no VISIBLE member under the current filters — it reads the cached `h.empty`
   // (kept current by recomputeHubEmpty). So when `hide offline` is ON this
   // means "no ONLINE member"; when it's OFF a channel that still shows offline members keeps its hub — the two
-  // toggles don't fight (review-critic R2). Gated on `feed.available`: without the authoritative feed there
-  // are no membership edges, so every hub would read empty — we can't tell a quiet channel from an unknown
-  // one, so we don't hide. Reading the cached flag keeps isHidden(hub) O(1), not an all-edges scan per call.
+  // toggles don't fight (review-critic R2). Gated on the feed being AUTHORITATIVE: without the
+  // authoritative feed there are no membership edges, so every hub would read empty — we can't tell a
+  // quiet channel from an unknown one, so we don't hide. Reading the cached flag keeps isHidden(hub)
+  // O(1), not an all-edges scan per call.
   // Hiding suppresses node/spoke rendering, hit-testing, camera framing, and physics participation; the node
   // stays in the model, so toggling reveals it instantly.
+  //
+  // `feedAuthoritative()` rather than `feed.available` alone. Those came apart the moment the feed
+  // could report that it could not be READ: the last snapshot is still the last thing we KNEW, but it
+  // is no longer what IS, and `hide empty` asserts a hub has no member NOW. That is the gate's own
+  // stated reason applied to the case where we hold stale edges rather than none — otherwise the pill
+  // says "unreadable" while the page keeps acting on the reading it just disowned.
+  //
+  // The snapshot itself is deliberately NOT discarded: `asOf` and the spokes remain the honest record
+  // of the last successful read, which is true and worth showing. What stops is treating it as current.
+  const feedAuthoritative = () => feed.available && !feed.unreadable;
   const isHidden = (n) => n.kind === "hub"
-    ? filter.hideEmpty && feed.available && n.empty
+    ? filter.hideEmpty && feedAuthoritative() && n.empty
     : filter.hideOffline && isOffline(n);
   // Per-CHANNEL visibility of a membership spoke: hidden when `hide offline` is on AND this edge is offline
   // for its channel (durable-only, or the agent is offline) — so "hide offline" holds per channel, not just


### PR DESCRIPTION
Follow-up to #450, from its review. #450 taught the wire and the pill to distinguish "could not read"
from "nothing to read". This finishes the job on the half of the page that kept acting on the older
answer.

## The gap

`membershipUnreadable()` set `feed.unreadable` and the pill, and nothing else. `hide empty` collapses
a hub with no visible member, and it was gated on `feed.available`, which an unreadable feed leaves
`true`. So the page reported that it could not read membership and went on collapsing hubs as empty
from the last snapshot.

That state is internally inconsistent with one honest half. Before #450 the page was internally
consistent and false, and nothing on it could reveal the difference; after #450 the pill can. This is
a strict improvement and a bad place to stop.

## The change

Hiding now requires the feed to be authoritative, meaning available **and** readable:

```js
const feedAuthoritative = () => feed.available && !feed.unreadable;
```

This is the gate's own stated reason applied to a case it predates. The existing comment says the
gate exists because "we can't tell a quiet channel from an unknown one, so we don't hide". While the
feed is unreadable we equally cannot tell, so we equally should not hide. `feed.available` had been
standing in for "we currently know", and the two came apart the moment the feed could report that it
could not be read.

`unreadable` is also declared in the `feed` initialiser rather than springing into existence on the
first failure, so the shape of that state is readable in one place.

## What is deliberately NOT done

The snapshot is not discarded. `asOf` means "when we last read successfully", which is true and worth
showing, and the spokes remain the honest record of the last good read. What stops is treating any of
it as current. Discarding it would be the over-correction: throwing away a fact the page legitimately
has, and making a genuine empty read indistinguishable from a failed one, which is the defect #450
removed.

Two cells hold that line, because it is the tempting mistake here.

## Verification

`smoke:web-membership-refusal`: **44 cells, `rc=0`** (36 before). No new list entry; the cells live in
the suite that already covers this file, so this PR does not contend for `bin/smoke/ci-suites.txt`.

The new cells drive the **shipped** `isHidden` and `membershipUnreadable`, lifted out of `graph.js`
rather than restated, so a change to the source that the cells do not follow breaks them.

Both mutations were predicted before being run, and each names the first assertion it reddens, since
the suite stops on first failure:

| mutation | expected red | result |
| --- | --- | --- |
| `feedAuthoritative()` reverted to `feed.available` | `AN UNREADABLE FEED IS NOT AUTHORITATIVE` | KILLED, 40 marks against a 44 baseline |
| `membershipUnreadable` also clears `asOf` and `available` | `asOf is not discarded` | KILLED, 42 marks against a 44 baseline |

Tree restored and verified clean after each, with no mutant residue left in the file.

Controls are included so neither neighbouring state is collateral damage: an authoritative feed still
hides an empty hub, and a mesh with no feed at all still does not hide.

## Scope

Proves the suite depends on the shipped source. It does not prove a live browser reaches these lines;
that needs a real `EventSource` over a real stream, which is noted as out of reach here for the same
reason it was in #450.
