### PR TITLE
fix(core): a self-contradictory reply is not a bind refusal

### DIFF
--- a/.changeset/bind-refused-self-consistent.md
+++ b/.changeset/bind-refused-self-consistent.md
@@ -1,0 +1,11 @@
+---
+"@cotal-ai/core": minor
+---
+
+`replyRefusedBeforeEffect` no longer reads a self-contradictory reply as a refusal. The
+`bind-refused` marker asserts that the command did not run, but the detail carries no outcome of its
+own, so a reply could pair the marker with `outcome: "executed"`. The only consumer of this predicate
+re-issues a command without the repeat-safe gate, so that contradiction was being resolved by
+re-sending a command the same reply said had already run. A present outcome that disagrees with the
+marker now wins. An absent outcome is still accepted, because the spec permits omitting it and
+requiring it would stop core repairing splits for responders that do.

--- a/packages/core/smoke/bind-fence.smoke.ts
+++ b/packages/core/smoke/bind-fence.smoke.ts
@@ -64,7 +64,7 @@ const throws = (name: string, fn: () => unknown, code?: string) => {
 /** Declared, not implied: a live suite can end early in ways that redden no cell — a broker that
  *  never came up, a hang the runner kills, a top-level rejection — and `fail === 0` reads as PASS
  *  in every one of them, with the exit code to match. */
-const EXPECTED_CELLS = 20;
+const EXPECTED_CELLS = 25;
 process.on("exit", () => {
   const ran = pass + fail;
   if (ran !== EXPECTED_CELLS) {
@@ -72,6 +72,32 @@ process.on("exit", () => {
     process.exitCode = 1;
   }
 });
+
+// ── A REPLY THAT CONTRADICTS ITSELF IS NOT A REFUSAL (no broker needed; the predicate is pure) ───
+// `replyRefusedBeforeEffect` is what licenses core to re-issue a command WITHOUT the repeat-safe
+// gate. It read the marker alone, and `EpBindRefusedDetail` carries no outcome, so a reply asserting
+// BOTH "refused before any effect" and `outcome: "executed"` was resolved toward re-issuing — sending
+// again a command the same reply said had already run. These cells run before the broker so they
+// still grade if it never comes up.
+const refusalDetail = { kind: EP_BIND_REFUSED, endpoint: "manager", command: "define-persona",
+  boundTo: { instanceId: "a".repeat(26), epoch: 1 }, servedBy: { instanceId: "b".repeat(26), epoch: 1 } };
+const withOutcome = (outcome?: string) => ({ code: "failed-precondition", message: "refused",
+  details: [refusalDetail], ...(outcome ? { outcome } : {}) }) as unknown as Parameters<typeof replyRefusedBeforeEffect>[0];
+
+c("a refusal stating `not-executed` is a refusal (the conforming case, unchanged)",
+  replyRefusedBeforeEffect(withOutcome("not-executed")) === true);
+// §13.3 permits omitting the field, and a responder too old to know it emits exactly this. Refusing
+// it here would stop core repairing splits for a third party that is otherwise behaving.
+c("a refusal omitting the outcome is STILL a refusal (absence is permitted, so it stays accepted)",
+  replyRefusedBeforeEffect(withOutcome(undefined)) === true);
+c("SELF-CONTRADICTORY: the marker paired with `executed` is NOT a refusal, so it cannot ungate a re-issue",
+  replyRefusedBeforeEffect(withOutcome("executed")) === false);
+c("the marker paired with `unknown` is NOT a refusal either (a responder that cannot tell has not said no)",
+  replyRefusedBeforeEffect(withOutcome("unknown")) === false);
+// CONTROL: the outcome alone must not manufacture a refusal out of a reply that carries no marker,
+// or the predicate would have stopped testing the thing it is named for.
+c("CONTROL: `not-executed` WITHOUT the marker is not a refusal (the marker is still required)",
+  replyRefusedBeforeEffect({ code: "failed-precondition", message: "x", outcome: "not-executed" }) === false);
 
 const SPACE = "bindfence";
 const EP = "manager";

--- a/packages/core/src/endpoint-error.ts
+++ b/packages/core/src/endpoint-error.ts
@@ -141,9 +141,25 @@ export interface EpBindRefusedDetail extends EpErrorDetail {
  *
  *  It takes an `EpError` and not a thrown value, unlike its sibling predicates, because this
  *  refusal never arrives as a throw: it is the responder's own application-level failure and
- *  those ride the reply (§13.5). A consumer reads it off `reply.error`. */
+ *  those ride the reply (§13.5). A consumer reads it off `reply.error`.
+ *
+ *  A REPLY THAT CONTRADICTS ITSELF IS NOT A REFUSAL. The marker IS the assertion that the command
+ *  did not run, and {@link EpError.outcome} says a responder refusing before dispatch MUST carry
+ *  `not-executed` — but {@link EpBindRefusedDetail} carries no outcome of its own, so nothing in the
+ *  type stops a reply pairing the marker with `executed`. That combination is not merely odd: the
+ *  only consumer of this predicate re-issues a command **without** the {@link isRepeatSafeCommand}
+ *  gate, on the strength of the marker, so resolving the contradiction toward "refused" re-sends a
+ *  command the reply just said had ALREADY RUN. A present outcome that disagrees therefore wins, and
+ *  the reply is not read as a refusal.
+ *
+ *  AN ABSENT OUTCOME IS STILL ACCEPTED, and that is deliberate rather than an oversight. §13.3
+ *  permits omitting it, and a responder too old to know the field emits exactly that; refusing those
+ *  would stop core repairing splits for a third-party responder that is behaving, turning a healed
+ *  split into a surfaced failure. Requiring presence is a protocol tightening with a real victim
+ *  class, and it is a SPEC question rather than one settled by editing this predicate. */
 export function replyRefusedBeforeEffect(e: EpError | undefined): boolean {
-  return (e?.details ?? []).some((d) => d.kind === EP_BIND_REFUSED);
+  if (!(e?.details ?? []).some((d) => d.kind === EP_BIND_REFUSED)) return false;
+  return e?.outcome === undefined || e.outcome === "not-executed";
 }
 
 /** §13.3 **Effect outcome**: whether the command's effect occurred. Emitted by the RESPONDER,


### PR DESCRIPTION
`replyRefusedBeforeEffect` decided that a command had not run from the `bind-refused` marker alone.

## Why that is not just untidy

The marker genuinely is the assertion of non-execution. Its own docstring says it "marks what no
caller-side check can establish: the command did not run, and no effect of it exists", and
`EpError.outcome` says a responder refusing before dispatch MUST carry `not-executed`. So reading the
marker as the claim is correct.

What was missing is that nothing required the reply to be **self-consistent**. `EpBindRefusedDetail`
carries `kind`, `endpoint`, `command`, `boundTo` and `servedBy`, and no outcome, so the type permits a
reply asserting both the marker and `outcome: "executed"`.

This change therefore adds no new rule. The file states the requirement three ways, in the marker's
docstring, in `EpError.outcome`, and in SPEC 13.3, and checked it in none of them. A reply pairing
the marker with `executed` already violated 13.3 as documented nine lines below the predicate that
accepted it.

That combination had a live consequence. The only consumer of this predicate re-issues the command
**without** the `isRepeatSafeCommand` gate, precisely because the marker is taken as proof nothing
ran. So a contradictory reply was resolved in the direction of re-sending a command the same reply
said had **already executed**. For a write, that is a duplicate effect, and the caller cannot see it.

## The change

```ts
if (!(e?.details ?? []).some((d) => d.kind === EP_BIND_REFUSED)) return false;
return e?.outcome === undefined || e.outcome === "not-executed";
```

A present outcome that disagrees with the marker wins, and the reply is not read as a refusal.

## What is deliberately NOT changed

**An absent outcome is still accepted.** SPEC 13.3 permits omitting the field, and a responder too
old to know it emits exactly that. Requiring presence would stop core repairing splits for any
third-party responder that omits it, turning a healed split into a surfaced failure for something
that is otherwise behaving. That is a protocol tightening with a real victim class, and it belongs in
a spec discussion rather than in this predicate. It is noted, not bundled.

Only the contradiction is closed here, and closing it has no interop cost: every responder that omits
the field behaves exactly as before, and every first-party responder already sets it correctly.

## Verification

`smoke:bind-fence`: **25 cells, `rc=0`** (20 before). No new list entry; the suite is already in the
chain. The five new cells are pure and run before the broker starts, so they still grade if it never
comes up, and the suite's declared cell count moved 20 to 25 with it.

Mutation predicted before running, naming the first assertion it reddens since the suite stops on
first failure:

| mutation | expected red | result |
| --- | --- | --- |
| predicate reverted to the marker-only test | `SELF-CONTRADICTORY` | KILLED, 23 marks against a 25 baseline |

Tree restored and verified clean, fix confirmed present in the file afterwards.

A control is included so the outcome cannot manufacture a refusal on its own: `not-executed` with no
marker is still not a refusal, which keeps the predicate testing the thing it is named for.

