### PR TITLE
fix(smoke): keep the mutation-fixture walk out of git submodules

### DIFF
--- a/.changeset/mutation-fixture-submodule-skip.md
+++ b/.changeset/mutation-fixture-submodule-skip.md
@@ -1,0 +1,7 @@
+---
+---
+
+Test-only: keeps the mutation-fixture walk out of git submodules, so the gate reads the same file
+set locally as it does on CI, and adds four self-check cells (one of which reports itself
+unobserved rather than passing when the submodule is absent). No shipped behaviour changes, so no
+release.

--- a/bin/smoke/fixtures/mutation-fixtures.mutations.json
+++ b/bin/smoke/fixtures/mutation-fixtures.mutations.json
@@ -15,7 +15,18 @@
     "so a mutation that reddens for an unrelated reason cannot be mistaken for a kill.",
     "",
     "The subject is this repo's own restore-mtime fixture rather than another lane's, so a graded",
-    "run cannot leave someone else's file mid-edit if the tool dies between mutation and restore."
+    "run cannot leave someone else's file mid-edit if the tool dies between mutation and restore.",
+    "",
+    "THE LAST TWO MUTATIONS BREAK CODE, NOT DATA, AND THE DIRECTION STILL WORKS. The walk's",
+    "submodule skip is the one guard here whose removal REDDENS rather than greens: the suite",
+    "self-checks that it skips submodules, so disabling the skip fails a cell instead of quietly",
+    "widening the walk. That is why these two can be proved at all while the four above had to",
+    "target fixture data.",
+    "",
+    "Neither of them depends on the submodule being checked out. That matters: CI never checks it",
+    "out, and a fixture provable only on a developer box would be exactly the local/CI asymmetry",
+    "this change exists to remove. Mutation A kills on the parse of `.gitmodules`, which is tracked",
+    "and always present; mutation B kills on a tree the cell builds itself."
   ],
   "mutations": [
     {
@@ -49,6 +60,22 @@
       "replace": "      \"file\": \"scripts/mutation-proof-that-was-renamed.mjs\",\n      \"find\": \"    if (ok) utimesSync(path, atimeBefore, mtimeBefore);\",",
       "expectRed": "TARGET FILE MISSING",
       "cell": "TARGET FILE MISSING"
+    },
+    {
+      "name": "the submodule set comes back empty, so the walk has nothing to skip",
+      "file": "bin/smoke/mutation-fixtures.smoke.ts",
+      "find": "  if (!existsSync(gitmodules)) return new Set();\n  const paths = [...readFileSync(gitmodules, \"utf8\").matchAll(/^\\s*path\\s*=\\s*(.+)$/gm)];",
+      "replace": "  return new Set();\n  const paths = [...readFileSync(gitmodules, \"utf8\").matchAll(/^\\s*path\\s*=\\s*(.+)$/gm)];",
+      "expectRed": "✗ the real .gitmodules yields at least one submodule path to skip",
+      "cell": "✗ the real .gitmodules yields at least one submodule path to skip"
+    },
+    {
+      "name": "the walk stops honouring the skip set and descends into a submodule",
+      "file": "bin/smoke/mutation-fixtures.smoke.ts",
+      "find": "    if (skip.has(relative(root, path))) continue;\n    let st;",
+      "replace": "    let st;",
+      "expectRed": "✗ a fixture-shaped file inside a submodule path is not walked",
+      "cell": "✗ a fixture-shaped file inside a submodule path is not walked"
     }
   ]
 }

--- a/bin/smoke/mutation-fixtures.smoke.ts
+++ b/bin/smoke/mutation-fixtures.smoke.ts
@@ -44,21 +44,45 @@
  * a fixture. Globbing `*mutation*` would have been shorter and would miss the one fixture somebody
  * files somewhere unexpected, which is precisely the one nobody is validating.
  */
-import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import {
+  readFileSync, readdirSync, statSync, existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { join, dirname, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const SKIP = new Set(["node_modules", "dist", ".git", ".changeset", "coverage", "build"]);
 
+/**
+ * The submodule paths, read from `.gitmodules` rather than named here.
+ *
+ * A SUBMODULE IS NOT THIS TREE, AND CI DOES NOT CHECK IT OUT. Walking one makes this gate read a
+ * different set of files on a developer box than on CI: the anchor count moves with whatever
+ * commit the submodule happens to sit at, and a fixture-shaped `.json` inside it gets graded by a
+ * gate that CI can never see. That asymmetry is the defect. A gate that is red locally and green
+ * on CI does not get fixed, it gets ignored, and an ignored gate is worse than no gate because it
+ * still reads as coverage.
+ *
+ * Parsed from `.gitmodules` instead of hardcoding a directory, so adding a second submodule does
+ * not quietly reintroduce this.
+ */
+function submodulePaths(gitmodules: string): Set<string> {
+  if (!existsSync(gitmodules)) return new Set();
+  const paths = [...readFileSync(gitmodules, "utf8").matchAll(/^\s*path\s*=\s*(.+)$/gm)];
+  return new Set(paths.map((m) => m[1].trim()).filter(Boolean));
+}
+const SUBMODULES = submodulePaths(join(ROOT, ".gitmodules"));
+
 /** Every `.json` in the tree, minus the directories that hold other people's. */
-function jsonFiles(dir: string, out: string[] = []): string[] {
+function jsonFiles(dir: string, out: string[] = [], root = ROOT, skip = SUBMODULES): string[] {
   for (const entry of readdirSync(dir)) {
     if (SKIP.has(entry)) continue;
     const path = join(dir, entry);
+    if (skip.has(relative(root, path))) continue;
     let st;
     try { st = statSync(path); } catch { continue; }
-    if (st.isDirectory()) jsonFiles(path, out);
+    if (st.isDirectory()) jsonFiles(path, out, root, skip);
     else if (entry.endsWith(".json")) out.push(path);
   }
   return out;
@@ -93,6 +117,67 @@ function commentLines(find: string): string[] {
     if (/^\*\s/.test(line) || line === "*") return true;      // docblock continuation
     return /(^|[^:])\/\/(?!\/)/.test(line) && !/\w+:\/\//.test(line);  // trailing `// note`
   });
+}
+
+/**
+ * SELF-CHECK: the walk must not enter a submodule.
+ *
+ * Three cells rather than one, because the obvious cell passes for the wrong reason exactly where
+ * it runs. CI does not check the submodule out, so "no fixtures found under it" is true on CI
+ * whether the skip works or not; asserting only that absence would be vacuous on the very machine
+ * the gate is meant to protect. So: prove the real `.gitmodules` yields a path to skip, then prove
+ * the skip on a tree built to contain a planted fixture, with a control proving the same tree
+ * WITHOUT the skip does find it.
+ */
+const selfChecks: string[] = [];
+function cell(name: string, ok: boolean): void {
+  console.log(`  ${ok ? "✓" : "✗"} ${name}`);
+  if (!ok) selfChecks.push(name);
+}
+
+cell("the real .gitmodules yields at least one submodule path to skip", SUBMODULES.size > 0);
+
+const probe = mkdtempSync(join(tmpdir(), "mutation-fixtures-probe-"));
+try {
+  mkdirSync(join(probe, "sub"), { recursive: true });
+  writeFileSync(
+    join(probe, "sub", "planted.mutations.json"),
+    JSON.stringify({ mutations: [{ name: "planted", file: "gone.ts", find: "// a prose anchor" }] }),
+  );
+  cell(
+    "a fixture-shaped file inside a submodule path is not walked",
+    jsonFiles(probe, [], probe, new Set(["sub"])).length === 0,
+  );
+  // The control. Without it the cell above proves nothing: a walk that found nothing because the
+  // tree was empty reads exactly like a walk that skipped, and only one of those is the guard.
+  cell(
+    "and the same tree WITHOUT the skip finds it, so the 0 above is a skip and not an empty tree",
+    jsonFiles(probe, [], probe, new Set()).length === 1,
+  );
+} finally {
+  rmSync(probe, { recursive: true, force: true });
+}
+
+// The real entry point, which the three cells above do not cover: they build their input by hand,
+// so they show the walker obeys a skip set, not that the production walk is given one. This cell
+// closes that -- and it is only observable when the submodule is actually checked out, so when it
+// is not, it says so instead of counting as a pass.
+const populated = [...SUBMODULES].filter((p) => {
+  const abs = join(ROOT, p);
+  try { return readdirSync(abs).length > 0; } catch { return false; }
+});
+if (populated.length) {
+  const leaked = jsonFiles(ROOT)
+    .map((p) => relative(ROOT, p))
+    .filter((r) => populated.some((s) => r === s || r.startsWith(`${s}/`)));
+  cell(
+    `the production walk returns nothing from inside ${populated.join(", ")}`,
+    leaked.length === 0,
+  );
+  if (leaked.length) console.log(`      leaked: ${leaked.slice(0, 3).join(", ")}`);
+} else {
+  console.log("  · submodule not checked out here, so the production-walk cell has nothing to");
+  console.log("    observe. It is UNOBSERVED, not passed, and on CI it is always this branch.");
 }
 
 const fixtures: { path: string; mutations: Mutation[] }[] = [];
@@ -194,12 +279,13 @@ for (const { path, mutations } of fixtures) {
   else console.log(`  ✓ ${rel} — ${here} anchor(s) present and unique`);
 }
 
-const failed = stale.length + ambiguous.length + missing.length + prose.length;
+const failed = stale.length + ambiguous.length + missing.length + prose.length + selfChecks.length;
 console.log(`\n${fixtures.length} fixture file(s), ${checked} anchor(s) checked at this commit`);
 console.log(`  dead anchors:        ${stale.length}`);
 console.log(`  ambiguous anchors:   ${ambiguous.length}`);
 console.log(`  anchors spanning prose: ${prose.length}`);
 console.log(`  missing file/key:    ${missing.length}`);
+console.log(`  walk self-checks failed: ${selfChecks.length}`);
 // The caveat belongs where the verdict is read, not only in the prologue: a ✓ reads as "the
 // fixtures are good" unless it says otherwise in the same breath.
 console.log(


### PR DESCRIPTION
## What

The mutation-fixture gate discovers fixtures **by shape**: any `.json` in the tree with a top-level
`mutations` array. Its skip set covered build output (`node_modules`, `dist`, `.git`, `.changeset`,
`coverage`, `build`) but not **git submodules**.

A submodule is not this tree, and CI does not check one out. So the gate read a different set of
files on a developer machine than it did on CI:

- the anchor count moved with whatever commit the submodule happened to sit at, and
- a fixture-shaped `.json` inside the submodule was discovered and graded by a gate that CI can
  never see.

Measured on this branch's base, same tree, submodule checked out:

| walker | fixture files | anchors |
| --- | --- | --- |
| before | 11 | 110 |
| after | 10 | 40 |

The 70-anchor difference is one fixture-shaped file inside the submodule that the walk was reading
and grading. Nothing about that file is wrong; it simply is not this repo's to check.

The failure mode this removes is not "an extra file gets checked". It is a gate that can be **red
locally and green on CI**. That state does not get fixed, it gets ignored, and an ignored gate is
worse than no gate because it still reads as coverage.

## How

The skip set is parsed from `.gitmodules` rather than naming a directory, so adding a second
submodule later cannot quietly reintroduce this.

## The self-checks, and why there are four

The obvious cell would assert "no fixtures found under the submodule". That cell is **vacuous on
CI** for the same reason the bug is invisible there: CI never checks the submodule out, so the
assertion is true whether the skip works or not. It would pass on the exact machine it is meant to
protect.

So instead:

1. the real `.gitmodules` parse yields at least one path to skip;
2. a fixture-shaped file inside a submodule path is not walked, on a tree built to contain one;
3. **a control** proving the same tree *without* the skip does find it, because otherwise an empty
   result is indistinguishable from an empty tree;
4. the production walk returns nothing from inside the submodule.

Only (4) needs the submodule present. When it is absent the suite prints that the cell is
**UNOBSERVED rather than passed** and does not count it, because "we have no observation there" is
not the same claim as "we observed nothing there".

## Proof

Two new mutations, both anchored on code-only windows, both predicted before the run and both
KILLED on the named cell:

- the submodule set comes back empty, so the walk has nothing to skip -> reddens
  `the real .gitmodules yields at least one submodule path to skip` (11 marks, baseline 14)
- the walk stops honouring the skip set -> reddens
  `a fixture-shaped file inside a submodule path is not walked` (12 marks, baseline 14)

All 6 mutations in the fixture killed. Neither new mutation depends on the submodule being checked
out: one kills on the `.gitmodules` parse, which is tracked and always present, and the other on a
tree the cell builds itself. A fixture provable only on a developer box would be the very
local/CI asymmetry this change exists to remove.

`mutation-proof` proves the suite *depends* on the mutated code, not that a real entry point
reaches it, and cells (2) and (3) build their inputs by hand. The before/after table above is that
separate proof, run through the production entry point on the same tree.

Typecheck rc=0. Test-only, no shipped behaviour change, so the changeset releases nothing.
