### PR TITLE
test(core): fix three smoke suites that leaked a store dir on every passing run

### DIFF
--- a/.changeset/broker-teardown-core-corrective.md
+++ b/.changeset/broker-teardown-core-corrective.md
@@ -1,0 +1,6 @@
+---
+---
+
+Test-only: fixes three `packages/core` smoke suites that leaked a broker store dir on every passing
+run, and corrects the helper's scope note, which generalised one suite's measurement to all of them.
+No shipped behaviour changes, so no release.

--- a/packages/core/smoke/broker-teardown.smoke.ts
+++ b/packages/core/smoke/broker-teardown.smoke.ts
@@ -139,10 +139,19 @@ try {
     reapOwn(s.brokerPid, s.storeDir);
   }
 
-  // 4. The normal path must be UNCHANGED. It was already correct (measured: ten bind-fence runs left
-  //    zero brokers and zero store dirs), so this cell guards against the helper breaking it. The
-  //    fixture models a real suite here: it kills the broker itself and releases ownership, because a
-  //    live spawned child holds the event loop open and a suite that skipped that would never exit.
+  // 4. The normal path must be UNCHANGED where a suite HAS one, which is the claim this cell makes
+  //    and the only one it can make. The fixture tears its own broker down, so what is guarded here
+  //    is that the helper does not break a teardown that already works: measured on bind-fence, ten
+  //    runs, zero brokers and zero store dirs left.
+  //
+  //    It says nothing about a suite with NO normal-path teardown, and an earlier version of this
+  //    comment implied otherwise by calling the normal path "already correct" without a subject. Six
+  //    suites have none; `channels-auth` passes and leaks a store dir every run. For those, adopting
+  //    the helper is a rename rather than a fix, and this cell would stay green throughout.
+  //
+  //    The fixture models a real suite here: it kills the broker itself and releases ownership,
+  //    because a live spawned child holds the event loop open and a suite that skipped that would
+  //    never exit.
   {
     const s = await start("clean");
     const how = await ended(s.proc);

--- a/packages/core/smoke/channels-auth.smoke.ts
+++ b/packages/core/smoke/channels-auth.smoke.ts
@@ -1,8 +1,10 @@
 import { strict as assert } from "node:assert";
-import { writeFileSync, mkdirSync, mkdtempSync, openSync, readFileSync } from "node:fs";
+import { writeFileSync, mkdirSync, mkdtempSync, openSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+import { pickFreePort } from "./_free-port.js";
 import {
   createSpaceAuth, serverConfig, mintCreds, newIdentity, isReachable,
   setupSpaceStreams, seedChannelRegistry, provisionAgent, CotalEndpoint,
@@ -21,8 +23,14 @@ import {
 // No external server (spins its own JWT-auth nats-server).
 // Scratch lives under the OS temp dir (NOT a hardcoded POSIX `/tmp/*`, which on Windows resolves
 // drive-relative and hands nats-server.exe a bogus storeDir) so the suite is portable.
-const dir = mkdtempSync(join(tmpdir(), "cotal-authcheck-"));
-const space = "authcheck", port = 4227, server = `nats://127.0.0.1:${port}`, storeDir = join(dir, "nats"), conf = join(dir, "authcheck.conf"), log = join(dir, "authcheck.log");
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
+// An OS-assigned port, not the 4227 this suite used to hardcode. Two concurrent runs collided by
+// construction, and the collision did not report itself as one: the second broker died with
+// `bind: address already in use` in its own log, the suite then reached the FIRST run's broker,
+// whose trust chain rejected these creds, and the failure surfaced as `AuthorizationError:
+// Authorization Violation` from deep inside the test. Reproduced before this line changed.
+const port = await pickFreePort();
+const space = "authcheck", server = `nats://127.0.0.1:${port}`, storeDir = join(dir, "nats"), conf = join(dir, "authcheck.conf"), log = join(dir, "authcheck.log");
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 const textOf = (m: CotalMessage) => m.parts.map((p) => (p.kind === "text" ? p.text : "")).join("");
 
@@ -31,12 +39,22 @@ const auth = await createSpaceAuth(space);
 writeFileSync(conf, serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port, storeDir }));
 const fd = openSync(log, "w");
 const child = spawn("nats-server", ["-c", conf], { stdio: ["ignore", fd, fd] });
-process.on("exit", () => child.kill("SIGTERM"));
+// Owned, so a SIGNALLED run takes the broker and the store dir with it. The `process.on("exit")`
+// hook this replaces killed the broker and left the directory, which is why four days of leaked
+// dirs went unnoticed: the loud half of the defect was silenced and the quiet half accumulated.
+const releaseBroker = teardownOnSignal(child, dir);
 
 const mgrCreds = await mintCreds(auth, newIdentity(), "provisioner");
 let up = false;
-for (let i = 0; i < 50; i++) { if (await isReachable(server, { creds: mgrCreds })) { up = true; break; } await sleep(200); }
-if (!up) throw new Error(`server not up:\n${readFileSync(log, "utf8")}`);
+for (let i = 0; i < 50; i++) {
+  // OUR child, before reachability. `isReachable` answers true against a FOREIGN broker squatting
+  // the port, so waiting on reachability alone is what turned a bind failure into an authorization
+  // error above. Our server exits within ~100ms of a failed bind, so it is visible right here.
+  if (child.exitCode !== null) break;
+  if (await isReachable(server, { creds: mgrCreds })) { up = true; break; }
+  await sleep(200);
+}
+if (!up) throw new Error(`server not up (exit ${child.exitCode}):\n${readFileSync(log, "utf8")}`);
 
 await setupSpaceStreams({ servers: server, space, creds: mgrCreds });
 await seedChannelRegistry({ servers: server, space, creds: mgrCreds, file: { defaults: { replay: false }, channels: { log: { replay: true }, incident: { replay: true } } } });
@@ -129,4 +147,11 @@ await poster.stop();
 await sup.stop();
 await mgr.stop();
 child.kill("SIGTERM");
+// The store dir goes too. Its absence here is the whole reason this suite leaked: it passed, said
+// so, and left a directory behind on every green run. The pause is the same one `_boot-broker` uses:
+// removing the tree while the broker is still flushing JetStream state leaves files behind it
+// recreates, so the directory survives the removal that was supposed to take it.
+await sleep(200);
+rmSync(dir, { recursive: true, force: true });
+releaseBroker(); // last: ownership is held until this teardown has actually finished
 process.exit(0);

--- a/packages/core/smoke/tls-serve.smoke.ts
+++ b/packages/core/smoke/tls-serve.smoke.ts
@@ -1,11 +1,12 @@
 import { strict as assert } from "node:assert";
-import { writeFileSync, mkdirSync, mkdtempSync, openSync, readFileSync } from "node:fs";
+import { writeFileSync, mkdirSync, mkdtempSync, openSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 import net from "node:net";
 import tlsMod from "node:tls";
 import { createSpaceAuth, serverConfig, openServerConfig, mintCreds, newIdentity, isReachable, validateTlsMaterial, probeServedCert } from "../src/index.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 // The broker-TLS fence, proved by EXECUTION rather than by inspecting the rendered config.
 //
@@ -21,7 +22,7 @@ import { createSpaceAuth, serverConfig, openServerConfig, mintCreds, newIdentity
 // Non-circularity is built in: `plaintextConnectAccepted` is asserted TRUE against a plaintext
 // broker in the same run. Without that control, "the plaintext client was refused" would also be
 // satisfied by a probe that is simply broken, or by a broker that never started at all.
-const dir = mkdtempSync(join(tmpdir(), "cotal-tlsserve-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const space = "tlsserve";
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -141,9 +142,12 @@ function freePort(): Promise<number> {
 }
 
 // Every broker this smoke starts, so the finally-block can reap them even when an assertion throws.
-const started: Array<{ tag: string; child: ReturnType<typeof spawn> }> = [];
+const started: Array<{ tag: string; child: ReturnType<typeof spawn>; release: () => void }> = [];
 function killAll(): void {
-  for (const s of started) { try { s.child.kill("SIGKILL"); } catch { /* already gone */ } }
+  for (const s of started) {
+    try { s.child.kill("SIGKILL"); } catch { /* already gone */ }
+    s.release();
+  }
   started.length = 0;
 }
 process.on("exit", killAll);
@@ -152,7 +156,10 @@ async function startBroker(tag: string, conf: string): Promise<{ log: string; ki
   const log = join(dir, `${tag}.log`);
   const fd = openSync(log, "w");
   const child = spawn("nats-server", ["-c", conf], { stdio: ["ignore", fd, fd] });
-  const entry = { tag, child };
+  // Each broker is owned, and each carries the one shared scratch dir: removing it is idempotent
+  // under `force`, and it means whichever broker is still owned when a signal lands takes the
+  // directory with it rather than leaving it to whichever one happened to be reaped last.
+  const entry = { tag, child, release: teardownOnSignal(child, dir) };
   started.push(entry);
   // A broker that dies at boot (bad cert, bound port) must not surface later as a mysterious
   // assertion failure — say so at the point of death, with the log that explains it.
@@ -315,4 +322,7 @@ await sleep(300);
 console.log("tls-serve smoke: OK - cleartext refused by TLS-required listeners in BOTH auth and open mode, served leaf matches disk, controls proved each probe detects a real handshake");
 } finally {
   killAll();
+  // The scratch dir goes with them. Its absence here is why this suite leaked a directory on
+  // every green run: the brokers were reaped and the tree they wrote was not.
+  rmSync(dir, { recursive: true, force: true });
 }

--- a/packages/core/smoke/unfenced-responder.smoke.ts
+++ b/packages/core/smoke/unfenced-responder.smoke.ts
@@ -38,7 +38,7 @@
  * Run: pnpm smoke:unfenced-responder
  */
 import { spawn } from "node:child_process";
-import { mkdtempSync, readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { connect } from "@nats-io/transport-node";
@@ -50,6 +50,7 @@ import {
   type EndpointReply, type EpCaller, type ResolvedService,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let pass = 0, fail = 0;
 const c = (name: string, cond: boolean, extra?: unknown) => {
@@ -80,8 +81,9 @@ const argsContract = compileContract({ root: { type: "object", properties: { n: 
 const outContract = compileContract({ root: { type: "object", properties: { ran: { type: "boolean" } }, required: ["ran"], additionalProperties: false } });
 
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "unfenced-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 await new Promise((r) => setTimeout(r, 900));
 
 const enc = new TextEncoder(), dec = new TextDecoder();
@@ -401,6 +403,10 @@ try {
   await ep.stop().catch(() => {});
   await nc.drain().catch(() => nc.close());
   broker.kill("SIGKILL");
+  // The store dir goes with it. Reaping the broker and leaving its tree is what made this
+  // suite leak a directory on every green run.
+  rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(`\n${fail === 0 ? "PASS" : "FAIL"} — ${pass} passed, ${fail} failed`);

--- a/packages/smoke-kit/src/broker-teardown.ts
+++ b/packages/smoke-kit/src/broker-teardown.ts
@@ -2,10 +2,23 @@
  * Shared smoke helper: own a spawned `nats-server` so it dies when this process is SIGNALLED, not
  * only when the suite returns and its `finally` runs.
  *
- * SCOPE, measured rather than assumed. `finally` teardown is already correct on the normal path: ten
- * `bind-fence` runs on a long-lived box left zero `bindfence-*` brokers and zero store dirs behind.
- * The defect is exactly and only the signal path, because a signalled suite never unwinds its
- * `finally`. So this adds teardown that does not depend on unwinding, and changes nothing else.
+ * SCOPE, AND A CORRECTION TO THE FIRST VERSION OF IT. This helper covers ONE of two defects, and an
+ * earlier draft of this paragraph claimed it covered the only one. It said `finally` teardown is
+ * already correct on the normal path, which was measured — ten `bind-fence` runs on a long-lived box
+ * left zero brokers and zero store dirs — but measured on ONE suite and then stated about all of
+ * them. It does not hold generally. `channels-auth.smoke.ts` has no teardown at all: it passes,
+ * reports `AUTH GRANT CHECKS PASSED`, and leaks its store dir on every green run. Sixty-two of them
+ * had accumulated over four days when that was finally counted.
+ *
+ * So there are two defects, and this helper is only the answer to the second:
+ *
+ *   1. NO NORMAL-PATH TEARDOWN. Nothing to unwind, so the suite leaks whether or not it is killed.
+ *      Six suites are in this state. Ownership does NOT fix them, and worse, it makes them read as
+ *      handled while they keep manufacturing directories on every pass.
+ *   2. TEARDOWN THAT NEVER UNWINDS. The `finally` is correct and the process is SIGNALLED, so it
+ *      never runs. That is what this file exists for, and it changes nothing else.
+ *
+ * Adopting this helper in a suite with defect 1 is a rename, not a fix. Check the normal path first.
  *
  * The two registrations below are INDEPENDENTLY SUFFICIENT under `tsx`, which is worth stating
  * because it is not obvious and it was only established by trying to disable each one: removing


### PR DESCRIPTION
Item 2's next batch, and it opens with a correction rather than a migration.

## The premise was measured on one suite and stated about all of them

#503 shipped this claim in the helper's scope paragraph: `finally` teardown is already correct on
the normal path, so the defect is exactly and only the signal path. The measurement behind it was
real, ten `bind-fence` runs leaving zero brokers and zero store dirs. It was taken on one suite.

It does not hold. `channels-auth.smoke.ts` has no teardown at all. It passes, prints
`AUTH GRANT CHECKS PASSED`, and leaves a store dir behind on every green run. Sixty-two of those
directories had accumulated on a long lived box, the oldest four days old, by the time anyone
counted them.

So the class is two defects, not one:

1. **No normal-path teardown.** Nothing to unwind, so the suite leaks whether or not it is killed.
   Ownership does not fix this. Worse, it makes the suite read as handled while it keeps
   manufacturing directories on every pass.
2. **Teardown that never unwinds.** The `finally` is correct and the process is signalled, so it
   never runs. That is what the helper is for.

Adopting the helper in a suite with defect 1 is a rename, not a fix. The first commit rewrites both
places that carried the overgeneralisation, including the comment on the cell that guards the normal
path, which stays green throughout either way and now says so.

Six suites repo wide are in state 1: three here, three in `implementations/manager`. This PR is the
three in core. Every one was reproduced by directory count before it was touched, and re-counted
after.

## channels-auth had three defects, not one

The leak, then two more found while fixing it, each reproduced first.

**It hardcoded port 4227**, so two concurrent runs collided by construction. Run A passed, run B
failed. **The collision did not report itself as one.** B's broker died with
`bind: address already in use` in its own log; B then reached A's broker; A's trust chain rejected
B's credentials; and the failure surfaced as `AuthorizationError: Authorization Violation` from deep
inside the test. A correct verdict with a diagnosis pointing somewhere else.

**Its boot loop waited on reachability alone**, which is what allowed that: `isReachable` answers
true against a foreign broker squatting the port. It now checks that our own child survived the bind
first, so a bind failure fails as itself. `_boot-broker.ts` already documents this exact hazard; the
suite simply predates it.

The suite also had a `process.on("exit")` hook that killed the broker, which is the likely reason
four days of leaked directories went unnoticed: **the hook silenced the loud half of the defect and
left the quiet half accumulating.**

## Measurements

Each suite, on a green run, counted before and after the fix:

| suite | dirs before fix | dirs after fix | cells |
| --- | --- | --- | --- |
| `channels-auth` | 61 to 62 | 64 to 64 | passes, no cell counter |
| `tls-serve` | 41 to 42 | 42 to 42 | passes, no cell counter |
| `unfenced-responder` | 73 to 74 | 74 to 74 | 34 of 34 both times |

Concurrency, `channels-auth`, two simultaneous runs: rc 0 and rc 1 before, rc 0 and rc 0 after.

The retired prefixes are `cotal-authcheck-`, `cotal-tlsserve-` and `unfenced-`. They now match
nothing by construction, which is worth stating because a retired grep returns zero and reads as
healthy while measuring nothing. The replacement token is `cotal-smoke-broker-`.

## Scope

Three of the 64 broker spawning suites in `packages/core`, chosen because they are the corrective
ones. The remaining 61 are mechanical adoption and follow in tranches. Survey bounds, since a bound
nobody states gets read as a guarantee:

- Broker suites were found by the `spawn("nats-server"` literal. A suite building its arguments in a
  variable is invisible to it, and at least one such suite is known to exist.
- Teardown presence was tested by whether `rmSync` appears in the file at all, not by control flow.
  It cannot tell a teardown that runs from one that is unreachable. An earlier version of the same
  survey tested for `finally {` and wrongly flagged a suite that uses a promise `.finally(`.
- Ports were read by eye after a regex, not from the regex. The regex said six core suites avoid the
  free port helper; reading them, two are genuinely hardcoded, two use a random range, and two take
  an OS assigned port and were false positives.

## Gates

- Each fix reproduced before and verified after, by directory count on a green run.
- `pnpm typecheck` rc=0.
- `pnpm smoke:core-boundary` green.
- No change to `bin/smoke/ci-suites.txt`, none under `docs/`, no manifest or lockfile change.

Test only; the changeset declares no release.
