### PR TITLE
test(manager): count requests per command, not every message on the connection

### DIFF
--- a/.changeset/pin-attempts-counter.md
+++ b/.changeset/pin-attempts-counter.md
@@ -1,0 +1,6 @@
+---
+---
+
+Test-only: the instance-pin probe now counts requests per command instead of all connection
+traffic, so its "the re-issue went out" cells can fail for the reason they state. No shipped
+behaviour changes, so no release.

--- a/implementations/manager/smoke/fixtures/pin-recut.mutations.json
+++ b/implementations/manager/smoke/fixtures/pin-recut.mutations.json
@@ -6,22 +6,33 @@
       "file": "packages/core/src/endpoint-serve.ts",
       "find": "      assertBoundIncarnation(env, identity);\n",
       "replace": "",
-      "expectRed": "...and it healed through the REFUSAL, not the allowlist: the recovery counter moved"
+      "expectRed": "...and it healed through the REFUSAL, not the allowlist: the recovery counter moved",
+      "afterRestore": "pnpm --filter @cotal-ai/core build"
     },
     {
-      "name": "SURVIVED (measured, not predicted) - the client counts and drops but never re-issues, so a refusal is handed to the caller and no repair happens",
+      "name": "PREDICTED KILLED (2 red) - the client counts and drops but never re-issues, so the heal publishes no second request",
       "file": "packages/core/src/endpoint.ts",
       "find": "          return await invokeCommand(nc, this.space, reissueTarget, command, args, invokeOpts);",
       "replace": "          return r;",
-      "expectRed": "...and the re-issue DID go out \u2014 more than one publish, and every one of them safe",
-      "note": "Re-anchored 2026-08-17 after the old anchor went dead in the resolve/invoke split, and it does NOT kill. The cell named in expectRed reads the connection's raw outMsgs, and the delta across the purge window is 51 on a healthy run, so `> 1` is satisfied by the scenario's own traffic and cannot fail for the reason it states. Nothing else notices either: the recovery counter moves before the re-issue, the resolved-service cache was already dropped, and a returned refusal throws nothing. Real coverage gap in instrument-instance-pin, not a fixture defect - the dead anchor had been concealing it. Owner: the pin suite. Two sibling cells (the read window and the third window) read outMsgs the same way."
+      "expectRed": "...and that heal re-issued (more than one `ps` REQUEST left the caller, not merely more traffic)",
+      "note": "Re-pointed 2026-08-17 with the cell it grades. It previously read the connection's raw outMsgs (`> 1`), which across that window is ~51 on a healthy run, so it was satisfied by the scenario's own describes and KV traffic and could not fail for the reason it stated - measured SURVIVED at 51 marks with the call gutted and 51 without. The cells now count requests per (endpoint, command) off the shipped subject parser. The `purge` cell reds too; the third arm does NOT, because its re-issue target is resolved before this line and its describe still goes out.",
+      "afterRestore": "pnpm --filter @cotal-ai/core build"
     },
     {
       "name": "PREDICTED KILLED (3 red) - the recovery is silent, so a handled split stops being a measurable one",
       "file": "packages/core/src/endpoint.ts",
       "find": "          this.splitsRecovered++;\n",
       "replace": "",
-      "expectRed": "...and the recovery was counted, so a handled split is still a measurable one"
+      "expectRed": "...and the recovery was counted, so a handled split is still a measurable one",
+      "afterRestore": "pnpm --filter @cotal-ai/core build"
+    },
+    {
+      "name": "PREDICTED KILLED (3 red) - the attempts counter stops counting, so no cell can witness a re-issue",
+      "file": "implementations/manager/smoke/instrument-instance-pin.smoke.ts",
+      "find": "      sent.set(k, (sent.get(k) ?? 0) + 1);\n",
+      "replace": "",
+      "expectRed": "...and that heal re-issued (more than one `ps` REQUEST left the caller, not merely more traffic)",
+      "note": "The instrument's own guard. Without it the three re-pointed cells could be re-pointed onto a counter that never moves and still read as passing, which is the failure the old outMsgs proxy actually had."
     }
   ],
   "_note": "THE SUITE LOADS dist, NOT src. `instrument-instance-pin` imports `@cotal-ai/core`, whose exports point at ./dist/index.js, so mutating packages/core/src leaves the module the suite actually runs untouched. MEASURED: all three of these mutations first reported SURVIVED at 55/55 marks, the full baseline, for that reason alone -- not because the suite fails to discriminate. The command therefore rebuilds core from the mutated source before running. Restoring src is not enough afterwards: dist is left carrying the last mutant, so core must be rebuilt from the restored source before any other suite is believed."

--- a/implementations/manager/smoke/instrument-instance-pin.smoke.ts
+++ b/implementations/manager/smoke/instrument-instance-pin.smoke.ts
@@ -47,7 +47,7 @@ import {
   mintLifecycleUid, standaloneConnectOpts, DEV_OWNER, EpEnvelopeError,
   resolveService, invokeCommand, permissionsFor,
   instancePinnedInstrumentCapabilities, respondedButUnbound, replyRefusedBeforeEffect, EP_UNBOUND_RESPONDER, CotalEndpoint,
-  isRepeatSafeCommand, MANAGER_ADMIN_COMMANDS,
+  isRepeatSafeCommand, MANAGER_ADMIN_COMMANDS, parseEpSubject,
   type EpCaller,
   type ResolvedService,
 } from "@cotal-ai/core";
@@ -95,6 +95,37 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
  *  and after a call, compare the delta. */
 const pubs = (ep: CotalEndpoint): number =>
   (ep as unknown as { nc: { stats(): { outMsgs: number } } }).nc.stats().outMsgs;
+
+/** REQUESTS this endpoint published on one command's request rail, counted by decoding each
+ *  published subject with the SHIPPED parser rather than a hand-rolled match.
+ *
+ *  {@link pubs} counts every message the connection sends, which is why it could not witness a
+ *  re-issue: across these windows a healthy run publishes ~51 messages of describes,
+ *  contract-store reads and KV traffic, so `> 1` was satisfied by the scenario's own noise and
+ *  could not fail for the reason it stated. Measured: gutting the re-issue leaves 51 either way.
+ *
+ *  Counting per (endpoint, command) removes exactly that: a describe is a different command and a
+ *  contract read is not a request at all, so the only thing that can move this counter for `ps` is
+ *  a `ps` request leaving the caller. The re-issue is the second one.
+ *
+ *  This does NOT replace the handler-entry counter and is not its job. That one counts entries
+ *  BEHIND the fence, so it says the command EXECUTED; a re-issue whose first attempt was refused
+ *  ahead of the handler is invisible to it by construction. The suite owned a counter for effects
+ *  and none for attempts; this is the second one. */
+const requestsSent = (ep: CotalEndpoint): ((endpoint: string, command: string) => number) => {
+  const sent = new Map<string, number>();
+  const nc = (ep as unknown as { nc: { publish: (s: string, ...rest: unknown[]) => unknown } }).nc;
+  const orig = nc.publish.bind(nc);
+  nc.publish = (subject: string, ...rest: unknown[]): unknown => {
+    const p = parseEpSubject(subject);
+    if (p && p.plane === "request") {
+      const k = `${p.endpoint} ${p.command}`;
+      sent.set(k, (sent.get(k) ?? 0) + 1);
+    }
+    return orig(subject, ...rest);
+  };
+  return (endpoint: string, command: string) => sent.get(`${endpoint} ${command}`) ?? 0;
+};
 
 /**
  * THE DISPOSITION AND THE EFFECT MUST AGREE — the deterministic form of "exactly once", and the
@@ -346,6 +377,7 @@ try {
     });
     ep.on("error", () => {});
     await ep.start();
+    const reqs = requestsSent(ep);
     try {
       const warm = await readTolerant(ep, "warm-up");
       check("the probe can invoke ps before the split is forced", warm.ok, warm.last);
@@ -431,7 +463,7 @@ try {
       // mechanisms are separated here: this arm asserts the REFUSAL path (the recovery counter
       // moves), and the allowlist path is asserted where it is still reachable — against a
       // responder without a fence, in `smoke:unfenced-responder`.
-      const readPubs = pubs(ep);
+      const readReqs = reqs(MANAGER_ENDPOINT, "ps");
       const readSplitsBefore = ep.splitRecoveryCount;
       const psBefore = totalRuns("ps");
       let readThrew: unknown;
@@ -454,8 +486,8 @@ try {
         { ran: totalRuns("ps") - psBefore, reply: readReply });
       // A re-resolve is a describe plus the contract-store reads behind it, so the heal is many
       // publishes; the point is that it is MORE than the single publish a held guard leaves.
-      check("...and that heal re-issued (more than the one publish a held guard leaves)",
-        pubs(ep) - readPubs > 1, { publishes: pubs(ep) - readPubs });
+      check("...and that heal re-issued (more than one `ps` REQUEST left the caller, not merely more traffic)",
+        reqs(MANAGER_ENDPOINT, "ps") - readReqs > 1, { psRequests: reqs(MANAGER_ENDPOINT, "ps") - readReqs });
     } finally { await ep.stop().catch(() => {}); }
   }
 
@@ -518,6 +550,7 @@ try {
     });
     ep.on("error", () => {});
     await ep.start();
+    const reqs = requestsSent(ep);
     try {
       // Resolve for real, then doctor the cached responder id (identical to cell 6, because the
       // point is that the COMMAND changed the outcome, nothing else).
@@ -531,7 +564,7 @@ try {
 
       let threw: unknown;
       let returned: unknown;
-      const purgePubs = pubs(ep);
+      const purgeReqs = reqs(MANAGER_ENDPOINT, "purge");
       const purgedBefore = totalRuns("purge");
       const purgeSplitsBefore = ep.splitRecoveryCount;
       try {
@@ -567,8 +600,8 @@ try {
       // "exactly one publish" would today be the signature of a client that had STRANDED on its
       // stale bind. What must still hold is that the extra publishes carry no extra effect, which
       // the execution count above states directly.
-      check("...and the re-issue DID go out — more than one publish, and every one of them safe",
-        pubs(ep) - purgePubs > 1, { publishes: pubs(ep) - purgePubs });
+      check("...and the re-issue DID go out — more than one `purge` REQUEST, and every one of them safe",
+        reqs(MANAGER_ENDPOINT, "purge") - purgeReqs > 1, { purgeRequests: reqs(MANAGER_ENDPOINT, "purge") - purgeReqs });
       // GROUP B, NARROWED TO WHAT IT ACTUALLY MEASURES. The claim was: the bind naming a gone
       // incarnation must not survive the call, or every later deliberate call on this long-lived
       // handle reuses it and meets the same refusal forever — permanent, on an endpoint with no
@@ -625,7 +658,7 @@ try {
       if (mgrRecord) cache.set(third, { ...mgrRecord, responder: { ...mgrRecord.responder, instanceId: ghost } });
       let thirdThrew: unknown;
       let thirdReturned: unknown;
-      const thirdPubs = pubs(ep);
+      const thirdDescribes = reqs(third, "describe");
       const thirdPsBefore = totalRuns("ps");
       try {
         thirdReturned = await ep.invokeService(third, "ps");
@@ -649,9 +682,16 @@ try {
       // A re-issue is now the correct response to a refusal that proves nothing ran, so one publish
       // would today be the signature of a client stranded on its stale bind. What must still hold is
       // that no effect went with the extra publish — the manager's `ps` handler was never entered.
-      check("...and the re-issue WAS attempted (more than one publish) while nothing ran for it",
-        pubs(ep) - thirdPubs > 1 && totalRuns("ps") === thirdPsBefore,
-        { publishes: pubs(ep) - thirdPubs });
+      // THE REPAIR IS WITNESSED AT THE RESOLVE, NOT AT A RE-ISSUE, and that is the honest reading of
+      // this arm rather than a weaker one. The recovery drops the stale bind and re-resolves; for an
+      // endpoint nothing serves, that resolve finds no responder and the ORIGINAL refusal rethrows,
+      // so no second `ps` request is ever published (measured: zero). What the cell exists to state
+      // is WHICH endpoint the repair went looking for -- "the endpoint the account NAMES" -- and the
+      // describe carries exactly that. A recovery that resolved "manager" instead would have moved
+      // the manager's counter and left this one at zero.
+      check("...and the repair re-resolved against the endpoint the account NAMES, while nothing ran for it",
+        reqs(third, "describe") - thirdDescribes > 0 && totalRuns("ps") === thirdPsBefore,
+        { thirdDescribes: reqs(third, "describe") - thirdDescribes, psRuns: totalRuns("ps") - thirdPsBefore });
       check("...and the unknown endpoint's stale bind was dropped",
         cache.get(third) === undefined, { got: cache.get(third)?.responder.instanceId });
       cache.delete(third);


### PR DESCRIPTION
`pin-recut.mutations.json[1]` was re-anchored onto a live code window and then measured: it
**SURVIVED at 51 marks with the re-issue gutted and 51 without**. The suite does not depend on that
line at all.

## Why it cannot fail

Three cells assert that a re-issue went out by reading the caller connection's raw `outMsgs`:

```js
pubs(ep) - purgePubs > 1
```

Across those windows a healthy run publishes about **51** messages of describes, contract-store
reads and KV traffic. `> 1` is satisfied by the scenario's own noise, so the cell **cannot fail for
the reason it states**.

## The suite had already found this, and fixed it everywhere else

Its own note says: *"Counting publishes cannot be made to work here; it has to be counted where the
effect is applied."* It then builds a per-manager handler-entry counter and moves the
duplicate-effect cells onto it.

That migration was correct and incomplete. The handler counter sits **behind the fence** and says so:
*"an increment means the command RAN - not that a request arrived."* **A re-issue whose first attempt
was refused ahead of the handler is invisible to it by construction**, so the three "did it go out"
cells had nowhere to move and stayed on the proxy.

**The suite owned a counter for effects and none for attempts.**

## The change

Requests are counted per `(endpoint, command)`, decoded with the **shipped `parseEpSubject`** rather
than a hand-rolled match, so a describe is a different command and a contract read is not a request
at all. Only a `ps` request can move the `ps` counter.

## The third cell is narrowed, deliberately

It asserted *"the re-issue WAS attempted (more than one publish)"*. **Measured: for that endpoint the
re-issue is never attempted. Zero requests go out.** Nothing serves it, the re-resolve finds no
responder, and the original refusal rethrows. The old threshold was counting the resolve's describes
and calling them a re-issue.

It now asserts that **the repair re-resolved against the endpoint the account names**, which is the
sentence in its own comment. **A cell that asserts what is true (a re-resolve against the named
endpoint, and zero requests to it) beats one that asserted a re-issue that never happened.** A recovery that looked up `manager` instead would move the manager's
counter and leave this one at zero. This is a smaller claim than the old text implied, and the
stronger reading was never true.

## Verification

Both results were **predicted in writing before the run**, including which cells stay green.

| mutation | predicted | result |
| --- | --- | --- |
| the client never re-issues (`return r`) | KILLED, red on the `ps` heal cell; `purge` also red; **third cell green** | KILLED, **53 of 55** = exactly 2 red |
| the attempts counter stops counting | KILLED, all three red | KILLED, **52 of 55** = exactly 3 red |

The mark deltas confirm the cell counts, not just the colour. The third cell staying green under the
first mutation is what proves the three measure different things: its resolve target is computed
before the gutted line.

**Full fixture: 4 of 4 killed**, each red on its own named assertion, at 42, 53, 52 and 52 against a
baseline of 55. The counter's own guard is checked in, so it cannot be re-pointed onto a counter that
never moves.

## A fixture defect fixed on the way

The core mutations prepend a core build and had **no `afterRestore`**, so a run left `dist` built from
the last mutant. The next suite then reddens for a reason that has nothing to do with it - which
happened to me mid-verification. Each now rebuilds on restore.

