### PR TITLE
feat(web): order event frames against the backfill, and list chat only

### DIFF
--- a/.changeset/agui-frame-ordering.md
+++ b/.changeset/agui-frame-ordering.md
@@ -19,7 +19,20 @@ incomplete and applied forward. A discontinuity after the baseline is a fault, r
 ends named. The two are never reported as one thing, because the first is what always happens and the
 second is what must never pass unnoticed. A detected gap still draws its frame: holding it back until
 a missing predecessor arrives would hold it forever when that frame is genuinely gone, which turns a
-visible gap into a silent loss.
+visible gap into a silent loss. The retained batch is audited across its whole range and not only at
+its ends, because a hole inside retained history leaves the baseline and the frontier both correct
+and every later frame following contiguously, which is the one discontinuity no live arrival can
+reveal.
+
+What the bootstrap finds is now DRAWN, above the rows, in the all-activity feed and in a channel
+view. Four things are said separately rather than as one warning: frames are missing, a start-up hole
+could not be attributed, a retained prefix had rolled before this reader joined, and history was
+unavailable. The live tap and the history read are two reads with no shared cut, so the first frame
+buffered during the fetch can sit above the retained top with nothing lost at all; that one hole is
+reported as unconfirmed rather than as loss, and a hole between two buffered frames, which arrived
+through the same subscription, still is a fault. A history read that fails is treated as the empty
+batch it cannot be distinguished from, and the surface says so, so the ordering degrades in the open
+rather than quietly.
 
 The all-activity feed and the selected-channel view now MERGE their backfill with what arrived live
 during the fetch instead of assigning over it. The assignment discarded every live arrival in that

--- a/.changeset/agui-frame-ordering.md
+++ b/.changeset/agui-frame-ordering.md
@@ -1,0 +1,41 @@
+---
+"@cotal-ai/web": minor
+---
+
+Order event frames on the dashboard, and stop listing and backfilling every agent's event channel.
+
+The dashboard opens its live feed and only then fetches the backfill, so it is the surface that runs
+the two-phase bootstrap rather than one that can assume an ordered stream. A frame's position in its
+stream is its sequence number, and that is the only thing that can say a frame is MISSING; message-id
+dedupe cannot, because two ids are either equal or they are not, which says nothing about what
+belongs between them. Frames arriving while the fetch is in flight are now held and released in
+sequence order once the batch settles, the baseline is the settled batch's minimum rather than the
+first frame observed, and sequence checking is not armed until the boundary passes. Baselining on
+arrival would read the entire backfill as running backwards, and arming early would read the same
+backfill as a hole.
+
+A baseline above the first sequence means the retained prefix has rolled, so the chain is marked
+incomplete and applied forward. A discontinuity after the baseline is a fault, reported with both
+ends named. The two are never reported as one thing, because the first is what always happens and the
+second is what must never pass unnoticed. A detected gap still draws its frame: holding it back until
+a missing predecessor arrives would hold it forever when that frame is genuinely gone, which turns a
+visible gap into a silent loss.
+
+The all-activity feed and the selected-channel view now MERGE their backfill with what arrived live
+during the fetch instead of assigning over it. The assignment discarded every live arrival in that
+window. Retention hid it, since the backfill re-read the same messages from the broker and they came
+back, and the filter below is what would have turned it into a real loss.
+
+The channel list and the all-activity backfill carry chat only. A channel row is derived from every
+retained concrete subject and the chat stream caps per subject rather than by age, so an unfiltered
+list grows by one row per agent that has ever run and never shrinks: the sidebar fills with machine
+streams, the graph page grows a node for each, and the activity route pays one history round trip per
+event channel to merge results nobody reading chat asked for. The filter runs before the fetch, not
+on its output, so the round trips are not paid and then discarded, and it uses the shared classifier
+rather than a local prefix test, because a human channel called `events.standup` is not
+principal-shaped and must stay where it was being read.
+
+Two things are deliberately left unfiltered. The live feed still carries frames, marked rather than
+dropped, since dropping them would delete the only traffic this surface was just taught to draw.
+History for a channel named explicitly is still served, or the dashboard could render a frame it
+could never fetch.

--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -288,3 +288,5 @@ smoke:agui-render
 smoke:agui-render-parity
 smoke:agui-frame-dispatch
 smoke:view-events-filter
+smoke:event-order
+smoke:web-events-filter

--- a/implementations/web/smoke/channel-authority.smoke.ts
+++ b/implementations/web/smoke/channel-authority.smoke.ts
@@ -414,6 +414,15 @@ async function runBackfillFunction(code: string, fnName: string, file: string, e
   };
   const c = createContext(ctx);
   runInContext(read("../src/web/event-order.js"), c, { filename: "event-order.js" });
+  if (file.includes("app.js")) {
+    // The single-flight state the shipped backfill reads. TAKEN FROM THE FILE, not restated here: one
+    // bootstrap must pair with one settle, so coalescing overlapping callers is part of the backfill
+    // path, and a hand-written stand-in would let this harness keep running after the real declaration
+    // changed underneath it.
+    const decls = read("../src/web/app.js").match(/^let (?:refreshing|selecting) = .*$/gm) ?? [];
+    assert.equal(decls.length, 2, "app.js must declare the single-flight state this harness runs");
+    runInContext(decls.join("\n"), c, { filename: "app.js (state)" });
+  }
   runInContext(`${code}\n__p = ${fnName}();`, c, { filename: file });
   await (ctx.__p as Promise<void>);
   // `entries` is returned rather than `ctx.activity` ON PURPOSE. In `app.js` the backfill assigns

--- a/implementations/web/smoke/channel-authority.smoke.ts
+++ b/implementations/web/smoke/channel-authority.smoke.ts
@@ -404,8 +404,16 @@ async function runBackfillFunction(code: string, fnName: string, file: string, e
     partsText: () => "", shortId: (x: unknown) => x, physics() {}, fitTarget: () => ({ x: 0, y: 0, scale: 1 }),
     cam: { x: 0, y: 0, scale: 1 }, alpha: 0,
     __p: undefined,
+    // `app.js`'s `refresh()` re-arms the shape-B ordering machine before it fetches, so the machine
+    // is a collaborator of the BACKFILL path too. Loaded from the shipped file, not stubbed, for the
+    // same reason as the live path: the entry list this function returns is the one the shipped merge
+    // produced, and a stub would let a broken merge report a correct channel.
+    window: {} as Record<string, unknown>,
+    feedOrder: undefined, channelOrder: undefined, orderNotes: [] as unknown[],
+    noteOrder() {},
   };
   const c = createContext(ctx);
+  runInContext(read("../src/web/event-order.js"), c, { filename: "event-order.js" });
   runInContext(`${code}\n__p = ${fnName}();`, c, { filename: file });
   await (ctx.__p as Promise<void>);
   // `entries` is returned rather than `ctx.activity` ON PURPOSE. In `app.js` the backfill assigns
@@ -464,8 +472,29 @@ function runAppOnMessage(code: string, entry: unknown, selected = "*") {
     selected,
     dmSel: null,
     renderDMs() {}, renderChannels() {}, renderCenter() {},
+    // The shipped `onMessage` now routes every arrival through the shape-B ordering machine, so the
+    // machine is a collaborator this context has to supply. It is loaded from the REAL
+    // `event-order.js` below rather than stubbed, for the reason this whole file exists: a stub that
+    // returned `{emit:[entry]}` would satisfy every cell here while the shipped page held the entry
+    // forever, and the ingress trust rule would be graded against a merge that does not ship.
+    window: {} as Record<string, unknown>,
+    feedOrder: undefined as unknown,
+    channelOrder: undefined as unknown,
+    orderNotes: [] as unknown[],
+    noteOrder(notes: unknown[]) { for (const n of notes) ctx.orderNotes.push(n); },
   };
-  runInContext(`${code}\nonMessage(__entry);`, createContext(ctx), { filename: "app.js" });
+  const c = createContext(ctx);
+  runInContext(read("../src/web/event-order.js"), c, { filename: "event-order.js" });
+  // Both machines are settled immediately: these cells drive the LIVE ingress, and an unsettled
+  // machine would legitimately hold a frame, which is the ordering behaviour its own suite measures
+  // and not the trust rule this one does.
+  runInContext(
+    "feedOrder = window.COTAL_EVENT_ORDER.create(); feedOrder.backfill([]);" +
+      "channelOrder = window.COTAL_EVENT_ORDER.create(); channelOrder.backfill([]);",
+    c,
+    { filename: "event-order bootstrap" },
+  );
+  runInContext(`${code}\nonMessage(__entry);`, c, { filename: "app.js" });
   return ctx;
 }
 

--- a/implementations/web/smoke/event-order.smoke.ts
+++ b/implementations/web/smoke/event-order.smoke.ts
@@ -133,6 +133,7 @@ const seqsOf = (rows: unknown[]): (number | string)[] =>
   });
 const gaps = (notes: Note[]) => notes.filter((n) => n.type === "gap");
 const prefixNotes = (notes: Note[]) => notes.filter((n) => n.type === "prefix-incomplete");
+const straddles = (notes: Note[]) => notes.filter((n) => n.type === "boundary-hole");
 
 console.log("event-order smoke");
 
@@ -395,16 +396,28 @@ console.log("event-order smoke");
 // during it is invisible for the life of the page. That was introduced by the buffering itself, since
 // the code this replaced simply left the live arrivals in place on a failed fetch. So this section
 // runs the REAL `refresh()` and `select()` out of `app.js`, with a fetch that rejects.
+//
+// The harness this builds is shared with §13, §14 and §15, which need the same thing: the shipped
+// bootstrap, driven, rather than a restatement of it.
 {
   const appSrc = readFileSync(join(webSrc, "app.js"), "utf8");
   const sf = ts.createSourceFile("app.js", appSrc, ts.ScriptTarget.ESNext, true, ts.ScriptKind.JS);
-  const wanted = new Set(["refresh", "onMessage", "noteOrder", "select"]);
+  const wanted = new Set(["refresh", "onMessage", "noteOrder", "select", "orderNoticeHtml"]);
+  // The single-flight state the shipped functions read. TAKEN FROM THE FILE, not restated: a
+  // hand-written `let refreshing = null` here would let the harness keep passing after the real
+  // declaration changed, and a bootstrap that coalesces is the whole of blocker 1.
+  const wantedState = new Set(["refreshing", "selecting"]);
   const fns: string[] = [];
+  const state: string[] = [];
   sf.forEachChild((n) => {
     if (ts.isFunctionDeclaration(n) && n.name && wanted.has(n.name.text)) fns.push(appSrc.slice(n.getStart(sf), n.end));
+    if (ts.isVariableStatement(n))
+      for (const d of n.declarationList.declarations)
+        if (ts.isIdentifier(d.name) && wantedState.has(d.name.text)) state.push(appSrc.slice(n.getStart(sf), n.end));
   });
   // Pinned first: a short extraction would make every cell below vacuous.
-  ok("12.1 all four shipped functions are extractable", fns.length === 4, fns.length);
+  ok("12.1 all five shipped functions are extractable", fns.length === 5, fns.length);
+  ok("12.1b and the in-flight state they coalesce on", state.length === 2, state);
 
   type Ctx = Record<string, unknown> & {
     activity: unknown[];
@@ -436,7 +449,7 @@ console.log("event-order smoke");
     const c = createContext(ctx);
     runInContext(readFileSync(join(webSrc, "event-order.js"), "utf8"), c, { filename: "event-order.js" });
     runInContext("feedOrder = window.COTAL_EVENT_ORDER.create(); channelOrder = window.COTAL_EVENT_ORDER.create();", c);
-    runInContext(fns.join("\n"), c, { filename: "app.js" });
+    runInContext([...state, ...fns].join("\n"), c, { filename: "app.js" });
     (ctx as Record<string, unknown>).__ctx = c;
     return ctx as unknown as Ctx;
   };
@@ -475,6 +488,196 @@ console.log("event-order smoke");
     ok("12.10 nothing is left held on that path either", ctx.channelOrder.pendingCount === 0);
     ok("12.11 and it too surfaces the failure", ctx.orderNotes.some((n) => n.type === "backfill-failed"));
   }
+
+  // ── 13. TWO BOOTSTRAPS AT ONCE, which the stock startup performs on every load ──────────────────
+  // Arming a machine and settling it are the two ends of ONE bootstrap. When `refresh()` could be
+  // re-entered between them, the second call rebound `feedOrder` and the first machine, holding
+  // whatever the tap had delivered in that window, became unreachable: its buffer was never drained
+  // and never merged. This is not a hypothetical schedule. The page ends with `refresh(); connect();`
+  // and `connect()`'s open handler calls `refresh()` again, so the second call is the norm, and a
+  // reconnect flap repeats it.
+  {
+    // The structural half: the two call sites this race needs both exist in the shipped file.
+    const startup = /\n\s*refresh\(\);\n\s*connect\(\);/.test(appSrc);
+    const onOpen = /addEventListener\("open",[\s\S]{0,120}?refresh\(\);/.test(appSrc);
+    ok("13.1 the shipped startup calls refresh() and then connect()", startup);
+    ok("13.2 and connect()'s open handler calls refresh() again", onOpen);
+  }
+  {
+    const ctx = page("resolve");
+    const c = (ctx as unknown as { __ctx: ReturnType<typeof createContext> }).__ctx;
+    // Both calls are in flight together, with a frame arriving in between, exactly as the tap would
+    // deliver one between the startup call and the open handler's.
+    (ctx as Record<string, unknown>).__E = frame(7);
+    runInContext("__p = refresh();", c);
+    const first = ctx.feedOrder; // the machine the FIRST call armed, captured while it is in flight
+    runInContext("onMessage(__E);", c);
+    runInContext("__p2 = refresh();", c);
+    await (ctx.__p as Promise<void>).catch(() => undefined);
+    await ((ctx as Record<string, unknown>).__p2 as Promise<void>).catch(() => undefined);
+    ok("13.3 the second call did NOT arm a rival machine", ctx.feedOrder === first);
+    ok("13.4 so the frame held by the first one still reaches the feed", ctx.activity.length === 1, seqsOf(ctx.activity));
+    ok("13.5 and nothing is left held", ctx.feedOrder.pendingCount === 0, ctx.feedOrder.pendingCount);
+  }
+  {
+    // The same race on the channel view, which `refresh()` drives itself: it calls `select(selected)`
+    // on every poll, so two bootstraps for the SAME open channel overlap routinely.
+    const ctx = page("resolve");
+    const c = (ctx as unknown as { __ctx: ReturnType<typeof createContext> }).__ctx;
+    ctx.selected = "events.local.alice";
+    (ctx as Record<string, unknown>).__E = frame(7);
+    runInContext('__p = select("events.local.alice");', c);
+    const first = ctx.channelOrder; // armed by the first selection, captured while it is in flight
+    runInContext("onMessage(__E);", c);
+    runInContext('__p2 = select("events.local.alice");', c);
+    await (ctx.__p as Promise<void>).catch(() => undefined);
+    await ((ctx as Record<string, unknown>).__p2 as Promise<void>).catch(() => undefined);
+    ok("13.6 a second selection of the same channel shares the bootstrap", ctx.channelOrder === first);
+    ok("13.7 so its held frame reaches the channel view", ctx.channelMsgs.length === 1, ctx.channelMsgs.length);
+    ok("13.8 and nothing is left held there either", ctx.channelOrder.pendingCount === 0);
+    ok("13.9 CONTROL: the refresh path is what calls select on a poll", /\n\s*select\(selected\);/.test(appSrc));
+  }
+
+  // ── 14. THE BOUNDARY PASSES ON EVERY BRANCH, not only on all-activity ──────────────────────────
+  // `feedOrder` is re-armed at the top of `refresh()` unconditionally, and the settle used to live
+  // inside the `selected === "*"` branch. So for a reader sitting on a channel, a DM or an agent
+  // drill-down, every live frame was held by a machine that would never settle: absent from the feed,
+  // then discarded wholesale by the next poll's re-arm. A `finally` is the only placement that covers
+  // all four branches AND a throw from any earlier request.
+  for (const branch of ["channel", "dm", "agent"] as const) {
+    const ctx = page("resolve");
+    if (branch === "channel") ctx.selected = "team.backend";
+    if (branch === "dm") ctx.dmSel = { peer: "p", with: "q" };
+    if (branch === "agent") ctx.agentSel = "p";
+    await drive(ctx, "refresh()", frame(9));
+    ok(`14.${branch === "channel" ? 1 : branch === "dm" ? 3 : 5} the boundary passes with a ${branch} open`, ctx.feedOrder.settled === true);
+    ok(`14.${branch === "channel" ? 2 : branch === "dm" ? 4 : 6} and the held frame is not stranded`, ctx.feedOrder.pendingCount === 0, ctx.feedOrder.pendingCount);
+  }
+  {
+    // An EARLIER request throwing, which the failure arm around `/api/activity` never covered:
+    // `/api/roster` is the first fetch in the function and it was unguarded.
+    const ctx = page("resolve");
+    (ctx as Record<string, unknown>).fetch = async (u: string) => {
+      if (u.includes("/api/roster")) throw new Error("network down");
+      return { ok: true, json: async () => [] };
+    };
+    await drive(ctx, "refresh()", frame(9));
+    ok("14.7 a throw from the FIRST request still settles the boundary", ctx.feedOrder.settled === true);
+    ok("14.8 and the frame held during it still reaches the feed", ctx.activity.length === 1, seqsOf(ctx.activity));
+  }
+
+  // ── 15. THE NOTES ARE DRAWN, which is a different claim from computing them ─────────────────────
+  // The notes were collected into an array nothing read: the machine detected a missing frame and the
+  // page said nothing. A gap that reaches only an unused variable is the same silence this lane exists
+  // to remove, one layer up, and it is also what decides whether treating a failed read as an empty
+  // history is an honest degrade or a quiet one.
+  {
+    const c = createContext({ orderNotes: [] as Note[] });
+    runInContext(fns.find((f) => f.startsWith("function orderNoticeHtml")) as string, c);
+    const html = (notes: Note[]) => {
+      (c as unknown as { orderNotes: Note[] }).orderNotes = notes;
+      return runInContext("orderNoticeHtml()", c) as string;
+    };
+    ok("15.1 an ordinary feed draws no notice", html([]) === "");
+    const gapHtml = html([{ type: "gap", expected: 4, got: 7, missing: 3 }]);
+    ok("15.2 a gap is drawn, and says how many frames are missing", /\b3\b/.test(gapHtml) && /missing/.test(gapHtml), gapHtml);
+    const prefixHtml = html([{ type: "prefix-incomplete", baseline: 900 }]);
+    ok("15.3 an evicted prefix is drawn too", prefixHtml !== "" && /not retained/.test(prefixHtml), prefixHtml);
+    // THE ONE THAT ALWAYS HAPPENS ON A LATE JOIN MUST NOT READ LIKE THE ONE THAT MUST NEVER BE
+    // IGNORED. Collapsing them into one banner would spend the reader's attention on retention.
+    ok("15.4 and the two are not the same statement", gapHtml !== prefixHtml && !/missing/.test(prefixHtml));
+    const straddleHtml = html([{ type: "boundary-hole", expected: 4, got: 5, missing: 1 }]);
+    ok("15.5 an unattributable start-up hole is drawn as unconfirmed, not as loss", /unconfirmed/.test(straddleHtml) && !/missing/.test(straddleHtml), straddleHtml);
+    const failHtml = html([{ type: "backfill-failed" } as Note]);
+    ok("15.6 a failed history read is drawn, so the empty-batch settle is not a silent degrade", /history unavailable/.test(failHtml), failHtml);
+    ok("15.7 a fault is marked as one, and not by colour alone", /order-notice fault/.test(gapHtml) && !/fault/.test(prefixHtml));
+
+    // The rendering half: the feed views actually call it. Without this the function could be dead.
+    const drawn = new Set<string>();
+    sf.forEachChild((n) => {
+      if (ts.isFunctionDeclaration(n) && n.name && /^render(AllActivity|Channel)$/.test(n.name.text))
+        if (appSrc.slice(n.getStart(sf), n.end).includes("orderNoticeHtml()")) drawn.add(n.name.text);
+    });
+    ok("15.8 the all-activity view draws it", drawn.has("renderAllActivity"), [...drawn]);
+    ok("15.9 the channel view draws it", drawn.has("renderChannel"), [...drawn]);
+    ok("15.10 and the page styles it", readFileSync(join(webSrc, "index.html"), "utf8").includes(".order-notice"));
+  }
+}
+
+// ── 16. A HOLE INSIDE THE RETAINED BATCH, which no live arrival will ever reveal ─────────────────
+// The minimum, the maximum and the membership set place the baseline and dedupe, and they are not
+// enough to notice that the middle is missing. A batch of 1, 2, 5 has baseline 1 and frontier 6, and
+// every frame after it follows contiguously, so the chain reads healthy forever while two frames are
+// gone. It is the one discontinuity the live path cannot expose, because nothing after it is out of
+// order.
+{
+  const o = API.create();
+  const settled = o.backfill([frame(1), frame(2), frame(5)]);
+  ok("16.1 a hole inside the batch IS reported", gaps(settled.notes).length === 1, settled.notes);
+  ok("16.2 naming both ends and the count", gaps(settled.notes)[0]?.expected === 3 && gaps(settled.notes)[0]?.got === 5 && gaps(settled.notes)[0]?.missing === 2);
+  ok("16.3 and the chain is faulted", o.state(o.chainKeys[0])?.faulted === true);
+  ok("16.4 every retained frame is still drawn", seqsOf(settled.emit).join(",") === "1,2,5");
+  ok("16.5 the frontier is still past the highest", o.state(o.chainKeys[0])?.next === 6);
+
+  // CONTROL: the same walk over a complete batch reports nothing, so 16.1 is not a check that fires
+  // on everything.
+  const o2 = API.create();
+  ok("16.6 CONTROL: a complete batch reports no gap", gaps(o2.backfill([frame(1), frame(2), frame(3)]).notes).length === 0);
+  // A run of one, and two runs, so the report is per BREAK and not per missing number: losing a
+  // thousand frames must be one note naming both ends, not a thousand notes burying it.
+  const o3 = API.create();
+  ok("16.7 a single missing frame is one note", gaps(o3.backfill([frame(1), frame(3)]).notes).length === 1);
+  const o4 = API.create();
+  const two = gaps(o4.backfill([frame(1), frame(3), frame(5)]).notes);
+  ok("16.8 two breaks are two notes", two.length === 2, two);
+  ok("16.9 each naming its own ends", two[0]?.expected === 2 && two[0]?.got === 3 && two[1]?.expected === 4 && two[1]?.got === 5);
+  // Below the baseline is retention, not loss, and must never be reported as a break.
+  const o5 = API.create();
+  const late = o5.backfill([frame(900), frame(901)]);
+  ok("16.10 nothing below the baseline is reported", gaps(late.notes).length === 0, late.notes);
+  ok("16.11 that arm reports the evicted prefix instead", prefixNotes(late.notes).length === 1);
+  // The batch is ts-sorted, so the walk must not depend on row order.
+  const o6 = API.create();
+  ok("16.12 an unsorted batch is walked by seq, not by row", gaps(o6.backfill([frame(5), frame(1), frame(2)]).notes).length === 1);
+}
+
+// ── 17. THE ONE HOLE THIS PAGE CANNOT ATTRIBUTE, and the one it can ─────────────────────────────
+// The live tap and the history read are two reads with no shared cut, and on this page the fetch is
+// issued before the tap is open. So the FIRST buffered frame of a chain can sit above the retained
+// top by more than one with nothing lost at all. Reported as a fault it latched forever on healthy
+// traffic, and the frame that filled the hole did not clear it. Reported as nothing, the page would be
+// claiming an answer it does not have. It is reported as its own kind, and only for the frame that
+// straddles the seam.
+{
+  const o = API.create();
+  o.live(frame(1004)); // buffered while the fetch is in flight
+  const settled = o.backfill([frame(1000), frame(1001), frame(1002)]);
+  ok("17.1 the straddling hole is NOT a gap", gaps(settled.notes).length === 0, settled.notes);
+  ok("17.2 it is reported as its own kind", straddles(settled.notes).length === 1, settled.notes);
+  ok("17.3 naming both ends, so it is not a vague warning", straddles(settled.notes)[0]?.expected === 1003 && straddles(settled.notes)[0]?.got === 1004);
+  ok("17.4 and it does NOT latch the chain as faulted", o.state(o.chainKeys[0])?.faulted === false, o.state(o.chainKeys[0]));
+  // The frame that fills it arrives a moment later. Under the fault reading this cleared nothing.
+  const fill = o.live(frame(1003));
+  ok("17.5 the frame that fills it is admitted", fill.emit.length === 1);
+  ok("17.6 without reporting a gap", gaps(fill.notes).length === 0, fill.notes);
+  ok("17.7 and the chain is still not faulted", o.state(o.chainKeys[0])?.faulted === false);
+  ok("17.8 the stream continues clean", gaps(o.live(frame(1005)).notes).length === 0);
+
+  // ONLY THE FRAME THAT STRADDLES THE SEAM. Every later buffered frame arrived through the SAME tap
+  // as the one before it, and a subscription delivers a subject in order, so a number missing between
+  // two buffered frames was never delivered while the page was listening: a real loss.
+  const o2 = API.create();
+  o2.live(frame(1004));
+  o2.live(frame(1006));
+  const s2 = o2.backfill([frame(1000), frame(1002)]);
+  ok("17.9 a hole between two BUFFERED frames is a gap", gaps(s2.notes).some((g) => g.expected === 1005 && g.got === 1006), s2.notes);
+  ok("17.10 the straddling one is still only unconfirmed", straddles(s2.notes).length === 1, straddles(s2.notes));
+  ok("17.11 and the batch-internal one is a gap too", gaps(s2.notes).some((g) => g.expected === 1001 && g.got === 1002));
+  ok("17.12 so that chain IS faulted", o2.state(o2.chainKeys[0])?.faulted === true);
+  // CONTROL: after the boundary there is no such window, so a hole in live traffic is a hard fault.
+  const o3 = API.create();
+  o3.backfill([frame(10)]);
+  ok("17.13 CONTROL: a post-boundary hole is a gap, not an unconfirmed one", gaps(o3.live(frame(12)).notes).length === 1 && straddles(o3.live(frame(20)).notes).length === 0);
 }
 
 console.log(`event-order smoke: ${cells - failed} passed, ${failed} failed`);

--- a/implementations/web/smoke/event-order.smoke.ts
+++ b/implementations/web/smoke/event-order.smoke.ts
@@ -39,6 +39,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createContext, runInContext } from "node:vm";
+import ts from "typescript";
 import { PAGE } from "../src/web.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -386,6 +387,94 @@ console.log("event-order smoke");
   ok("11.1 chat rows in the batch are preserved", settled.emit.filter((r) => API.frameOf(r) === undefined).length === 2);
   ok("11.2 and the frames still order among themselves", JSON.stringify(seqsOf(settled.emit).filter((s) => s !== "chat")) === JSON.stringify([100, 101]));
   ok("11.3 the batch's own order is not disturbed", API.frameOf(settled.emit[0]) === undefined);
+}
+
+// ── 12. THE BOUNDARY PASSES EVEN WHEN THE FETCH FAILS, driven through the SHIPPED functions ──────
+// Every cell above builds its own inputs, so none of them can see this: `pending` is drained only by
+// `backfill()`, so a rejected history request means the machine never settles and every frame held
+// during it is invisible for the life of the page. That was introduced by the buffering itself, since
+// the code this replaced simply left the live arrivals in place on a failed fetch. So this section
+// runs the REAL `refresh()` and `select()` out of `app.js`, with a fetch that rejects.
+{
+  const appSrc = readFileSync(join(webSrc, "app.js"), "utf8");
+  const sf = ts.createSourceFile("app.js", appSrc, ts.ScriptTarget.ESNext, true, ts.ScriptKind.JS);
+  const wanted = new Set(["refresh", "onMessage", "noteOrder", "select"]);
+  const fns: string[] = [];
+  sf.forEachChild((n) => {
+    if (ts.isFunctionDeclaration(n) && n.name && wanted.has(n.name.text)) fns.push(appSrc.slice(n.getStart(sf), n.end));
+  });
+  // Pinned first: a short extraction would make every cell below vacuous.
+  ok("12.1 all four shipped functions are extractable", fns.length === 4, fns.length);
+
+  type Ctx = Record<string, unknown> & {
+    activity: unknown[];
+    channelMsgs: unknown[];
+    orderNotes: { type: string }[];
+    feedOrder: Order;
+    channelOrder: Order;
+    __p?: Promise<void>;
+  };
+  /** A page-like context running the shipped functions, with `/api/activity` and the per-channel
+   *  history either answering or rejecting. */
+  const page = (mode: "reject" | "resolve"): Ctx => {
+    const ctx = {
+      console,
+      fetch: async (u: string) => {
+        const isBackfill = u.includes("/api/activity") || u.includes("/history");
+        if (isBackfill && mode === "reject") throw new Error("network down");
+        return { ok: true, json: async () => [] };
+      },
+      refreshDerived() {}, renderSidebarNav() {}, renderCenter() {}, renderChannels() {},
+      renderDMs() {}, renderRoster() {}, renderRail() {}, rosterRows: () => [],
+      roster: [], channels: new Map(), dms: [], activity: [] as unknown[], agentSel: null,
+      dmSel: null, selected: "*", unread: new Map(), channelMsgs: [] as unknown[],
+      orderNotes: [] as { type: string }[], isDemo: false, loadSeq: 0,
+      window: {} as Record<string, unknown>,
+      feedOrder: undefined as unknown, channelOrder: undefined as unknown,
+      __p: undefined as Promise<void> | undefined, __E: undefined as unknown,
+    };
+    const c = createContext(ctx);
+    runInContext(readFileSync(join(webSrc, "event-order.js"), "utf8"), c, { filename: "event-order.js" });
+    runInContext("feedOrder = window.COTAL_EVENT_ORDER.create(); channelOrder = window.COTAL_EVENT_ORDER.create();", c);
+    runInContext(fns.join("\n"), c, { filename: "app.js" });
+    (ctx as Record<string, unknown>).__ctx = c;
+    return ctx as unknown as Ctx;
+  };
+  const drive = async (ctx: Ctx, call: string, entry: unknown) => {
+    const c = (ctx as unknown as { __ctx: ReturnType<typeof createContext> }).__ctx;
+    (ctx as Record<string, unknown>).__E = entry;
+    runInContext(`__p = ${call};`, c);
+    runInContext("onMessage(__E);", c); // a frame arrives live while the request is in flight
+    await (ctx.__p as Promise<void>).catch(() => undefined);
+  };
+
+  // The all-activity feed, backfill REJECTING.
+  {
+    const ctx = page("reject");
+    await drive(ctx, "refresh()", frame(1));
+    ok("12.2 a frame held during a FAILED backfill still reaches the feed", ctx.activity.length === 1, ctx.activity.length);
+    ok("12.3 nothing is left held", ctx.feedOrder.pendingCount === 0, ctx.feedOrder.pendingCount);
+    ok("12.4 the boundary passed", ctx.feedOrder.settled === true);
+    ok("12.5 and the failure is SURFACED rather than swallowed", ctx.orderNotes.some((n) => n.type === "backfill-failed"), ctx.orderNotes);
+    ok("12.6 the baseline came from the buffered frame", ctx.feedOrder.state(ctx.feedOrder.chainKeys[0])?.baseline === 1);
+  }
+  // CONTROL: the same harness with the fetch RESOLVING. Without this, 12.2 could be passing because
+  // the harness never held the frame in the first place.
+  {
+    const ctx = page("resolve");
+    await drive(ctx, "refresh()", frame(1));
+    ok("12.7 CONTROL: the same harness with a working fetch also delivers the frame", ctx.activity.length === 1, ctx.activity.length);
+    ok("12.8 CONTROL: and reports no failure note", !ctx.orderNotes.some((n) => n.type === "backfill-failed"));
+  }
+  // The selected-channel view, history REJECTING.
+  {
+    const ctx = page("reject");
+    ctx.selected = "events.local.alice";
+    await drive(ctx, 'select("events.local.alice")', frame(1));
+    ok("12.9 a frame held during a FAILED channel history still reaches that channel's view", ctx.channelMsgs.length === 1, ctx.channelMsgs.length);
+    ok("12.10 nothing is left held on that path either", ctx.channelOrder.pendingCount === 0);
+    ok("12.11 and it too surfaces the failure", ctx.orderNotes.some((n) => n.type === "backfill-failed"));
+  }
 }
 
 console.log(`event-order smoke: ${cells - failed} passed, ${failed} failed`);

--- a/implementations/web/smoke/event-order.smoke.ts
+++ b/implementations/web/smoke/event-order.smoke.ts
@@ -1,0 +1,392 @@
+/**
+ * The shape-B bootstrap: what this surface does when the live tap is delivering frames before the
+ * backfill it should follow has arrived.
+ *
+ * WHY THIS SUITE IS THE ONLY PLACE GAP DETECTION MAY BE CLAIMED FROM. The claim "the dashboard can
+ * tell that a frame is missing" is a claim about ORDER, and every part of the machinery that could
+ * make it true is in `event-order.js`. Until these cells run, nothing in this tree is entitled to say
+ * a gap would be noticed, and the build order this lane follows says so explicitly.
+ *
+ * WHAT IT DRIVES. `event-order.js` is READ OFF DISK and evaluated in a `vm` context with a stub
+ * `window`, exactly as the classic `<script>` runs in the page, and the route table it is served
+ * through is the REAL `PAGE` export. Nothing is restated here, so no cell can pass against a version
+ * that no longer ships.
+ *
+ * THE SHAPE OF THE RACE, since it decides every assertion below. The transport arms its watermark,
+ * goes live, and only then surfaces retained history (`SPEC.md` orders the join that way, and the
+ * page follows it: `connect()` opens the feed and its `open` handler calls `refresh()`). So the FIRST
+ * frame the page sees can be a live one that belongs AFTER frames it has not received yet. Two
+ * consequences are asserted repeatedly and in both directions:
+ *
+ *   · the baseline is the settled history batch's MINIMUM, never the first frame observed
+ *   · gap checking is not armed until the batch settles
+ *
+ * A first-arrival baseline is not merely different, it is wrong in a specific measurable way, so
+ * §5 asserts what it WOULD have produced rather than only what the machine does produce. A cell that
+ * says "no gap was reported" is worthless without a sibling proving this suite can see a gap at all,
+ * so every negative here has a positive control beside it.
+ *
+ * WHAT IT DOES NOT CLAIM. No DOM, no browser, no `MD.render`. It measures the machine and its seam,
+ * not the pixels. It also does not claim the RETAINED arm is reachable from the dashboard's current
+ * UI: with event channels filtered out of `/api/channels`, the sidebar offers no event channel to
+ * select, so the retained-minimum path is reached today by `/api/channels/<name>/history` for a
+ * caller that names one, and by these cells. That gap is stated, not implied.
+ *
+ * Run: pnpm smoke:event-order
+ */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createContext, runInContext } from "node:vm";
+import { PAGE } from "../src/web.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const webSrc = join(here, "..", "src", "web");
+
+let cells = 0;
+let failed = 0;
+const ok = (name: string, cond: boolean, detail?: unknown) => {
+  cells++;
+  if (cond) return;
+  failed++;
+  console.log(`  x FAIL  ${name}${detail === undefined ? "" : `: ${JSON.stringify(detail)}`}`);
+};
+
+const KIND = "ag-ui.frame";
+
+type Note = { type: string; key?: string; baseline?: number; expected?: number; got?: number; missing?: number };
+type Result = { emit: unknown[]; held?: boolean; notes: Note[] };
+interface Order {
+  live(entry: unknown): Result;
+  backfill(batch: unknown): Result;
+  readonly settled: boolean;
+  readonly pendingCount: number;
+  state(key: string): { baseline?: number; next?: number; prefixIncomplete: boolean; faulted: boolean } | undefined;
+  readonly chainKeys: string[];
+}
+interface Api {
+  KIND: string;
+  FIRST_SEQ: number;
+  frameOf(entry: unknown): unknown;
+  chainKey(entry: unknown, frame: unknown): string;
+  create(): Order;
+}
+
+/** The file as the page runs it: a classic script against a bare `window`. */
+function load(): Api {
+  const ctx: { window: Record<string, unknown> } = { window: {} };
+  const c = createContext(ctx);
+  runInContext(readFileSync(join(webSrc, "event-order.js"), "utf8"), c, { filename: "event-order.js" });
+  const api = ctx.window.COTAL_EVENT_ORDER as Api | undefined;
+  assert.ok(api, "event-order.js must register window.COTAL_EVENT_ORDER");
+  return api;
+}
+
+const API = load();
+
+let idSeq = 0;
+/** A feed entry carrying one frame, in the all-activity shape. */
+const frame = (
+  seq: number,
+  opts: { from?: string; epoch?: string; thread?: string; channel?: string } = {},
+) => ({
+  mode: "chat" as const,
+  channel: opts.channel ?? "events.local.alice",
+  msg: {
+    id: `m${++idSeq}`,
+    ts: 1000 + seq,
+    from: { id: opts.from ?? "ID_ALICE", name: "alice", role: "agent" },
+    channel: opts.channel ?? "events.local.alice",
+    parts: [
+      {
+        kind: KIND,
+        protocol: "ag-ui/0.0.57",
+        threadId: opts.thread ?? "T1",
+        runId: "R1",
+        epoch: opts.epoch ?? "E1",
+        seq,
+        events: [{ type: "RUN_STARTED", threadId: opts.thread ?? "T1", runId: "R1" }],
+      },
+    ],
+  },
+});
+
+/** An ordinary chat entry, which this machine must never delay or reorder. */
+const chat = (text: string) => ({
+  mode: "chat" as const,
+  channel: "general",
+  msg: {
+    id: `c${++idSeq}`,
+    ts: 1,
+    from: { id: "ID_HUMAN", name: "dave", role: "human" },
+    channel: "general",
+    parts: [{ kind: "text", text }],
+  },
+});
+
+const seqsOf = (rows: unknown[]): (number | string)[] =>
+  rows.map((r) => {
+    const f = API.frameOf(r) as { seq: number } | undefined;
+    return f ? f.seq : "chat";
+  });
+const gaps = (notes: Note[]) => notes.filter((n) => n.type === "gap");
+const prefixNotes = (notes: Note[]) => notes.filter((n) => n.type === "prefix-incomplete");
+
+console.log("event-order smoke");
+
+// ── 1. the seam: served, loaded, registered, and loaded before its consumer ───────────────────────
+{
+  const row = PAGE["/event-order.js"];
+  ok("1.1 the machine is served by the real route table", row !== undefined);
+  ok("1.2 the served path is the file this suite drove", row?.path === join(webSrc, "event-order.js"));
+  ok("1.3 served as javascript", typeof row?.type === "string" && row.type.includes("javascript"));
+
+  const html = readFileSync(join(webSrc, "index.html"), "utf8");
+  const orderAt = html.indexOf("/event-order.js");
+  const appAt = html.indexOf("/app.js");
+  ok("1.4 the page loads the machine", orderAt !== -1);
+  // A classic script that loads AFTER its consumer is an absent script as far as the consumer's
+  // module-scope initialisation is concerned, and `app.js` calls `create()` at module scope.
+  ok("1.5 loaded BEFORE app.js, which calls create() at module scope", orderAt !== -1 && appAt !== -1 && orderAt < appAt);
+
+  ok("1.6 the wire kind is the frame kind", API.KIND === KIND);
+  ok("1.7 the first published seq is 1", API.FIRST_SEQ === 1);
+}
+
+// ── 2. chat is never held, never reordered ───────────────────────────────────────────────────────
+{
+  const o = API.create();
+  const r = o.live(chat("hello"));
+  ok("2.1 a chat entry emits immediately, before any boundary", r.emit.length === 1);
+  ok("2.2 and is not held", r.held === false && o.pendingCount === 0);
+  ok("2.3 and produces no notes", r.notes.length === 0);
+
+  // The latency claim: a held frame must not block the chat behind it.
+  const o2 = API.create();
+  o2.live(frame(7));
+  const after = o2.live(chat("still flowing"));
+  ok("2.4 chat behind a HELD frame still passes straight through", after.emit.length === 1);
+  ok("2.5 while the frame is still held", o2.pendingCount === 1);
+}
+
+// ── 3. before the boundary a frame is held, and NOTHING is graded ────────────────────────────────
+{
+  const o = API.create();
+  const r = o.live(frame(1003));
+  ok("3.1 a live frame before the boundary is held", r.emit.length === 0 && r.held === true);
+  ok("3.2 held count is 1", o.pendingCount === 1);
+  ok("3.3 not settled", o.settled === false);
+  ok("3.4 no note is produced while holding", r.notes.length === 0);
+
+  // Gap checking is NOT armed yet: 1003 then 1005 is a hole, and it must not be reported here.
+  const r2 = o.live(frame(1005));
+  ok("3.5 a hole between two HELD frames reports nothing before the boundary", gaps(r2.notes).length === 0);
+  ok("3.6 both are still held", o.pendingCount === 2);
+  ok("3.7 no chain has been graded yet", o.chainKeys.length === 0);
+}
+
+// ── 4. THE REQUIRED ROW: live ahead of the retained range ────────────────────────────────────────
+// The tap is open and the fetch is in flight. A live frame at seq 1003 arrives BEFORE retained
+// 1000-1002. Baseline must be the retained minimum, the live frame must be released in seq order,
+// and no gap may be reported.
+{
+  const o = API.create();
+  const live = o.live(frame(1003));
+  ok("4.1 the live frame is held rather than emitted first", live.emit.length === 0);
+
+  const settled = o.backfill([frame(1000), frame(1001), frame(1002)]);
+  ok("4.2 released in seq order, retained first", JSON.stringify(seqsOf(settled.emit)) === JSON.stringify([1000, 1001, 1002, 1003]));
+  ok("4.3 NO gap is reported", gaps(settled.notes).length === 0, settled.notes);
+  ok("4.4 nothing is left held", o.pendingCount === 0);
+  ok("4.5 the boundary has passed", o.settled === true);
+
+  const key = o.chainKeys[0];
+  const st = o.state(key);
+  ok("4.6 the baseline is the RETAINED minimum, not the first frame observed", st?.baseline === 1000, st);
+  ok("4.7 prefix-incomplete, because the baseline is above the first seq", st?.prefixIncomplete === true);
+  ok("4.8 and it is a marker, NOT a fault", st?.faulted === false);
+  ok("4.9 the prefix note names its baseline", prefixNotes(settled.notes)[0]?.baseline === 1000);
+  ok("4.10 next is one past the highest applied", st?.next === 1004);
+
+  // THE POSITIVE CONTROL for 4.3 and 4.6, and the reason this row is worth asserting. Had the
+  // baseline been the first frame OBSERVED (1003), the retained range would have read as three
+  // frames arriving below the baseline and 1003 would have been the only thing applied. Asserting
+  // "no gap" without showing the wrong answer differs is asserting that nothing happened.
+  ok("4.11 CONTROL: a first-arrival baseline would have differed", 1003 !== st?.baseline);
+}
+
+// ── 4b. the batch is sorted by `ts`, and `ts` is not `seq` ───────────────────────────────────────
+// The server merges channels and sorts the union by timestamp, and a frame's timestamp is set by its
+// producer. So the batch's FIRST frame is not necessarily its lowest `seq`, and a baseline taken from
+// the first row rather than the minimum would be wrong in exactly the direction that manufactures a
+// gap under it.
+{
+  const o = API.create();
+  const settled = o.backfill([frame(1002), frame(1000), frame(1001)]);
+  const st = o.state(o.chainKeys[0]);
+  ok("4.12 the baseline is the batch MINIMUM, not its first row", st?.baseline === 1000, st);
+  ok("4.13 CONTROL: the batch's first row was NOT its minimum", (API.frameOf(settled.emit[0]) as { seq: number }).seq === 1002);
+  ok("4.14 no gap is reported for a batch that is complete but unsorted", gaps(settled.notes).length === 0, settled.notes);
+  ok("4.15 next is past the highest, not past the last", st?.next === 1003);
+}
+
+// ── 5. the empty-history arm: the baseline is the earliest BUFFERED frame ────────────────────────
+{
+  const o = API.create();
+  o.live(frame(5)); // arrives first
+  o.live(frame(3)); // arrives second, belongs first
+  const settled = o.backfill([]);
+  ok("5.1 an empty history batch baselines on the earliest buffered frame", o.state(o.chainKeys[0])?.baseline === 3);
+  ok("5.2 released in seq order, not arrival order", JSON.stringify(seqsOf(settled.emit)) === JSON.stringify([3, 5]));
+  // 3 is the baseline and 5 is two above it, so the hole at 4 is above the baseline and IS a fault.
+  ok("5.3 a hole above the baseline is reported", gaps(settled.notes).length === 1, settled.notes);
+  ok("5.4 the gap names both ends", gaps(settled.notes)[0]?.expected === 4 && gaps(settled.notes)[0]?.got === 5);
+  ok("5.5 prefix-incomplete too, since 3 > 1", o.state(o.chainKeys[0])?.prefixIncomplete === true);
+}
+
+// ── 6. a baseline at the first seq is complete from origin ───────────────────────────────────────
+{
+  const o = API.create();
+  const settled = o.backfill([frame(1), frame(2)]);
+  const st = o.state(o.chainKeys[0]);
+  ok("6.1 baseline 1 is NOT prefix-incomplete", st?.prefixIncomplete === false, st);
+  ok("6.2 and produces no prefix note", prefixNotes(settled.notes).length === 0);
+  ok("6.3 both frames are emitted", settled.emit.length === 2);
+
+  // seq 0 is structurally valid (the validator admits any non-negative safe integer) and no emitter
+  // produces it. It must not be reported as an evicted prefix.
+  const o2 = API.create();
+  o2.backfill([frame(0)]);
+  ok("6.4 a seq 0 baseline is not reported as an evicted prefix", o2.state(o2.chainKeys[0])?.prefixIncomplete === false);
+}
+
+// ── 7. after the boundary, a discontinuity is a fault ────────────────────────────────────────────
+{
+  const o = API.create();
+  o.backfill([frame(10)]);
+  const good = o.live(frame(11));
+  ok("7.1 the contiguous successor reports nothing", gaps(good.notes).length === 0);
+  ok("7.2 and is emitted", good.emit.length === 1);
+
+  const hole = o.live(frame(14));
+  ok("7.3 a post-baseline discontinuity IS reported", gaps(hole.notes).length === 1, hole.notes);
+  ok("7.4 naming what is missing, not merely that something is", gaps(hole.notes)[0]?.expected === 12 && gaps(hole.notes)[0]?.got === 14 && gaps(hole.notes)[0]?.missing === 2);
+  ok("7.5 the chain is faulted", o.state(o.chainKeys[0])?.faulted === true);
+  // DETECTION IS NOT RECOVERY. Holding 14 back until 12 and 13 turn up would hold it forever when
+  // they are genuinely gone, turning a visible gap into the silent loss this lane exists to remove.
+  ok("7.6 and the frame is still DRAWN, not withheld", hole.emit.length === 1);
+
+  // One gap must report once. Reporting on every later frame would bury the event that matters.
+  const next = o.live(frame(15));
+  ok("7.7 the frame after a gap does not re-report it", gaps(next.notes).length === 0, next.notes);
+  ok("7.8 and is emitted", next.emit.length === 1);
+}
+
+// ── 8. duplicates: the backfill and the tap both carry one frame ─────────────────────────────────
+{
+  const o = API.create();
+  const dup = frame(21);
+  o.live(dup);
+  const settled = o.backfill([dup]);
+  ok("8.1 a frame in BOTH the batch and the buffer is emitted once", seqsOf(settled.emit).filter((s) => s === 21).length === 1, seqsOf(settled.emit));
+
+  const again = o.live(frame(21));
+  ok("8.2 a re-delivered seq after the boundary is dropped, not re-drawn", again.emit.length === 0);
+  ok("8.3 and is not mistaken for a gap", gaps(again.notes).length === 0);
+}
+
+// ── 9. chains are separate, and the key is what keeps them apart ─────────────────────────────────
+{
+  // Same runId, same threadId, same seq, DIFFERENT epoch: two writers' (runId, seq) pairs collide by
+  // construction, so epoch is the only thing that makes a stream its own.
+  const o = API.create();
+  o.backfill([frame(50, { epoch: "E1" }), frame(50, { epoch: "E2" })]);
+  ok("9.1 two epochs are two chains", o.chainKeys.length === 2, o.chainKeys);
+  const a = o.live(frame(51, { epoch: "E1" }));
+  const b = o.live(frame(51, { epoch: "E2" }));
+  ok("9.2 each advances independently, no cross-chain gap", gaps(a.notes).length === 0 && gaps(b.notes).length === 0);
+
+  const o2 = API.create();
+  o2.backfill([frame(50, { from: "ID_A" }), frame(50, { from: "ID_B" })]);
+  ok("9.3 two senders are two chains", o2.chainKeys.length === 2);
+
+  const o3 = API.create();
+  o3.backfill([frame(50, { thread: "T1" }), frame(50, { thread: "T2" })]);
+  ok("9.4 two threads are two chains", o3.chainKeys.length === 2);
+
+  // A thread id is a producer-supplied string. If the key were built by joining with a separator,
+  // an id containing that separator could fuse two chains, and a fused chain HIDES a gap.
+  const o4 = API.create();
+  o4.backfill([frame(50, { thread: 'x","E1","y' }), frame(50, { thread: "z" })]);
+  ok("9.5 a thread id containing the key's own punctuation does not fuse two chains", o4.chainKeys.length === 2, o4.chainKeys);
+}
+
+// ── 10. what is not orderable passes through, and nothing here throws ───────────────────────────
+{
+  const o = API.create();
+  const bad = (seq: unknown) => {
+    const e = frame(1);
+    (e.msg.parts[0] as unknown as { seq: unknown }).seq = seq;
+    return e;
+  };
+  for (const [label, value] of [
+    ["absent", undefined],
+    ["a string", "3"],
+    ["negative", -1],
+    ["fractional", 1.5],
+    ["NaN", Number.NaN],
+    ["unsafe", Number.MAX_SAFE_INTEGER + 2],
+  ] as [string, unknown][]) {
+    const r = o.live(bad(value));
+    ok(`10.1 a frame whose seq is ${label} passes through rather than being held`, r.emit.length === 1 && r.held === false);
+  }
+  ok("10.2 none of them were buffered", o.pendingCount === 0);
+
+  // `frameOf` answers a ROUTING question, so it must survive anything the page can hand it.
+  const hostile: unknown[] = [
+    null,
+    undefined,
+    42,
+    "frame",
+    true,
+    {},
+    { msg: null },
+    { msg: { parts: null } },
+    { msg: { parts: "nope" } },
+    { msg: { parts: [null, undefined, 7] } },
+    { msg: { get parts() { throw new Error("boom"); } } },
+    new Proxy({}, { get() { throw new Error("hostile"); } }),
+  ];
+  let threw: string | undefined;
+  for (const h of hostile) {
+    try {
+      API.frameOf(h);
+      o.live(h);
+    } catch (e) {
+      threw = `${String((e as Error).message)} on ${JSON.stringify(h)}`;
+    }
+  }
+  ok("10.3 no hostile input makes the machine throw", threw === undefined, threw);
+  // CONTROL: the hostile list must actually be reaching a property read, or 10.3 passes vacuously.
+  let controlThrew = false;
+  try {
+    (hostile[10] as { msg: { parts: unknown } }).msg.parts;
+  } catch {
+    controlThrew = true;
+  }
+  ok("10.4 CONTROL: the throwing-getter input really does throw when read directly", controlThrew);
+}
+
+// ── 11. a mixed batch: chat and frames settle together ──────────────────────────────────────────
+{
+  const o = API.create();
+  o.live(frame(101));
+  const settled = o.backfill([chat("older"), frame(100), chat("newer")]);
+  ok("11.1 chat rows in the batch are preserved", settled.emit.filter((r) => API.frameOf(r) === undefined).length === 2);
+  ok("11.2 and the frames still order among themselves", JSON.stringify(seqsOf(settled.emit).filter((s) => s !== "chat")) === JSON.stringify([100, 101]));
+  ok("11.3 the batch's own order is not disturbed", API.frameOf(settled.emit[0]) === undefined);
+}
+
+console.log(`event-order smoke: ${cells - failed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/implementations/web/smoke/fixtures/event-order.mutations.json
+++ b/implementations/web/smoke/fixtures/event-order.mutations.json
@@ -1,0 +1,61 @@
+{
+  "command": "pnpm smoke:event-order",
+  "mutations": [
+    {
+      "name": "O1 the baseline is taken from the batch's first row instead of its minimum, so a history batch sorted by timestamp rather than by seq baselines on whichever frame the producer stamped earliest and manufactures a gap beneath it",
+      "file": "implementations/web/src/web/event-order.js",
+      "find": "          if (c.baseline === undefined || f.seq < c.baseline) c.baseline = f.seq;",
+      "replace": "          if (c.baseline === undefined) c.baseline = f.seq;",
+      "expectRed": "4.12 the baseline is the batch MINIMUM, not its first row"
+    },
+    {
+      "name": "O2 the buffered frames are released in arrival order instead of seq order, so a frame that arrived early is drawn before the frames it comes after and the reader sees the stream run backwards",
+      "file": "implementations/web/src/web/event-order.js",
+      "find": "        heldFrames.sort((a, b) => (a.frame.seq - b.frame.seq) || (a.i - b.i));\n",
+      "replace": "",
+      "expectRed": "5.2 released in seq order, not arrival order"
+    },
+    {
+      "name": "O3 live frames are no longer held before the boundary, which is the first-arrival baseline this design exists to refuse: the first frame observed becomes the baseline and the retained range that follows reads as arriving beneath it",
+      "file": "implementations/web/src/web/event-order.js",
+      "find": "        if (!settled) {\n          pending.push(entry);\n          return { emit: [], held: true, notes: [] };\n        }\n",
+      "replace": "",
+      "expectRed": "3.1 a live frame before the boundary is held"
+    },
+    {
+      "name": "O4 prefix-incomplete is reported at the first sequence too, so every chain that is complete from origin is marked as having lost its prefix and the marker stops meaning anything",
+      "file": "implementations/web/src/web/event-order.js",
+      "find": "          c.prefixIncomplete = c.baseline > FIRST_SEQ;",
+      "replace": "          c.prefixIncomplete = c.baseline >= FIRST_SEQ;",
+      "expectRed": "6.1 baseline 1 is NOT prefix-incomplete"
+    },
+    {
+      "name": "O5 the gap note and the fault flag are dropped, so a missing frame is applied forward silently: the consumer's sequence shows no hole and the wire shows nothing wrong",
+      "file": "implementations/web/src/web/event-order.js",
+      "find": "        notes.push({ type: \"gap\", key, expected: c.next, got: seq, missing: seq - c.next });\n        c.faulted = true;\n",
+      "replace": "",
+      "expectRed": "7.3 a post-baseline discontinuity IS reported"
+    },
+    {
+      "name": "O6 epoch leaves the chain key, so two writers whose runId and seq collide by construction are folded into one chain and each one's frames read as gaps in the other's",
+      "file": "implementations/web/src/web/event-order.js",
+      "find": "      typeof frame.epoch === \"string\" ? frame.epoch : null,\n",
+      "replace": "",
+      "expectRed": "9.1 two epochs are two chains"
+    },
+    {
+      "name": "O7 the frontier only advances on an exact match, so one lost frame re-reports on every frame that follows it and the single event that mattered is buried under repetitions of itself",
+      "file": "implementations/web/src/web/event-order.js",
+      "find": "      if (seq >= c.next) c.next = seq + 1;",
+      "replace": "      if (seq === c.next) c.next = seq + 1;",
+      "expectRed": "7.7 the frame after a gap does not re-report it"
+    },
+    {
+      "name": "O8 the seq check leaves the frame test, so a part whose seq is a string or absent is treated as orderable: it is held at a boundary it can never satisfy and compared with arithmetic that yields nothing",
+      "file": "implementations/web/src/web/event-order.js",
+      "find": "        if (p && typeof p === \"object\" && p.kind === KIND && isSeq(p.seq)) return p;",
+      "replace": "        if (p && typeof p === \"object\" && p.kind === KIND) return p;",
+      "expectRed": "10.1 a frame whose seq is a string passes through rather than being held"
+    }
+  ]
+}

--- a/implementations/web/smoke/fixtures/event-order.mutations.json
+++ b/implementations/web/smoke/fixtures/event-order.mutations.json
@@ -32,7 +32,7 @@
     {
       "name": "O5 the gap note and the fault flag are dropped, so a missing frame is applied forward silently: the consumer's sequence shows no hole and the wire shows nothing wrong",
       "file": "implementations/web/src/web/event-order.js",
-      "find": "        notes.push({ type: \"gap\", key, expected: c.next, got: seq, missing: seq - c.next });\n        c.faulted = true;\n",
+      "find": "          notes.push({ type: \"gap\", ...hole });\n          c.faulted = true;\n",
       "replace": "",
       "expectRed": "7.3 a post-baseline discontinuity IS reported"
     },
@@ -58,18 +58,88 @@
       "expectRed": "10.1 a frame whose seq is a string passes through rather than being held"
     },
     {
-      "name": "O9 the activity backfill loses its failure arm, which restores the defect the buffering introduced: a rejected request never settles the machine, so every frame held during it stays invisible for the life of the page and nothing on screen says so",
+      "name": "O9 the activity backfill loses its failure arm, so a rejected request degrades the ordering with nothing on screen saying so: the settle still happens, and the reader is told the frames are complete when the half that would have proved it was never read",
       "file": "implementations/web/src/web/app.js",
-      "find": "    let backfilled;\n    try {\n      backfilled = await (await fetch(\"/api/activity?limit=200\")).json();\n    } catch (err) {\n      backfilled = [];\n      noteOrder([{ type: \"backfill-failed\", reason: err && err.message ? err.message : String(err) }]);\n    }\n    activity = backfilled;",
-      "replace": "    activity = await (await fetch(\"/api/activity?limit=200\")).json();",
-      "expectRed": "12.2 a frame held during a FAILED backfill still reaches the feed"
+      "find": "      try {\n        batch = await (await fetch(\"/api/activity?limit=200\")).json();\n      } catch (err) {\n        batch = [];\n        noteOrder([{ type: \"backfill-failed\", reason: err && err.message ? err.message : String(err) }]);\n      }",
+      "replace": "      batch = await (await fetch(\"/api/activity?limit=200\")).json();",
+      "expectRed": "12.5 and the failure is SURFACED rather than swallowed"
     },
     {
-      "name": "O10 the selected-channel history loses the same arm, so opening a channel whose history read fails holds that channel's frames out of the very view that was opened to look at them",
+      "name": "O10 the selected-channel history loses the same arm, so a channel whose history read failed is presented as a channel whose history was empty",
       "file": "implementations/web/src/web/app.js",
-      "find": "    let msgs;\n    try {\n      msgs = await (await fetch(`/api/channels/${encodeURIComponent(key)}/history?limit=200`)).json();\n    } catch (err) {\n      msgs = [];\n      noteOrder([{ type: \"backfill-failed\", channel: key, reason: err && err.message ? err.message : String(err) }]);\n    }",
-      "replace": "    const msgs = await (await fetch(`/api/channels/${encodeURIComponent(key)}/history?limit=200`)).json();",
-      "expectRed": "12.9 a frame held during a FAILED channel history still reaches that channel's view"
+      "find": "      msgs = await (await fetch(`/api/channels/${encodeURIComponent(key)}/history?limit=200`)).json();\n    } catch (err) {\n      msgs = [];\n      noteOrder([{ type: \"backfill-failed\", channel: key, reason: err && err.message ? err.message : String(err) }]);\n    } finally {",
+      "replace": "      msgs = await (await fetch(`/api/channels/${encodeURIComponent(key)}/history?limit=200`)).json();\n    } finally {",
+      "expectRed": "12.11 and it too surfaces the failure"
+    },
+    {
+      "name": "O11 the feed bootstrap loses its single flight, so the stock startup's second call re-arms the machine while the first is still fetching and the frames the first one is holding become unreachable",
+      "file": "implementations/web/src/web/app.js",
+      "find": "  if (refreshing) return refreshing;\n",
+      "replace": "",
+      "expectRed": "13.4 so the frame held by the first one still reaches the feed"
+    },
+    {
+      "name": "O12 the channel bootstrap loses its single flight, so the poll's own repeated select for the SAME open channel supersedes the load in flight and the frames it held are dropped instead of drawn",
+      "file": "implementations/web/src/web/app.js",
+      "find": "    if (selecting && selecting.key === key) return selecting.promise;\n",
+      "replace": "",
+      "expectRed": "13.7 so its held frame reaches the channel view"
+    },
+    {
+      "name": "O13 the settle goes back inside the all-activity branch while the arm stays unconditional, so a reader sitting on a channel, a DM or an agent holds every live frame in a machine that never settles",
+      "file": "implementations/web/src/web/app.js",
+      "find": "    const settled = feedOrder.backfill(activity);",
+      "replace": "    const settled = selected === \"*\" ? feedOrder.backfill(activity) : { emit: [], notes: [] };",
+      "expectRed": "14.1 the boundary passes with a channel open"
+    },
+    {
+      "name": "O14 the settle moves off the failure path and back into the normal tail, so a throw from any request before the backfill leaves the boundary unpassed: the roster read was one of those, and no failure arm around the backfill covers it",
+      "file": "implementations/web/src/web/app.js",
+      "find": "\n  } finally {\n",
+      "replace": "\n  } catch (__e) {\n    throw __e;\n  }\n  {\n",
+      "expectRed": "14.7 a throw from the FIRST request still settles the boundary"
+    },
+    {
+      "name": "O15 the retained range is no longer audited, only its ends, so a batch whose middle is missing reads healthy forever: the baseline is right, the frontier is right, every later frame follows contiguously, and nothing on the live path can ever reveal it",
+      "file": "implementations/web/src/web/event-order.js",
+      "find": "          let run = 0;\n          for (let s = c.baseline + 1; s <= highest; s++) {\n            if (!c.seen.has(s)) {\n              run++;\n              continue;\n            }\n            if (run > 0) {\n              notes.push({ type: \"gap\", key, expected: s - run, got: s, missing: run });\n              c.faulted = true;\n              run = 0;\n            }\n          }\n",
+      "replace": "",
+      "expectRed": "16.1 a hole inside the batch IS reported"
+    },
+    {
+      "name": "O16 the hole that straddles the bootstrap seam is reported as a hard fault again, which fires on a healthy continuously publishing stream and latches: the frame that fills it a moment later clears nothing",
+      "file": "implementations/web/src/web/event-order.js",
+      "find": "        if (straddle) {",
+      "replace": "        if (false) {",
+      "expectRed": "17.1 the straddling hole is NOT a gap"
+    },
+    {
+      "name": "O17 every released frame is treated as straddling the seam, not just the first of its chain, so a frame missing BETWEEN two buffered arrivals of the same tap is downgraded to unconfirmed when it is a real loss",
+      "file": "implementations/web/src/web/event-order.js",
+      "find": "          const straddle = !c.released;",
+      "replace": "          const straddle = true;",
+      "expectRed": "17.9 a hole between two BUFFERED frames is a gap"
+    },
+    {
+      "name": "O18 the all-activity view stops drawing the notice, so the machine detects a missing frame and the surface the reader is actually looking at says nothing",
+      "file": "implementations/web/src/web/app.js",
+      "find": "    ${orderNoticeHtml()}\n    <div class=\"feed\">",
+      "replace": "    <div class=\"feed\">",
+      "expectRed": "15.8 the all-activity view draws it"
+    },
+    {
+      "name": "O19 the channel view stops drawing it, so a reader who opened one channel to look at its frames is the one reader who cannot be told a frame is missing from it",
+      "file": "implementations/web/src/web/app.js",
+      "find": "    ${orderNoticeHtml()}\n    <div class=\"clist\">",
+      "replace": "    <div class=\"clist\">",
+      "expectRed": "15.9 the channel view draws it"
+    },
+    {
+      "name": "O20 the unattributable start-up hole stops being drawn, so the page reports the one thing it could not find out as though it had found nothing wrong",
+      "file": "implementations/web/src/web/app.js",
+      "find": "  if (races.length) parts.push(`${races.length} possible ordering race${races.length === 1 ? \"\" : \"s\"} at start-up, unconfirmed`);\n",
+      "replace": "",
+      "expectRed": "15.5 an unattributable start-up hole is drawn as unconfirmed, not as loss"
     }
   ]
 }

--- a/implementations/web/smoke/fixtures/event-order.mutations.json
+++ b/implementations/web/smoke/fixtures/event-order.mutations.json
@@ -56,6 +56,20 @@
       "find": "        if (p && typeof p === \"object\" && p.kind === KIND && isSeq(p.seq)) return p;",
       "replace": "        if (p && typeof p === \"object\" && p.kind === KIND) return p;",
       "expectRed": "10.1 a frame whose seq is a string passes through rather than being held"
+    },
+    {
+      "name": "O9 the activity backfill loses its failure arm, which restores the defect the buffering introduced: a rejected request never settles the machine, so every frame held during it stays invisible for the life of the page and nothing on screen says so",
+      "file": "implementations/web/src/web/app.js",
+      "find": "    let backfilled;\n    try {\n      backfilled = await (await fetch(\"/api/activity?limit=200\")).json();\n    } catch (err) {\n      backfilled = [];\n      noteOrder([{ type: \"backfill-failed\", reason: err && err.message ? err.message : String(err) }]);\n    }\n    activity = backfilled;",
+      "replace": "    activity = await (await fetch(\"/api/activity?limit=200\")).json();",
+      "expectRed": "12.2 a frame held during a FAILED backfill still reaches the feed"
+    },
+    {
+      "name": "O10 the selected-channel history loses the same arm, so opening a channel whose history read fails holds that channel's frames out of the very view that was opened to look at them",
+      "file": "implementations/web/src/web/app.js",
+      "find": "    let msgs;\n    try {\n      msgs = await (await fetch(`/api/channels/${encodeURIComponent(key)}/history?limit=200`)).json();\n    } catch (err) {\n      msgs = [];\n      noteOrder([{ type: \"backfill-failed\", channel: key, reason: err && err.message ? err.message : String(err) }]);\n    }",
+      "replace": "    const msgs = await (await fetch(`/api/channels/${encodeURIComponent(key)}/history?limit=200`)).json();",
+      "expectRed": "12.9 a frame held during a FAILED channel history still reaches that channel's view"
     }
   ]
 }

--- a/implementations/web/smoke/fixtures/web-events-filter.mutations.json
+++ b/implementations/web/smoke/fixtures/web-events-filter.mutations.json
@@ -1,0 +1,26 @@
+{
+  "command": "pnpm smoke:web-events-filter",
+  "mutations": [
+    {
+      "name": "F1 the derivation is replaced by a bare prefix test, which is the silent chat loss this classifier was moved into core to remove: a human channel called events.standup is swept out of the sidebar it was being read in",
+      "file": "implementations/web/src/web.ts",
+      "find": "  return rows.filter((row) => !isEventChannel(row.channel));",
+      "replace": "  return rows.filter((row) => !row.channel.startsWith(\"events.\"));",
+      "expectRed": "1.3 `events.standup` STAYS: prefix-shaped, not principal-shaped"
+    },
+    {
+      "name": "F2 the backfill filters nothing before it fetches, so every event channel is still asked for and its history still merged: the answer looks the same and the cost is exactly what it was",
+      "file": "implementations/web/src/web.ts",
+      "find": "  const chans = chatOnly(await ep.listChannels());",
+      "replace": "  const chans = await ep.listChannels();",
+      "expectRed": "2.1 no event channel was ever ASKED for"
+    },
+    {
+      "name": "F3 the channel list route drops its filter, so the sidebar and the graph page grow one row per agent that has ever run while the backfill stays clean and the two surfaces disagree about what a channel is",
+      "file": "implementations/web/src/web.ts",
+      "find": "      const channels = chatOnly(await ep.listChannels());",
+      "replace": "      const channels = await ep.listChannels();",
+      "expectRed": "5.1 SOURCE-SHAPE: chatOnly has exactly two call sites"
+    }
+  ]
+}

--- a/implementations/web/smoke/web-events-filter.smoke.ts
+++ b/implementations/web/smoke/web-events-filter.smoke.ts
@@ -1,0 +1,173 @@
+/**
+ * The dashboard lists and backfills CHAT, and an agent's event channel is not chat.
+ *
+ * WHAT THE DEFECT WAS. `/api/channels` and `/api/activity` both walked `listChannels()` with no
+ * classifier: the sidebar listed one row per agent that has ever run, the graph page grew a hub node
+ * for each, and the activity route issued one `channelHistory` round trip PER EVENT CHANNEL and then
+ * merged the results into a global top-N nobody reading chat asked for. `listChannels()` derives a
+ * row from every retained concrete subject and the chat stream caps per subject rather than by age,
+ * so those rows never age out: the cost scales with the number of agents ever run.
+ *
+ * THE CLAIM THIS SUITE EXISTS TO MAKE IS ABOUT ORDER, NOT ABOUT OUTPUT. Filtering the merged result
+ * would produce the same JSON while still paying every round trip. So the load-bearing cell is not
+ * "no event channel appears in the answer" but "no event channel was ever ASKED FOR", and the mock
+ * records exactly that. A suite that only checked the output would pass against the version this
+ * change replaces.
+ *
+ * IT USES THE REAL CLASSIFIER, NOT A LOCAL PREFIX TEST. `isEventChannel` is a full derivation rather
+ * than `startsWith("events.")`, and the difference is a silent chat loss: a human channel called
+ * `events.standup` is not principal-shaped, so it must stay in the sidebar. Those near-misses are in
+ * the fixture data below and asserted in both directions, because a filter that is too eager deletes
+ * a person's messages from the view they were sent to.
+ *
+ * WHAT IS DELIBERATELY NOT FILTERED is asserted here too, as SOURCE-SHAPE cells and labelled as
+ * such: the live SSE tap (frames are marked, never dropped) and `/api/channels/<name>/history` (a
+ * caller naming an event channel gets it, or the surface could render a frame it could never fetch).
+ * Those two are pinned by reading the shipped source rather than by executing a request, because the
+ * request handler is a closure inside `web()` and no seam reaches it. Stated as the weaker evidence
+ * it is, so a later reader does not mistake it for a behavioural test.
+ *
+ * Run: pnpm smoke:web-events-filter
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { CotalMessage } from "@cotal-ai/core";
+import { activityBackfill, chatOnly, type ActivitySource } from "../src/web.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+let cells = 0;
+let failed = 0;
+const ok = (name: string, cond: boolean, detail?: unknown) => {
+  cells++;
+  if (cond) return;
+  failed++;
+  console.log(`  x FAIL  ${name}${detail === undefined ? "" : `: ${JSON.stringify(detail)}`}`);
+};
+
+// The channel list a real mesh hands back once a few agents have run: two channels a human talks on,
+// three per-agent event channels, and the two near-misses a bare prefix test also swallowed.
+const CHANNELS = [
+  { channel: "general", messages: 12 },
+  { channel: "fix-lane", messages: 4 },
+  { channel: "events.local.alice", messages: 900 },
+  { channel: "events.local.bob", messages: 850 },
+  { channel: "events.acme.carol", messages: 77 },
+  { channel: "events.standup", messages: 3 },
+  { channel: "events.my-team.notes", messages: 2 },
+];
+const EVENT_CHANNELS = ["events.local.alice", "events.local.bob", "events.acme.carol"];
+const KEPT = ["general", "fix-lane", "events.standup", "events.my-team.notes"];
+
+let n = 0;
+const msg = (channel: string, ts: number): CotalMessage =>
+  ({
+    id: `m${++n}`,
+    ts,
+    space: "filter-test",
+    from: { id: "ID_A", name: "alice", role: "agent" },
+    parts: [{ kind: "text", text: `on ${channel}` }],
+    channel,
+  }) as CotalMessage;
+
+/** Records every channel history was ASKED for. That list is the order-of-operations evidence. */
+class Source implements ActivitySource {
+  readonly historyAsked: string[] = [];
+  readonly limitsSeen: number[] = [];
+  dmAsked = 0;
+  constructor(private readonly rows = CHANNELS) {}
+  async listChannels() {
+    return this.rows.map((r) => ({ ...r }));
+  }
+  async channelHistory(channel: string, opts: { limit: number }): Promise<CotalMessage[]> {
+    this.historyAsked.push(channel);
+    this.limitsSeen.push(opts.limit);
+    // Two messages per channel, timestamps spread so the merge order is observable.
+    const base = 1000 + this.historyAsked.length * 10;
+    return [msg(channel, base), msg(channel, base + 1)];
+  }
+  async dmHistory(opts: { limit: number }): Promise<CotalMessage[]> {
+    this.dmAsked++;
+    this.limitsSeen.push(opts.limit);
+    return [msg("dm", 5000)];
+  }
+}
+
+console.log("web-events-filter smoke");
+
+// ── 1. the classifier, in both directions ────────────────────────────────────────────────────────
+{
+  const kept = chatOnly(CHANNELS).map((c) => c.channel);
+  ok("1.1 every per-agent event channel is dropped", EVENT_CHANNELS.every((c) => !kept.includes(c)), kept);
+  ok("1.2 the chat channels are kept", kept.includes("general") && kept.includes("fix-lane"));
+  ok("1.3 `events.standup` STAYS: prefix-shaped, not principal-shaped", kept.includes("events.standup"));
+  ok("1.4 `events.my-team.notes` STAYS: a hyphen is not an owner token", kept.includes("events.my-team.notes"));
+  ok("1.5 exactly the expected set, no more and no fewer", JSON.stringify(kept) === JSON.stringify(KEPT), kept);
+  ok("1.6 order is preserved", kept[0] === "general");
+
+  // CONTROL. Without this, 1.3 and 1.4 could pass against a filter that is simply broken, and the
+  // whole point of using the derivation over a prefix test would be unmeasured.
+  const naive = CHANNELS.filter((c) => !c.channel.startsWith("events.")).map((c) => c.channel);
+  ok("1.7 CONTROL: a bare prefix test would have deleted both near-misses", naive.length === 2 && !naive.includes("events.standup"), naive);
+
+  ok("1.8 an empty list yields an empty list", chatOnly([]).length === 0);
+}
+
+// ── 2. the backfill asks only for chat, and asks BEFORE it merges ────────────────────────────────
+{
+  const src = new Source();
+  const out = await activityBackfill(src, 200);
+
+  ok("2.1 no event channel was ever ASKED for", EVENT_CHANNELS.every((c) => !src.historyAsked.includes(c)), src.historyAsked);
+  ok("2.2 history was asked for exactly the chat channels", JSON.stringify(src.historyAsked) === JSON.stringify(KEPT), src.historyAsked);
+  ok("2.3 four round trips, not seven", src.historyAsked.length === 4, src.historyAsked.length);
+  ok("2.4 the limit is passed down", src.limitsSeen.every((l) => l === 200));
+  ok("2.5 DM history is still read", src.dmAsked === 1);
+
+  const chatRows = out.filter((e) => e.mode === "chat") as { mode: "chat"; channel: string; msg: CotalMessage }[];
+  ok("2.6 no event-channel message reaches the feed", chatRows.every((e) => !EVENT_CHANNELS.includes(e.channel)));
+  ok("2.7 chat rows are tagged with the channel the SERVER requested", chatRows.every((e) => e.channel === e.msg.channel));
+  ok("2.8 DMs are merged as unicast", out.some((e) => e.mode === "unicast"));
+  ok("2.9 oldest first", out.every((e, i) => i === 0 || out[i - 1].msg.ts <= e.msg.ts));
+  ok("2.10 the DM is newest, so it survives the cap", out[out.length - 1]?.mode === "unicast");
+}
+
+// ── 3. the cap keeps the NEWEST, which is what a top-N means ─────────────────────────────────────
+{
+  const src = new Source();
+  const out = await activityBackfill(src, 3);
+  ok("3.1 capped to the limit", out.length === 3, out.length);
+  ok("3.2 and it is the newest three, not the first three", out[out.length - 1]?.mode === "unicast");
+}
+
+// ── 4. a mesh with nothing but event channels ────────────────────────────────────────────────────
+{
+  const src = new Source(EVENT_CHANNELS.map((channel) => ({ channel, messages: 10 })));
+  const out = await activityBackfill(src, 200);
+  ok("4.1 no history round trip at all", src.historyAsked.length === 0, src.historyAsked);
+  ok("4.2 the feed is DMs only, not an error", out.every((e) => e.mode === "unicast"));
+}
+
+// ── 5. what is NOT filtered, pinned as SOURCE-SHAPE claims ──────────────────────────────────────
+// Weaker evidence than the cells above, and labelled so: the request handler is a closure inside
+// `web()`, so these read the shipped source instead of issuing a request.
+{
+  const src = readFileSync(join(here, "..", "src", "web.ts"), "utf8");
+  // Two call sites: the channel list and the activity backfill. The declaration carries a type
+  // parameter (`chatOnly<T extends ...>`) so it does not match this pattern and is not counted. A
+  // third call site is a behaviour change this cell should force someone to look at.
+  const calls = src.split("chatOnly(").length - 1;
+  ok("5.1 SOURCE-SHAPE: chatOnly has exactly two call sites", calls === 2, calls);
+
+  const byName = src.slice(src.indexOf('path.startsWith("/api/channels/")'));
+  const routeBody = byName.slice(0, byName.indexOf("}"));
+  ok("5.2 SOURCE-SHAPE: the by-name history route applies no filter", !routeBody.includes("chatOnly"), routeBody.slice(0, 200));
+  ok("5.3 SOURCE-SHAPE: it still serves whatever channel is named", routeBody.includes("channelHistory"));
+
+  const tap = src.slice(src.indexOf("ep.tap("), src.indexOf("ep.tap(") + 200);
+  ok("5.4 SOURCE-SHAPE: the live tap is not filtered, so frames stay visible", !tap.includes("chatOnly"), tap.slice(0, 120));
+}
+
+console.log(`web-events-filter smoke: ${cells - failed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/implementations/web/src/web.ts
+++ b/implementations/web/src/web.ts
@@ -6,11 +6,13 @@ import { dirname, join } from "node:path";
 import {
   CotalEndpoint,
   deliveryOf,
+  isEventChannel,
   parseSubject,
   spacePrefix,
   mintCreds,
   newIdentity,
   clearChannel,
+  type CotalMessage,
   type ParsedArgs,
 } from "@cotal-ai/core";
 import {
@@ -112,6 +114,12 @@ export const PAGE: Record<string, { path: string; type: string }> = {
   // frame is as likely to arrive on the graph's detail row as in the console body, and a kind that
   // draws on one page and shows a marker on the other is worse than one that shows a marker on both.
   "/agui-frame.js": { path: join(here, "web/agui-frame.js"), type: jsType },
+  // The shape-B bootstrap: this page taps live before it reads history, so a frame's `seq` order has
+  // to be imposed by the consumer. Served to `/` only. The graph page reads the backfill into
+  // transient glow and "recently active" buffers and keeps no feed a live arrival appends to, so it
+  // has no merge to order; giving it the machine anyway would imply an ordering guarantee on a
+  // surface where nothing consumes one.
+  "/event-order.js": { path: join(here, "web/event-order.js"), type: jsType },
   "/md.js": { path: join(here, "web/md.js"), type: jsType },
   "/app.js": { path: join(here, "web/app.js"), type: jsType },
   "/graph": { path: join(here, "web/graph.html"), type: "text/html; charset=utf-8" },
@@ -119,6 +127,67 @@ export const PAGE: Record<string, { path: string; type: string }> = {
   "/vendor/marked.umd.js": { path: join(here, "web/vendor/marked.umd.js"), type: jsType },
   "/vendor/purify.min.js": { path: join(here, "web/vendor/purify.min.js"), type: jsType },
 };
+
+/** What the two backfill routes need from an endpoint. Narrow on purpose: it is the seam the filter
+ *  is measured through, and a mock satisfying six methods it never calls would prove less. */
+export interface ActivitySource {
+  listChannels(): Promise<{ channel: string; messages: number; config?: unknown }[]>;
+  channelHistory(channel: string, opts: { limit: number }): Promise<CotalMessage[]>;
+  dmHistory(opts: { limit: number }): Promise<CotalMessage[]>;
+}
+
+/** The channels this dashboard LISTS and BACKFILLS: chat only.
+ *
+ * WHY AN AGENT'S EVENT CHANNEL IS NOT ONE OF THEM. `listChannels()` derives a row from every
+ * retained concrete subject and the chat stream caps per subject rather than by age, so the list
+ * grows by one row per agent that has ever run and those rows never age out. Unfiltered, the channel
+ * sidebar is buried under machine streams, the graph page grows a hub node for each, and
+ * `/api/activity` issues one `channelHistory` round trip per event channel and then merges the
+ * results into a global top-N that a human reading chat did not ask for. That is a cost that scales
+ * with the number of agents ever run, which is the wrong axis entirely.
+ *
+ * FILTERED BEFORE THE FETCH, NOT AFTER, AND THE ORDER IS THE CLAIM. Filtering the merged output
+ * would still pay every round trip and then discard the bytes. The console applies the identical
+ * rule at the identical point (`mesh-view.ts` filters `listChannels()` before `channelHistory`), and
+ * the two surfaces share this classifier rather than each spelling the convention, so they cannot
+ * disagree about what a channel is.
+ *
+ * WHAT IS NOT FILTERED, DELIBERATELY, IN TWO PLACES. The live SSE tap still carries frames, marked
+ * rather than dropped: dropping them would delete the only traffic this release taught the surface
+ * to draw, and delete it silently. And `/api/channels/<name>/history` still serves an event channel
+ * when a caller names one, because that route answers a question about a channel the caller already
+ * identified; a filter there would mean the dashboard could render a frame it could never fetch. */
+export function chatOnly<T extends { channel: string }>(rows: readonly T[]): T[] {
+  return rows.filter((row) => !isEventChannel(row.channel));
+}
+
+/** The all-activity backfill: recent chat history merged with DM history, oldest-first, capped.
+ *
+ * Extracted from the route so the filter above is reachable by a test that can see WHICH channels
+ * were asked for, which is the only evidence that separates filtering before the fetch from
+ * filtering after it. The route is a thin caller. */
+export async function activityBackfill(
+  ep: ActivitySource,
+  limit: number,
+): Promise<({ mode: "chat"; channel: string; msg: CotalMessage } | { mode: "unicast"; msg: CotalMessage })[]> {
+  const chans = chatOnly(await ep.listChannels());
+  // Each message is tagged with the channel this server REQUESTED, so the backfill path does
+  // not depend on the payload claim either.
+  const chat = (
+    await Promise.all(
+      chans.map(async (ch) =>
+        (await ep.channelHistory(ch.channel, { limit })).map((msg) => ({
+          mode: "chat" as const,
+          channel: ch.channel,
+          msg,
+        })),
+      ),
+    )
+  ).flat();
+  const dms = (await ep.dmHistory({ limit })).map((msg) => ({ mode: "unicast" as const, msg }));
+  const all = [...chat, ...dms].sort((a, b) => a.msg.ts - b.msg.ts);
+  return all.slice(-limit);
+}
 
 /** A live observability dashboard for a space, served over HTTP + SSE. A read-only
  *  observer endpoint (invisible to peers) feeds the page presence, channel history,
@@ -307,7 +376,7 @@ export async function web(args: ParsedArgs): Promise<void> {
     if (path === "/api/channels") {
       // Resolve defaults at the endpoint so every web client renders the same channel policy the
       // core applies; the registry's `config` holds only per-channel overrides.
-      const channels = await ep.listChannels();
+      const channels = chatOnly(await ep.listChannels());
       return json(res, channels.map(({ channel, messages, config }) => ({
         channel,
         messages,
@@ -335,23 +404,7 @@ export async function web(args: ParsedArgs): Promise<void> {
       // worth doing, with a test encoding the counterexample above, and it is not this change.
       // Correctness first: fetch a full page per channel and merge.
       const limit = query.get("limit") ? Number(query.get("limit")) : 200;
-      const chans = await ep.listChannels();
-      // Each message is tagged with the channel this server REQUESTED, so the backfill path does
-      // not depend on the payload claim either.
-      const chat = (
-        await Promise.all(
-          chans.map(async (ch) =>
-            (await ep.channelHistory(ch.channel, { limit })).map((msg) => ({
-              mode: "chat" as const,
-              channel: ch.channel,
-              msg,
-            })),
-          ),
-        )
-      ).flat();
-      const dms = (await ep.dmHistory({ limit })).map((msg) => ({ mode: "unicast" as const, msg }));
-      const all = [...chat, ...dms].sort((a, b) => a.msg.ts - b.msg.ts);
-      return json(res, all.slice(-limit));
+      return json(res, await activityBackfill(ep, limit));
     }
     if (path === "/api/dms") {
       // DM history for the Direct-messages lens (god-view); the client groups it by peer/pair.

--- a/implementations/web/src/web/app.js
+++ b/implementations/web/src/web/app.js
@@ -774,7 +774,16 @@ async function select(key) {
     // already delivering into it.
     channelOrder = window.COTAL_EVENT_ORDER.create();
     renderCenter();
-    const msgs = await (await fetch(`/api/channels/${encodeURIComponent(key)}/history?limit=200`)).json();
+    // Same reason as the activity feed: a failed history read is an empty batch, not a reason to
+    // leave the boundary unpassed and the frames of this channel held out of the view that was
+    // opened to look at them.
+    let msgs;
+    try {
+      msgs = await (await fetch(`/api/channels/${encodeURIComponent(key)}/history?limit=200`)).json();
+    } catch (err) {
+      msgs = [];
+      noteOrder([{ type: "backfill-failed", channel: key, reason: err && err.message ? err.message : String(err) }]);
+    }
     if (seq !== loadSeq) return;
     const settled = channelOrder.backfill(msgs);
     noteOrder(settled.notes);
@@ -844,7 +853,24 @@ async function refresh() {
     // filter, so for a frame there is nothing to come back and the old assignment was a silent
     // deletion of exactly the traffic this lane exists to make visible.
     const live = activity;
-    activity = await (await fetch("/api/activity?limit=200")).json();
+    // THE BOUNDARY MUST PASS EVEN WHEN THE FETCH DOES NOT, and this is not a soft failure mode
+    // invented here. `pending` is drained only by `backfill()`, so a rejected request means the
+    // machine never settles and every frame held during it stays invisible for the life of the page,
+    // with nothing on screen saying so. That is strictly worse than what this code replaced, where a
+    // failed fetch simply left the live arrivals in place.
+    //
+    // A failed history read IS an empty history batch: the machine already specifies that case, and
+    // specifies that the baseline then comes from the earliest BUFFERED frame. So the boundary is
+    // settled on empty rather than skipped, and the failure is SURFACED as a note instead of being
+    // swallowed. Reporting it is what keeps this from being a silent degrade.
+    let backfilled;
+    try {
+      backfilled = await (await fetch("/api/activity?limit=200")).json();
+    } catch (err) {
+      backfilled = [];
+      noteOrder([{ type: "backfill-failed", reason: err && err.message ? err.message : String(err) }]);
+    }
+    activity = backfilled;
     // Same trust rule as the live feed: the backfill is tagged with the channel the SERVER
     // requested, so the payload claim is overwritten at ingress rather than downstream.
     for (const e of activity) if (e?.msg) e.msg.channel = e.channel;

--- a/implementations/web/src/web/app.js
+++ b/implementations/web/src/web/app.js
@@ -36,6 +36,36 @@ function noteOrder(notes) {
   for (const n of notes) orderNotes.push(n);
   if (orderNotes.length > 50) orderNotes = orderNotes.slice(-50);
 }
+/** In-flight bootstrap, so a second caller shares it instead of arming a rival machine. */
+let refreshing = null;
+
+/** The notes, as the banner the feed views draw above their rows.
+ *
+ *  THIS EXISTS BECAUSE COMPUTING A GAP AND DRAWING ONE ARE DIFFERENT CLAIMS. The notes were collected
+ *  into an array that nothing read, so the machine detected a missing frame and the page said nothing:
+ *  a gap that reaches only an unused variable is a gap nobody sees, which is the same silence this
+ *  lane exists to remove, one layer up. A reader has to be able to act differently on a lost frame, an
+ *  evicted prefix and an ordinary feed.
+ *
+ *  The three kinds are drawn as three different statements, because collapsing them would put the one
+ *  that always happens on a late join next to the one that must never be ignored. */
+function orderNoticeHtml() {
+  if (!orderNotes.length) return "";
+  const gaps = orderNotes.filter((n) => n.type === "gap");
+  const races = orderNotes.filter((n) => n.type === "boundary-hole");
+  const prefixes = orderNotes.filter((n) => n.type === "prefix-incomplete");
+  const failures = orderNotes.filter((n) => n.type === "backfill-failed");
+  const parts = [];
+  if (gaps.length) {
+    const missing = gaps.reduce((sum, g) => sum + (g.missing || 0), 0);
+    parts.push(`<b>${missing} event frame${missing === 1 ? "" : "s"} missing</b> (${gaps.length} break${gaps.length === 1 ? "" : "s"} in the stream)`);
+  }
+  if (races.length) parts.push(`${races.length} possible ordering race${races.length === 1 ? "" : "s"} at start-up, unconfirmed`);
+  if (prefixes.length) parts.push(`${prefixes.length} stream${prefixes.length === 1 ? "" : "s"} joined after the start, earlier frames not retained`);
+  if (failures.length) parts.push(`history unavailable, so ordering is based on live frames only`);
+  if (!parts.length) return "";
+  return `<div class="order-notice${gaps.length ? " fault" : ""}">${parts.join(" · ")}</div>`;
+}
 let modes = new Set(MODES); // delivery modes currently shown
 let paused = false; // freeze auto-scroll so a value can be read
 let expandAll = false; // channel-wide: expand every clamped message body (else per-message toggle)
@@ -445,6 +475,7 @@ function renderAllActivity() {
         <span class="chip pause${paused ? " on" : ""}" id="pause">${paused ? "▶ resume" : "⏸ pause"}</span>
       </span>
     </div>
+    ${orderNoticeHtml()}
     <div class="feed">${rows.length ? rows.map(rowHTML).join("") : `<div class="empty">waiting for messages…</div>`}</div>`;
   for (const chip of center.querySelectorAll(".chip[data-mode]"))
     chip.onclick = () => {
@@ -529,6 +560,7 @@ function renderChannel() {
       </div>
       <div class="purpose">${purpose}</div>
     </div>
+    ${orderNoticeHtml()}
     <div class="clist">${items.length ? items.map(cmsgHTML).join("") : `<div class="empty">no messages</div>`}</div>`;
   const list = $("center").querySelector(".clist");
   list.scrollTop = list.scrollHeight;
@@ -758,6 +790,8 @@ function refreshDerived() {
 }
 
 let loadSeq = 0;
+/** The in-flight channel bootstrap: `{key, promise}`, so a second call for the same channel shares it. */
+let selecting = null;
 async function select(key) {
   agentSel = null;
   dmSel = null;
@@ -767,33 +801,51 @@ async function select(key) {
   if (!isDemo) renderRoster(rosterRows()); // clear any stale Agent Detail highlight
   if (isDemo) return (renderCenter(), renderRail());
   if (key !== "*") {
+    // SINGLE FLIGHT PER CHANNEL, for the reason the feed has one. `refresh()` calls `select(selected)`
+    // on every poll, so two bootstraps for the SAME open channel overlapped routinely: the second
+    // re-armed `channelOrder` while the first was still fetching, and the first machine, holding every
+    // frame that arrived in that window, became unreachable. The staleness guard did not save it,
+    // because returning early is exactly what left the buffer undrained.
+    if (selecting && selecting.key === key) return selecting.promise;
     const seq = ++loadSeq;
     channelMsgs = [];
     // ARMED BEFORE THE FETCH IS ISSUED, which is the whole ordering. Re-armed on every selection
     // because each one is a fresh two-phase bootstrap: a new history read, and a live tap that is
-    // already delivering into it.
-    channelOrder = window.COTAL_EVENT_ORDER.create();
+    // already delivering into it. Held in a LOCAL as well, so this bootstrap settles the machine it
+    // armed even if a selection of a different channel has since rebound the global.
+    const order = window.COTAL_EVENT_ORDER.create();
+    channelOrder = order;
+    let release;
+    selecting = { key, promise: new Promise((r) => (release = r)) };
     renderCenter();
     // Same reason as the activity feed: a failed history read is an empty batch, not a reason to
     // leave the boundary unpassed and the frames of this channel held out of the view that was
     // opened to look at them.
-    let msgs;
+    let msgs = [];
     try {
       msgs = await (await fetch(`/api/channels/${encodeURIComponent(key)}/history?limit=200`)).json();
     } catch (err) {
       msgs = [];
       noteOrder([{ type: "backfill-failed", channel: key, reason: err && err.message ? err.message : String(err) }]);
+    } finally {
+      // SETTLED ON EVERY PATH, INCLUDING THE STALE ONE. A superseded load must not rebind the view it
+      // no longer owns, and it must still drain the machine it armed; skipping the settle is what
+      // orphaned frames. When the selection has moved on, the released rows are dropped with the rest
+      // of that view, which is correct because the reader is no longer looking at that channel.
+      const settled = order.backfill(msgs);
+      if (seq === loadSeq) {
+        noteOrder(settled.notes);
+        // Same merge as the activity feed and for the same reason: chat that arrived live during this
+        // fetch is only in `channelMsgs`, released frames are only in `settled.emit`, and an assignment
+        // either way round drops one of them.
+        const merged = settled.emit.slice();
+        const ids = new Set(merged.map((m) => m && m.id));
+        for (const m of channelMsgs) if (m && !ids.has(m.id)) merged.push(m);
+        channelMsgs = merged.slice(-500);
+      }
+      if (selecting && selecting.key === key) selecting = null;
+      release();
     }
-    if (seq !== loadSeq) return;
-    const settled = channelOrder.backfill(msgs);
-    noteOrder(settled.notes);
-    // Same merge as the activity feed and for the same reason: chat that arrived live during this
-    // fetch is only in `channelMsgs`, released frames are only in `settled.emit`, and an assignment
-    // either way round drops one of them.
-    const merged = settled.emit.slice();
-    const ids = new Set(merged.map((m) => m && m.id));
-    for (const m of channelMsgs) if (m && !ids.has(m.id)) merged.push(m);
-    channelMsgs = merged.slice(-500);
   }
   renderCenter();
   renderRail();
@@ -810,88 +862,119 @@ function selectDM(peer, w) {
 }
 
 async function refresh() {
-  // Re-armed at the TOP, before the first await, because everything below it is the fetch half of the
-  // bootstrap and the live feed is already open. `refresh()` runs on every SSE open, so a reconnect
-  // is a new bootstrap: a new backfill, and a new buffer to hold what arrives during it.
+  // ── ONE BOOTSTRAP AT A TIME, AND IT ALWAYS ENDS ─────────────────────────────────────────────────
+  //
+  // SINGLE FLIGHT. Arming a machine and settling it are two ends of ONE bootstrap, and this function
+  // could previously be re-entered between them. The stock startup does exactly that: the file ends
+  // with `refresh(); connect();`, and `connect()`'s open handler calls `refresh()` again, so a second
+  // call re-armed `feedOrder` while the first was still fetching. The first machine, holding whatever
+  // arrived in that window, was then unreachable: the settle ran on the NEW binding and the old
+  // machine's buffer went with it. Measured on the shipped merge logic, a frame held on the first
+  // machine was simply absent from the feed afterwards. A reconnect flap did it too.
+  //
+  // Overlapping callers now share the in-flight bootstrap instead of starting a rival one. A
+  // concurrent duplicate would have re-fetched the same pages anyway, so nothing is lost by
+  // coalescing, and the pairing of one arm to one settle is restored.
+  if (refreshing) return refreshing;
+  let release;
+  refreshing = new Promise((r) => (release = r));
+  // Captured before the first await: `onMessage` appends here while every request below is in flight,
+  // and the settle rebinds `activity`.
+  const live = activity;
   feedOrder = window.COTAL_EVENT_ORDER.create();
-  roster = await (await fetch("/api/roster")).json();
-  refreshDerived();
-  const list = await (await fetch("/api/channels")).json();
-  // L2 shape is flat {channel,messages,description?,replay,replayWindow?,deliveryClass}.
-  // Tolerate a nested-config server briefly (pre-restart) without re-deriving defaults.
-  channels = new Map(
-    list.map((c) => {
-      if (c.replay !== undefined || c.deliveryClass !== undefined || (c.description && !c.config))
-        return [c.channel, c];
-      const cfg = c.config || {};
-      return [
-        c.channel,
-        {
-          messages: c.messages,
-          description: cfg.description,
-          replay: cfg.replay,
-          replayWindow: cfg.replayWindow,
-          deliveryClass: cfg.deliveryClass,
-        },
-      ];
-    }),
-  );
-  dms = await (await fetch("/api/dms?limit=500")).json();
-  renderSidebarNav();
-  if (agentSel) {
-    renderCenter();
-  } else if (dmSel) {
-    renderCenter();
-  } else if (selected !== "*") {
-    select(selected);
-  } else {
-    // CAPTURED BEFORE THE FETCH IS AWAITED, and that order is the fix. `onMessage` pushes into this
-    // array while the request is in flight; the assignment below rebinds `activity` to the fetched
-    // page, so without holding a reference first, every live arrival during the fetch is dropped on
-    // the floor. Retention hid that for chat, because the backfill re-read the same messages from
-    // the broker and they came back. Event channels are no longer in this backfill, by the server's
-    // filter, so for a frame there is nothing to come back and the old assignment was a silent
-    // deletion of exactly the traffic this lane exists to make visible.
-    const live = activity;
-    // THE BOUNDARY MUST PASS EVEN WHEN THE FETCH DOES NOT, and this is not a soft failure mode
-    // invented here. `pending` is drained only by `backfill()`, so a rejected request means the
-    // machine never settles and every frame held during it stays invisible for the life of the page,
-    // with nothing on screen saying so. That is strictly worse than what this code replaced, where a
-    // failed fetch simply left the live arrivals in place.
-    //
-    // A failed history read IS an empty history batch: the machine already specifies that case, and
-    // specifies that the baseline then comes from the earliest BUFFERED frame. So the boundary is
-    // settled on empty rather than skipped, and the failure is SURFACED as a note instead of being
-    // swallowed. Reporting it is what keeps this from being a silent degrade.
-    let backfilled;
-    try {
-      backfilled = await (await fetch("/api/activity?limit=200")).json();
-    } catch (err) {
-      backfilled = [];
-      noteOrder([{ type: "backfill-failed", reason: err && err.message ? err.message : String(err) }]);
+  // The batch the settle will use. Only the all-activity path fills it; every other path settles on
+  // empty, which is the machine's specified empty-history arm rather than a shortcut.
+  let batch = [];
+  try {
+    roster = await (await fetch("/api/roster")).json();
+    refreshDerived();
+    const list = await (await fetch("/api/channels")).json();
+    // L2 shape is flat {channel,messages,description?,replay,replayWindow?,deliveryClass}.
+    // Tolerate a nested-config server briefly (pre-restart) without re-deriving defaults.
+    channels = new Map(
+      list.map((c) => {
+        if (c.replay !== undefined || c.deliveryClass !== undefined || (c.description && !c.config))
+          return [c.channel, c];
+        const cfg = c.config || {};
+        return [
+          c.channel,
+          {
+            messages: c.messages,
+            description: cfg.description,
+            replay: cfg.replay,
+            replayWindow: cfg.replayWindow,
+            deliveryClass: cfg.deliveryClass,
+          },
+        ];
+      }),
+    );
+    dms = await (await fetch("/api/dms?limit=500")).json();
+    renderSidebarNav();
+    if (agentSel) {
+      renderCenter();
+    } else if (dmSel) {
+      renderCenter();
+    } else if (selected !== "*") {
+      select(selected);
+    } else {
+      // THE BOUNDARY MUST PASS EVEN WHEN THE FETCH DOES NOT, and this is not a soft failure mode
+      // invented here. `pending` is drained only by the settle, so a rejected request used to mean the
+      // machine never settled and every frame held during it stayed invisible for the life of the page,
+      // with nothing on screen saying so. That is strictly worse than what this code replaced, where a
+      // failed fetch simply left the live arrivals in place.
+      //
+      // A failed history read IS an empty history batch: the machine already specifies that case, and
+      // specifies that the baseline then comes from the earliest BUFFERED frame. So the boundary is
+      // settled on empty rather than skipped, and the failure is SURFACED as a note instead of being
+      // swallowed. Reporting it is what keeps this from being a silent degrade.
+      try {
+        batch = await (await fetch("/api/activity?limit=200")).json();
+      } catch (err) {
+        batch = [];
+        noteOrder([{ type: "backfill-failed", reason: err && err.message ? err.message : String(err) }]);
+      }
     }
-    activity = backfilled;
+  } finally {
+    // ── THE SETTLE, ON EVERY EXIT PATH ────────────────────────────────────────────────────────────
+    //
+    // IT USED TO RUN ONLY ON THE ALL-ACTIVITY BRANCH, while the arm ran unconditionally at the top.
+    // So whenever the reader was on a channel, a DM or an agent, every live frame was held by a
+    // machine that this function had armed and would never settle, and none of them reached the feed.
+    // Switching back to all activity showed a feed that had never received them, and the next refresh
+    // replaced the machine and took the buffer with it. A `finally` is the only placement that
+    // survives all four branches plus a throw from any of the fetches above, and an unguarded
+    // `/api/roster` was one of those throws.
+    activity = batch;
     // Same trust rule as the live feed: the backfill is tagged with the channel the SERVER
     // requested, so the payload claim is overwritten at ingress rather than downstream.
     for (const e of activity) if (e?.msg) e.msg.channel = e.channel;
     // MERGED, NOT ASSIGNED OVER. This read `activity = await fetch(...)`, which DISCARDED every live
     // entry `onMessage` had appended while the fetch was in flight. Retention hid it: the backfill
     // re-read the same messages from the broker, so the overwritten arrivals came back. Event
-    // channels are no longer in that backfill, by the filter above, so for a frame there is nothing
-    // to come back and the assignment would be a silent deletion of exactly the traffic this lane
-    // exists to make visible. The two halves of this change are that tightly coupled: the filter is
-    // what turns the pre-existing overwrite into a loss, and this is what makes the filter safe.
+    // channels are no longer in that backfill, by the server's filter, so for a frame there is
+    // nothing to come back and the assignment would be a silent deletion of exactly the traffic this
+    // lane exists to make visible. The two halves of this change are that tightly coupled: the filter
+    // is what turns the pre-existing overwrite into a loss, and this is what makes the filter safe.
     const settled = feedOrder.backfill(activity);
     noteOrder(settled.notes);
     // Live frames were HELD by the machine and come back inside `settled.emit` in seq order; live
     // chat passed straight through and is only in `live`. Both have to survive, so the backfill is
     // the BASE and unseen live arrivals are appended after it, newest last, deduped by id against
     // what the backfill already carried.
+    //
+    // WHAT THIS ORDER DOES AND DOES NOT CLAIM. Frames of one chain are exactly ordered, by `seq`,
+    // which is the claim this file exists to make. Where a released frame sits relative to a chat
+    // message that arrived during the same fetch is approximate. It is deliberately not fixed by
+    // sorting the merged rows on `ts`: a producer's clock is not its sequence, so two frames whose
+    // timestamps disagree with their sequence numbers would be swapped back by that sort, trading the
+    // guarantee for the cosmetic.
     const merged = settled.emit.slice();
     const ids = new Set(merged.map((e) => e && e.msg && e.msg.id));
     for (const e of live) if (e && e.msg && !ids.has(e.msg.id)) merged.push(e);
     activity = merged.slice(-500);
     renderCenter();
+    refreshing = null;
+    release();
   }
 }
 

--- a/implementations/web/src/web/app.js
+++ b/implementations/web/src/web/app.js
@@ -23,6 +23,19 @@ let dmSel = null; // { peer, with } when a Direct-messages thread is open
 let agentSel = null; // peer id when an Agent Detail drill-down is open (else selected/dmSel drive the view)
 let activity = []; // {mode, msg} ring buffer for the all-activity view
 let channelMsgs = []; // messages for the selected channel
+// The shape-B bootstrap for each of the two merge sites: this page opens the live feed and only then
+// fetches the backfill, so a frame's `seq` order is the consumer's problem. One machine per
+// bootstrap, re-armed BEFORE its fetch starts, so frames arriving during the fetch are held rather
+// than ordered against a baseline that has not been established yet.
+let feedOrder = window.COTAL_EVENT_ORDER.create();
+let channelOrder = window.COTAL_EVENT_ORDER.create();
+// Gap and prefix notes, newest last, keyed for the surface that draws them. Kept rather than logged:
+// a gap that only reaches the console is a gap nobody sees.
+let orderNotes = [];
+function noteOrder(notes) {
+  for (const n of notes) orderNotes.push(n);
+  if (orderNotes.length > 50) orderNotes = orderNotes.slice(-50);
+}
 let modes = new Set(MODES); // delivery modes currently shown
 let paused = false; // freeze auto-scroll so a value can be read
 let expandAll = false; // channel-wide: expand every clamped message body (else per-message toggle)
@@ -756,10 +769,22 @@ async function select(key) {
   if (key !== "*") {
     const seq = ++loadSeq;
     channelMsgs = [];
+    // ARMED BEFORE THE FETCH IS ISSUED, which is the whole ordering. Re-armed on every selection
+    // because each one is a fresh two-phase bootstrap: a new history read, and a live tap that is
+    // already delivering into it.
+    channelOrder = window.COTAL_EVENT_ORDER.create();
     renderCenter();
     const msgs = await (await fetch(`/api/channels/${encodeURIComponent(key)}/history?limit=200`)).json();
     if (seq !== loadSeq) return;
-    channelMsgs = msgs;
+    const settled = channelOrder.backfill(msgs);
+    noteOrder(settled.notes);
+    // Same merge as the activity feed and for the same reason: chat that arrived live during this
+    // fetch is only in `channelMsgs`, released frames are only in `settled.emit`, and an assignment
+    // either way round drops one of them.
+    const merged = settled.emit.slice();
+    const ids = new Set(merged.map((m) => m && m.id));
+    for (const m of channelMsgs) if (m && !ids.has(m.id)) merged.push(m);
+    channelMsgs = merged.slice(-500);
   }
   renderCenter();
   renderRail();
@@ -776,6 +801,10 @@ function selectDM(peer, w) {
 }
 
 async function refresh() {
+  // Re-armed at the TOP, before the first await, because everything below it is the fetch half of the
+  // bootstrap and the live feed is already open. `refresh()` runs on every SSE open, so a reconnect
+  // is a new bootstrap: a new backfill, and a new buffer to hold what arrives during it.
+  feedOrder = window.COTAL_EVENT_ORDER.create();
   roster = await (await fetch("/api/roster")).json();
   refreshDerived();
   const list = await (await fetch("/api/channels")).json();
@@ -807,10 +836,35 @@ async function refresh() {
   } else if (selected !== "*") {
     select(selected);
   } else {
+    // CAPTURED BEFORE THE FETCH IS AWAITED, and that order is the fix. `onMessage` pushes into this
+    // array while the request is in flight; the assignment below rebinds `activity` to the fetched
+    // page, so without holding a reference first, every live arrival during the fetch is dropped on
+    // the floor. Retention hid that for chat, because the backfill re-read the same messages from
+    // the broker and they came back. Event channels are no longer in this backfill, by the server's
+    // filter, so for a frame there is nothing to come back and the old assignment was a silent
+    // deletion of exactly the traffic this lane exists to make visible.
+    const live = activity;
     activity = await (await fetch("/api/activity?limit=200")).json();
     // Same trust rule as the live feed: the backfill is tagged with the channel the SERVER
     // requested, so the payload claim is overwritten at ingress rather than downstream.
     for (const e of activity) if (e?.msg) e.msg.channel = e.channel;
+    // MERGED, NOT ASSIGNED OVER. This read `activity = await fetch(...)`, which DISCARDED every live
+    // entry `onMessage` had appended while the fetch was in flight. Retention hid it: the backfill
+    // re-read the same messages from the broker, so the overwritten arrivals came back. Event
+    // channels are no longer in that backfill, by the filter above, so for a frame there is nothing
+    // to come back and the assignment would be a silent deletion of exactly the traffic this lane
+    // exists to make visible. The two halves of this change are that tightly coupled: the filter is
+    // what turns the pre-existing overwrite into a loss, and this is what makes the filter safe.
+    const settled = feedOrder.backfill(activity);
+    noteOrder(settled.notes);
+    // Live frames were HELD by the machine and come back inside `settled.emit` in seq order; live
+    // chat passed straight through and is only in `live`. Both have to survive, so the backfill is
+    // the BASE and unseen live arrivals are appended after it, newest last, deduped by id against
+    // what the backfill already carried.
+    const merged = settled.emit.slice();
+    const ids = new Set(merged.map((e) => e && e.msg && e.msg.id));
+    for (const e of live) if (e && e.msg && !ids.has(e.msg.id)) merged.push(e);
+    activity = merged.slice(-500);
     renderCenter();
   }
 }
@@ -835,8 +889,15 @@ function onMessage(entry) {
   // A conditional trust rule is not a trust rule. "Overwrite when I have something better" leaves
   // the untrusted value in place exactly when the trusted one is missing.
   msg.channel = entry.channel;
-  if (!activity.some((e) => e.msg.id === msg.id)) {
-    activity.push(entry);
+  // ORDERED, NOT JUST DEDUPED. Message-id dedupe answers "have I seen this exact message"; it cannot
+  // answer "is a frame missing between these two", because the thing that would say so is `seq`. A
+  // frame arriving before the backfill it belongs after is HELD here and released by `backfill()` in
+  // `seq` order; everything else passes through and is deduped by id exactly as before.
+  const fed = feedOrder.live(entry);
+  noteOrder(fed.notes);
+  for (const e of fed.emit) {
+    if (activity.some((a) => a.msg.id === e.msg.id)) continue;
+    activity.push(e);
     if (activity.length > 500) activity.shift();
   }
   if (mode === "unicast" && !dms.some((m) => m.id === msg.id)) {
@@ -849,8 +910,14 @@ function onMessage(entry) {
     const ch = channels.get(msg.channel);
     channels.set(msg.channel, { ...(ch ?? {}), messages: (ch?.messages ?? 0) + 1 });
     if (!dmSel && selected === msg.channel) {
-      channelMsgs.push(msg);
-      if (channelMsgs.length > 500) channelMsgs.shift();
+      // The selected-channel view runs the same race: `select()` fetches this channel's history with
+      // the feed already open, so a live frame can arrive before the retained range it follows.
+      const sel = channelOrder.live(msg);
+      noteOrder(sel.notes);
+      for (const m of sel.emit) {
+        channelMsgs.push(m);
+        if (channelMsgs.length > 500) channelMsgs.shift();
+      }
     } else {
       unread.set(msg.channel, (unread.get(msg.channel) ?? 0) + 1);
     }

--- a/implementations/web/src/web/event-order.js
+++ b/implementations/web/src/web/event-order.js
@@ -1,0 +1,224 @@
+// The bootstrap ordering this surface needs because it taps live BEFORE it reads history.
+//
+// THE RACE IS THIS PAGE'S, NOT A HYPOTHETICAL. `app.js` opens the SSE feed and only then calls
+// `refresh()`, so `onMessage` is already appending live traffic while the backfill fetch is still in
+// flight. For ordinary chat that is harmless: entries carry `ts`, the feed is a window, and a
+// duplicate is caught by message id. For an event frame it is not harmless, because a frame's
+// position in its stream is `seq`, and `seq` is the only thing that can tell a reader that a frame
+// is MISSING. Message-id dedupe cannot: two ids are equal or they are not, which says nothing about
+// what belongs between them.
+//
+// SO THE CONSUMER HAS TO IMPOSE ITS OWN PHASE BOUNDARY. The transport arms the watermark, goes live,
+// and only then surfaces retained history, so a live frame at `seq` 1003 can legitimately be the
+// FIRST frame this page ever sees, ahead of the retained 1000-1002. Two rules follow, and both are
+// the opposite of what a first-arrival reading would do:
+//
+//   · The baseline is the MINIMUM of the settled history batch, not the first frame observed.
+//     Baselining on arrival makes the entire backfill look like it ran backwards.
+//   · Gap checking is not armed until the boundary passes. Armed earlier, the same backfill reads as
+//     a hole between 1003 and 1000.
+//
+// WHAT A BASELINE ABOVE THE FIRST SEQUENCE MEANS, AND WHAT IT DOES NOT. The chat stream caps per
+// subject, so a reader that arrives late finds the earliest retained frame at some `seq` N > 1. That
+// is ordinary retention and NOT a fault: the chain is marked prefix-incomplete and applied forward.
+// A discontinuity AFTER the baseline is the fault, and the two must never be reported as one thing,
+// because the first is what always happens and the second is what must never be ignored.
+//
+// DETECTION IS NOT RECOVERY, AND A DETECTED GAP STILL DRAWS THE FRAME. A gap note is surfaced and
+// the frame is emitted anyway. Holding it back until the missing predecessor turns up would hold it
+// forever when the predecessor is genuinely gone, which converts a visible gap into a silent loss:
+// the exact trade this lane exists to refuse. `next` also advances past the hole, so one lost frame
+// reports once instead of reporting on every frame that follows it.
+//
+// FIRST SEQUENCE. The emitter publishes its first frame at `seq` 1 (`firstSeq` is the WAL frontier
+// plus one, from a zero frontier), while the frame validator admits any non-negative safe integer.
+// "Complete from origin" therefore keys on `<= 1` and not on `=== 1`, so a `seq` 0 frame, which is
+// structurally valid and which no emitter produces, cannot be reported as an evicted prefix.
+//
+// NOT ORDERED, DELIBERATELY: anything that is not a frame carrying a usable `seq`. Chat, presence,
+// DMs and a malformed frame all pass straight through in arrival order. A machine that held a frame
+// it could not sequence would either hold it forever or invent a gap around it, and delaying chat
+// behind a frame's backfill would make this file a latency bug for the traffic it does not own.
+(() => {
+  const KIND = "ag-ui.frame";
+  /** The first `seq` any emitter publishes. A baseline at or below this is complete from origin. */
+  const FIRST_SEQ = 1;
+
+  const isSeq = (v) => Number.isSafeInteger(v) && v >= 0;
+
+  /** The frame part an entry carries, or `undefined`. A ROUTING question, so it never throws.
+   *
+   *  Accepts a feed entry (`{mode, channel, msg}`, the all-activity shape) or a bare message (the
+   *  selected-channel shape), because both merge sites run this race and a machine that only
+   *  understood one of them would leave the other unordered. */
+  const frameOf = (entry) => {
+    try {
+      const msg = entry && typeof entry === "object" ? entry.msg || entry : undefined;
+      const parts = msg && msg.parts;
+      if (!Array.isArray(parts)) return undefined;
+      for (const p of parts)
+        if (p && typeof p === "object" && p.kind === KIND && isSeq(p.seq)) return p;
+      return undefined;
+    } catch {
+      return undefined;
+    }
+  };
+
+  /** The chain a frame belongs to: `(from.id, epoch, threadId)`.
+   *
+   *  EPOCH IS IN THE KEY BECAUSE `runId` CANNOT DISCRIMINATE. Two writers pick run ids and sequences
+   *  independently, so their `(runId, seq)` pairs collide by construction; `epoch` is what makes one
+   *  writer's stream its own. A JSON array is the delimiter rather than a joining character, because
+   *  a thread id is a producer-supplied string and any separator chosen here could appear inside it,
+   *  which would fuse two chains into one and hide a gap in the merge. */
+  const chainKey = (entry, frame) => {
+    const msg = entry && typeof entry === "object" ? entry.msg || entry : undefined;
+    const from = msg && msg.from;
+    return JSON.stringify([
+      (from && typeof from.id === "string" ? from.id : null),
+      typeof frame.epoch === "string" ? frame.epoch : null,
+      typeof frame.threadId === "string" ? frame.threadId : null,
+    ]);
+  };
+
+  /** A two-phase shape-B bootstrap. One instance per bootstrap: a reconnect re-runs both phases. */
+  const create = () => {
+    /** key -> {baseline, next, prefixIncomplete, faulted, seen:Set<seq>} */
+    const chains = new Map();
+    /** Live frames arriving before the boundary, in arrival order. */
+    const pending = [];
+    let settled = false;
+
+    const chainOf = (key) => {
+      let c = chains.get(key);
+      if (!c) {
+        c = { baseline: undefined, next: undefined, prefixIncomplete: false, faulted: false, seen: new Set() };
+        chains.set(key, c);
+      }
+      return c;
+    };
+
+    /** Admit one frame against an armed chain. Returns the notes it produced. */
+    const admit = (c, key, seq) => {
+      const notes = [];
+      if (c.seen.has(seq)) return { emit: false, notes };
+      c.seen.add(seq);
+      if (seq > c.next) {
+        // The fault. Named with both ends so a reader can see WHAT is missing, not merely that
+        // something is.
+        notes.push({ type: "gap", key, expected: c.next, got: seq, missing: seq - c.next });
+        c.faulted = true;
+      }
+      if (seq >= c.next) c.next = seq + 1;
+      return { emit: true, notes };
+    };
+
+    return {
+      /** A live arrival. Before the boundary a frame is HELD; everything else always passes. */
+      live(entry) {
+        const f = frameOf(entry);
+        if (!f) return { emit: [entry], held: false, notes: [] };
+        if (!settled) {
+          pending.push(entry);
+          return { emit: [], held: true, notes: [] };
+        }
+        const key = chainKey(entry, f);
+        const c = chainOf(key);
+        if (c.next === undefined) {
+          // First frame for a chain that the settled history did not mention: this arrival is the
+          // baseline, which is sound now only because the boundary has passed.
+          c.baseline = f.seq;
+          c.next = f.seq;
+          c.prefixIncomplete = f.seq > FIRST_SEQ;
+        }
+        const r = admit(c, key, f.seq);
+        return { emit: r.emit ? [entry] : [], held: false, notes: r.notes };
+      },
+
+      /** THE PHASE BOUNDARY: the history batch has settled.
+       *
+       *  Returns the merged feed to render, oldest-first: the batch in the order the server sorted
+       *  it, then every held live frame that the batch did not already carry, released in `seq`
+       *  order per chain. The batch is the baseline source, so a live frame that ran ahead of it
+       *  lands after its own retained predecessors instead of before them. */
+      backfill(batch) {
+        const notes = [];
+        const rows = Array.isArray(batch) ? batch.slice() : [];
+
+        // Phase one: the batch establishes each chain's baseline. Taken as a MINIMUM over the batch
+        // rather than from its first row, because the server sorts the union by `ts` across channels
+        // and a frame's `ts` is not its `seq`.
+        for (const row of rows) {
+          const f = frameOf(row);
+          if (!f) continue;
+          const c = chainOf(chainKey(row, f));
+          if (c.baseline === undefined || f.seq < c.baseline) c.baseline = f.seq;
+          c.seen.add(f.seq);
+        }
+        for (const [key, c] of chains) {
+          if (c.baseline === undefined) continue;
+          let highest = c.baseline;
+          for (const s of c.seen) if (s > highest) highest = s;
+          c.next = highest + 1;
+          c.prefixIncomplete = c.baseline > FIRST_SEQ;
+          if (c.prefixIncomplete) notes.push({ type: "prefix-incomplete", key, baseline: c.baseline });
+        }
+
+        // Phase two: release what the tap delivered while the fetch was in flight. Sorted by `seq`
+        // within a chain and stable across chains, so a chain's frames are contiguous with the
+        // retained range they follow.
+        const heldFrames = pending
+          .map((entry, i) => ({ entry, frame: frameOf(entry), i }))
+          .filter((h) => h.frame !== undefined);
+        heldFrames.sort((a, b) => (a.frame.seq - b.frame.seq) || (a.i - b.i));
+
+        for (const h of heldFrames) {
+          const key = chainKey(h.entry, h.frame);
+          const c = chainOf(key);
+          if (c.next === undefined) {
+            // No retained frame for this chain, so the earliest BUFFERED frame is the baseline. This
+            // is the empty-history arm, and it is why the buffer is sorted before it is walked.
+            c.baseline = h.frame.seq;
+            c.next = h.frame.seq;
+            c.prefixIncomplete = h.frame.seq > FIRST_SEQ;
+            if (c.prefixIncomplete)
+              notes.push({ type: "prefix-incomplete", key, baseline: c.baseline });
+          }
+          const r = admit(c, key, h.frame.seq);
+          for (const n of r.notes) notes.push(n);
+          if (r.emit) rows.push(h.entry);
+        }
+
+        pending.length = 0;
+        settled = true;
+        return { emit: rows, notes };
+      },
+
+      /** Whether the boundary has passed. Gap checking is armed only after it has. */
+      get settled() {
+        return settled;
+      },
+      /** Held-but-unreleased count. Zero after the boundary, by construction. */
+      get pendingCount() {
+        return pending.length;
+      },
+      /** A chain's observed state, for a surface that wants to mark it and for the suite. */
+      state(key) {
+        const c = chains.get(key);
+        return c === undefined
+          ? undefined
+          : {
+              baseline: c.baseline,
+              next: c.next,
+              prefixIncomplete: c.prefixIncomplete,
+              faulted: c.faulted,
+            };
+      },
+      get chainKeys() {
+        return [...chains.keys()];
+      },
+    };
+  };
+
+  window.COTAL_EVENT_ORDER = { KIND, FIRST_SEQ, frameOf, chainKey, create };
+})();

--- a/implementations/web/src/web/event-order.js
+++ b/implementations/web/src/web/event-order.js
@@ -92,22 +92,54 @@
     const chainOf = (key) => {
       let c = chains.get(key);
       if (!c) {
-        c = { baseline: undefined, next: undefined, prefixIncomplete: false, faulted: false, seen: new Set() };
+        c = { baseline: undefined, next: undefined, prefixIncomplete: false, faulted: false, released: false, seen: new Set() };
         chains.set(key, c);
       }
       return c;
     };
 
-    /** Admit one frame against an armed chain. Returns the notes it produced. */
-    const admit = (c, key, seq) => {
+    /** Admit one frame against an armed chain. Returns the notes it produced.
+     *
+     *  `straddle` marks the ONE frame per chain whose predecessor lies on the other side of the
+     *  bootstrap seam, and it changes what a hole MEANS rather than merely how it is worded. See
+     *  {@link STRADDLE} below. */
+    const admit = (c, key, seq, straddle) => {
       const notes = [];
       if (c.seen.has(seq)) return { emit: false, notes };
       c.seen.add(seq);
       if (seq > c.next) {
-        // The fault. Named with both ends so a reader can see WHAT is missing, not merely that
+        // Both ends are named either way, so a reader sees WHAT is missing rather than only that
         // something is.
-        notes.push({ type: "gap", key, expected: c.next, got: seq, missing: seq - c.next });
-        c.faulted = true;
+        const hole = { key, expected: c.next, got: seq, missing: seq - c.next };
+        if (straddle) {
+          // STRADDLE: THE ONE HOLE THIS PAGE CANNOT ATTRIBUTE, and calling it a fault was a measured
+          // false positive on healthy traffic.
+          //
+          // The two halves of the bootstrap are two independent reads with no shared cut: a live
+          // subscription, and a history request. Nothing makes the point the read was served equal
+          // the point the tap began delivering, and on this page the fetch is issued before the tap
+          // is even open. So a frame published inside that window is in NEITHER half, and the first
+          // buffered frame of a chain can therefore sit above the retained range's top by more than
+          // one with nothing lost by the broker at all. Reported as a fault, it latched `faulted`
+          // forever on a stream that was fine, and the frame that filled the hole a moment later did
+          // not clear it.
+          //
+          // A fault that fires on healthy traffic is worse than no fault at all, because it teaches
+          // the reader to ignore the one signal that matters. So this is reported as its own kind,
+          // named as unconfirmed on the surface, and it does NOT set `faulted`. What it is not is
+          // silence: the page says it could not establish the join, rather than saying nothing was
+          // missing.
+          //
+          // ONLY THE FIRST RELEASED FRAME OF A CHAIN GETS THIS TREATMENT. Every later buffered frame
+          // arrived through the SAME tap as the one before it, and a subscription delivers a subject
+          // in order, so a number missing BETWEEN two buffered frames was never delivered while the
+          // page was listening. That is a real loss and takes the hard path below, exactly like a
+          // post-boundary hole.
+          notes.push({ type: "boundary-hole", ...hole });
+        } else {
+          notes.push({ type: "gap", ...hole });
+          c.faulted = true;
+        }
       }
       if (seq >= c.next) c.next = seq + 1;
       return { emit: true, notes };
@@ -162,6 +194,29 @@
           c.next = highest + 1;
           c.prefixIncomplete = c.baseline > FIRST_SEQ;
           if (c.prefixIncomplete) notes.push({ type: "prefix-incomplete", key, baseline: c.baseline });
+          // THE RETAINED RANGE IS AUDITED, NOT JUST ITS ENDS. Recording the minimum, the maximum and
+          // the set is enough to place the baseline and to dedupe, and it is NOT enough to notice that
+          // the middle is missing: a batch of 1, 2, 5 has a baseline of 1 and a frontier of 6, and
+          // every later frame follows contiguously, so the chain reads healthy forever while two
+          // frames are gone. A discontinuity that exists only inside retained history is still a
+          // discontinuity after the baseline, and it is the one kind no live arrival will ever
+          // reveal, because nothing after it is out of order.
+          //
+          // Reported as runs rather than per missing number, so losing a thousand frames is one note
+          // naming both ends instead of a thousand notes burying it. The walk stops at `highest`,
+          // which is in the set by construction, so a run always terminates on a present frame.
+          let run = 0;
+          for (let s = c.baseline + 1; s <= highest; s++) {
+            if (!c.seen.has(s)) {
+              run++;
+              continue;
+            }
+            if (run > 0) {
+              notes.push({ type: "gap", key, expected: s - run, got: s, missing: run });
+              c.faulted = true;
+              run = 0;
+            }
+          }
         }
 
         // Phase two: release what the tap delivered while the fetch was in flight. Sorted by `seq`
@@ -184,7 +239,11 @@
             if (c.prefixIncomplete)
               notes.push({ type: "prefix-incomplete", key, baseline: c.baseline });
           }
-          const r = admit(c, key, h.frame.seq);
+          // The seam is crossed once per chain: this frame's predecessor is retained history (or
+          // nothing), every later one's predecessor came through the same tap it did.
+          const straddle = !c.released;
+          c.released = true;
+          const r = admit(c, key, h.frame.seq, straddle);
           for (const n of r.notes) notes.push(n);
           if (r.emit) rows.push(h.entry);
         }

--- a/implementations/web/src/web/index.html
+++ b/implementations/web/src/web/index.html
@@ -229,6 +229,14 @@
       .chip.danger { color: var(--red); }
       .chip.danger:hover { background: #2a1717; border-color: var(--red); }
 
+      /* Ordering notice: what the bootstrap found out about the event stream it merged. Shape and
+         text carry the meaning; `.fault` only adds emphasis, so colour is never the whole signal. */
+      .order-notice {
+        flex: none; padding: 8px 20px; font-size: 12px; color: var(--fg);
+        background: var(--tile); border-bottom: 1px solid var(--line);
+      }
+      .order-notice.fault { border-left: 3px solid var(--amber); }
+
       .feed { overflow-y: auto; min-height: 0; flex: 1; display: flex; flex-direction: column;
         gap: 2px; padding: 8px; }
       .sys { text-align: center; padding: 5px 12px; font-size: 11px; color: var(--faint); }

--- a/implementations/web/src/web/index.html
+++ b/implementations/web/src/web/index.html
@@ -497,6 +497,7 @@
     <script src="/harness.js"></script>
     <script src="/parts.js"></script>
     <script src="/agui-frame.js"></script>
+    <script src="/event-order.js"></script>
     <script src="/md.js"></script>
     <script src="/app.js"></script>
   </body>

--- a/package.json
+++ b/package.json
@@ -195,6 +195,8 @@
     "smoke:agui-render-parity": "tsx bin/smoke/agui-render-parity.smoke.ts",
     "smoke:agui-frame-dispatch": "tsx implementations/web/smoke/agui-frame-dispatch.smoke.ts",
     "smoke:view-events-filter": "tsx implementations/cli/smoke/view-events-filter.smoke.ts",
+    "smoke:event-order": "tsx implementations/web/smoke/event-order.smoke.ts",
+    "smoke:web-events-filter": "tsx implementations/web/smoke/web-events-filter.smoke.ts",
     "smoke:event-channel": "tsx extensions/connector-core/smoke/event-channel.smoke.ts",
     "smoke:event-channel-resolve": "tsx extensions/connector-core/smoke/event-channel-resolve.smoke.ts",
     "smoke:agui-split": "tsx extensions/connector-core/smoke/agui-split.smoke.ts",


### PR DESCRIPTION
The dashboard opens its live feed and only then fetches history, so it is a two-phase consumer rather
than one that can assume an ordered stream. This teaches it to order what it draws, to say what it
could not establish, and stops it listing and backfilling every agent's structured-event channel.

## Ordering

A frame's place in its stream is its sequence number, and that is the only thing that can say a frame
is missing. Message-id dedupe answers whether two messages are the same, which says nothing about what
belongs between them.

`implementations/web/src/web/event-order.js` is the two-phase bootstrap, served to the console page as
a classic script:

- frames arriving while the fetch is in flight are held, then released in sequence order once the
  batch settles
- the baseline is the settled batch's minimum, never the first frame observed. Baselining on arrival
  reads the whole backfill as running backwards
- sequence checking is not armed until the boundary passes. Armed earlier, the same backfill reads as
  a hole
- a baseline above the first sequence means the retained prefix has rolled: the chain is marked
  incomplete and applied forward, which is not a fault
- a discontinuity after the baseline is a fault, reported with both ends named, and the frontier
  advances past the hole so one lost frame reports once rather than on every frame after it
- the retained range is audited, not only its ends. A batch of 1, 2, 5 has the right baseline and the
  right frontier and every later frame follows it contiguously, so a hole inside retained history is
  the one discontinuity no live arrival can ever reveal. Breaks are reported as runs, so losing a
  thousand frames is one report naming both ends rather than a thousand burying it
- a detected gap still draws its frame. Holding it until a missing predecessor arrives would hold it
  forever when that frame is genuinely gone, and a visible gap is worth more than a silent loss
- chains are keyed on sender, epoch and thread. Two writers pick run ids and sequences independently,
  so epoch is what makes a stream its own, and the key is built so a thread id containing the key's
  own punctuation cannot fuse two chains
- anything not carrying a usable sequence number, including chat and a malformed frame, passes straight
  through in arrival order. Delaying chat behind a frame's backfill would make this a latency bug for
  traffic it does not own

## One bootstrap, one settle

Arming the machine and settling it are the two ends of one bootstrap, and the page can start a second
before the first ends. It does so on every load: the page calls `refresh()` and then `connect()`, and
the feed's open handler calls `refresh()` again. A second call that re-armed the machine left the first
one holding frames nothing could reach, so they were never drawn and the next poll discarded them. The
channel view had the same shape, driven by the poll's own repeated selection of the channel already
open. Overlapping callers now share the bootstrap in flight, and the channel path settles the machine
it armed rather than whichever one the global currently holds.

The settle now runs on every exit path. It used to live inside the all-activity branch while the arm
was unconditional, so a reader sitting on a channel, a DM or an agent held every live frame in a
machine that would never settle. A throw from any earlier request, the roster read among them, did the
same. Covering all four branches and a throw from any of them is what makes the arm safe to be
unconditional.

Both merge sites merge rather than assign over what arrived live during the fetch. The assignment
discarded every live arrival in that window. Retention hid it for chat, because the backfill re-read
the same messages from the broker and they came back, and the filter below is what would have turned
it into a real loss of frames.

## What the page says when it cannot know

The live tap and the history read are two reads with no shared cut, and the fetch is issued before the
tap is open, so the first buffered frame of a chain can sit above the retained range's top with nothing
lost at all. Reported as a fault, that fired on healthy continuously published traffic and latched, and
the frame that filled the hole a moment later cleared nothing. A fault that fires on a healthy stream
is worse than no fault, because it teaches the reader to ignore the one signal that matters. So the
hole that straddles the seam is its own kind, drawn as unconfirmed, and only for the one frame per
chain that straddles it: a number missing between two buffered frames arrived through the same
subscription while the page was listening, and that is a real loss.

A failed history read is an empty history batch, a case the machine already specifies, where the
baseline comes from the earliest buffered frame. Both merge sites settle on empty rather than skipping
the boundary, and each surfaces the failure. Without that the held frames would be invisible for the
life of the page with nothing saying so.

None of the above is worth anything unheard, so both feed views draw the notes. They were previously
collected into an array nothing read, which let the machine detect a missing frame while the page said
nothing. They are drawn as separate statements: frames missing, an unconfirmed start-up hole, a rolled
prefix, and history unavailable. Collapsing them would put the one that always happens on a late join
next to the one that must never be ignored, and it is what makes an empty-batch settle an honest
degrade rather than a quiet one.

## The channel filter

`/api/channels` and `/api/activity` now carry chat only. A channel row is derived from every retained
concrete subject and the chat stream caps per subject rather than by age, so an unfiltered list grows
by one row per agent that has ever run and never shrinks: the sidebar fills with machine streams, the
graph page grows a node for each, and the activity route pays one history round trip per event channel
to merge results nobody reading chat asked for.

The filter runs before the fetch rather than on its output, so those round trips are not paid and then
discarded, and it uses the shared classifier rather than a local prefix test, because a channel a human
called `events.standup` is not principal-shaped and must stay where it was being read. The two backfill
routes moved behind `chatOnly` and `activityBackfill`, exported so the order of operations is reachable
by a test.

Two things stay unfiltered on purpose: the live feed still carries frames, marked rather than dropped,
and history for a channel named explicitly is still served, or the surface could render a frame it
could never fetch.

## Evidence

- `smoke:event-order`, 135 cells: the seam, the required live-ahead-of-retained row, the empty-history
  arm, the fault, duplicates, chain separation, holes inside the retained batch, the straddling hole
  and its late fill, and the degenerate inputs, executed rather than reasoned about. Every negative has
  a positive control beside it, and the required row is asserted against what a first-arrival baseline
  would have produced rather than only against what the machine does produce.
- Thirty-two of those cells drive the shipped `refresh()`, `select()` and notice renderer out of
  `app.js` rather than a restatement of them: overlapping bootstraps with a frame arriving between
  them, each of the four branches, a throw from the first request, a rejecting fetch with a resolving
  control beside it, and the rendered output of each note kind.
- `smoke:web-events-filter`, 26 cells: the classifier in both directions, and which channels history
  was ASKED for, since the claim is about order and not output. What is deliberately unfiltered is
  pinned as source-shape cells, labelled as the weaker evidence they are.
- 23 mutations across two fixtures, all 23 killed on the cell named in the fixture before the run.
- `channel-authority`'s harness now supplies the ordering machine and the single-flight state loaded
  from the shipped file rather than a stub, because its cells execute the real ingress and backfill
  functions and those now route through both. A stub returning the entry unchanged would have satisfied
  every cell while the page held it forever.
- Suite list appended, never reordered: two entries, no duplicates, both defined in `package.json`.
- No change to `SPEC.md`, `docs/` or `README.md`, and no wire change.

## Scope this does not claim

With event channels out of the channel list, the sidebar offers no event channel to select, so the
retained-minimum path is reached today by naming a channel to the history route, and by the suite. A
per-agent event-stream view is the natural closure and is not in this change.

Frames of one chain are exactly ordered by sequence. Where a released frame sits relative to a chat
message that arrived during the same fetch is approximate, and deliberately not fixed by sorting the
merged rows on timestamp: a producer's clock is not its sequence, so two frames whose timestamps
disagree with their sequence numbers would be swapped back by that sort, trading the guarantee for the
cosmetic.
