### PR TITLE
test(core): adopt the broker teardown helper in four more core suites

### DIFF
--- a/.changeset/broker-teardown-migration-1.md
+++ b/.changeset/broker-teardown-migration-1.md
@@ -1,0 +1,5 @@
+---
+---
+
+Test-only: adopts the smoke broker teardown helper in four more `packages/core` suites, so a killed
+suite tears its broker down instead of orphaning it. No shipped behaviour changes, so no release.

--- a/packages/core/smoke/broker-teardown.smoke.ts
+++ b/packages/core/smoke/broker-teardown.smoke.ts
@@ -87,6 +87,14 @@ function reapOwn(brokerPid: number, storeDir: string): void {
 try {
   // 1. POSITIVE CONTROL. The identical fixture without ownership must leak on SIGTERM. This is the
   //    reproduction, run as a cell, and it is what makes cells 2-4 mean something.
+  //
+  //    IF THIS CELL JUST WENT RED ON YOU, READ THIS BEFORE TREATING IT AS A REGRESSION. It asserts
+  //    that the leak HAPPENS. It is not a leak detector and it does not guard anything; it keeps
+  //    passing whether or not the teardown works, which is exactly its job. So it goes red in one
+  //    interesting case: somebody fixed the leak AT ITS SOURCE, and an unowned broker no longer
+  //    outlives its signalled parent. If that is what you just did, this cell is correct to fail and
+  //    the right response is to delete it and the cells it was propping up, not to make it pass
+  //    again. Confirm it first: run the fixture in `unowned` mode by hand and watch the broker's pid.
   {
     const s = await start("unowned");
     process.kill(s.selfPid, "SIGTERM");

--- a/packages/core/smoke/endpoint-checkpoint.smoke.ts
+++ b/packages/core/smoke/endpoint-checkpoint.smoke.ts
@@ -32,6 +32,7 @@ import {
   type CheckpointRef,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "./_broker-teardown.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -51,8 +52,11 @@ const holderA = { id: "u_abc.worker", lifecycleUid: "u".repeat(26) };
 const holderB = { id: "u_abc.other", lifecycleUid: "v".repeat(26) };
 
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-epcp-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
+// The `finally` below stays and still does the work on every normal exit; ownership only covers
+// the path where this process is killed and the `finally` never unwinds.
+const releaseBroker = teardownOnSignal(broker, sd);
 
 try {
   let up = false;
@@ -513,6 +517,7 @@ try {
   broker.kill("SIGKILL");
   await new Promise<void>((resolve) => { broker.once("exit", () => resolve()); broker.once("error", () => resolve()); });
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until cleanup has actually finished
 }
 
 console.log(`\nENDPOINT CHECKPOINT SMOKE ${fail === 0 ? "OK ✅ " : "FAILED ❌ "} (${ok} passed, ${fail} failed)`);

--- a/packages/core/smoke/endpoint-records.smoke.ts
+++ b/packages/core/smoke/endpoint-records.smoke.ts
@@ -20,6 +20,7 @@ import {
   type MergedRecord,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "./_broker-teardown.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -160,8 +161,11 @@ const tK = recordStatusKey(RECORD_KINDS.svc, svcQ);
 
 // ── the live half: CAS, merged read, head, watch ──
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-eprec-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
+// The `finally` below stays and still does the work on every normal exit; ownership only covers
+// the path where this process is killed and the `finally` never unwinds.
+const releaseBroker = teardownOnSignal(broker, sd);
 
 try {
   let up = false;
@@ -272,5 +276,6 @@ try {
   if (broker.pid) { try { process.kill(broker.pid, "SIGKILL"); } catch { /* gone */ } }
   await wait(200);
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until cleanup has actually finished
   process.exit(process.exitCode ?? 0);
 }

--- a/packages/core/smoke/endpoint-work.smoke.ts
+++ b/packages/core/smoke/endpoint-work.smoke.ts
@@ -30,6 +30,7 @@ import {
   type EpCaller, type WorkItemRef, type WorkWorker, type WorkPoolContext,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "./_broker-teardown.js";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -50,8 +51,11 @@ const epWorker = (epoch: number): WorkWorker => ({ kind: "endpoint", owner: "u_w
 const enc = (s: string) => new TextEncoder().encode(s);
 
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-epwork-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
+// The `finally` below stays and still does the work on every normal exit; ownership only covers
+// the path where this process is killed and the `finally` never unwinds.
+const releaseBroker = teardownOnSignal(broker, sd);
 
 try {
   let up = false;
@@ -502,6 +506,7 @@ try {
   broker.kill("SIGKILL");
   await new Promise<void>((resolve) => { broker.once("exit", () => resolve()); broker.once("error", () => resolve()); });
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until cleanup has actually finished
 }
 
 console.log(`\nENDPOINT WORK SMOKE ${fail === 0 ? "OK ✅ " : "FAILED ❌ "} (${ok} passed, ${fail} failed)`);

--- a/packages/core/smoke/kv-scan.smoke.ts
+++ b/packages/core/smoke/kv-scan.smoke.ts
@@ -27,10 +27,11 @@ import { connect } from "@nats-io/transport-node";
 import { jetstreamManager } from "@nats-io/jetstream";
 import { Kvm } from "@nats-io/kv";
 import { IncompleteKvScan, isReachable, liveKvEntries } from "../src/index.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "./_broker-teardown.js";
 
 const PORT = 14771;
 const SERVER = `nats://127.0.0.1:${PORT}`;
-const store = mkdtempSync(join(tmpdir(), "cotal-kvscan-"));
+const store = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 let pass = 0;
 const check = (name: string, cond: boolean, extra?: unknown) => {
   assert.ok(cond, `${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
@@ -40,6 +41,9 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 const srv = spawn("nats-server", ["-p", String(PORT), "-js", "-sd", store], { stdio: "ignore" });
+// The `finally` below stays and still does the work on every normal exit; ownership only covers the
+// path where this process is killed and the `finally` never unwinds.
+const releaseBroker = teardownOnSignal(srv, store);
 try {
   let up = false;
   for (let i = 0; i < 60; i++) { if (await isReachable(SERVER)) { up = true; break; } await wait(150); }
@@ -211,5 +215,6 @@ try {
 } finally {
   srv.kill("SIGKILL");
   rmSync(store, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until cleanup has actually finished
 }
 process.exit(0);


### PR DESCRIPTION
First migration batch for the smoke broker teardown helper landed in #503. Four suites in
`packages/core/smoke`, one per commit, no bulk sweep.

| suite | checks before | checks after | retired prefix |
| --- | --- | --- | --- |
| `kv-scan` | 24 | 24 | `cotal-kvscan-` |
| `endpoint-checkpoint` | 74 | 74 | `cotal-epcp-` |
| `endpoint-work` | 71 | 71 | `cotal-epwork-` |
| `endpoint-records` | 46 | 46 | `cotal-eprec-` |

Each suite keeps its existing `finally` teardown, which is correct and does the work on every normal
exit. Ownership only covers the path where the process is killed and the `finally` never unwinds.
`release()` is the **last** statement in each `finally`, so ownership is held until cleanup has
actually finished and an uncaught throw still exits with the broker owned.

## Why the store dir prefix moves

Each suite's prefix becomes the minted `cotal-smoke-broker-` token. That is not cosmetic: a broker
started through the helper is recognisable after its owner is SIGKILLed, and a broker started around
it is not. The token is the only evidence a later reaper can match, so a suite that keeps its own
prefix stays unreapable even after adopting the helper.

**Four greps are retired by this**, listed because a retired check is worse than a missing one: it
returns zero and reads as healthy while measuring nothing. `cotal-kvscan-`, `cotal-epcp-`,
`cotal-epwork-` and `cotal-eprec-` now match nothing by construction. The replacement token is
`cotal-smoke-broker-`.

## Scope

Four of 71 broker-spawning suites in `packages/core/smoke`, and of roughly 137 across the repo. The
rest are not in this PR by design: the plan calls for owners to migrate their own suites in small
batches, not for one agent to sweep the tree. These four are the ones this lane owns.

**Note for anyone migrating a suite outside `packages/core`:** the helper is colocated in
`packages/core/smoke` following the `_free-port.ts` convention, so suites in other packages cannot
import it as-is. That needs a decision before it is duplicated by hand, and it is not made here.

## Gates

- Every suite run before and after, with identical check counts (table above).
- `pnpm typecheck` rc=0.
- Box state checked around the runs: `nats-server` count 14 before and after, no store dirs left by
  these runs. One `cotal-eprec-` directory dated three days ago is present on the box with no process
  referencing it; it predates this work and was deliberately left alone rather than quietly deleted.
- No change to `bin/smoke/ci-suites.txt` or to any package script: this PR edits suite internals only.

Test-only; the changeset declares no release.
