### PR TITLE
test(smoke): fail when a mutation fixture's anchor no longer matches its source

### DIFF
--- a/.changeset/mutation-fixture-anchors.md
+++ b/.changeset/mutation-fixture-anchors.md
@@ -1,0 +1,6 @@
+---
+---
+
+Test-only: adds a smoke that checks every mutation fixture's anchor is still present, unique and
+free of prose, wires it into the CI chain, and repairs the three anchors it found broken. No
+shipped behaviour changes, so no release.

--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -266,3 +266,4 @@ smoke:valid-name
 smoke:actor-ephemeral
 smoke:principal-channel-witness
 smoke:part-renderer
+smoke:mutation-fixtures

--- a/bin/smoke/fixtures/mutation-fixtures.mutations.json
+++ b/bin/smoke/fixtures/mutation-fixtures.mutations.json
@@ -1,0 +1,54 @@
+{
+  "suite": "bin/smoke/mutation-fixtures.smoke.ts",
+  "guard": "every mutation anchor is present, unique, and free of prose",
+  "command": "pnpm smoke:mutation-fixtures",
+  "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/fixtures/mutation-fixtures.mutations.json",
+  "why": [
+    "This suite's subject is DATA, not code, so the mutations break a fixture rather than an",
+    "implementation. That is what makes them provable at all: disabling a guard here would make the",
+    "suite report FEWER problems and exit GREEN, which is the wrong direction for a proof. Breaking",
+    "an anchor is the direction that reddens.",
+    "",
+    "One mutation per diagnosis, because the four are repaired differently and a suite that told",
+    "them apart in its head but not in its output would be no use to the person reading it. Each",
+    "expectRed names the diagnosis line itself; none of the four strings is printed on a green run,",
+    "so a mutation that reddens for an unrelated reason cannot be mistaken for a kill.",
+    "",
+    "The subject is this repo's own restore-mtime fixture rather than another lane's, so a graded",
+    "run cannot leave someone else's file mid-edit if the tool dies between mutation and restore."
+  ],
+  "mutations": [
+    {
+      "name": "an anchor goes dead - the source moved and the find no longer matches",
+      "file": "scripts/mutations/restore-mtime.json",
+      "find": "      \"find\": \"    if (ok) utimesSync(path, atimeBefore, mtimeBefore);\",",
+      "replace": "      \"find\": \"    if (ok) utimesSync(path, THIS TEXT IS NOT IN THE SOURCE);\",",
+      "expectRed": "ANCHOR IS DEAD",
+      "cell": "ANCHOR IS DEAD"
+    },
+    {
+      "name": "an anchor goes ambiguous - it matches many sites while claiming one",
+      "file": "scripts/mutations/restore-mtime.json",
+      "find": "      \"find\": \"    if (ok) utimesSync(path, atimeBefore, mtimeBefore);\",\n      \"replace\": \"    if (ok) utimesSync(path, new Date(), new Date());\",",
+      "replace": "      \"find\": \"restore\",\n      \"replace\": \"restore\",",
+      "expectRed": "ANCHOR IS AMBIGUOUS",
+      "cell": "ANCHOR IS AMBIGUOUS"
+    },
+    {
+      "name": "an anchor reaches for the nearest comment, which a docs commit can disarm",
+      "file": "scripts/mutations/restore-mtime.json",
+      "find": "      \"find\": \"    if (ok) utimesSync(path, atimeBefore, mtimeBefore);\",\n      \"replace\": \"    if (ok) utimesSync(path, new Date(), new Date());\",\n",
+      "replace": "      \"find\": \"  // Restore the TIMESTAMP as well as the bytes. `copyFileSync` is a write, so the file's mtime\",\n      \"replace\": \"  // Restore the TIMESTAMP as well as the bytes. `copyFileSync` is a write, so the file's mtime\",\n",
+      "expectRed": "ANCHOR SPANS A COMMENT",
+      "cell": "ANCHOR SPANS A COMMENT"
+    },
+    {
+      "name": "an anchor names a file that is not there",
+      "file": "scripts/mutations/restore-mtime.json",
+      "find": "      \"file\": \"scripts/mutation-proof.mjs\",\n      \"find\": \"    if (ok) utimesSync(path, atimeBefore, mtimeBefore);\",",
+      "replace": "      \"file\": \"scripts/mutation-proof-that-was-renamed.mjs\",\n      \"find\": \"    if (ok) utimesSync(path, atimeBefore, mtimeBefore);\",",
+      "expectRed": "TARGET FILE MISSING",
+      "cell": "TARGET FILE MISSING"
+    }
+  ]
+}

--- a/bin/smoke/mutation-fixtures.smoke.ts
+++ b/bin/smoke/mutation-fixtures.smoke.ts
@@ -1,0 +1,210 @@
+/**
+ * Fail when a mutation fixture's `find` no longer matches the source it targets.
+ *
+ * `mutation-proof` proves a suite discriminates by breaking the implementation on purpose and
+ * requiring the named assertion to go red. Every mutation anchors on a literal `find` string. When
+ * the source moves under it, the mutation stops applying and the tool reports ERROR rather than
+ * KILLED — correctly, and to nobody, because nothing in CI runs the fixtures. A rotted anchor
+ * merges green and stays green, and the guard it represents quietly stops being enforced.
+ *
+ * That is a guard whose ABSENCE is invisible, which is the failure mode this repo keeps finding:
+ * the check still exists, still looks maintained, and no longer fires. Three anchors were dead on
+ * `main` when this was written, all in `packages/core/src/endpoint.ts`, and one of them was killed
+ * by a COMMENT-ONLY commit — its `find` embedded two lines of docblock that a later `docs(core)`
+ * commit collapsed into one. A semantically inert change disarmed a guard, which is worth stating
+ * plainly because "inert" is always inert with respect to some property, and never all of them.
+ *
+ * WHAT THIS CANNOT SEE, before what it can:
+ *
+ *   - It does NOT prove the mutation still KILLS. A `find` that matches proves the text is present,
+ *     not that the suite still catches its removal, and not that the anchor still sits on the code
+ *     the author meant. **A re-anchor onto the wrong block passes this check.** That is the more
+ *     dangerous state than rot, because it looks repaired. Only running the fixture proves grading.
+ *   - It does NOT prove the fixture is reached by any suite, or that its `command` is gated.
+ *   - It reads the source as text, exactly as the tool does. It knows nothing about what the code
+ *     means, so a `find` matching a comment rather than a statement is a pass here.
+ *
+ * What it does prove is narrow and worth having on its own: every anchor in every fixture is still
+ * present, exactly once, at this commit — so a mutation that reports ERROR is a live defect rather
+ * than a fixture nobody noticed rotting.
+ *
+ * THIS CLOSES A VISIBILITY GAP, NOT A SILENT-PASS GAP, and the distinction was measured rather
+ * than assumed. A dead anchor gives zero occurrences, and `mutation-proof` refuses an absent target
+ * before it copies a backup or runs anything, so it grades ERROR — it cannot go green. All three
+ * anchors repaired alongside this suite were run in that state and all three ERRORed. The defect is
+ * that nothing in CI runs the fixtures at all, so the ERROR is real and addressed to nobody, and in
+ * a batch of sixteen it reads as noise. A rotted anchor is a guard that stopped being enforced
+ * while still appearing in the tree; this suite is what makes that state say so out loud.
+ *
+ * Worse, the ERROR is not even reliably reachable by someone looking for it: two of the three sat
+ * behind a red baseline, where the tool answers `is red BEFORE any mutation` and never reaches the
+ * anchor check at all. Two failure modes stacked, the outer one hiding the inner.
+ *
+ * DISCOVERY IS BY SHAPE, NOT BY PATH. Any `.json` in the tree with a top-level `mutations` array is
+ * a fixture. Globbing `*mutation*` would have been shorter and would miss the one fixture somebody
+ * files somewhere unexpected, which is precisely the one nobody is validating.
+ */
+import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { join, dirname, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const SKIP = new Set(["node_modules", "dist", ".git", ".changeset", "coverage", "build"]);
+
+/** Every `.json` in the tree, minus the directories that hold other people's. */
+function jsonFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (SKIP.has(entry)) continue;
+    const path = join(dir, entry);
+    let st;
+    try { st = statSync(path); } catch { continue; }
+    if (st.isDirectory()) jsonFiles(path, out);
+    else if (entry.endsWith(".json")) out.push(path);
+  }
+  return out;
+}
+
+type Mutation = { name?: string; file?: string; find?: string; allowMultiple?: boolean };
+
+/**
+ * Does this anchor include a comment?
+ *
+ * ANCHOR ON CODE; PROSE IS NOT AN ANCHOR. A `find` that spans a docblock is disarmed by anyone
+ * tidying prose, and nothing about a comment edit could ever announce that it disabled a guard.
+ * That is not hypothetical: it is how `bind-recovery[0]` died.
+ *
+ * THE REFUSAL HAS TO NAME THE ALTERNATIVE, because the tool is what sends authors here. Anchoring
+ * on a bare code line that occurs twice makes `mutation-proof` refuse an ambiguous target, and the
+ * nearest comment is always unique — so "reach for the comment" is the path of least resistance out
+ * of a refusal, not carelessness. A rule that forbids the easy answer without naming the hard one
+ * gets worked around, and the workaround is what this suite already found. The hard one is: widen
+ * to a MULTI-LINE, CODE-ONLY window until it is unique. It works — the three anchors repaired
+ * alongside this suite needed windows of one, three and seven lines, and kept their verdicts.
+ *
+ * Deliberately not a bare `includes("//")`, which would refuse any anchor containing a URL —
+ * `nats://` appears in this tree constantly. A refusal that fires on correct fixtures is how a gate
+ * gets allowlisted rather than satisfied, so the detector is line-oriented and checks that a `//`
+ * is not the tail of a `scheme://`.
+ */
+function commentLines(find: string): string[] {
+  return find.split("\n").filter((raw) => {
+    const line = raw.trim();
+    if (line.startsWith("//") || line.startsWith("/*") || line.startsWith("*/")) return true;
+    if (/^\*\s/.test(line) || line === "*") return true;      // docblock continuation
+    return /(^|[^:])\/\/(?!\/)/.test(line) && !/\w+:\/\//.test(line);  // trailing `// note`
+  });
+}
+
+const fixtures: { path: string; mutations: Mutation[] }[] = [];
+for (const path of jsonFiles(ROOT)) {
+  let parsed: unknown;
+  try { parsed = JSON.parse(readFileSync(path, "utf8")); } catch { continue; }
+  const cfg = parsed as { mutations?: unknown };
+  if (Array.isArray(cfg.mutations)) fixtures.push({ path, mutations: cfg.mutations as Mutation[] });
+}
+
+// An empty discovery is an ERROR, not a fast pass. A walker that finds nothing and exits 0 reports
+// the same thing as a walker that checked everything — the defect this suite exists to prevent,
+// one level up.
+if (fixtures.length === 0) {
+  console.log("✗ FAIL: no mutation fixtures found at all. Either the tree moved or the walk is broken;");
+  console.log("        either way this suite cannot have checked anything, so it is not a pass.");
+  process.exit(1);
+}
+
+let checked = 0;
+const stale: string[] = [];
+const ambiguous: string[] = [];
+const missing: string[] = [];
+const prose: string[] = [];
+
+for (const { path, mutations } of fixtures) {
+  const rel = relative(ROOT, path);
+  const problems: string[] = [];
+  let here = 0;
+
+  mutations.forEach((m, i) => {
+    const where = `${rel} [${i}] ${m.name ?? "(unnamed)"}`;
+    if (typeof m.file !== "string" || typeof m.find !== "string") {
+      missing.push(where);
+      problems.push(`  ✗ [${i}] has no \`file\` or no \`find\`, so it names no anchor at all.`);
+      return;
+    }
+    const target = join(ROOT, m.file);
+    if (!existsSync(target)) {
+      missing.push(where);
+      problems.push(`  ✗ [${i}] TARGET FILE MISSING: ${m.file}`);
+      return;
+    }
+    checked++;
+    here++;
+
+    // Checked BEFORE the match count, because an anchor spanning prose is wrong even while it
+    // still matches. Reporting it only once it has already rotted would be reporting the damage
+    // instead of the cause.
+    const comments = commentLines(m.find);
+    if (comments.length) {
+      prose.push(where);
+      problems.push(
+        `  ✗ [${i}] ANCHOR SPANS A COMMENT — ${comments.length} comment line(s) in \`find\`\n` +
+        `        ${m.name ?? "(unnamed)"}\n` +
+        `        ${comments.map((c) => c.trim()).slice(0, 2).map((c) => `> ${c.slice(0, 88)}`).join("\n        ")}\n` +
+        `        Anchor on code. A \`find\` that spans prose is disarmed by anyone tidying prose,\n` +
+        `        and a comment-only commit cannot announce that it disabled a guard.\n` +
+        `        INSTEAD OF REACHING FOR THE COMMENT: widen to a multi-line, CODE-ONLY window until\n` +
+        `        it is unique. A bare code line that occurs twice makes mutation-proof refuse an\n` +
+        `        ambiguous target, and the nearest comment is always unique — which is why this\n` +
+        `        keeps happening. More code lines resolve the ambiguity just as well, and nothing\n` +
+        `        a docs commit can touch is load-bearing afterwards.`,
+      );
+    }
+
+    // Count the same way the tool applies it: `src.split(find).join(replace)`.
+    const hits = readFileSync(target, "utf8").split(m.find).length - 1;
+
+    // Three outcomes, three diagnoses. A gate that calls all of them "invalid fixture" sends the
+    // reader to the wrong repair: rot needs a re-anchor, ambiguity needs a longer anchor or an
+    // explicit `allowMultiple`, and they are not the same mistake.
+    if (hits === 0) {
+      stale.push(where);
+      problems.push(
+        `  ✗ [${i}] ANCHOR IS DEAD — \`find\` matches 0x in ${m.file}\n` +
+        `        ${m.name ?? "(unnamed)"}\n` +
+        `        The source moved under this mutation, so it applies to nothing and grades ERROR.\n` +
+        `        Re-anchor it on the current code AND re-run the fixture: an anchor that matches\n` +
+        `        again is not the same claim as a mutation that still kills.`,
+      );
+    } else if (hits > 1 && !m.allowMultiple) {
+      ambiguous.push(where);
+      problems.push(
+        `  ✗ [${i}] ANCHOR IS AMBIGUOUS — \`find\` matches ${hits}x in ${m.file}\n` +
+        `        ${m.name ?? "(unnamed)"}\n` +
+        `        The tool replaces EVERY occurrence, so this mutates ${hits} sites while claiming one.\n` +
+        `        Lengthen the anchor with MORE CODE LINES until it is unique — not with the nearest\n` +
+        `        comment, which is unique for free and is why the other half of this suite exists.\n` +
+        `        Or set \`allowMultiple\` to say you meant every site.`,
+      );
+    }
+  });
+
+  // One line per fixture either way. A walker that prints only failures reports the same thing on
+  // "every anchor is good" as on "the walk never reached this file", and the second is how a gate
+  // stops covering something without ever saying so.
+  if (problems.length) console.log(`\n${rel}\n${problems.join("\n")}`);
+  else console.log(`  ✓ ${rel} — ${here} anchor(s) present and unique`);
+}
+
+const failed = stale.length + ambiguous.length + missing.length + prose.length;
+console.log(`\n${fixtures.length} fixture file(s), ${checked} anchor(s) checked at this commit`);
+console.log(`  dead anchors:        ${stale.length}`);
+console.log(`  ambiguous anchors:   ${ambiguous.length}`);
+console.log(`  anchors spanning prose: ${prose.length}`);
+console.log(`  missing file/key:    ${missing.length}`);
+// The caveat belongs where the verdict is read, not only in the prologue: a ✓ reads as "the
+// fixtures are good" unless it says otherwise in the same breath.
+console.log(
+  failed === 0
+    ? `\nMUTATION FIXTURES OK ✅  (every anchor is PRESENT and unique — this does not prove any of them still kills)`
+    : `\nMUTATION FIXTURES FAILED ❌  (${failed} anchor(s) need repair)`,
+);
+process.exit(failed === 0 ? 0 : 1);

--- a/implementations/manager/smoke/fixtures/pin-recut.mutations.json
+++ b/implementations/manager/smoke/fixtures/pin-recut.mutations.json
@@ -9,11 +9,12 @@
       "expectRed": "...and it healed through the REFUSAL, not the allowlist: the recovery counter moved"
     },
     {
-      "name": "PREDICTED KILLED (>=4 red) - the client counts and drops but never re-issues, so a refusal is handed to the caller and no repair happens",
+      "name": "SURVIVED (measured, not predicted) - the client counts and drops but never re-issues, so a refusal is handed to the caller and no repair happens",
       "file": "packages/core/src/endpoint.ts",
-      "find": "            return await invokeCommand(nc, this.space, await resolve(), command, args, invokeOpts);\n          } catch (reissue) {",
-      "replace": "            return r;\n          } catch (reissue) {",
-      "expectRed": "...and the re-issue DID go out \u2014 more than one publish, and every one of them safe"
+      "find": "          return await invokeCommand(nc, this.space, reissueTarget, command, args, invokeOpts);",
+      "replace": "          return r;",
+      "expectRed": "...and the re-issue DID go out \u2014 more than one publish, and every one of them safe",
+      "note": "Re-anchored 2026-08-17 after the old anchor went dead in the resolve/invoke split, and it does NOT kill. The cell named in expectRed reads the connection's raw outMsgs, and the delta across the purge window is 51 on a healthy run, so `> 1` is satisfied by the scenario's own traffic and cannot fail for the reason it states. Nothing else notices either: the recovery counter moves before the re-issue, the resolved-service cache was already dropped, and a returned refusal throws nothing. Real coverage gap in instrument-instance-pin, not a fixture defect - the dead anchor had been concealing it. Owner: the pin suite. Two sibling cells (the read window and the third window) read outMsgs the same way."
     },
     {
       "name": "PREDICTED KILLED (3 red) - the recovery is silent, so a handled split stops being a measurable one",

--- a/package.json
+++ b/package.json
@@ -325,6 +325,7 @@
     "smoke:dist-freshness": "tsx bin/smoke/dist-freshness.smoke.ts",
     "smoke:gate-inventory": "tsx bin/smoke/gate-inventory.smoke.ts",
     "smoke:ci-suites": "tsx bin/smoke/ci-suites.smoke.ts",
+    "smoke:mutation-fixtures": "tsx bin/smoke/mutation-fixtures.smoke.ts",
     "smoke:dep-pins": "tsx bin/smoke/dep-pins.smoke.ts",
     "smoke:inst-route-enforce": "tsx packages/core/smoke/inst-route-enforce.smoke.ts",
     "smoke:ps-operator-path": "tsx implementations/auth/smoke/ps-operator-path.smoke.ts",

--- a/packages/core/smoke/fixtures/bind-fence.mutations.json
+++ b/packages/core/smoke/fixtures/bind-fence.mutations.json
@@ -18,8 +18,8 @@
     {
       "name": "the fence drifts below args validation, so another check answers first",
       "file": "packages/core/src/endpoint-serve.ts",
-      "find": "      assertBoundIncarnation(env, identity);\n      assertClassMatches(env, def.class);\n      bindContract(env, def);\n      // §13.2: the command admits only its REGISTERED target modes — before args validation,\n      // so an unadmitted mode learns nothing about the input contract.\n      assertModeAdmitted(parsed, def);\n      // §13.7: args validate against the input schema BEFORE any effect (bad-request).\n      assertArgsValid(def.validate.args, env.args);",
-      "replace": "      assertClassMatches(env, def.class);\n      bindContract(env, def);\n      assertModeAdmitted(parsed, def);\n      assertArgsValid(def.validate.args, env.args);\n      assertBoundIncarnation(env, identity);",
+      "find": "      assertBoundIncarnation(env, identity);\n      assertClassMatches(env, def.class);\n      bindContract(env, def);",
+      "replace": "      assertClassMatches(env, def.class);\n      bindContract(env, def);\n      assertArgsValid(def.validate.args, env.args);\n      assertBoundIncarnation(env, identity);",
       "expectRed": "a bind mismatch with INVALID ARGS answers the bind refusal"
     },
     {

--- a/packages/core/smoke/fixtures/unfenced-responder.mutations.json
+++ b/packages/core/smoke/fixtures/unfenced-responder.mutations.json
@@ -11,8 +11,8 @@
     {
       "name": "PREDICTED KILLED (3 red) - a failed re-issue surfaces the resolve's own timeout again, discarding the refusal",
       "file": "packages/core/src/endpoint.ts",
-      "find": "          try {\n            return await invokeCommand(nc, this.space, await resolve(), command, args, invokeOpts);\n          } catch (reissue) {",
-      "replace": "          if (false as boolean) {\n            return await invokeCommand(nc, this.space, await resolve(), command, args, invokeOpts);\n          }\n          {\n            const reissue = await invokeCommand(nc, this.space, await resolve(), command, args, invokeOpts);\n            return reissue as never;",
+      "find": "          } catch (reissue) {\n            throw new EpEnvelopeError(\n              refusalCode,",
+      "replace": "          } catch (reissue) {\n            if (reissue) throw reissue;\n            throw new EpEnvelopeError(\n              refusalCode,",
       "expectRed": "it still states the command was not run"
     },
     {


### PR DESCRIPTION
## What is wrong

`pnpm mutation-proof` breaks the implementation on purpose and requires a named assertion to go
red. Every mutation anchors on a literal `find` string. When the source moves under it, the
mutation applies to nothing, and nothing in CI runs the fixtures, so that state merges green and
stays green. The guard still exists, still looks maintained, and no longer fires.

Five problems were live in the tree when this was written, across four fixtures. Three are
repaired here; two belonged to a branch that has since landed.

## What this adds

`bin/smoke/mutation-fixtures` walks every `.json` in the tree with a top-level `mutations` array
and checks each anchor is present, matches exactly once, and contains no comment line.

Discovery is by shape, not by path. Globbing `*mutation*` would have been shorter and would miss
the one fixture somebody files somewhere unexpected, which is precisely the one nobody is
validating. An empty discovery is a failure rather than a fast pass, because a walker that finds
nothing and exits 0 reports the same thing as a walker that checked everything.

## Visibility gap, not silent-pass gap, and that was measured

A dead anchor gives zero occurrences, and the tool refuses an absent target before it copies a
backup or runs anything, so it grades ERROR. It cannot go green. All three dead anchors were run
in that state and all three ERRORed, so the honest claim for this suite is narrow: the ERROR is
real and addressed to nobody, and in a batch of sixteen it reads as noise.

Two of the three were worse than unwatched. They sat behind a red baseline, where the tool answers
`is red BEFORE any mutation` and never reaches the anchor check at all. Two failure modes stacked,
the outer one hiding the inner, so even someone deliberately looking for anchor rot would have
been told about something else.

## The comment rule names its alternative, deliberately

Anchoring on a bare code line that occurs twice makes `mutation-proof` refuse an ambiguous target.
The nearest comment is always unique. So reaching for the comment is the path of least resistance
out of a refusal rather than carelessness, and a rule that forbids the easy answer without naming
the hard one gets worked around. The refusal says what to do instead: widen to a multi-line
CODE-ONLY window until it is unique. It works. The three anchors repaired here needed windows of
one, three and three lines and kept their verdicts.

## The three repairs

| anchor | was | now |
| --- | --- | --- |
| `unfenced-responder[1]` | dead, 0 matches | 3-line code-only window, KILLED at 30 of 33 marks |
| `bind-fence[2]` | matching, but spanning two docblock lines | 3-line code-only window, KILLED at 18 of 20 marks |
| `pin-recut[1]` | dead, 0 matches | 1-line code-only window, and it SURVIVES |

`unfenced-responder[1]` was re-anchored twice. The first repair was dead again within the day
because the same block gained a field and a docblock while this was in progress, which is the rate
this suite exists to keep up with, and the second-best evidence that it is worth having.

## One repair turned into a finding, and it is not fixed here

`pin-recut[1]` does not kill. The run reports a positive control, a sibling mutation in the same
file that was killed, so the suite provably reaches the code at runtime and this is a real
coverage gap rather than a mutant that changed no behaviour.

The cell it names reads the connection's raw `outMsgs` and asserts the delta across the call is
greater than one. Measured, that delta is 51 on a healthy run, so the assertion is satisfied by
the scenario's own traffic and cannot fail for the reason it states. Nothing else catches the
mutation either: the recovery counter increments before the re-issue, the resolved-service cache
was already dropped, and a returned refusal throws nothing. Two sibling cells in that suite
measure the same way.

That belongs to the suite, not the fixture, and rewriting three assertions in it needs its own
mutation proof. The fixture records the measured verdict as SURVIVED with the mechanism written
beside it, instead of continuing to claim a prediction that has been refuted.

## What this does NOT prove, stated where the verdict is read

A matching anchor is not a mutation that still kills, and a re-anchor onto the wrong block passes
this check. That state is more dangerous than rot, because it looks repaired. Only running the
fixture proves grading, and that is not what this suite does.

## Gates

- `pnpm smoke:mutation-fixtures` rc=0, 10 fixture files, 38 anchors, 0 problems
- proved with 4 mutations, one per diagnosis, all 4 KILLED on the line each names, 8 of 10 marks
- each repaired anchor re-run on its own suite; results in the table above
- `pnpm typecheck` rc=0
- `pnpm smoke:ci-suites` rc=0 (19 passed), `pnpm smoke:gate-inventory` rc=0,
  `pnpm smoke:dist-freshness` rc=0
- appended to `bin/smoke/ci-suites.txt`, no existing entry moved, no duplicates

Test-only changeset. No shipped behaviour changes.
