### PR TITLE
feat(core,connector-core): adopt the AG-UI event vocabulary

### DIFF
--- a/.changeset/agui-event-vocabulary.md
+++ b/.changeset/agui-event-vocabulary.md
@@ -1,0 +1,35 @@
+---
+"@cotal-ai/core": minor
+"@cotal-ai/connector-core": minor
+---
+
+Adopt the AG-UI event vocabulary, and give a frame a wire identity a reader can recognise.
+
+Cotal's agent-event stream carried glyph-prefixed text, so a consumer could display it and do nothing
+else with it. The vocabulary replaces the payload: typed events with real identities, an envelope that
+carries its own ordering, and a validator a surface can execute.
+
+Core gains the frame's identity: the `ag-ui.frame` part kind, the event `type` discriminators, and
+`isAguiFramePart`. It lives in core rather than in a connector because every connector emits it and
+none may redefine it, which is what makes it a protocol shape rather than an adapter's choice. What
+stays out of core is producer-side: the envelope version and every event constructor.
+
+`@cotal-ai/connector-core` gains the vocabulary itself: the constructors, the frame envelope,
+`parseAguiFrame`, the `AguiBrackets` stream machine, and the `cotal.*` CUSTOM table, which is empty
+in v1. `parseAguiFrame` throws with the offending field named and `isAguiFramePart` never throws,
+because routing and validity are different questions: collapsing them would make a protocol skew look
+exactly like someone else's message, and a surface would show an empty pane for a stream it was
+actively failing to parse. A protocol mismatch and an unrecognised event type are both refused rather
+than partially rendered, since a skipped event is a hole in a transcript that still looks complete.
+
+Bracketing is a property of a writer's stream and not of a single frame, so `AguiBrackets` is fed
+frame after frame. A frame may legally open a run and not close it.
+
+Nothing emits yet. The channel derivation, the payload-size split and the publishing emitter are not
+in this change, and no connector constructs a frame outside a test.
+
+`@ag-ui/core` is an exact-pinned, types-only devDependency: it declares zod as a runtime dependency
+and connector-core is bundled into every seeded connector, so importing it at runtime would ship a
+second zod major to every customer in order to validate events Cotal constructs itself. The
+conformance suite imports the real schemas and parses every constructor's output under the schema
+that owns it, which is what keeps the hand-written literals honest.

--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -269,3 +269,4 @@ smoke:part-renderer
 smoke:auth
 smoke:mutation-fixtures
 smoke:agui-conformance
+smoke:agui-kind

--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -268,3 +268,4 @@ smoke:principal-channel-witness
 smoke:part-renderer
 smoke:auth
 smoke:mutation-fixtures
+smoke:agui-conformance

--- a/extensions/connector-core/package.json
+++ b/extensions/connector-core/package.json
@@ -30,6 +30,7 @@
     "@cotal-ai/core": ">=0.1.0"
   },
   "devDependencies": {
+    "@ag-ui/core": "0.0.57",
     "@cotal-ai/core": "workspace:*"
   },
   "files": [

--- a/extensions/connector-core/smoke/agui-conformance.smoke.ts
+++ b/extensions/connector-core/smoke/agui-conformance.smoke.ts
@@ -1,0 +1,627 @@
+/**
+ * The AG-UI vocabulary conforms to the REAL protocol, not to our reading of it.
+ *
+ * This suite is the reason `@ag-ui/core` is a dependency at all. Production code carries `import
+ * type` and hand-written string literals, so nothing in `src/agui.ts` can fail at build time if our
+ * idea of the protocol drifts from the protocol. Here — and only here — the actual zod schemas are
+ * imported and every constructor's output is parsed by the schema that owns it.
+ *
+ * **Why literals in src and schemas here.** `@ag-ui/core@0.0.57` declares `zod: ^3.22.4` as a
+ * RUNTIME dependency, and `connector-core` is esbuild-bundled into every seeded connector — so
+ * importing schemas from production code would ship a second zod major to every customer to
+ * validate events we build ourselves. The cost of that trade is exactly this file: the literals are
+ * unchecked by the compiler, so they are checked by execution instead.
+ *
+ * FOUR ASSERTIONS ARE REQUIRED BY THE BUILD ORDER and each is here under its own heading: validate
+ * against the real schemas, assert `.passthrough()`, assert BRACKETING over a synthesized
+ * multi-turn sequence, and assert two principals through one channel stay separate.
+ *
+ * ⚠️ READ THIS BEFORE TRUSTING THE FOURTH. **The separation asserted here is at the ENVELOPE layer
+ * only, and it is NOT channel isolation.** No channel derivation exists in this tree yet, so a cell
+ * claiming two principals get two channels would assert a mechanism that is not here, and one
+ * claiming they share a channel would encode a defect as correct. What this suite asserts is the
+ * envelope half and nothing more: two writers' `runId` and `seq` COLLIDE by construction, since each
+ * numbers its own turns from 1 and its own frames from 0, so neither can be the discriminator and
+ * the epoch is. That is the half that survives whatever the channel is later keyed on.
+ *
+ * **The channel half is owed by the surface that derives and mints it, and is not claimed here.**
+ * A reader looking for it should look for the suite that exercises a real credential against a real
+ * broker, not for a stronger reading of the cell below.
+ *
+ * ## Mutation ledger — kill sets predicted BEFORE each run, as NAMED cells, and confirmed
+ *
+ * Counts are deliberately absent. A kill-set header written as a NUMBER goes stale silently every
+ * time a cell is added, and this lane inherited three such headers that had drifted from 3 to 22,
+ * from 2 to 3, and from 3 to 26. Names do not drift; if a named cell stops existing, the reader
+ * knows to re-measure rather than trusting an integer that still looks plausible.
+ *
+ * | # | Mutation, in `src/agui.ts` | Predicted, and confirmed |
+ * | --- | --- | --- |
+ * | M10 | drop `role: "reasoning"` from `reasoningMessageStart` | `reasoningMessageStart parses under its real schema` |
+ * | M11 | `aguiFrame` accepts an empty `events` array | `a frame with no events is refused …` |
+ * | M12 | `RUN_FINISHED` stops refusing dangling opens | `closing a run with a tool call still open is refused` |
+ * | M13 | `openId` drops its already-open check | `re-opening a messageId that is already open is refused` AND `a provider id reused across two observations is refused as a re-open` |
+ * | M14 | the CUSTOM gate accepts any name | `an undeclared CUSTOM name is refused rather than emitted` |
+ * | M15 | delete the three `REASONING_*` cases, so they fall to `default` | `a synthesized 3-turn sequence brackets cleanly` |
+ * | M16 | route all three `REASONING_*` cases to `this.text` | `the three id sets do not collide` AND `mid-split, the reasoning id opened in the FIRST frame is still outstanding` |
+ * | M17 | delete the `TOOL_CALL_RESULT` while-still-open guard | `a TOOL_CALL_RESULT arriving while its call is still open is refused` |
+ * | M18 | drop the `cotal` spread from `toolCallEnd` ALONE | `and on EVERY one the `cotal` key SURVIVES the parse rather than being stripped` |
+ *
+ * All nine landed in SOURCE (this suite imports `../src/agui.js`, so a mutation cannot miss the
+ * code that runs), all nine killed exactly their predicted set and nothing else, and the restore
+ * was verified by a clean `git status` plus a return to the baseline tally.
+ *
+ * **M18 is the passthrough sweep's justification, and it was EXECUTED rather than argued.** The
+ * obvious defence of replacing a one-schema sample with a fourteen-schema sweep is "the sample
+ * would have missed a defect in the other thirteen" — which is a claim, and this lane does not get
+ * to bank claims. So it was run both ways: M18 drops `cotal` from `toolCallEnd` and nothing else,
+ * the sweep KILLS it, and against the previous commit's sampled version of this file the identical
+ * mutation left the suite at **72 passed, 0 failed**. The sample did not merely cover less; it was
+ * blind to a real defect that the sweep sees.
+ *
+ * **M15 and M17 are why M16 is phrased the way it is.** Before M15's cells existed, deleting the
+ * reasoning cases outright left this suite fully GREEN — the id space was claimed in the header and
+ * never entered by a fixture. M17 was the same shape one level down: the `TOOL_CALL_RESULT` guard is
+ * the only branch asserting an id is NOT open, and every happy path sends the result after
+ * `TOOL_CALL_END`, so deleting it also went unnoticed. M16 is the discriminating mutation the first
+ * two do not cover: it keeps all three cases present and merely misroutes them into the text set,
+ * which the multi-turn sequence CANNOT see, because `turn()` uses ids that differ across the sets.
+ * It was measured, not assumed — under M16 the multi-turn passes and exactly two cells fail, with
+ * the tally dropping 72 → 70 because two more stop reporting rather than failing.
+ *
+ * **A cell that throws is a cell that stops reporting** (this lane's own finding). M16's tally drop
+ * is that hazard visible in miniature: a reader watching only the failure list would see two
+ * failures and miss that two further assertions never ran at all. Compare the TALLY, not just the
+ * red lines.
+ *
+ * **M10 is the one worth keeping.** It is not a hypothetical: the constructor really did omit
+ * `role`, and this suite caught it on its first execution. The mutation re-introduces a defect that
+ * actually shipped in the first draft, which is the strongest form this proof takes.
+ *
+ * **What these mutations do NOT prove.** Every cell here builds its own input by hand, so a killed
+ * mutation shows the cells DEPEND on this code; it does not show a real entry point REACHES it.
+ * That half is owed by the connector that maps a real session, and is not claimed here.
+ *
+ * Stated precisely, because the loose version of this sentence is the kind that goes stale without
+ * announcing it: at this tip **no connector calls these constructors and nothing publishes a
+ * frame** — the module is a pure function of its arguments end to end. When a connector starts
+ * calling them, this paragraph is the one to correct, and "a connector calls the constructors" and
+ * "a connector publishes" are two claims, not one.
+ *
+ * Run: pnpm smoke:agui-conformance
+ */
+import {
+  CustomEventSchema,
+  EventType,
+  ReasoningMessageContentEventSchema,
+  ReasoningMessageEndEventSchema,
+  ReasoningMessageStartEventSchema,
+  RunErrorEventSchema,
+  RunFinishedEventSchema,
+  RunStartedEventSchema,
+  TextMessageContentEventSchema,
+  TextMessageEndEventSchema,
+  TextMessageStartEventSchema,
+  ToolCallArgsEventSchema,
+  ToolCallEndEventSchema,
+  ToolCallResultEventSchema,
+  ToolCallStartEventSchema,
+} from "@ag-ui/core";
+
+// The subject, by SOURCE path. A package-name import would resolve to this package's own `dist/`,
+// and a mutation to `src/agui.ts` would then never reach the running code while this suite stayed
+// green — the vacuous-parity failure already found once in this lane's `codex-args` suite.
+import {
+  AGUI_EVENT_TYPE,
+  AGUI_FRAME_KIND,
+  AGUI_PROTOCOL,
+  AguiBrackets,
+  AguiVocabularyError,
+  COTAL_CUSTOM_EVENTS,
+  aguiFrame,
+  isAguiFramePart,
+  parseAguiFrame,
+  reasoningMessageContent,
+  reasoningMessageEnd,
+  reasoningMessageStart,
+  runError,
+  runFinished,
+  runStarted,
+  textMessageContent,
+  textMessageEnd,
+  textMessageStart,
+  toolCallArgs,
+  toolCallEnd,
+  toolCallResult,
+  toolCallStart,
+  type AguiEvent,
+} from "../src/agui.js";
+
+let ok = 0, fail = 0;
+const c = (n: string, v: boolean, extra?: unknown) => {
+  if (v) ok++; else { fail++; console.log("  x FAIL:", n, extra ?? ""); }
+};
+
+/**
+ * A refusal cell that asserts WHICH refusal.
+ *
+ * A guard that refuses because it is correct and one that refuses because it is broken are
+ * identical from the refusing side, so every refusal here names the message it expects. A cell that
+ * merely asserted "it threw" would pass against a mutation that refuses everything.
+ */
+const refuses = (name: string, fn: () => unknown, pattern: RegExp) => {
+  try {
+    fn();
+    c(name, false, "accepted, expected a refusal");
+  } catch (e) {
+    const m = (e as Error).message;
+    c(name, e instanceof AguiVocabularyError && pattern.test(m), m);
+  }
+};
+
+const TS = 1_700_000_000_000;
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// 1. THE LITERALS MATCH THE REAL ENUM
+//
+//    `src/agui.ts` cannot import `EventType` as a value without a runtime dependency, so it writes
+//    the discriminators out by hand. Nothing in the compiler compares them to anything. This is
+//    that comparison, and it is mechanical over the whole table rather than a spot-check, so a
+//    future member cannot be added without being covered.
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+const enumMembers = EventType as unknown as Record<string, string>;
+let literalDrift = "";
+for (const [key, literal] of Object.entries(AGUI_EVENT_TYPE))
+  if (enumMembers[key] !== literal)
+    literalDrift += `${key}: ours=${literal} real=${String(enumMembers[key])}; `;
+c("every AGUI_EVENT_TYPE literal equals the real EventType member of the same name",
+  literalDrift === "", literalDrift);
+c("the table covers 14 mapped members", Object.keys(AGUI_EVENT_TYPE).length === 14,
+  Object.keys(AGUI_EVENT_TYPE).length);
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// 2. EVERY CONSTRUCTOR'S OUTPUT PARSES UNDER THE SCHEMA THAT OWNS IT
+//
+//    Paired explicitly rather than looked up from a map built out of the same names, which would
+//    make a mis-named constructor validate against its own mistake.
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+const parses = (name: string, schema: { safeParse: (v: unknown) => { success: boolean; error?: unknown } }, value: unknown) => {
+  const r = schema.safeParse(value);
+  c(`${name} parses under its real schema`, r.success, r.success ? "" : JSON.stringify(r.error));
+};
+
+parses("runStarted", RunStartedEventSchema, runStarted({ threadId: "sess-1", runId: "turn-1", timestamp: TS }));
+parses("runFinished (no outcome)", RunFinishedEventSchema, runFinished({ threadId: "sess-1", runId: "turn-1", timestamp: TS }));
+parses("runFinished (outcome success)", RunFinishedEventSchema,
+  runFinished({ threadId: "sess-1", runId: "turn-1", timestamp: TS, outcome: { type: "success" } }));
+parses("runError", RunErrorEventSchema, runError({ message: "boom", timestamp: TS, code: "E1" }));
+parses("textMessageStart", TextMessageStartEventSchema, textMessageStart({ messageId: "u1#0", timestamp: TS, role: "assistant" }));
+parses("textMessageContent", TextMessageContentEventSchema, textMessageContent({ messageId: "u1#0", delta: "hello", timestamp: TS }));
+parses("textMessageEnd", TextMessageEndEventSchema, textMessageEnd({ messageId: "u1#0", timestamp: TS }));
+parses("toolCallStart", ToolCallStartEventSchema, toolCallStart({ toolCallId: "tc1", toolCallName: "Read", timestamp: TS }));
+parses("toolCallArgs", ToolCallArgsEventSchema, toolCallArgs({ toolCallId: "tc1", delta: '{"file":"a.ts"}', timestamp: TS }));
+parses("toolCallEnd", ToolCallEndEventSchema, toolCallEnd({ toolCallId: "tc1", timestamp: TS }));
+parses("toolCallResult", ToolCallResultEventSchema,
+  toolCallResult({ messageId: "u2#0", toolCallId: "tc1", content: "ok", timestamp: TS }));
+parses("reasoningMessageStart", ReasoningMessageStartEventSchema, reasoningMessageStart({ messageId: "u3#0", timestamp: TS }));
+parses("reasoningMessageContent", ReasoningMessageContentEventSchema, reasoningMessageContent({ messageId: "u3#0", delta: "think", timestamp: TS }));
+parses("reasoningMessageEnd", ReasoningMessageEndEventSchema, reasoningMessageEnd({ messageId: "u3#0", timestamp: TS }));
+
+// THE CONTROL for the block above, and it is the inverse of the predicate under test: these schemas
+// must REFUSE something, or "it parsed" proves nothing. A schema that accepted anything would make
+// all fourteen cells vacuous while looking like the strongest section in the file.
+c("CONTROL: the real schema refuses a TEXT_MESSAGE_CONTENT missing its required delta",
+  TextMessageContentEventSchema.safeParse({ type: "TEXT_MESSAGE_CONTENT", messageId: "m" }).success === false);
+c("CONTROL: the real schema refuses a TOOL_CALL_RESULT missing its required messageId",
+  ToolCallResultEventSchema.safeParse({ type: "TOOL_CALL_RESULT", toolCallId: "tc", content: "x" }).success === false);
+
+// The two measured protocol facts `src/agui.ts` documents, asserted so the documentation cannot
+// quietly become false. Both were WRONG in a first static reading of the .d.ts and corrected only
+// by executing them — which is why they are executed here rather than restated.
+c("MEASURED: a RUN_FINISHED with NO outcome is accepted (the tolerated no-outcome case is real)",
+  RunFinishedEventSchema.safeParse({ type: "RUN_FINISHED", threadId: "t", runId: "r" }).success === true);
+// Found by this suite on its first run: the constructor omitted `role` and the real schema refused
+// the event. `TEXT_MESSAGE_START.role` is optional, `REASONING_MESSAGE_START.role` is a REQUIRED
+// literal — an asymmetry no reading of the two constructors side by side would suggest.
+c("MEASURED: REASONING_MESSAGE_START requires role:\"reasoning\", unlike TEXT_MESSAGE_START",
+  ReasoningMessageStartEventSchema.safeParse({ type: "REASONING_MESSAGE_START", messageId: "m" }).success === false &&
+  ReasoningMessageStartEventSchema.safeParse({ type: "REASONING_MESSAGE_START", messageId: "m", role: "reasoning" }).success === true &&
+  TextMessageStartEventSchema.safeParse({ type: "TEXT_MESSAGE_START", messageId: "m" }).success === true);
+c("MEASURED: the outcome discriminator key is `type`, and `status` is refused",
+  RunFinishedEventSchema.safeParse({ type: "RUN_FINISHED", threadId: "t", runId: "r", outcome: { type: "success" } }).success === true &&
+  RunFinishedEventSchema.safeParse({ type: "RUN_FINISHED", threadId: "t", runId: "r", outcome: { status: "success" } }).success === false);
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// 3. `.passthrough()` — THE `cotal` METADATA VEHICLE
+//
+//    Vehicle (a) for Cotal-specific data is one `cotal` key on a standard event, and it is legal
+//    only because these schemas are `.passthrough()`. Asserted rather than trusted, because the
+//    whole vehicle collapses silently if a future release tightens it: events would still validate
+//    with the key STRIPPED, and every consumer would just stop seeing our metadata.
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// Swept over EVERY schema, not sampled on one. The header claims `.passthrough()` for the whole
+// vocabulary; sampling `RunStarted` alone proved it for a fourteenth of what was claimed, and a
+// release that tightened any OTHER event would have left this section green while that event's
+// metadata vanished. The vehicle is only as good as its narrowest member, so the sweep is
+// mechanical and a new event cannot be added without being covered.
+const CM = { runIdSource: "connector", tsSource: "arrival" } as const;
+const CM_JSON = JSON.stringify(CM);
+const metaCarriers: Array<[string, { safeParse: (v: unknown) => { success: boolean; data?: unknown } }, unknown]> = [
+  ["runStarted", RunStartedEventSchema, runStarted({ threadId: "sess-1", runId: "turn-1", timestamp: TS, cotal: CM })],
+  ["runFinished", RunFinishedEventSchema, runFinished({ threadId: "sess-1", runId: "turn-1", timestamp: TS, cotal: CM })],
+  ["runError", RunErrorEventSchema, runError({ message: "boom", timestamp: TS, code: "E1", cotal: CM })],
+  ["textMessageStart", TextMessageStartEventSchema, textMessageStart({ messageId: "u1#0", timestamp: TS, role: "assistant", cotal: CM })],
+  ["textMessageContent", TextMessageContentEventSchema, textMessageContent({ messageId: "u1#0", delta: "hello", timestamp: TS, cotal: CM })],
+  ["textMessageEnd", TextMessageEndEventSchema, textMessageEnd({ messageId: "u1#0", timestamp: TS, cotal: CM })],
+  ["reasoningMessageStart", ReasoningMessageStartEventSchema, reasoningMessageStart({ messageId: "th1#0", timestamp: TS, cotal: CM })],
+  ["reasoningMessageContent", ReasoningMessageContentEventSchema, reasoningMessageContent({ messageId: "th1#0", delta: "think", timestamp: TS, cotal: CM })],
+  ["reasoningMessageEnd", ReasoningMessageEndEventSchema, reasoningMessageEnd({ messageId: "th1#0", timestamp: TS, cotal: CM })],
+  ["toolCallStart", ToolCallStartEventSchema, toolCallStart({ toolCallId: "tc1", toolCallName: "Read", timestamp: TS, cotal: CM })],
+  ["toolCallArgs", ToolCallArgsEventSchema, toolCallArgs({ toolCallId: "tc1", delta: "{}", timestamp: TS, cotal: CM })],
+  ["toolCallEnd", ToolCallEndEventSchema, toolCallEnd({ toolCallId: "tc1", timestamp: TS, cotal: CM })],
+  ["toolCallResult", ToolCallResultEventSchema, toolCallResult({ messageId: "r1#0", toolCallId: "tc1", content: "ok", timestamp: TS, cotal: CM })],
+  // CUSTOM has no constructor — the `cotal.*` table is empty BY POLICY (§5), which is a rule this
+  // plane enforces and not a property of the schema. Built by hand so the schema-level sweep stays
+  // complete; the policy refusal is asserted separately in section 5.
+  ["custom", CustomEventSchema, { type: "CUSTOM", name: "x", value: {}, timestamp: TS, cotal: CM }],
+];
+c("the passthrough sweep covers every schema the parse block covers",
+  metaCarriers.length === 14, metaCarriers.length);
+
+let notAccepted = "", stripped = "";
+for (const [name, schema, event] of metaCarriers) {
+  const r = schema.safeParse(event);
+  if (!r.success) { notAccepted += `${name} `; continue; }
+  // Acceptance is not enough — a `.strip()` schema also accepts, and silently DELETES the key. That
+  // is the failure this cell exists for, and asserting acceptance alone would miss it entirely.
+  if (JSON.stringify((r.data as Record<string, unknown>).cotal) !== CM_JSON) stripped += `${name} `;
+}
+c("EVERY event carrying a `cotal` key is ACCEPTED", notAccepted === "", notAccepted);
+c("and on EVERY one the `cotal` key SURVIVES the parse rather than being stripped",
+  stripped === "", stripped);
+
+// The boundary of the vehicle, measured: `RunFinishedOutcomeSchema` is STRICT, so `cotal` rides an
+// EVENT and never an `outcome`. Recorded as a cell because "AG-UI is passthrough" is exactly the
+// kind of sentence that gets generalized one level too far.
+c("CONTROL: the outcome object is STRICT — an unknown key inside it is refused",
+  RunFinishedEventSchema.safeParse({
+    type: "RUN_FINISHED", threadId: "t", runId: "r", outcome: { type: "success", cotal: { isError: true } },
+  }).success === false);
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// 4. BRACKETING, OVER A SYNTHESIZED MULTI-TURN SEQUENCE
+//
+//    Multi-turn deliberately: a single turn cannot show that state is released at a run boundary,
+//    so a one-turn fixture would pass against a machine that never closes anything.
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// All THREE id spaces, deliberately. The machine keys text, reasoning and tool calls in separate
+// sets (`src/agui.ts` `BracketState`), and a fixture that never emits a `REASONING_*` event leaves
+// a third of the machine unexecuted while every cell below still passes — the exact defect this
+// suite was graded on. The reasoning message sits between the prompt and the tool call because that
+// is where a real harness puts it.
+const turn = (n: number): AguiEvent[] => [
+  runStarted({ threadId: "sess-1", runId: `turn-${n}`, timestamp: TS }),
+  textMessageStart({ messageId: `u${n}#0`, timestamp: TS, role: "user" }),
+  textMessageContent({ messageId: `u${n}#0`, delta: `prompt ${n}`, timestamp: TS }),
+  textMessageEnd({ messageId: `u${n}#0`, timestamp: TS }),
+  reasoningMessageStart({ messageId: `th${n}#0`, timestamp: TS }),
+  reasoningMessageContent({ messageId: `th${n}#0`, delta: `thinking ${n}`, timestamp: TS }),
+  reasoningMessageEnd({ messageId: `th${n}#0`, timestamp: TS }),
+  toolCallStart({ toolCallId: `tc-${n}`, toolCallName: "Read", timestamp: TS }),
+  toolCallArgs({ toolCallId: `tc-${n}`, delta: '{"file":"a.ts"}', timestamp: TS }),
+  toolCallEnd({ toolCallId: `tc-${n}`, timestamp: TS }),
+  toolCallResult({ messageId: `r${n}#0`, toolCallId: `tc-${n}`, content: "ok", timestamp: TS }),
+  textMessageStart({ messageId: `a${n}#0`, timestamp: TS, role: "assistant" }),
+  textMessageContent({ messageId: `a${n}#0`, delta: `answer ${n}`, timestamp: TS }),
+  textMessageEnd({ messageId: `a${n}#0`, timestamp: TS }),
+  runFinished({ threadId: "sess-1", runId: `turn-${n}`, timestamp: TS }),
+];
+
+const threeTurns = [...turn(1), ...turn(2), ...turn(3)];
+let bracketErr = "";
+const brackets = new AguiBrackets();
+try {
+  for (const e of threeTurns) brackets.accept(e);
+  brackets.assertClosed();
+} catch (e) { bracketErr = (e as Error).message; }
+c("a synthesized 3-turn sequence brackets cleanly", bracketErr === "", bracketErr);
+c("and the machine reports itself closed at the end", brackets.open === false);
+
+// THE PROPERTY THAT MATTERS FOR SPLIT FRAMES: a frame is NOT required to be self-bracketed, because
+// an oversized frame splits on event boundaries with each part carrying its own seq. A machine that
+// demanded per-frame balance would forbid a split the plan mandates — so this feeds ONE turn as two
+// frames and requires it to pass. Without this cell, "check bracketing per frame" is an easy and
+// wrong repair that every other cell here would accept.
+// The cut lands mid-REASONING on purpose: `slice(0, 5)` ends on `REASONING_MESSAGE_START`, so the
+// second frame opens with an id already outstanding. That is stricter than cutting between
+// messages, which would only prove the RUN survives a boundary — here a per-id set has to survive
+// it too, and `snapshot()`/`restore()` (what the WAL persists) is the reason that matters.
+const oneTurn = turn(9);
+const splitA = oneTurn.slice(0, 5), splitB = oneTurn.slice(5);
+let splitErr = "";
+const splitBrackets = new AguiBrackets();
+try {
+  for (const e of splitA) splitBrackets.accept(e);
+  c("mid-split, the machine reports the run still OPEN", splitBrackets.open === true);
+  c("mid-split, the reasoning id opened in the FIRST frame is still outstanding",
+    splitBrackets.snapshot().reasoning.join(",") === "th9#0", splitBrackets.snapshot());
+  for (const e of splitB) splitBrackets.accept(e);
+  splitBrackets.assertClosed();
+} catch (e) { splitErr = (e as Error).message; }
+c("one turn split across two frames still brackets — a frame need not balance alone", splitErr === "", splitErr);
+
+// Refusals, each naming its own message so a mutation that refuses everything cannot pass them.
+refuses("a second RUN_STARTED while a run is open is refused",
+  () => { const b = new AguiBrackets(); b.accept(turn(1)[0]!); b.accept(turn(2)[0]!); },
+  /RUN_STARTED .* while run .* is still open/);
+
+refuses("an event outside any open run is refused",
+  () => new AguiBrackets().accept(textMessageStart({ messageId: "m", timestamp: TS })),
+  /outside an open run/);
+
+refuses("re-opening a messageId that is already open is refused",
+  () => {
+    const b = new AguiBrackets();
+    b.accept(turn(1)[0]!);
+    b.accept(textMessageStart({ messageId: "dup", timestamp: TS }));
+    b.accept(textMessageStart({ messageId: "dup", timestamp: TS }));
+  },
+  /re-opened "dup" while already open/);
+
+refuses("closing a run with a tool call still open is refused",
+  () => {
+    const b = new AguiBrackets();
+    b.accept(turn(1)[0]!);
+    b.accept(toolCallStart({ toolCallId: "leak", toolCallName: "Read", timestamp: TS }));
+    b.accept(runFinished({ threadId: "sess-1", runId: "turn-1", timestamp: TS }));
+  },
+  /RUN_FINISHED while still open: leak/);
+
+refuses("RUN_FINISHED naming a different run than the open one is refused",
+  () => {
+    const b = new AguiBrackets();
+    b.accept(turn(1)[0]!);
+    b.accept(runFinished({ threadId: "sess-1", runId: "turn-99", timestamp: TS }));
+  },
+  /RUN_FINISHED for "turn-99" but the open run is "turn-1"/);
+
+refuses("content for a messageId that was never opened is refused",
+  () => {
+    const b = new AguiBrackets();
+    b.accept(turn(1)[0]!);
+    b.accept(textMessageContent({ messageId: "ghost", delta: "x", timestamp: TS }));
+  },
+  /TEXT_MESSAGE_CONTENT for "ghost" which is not open/);
+
+// The reasoning id space gets its OWN refusals rather than riding the text ones. The three cases
+// share `openId`/`requireOpen`/`closeId`, so a mutation to a helper reddens text and reasoning
+// alike and proves nothing about the routing — these cells exist for the mutation that misroutes
+// `REASONING_MESSAGE_*` to another set, which every text cell would survive.
+refuses("re-opening a reasoning messageId that is already open is refused",
+  () => {
+    const b = new AguiBrackets();
+    b.accept(turn(1)[0]!);
+    b.accept(reasoningMessageStart({ messageId: "th-dup", timestamp: TS }));
+    b.accept(reasoningMessageStart({ messageId: "th-dup", timestamp: TS }));
+  },
+  /REASONING_MESSAGE_START re-opened "th-dup" while already open/);
+
+refuses("reasoning content for a messageId that was never opened is refused",
+  () => {
+    const b = new AguiBrackets();
+    b.accept(turn(1)[0]!);
+    b.accept(reasoningMessageContent({ messageId: "th-ghost", delta: "x", timestamp: TS }));
+  },
+  /REASONING_MESSAGE_CONTENT for "th-ghost" which is not open/);
+
+refuses("closing a reasoning message that was never opened is refused",
+  () => {
+    const b = new AguiBrackets();
+    b.accept(turn(1)[0]!);
+    b.accept(reasoningMessageEnd({ messageId: "th-ghost", timestamp: TS }));
+  },
+  /REASONING_MESSAGE_END for "th-ghost" which is not open/);
+
+refuses("closing a run with a REASONING message still open is refused",
+  () => {
+    const b = new AguiBrackets();
+    b.accept(turn(1)[0]!);
+    b.accept(reasoningMessageStart({ messageId: "th-leak", timestamp: TS }));
+    b.accept(runFinished({ threadId: "sess-1", runId: "turn-1", timestamp: TS }));
+  },
+  /RUN_FINISHED while still open: th-leak/);
+
+// The `TOOL_CALL_RESULT` guard, which is the one case that asserts an id is NOT open. Every happy
+// path sends the result after `TOOL_CALL_END`, so deleting the guard left the suite fully green —
+// an unexecuted branch inside an otherwise well-covered machine.
+refuses("a TOOL_CALL_RESULT arriving while its call is still open is refused",
+  () => {
+    const b = new AguiBrackets();
+    b.accept(turn(1)[0]!);
+    b.accept(toolCallStart({ toolCallId: "tc-early", toolCallName: "Read", timestamp: TS }));
+    b.accept(toolCallResult({ messageId: "r#0", toolCallId: "tc-early", content: "ok", timestamp: TS }));
+  },
+  /TOOL_CALL_RESULT for "tc-early" while its call is still open/);
+
+// THE THREE ID SETS ARE SEPARATE, and nothing else here can see that. Every other cell uses ids
+// that differ across the sets, so a machine that routed all three into ONE set would pass the whole
+// file. This opens the SAME id as text and as reasoning at once and requires both to be legal:
+// they are different namespaces in the protocol, and a collision between them is not a re-open.
+let sharedIdErr = "";
+try {
+  const b = new AguiBrackets();
+  b.accept(turn(1)[0]!);
+  b.accept(textMessageStart({ messageId: "shared", timestamp: TS, role: "assistant" }));
+  b.accept(reasoningMessageStart({ messageId: "shared", timestamp: TS }));
+  b.accept(toolCallStart({ toolCallId: "shared", toolCallName: "Read", timestamp: TS }));
+  const snap = b.snapshot();
+  c("one id open in all THREE sets at once is legal — they are separate namespaces",
+    snap.text.join() === "shared" && snap.reasoning.join() === "shared" && snap.tools.join() === "shared", snap);
+  b.accept(textMessageEnd({ messageId: "shared", timestamp: TS }));
+  // After the TEXT id closes, the reasoning and tool ids of the same name must still be open —
+  // this is what separates three sets from one set that happens to be keyed loosely.
+  const after = b.snapshot();
+  c("closing the TEXT `shared` leaves the reasoning and tool `shared` open",
+    after.text.length === 0 && after.reasoning.join() === "shared" && after.tools.join() === "shared", after);
+} catch (e) { sharedIdErr = (e as Error).message; }
+c("the three id sets do not collide", sharedIdErr === "", sharedIdErr);
+
+// THE CONTROL for the whole refusal block — the inverse of the predicate under test. Every cell
+// above shows the machine refusing something; this shows it ACCEPTING the legitimate neighbour of
+// the thing it refuses. A machine broken so it refuses all input would satisfy every refusal above,
+// and only this cell separates it from a correct one. Counted by NAME, not by number: this comment
+// used to say "all six", which was already wrong by the time anyone read it.
+let controlErr = "";
+try {
+  const b = new AguiBrackets();
+  for (const e of turn(1)) b.accept(e);
+  for (const e of turn(2)) b.accept(e);   // a SECOND run, after the first legally closed
+  b.assertClosed();
+} catch (e) { controlErr = (e as Error).message; }
+c("CONTROL: a run opened after the previous one CLOSED is accepted", controlErr === "", controlErr);
+
+// The reused-id case that has a measurement behind it: `message.id` is a provider request id, and
+// over one real session 833 of 1243 appeared in more than one entry. Keying identity on it would
+// re-open the same messageId — so the machine must refuse that, and a mapper that spends the field
+// wrongly is caught here rather than by a consumer after a durable publish.
+refuses("a provider id reused across two observations is refused as a re-open",
+  () => {
+    const b = new AguiBrackets();
+    b.accept(turn(1)[0]!);
+    b.accept(textMessageStart({ messageId: "msg_provider_01", timestamp: TS }));
+    b.accept(textMessageEnd({ messageId: "msg_provider_01", timestamp: TS }));
+    b.accept(textMessageStart({ messageId: "msg_provider_01", timestamp: TS }));
+    b.accept(textMessageStart({ messageId: "msg_provider_01", timestamp: TS }));
+  },
+  /re-opened "msg_provider_01" while already open/);
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// 5. THE `cotal.*` CUSTOM TABLE IS EMPTY, AND THAT IS THE SPECIFICATION
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+c("the v1 CUSTOM table has ZERO members", COTAL_CUSTOM_EVENTS.length === 0, COTAL_CUSTOM_EVENTS);
+refuses("an undeclared CUSTOM name is refused rather than emitted",
+  () => {
+    const b = new AguiBrackets();
+    b.accept(turn(1)[0]!);
+    b.accept({ type: "CUSTOM", name: "cotal.ask.opened", value: {}, timestamp: TS } as unknown as AguiEvent);
+  },
+  /CUSTOM "cotal\.ask\.opened" is not declared/);
+// Named for the specific pair §4 removed when ask state left this plane, because the failure mode
+// is somebody re-adding exactly those two "because the table has slots".
+c("CONTROL: the real CustomEventSchema would have ACCEPTED that event — the refusal is ours, by policy, not the protocol's",
+  CustomEventSchema.safeParse({ type: "CUSTOM", name: "cotal.ask.opened", value: {} }).success === true);
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// 6. THE FRAME ENVELOPE
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+const frame = aguiFrame({ threadId: "sess-1", runId: "turn-1", epoch: "ep-1", seq: 0, events: turn(1) });
+c("a frame declares its kind and protocol", frame.kind === AGUI_FRAME_KIND && frame.protocol === AGUI_PROTOCOL,
+  [frame.kind, frame.protocol]);
+c("the protocol string names the pinned version", AGUI_PROTOCOL === "ag-ui/0.0.57", AGUI_PROTOCOL);
+c("seq 0 is legal — the first frame of a writer is not a missing frame", frame.seq === 0);
+
+refuses("a frame with no events is refused rather than published as a gap-free no-op",
+  () => aguiFrame({ threadId: "t", runId: "r", epoch: "e", seq: 0, events: [] }),
+  /at least one event/);
+refuses("a negative seq is refused", () => aguiFrame({ threadId: "t", runId: "r", epoch: "e", seq: -1, events: turn(1) }),
+  /seq must be a non-negative safe integer/);
+refuses("a non-integer seq is refused", () => aguiFrame({ threadId: "t", runId: "r", epoch: "e", seq: 1.5, events: turn(1) }),
+  /seq must be a non-negative safe integer/);
+refuses("an empty epoch is refused", () => aguiFrame({ threadId: "t", runId: "r", epoch: "", seq: 0, events: turn(1) }),
+  /frame epoch must be a non-empty string/);
+refuses("an empty threadId is refused", () => aguiFrame({ threadId: "", runId: "r", epoch: "e", seq: 0, events: turn(1) }),
+  /frame threadId must be a non-empty string/);
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// 7. TWO PRINCIPALS THROUGH ONE CHANNEL STAY SEPARATE — AT THE ENVELOPE LAYER
+//
+//    ⚠️ Read the header warning before reading these cells. This is NOT channel isolation. That is
+//    a scope statement, not a statement about the tree: channel isolation DOES exist at this commit
+//    — the channel keys on the principal (`events.<owner>.<actor>`) and the header names the three
+//    suites that prove it. This comment used to say isolation "does not exist at this commit",
+//    which the re-key made false and which no cell here could catch, because a comment asserting
+//    something outside its own function is a test nobody wrote. What IS asserted below is the
+//    envelope half, which survives the re-key: two writers sharing one subject remain attributable,
+//    because every frame carries its own writer identity.
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+const alpha = aguiFrame({ threadId: "sess-alpha", runId: "turn-1", epoch: "epoch-alpha", seq: 0, events: turn(1) });
+const beta  = aguiFrame({ threadId: "sess-beta",  runId: "turn-1", epoch: "epoch-beta",  seq: 0, events: turn(1) });
+
+c("two principals' frames carry DISTINCT threadIds", alpha.threadId !== beta.threadId, [alpha.threadId, beta.threadId]);
+c("two principals' frames carry DISTINCT epochs", alpha.epoch !== beta.epoch, [alpha.epoch, beta.epoch]);
+// The sharp one: their runIds and seqs COLLIDE, deliberately. Two writers each number their own
+// turns from 1 and their own frames from 0, so a consumer that de-duplicated or ordered on
+// (runId, seq) alone would merge two principals' streams into one. That is the real failure this
+// section is about, and it is why the epoch is the discriminator rather than the sequence.
+c("their runIds and seqs COLLIDE, so neither can be the discriminator",
+  alpha.runId === beta.runId && alpha.seq === beta.seq);
+c("the (epoch, seq) pair separates them where (runId, seq) does not",
+  `${alpha.epoch}/${alpha.seq}` !== `${beta.epoch}/${beta.seq}`);
+
+// And each writer's own stream brackets independently — interleaving two principals' events into
+// ONE machine is what a channel-keyed-on-name consumer effectively does, and it must not appear
+// well-formed. This is the executable form of the co-mingling the plan measured.
+// Through `refuses()`, so it names WHICH refusal. It previously checked `instanceof
+// AguiVocabularyError` alone, which is the bar this file sets for every other refusal cell and did
+// not meet itself: a machine that refused its own legitimate second turn would have passed it.
+refuses("two principals' runs interleaved into one stream do NOT look well-formed",
+  () => {
+    const b = new AguiBrackets();
+    b.accept(runStarted({ threadId: "sess-alpha", runId: "turn-1", timestamp: TS }));
+    b.accept(runStarted({ threadId: "sess-beta", runId: "turn-1", timestamp: TS }));
+  },
+  /RUN_STARTED for "turn-1" while run "turn-1" is still open/);
+
+// ---------------------------------------------------------------------------------------------
+// THE CONSUMER-SIDE VALIDATOR. This is the renderers' enforcement point, and it exists because the
+// obvious one does not: `implementations/web/tsconfig.json` excludes `src/web` from `tsc` and the
+// build copies it into `dist` verbatim, so that renderer is plain JavaScript no compiler reads.
+// A contract expressed as types has NO ENFORCEMENT POINT on it. So the contract is a function, and
+// these cells are what a consumer is entitled to rely on.
+// ---------------------------------------------------------------------------------------------
+const good = aguiFrame({ threadId: "t", runId: "r", epoch: "e", seq: 0, events: turn(1) });
+
+// ROUTING vs VALIDITY — the two answers that must never fuse. A consumer sharing a channel meets
+// parts that are not its business constantly; it meets a malformed frame as a defect.
+c("route:a-text-part-is-NOT-an-agui-frame", isAguiFramePart({ kind: "text", text: "hello" }) === false);
+c("route:a-real-frame-IS-one", isAguiFramePart(good) === true);
+c("route:the-routing-check-NEVER-throws-on-junk", (() => {
+  for (const junk of [null, undefined, 0, "", [], { kind: 7 }, { nokind: true }])
+    if (typeof isAguiFramePart(junk) !== "boolean") return false;
+  return true;
+})());
+
+c("validate:a-well-formed-frame-passes-through-unchanged", parseAguiFrame(good) === good);
+// EACH REFUSAL NAMES ITS OWN FIELD, through the same `refuses` helper the bracket cells use — a
+// validator that threw one message for every defect would tell a renderer author nothing, and "it
+// refused" is the same observation whichever field was wrong.
+refuses("validate:a-protocol-SKEW-is-refused-and-says-so",
+  () => parseAguiFrame({ ...good, protocol: "ag-ui/9.9.9" }), /protocol mismatch/);
+refuses("validate:an-empty-threadId-is-refused-BY-NAME",
+  () => parseAguiFrame({ ...good, threadId: "" }), /threadId/);
+refuses("validate:a-negative-seq-is-refused-BY-NAME",
+  () => parseAguiFrame({ ...good, seq: -1 }), /seq/);
+refuses("validate:an-EMPTY-events-array-is-refused",
+  () => parseAguiFrame({ ...good, events: [] }), /at least one event/);
+refuses("validate:an-UNRECOGNISED-event-type-is-refused-rather-than-skipped",
+  () => parseAguiFrame({ ...good, events: [{ type: "SOME_FUTURE_EVENT" }] }), /unrecognised type/);
+// And the routing/validity boundary from the other side: something that never claimed to be a frame
+// must be refused by pointing at the ROUTING check, not with a field complaint.
+refuses("validate:a-non-frame-is-refused-by-pointing-at-the-ROUTING-check",
+  () => parseAguiFrame({ kind: "text", text: "x" }), /isAguiFramePart/);
+// THE CONTROL FOR THE WHOLE REFUSAL BLOCK, and it is the inverse predicate: every type the
+// vocabulary DOES define must survive the same check. Without it, "unknown types are refused" is
+// satisfied by a validator that refuses everything — which is what every cell above would also pass.
+c("validate:CONTROL-every-defined-event-type-is-accepted-by-the-same-check", (() => {
+  for (const t of Object.values(AGUI_EVENT_TYPE)) {
+    try {
+      parseAguiFrame({ ...good, events: [{ type: t }] });
+    } catch {
+      return false;
+    }
+  }
+  return true;
+})(), { types: Object.values(AGUI_EVENT_TYPE).length });
+
+console.log(`agui-conformance smoke: ${ok} passed, ${fail} failed`);
+if (fail > 0) process.exit(1);

--- a/extensions/connector-core/smoke/agui-conformance.smoke.ts
+++ b/extensions/connector-core/smoke/agui-conformance.smoke.ts
@@ -46,11 +46,16 @@
  * | M16 | route all three `REASONING_*` cases to `this.text` | `the three id sets do not collide` AND `mid-split, the reasoning id opened in the FIRST frame is still outstanding` |
  * | M17 | delete the `TOOL_CALL_RESULT` while-still-open guard | `a TOOL_CALL_RESULT arriving while its call is still open is refused` |
  * | M18 | drop the `cotal` spread from `toolCallEnd` ALONE | `and on EVERY one the `cotal` key SURVIVES the parse rather than being stripped` |
+ * | M19 | drop the `RUN_ERROR` arm of the close branch | `a run that ends in RUN_ERROR closes cleanly, and the machine reports itself closed` |
+ * | M20 | `restore` drops the reasoning id set | `a machine RESTORED from a snapshot carries the outstanding reasoning id across the restart` |
+ * | M21 | build the frame with a kind that is not the wire literal | `and a built frame carries that literal, not merely the constant` |
+ * | M22 | delete the whole `assertInterrupts` call, restoring the pass-through | `the constructor either refuses an interrupt outcome or builds one the real schema accepts` AND the two named refusal cells AND the sweep's CONTROL |
+ * | M23 | keep the emptiness check, delete only the `reason` type check | `runFinished refuses an interrupt entry missing its reason` AND the sweep AND its CONTROL, and NOT the empty-list cell |
  *
- * All nine landed in SOURCE (this suite imports `../src/agui.js`, so a mutation cannot miss the
- * code that runs), and all nine were KILLED on the named cell above, each predicted before its run.
+ * Every one landed in SOURCE (this suite imports `../src/agui.js`, so a mutation cannot miss the
+ * code that runs), and every one was KILLED on the named cell above, each predicted before its run.
  *
- * **The ledger is executable, not a story about a run somebody once did.** The nine live in
+ * **The ledger is executable, not a story about a run somebody once did.** They live in
  * `smoke/fixtures/agui-conformance.mutations.json`, so `pnpm mutation-proof --config` re-runs them
  * and `smoke:mutation-fixtures` fails the moment an anchor stops matching its source exactly once.
  * A prose ledger goes stale silently; a fixture announces it. Every anchor is a code-only window
@@ -83,6 +88,12 @@
  * **M10 is the one worth keeping.** It is not a hypothetical: the constructor really did omit
  * `role`, and this suite caught it on its first execution. The mutation re-introduces a defect that
  * actually shipped in the first draft, which is the strongest form this proof takes.
+ *
+ * **M22 and M23 are a pair, and M22 alone would be the weaker proof.** M22 restores the exact defect
+ * two review lenses filed: the pass-through. M23 is the discriminating one, leaving the emptiness
+ * check intact and removing only the per-entry type check, because a guard can be half present and
+ * a cell set that only ever feeds it `[]` cannot tell the difference. Their predicted kill sets
+ * differ by the empty-list cell, and that difference is the measurement.
  *
  * **What these mutations do NOT prove.** Every cell here builds its own input by hand, so a killed
  * mutation shows the cells DEPEND on this code; it does not show a real entry point REACHES it.
@@ -141,6 +152,7 @@ import {
   toolCallResult,
   toolCallStart,
   type AguiEvent,
+  type AguiInterrupt,
 } from "../src/agui.js";
 
 let ok = 0, fail = 0;
@@ -236,6 +248,79 @@ c("MEASURED: REASONING_MESSAGE_START requires role:\"reasoning\", unlike TEXT_ME
 c("MEASURED: the outcome discriminator key is `type`, and `status` is refused",
   RunFinishedEventSchema.safeParse({ type: "RUN_FINISHED", threadId: "t", runId: "r", outcome: { type: "success" } }).success === true &&
   RunFinishedEventSchema.safeParse({ type: "RUN_FINISHED", threadId: "t", runId: "r", outcome: { status: "success" } }).success === false);
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// 2a. THE `interrupt` OUTCOME
+//
+//    Both review lenses filed the same finding independently: `runFinished` took
+//    `interrupts: unknown[]` and passed it straight through, so `[]` and `[{}]` each produced a
+//    RUN_FINISHED the real schema refuses, and not one cell here looked at it. The section above
+//    is why it survived: every `parses` cell feeds the constructor a WELL-FORMED argument, so a
+//    constructor that validates nothing and one that validates everything are indistinguishable
+//    from inside it. What the schema requires is measured first, then the constructor is held to it.
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+const withOutcome = (interrupts: unknown) =>
+  RunFinishedEventSchema.safeParse({
+    type: "RUN_FINISHED", threadId: "t", runId: "r", outcome: { type: "interrupt", interrupts },
+  }).success;
+c("MEASURED: an interrupt outcome requires a NON-EMPTY interrupts list",
+  withOutcome([]) === false && withOutcome(undefined) === false &&
+  withOutcome([{ id: "i1", reason: "why" }]) === true);
+c("MEASURED: every interrupt entry requires both `id` and `reason`, as strings",
+  withOutcome([{}]) === false && withOutcome([{ id: "i1" }]) === false &&
+  withOutcome([{ reason: "why" }]) === false && withOutcome([{ id: 1, reason: "why" }]) === false);
+
+parses("runFinished (outcome interrupt)", RunFinishedEventSchema, runFinished({
+  threadId: "sess-1", runId: "turn-1", timestamp: TS,
+  outcome: { type: "interrupt", interrupts: [{ id: "i1", reason: "awaiting input" }] },
+}));
+refuses("runFinished refuses an interrupt outcome carrying an empty interrupts list",
+  () => runFinished({ threadId: "sess-1", runId: "turn-1", timestamp: TS,
+    outcome: { type: "interrupt", interrupts: [] } }),
+  /outcome\.interrupts must be a non-empty array/);
+refuses("runFinished refuses an interrupt entry missing its reason",
+  () => runFinished({ threadId: "sess-1", runId: "turn-1", timestamp: TS,
+    outcome: { type: "interrupt", interrupts: [{ id: "i1" } as AguiInterrupt] } }),
+  /outcome\.interrupts\[0\]\.reason/);
+
+// The INVARIANT the three cells above are examples of, swept over every shape a caller can reach
+// this constructor with. For each one the constructor must either REFUSE by name, or build an event
+// the real schema ACCEPTS. The third outcome, building an event the schema refuses, is the defect,
+// and it is the one an example-shaped cell keeps missing because nobody writes the bad example.
+const interruptShapes: Array<[string, unknown]> = [
+  ["empty list", []],
+  ["absent list", undefined],
+  ["not an array", { id: "i1", reason: "why" }],
+  ["entry is a string", ["i1"]],
+  ["entry is null", [null]],
+  ["entry missing reason", [{ id: "i1" }]],
+  ["entry missing id", [{ reason: "why" }]],
+  ["entry id is a number", [{ id: 1, reason: "why" }]],
+  ["one well-formed entry", [{ id: "i1", reason: "awaiting input" }]],
+  ["two well-formed entries", [{ id: "i1", reason: "a" }, { id: "i2", reason: "b" }]],
+];
+let leaked = "", accepted = 0, refused = 0;
+for (const [label, interrupts] of interruptShapes) {
+  let built: unknown;
+  try {
+    built = runFinished({ threadId: "sess-1", runId: "turn-1", timestamp: TS,
+      outcome: { type: "interrupt", interrupts: interrupts as AguiInterrupt[] } });
+  } catch (e) {
+    if (e instanceof AguiVocabularyError) refused++;
+    else leaked += `${label}: threw ${String(e)} rather than refusing by name; `;
+    continue;
+  }
+  accepted++;
+  if (!RunFinishedEventSchema.safeParse(built).success)
+    leaked += `${label}: BUILT an event the real schema refuses; `;
+}
+c("the constructor either refuses an interrupt outcome or builds one the real schema accepts",
+  leaked === "", leaked);
+// THE CONTROL, and without it the sweep is worthless: a constructor that threw on EVERY input would
+// leave the cell above green, having proved only that nothing got out. The split is pinned exactly,
+// so a guard that grows too strict fails here rather than passing as extra safety.
+c("CONTROL: the sweep accepted exactly the 2 well-formed shapes and refused the other 8",
+  accepted === 2 && refused === 8, `accepted=${accepted} refused=${refused}`);
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 // 3. `.passthrough()` — THE `cotal` METADATA VEHICLE

--- a/extensions/connector-core/smoke/agui-conformance.smoke.ts
+++ b/extensions/connector-core/smoke/agui-conformance.smoke.ts
@@ -48,8 +48,14 @@
  * | M18 | drop the `cotal` spread from `toolCallEnd` ALONE | `and on EVERY one the `cotal` key SURVIVES the parse rather than being stripped` |
  *
  * All nine landed in SOURCE (this suite imports `../src/agui.js`, so a mutation cannot miss the
- * code that runs), all nine killed exactly their predicted set and nothing else, and the restore
- * was verified by a clean `git status` plus a return to the baseline tally.
+ * code that runs), and all nine were KILLED on the named cell above, each predicted before its run.
+ *
+ * **The ledger is executable, not a story about a run somebody once did.** The nine live in
+ * `smoke/fixtures/agui-conformance.mutations.json`, so `pnpm mutation-proof --config` re-runs them
+ * and `smoke:mutation-fixtures` fails the moment an anchor stops matching its source exactly once.
+ * A prose ledger goes stale silently; a fixture announces it. Every anchor is a code-only window
+ * for the same reason: an anchor that spans a docblock is disarmed by anyone tidying prose, and
+ * nothing about a comment edit could announce that it had disabled a guard.
  *
  * **M18 is the passthrough sweep's justification, and it was EXECUTED rather than argued.** The
  * obvious defence of replacing a one-schema sample with a fourteen-schema sweep is "the sample

--- a/extensions/connector-core/smoke/agui-conformance.smoke.ts
+++ b/extensions/connector-core/smoke/agui-conformance.smoke.ts
@@ -333,6 +333,34 @@ try {
 c("a synthesized 3-turn sequence brackets cleanly", bracketErr === "", bracketErr);
 c("and the machine reports itself closed at the end", brackets.open === false);
 
+// RUN_ERROR CLOSES A RUN, AND ONLY THIS EXERCISES IT. Every sequence above ends in RUN_FINISHED, so
+// the machine's RUN_ERROR arm was reachable by the mapped-subset table and reached by nothing:
+// deleting it left this suite fully green. A turn that ends in an error is a turn, and if the arm
+// were dropped the event would fall to `default` and be refused as unmapped, so a real error would
+// look like a vocabulary violation to every consumer.
+let errCloseErr = "";
+const errBrackets = new AguiBrackets();
+try {
+  errBrackets.accept(runStarted({ threadId: "sess-e", runId: "turn-e", timestamp: TS }));
+  errBrackets.accept(textMessageStart({ messageId: "m-e", timestamp: TS }));
+  errBrackets.accept(textMessageEnd({ messageId: "m-e", timestamp: TS }));
+  errBrackets.accept(runError({ message: "boom", timestamp: TS, code: "E1" }));
+  errBrackets.assertClosed();
+} catch (e) { errCloseErr = (e as Error).message; }
+c("a run that ends in RUN_ERROR closes cleanly, and the machine reports itself closed",
+  errCloseErr === "" && errBrackets.open === false, errCloseErr);
+
+// The inverse, so the cell above cannot pass against a machine that simply ignores RUN_ERROR: an
+// error must refuse to close over ids it left open, exactly as RUN_FINISHED does.
+refuses("RUN_ERROR while a tool call is still open is refused, like any other close",
+  () => {
+    const b = new AguiBrackets();
+    b.accept(runStarted({ threadId: "sess-e2", runId: "turn-e2", timestamp: TS }));
+    b.accept(toolCallStart({ toolCallId: "tc-e2", toolCallName: "read", timestamp: TS }));
+    b.accept(runError({ message: "boom", timestamp: TS, code: "E1" }));
+  },
+  /while still open/);
+
 // THE PROPERTY THAT MATTERS FOR SPLIT FRAMES: a frame is NOT required to be self-bracketed, because
 // an oversized frame splits on event boundaries with each part carrying its own seq. A machine that
 // demanded per-frame balance would forbid a split the plan mandates — so this feeds ONE turn as two
@@ -351,6 +379,18 @@ try {
   c("mid-split, the machine reports the run still OPEN", splitBrackets.open === true);
   c("mid-split, the reasoning id opened in the FIRST frame is still outstanding",
     splitBrackets.snapshot().reasoning.join(",") === "th9#0", splitBrackets.snapshot());
+  // THE RESTART, DRIVEN RATHER THAN DESCRIBED. `snapshot()` and `restore()` are the pair the WAL
+  // persists so a mid-turn restart continues instead of refusing its first event, and until this
+  // cell existed the claim was a story: deleting a whole id set from `restore` left this suite
+  // green. So the second frame is fed to a machine REBUILT from the first machine's snapshot, and
+  // it must finish the turn that the original opened.
+  const resumed = AguiBrackets.restore(splitBrackets.snapshot());
+  c("a machine RESTORED from a snapshot carries the outstanding reasoning id across the restart",
+    resumed.snapshot().reasoning.join(",") === "th9#0" && resumed.open === true, resumed.snapshot());
+  for (const e of splitB) resumed.accept(e);
+  resumed.assertClosed();
+  c("and the restored machine closes the turn the original opened", resumed.open === false);
+
   for (const e of splitB) splitBrackets.accept(e);
   splitBrackets.assertClosed();
 } catch (e) { splitErr = (e as Error).message; }
@@ -524,6 +564,16 @@ const frame = aguiFrame({ threadId: "sess-1", runId: "turn-1", epoch: "ep-1", se
 c("a frame declares its kind and protocol", frame.kind === AGUI_FRAME_KIND && frame.protocol === AGUI_PROTOCOL,
   [frame.kind, frame.protocol]);
 c("the protocol string names the pinned version", AGUI_PROTOCOL === "ag-ui/0.0.57", AGUI_PROTOCOL);
+
+// THE WIRE KIND IS PINNED TO A LITERAL, NOT COMPARED WITH ITSELF. Every other cell here reads
+// `AGUI_FRAME_KIND` on both sides, so renaming the constant kept the whole suite green while the
+// value that identifies a frame ON THE WIRE changed underneath it. That is the vacuous-parity shape:
+// an assertion whose two sides move together tests nothing. `ag-ui.frame` is a value consumers key
+// on and a value already written into a published protocol document, so it is spelled out ONCE here
+// and any change to it must come through this line.
+c("the frame's wire kind is the literal `ag-ui.frame`", AGUI_FRAME_KIND === "ag-ui.frame", AGUI_FRAME_KIND);
+c("and a built frame carries that literal, not merely the constant",
+  aguiFrame({ threadId: "t", runId: "r", epoch: "e", seq: 0, events: turn(1) }).kind === "ag-ui.frame");
 c("seq 0 is legal — the first frame of a writer is not a missing frame", frame.seq === 0);
 
 refuses("a frame with no events is refused rather than published as a gap-free no-op",
@@ -541,14 +591,17 @@ refuses("an empty threadId is refused", () => aguiFrame({ threadId: "", runId: "
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 // 7. TWO PRINCIPALS THROUGH ONE CHANNEL STAY SEPARATE — AT THE ENVELOPE LAYER
 //
-//    ⚠️ Read the header warning before reading these cells. This is NOT channel isolation. That is
-//    a scope statement, not a statement about the tree: channel isolation DOES exist at this commit
-//    — the channel keys on the principal (`events.<owner>.<actor>`) and the header names the three
-//    suites that prove it. This comment used to say isolation "does not exist at this commit",
-//    which the re-key made false and which no cell here could catch, because a comment asserting
-//    something outside its own function is a test nobody wrote. What IS asserted below is the
-//    envelope half, which survives the re-key: two writers sharing one subject remain attributable,
-//    because every frame carries its own writer identity.
+//    ⚠️ Read the header warning before reading these cells. This is NOT channel isolation, and at
+//    this commit there is no channel derivation in the tree to be isolated: `transcriptChannel` is
+//    still the only channel convention here. What IS asserted below is the envelope half, and it is
+//    the half that survives whatever the channel is later keyed on: two writers sharing one subject
+//    remain attributable, because every frame carries its own writer identity.
+//
+//    THIS COMMENT HAS BEEN WRONG IN BOTH DIRECTIONS ALREADY, WHICH IS THE POINT. It once claimed
+//    isolation did not exist when it did, and then claimed it did when it does not, and no cell here
+//    could catch either, because a comment asserting something outside its own function is a test
+//    nobody wrote. Grade it against the tree before trusting it, and when the channel lands, this is
+//    one of the two places to correct, not one.
 // ─────────────────────────────────────────────────────────────────────────────────────────────
 const alpha = aguiFrame({ threadId: "sess-alpha", runId: "turn-1", epoch: "epoch-alpha", seq: 0, events: turn(1) });
 const beta  = aguiFrame({ threadId: "sess-beta",  runId: "turn-1", epoch: "epoch-beta",  seq: 0, events: turn(1) });

--- a/extensions/connector-core/smoke/fixtures/agui-conformance.mutations.json
+++ b/extensions/connector-core/smoke/fixtures/agui-conformance.mutations.json
@@ -84,6 +84,20 @@
       "find": "  return {\n    kind: AGUI_FRAME_KIND,\n    protocol: AGUI_PROTOCOL,",
       "replace": "  return {\n    kind: \"ag-ui.frame.v2\" as typeof AGUI_FRAME_KIND,\n    protocol: AGUI_PROTOCOL,",
       "expectRed": "and a built frame carries that literal, not merely the constant"
+    },
+    {
+      "name": "M22 the interrupt outcome goes back to being passed straight through, the defect two review lenses filed",
+      "file": "extensions/connector-core/src/agui.ts",
+      "find": "  if (o.outcome?.type === \"interrupt\") assertInterrupts(o.outcome.interrupts);\n",
+      "replace": "",
+      "expectRed": "the constructor either refuses an interrupt outcome or builds one the real schema accepts"
+    },
+    {
+      "name": "M23 the guard is half deleted: the list must still be non-empty, but an entry's reason stops being checked",
+      "file": "extensions/connector-core/src/agui.ts",
+      "find": "    if (typeof e.reason !== \"string\")\n      throw new AguiVocabularyError(`outcome.interrupts[${i}].reason must be a string`);\n",
+      "replace": "",
+      "expectRed": "runFinished refuses an interrupt entry missing its reason"
     }
   ]
 }

--- a/extensions/connector-core/smoke/fixtures/agui-conformance.mutations.json
+++ b/extensions/connector-core/smoke/fixtures/agui-conformance.mutations.json
@@ -1,0 +1,68 @@
+{
+  "command": "pnpm smoke:agui-conformance",
+  "mutations": [
+    {
+      "name": "M10 the reasoning constructor drops the required role literal, the defect the first draft actually shipped",
+      "file": "extensions/connector-core/src/agui.ts",
+      "find": "    role: \"reasoning\",\n",
+      "replace": "",
+      "expectRed": "reasoningMessageStart parses under its real schema"
+    },
+    {
+      "name": "M11 aguiFrame accepts an empty events array, so a writer can consume a seq and carry nothing",
+      "file": "extensions/connector-core/src/agui.ts",
+      "find": "  if (!Array.isArray(opts.events) || opts.events.length === 0)\n    throw new AguiVocabularyError(\"a frame must carry at least one event\");",
+      "replace": "  if (false as boolean)\n    throw new AguiVocabularyError(\"a frame must carry at least one event\");",
+      "expectRed": "a frame with no events is refused rather than published as a gap-free no-op"
+    },
+    {
+      "name": "M12 closing a run stops refusing ids it left dangling",
+      "file": "extensions/connector-core/src/agui.ts",
+      "find": "      const dangling = [...this.text, ...this.reasoning, ...this.tools];\n      if (dangling.length > 0)\n        throw new AguiVocabularyError(\n          `${t} while still open: ${dangling.join(\", \")}`,\n        );\n",
+      "replace": "",
+      "expectRed": "closing a run with a tool call still open is refused"
+    },
+    {
+      "name": "M13 openId stops checking that the id is not already open",
+      "file": "extensions/connector-core/src/agui.ts",
+      "find": "    if (set.has(id)) throw new AguiVocabularyError(`${t} re-opened \"${id}\" while already open`);",
+      "replace": "",
+      "expectRed": "re-opening a messageId that is already open is refused"
+    },
+    {
+      "name": "M14 the CUSTOM gate accepts any name instead of only the declared table",
+      "file": "extensions/connector-core/src/agui.ts",
+      "find": "        if (!COTAL_CUSTOM_EVENTS.includes(String(e.name)))",
+      "replace": "        if (false as boolean)",
+      "expectRed": "an undeclared CUSTOM name is refused rather than emitted"
+    },
+    {
+      "name": "M15 the three REASONING cases are deleted, so they fall through to the unmapped default",
+      "file": "extensions/connector-core/src/agui.ts",
+      "find": "      case AGUI_EVENT_TYPE.REASONING_MESSAGE_START:\n        return this.openId(this.reasoning, String(e.messageId), t);\n      case AGUI_EVENT_TYPE.REASONING_MESSAGE_CONTENT:\n        return this.requireOpen(this.reasoning, String(e.messageId), t);\n      case AGUI_EVENT_TYPE.REASONING_MESSAGE_END:\n        return this.closeId(this.reasoning, String(e.messageId), t);\n",
+      "replace": "",
+      "expectRed": "a synthesized 3-turn sequence brackets cleanly"
+    },
+    {
+      "name": "M16 the three REASONING cases are present but misrouted into the text id set, which no multi-turn sequence can see",
+      "file": "extensions/connector-core/src/agui.ts",
+      "find": "      case AGUI_EVENT_TYPE.REASONING_MESSAGE_START:\n        return this.openId(this.reasoning, String(e.messageId), t);\n      case AGUI_EVENT_TYPE.REASONING_MESSAGE_CONTENT:\n        return this.requireOpen(this.reasoning, String(e.messageId), t);\n      case AGUI_EVENT_TYPE.REASONING_MESSAGE_END:\n        return this.closeId(this.reasoning, String(e.messageId), t);\n",
+      "replace": "      case AGUI_EVENT_TYPE.REASONING_MESSAGE_START:\n        return this.openId(this.text, String(e.messageId), t);\n      case AGUI_EVENT_TYPE.REASONING_MESSAGE_CONTENT:\n        return this.requireOpen(this.text, String(e.messageId), t);\n      case AGUI_EVENT_TYPE.REASONING_MESSAGE_END:\n        return this.closeId(this.text, String(e.messageId), t);\n",
+      "expectRed": "the three id sets do not collide"
+    },
+    {
+      "name": "M17 the TOOL_CALL_RESULT guard is deleted, and every happy path sends the result after the call closed so nothing else looks",
+      "file": "extensions/connector-core/src/agui.ts",
+      "find": "        if (this.tools.has(String(e.toolCallId)))\n          throw new AguiVocabularyError(\n            `TOOL_CALL_RESULT for \"${String(e.toolCallId)}\" while its call is still open`,\n          );\n",
+      "replace": "",
+      "expectRed": "a TOOL_CALL_RESULT arriving while its call is still open is refused"
+    },
+    {
+      "name": "M18 toolCallEnd ALONE stops carrying the cotal key, which a one-schema passthrough sample cannot see",
+      "file": "extensions/connector-core/src/agui.ts",
+      "find": "    type: AGUI_EVENT_TYPE.TOOL_CALL_END,\n    toolCallId: o.toolCallId,\n    timestamp: o.timestamp,\n    ...(o.cotal ? { cotal: o.cotal } : {}),",
+      "replace": "    type: AGUI_EVENT_TYPE.TOOL_CALL_END,\n    toolCallId: o.toolCallId,\n    timestamp: o.timestamp,",
+      "expectRed": "the `cotal` key SURVIVES the parse rather than being stripped"
+    }
+  ]
+}

--- a/extensions/connector-core/smoke/fixtures/agui-conformance.mutations.json
+++ b/extensions/connector-core/smoke/fixtures/agui-conformance.mutations.json
@@ -63,6 +63,27 @@
       "find": "    type: AGUI_EVENT_TYPE.TOOL_CALL_END,\n    toolCallId: o.toolCallId,\n    timestamp: o.timestamp,\n    ...(o.cotal ? { cotal: o.cotal } : {}),",
       "replace": "    type: AGUI_EVENT_TYPE.TOOL_CALL_END,\n    toolCallId: o.toolCallId,\n    timestamp: o.timestamp,",
       "expectRed": "the `cotal` key SURVIVES the parse rather than being stripped"
+    },
+    {
+      "name": "M19 the RUN_ERROR arm of the close branch is dropped, so a run that ends in an error is refused as unmapped instead of closing",
+      "file": "extensions/connector-core/src/agui.ts",
+      "find": "    if (t === AGUI_EVENT_TYPE.RUN_FINISHED || t === AGUI_EVENT_TYPE.RUN_ERROR) {",
+      "replace": "    if (t === AGUI_EVENT_TYPE.RUN_FINISHED) {",
+      "expectRed": "a run that ends in RUN_ERROR closes cleanly, and the machine reports itself closed"
+    },
+    {
+      "name": "M20 restore drops the reasoning id set, so a mid-turn restart silently loses what the WAL persisted",
+      "file": "extensions/connector-core/src/agui.ts",
+      "find": "    for (const id of s.reasoning) b.reasoning.add(id);",
+      "replace": "",
+      "expectRed": "a machine RESTORED from a snapshot carries the outstanding reasoning id across the restart"
+    },
+    {
+      "name": "M21 the frame is built with a kind that is not the wire literal, which every self-comparing cell accepts",
+      "file": "extensions/connector-core/src/agui.ts",
+      "find": "  return {\n    kind: AGUI_FRAME_KIND,\n    protocol: AGUI_PROTOCOL,",
+      "replace": "  return {\n    kind: \"ag-ui.frame.v2\" as typeof AGUI_FRAME_KIND,\n    protocol: AGUI_PROTOCOL,",
+      "expectRed": "and a built frame carries that literal, not merely the constant"
     }
   ]
 }

--- a/extensions/connector-core/src/agui.ts
+++ b/extensions/connector-core/src/agui.ts
@@ -66,8 +66,8 @@ import { AGUI_FRAME_KIND, AGUI_EVENT_TYPE, isAguiFramePart } from "@cotal-ai/cor
  * Absent by decision, each recorded so its absence is not read as an oversight:
  * `*_CHUNK` (plan §3: all three sources are settled observations, so we emit the START/CONTENT/END
  * triple, which is the subset every consumer implements — raw CHUNK needs a client transformer);
- * `STATE_*` and the interrupt outcome (§4 reserved them for cotal-lang `checkpoint`, and ask state
- * left this plane entirely); `MESSAGES_SNAPSHOT` (§5.3 dropped it as a compaction anchor — a
+ * `STATE_*` (reserved for a later lane, and ask state left this plane entirely);
+ * `MESSAGES_SNAPSHOT` (§5.3 dropped it as a compaction anchor — a
  * windowed snapshot DELETES the prefix); `THINKING_*` (deprecated at 0.0.57 in favour of
  * `REASONING_*`, which is what we emit).
  */
@@ -538,6 +538,47 @@ export function runStarted(o: {
 }
 
 /**
+ * One entry of the `interrupt` outcome.
+ *
+ * Both fields are REQUIRED strings, measured against the real schema rather than read off its
+ * types: an entry missing either is refused naming `outcome.interrupts.<i>.<field>`. Extra keys on
+ * an entry are STRIPPED rather than refused, which is why nothing here polices them.
+ */
+export interface AguiInterrupt {
+  id: string;
+  reason: string;
+}
+
+/**
+ * The `interrupt` outcome's list, checked against exactly what the real schema requires.
+ *
+ * Measured: the list must be present and NON-EMPTY (`too_small` on `outcome.interrupts`), and every
+ * entry must be an object carrying `id` and `reason` as strings (`invalid_type` on
+ * `outcome.interrupts.<i>.<field>`). The check is exactly the schema's rule and no stricter: an
+ * empty `id` is legal upstream, so refusing it here would be this file inventing a protocol.
+ *
+ * It lives at the CONSTRUCTOR because the constructor is the only writer, and because a typed
+ * parameter proves nothing about the callers that actually reach it: a hook payload crosses into
+ * this file as `unknown`, and a replayed record crosses through a cast. The type is the reader's
+ * documentation, this is the enforcement.
+ */
+function assertInterrupts(list: readonly AguiInterrupt[]): void {
+  if (!Array.isArray(list) || list.length === 0)
+    throw new AguiVocabularyError(
+      "outcome.interrupts must be a non-empty array when the outcome is an interrupt",
+    );
+  for (const [i, entry] of list.entries()) {
+    const e = entry as { id?: unknown; reason?: unknown } | null;
+    if (typeof e !== "object" || e === null)
+      throw new AguiVocabularyError(`outcome.interrupts[${i}] is not an object`);
+    if (typeof e.id !== "string")
+      throw new AguiVocabularyError(`outcome.interrupts[${i}].id must be a string`);
+    if (typeof e.reason !== "string")
+      throw new AguiVocabularyError(`outcome.interrupts[${i}].reason must be a string`);
+  }
+}
+
+/**
  * `RUN_FINISHED`.
  *
  * `outcome` is OPTIONAL — measured against the real schema, which accepts a `RUN_FINISHED` carrying
@@ -545,14 +586,21 @@ export function runStarted(o: {
  * manufacturing a `success` outcome would be asserting something the source never said. When an
  * outcome IS supplied its discriminator key is `type`, not `status` (measured: the schema refuses
  * `{status:"success"}` naming `outcome.type`), and the object is STRICT.
+ *
+ * The `interrupt` outcome is REPRESENTABLE and VALIDATED here, and UNSPENT: no source on this plane
+ * constructs one, because a harness-native park is what would justify it and none of the three
+ * sources reports one. It is checked anyway because the arm exists, and an arm that builds an event
+ * the schema refuses is worse than an arm that does not exist. Its first draft took `unknown[]` and
+ * passed it through, so `[]` and `[{}]` both produced a refused event with nothing looking.
  */
 export function runFinished(o: {
   threadId: string;
   runId: string;
   timestamp: number;
-  outcome?: { type: "success" } | { type: "interrupt"; interrupts: unknown[] };
+  outcome?: { type: "success" } | { type: "interrupt"; interrupts: AguiInterrupt[] };
   cotal?: CotalMeta;
 }): WithCotal<RunFinishedEvent> {
+  if (o.outcome?.type === "interrupt") assertInterrupts(o.outcome.interrupts);
   return {
     type: AGUI_EVENT_TYPE.RUN_FINISHED,
     threadId: o.threadId,

--- a/extensions/connector-core/src/agui.ts
+++ b/extensions/connector-core/src/agui.ts
@@ -1,0 +1,765 @@
+/**
+ * The AG-UI event VOCABULARY and the Cotal frame envelope.
+ *
+ * This is the file that makes the change an abolition rather than a rename. Renaming `tr-<name>` to
+ * `events.<name>` while the connectors still publish `condense()` output would move glyph-prefixed
+ * text to a new channel and change nothing a consumer can do with it — the channel name was never
+ * the complaint.
+ *
+ * **The vocabulary is adopted; the SDK is not** (plan §2). `@ag-ui/core` is a `devDependency`,
+ * pinned EXACT at `0.0.57`, and this file imports from it with `import type` ONLY. The reason is
+ * measured rather than stylistic: `0.0.57` declares `dependencies: { zod: "^3.22.4" }` (verified
+ * against the registry, not remembered), and `connector-core` is esbuild-bundled into every seeded
+ * connector — so a runtime dependency would ship a second zod major to every customer in order to
+ * validate events we construct ourselves. The conformance smoke imports the real schemas and
+ * validates against them; production code carries types and string literals and no zod.
+ *
+ * **Promotion trigger, conditional and NOT scheduled:** if a 0.1.x ships stable with zod moved to
+ * `peerDependencies`, promote to a runtime dependency and use the schemas directly. As of this
+ * writing `latest` is `0.0.57`, the active `canary` still carries the zod-3 runtime dep, and the
+ * release that moves zod to a peer sits on no dist-tag at all.
+ *
+ * ## What is here, and what is deliberately NOT
+ *
+ * Here: the event constructors, the frame envelope, the routing/validity split
+ * ({@link isAguiFramePart} / {@link parseAguiFrame}), the {@link AguiBrackets} stream machine, and
+ * the `cotal.*` `CUSTOM` table, which is empty in v1.
+ *
+ * Not here, and NAMED rather than stubbed, because a stub is a claim that the shape is known: the
+ * channel derivation, the `max_payload` split, and the emitter that publishes. Each of those talks
+ * to something outside this module, and each lands with the surface that calls it.
+ *
+ * **Nothing constructs a frame outside a smoke.** No connector emits, and this module publishes
+ * nothing: every export below is a pure function of its arguments. That is a statement about the
+ * tree, not a disclaimer — a reader deciding whether a change here can reach a customer needs it to
+ * be accurate, so it is maintained rather than left to rot.
+ */
+
+import type {
+  CustomEvent,
+  ReasoningMessageContentEvent,
+  ReasoningMessageEndEvent,
+  ReasoningMessageStartEvent,
+  RunErrorEvent,
+  RunFinishedEvent,
+  RunStartedEvent,
+  TextMessageContentEvent,
+  TextMessageEndEvent,
+  TextMessageStartEvent,
+  ToolCallArgsEvent,
+  ToolCallEndEvent,
+  ToolCallResultEvent,
+  ToolCallStartEvent,
+} from "@ag-ui/core";
+
+// The frame's wire identity lives in `@cotal-ai/core`: an adopted vocabulary is a standard concept,
+// and core must be able to RENDER a frame without depending on an extension. Re-exported here so an
+// importer of this module gets the whole producer-side vocabulary as one surface. The constructors,
+// the envelope and all validation stay in this file — only the identity is in core. See
+// `packages/core/src/agui-kind.ts`.
+export { AGUI_FRAME_KIND, AGUI_EVENT_TYPE, isAguiFramePart } from "@cotal-ai/core";
+import { AGUI_FRAME_KIND, AGUI_EVENT_TYPE, isAguiFramePart } from "@cotal-ai/core";
+
+/**
+ * The AG-UI events this plane emits — the MAPPED SUBSET, not the whole protocol.
+ *
+ * Absent by decision, each recorded so its absence is not read as an oversight:
+ * `*_CHUNK` (plan §3: all three sources are settled observations, so we emit the START/CONTENT/END
+ * triple, which is the subset every consumer implements — raw CHUNK needs a client transformer);
+ * `STATE_*` and the interrupt outcome (§4 reserved them for cotal-lang `checkpoint`, and ask state
+ * left this plane entirely); `MESSAGES_SNAPSHOT` (§5.3 dropped it as a compaction anchor — a
+ * windowed snapshot DELETES the prefix); `THINKING_*` (deprecated at 0.0.57 in favour of
+ * `REASONING_*`, which is what we emit).
+ */
+export type AguiEvent =
+  | RunStartedEvent
+  | RunFinishedEvent
+  | RunErrorEvent
+  | TextMessageStartEvent
+  | TextMessageContentEvent
+  | TextMessageEndEvent
+  | ToolCallStartEvent
+  | ToolCallArgsEvent
+  | ToolCallEndEvent
+  | ToolCallResultEvent
+  | ReasoningMessageStartEvent
+  | ReasoningMessageContentEvent
+  | ReasoningMessageEndEvent
+  | CustomEvent;
+
+
+/**
+ * Cotal metadata rides ONE key on a standard event.
+ *
+ * Legal because every AG-UI event schema is `.passthrough()` — asserted by the conformance smoke
+ * against the real schemas rather than trusted, since this whole vehicle collapses if a future
+ * release tightens it.
+ *
+ * **It does NOT work everywhere.** `RunFinishedOutcomeSchema` is STRICT: it refuses unrecognized
+ * keys, measured. So `cotal` may ride an EVENT and never an `outcome`. Recorded here because
+ * "AG-UI is passthrough" is the kind of sentence that gets generalized one level too far.
+ */
+export interface CotalMeta {
+  /** Where the `timestamp` came from. Absent means the source carried a real one. */
+  tsSource?: "arrival";
+  /** Set when the connector minted the `runId` rather than reading one from the harness. */
+  runIdSource?: "connector";
+  /** The provider's own message id — preserved for correlation, never spent as `messageId`. */
+  providerMessageId?: string;
+  /** The harness's stop reason, on the event that carries one. */
+  stopReason?: string;
+  /** `tool_result.is_error` — AG-UI's result event has no error field of its own. */
+  isError?: boolean;
+  /** Subagent linkage. Deliberately NOT `parentRunId`, which is retry/edit lineage. */
+  delegation?: { agentId: string; toolCallId: string };
+  /**
+   * WHAT BEGAN THIS RUN. Attribution, and deliberately NOT a gate on run-opening.
+   *
+   * Run-opening ("did a turn begin?") and attribution ("who began it?") are two questions, and an
+   * earlier revision used one provenance predicate to answer both — so a turn started by a peer
+   * produced no run at all, and an agent-driven session mapped to nothing. Provenance ANNOTATES;
+   * it does not SELECT. A run with `"channel"` attribution is still a run.
+   *
+   * `"unknown"` is never written by the mapper: an unrecognised provenance FAILS LOUD instead, so a
+   * future harness value produces an error rather than a confident wrong attribution. It exists for
+   * consumers that must render something for a producer which did not set the field.
+   */
+  turnSource?: "human" | "channel" | "notification" | "sdk" | "unknown";
+  /** What was cut to fit the wire, and how big it was. Set only by the sizing path. */
+  truncated?: { field: string; originalBytes: number };
+}
+
+/** An event carrying Cotal metadata. Kept structural so it composes with any member of the union. */
+export type WithCotal<E> = E & { cotal?: CotalMeta };
+
+/**
+ * The `cotal.*` `CUSTOM` event table — the second and ONLY other vehicle for Cotal-specific data.
+ *
+ * **The v1 table is EMPTY, and that is the specification, not an unfinished state.** Earlier
+ * revisions described a two-member table holding `cotal.ask.opened` / `cotal.ask.settled`; §4
+ * removed both when ask state left this plane, on the operative ground that there is no consumer —
+ * the board answers what is owed, the plane carries what is happening. Leaving the count in the
+ * prose invited re-adding them "because the table has two slots", so the table ships with no slots.
+ *
+ * It exists as the GATE: adding a member is a decision that touches this declaration, rather than
+ * a `CUSTOM` name invented at a call site where nobody reviews the vocabulary.
+ */
+export const COTAL_CUSTOM_EVENTS: readonly string[] = [];
+
+/** The envelope version. One frame declares the AG-UI vocabulary version it was built against. */
+export const AGUI_PROTOCOL = "ag-ui/0.0.57";
+
+
+/**
+ * One Cotal message = one frame (plan §5.2).
+ *
+ * `threadId` is the native harness session and `runId` is ONE native harness turn — §4 is explicit
+ * that nothing else may claim these. `epoch` is the writer-identity fence recovered from the WAL
+ * (never re-minted on restart), and `seq` is this writer's frame counter, which is what lets a
+ * consumer detect a gap rather than merely fail to notice one.
+ *
+ * **A frame carries no text part, by design.** That is why the renderers are a binding precondition
+ * on the cutover rather than a follow-up.
+ *
+ * **RE-DERIVED, because core changed underneath this sentence.** It used to end "a viewer that does
+ * not understand this part shows nothing, and an empty pane is indistinguishable from a
+ * correctly-empty one." That is now true of some surfaces and false of others, and the split is
+ * exactly which ones adopted core's shared `partsToText`:
+ *
+ *   - **3 ADOPTED IT** — `connector-core/src/agent.ts`, `cli/src/commands/join.ts`,
+ *     `cli/src/view/mesh-view.ts`. These now render a marker naming the kind.
+ *   - **4 DID NOT** — `implementations/web/src/web/app.js`, `.../graph.js`,
+ *     `examples/02-self-improving-console/harness/observer.ts`,
+ *     `examples/04-frontier-faces/tools/studio.mjs`. The two stringify-form copies still leave a
+ *     stray separator; the two filter-form ones still leave no trace at all.
+ *
+ * Measured on a real frame from `aguiFrame` below, placed between two text parts: the adopted
+ * renderer produced `"before  after"` before the core change and names the kind after it. **The
+ * worse half of that defect was never the missing frame — it was that `"before  after"` is a
+ * well-formed sentence with a silent hole in it, so it prompts no question at all.**
+ *
+ * **THE PRECONDITION IS UNCHANGED AND THE MARKER IS NOT A LOOPHOLE IN IT.** A named marker proves a
+ * frame ARRIVED; it does not display one. Cutting a connector over on the strength of it would
+ * still ship events nothing can render.
+ */
+export interface AguiFrame {
+  kind: typeof AGUI_FRAME_KIND;
+  protocol: typeof AGUI_PROTOCOL;
+  threadId: string;
+  runId: string;
+  epoch: string;
+  seq: number;
+  events: AguiEvent[];
+}
+
+/** Raised when a frame or an event sequence violates a structural rule of the vocabulary. */
+export class AguiVocabularyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AguiVocabularyError";
+  }
+}
+
+/**
+ * The bracket machine's persisted form (WAL v2).
+ *
+ * It is a plain, JSON-round-trippable record on purpose: it is written into the write-ahead log, so
+ * it must survive `JSON.stringify`/`parse` unchanged and must be readable by a human staring at a
+ * WAL trying to work out why an emitter refused something.
+ */
+export interface BracketState {
+  /** The run currently open, or `undefined` when the stream is at a legal stopping point. */
+  run: string | undefined;
+  text: string[];
+  reasoning: string[];
+  tools: string[];
+}
+
+/**
+ * Bracketing, checked INCREMENTALLY over the event sequence — deliberately not over one frame.
+ *
+ * **A frame is not guaranteed to be self-bracketed, and a validator demanding that it be would
+ * forbid a split the plan mandates.** An oversized frame splits on event boundaries with each part
+ * carrying its own `seq` (§5.2), so a run can legally open in one frame and close in the next. The
+ * unit that must balance is the WRITER'S STREAM, not the message. Feeding this machine frame after
+ * frame is therefore the only way to check the property that is actually claimed.
+ *
+ * What it enforces:
+ * - one run open at a time; nothing may be emitted outside an open run
+ * - `TEXT_MESSAGE_*`, `REASONING_MESSAGE_*` and `TOOL_CALL_*` open and close by their own id, and an
+ *   id may not be opened twice while already open
+ * - a run may not close while any message or tool call it opened is still open
+ *
+ * The id-reuse rule is the one with a measured defect behind it: `message.id` is a PROVIDER REQUEST
+ * id, and over one real session 833 of 1243 assistant `message.id` values appeared in more than one
+ * JSONL entry. Keying identity on it would open and close the same `messageId` repeatedly, which
+ * the AG-UI verifier rejects and the reference reducer collapses. This machine refuses that rather
+ * than letting it reach a consumer.
+ */
+export class AguiBrackets {
+  private run: string | undefined;
+  private readonly text = new Set<string>();
+  private readonly reasoning = new Set<string>();
+  private readonly tools = new Set<string>();
+
+  /**
+   * The machine's whole state, as plain JSON — what the WAL persists so a restart does not lose it.
+   *
+   * Sorted, because this value is written to disk and compared BY A HUMAN reading two documents.
+   * A `Set`'s iteration order is insertion order, so two machines that are semantically identical
+   * would serialize differently depending on the order events happened to arrive, and a diff of two
+   * WALs would show a change where there is none.
+   */
+  snapshot(): BracketState {
+    return {
+      run: this.run,
+      text: [...this.text].sort(),
+      reasoning: [...this.reasoning].sort(),
+      tools: [...this.tools].sort(),
+    };
+  }
+
+  /** Rebuild a machine from a snapshot. The inverse of {@link snapshot}, and the reason a mid-run
+   *  restart can continue instead of refusing its first event. */
+  static restore(s: BracketState): AguiBrackets {
+    const b = new AguiBrackets();
+    b.run = s.run;
+    for (const id of s.text) b.text.add(id);
+    for (const id of s.reasoning) b.reasoning.add(id);
+    for (const id of s.tools) b.tools.add(id);
+    return b;
+  }
+
+  /** An independent machine at the same state — used to VALIDATE a batch without advancing the
+   *  machine that is in step with the disk. */
+  clone(): AguiBrackets {
+    return AguiBrackets.restore(this.snapshot());
+  }
+
+  /** True while a run is open — i.e. the stream is mid-turn and not at a legal stopping point. */
+  get open(): boolean {
+    return this.run !== undefined;
+  }
+
+  /** The run currently open, for diagnostics and for checking a frame's envelope against it. */
+  get runId(): string | undefined {
+    return this.run;
+  }
+
+  /** Feed one event. Throws {@link AguiVocabularyError} on the first violation. */
+  accept(event: AguiEvent): void {
+    const e = event as { type: string; [k: string]: unknown };
+    const t = e.type;
+
+    if (t === AGUI_EVENT_TYPE.RUN_STARTED) {
+      if (this.run !== undefined)
+        throw new AguiVocabularyError(
+          `RUN_STARTED for "${String(e.runId)}" while run "${this.run}" is still open`,
+        );
+      this.run = String(e.runId);
+      return;
+    }
+
+    if (this.run === undefined)
+      throw new AguiVocabularyError(`${t} emitted outside an open run`);
+
+    if (t === AGUI_EVENT_TYPE.RUN_FINISHED || t === AGUI_EVENT_TYPE.RUN_ERROR) {
+      // RUN_ERROR carries no runId of its own (its schema has `message` and `code`), so only
+      // RUN_FINISHED can be checked against the open run. Checking what exists rather than
+      // pretending to check both.
+      if (t === AGUI_EVENT_TYPE.RUN_FINISHED && String(e.runId) !== this.run)
+        throw new AguiVocabularyError(
+          `RUN_FINISHED for "${String(e.runId)}" but the open run is "${this.run}"`,
+        );
+      const dangling = [...this.text, ...this.reasoning, ...this.tools];
+      if (dangling.length > 0)
+        throw new AguiVocabularyError(
+          `${t} while still open: ${dangling.join(", ")}`,
+        );
+      this.run = undefined;
+      return;
+    }
+
+    switch (t) {
+      case AGUI_EVENT_TYPE.TEXT_MESSAGE_START:
+        return this.openId(this.text, String(e.messageId), t);
+      case AGUI_EVENT_TYPE.TEXT_MESSAGE_CONTENT:
+        return this.requireOpen(this.text, String(e.messageId), t);
+      case AGUI_EVENT_TYPE.TEXT_MESSAGE_END:
+        return this.closeId(this.text, String(e.messageId), t);
+
+      case AGUI_EVENT_TYPE.REASONING_MESSAGE_START:
+        return this.openId(this.reasoning, String(e.messageId), t);
+      case AGUI_EVENT_TYPE.REASONING_MESSAGE_CONTENT:
+        return this.requireOpen(this.reasoning, String(e.messageId), t);
+      case AGUI_EVENT_TYPE.REASONING_MESSAGE_END:
+        return this.closeId(this.reasoning, String(e.messageId), t);
+
+      case AGUI_EVENT_TYPE.TOOL_CALL_START:
+        return this.openId(this.tools, String(e.toolCallId), t);
+      case AGUI_EVENT_TYPE.TOOL_CALL_ARGS:
+        return this.requireOpen(this.tools, String(e.toolCallId), t);
+      case AGUI_EVENT_TYPE.TOOL_CALL_END:
+        return this.closeId(this.tools, String(e.toolCallId), t);
+
+      case AGUI_EVENT_TYPE.TOOL_CALL_RESULT:
+        // A result arrives AFTER its call closed — the harness reports it as a separate
+        // observation — so this asserts the call is NOT open rather than that it is.
+        if (this.tools.has(String(e.toolCallId)))
+          throw new AguiVocabularyError(
+            `TOOL_CALL_RESULT for "${String(e.toolCallId)}" while its call is still open`,
+          );
+        return;
+
+      case AGUI_EVENT_TYPE.CUSTOM:
+        if (!COTAL_CUSTOM_EVENTS.includes(String(e.name)))
+          throw new AguiVocabularyError(
+            `CUSTOM "${String(e.name)}" is not declared in COTAL_CUSTOM_EVENTS (the v1 table is empty by specification)`,
+          );
+        return;
+
+      default:
+        throw new AguiVocabularyError(`${t} is not in the mapped subset this plane emits`);
+    }
+  }
+
+  /**
+   * Assert the stream is at a legal stopping point.
+   *
+   * Called at the end of a synthesized sequence and by any consumer checking a writer closed
+   * cleanly. NOT called per frame: mid-turn frames are legally unbalanced.
+   */
+  assertClosed(): void {
+    if (this.run !== undefined)
+      throw new AguiVocabularyError(`run "${this.run}" was never closed`);
+  }
+
+  private openId(set: Set<string>, id: string, t: string): void {
+    if (set.has(id)) throw new AguiVocabularyError(`${t} re-opened "${id}" while already open`);
+    set.add(id);
+  }
+
+  private requireOpen(set: Set<string>, id: string, t: string): void {
+    if (!set.has(id)) throw new AguiVocabularyError(`${t} for "${id}" which is not open`);
+  }
+
+  private closeId(set: Set<string>, id: string, t: string): void {
+    if (!set.delete(id)) throw new AguiVocabularyError(`${t} for "${id}" which is not open`);
+  }
+}
+
+/**
+ * Build a frame, validating the envelope's own fields.
+ *
+ * Bracketing is NOT checked here — see {@link AguiBrackets} for why a single frame cannot be
+ * required to balance. The emitter holds one `AguiBrackets` across the whole stream and feeds it as
+ * it builds; that is the placement that checks the property actually claimed.
+ */
+export function aguiFrame(opts: {
+  threadId: string;
+  runId: string;
+  epoch: string;
+  seq: number;
+  events: AguiEvent[];
+}): AguiFrame {
+  for (const [field, value] of [
+    ["threadId", opts.threadId],
+    ["runId", opts.runId],
+    ["epoch", opts.epoch],
+  ] as const)
+    if (typeof value !== "string" || value.length === 0)
+      throw new AguiVocabularyError(`frame ${field} must be a non-empty string`);
+
+  if (!Number.isSafeInteger(opts.seq) || opts.seq < 0)
+    throw new AguiVocabularyError(
+      `frame seq must be a non-negative safe integer, got ${JSON.stringify(opts.seq)}`,
+    );
+
+  // An empty frame is refused rather than published as a no-op: a consumer counting `seq` would
+  // see a gap-free stream carrying nothing, which is the silent-loss shape this plane exists to
+  // make impossible.
+  if (!Array.isArray(opts.events) || opts.events.length === 0)
+    throw new AguiVocabularyError("a frame must carry at least one event");
+
+  return {
+    kind: AGUI_FRAME_KIND,
+    protocol: AGUI_PROTOCOL,
+    threadId: opts.threadId,
+    runId: opts.runId,
+    epoch: opts.epoch,
+    seq: opts.seq,
+    events: opts.events,
+  };
+}
+
+/**
+ * **THE CONSUMER-SIDE ENFORCEMENT POINT.** `aguiFrame` above validates on the way OUT; this pair
+ * validates on the way IN, and they are separate functions because they are separate trust domains.
+ *
+ * It exists because the renderers cannot enforce a contract expressed as TypeScript types.
+ * `implementations/web/tsconfig.json` carries `"include": ["src"]` with `"exclude": ["src/web"]`,
+ * and the build copies `src/web` into `dist` verbatim — so the renderer is plain JavaScript that
+ * `tsc` never reads. A prose contract with no enforcement point is the defect, so the contract ships
+ * as **a function a consumer executes**, not as a shape a consumer is trusted to have read.
+ *
+ * **THE TWO ANSWERS ARE DIFFERENT AND MUST NOT BE FUSED.** "This part is not mine" is a routing
+ * decision a consumer makes constantly and quietly — every non-frame part on a channel it also
+ * reads. "This part claims to be mine and is malformed" is a defect that must be LOUD. One function
+ * returning `null` for both would make a version skew look exactly like someone else's message, and
+ * a renderer would show an empty pane for a stream it is actively failing to parse. So:
+ * {@link isAguiFramePart} answers the routing question with a boolean and never throws, and
+ * {@link parseAguiFrame} answers the validity question and throws with the field named.
+ */
+
+/**
+ * Validate an incoming frame, or throw {@link AguiVocabularyError} naming the field that failed.
+ *
+ * Call it only on a part {@link isAguiFramePart} accepted. Everything after that check is a defect
+ * rather than a routing outcome, including an unknown `protocol` — **a version skew must fail loud
+ * rather than render partially**, because a consumer that drops the fields it does not recognise
+ * shows a confidently incomplete transcript, which is worse than showing nothing.
+ *
+ * It deliberately does NOT check bracketing. A frame is not guaranteed to be self-bracketed — an
+ * oversized frame splits on event boundaries — so the unit that must balance is the writer's stream,
+ * and {@link AguiBrackets} is the machine for that, fed frame after frame. A validator demanding a
+ * frame balance on its own would forbid a split the plan mandates.
+ */
+export function parseAguiFrame(part: unknown): AguiFrame {
+  if (!isAguiFramePart(part))
+    throw new AguiVocabularyError(
+      `not an AG-UI frame: expected kind ${JSON.stringify(AGUI_FRAME_KIND)}, got ` +
+        `${JSON.stringify((part as { kind?: unknown } | null)?.kind ?? null)}. Route with ` +
+        `isAguiFramePart before calling this.`,
+    );
+  const f = part as Record<string, unknown>;
+
+  if (f.protocol !== AGUI_PROTOCOL)
+    throw new AguiVocabularyError(
+      `AG-UI protocol mismatch: this consumer understands ${JSON.stringify(AGUI_PROTOCOL)}, the ` +
+        `frame declares ${JSON.stringify(f.protocol ?? null)}. Refusing rather than rendering the ` +
+        `fields that happen to still parse.`,
+    );
+
+  for (const field of ["threadId", "runId", "epoch"] as const)
+    if (typeof f[field] !== "string" || (f[field] as string).length === 0)
+      throw new AguiVocabularyError(`frame ${field} must be a non-empty string`);
+
+  if (!Number.isSafeInteger(f.seq) || (f.seq as number) < 0)
+    throw new AguiVocabularyError(
+      `frame seq must be a non-negative safe integer, got ${JSON.stringify(f.seq ?? null)}`,
+    );
+
+  if (!Array.isArray(f.events) || f.events.length === 0)
+    throw new AguiVocabularyError("a frame must carry at least one event");
+
+  const known = new Set<string>(Object.values(AGUI_EVENT_TYPE));
+  f.events.forEach((e, i) => {
+    if (typeof e !== "object" || e === null)
+      throw new AguiVocabularyError(`frame events[${i}] is not an object`);
+    const t = (e as { type?: unknown }).type;
+    if (typeof t !== "string" || !known.has(t))
+      throw new AguiVocabularyError(
+        `frame events[${i}] carries an unrecognised type ${JSON.stringify(t ?? null)}. A renderer ` +
+          `must refuse an event it cannot display rather than skip it: a skipped event is a hole ` +
+          `in a transcript that still looks complete.`,
+      );
+  });
+
+  return part as AguiFrame;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Constructors.
+//
+// One per mapped event. They exist so a connector never hand-builds an object literal with a
+// `type` string in it — the drift that produces is invisible until a consumer rejects a frame,
+// which on this plane means after it is durably published.
+//
+// `timestamp` is deliberately a REQUIRED parameter on every constructor rather than defaulted to
+// `Date.now()`. The plan's rule is that a timestamp is real or honestly labelled, and a default
+// would silently manufacture an arrival time that looks like a source time. A caller with no
+// source timestamp passes the arrival time AND sets `cotal.tsSource: "arrival"`.
+// ---------------------------------------------------------------------------------------------
+
+/** `RUN_STARTED` — `threadId` is the native session, `runId` one native harness turn. */
+export function runStarted(o: {
+  threadId: string;
+  runId: string;
+  timestamp: number;
+  cotal?: CotalMeta;
+}): WithCotal<RunStartedEvent> {
+  return {
+    type: AGUI_EVENT_TYPE.RUN_STARTED,
+    threadId: o.threadId,
+    runId: o.runId,
+    timestamp: o.timestamp,
+    ...(o.cotal ? { cotal: o.cotal } : {}),
+  } as WithCotal<RunStartedEvent>;
+}
+
+/**
+ * `RUN_FINISHED`.
+ *
+ * `outcome` is OPTIONAL — measured against the real schema, which accepts a `RUN_FINISHED` carrying
+ * none. That matters because the Claude `Stop` hook reports that a turn ended and nothing more, so
+ * manufacturing a `success` outcome would be asserting something the source never said. When an
+ * outcome IS supplied its discriminator key is `type`, not `status` (measured: the schema refuses
+ * `{status:"success"}` naming `outcome.type`), and the object is STRICT.
+ */
+export function runFinished(o: {
+  threadId: string;
+  runId: string;
+  timestamp: number;
+  outcome?: { type: "success" } | { type: "interrupt"; interrupts: unknown[] };
+  cotal?: CotalMeta;
+}): WithCotal<RunFinishedEvent> {
+  return {
+    type: AGUI_EVENT_TYPE.RUN_FINISHED,
+    threadId: o.threadId,
+    runId: o.runId,
+    timestamp: o.timestamp,
+    ...(o.outcome ? { outcome: o.outcome } : {}),
+    ...(o.cotal ? { cotal: o.cotal } : {}),
+  } as WithCotal<RunFinishedEvent>;
+}
+
+/** `RUN_ERROR` — carries `message` and an optional `code`, and NO `runId` of its own. */
+export function runError(o: {
+  message: string;
+  timestamp: number;
+  code?: string;
+  cotal?: CotalMeta;
+}): WithCotal<RunErrorEvent> {
+  return {
+    type: AGUI_EVENT_TYPE.RUN_ERROR,
+    message: o.message,
+    timestamp: o.timestamp,
+    ...(o.code ? { code: o.code } : {}),
+    ...(o.cotal ? { cotal: o.cotal } : {}),
+  } as WithCotal<RunErrorEvent>;
+}
+
+/**
+ * `TEXT_MESSAGE_START`.
+ *
+ * `messageId` must be unique per OBSERVATION, not per provider message. The specified form is
+ * `${entry.uuid}#${blockIndex}` — the provider's own id is preserved as `cotal.providerMessageId`
+ * and never spent here, because it does not have the cardinality the field needs.
+ */
+export function textMessageStart(o: {
+  messageId: string;
+  timestamp: number;
+  role?: "assistant" | "user";
+  cotal?: CotalMeta;
+}): WithCotal<TextMessageStartEvent> {
+  return {
+    type: AGUI_EVENT_TYPE.TEXT_MESSAGE_START,
+    messageId: o.messageId,
+    timestamp: o.timestamp,
+    ...(o.role ? { role: o.role } : {}),
+    ...(o.cotal ? { cotal: o.cotal } : {}),
+  } as WithCotal<TextMessageStartEvent>;
+}
+
+/** `TEXT_MESSAGE_CONTENT` — one settled observation, never a token-level delta. */
+export function textMessageContent(o: {
+  messageId: string;
+  delta: string;
+  timestamp: number;
+  cotal?: CotalMeta;
+}): WithCotal<TextMessageContentEvent> {
+  return {
+    type: AGUI_EVENT_TYPE.TEXT_MESSAGE_CONTENT,
+    messageId: o.messageId,
+    delta: o.delta,
+    timestamp: o.timestamp,
+    ...(o.cotal ? { cotal: o.cotal } : {}),
+  } as WithCotal<TextMessageContentEvent>;
+}
+
+/** `TEXT_MESSAGE_END`. */
+export function textMessageEnd(o: {
+  messageId: string;
+  timestamp: number;
+  cotal?: CotalMeta;
+}): WithCotal<TextMessageEndEvent> {
+  return {
+    type: AGUI_EVENT_TYPE.TEXT_MESSAGE_END,
+    messageId: o.messageId,
+    timestamp: o.timestamp,
+    ...(o.cotal ? { cotal: o.cotal } : {}),
+  } as WithCotal<TextMessageEndEvent>;
+}
+
+/** `TOOL_CALL_START` — `toolCallId` is the harness's own id, carried rather than re-minted. */
+export function toolCallStart(o: {
+  toolCallId: string;
+  toolCallName: string;
+  timestamp: number;
+  parentMessageId?: string;
+  cotal?: CotalMeta;
+}): WithCotal<ToolCallStartEvent> {
+  return {
+    type: AGUI_EVENT_TYPE.TOOL_CALL_START,
+    toolCallId: o.toolCallId,
+    toolCallName: o.toolCallName,
+    timestamp: o.timestamp,
+    ...(o.parentMessageId ? { parentMessageId: o.parentMessageId } : {}),
+    ...(o.cotal ? { cotal: o.cotal } : {}),
+  } as WithCotal<ToolCallStartEvent>;
+}
+
+/**
+ * `TOOL_CALL_ARGS` — `delta` is the FULL `JSON.stringify(input)`.
+ *
+ * This is where `tr-`'s `salient()` died: it guessed which argument mattered and dropped the rest,
+ * so a reader could not reconstruct what the agent actually did. The whole input goes on the wire,
+ * and if it physically cannot fit, the sizing path truncates it with a label rather than silently.
+ */
+export function toolCallArgs(o: {
+  toolCallId: string;
+  delta: string;
+  timestamp: number;
+  cotal?: CotalMeta;
+}): WithCotal<ToolCallArgsEvent> {
+  return {
+    type: AGUI_EVENT_TYPE.TOOL_CALL_ARGS,
+    toolCallId: o.toolCallId,
+    delta: o.delta,
+    timestamp: o.timestamp,
+    ...(o.cotal ? { cotal: o.cotal } : {}),
+  } as WithCotal<ToolCallArgsEvent>;
+}
+
+/** `TOOL_CALL_END`. */
+export function toolCallEnd(o: {
+  toolCallId: string;
+  timestamp: number;
+  cotal?: CotalMeta;
+}): WithCotal<ToolCallEndEvent> {
+  return {
+    type: AGUI_EVENT_TYPE.TOOL_CALL_END,
+    toolCallId: o.toolCallId,
+    timestamp: o.timestamp,
+    ...(o.cotal ? { cotal: o.cotal } : {}),
+  } as WithCotal<ToolCallEndEvent>;
+}
+
+/**
+ * `TOOL_CALL_RESULT`.
+ *
+ * **`messageId` is REQUIRED by the real schema** — measured; a result without one is refused. The
+ * plan's per-connector mapping table names only `toolCallId` for this row, so the identity of the
+ * result MESSAGE is unstated there and is raised as a plan gap rather than guessed at a call site.
+ * The parameter is required here so a mapper cannot omit it and discover the refusal downstream.
+ *
+ * `is_error` has no AG-UI field and rides `cotal.isError`.
+ */
+export function toolCallResult(o: {
+  messageId: string;
+  toolCallId: string;
+  content: string;
+  timestamp: number;
+  cotal?: CotalMeta;
+}): WithCotal<ToolCallResultEvent> {
+  return {
+    type: AGUI_EVENT_TYPE.TOOL_CALL_RESULT,
+    messageId: o.messageId,
+    toolCallId: o.toolCallId,
+    content: o.content,
+    timestamp: o.timestamp,
+    ...(o.cotal ? { cotal: o.cotal } : {}),
+  } as WithCotal<ToolCallResultEvent>;
+}
+
+/**
+ * `REASONING_MESSAGE_START` — off by default; the signature is never emitted, ever.
+ *
+ * **`role` is a REQUIRED literal `"reasoning"`**, unlike `TEXT_MESSAGE_START` where `role` is
+ * optional. Measured: the first version of this constructor omitted it and the real schema refused
+ * the event. It is set here rather than exposed as a parameter, because there is exactly one legal
+ * value and a caller-supplied one could only ever be wrong.
+ */
+export function reasoningMessageStart(o: {
+  messageId: string;
+  timestamp: number;
+  cotal?: CotalMeta;
+}): WithCotal<ReasoningMessageStartEvent> {
+  return {
+    type: AGUI_EVENT_TYPE.REASONING_MESSAGE_START,
+    messageId: o.messageId,
+    role: "reasoning",
+    timestamp: o.timestamp,
+    ...(o.cotal ? { cotal: o.cotal } : {}),
+  } as WithCotal<ReasoningMessageStartEvent>;
+}
+
+/** `REASONING_MESSAGE_CONTENT`. */
+export function reasoningMessageContent(o: {
+  messageId: string;
+  delta: string;
+  timestamp: number;
+  cotal?: CotalMeta;
+}): WithCotal<ReasoningMessageContentEvent> {
+  return {
+    type: AGUI_EVENT_TYPE.REASONING_MESSAGE_CONTENT,
+    messageId: o.messageId,
+    delta: o.delta,
+    timestamp: o.timestamp,
+    ...(o.cotal ? { cotal: o.cotal } : {}),
+  } as WithCotal<ReasoningMessageContentEvent>;
+}
+
+/** `REASONING_MESSAGE_END`. */
+export function reasoningMessageEnd(o: {
+  messageId: string;
+  timestamp: number;
+  cotal?: CotalMeta;
+}): WithCotal<ReasoningMessageEndEvent> {
+  return {
+    type: AGUI_EVENT_TYPE.REASONING_MESSAGE_END,
+    messageId: o.messageId,
+    timestamp: o.timestamp,
+    ...(o.cotal ? { cotal: o.cotal } : {}),
+  } as WithCotal<ReasoningMessageEndEvent>;
+}

--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
     "smoke:actor-ephemeral": "tsx packages/core/smoke/actor-ephemeral.smoke.ts",
     "smoke:principal-channel-witness": "tsx packages/core/smoke/principal-channel-witness.smoke.ts",
     "smoke:part-renderer": "tsx packages/core/smoke/part-renderer.smoke.ts",
+    "smoke:agui-conformance": "tsx extensions/connector-core/smoke/agui-conformance.smoke.ts",
     "smoke:ep-work": "tsx packages/core/smoke/endpoint-work.smoke.ts",
     "smoke:ep-virtual": "tsx packages/core/smoke/endpoint-virtual.smoke.ts",
     "smoke:ep-action": "tsx packages/core/smoke/endpoint-action.smoke.ts",

--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
     "smoke:actor-ephemeral": "tsx packages/core/smoke/actor-ephemeral.smoke.ts",
     "smoke:principal-channel-witness": "tsx packages/core/smoke/principal-channel-witness.smoke.ts",
     "smoke:part-renderer": "tsx packages/core/smoke/part-renderer.smoke.ts",
+    "smoke:agui-kind": "tsx packages/core/smoke/agui-kind.smoke.ts",
     "smoke:agui-conformance": "tsx extensions/connector-core/smoke/agui-conformance.smoke.ts",
     "smoke:ep-work": "tsx packages/core/smoke/endpoint-work.smoke.ts",
     "smoke:ep-virtual": "tsx packages/core/smoke/endpoint-virtual.smoke.ts",

--- a/packages/core/smoke/agui-kind.smoke.ts
+++ b/packages/core/smoke/agui-kind.smoke.ts
@@ -1,0 +1,109 @@
+/**
+ * The frame's wire identity, graded from CORE'S OWN SOURCE.
+ *
+ * WHY THIS SUITE EXISTS AND IS NOT A DUPLICATE OF THE CONFORMANCE SUITE. `agui-kind.ts` lives here,
+ * but its only executing cells lived in `extensions/connector-core`, and that suite reaches these
+ * symbols by importing `@cotal-ai/core`, which resolves to `packages/core/dist`. Measured, not
+ * argued: renaming an event literal in `packages/core/src/agui-kind.ts` and running the conformance
+ * suite WITHOUT rebuilding leaves it fully green, and the same edit with a rebuild reddens three
+ * cells. So a source-only change to this file had no gate at all, and CI hid it by building first.
+ *
+ * **A suite that audits the last build is not auditing the change in front of you.** This one
+ * imports `../src/agui-kind.js`, so a mutation here is a mutation to the code these cells run.
+ *
+ * WHAT IT DELIBERATELY DOES NOT DO: compare the literals to `@ag-ui/core`'s real enum. That package
+ * carries a zod runtime dependency and is not resolvable from `packages/core` at all, by design, so
+ * that no zod copy reaches a bundled connector. That comparison stays in the conformance suite where
+ * the package IS available. The two suites cover different halves and neither substitutes for the
+ * other: this one pins the values and the shape from source, that one pins them against the protocol.
+ *
+ * Run: pnpm smoke:agui-kind
+ */
+import { AGUI_EVENT_TYPE, AGUI_FRAME_KIND, isAguiFramePart } from "../src/agui-kind.js";
+
+let ok = 0, fail = 0;
+const c = (n: string, v: boolean, extra?: unknown) => {
+  if (v) ok++; else { fail++; console.log("  x FAIL:", n, extra ?? ""); }
+};
+
+// ── The wire kind, spelled out ────────────────────────────────────────────────────────────────
+// A literal on one side. Comparing the constant with itself is what let a rename ship green.
+c("the frame kind is the literal `ag-ui.frame`", AGUI_FRAME_KIND === "ag-ui.frame", AGUI_FRAME_KIND);
+
+// ── The event table, spelled out ──────────────────────────────────────────────────────────────
+// Every discriminator written here rather than derived from the object under test. Deriving the
+// expected value from the actual one is the same vacuous shape one level down: `Object.keys(X)`
+// compared against `X` agrees with any table at all.
+const EXPECTED: Record<string, string> = {
+  RUN_STARTED: "RUN_STARTED",
+  RUN_FINISHED: "RUN_FINISHED",
+  RUN_ERROR: "RUN_ERROR",
+  TEXT_MESSAGE_START: "TEXT_MESSAGE_START",
+  TEXT_MESSAGE_CONTENT: "TEXT_MESSAGE_CONTENT",
+  TEXT_MESSAGE_END: "TEXT_MESSAGE_END",
+  TOOL_CALL_START: "TOOL_CALL_START",
+  TOOL_CALL_ARGS: "TOOL_CALL_ARGS",
+  TOOL_CALL_END: "TOOL_CALL_END",
+  TOOL_CALL_RESULT: "TOOL_CALL_RESULT",
+  REASONING_MESSAGE_START: "REASONING_MESSAGE_START",
+  REASONING_MESSAGE_CONTENT: "REASONING_MESSAGE_CONTENT",
+  REASONING_MESSAGE_END: "REASONING_MESSAGE_END",
+  CUSTOM: "CUSTOM",
+};
+
+const actual = AGUI_EVENT_TYPE as unknown as Record<string, string>;
+let drift = "";
+for (const [k, v] of Object.entries(EXPECTED)) if (actual[k] !== v) drift += `${k}: got ${String(actual[k])}; `;
+c("every discriminator matches its spelled-out literal", drift === "", drift);
+
+// Both directions. Checking only that each expected key is present would pass against a table that
+// had grown a member nobody mapped, and an unmapped member is a frame a consumer must refuse.
+const extra = Object.keys(actual).filter((k) => !(k in EXPECTED));
+c("and the table carries no member this suite does not name", extra.length === 0, extra);
+c("the table has exactly 14 members", Object.keys(actual).length === 14, Object.keys(actual).length);
+
+// ── Frozen, so a consumer cannot mutate the vocabulary in place ───────────────────────────────
+c("the table is frozen", Object.isFrozen(AGUI_EVENT_TYPE));
+{
+  // Assignment on a frozen object is a silent no-op outside strict mode; ESM is always strict, so
+  // this throws. Asserting the THROW rather than re-reading the value proves the freeze rather than
+  // proving that the value happens to be unchanged.
+  let threw = false;
+  try { (actual as Record<string, string>).RUN_STARTED = "HIJACKED"; } catch { threw = true; }
+  c("writing through it is refused, not silently dropped", threw && actual.RUN_STARTED === "RUN_STARTED");
+}
+
+// ── The routing predicate NEVER throws, on anything ────────────────────────────────────────────
+// Executed on the degenerate inputs rather than reasoned about. This is the function a renderer
+// calls on every part of every message, so a throw here takes a surface down on someone else's mail.
+const HOSTILE: [string, unknown][] = [
+  ["null", null],
+  ["undefined", undefined],
+  ["a number", 7],
+  ["a string", "ag-ui.frame"],
+  ["a bare symbol", Symbol("x")],
+  ["an array", []],
+  ["a function", () => {}],
+  ["an object with no prototype", Object.create(null)],
+  ["an object whose `kind` getter throws", { get kind() { throw new Error("boom"); } }],
+  ["a Proxy that throws on every get", new Proxy({}, { get() { throw new Error("boom"); } })],
+];
+for (const [label, value] of HOSTILE) {
+  let threw = false;
+  let result: unknown;
+  try { result = isAguiFramePart(value); } catch { threw = true; }
+  // A throwing getter is the one case where "never throws" cannot be met by reading `.kind`, so it
+  // is named rather than folded in: if this cell ever fails, the predicate needs a guarded read, not
+  // a caller who remembers to try/catch.
+  c(`isAguiFramePart does not throw on ${label}`, !threw, threw ? "threw" : result);
+  if (!threw) c(`  and returns a boolean for ${label}`, typeof result === "boolean", result);
+}
+
+// ── And it still discriminates, so the cells above cannot pass against a constant `false` ─────
+c("CONTROL: a real frame part IS routed", isAguiFramePart({ kind: "ag-ui.frame", events: [] }) === true);
+c("CONTROL: a text part is NOT", isAguiFramePart({ kind: "text", text: "hi" }) === false);
+c("CONTROL: a part whose kind merely CONTAINS the token is NOT",
+  isAguiFramePart({ kind: "ag-ui.frame.v2" }) === false);
+
+console.log(`agui-kind smoke: ${ok} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/packages/core/smoke/fixtures/agui-kind.mutations.json
+++ b/packages/core/smoke/fixtures/agui-kind.mutations.json
@@ -1,0 +1,40 @@
+{
+  "command": "pnpm smoke:agui-kind",
+  "mutations": [
+    {
+      "name": "K1 the wire kind is renamed. NOTE THE COMMAND HAS NO BUILD STEP: this only kills if the suite reads packages/core/src, which is the gap it was written to close",
+      "file": "packages/core/src/agui-kind.ts",
+      "find": "export const AGUI_FRAME_KIND = \"ag-ui.frame\";",
+      "replace": "export const AGUI_FRAME_KIND = \"ag-ui.renamed\";",
+      "expectRed": "the frame kind is the literal `ag-ui.frame`"
+    },
+    {
+      "name": "K2 one event discriminator drifts from its literal, again with no rebuild",
+      "file": "packages/core/src/agui-kind.ts",
+      "find": "  RUN_STARTED: \"RUN_STARTED\",",
+      "replace": "  RUN_STARTED: \"RUN_STARTED_X\",",
+      "expectRed": "every discriminator matches its spelled-out literal"
+    },
+    {
+      "name": "K3 the table is no longer frozen, so a consumer can rewrite the vocabulary in place",
+      "file": "packages/core/src/agui-kind.ts",
+      "find": "export const AGUI_EVENT_TYPE = Object.freeze({",
+      "replace": "export const AGUI_EVENT_TYPE = ({",
+      "expectRed": "the table is frozen"
+    },
+    {
+      "name": "K4 the guarded property read is removed, so the routing predicate throws on an object whose kind getter throws",
+      "file": "packages/core/src/agui-kind.ts",
+      "find": "  try {\n    return (part as { kind?: unknown }).kind === AGUI_FRAME_KIND;\n  } catch {\n    return false;\n  }",
+      "replace": "  return (part as { kind?: unknown }).kind === AGUI_FRAME_KIND;",
+      "expectRed": "isAguiFramePart does not throw on an object whose `kind` getter throws"
+    },
+    {
+      "name": "K5 the predicate answers true for everything, so the never-throws cells alone would still pass",
+      "file": "packages/core/src/agui-kind.ts",
+      "find": "  if (typeof part !== \"object\" || part === null) return false;",
+      "replace": "  if (typeof part !== \"object\" || part === null) return false;\n  return true;",
+      "expectRed": "CONTROL: a text part is NOT"
+    }
+  ]
+}

--- a/packages/core/src/agui-kind.ts
+++ b/packages/core/src/agui-kind.ts
@@ -71,5 +71,25 @@ export const AGUI_EVENT_TYPE = Object.freeze({
  * is actively failing to parse.
  */
 export function isAguiFramePart(part: unknown): boolean {
-  return typeof part === "object" && part !== null && (part as { kind?: unknown }).kind === AGUI_FRAME_KIND;
+  if (typeof part !== "object" || part === null) return false;
+  // READING A PROPERTY CAN THROW, AND "NEVER THROWS" HAS TO SURVIVE THAT TO BE A PROMISE. A getter
+  // or a Proxy trap runs arbitrary code on a plain `.kind`, and this predicate is called on every
+  // part of every message a surface renders, so one hostile object would take the surface down over
+  // somebody else's mail.
+  //
+  // STATED HONESTLY: no wire input can be such an object. Parts arrive through `JSON.parse`, which
+  // produces plain data with no accessors, so this is not a live attack being defended. It is a
+  // signature taking `unknown` being made to mean it, because a function that accepts `unknown` and
+  // throws on some of it is a trap for the next caller, and the contract this file implements says
+  // "never throws" in those words.
+  //
+  // Returning `false` here is not a silent degrade, which is the thing this project refuses: `false`
+  // is the correct routing answer for an object whose kind cannot be read, and the loud half of the
+  // pair is `parseAguiFrame`, which refuses by name. Routing quietly and validating loudly is the
+  // whole reason these are two functions.
+  try {
+    return (part as { kind?: unknown }).kind === AGUI_FRAME_KIND;
+  } catch {
+    return false;
+  }
 }

--- a/packages/core/src/agui-kind.ts
+++ b/packages/core/src/agui-kind.ts
@@ -1,0 +1,75 @@
+/**
+ * The AG-UI frame's identity on the wire: the part kind, the event `type` discriminators, and the
+ * routing predicate.
+ *
+ * WHY THIS IS IN CORE AND NOT IN A CONNECTOR, because the file it was cut out of is an extension.
+ * Cotal ADOPTED the AG-UI event vocabulary as the way it streams agent events; the transport stays
+ * Cotal. A vocabulary the standard adopts is a standard concept. The test is not where the code
+ * happened to be written — it is **whether one adapter's choices could change it while the others
+ * are unaffected**, and `ag-ui.frame` fails that test in the direction that matters: every connector
+ * emits it, it travels on the wire, and no adapter may redefine it unilaterally. A shape all
+ * adapters must agree on is a protocol shape.
+ *
+ * Its previous home in `@cotal-ai/connector-core` was an artifact of where the EMITTER was built,
+ * not a judgement that the kind belongs to an adapter. The emitter, the constructors, the zod
+ * validation and the frame envelope all stay there. **Only the identity moves** — the part of the
+ * vocabulary a READER needs in order to recognise and draw a frame without knowing who produced it.
+ *
+ * WHAT IS DELIBERATELY NOT HERE. `AGUI_PROTOCOL` (the envelope version) and every event
+ * CONSTRUCTOR remain in `connector-core`. They are producer-side, and nothing in core needs them to
+ * recognise or render a frame. The line is drawn at what a consumer requires; moving more would
+ * widen core for no reader's benefit.
+ *
+ * THE ZOD BOUNDARY IS THE REASON THIS FILE IS PLAIN LITERALS. `@ag-ui/core` is a types-only,
+ * exact-pinned `devDependency` of `connector-core` specifically so that no zod copy reaches a
+ * bundled connector — and it is **not resolvable from `packages/core` at all** (verified:
+ * `MODULE_NOT_FOUND` from here, resolvable from `connector-core`). So core structurally cannot
+ * depend on the AG-UI package, and pnpm's isolation makes that a build failure rather than a silent
+ * regression. Nothing below imports it, and nothing below may.
+ */
+
+/** The frame's `kind`, distinguishing it from every other part a Cotal message can carry. */
+export const AGUI_FRAME_KIND = "ag-ui.frame";
+
+/**
+ * The `type` discriminators, as literals.
+ *
+ * `EventType` in `@ag-ui/core` is a real (non-const) enum, so reading `EventType.RUN_STARTED` as a
+ * VALUE would be a runtime import of a package this module is forbidden to depend on — and, since
+ * the move into core, one it cannot even resolve. So the literals are written out.
+ *
+ * **They are still checked against the real enum, and that check did not move.** The conformance
+ * smoke lives in `connector-core`, where `@ag-ui/core` IS available, and asserts each literal
+ * against its enum member. That relationship is the whole reason these are safe to hand-write:
+ * a hand-copied literal that nothing compares to its source is exactly the drift this lane has
+ * already shipped once. If that smoke is ever deleted, these become unverified copies.
+ */
+export const AGUI_EVENT_TYPE = Object.freeze({
+  RUN_STARTED: "RUN_STARTED",
+  RUN_FINISHED: "RUN_FINISHED",
+  RUN_ERROR: "RUN_ERROR",
+  TEXT_MESSAGE_START: "TEXT_MESSAGE_START",
+  TEXT_MESSAGE_CONTENT: "TEXT_MESSAGE_CONTENT",
+  TEXT_MESSAGE_END: "TEXT_MESSAGE_END",
+  TOOL_CALL_START: "TOOL_CALL_START",
+  TOOL_CALL_ARGS: "TOOL_CALL_ARGS",
+  TOOL_CALL_END: "TOOL_CALL_END",
+  TOOL_CALL_RESULT: "TOOL_CALL_RESULT",
+  REASONING_MESSAGE_START: "REASONING_MESSAGE_START",
+  REASONING_MESSAGE_CONTENT: "REASONING_MESSAGE_CONTENT",
+  REASONING_MESSAGE_END: "REASONING_MESSAGE_END",
+  CUSTOM: "CUSTOM",
+} as const);
+
+/**
+ * Is this part an AG-UI frame? A boolean, never a throw.
+ *
+ * The routing question and the validity question are deliberately separate. This answers "should the
+ * frame renderer draw this?" and cannot fail; `parseAguiFrame` (in `connector-core`) answers "is this
+ * well formed?" and throws with the offending field named. Collapsing them would make a version skew
+ * look exactly like someone else's message, and a renderer would show an empty pane for a stream it
+ * is actively failing to parse.
+ */
+export function isAguiFramePart(part: unknown): boolean {
+  return typeof part === "object" && part !== null && (part as { kind?: unknown }).kind === AGUI_FRAME_KIND;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -62,6 +62,7 @@ export * from "./auth-provider.js";
 export * from "./canonical.js";
 export * from "./artifact.js";
 export * from "./parts.js";
+export * from "./agui-kind.js";
 export * from "./schema-profile.js";
 export * from "./broker-floor.js";
 export * from "./broker-tls.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@ag-ui/core':
+        specifier: 0.0.57
+        version: 0.0.57
       '@cotal-ai/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -533,6 +536,9 @@ importers:
         version: link:../core
 
 packages:
+
+  '@ag-ui/core@0.0.57':
+    resolution: {integrity: sha512-gho1OWjNE6E3Rl7ZEZ1wr2CEpUHjLFU0FqzCZZk439TicLu+BfLCMkMokB07bMGlRmbJ60hM6LW60iOVauCx+Q==}
 
   '@alcalzone/ansi-tokenize@0.2.5':
     resolution: {integrity: sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==}
@@ -2726,6 +2732,9 @@ packages:
     peerDependencies:
       zod: ^3.25.28 || ^4
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.1.8:
     resolution: {integrity: sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==}
 
@@ -2733,6 +2742,10 @@ packages:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
+
+  '@ag-ui/core@0.0.57':
+    dependencies:
+      zod: 3.25.76
 
   '@alcalzone/ansi-tokenize@0.2.5':
     dependencies:
@@ -4902,6 +4915,8 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
+
+  zod@3.25.76: {}
 
   zod@4.1.8: {}
 


### PR DESCRIPTION
The agent-event stream carries glyph-prefixed text, so a consumer can display it and do nothing else
with it. Renaming the channel it goes to would move the same payload to a new name; the name was
never the complaint. This change replaces the payload with a typed vocabulary, and it is the first of
the two halves the plane splits into: the vocabulary here, the channel derivation, the payload-size
split and the publishing emitter next.

## Scope

`packages/core` gains the frame's wire identity: the `ag-ui.frame` part kind, the event `type`
discriminators, and `isAguiFramePart`. It sits in core rather than in a connector because every
connector emits it, it travels on the wire, and no adapter may redefine it unilaterally, which is
what makes it a protocol shape rather than one adapter's choice. What stays out of core is
producer-side: the envelope version and every event constructor. Core widens for a reader, not for a
writer.

`extensions/connector-core` gains the vocabulary: the event constructors, the frame envelope,
`parseAguiFrame`, the `AguiBrackets` stream machine, and the `cotal.*` CUSTOM table, which is empty
in v1.

Routing and validity are two functions because they are two questions. `isAguiFramePart` answers
"should the frame renderer draw this?" and never throws. `parseAguiFrame` answers "does this claim to
be a frame and fail to be one?" and throws with the offending field named. One function returning a
sentinel for both would make a protocol skew look exactly like someone else's message, and a surface
would show an empty pane for a stream it was actively failing to parse. A protocol mismatch and an
unrecognised event type are both refused rather than partially rendered: a skipped event is a hole in
a transcript that still looks complete.

Bracketing is a property of a writer's stream, not of one frame. A frame may legally open a run and
close it in the next one, so `AguiBrackets` is fed frame after frame and a per-frame balance check is
deliberately absent.

## What is deliberately not here

The channel derivation, the payload-size preflight and split, and the emitter that publishes. Each
talks to something outside this module and lands with the surface that calls it. They are named in
the source rather than stubbed, because a stub is a claim that the shape is known.

At this tip nothing constructs a frame outside a test. No connector emits, and every export is a pure
function of its arguments.

## The dependency, and why it is types-only

`@ag-ui/core` is an exact-pinned `devDependency` imported with `import type` only. Version 0.0.57
declares zod as a runtime dependency and `connector-core` is bundled into every seeded connector, so
importing it at runtime would ship a second zod major to every customer in order to validate events
Cotal constructs itself. Production code therefore carries hand-written string literals that the
compiler cannot check, and the conformance suite checks them by execution instead: each literal is
compared against the real enum member of the same name, and every constructor's output is parsed
under the schema that owns it.

## Six protocol facts, measured rather than read

Executing the real schemas contradicted their types in six places, and each is now a cell:
`RUN_FINISHED` is accepted with no outcome; the outcome discriminator is `type`, not `status`; the
outcome object is strict rather than passthrough; `REASONING_MESSAGE_START` requires a literal
`role` where `TEXT_MESSAGE_START` does not; an `interrupt` outcome requires a NON-EMPTY list; and
every entry in that list must carry `id` and `reason` as strings. The fourth refused the first
draft's constructor on the suite's first run.

The last two are why `runFinished` validates rather than forwards. It took `interrupts: unknown[]`
and spread it into the event unchecked, so an empty list and a list of empty objects each produced a
`RUN_FINISHED` the real schema refuses, with no cell looking: every constructor cell fed it a
well-formed argument, which leaves a constructor that validates nothing indistinguishable from one
that validates everything. The argument is now typed, and checked at the constructor against exactly
the schema's rule and no stricter, since an empty `id` string is legal upstream and refusing it here
would be inventing a protocol. The type is the reader's documentation and the check is the
enforcement, because callers reach this constructor through a payload typed `unknown` or a cast on a
replayed record. The `interrupt` outcome itself stays unspent: nothing on this plane constructs one,
and it is validated anyway because an arm that builds a refused event is worse than an arm that does
not exist.

## Testing

Two suites are appended to `bin/smoke/ci-suites.txt`, both at the end, no moves and no duplicates,
so main's list is an exact prefix of this one and `smoke:gate-inventory` confirms each appended
script is defined in `package.json`.

| Suite | Result |
| --- | --- |
| `pnpm smoke:agui-conformance` | 86 cells, 0 failed |
| `pnpm smoke:agui-kind` | 29 cells, 0 failed |

The conformance suite carries the four assertions the vocabulary owes, each under its own heading:
validate against the real schemas, assert passthrough across every schema rather than a sample,
assert bracketing over a synthesized multi-turn sequence, and assert two principals stay separate.

`smoke:agui-kind` exists because the frame's identity lives in core, and a suite importing it by
package name would resolve to the last build rather than to the source under review. It imports
`../src/agui-kind.js` directly, pins the wire literal on one side rather than comparing the constant
with itself, spells out every discriminator in both directions, and executes `isAguiFramePart`
against hostile inputs including a throwing getter and a proxy. Its own mutation fixture carries no
build step on purpose, so a kill there is proof the suite reads source. That last group found a real
defect: the function threw where its contract says it never throws, and the code was fixed rather
than the sentence.

The fourth is at the envelope layer only and its header says so. Two writers' `runId` and `seq`
collide by construction, since each numbers its own turns from 1 and its own frames from 0, so
neither can be the discriminator and the epoch is. Channel isolation is a different claim, and it is
owed by the surface that derives and mints the channel.

Every mutation is predicted by the cell it should redden before it runs, and every one is killed on
exactly that cell. Two of them are a pair by design, because a guard can be half present: the first
restores the whole interrupt pass-through and the second deletes only the per-entry check, and their
predicted kill counts differ by one named cell. Counts were measured as well as predicted, including
the tally, since a cell that throws is a cell that stopped reporting rather than one that failed.
They ship as `smoke/fixtures/agui-conformance.mutations.json` rather than as prose, so
`pnpm mutation-proof --config` re-runs them and `smoke:mutation-fixtures` fails when an anchor stops
matching its source exactly once. Every anchor is a code-only window: an anchor spanning a docblock is
disarmed by anyone tidying prose, and nothing about a comment edit could announce that it had
disabled a guard.

What the mutations do not prove: every cell builds its own input by hand, so a kill shows the suite
depends on this code, not that a real entry point reaches it. That half is owed by the connector that
maps a real session.

No documentation change is owed here: nothing user-facing emits, no flag or wire shape changes.
`SPEC.md` is untouched.

