### PR TITLE
fix(core): check a bind refusal's coherence on the marker, not on its outcome

### DIFF
--- a/.changeset/bind-refusal-coherence-on-marker.md
+++ b/.changeset/bind-refusal-coherence-on-marker.md
@@ -1,0 +1,10 @@
+---
+"@cotal-ai/core": patch
+---
+
+A bind refusal is now checked for self-consistency whenever it carries the bind-refused marker,
+rather than only when it also states `not-executed`. The checks establish that the reply is an
+answer to this request from this responder, and that question does not depend on the outcome
+field, so a refusal that omitted the outcome previously skipped them and was surfaced
+unvalidated. Whether a caller may act on such a refusal is unchanged and still requires an
+explicit `not-executed`.

--- a/packages/core/smoke/bind-fence.smoke.ts
+++ b/packages/core/smoke/bind-fence.smoke.ts
@@ -64,7 +64,7 @@ const throws = (name: string, fn: () => unknown, code?: string) => {
 /** Declared, not implied: a live suite can end early in ways that redden no cell — a broker that
  *  never came up, a hang the runner kills, a top-level rejection — and `fail === 0` reads as PASS
  *  in every one of them, with the exit code to match. */
-const EXPECTED_CELLS = 27;
+const EXPECTED_CELLS = 28;
 process.on("exit", () => {
   const ran = pass + fail;
   if (ran !== EXPECTED_CELLS) {
@@ -110,6 +110,7 @@ const EP = "manager";
 const IID_A = "a".repeat(26);
 const IID_B = "b".repeat(26);
 const IID_LIAR = "c".repeat(26);
+const IID_LIAR2 = "d".repeat(26); // the same forgery, with the outcome field left off
 const GHOST = "g".repeat(26); // a well-formed instance id that serves nothing
 const EPOCH = 1;
 const caller: EpCaller = { owner: "u_op", actor: "cli", uid: "u".repeat(26) };
@@ -162,7 +163,7 @@ try {
   /** Bring one instance up: register, publish READY, authorize the serve artifact, serve `poke`
    *  with a handler that COUNTS its entries. The count is the whole instrument — it is what turns
    *  "a refusal came back" into "and the command did not run". */
-  const runs: Record<string, number> = { [IID_A]: 0, [IID_B]: 0, [IID_LIAR]: 0 };
+  const runs: Record<string, number> = { [IID_A]: 0, [IID_B]: 0, [IID_LIAR]: 0, [IID_LIAR2]: 0 };
   const bring = async (instanceId: string, handler?: EpCommandDef["handler"]) => {
     const reg = await registerServiceInstance(kv as KV, { spec, instanceId, registrant: asOp, authority, space: SPACE, barrier: barrierFor(instanceId), readClusterArtifact });
     await writeServiceStatus(kv as KV, { endpoint: EP, instanceId, epoch: EPOCH, readProcessEpoch: () => EPOCH, status: { epoch: EPOCH, state: SERVICE_READY, observedSpecRevision: reg.registrationRevision } });
@@ -290,11 +291,9 @@ try {
   // The marker is a body field, so a responder could always emit one after doing the work; what
   // stops that from becoming a free "nothing ran" is the caller cross-checking it against the
   // reply SUBJECT, which the broker pins.
-  // The liar states `not-executed` as well as the marker, which is now the ONLY shape that reaches
-  // the coherence checks at all: they are gated on `replyRefusedBeforeEffect`, and a refusal that
-  // omits the outcome no longer satisfies it. That makes this the maximally credible forgery rather
-  // than a weaker one, so the cell tests a stronger case than before. A forger has no reason to omit
-  // a field that costs nothing to set, and one that does omit it is now inert instead of honored.
+  // The liar states `not-executed` as well as the marker, which makes it the maximally credible
+  // forgery: it is the shape that would license a re-issue if the caller believed it. The cell
+  // below it grades the opposite end, a refusal with the outcome left off, and both are checked.
   const liar = await bring(IID_LIAR, () => {
     runs[IID_LIAR]++;
     throw new EpEnvelopeError("failed-precondition", "I did not run this (I did)", [
@@ -307,6 +306,25 @@ try {
       { endpoint: EP, command: "poke", contract, caller, args: { n: 1 }, bind: { instanceId: IID_LIAR, epoch: EPOCH } },
       { deadlineMs: 8000, currentEpoch: registryEpoch }), "internal");
   c("...and the liar did run, which is the point: the marker alone is not proof", runs[IID_LIAR] === 1, runs[IID_LIAR]);
+
+  // THE SAME FORGERY WITH THE OUTCOME LEFT OFF. Requiring `not-executed` is what stops a caller
+  // ACTING on this reply, and that half is settled. It must not also decide whether the reply is
+  // CHECKED: the contradiction here is between the body and the reply subject the broker pins, and
+  // it is just as flatly a contradiction whether or not an outcome field is present. Gating the
+  // checks on the outcome let a forger skip them by omitting a field, so the least credible reply
+  // got the least scrutiny.
+  const liar2 = await bring(IID_LIAR2, () => {
+    runs[IID_LIAR2]++;
+    throw new EpEnvelopeError("failed-precondition", "I did not run this (I did), and I will not say so", [
+      { kind: EP_BIND_REFUSED, endpoint: EP, command: "poke", boundTo: { instanceId: IID_LIAR2, epoch: EPOCH }, servedBy: { instanceId: GHOST, epoch: EPOCH } },
+    ]);
+  });
+  await rejects("a bind refusal that OMITS the outcome is still checked against its attribution, not waved through",
+    () => epCall(nc, SPACE, { mode: "inst", instanceId: IID_LIAR2, epoch: EPOCH },
+      { endpoint: EP, command: "poke", contract, caller, args: { n: 1 }, bind: { instanceId: IID_LIAR2, epoch: EPOCH } },
+      { deadlineMs: 8000, currentEpoch: registryEpoch }), "internal");
+  await liar2.stop();
+
   // Off the class queue before section 6, or it wins some of those calls and answers them with
   // its fake refusal — which would be counted as neither served-by-A nor refused-by-B.
   await liar.stop();

--- a/packages/core/smoke/fixtures/bind-fence.mutations.json
+++ b/packages/core/smoke/fixtures/bind-fence.mutations.json
@@ -28,6 +28,13 @@
       "find": "      if (r.instanceId === op.bind.instanceId && r.epoch === op.bind.epoch)",
       "replace": "      if (false as boolean)",
       "expectRed": "a bind refusal from the very incarnation the caller bound is internal"
+    },
+    {
+      "name": "the coherence checks go back to being gated on the outcome, so omitting it skips them",
+      "file": "packages/core/src/endpoint-verbs.ts",
+      "find": "    if (attributed.reply.ok === false && bindRefusalMarked(attributed.reply.error)) {",
+      "replace": "    if (attributed.reply.ok === false && bindRefusalMarked(attributed.reply.error) && attributed.reply.error?.outcome === \"not-executed\") {",
+      "expectRed": "a bind refusal that OMITS the outcome is still checked against its attribution"
     }
   ]
 }

--- a/packages/core/src/endpoint-envelope.ts
+++ b/packages/core/src/endpoint-envelope.ts
@@ -21,7 +21,7 @@ import type { EndpointRef } from "./types.js";
 // use them without dragging in schema-profile's load-time digest (node:crypto). Re-exported here so
 // every existing `@cotal-ai/core` consumer keeps its import path.
 import { EP_ERROR_CODES, EpEnvelopeError, type EpErrorCode, type EpError, type EpErrorDetail, type EpEffectOutcome } from "./endpoint-error.js";
-export { EP_ERROR_CODES, EpEnvelopeError, EP_UNBOUND_RESPONDER, respondedButUnbound, EP_UNANSWERED, unansweredRequest, EP_REGISTRY_READ_FAILED, registryReadFailed, EP_BIND_REFUSED, replyRefusedBeforeEffect, type EpErrorCode, type EpError, type EpErrorDetail, type EpUnboundResponderDetail, type EpUnansweredDetail, type EpRegistryReadFailedDetail, type EpBindRefusedDetail, type EpEffectOutcome } from "./endpoint-error.js";
+export { EP_ERROR_CODES, EpEnvelopeError, EP_UNBOUND_RESPONDER, respondedButUnbound, EP_UNANSWERED, unansweredRequest, EP_REGISTRY_READ_FAILED, registryReadFailed, EP_BIND_REFUSED, replyRefusedBeforeEffect, bindRefusalMarked, type EpErrorCode, type EpError, type EpErrorDetail, type EpUnboundResponderDetail, type EpUnansweredDetail, type EpRegistryReadFailedDetail, type EpBindRefusedDetail, type EpEffectOutcome } from "./endpoint-error.js";
 
 /** The envelope schema version — independent of the wire `protocolVersion`; starts at its own
  *  v1 inside the v0.4 revision. Other values are rejected (`unsupported-version`). */

--- a/packages/core/src/endpoint-error.ts
+++ b/packages/core/src/endpoint-error.ts
@@ -136,6 +136,22 @@ export interface EpBindRefusedDetail extends EpErrorDetail {
   servedBy: { instanceId: string; epoch: number };
 }
 
+/** True iff an `EpError` CARRIES the {@link EP_BIND_REFUSED} marker, saying nothing about whether
+ *  the marker is believable. It is the claim's presence, not its acceptance.
+ *
+ *  The two questions come apart, and conflating them is what this pair exists to prevent. Whether a
+ *  caller may ACT on a bind refusal — re-issue a command it would otherwise never repeat — needs
+ *  the marker AND an explicit `not-executed`, which is {@link replyRefusedBeforeEffect}. Whether a
+ *  reply is CHECKED for self-consistency needs only the claim, because the contradiction being
+ *  checked is between the reply's BODY and the subject the broker pinned, and that is a
+ *  contradiction whatever the outcome field says — or does not say.
+ *
+ *  Gating the checks on the stronger predicate meant a reply could skip them by OMITTING a field,
+ *  so the least credible shape drew the least scrutiny. */
+export function bindRefusalMarked(e: EpError | undefined): boolean {
+  return (e?.details ?? []).some((d) => d.kind === EP_BIND_REFUSED);
+}
+
 /** True iff an `EpError` carries the {@link EP_BIND_REFUSED} marker: a responder refused BEFORE
  *  executing, because it is not the incarnation the caller bound — the command did not run.
  *
@@ -167,7 +183,7 @@ export interface EpBindRefusedDetail extends EpErrorDetail {
  *  before dispatch to carry `not-executed`, so what it loses is a repair it was never owed. This
  *  endpoint's own responder sets the field, so conforming deployments are unaffected. */
 export function replyRefusedBeforeEffect(e: EpError | undefined): boolean {
-  if (!(e?.details ?? []).some((d) => d.kind === EP_BIND_REFUSED)) return false;
+  if (!bindRefusalMarked(e)) return false;
   return e?.outcome === "not-executed";
 }
 

--- a/packages/core/src/endpoint-verbs.ts
+++ b/packages/core/src/endpoint-verbs.ts
@@ -20,7 +20,7 @@ import {
   type EpCaller, type EpRoute, type EpTarget,
 } from "./endpoint-subjects.js";
 import {
-  EpEnvelopeError, EP_UNBOUND_RESPONDER, EP_UNANSWERED, EP_REGISTRY_READ_FAILED, EP_BIND_REFUSED, registryReadFailed, replyRefusedBeforeEffect, parseEndpointReply, parseEndpointEvent, assertArgsValid, assertOutputValid,
+  EpEnvelopeError, EP_UNBOUND_RESPONDER, EP_UNANSWERED, EP_REGISTRY_READ_FAILED, EP_BIND_REFUSED, registryReadFailed, bindRefusalMarked, parseEndpointReply, parseEndpointEvent, assertArgsValid, assertOutputValid,
   type EndpointRequest, type EndpointReply, type EndpointEvent, type EpCorrelation, type EpTargetBlock, type EpUnboundResponderDetail, type EpBindRefusedDetail,
   type EpUnansweredDetail, type EpRegistryReadFailedDetail, type EpErrorDetail, type EpBindBlock,
 } from "./endpoint-envelope.js";
@@ -333,7 +333,12 @@ export async function epCall(
     // that says nothing about whether the command ran. Cross-checked against the SUBJECT first: a
     // reply attributed to the very incarnation the caller bound cannot coherently claim it is not
     // that incarnation (§13.3).
-    if (attributed.reply.ok === false && replyRefusedBeforeEffect(attributed.reply.error)) {
+    // Gated on the marker's PRESENCE, not on the outcome. Whether the caller may act on this
+    // refusal is a separate question, settled downstream by `replyRefusedBeforeEffect`; whether the
+    // reply is coherent is settled here, and a reply that omits the outcome is no less obliged to
+    // agree with its own attribution. Gating both on the same predicate let a refusal buy its way
+    // out of the checks by leaving a field off.
+    if (attributed.reply.ok === false && bindRefusalMarked(attributed.reply.error)) {
       if (op.bind === undefined)
         throw new EpEnvelopeError("internal", `${op.endpoint}.${op.command} replied with a bind refusal to a request that carried no bind`);
       const r = attributed.responder;


### PR DESCRIPTION
A bind refusal from a responder is subject to three joint checks that establish the reply is an
answer to this request, from this responder: the reply subject's attribution, the refusal's
`boundTo` against the bind this request carried, and its `servedBy` against the subject.

Those checks were gated on the same predicate that decides whether the caller may re-issue the
command, which requires an explicit `not-executed` outcome. A refusal carrying the marker but
omitting the outcome therefore reached none of them and was surfaced unvalidated. The least
credible shape drew the least scrutiny, and a forger could skip the checks by leaving a field off.

This splits the two questions.

Coherence is checked whenever the marker is present. The contradiction being checked is between
the reply body and the subject the broker pinned, and that is a contradiction whatever the outcome
field says, or does not say.

Acting on the refusal is unchanged. A re-issue still requires an explicit `not-executed`, so
nothing that was previously refused a repair now gets one.

`bindRefusalMarked` is added alongside `replyRefusedBeforeEffect`, which now delegates to it so the
relationship between the two is stated in code rather than duplicated.

## Behaviour change for third parties

A responder that emits the bind-refused marker without an outcome now has its reply validated. If
that reply also contradicts its own attribution it raises `internal` instead of being passed
through. Such a responder is already non-conforming, since a refusal raised before dispatch is
required to carry `not-executed`.

## Gates

`smoke:bind-fence` goes from 27 to 28 cells. The new cell drives a responder that emits the marker,
omits the outcome, and lies about which incarnation served it.

- Red first on unmodified main: the cell fails with "did not throw", 27 passed / 1 failed.
- Green with the fix: 28 passed / 0 failed.
- `smoke:unfenced-responder`, which exercises the same predicate: 34 passed / 0 failed.
- `pnpm typecheck`: clean across all packages.

One mutation is added to the suite's fixture. Predicted before running: re-gating the checks on the
outcome reddens exactly the new cell, at 27 marks against a baseline of 28. Observed: KILLED on that
cell, 27 marks against baseline 28.

## A pre-existing survivor this run exposed, not fixed here

Running the full fixture reports `SURVIVED` for the existing mutation "the caller stops
cross-checking a refusal against its own attribution". That is not introduced by this change. On
unmodified main the same mutation leaves the suite green; it is reported there as UNGRADABLE only
because, run alone, nothing proves the suite reaches that file. The new mutation supplies that
positive control and turns the verdict into a reportable one.

The cause is redundancy in the fixture rather than a missing check. The liar reply trips both the
subject-attribution check and the `servedBy` check, so disabling either one leaves the other to
raise `internal` and the cell stays green. Disabling both together reddens exactly that one cell,
at 26 passed / 1 failed, which is what identifies the two as mutually masking.

Grading either check therefore needs a fixture whose reply trips only one of them. That is a change
to the existing fixture rather than to this gate, so it is left out of this PR deliberately.