### PR TITLE
test(core): adopt the broker teardown helper in 15 more smoke suites

### DIFF
--- a/.changeset/broker-teardown-core-t1.md
+++ b/.changeset/broker-teardown-core-t1.md
@@ -1,0 +1,5 @@
+---
+---
+
+Test-only: adopts the smoke broker teardown helper in 15 more `packages/core` suites, so a killed
+suite tears its broker down instead of orphaning it. No shipped behaviour changes, so no release.

--- a/packages/core/smoke/acl-cas.smoke.ts
+++ b/packages/core/smoke/acl-cas.smoke.ts
@@ -18,6 +18,7 @@ import { connect } from "@nats-io/transport-node";
 import type { KV } from "@nats-io/kv";
 import { isReachable, openAclRegistry, readAcl, commitAcl, reissueAcl, deleteAcl, aclKey } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => {
@@ -31,8 +32,9 @@ const UG = "garbledbbbbbbbbbbbbbbbbbbbb";
 const UW = "wedgedcccccccccccccccccccc";
 
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-aclcas-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 
 try {
   let up = false;
@@ -93,5 +95,6 @@ try {
   if (broker.pid) { try { process.kill(broker.pid, "SIGKILL"); } catch { /* gone */ } }
   await wait(200);
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
   process.exit(process.exitCode ?? 0);
 }

--- a/packages/core/smoke/artifact-store.smoke.ts
+++ b/packages/core/smoke/artifact-store.smoke.ts
@@ -34,11 +34,13 @@ import {
   ARTIFACT_STORE_MAX_BYTES,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const SPACE = "artstore";
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-artstore-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 const servers = `nats://127.0.0.1:${PORT}`;
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -254,6 +256,7 @@ try {
 } finally {
   broker.kill("SIGKILL");
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(`\nartifact-store: ${ok} passed, ${fail} failed`);

--- a/packages/core/smoke/cas-publish.smoke.ts
+++ b/packages/core/smoke/cas-publish.smoke.ts
@@ -38,6 +38,7 @@ import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import { CotalEndpoint, isCasLoss, isReachable, mintLifecycleUid, type CotalMessage, type Delivery } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => {
@@ -46,8 +47,9 @@ const c = (n: string, v: boolean, extra?: unknown) => {
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cas-publish-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 const SPACE = "caspub";
 const CH = "events.probe.s1";
 
@@ -225,6 +227,7 @@ try {
 } finally {
   broker.kill("SIGKILL");
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 function throwsSync(what: string, fn: () => unknown) {

--- a/packages/core/smoke/endpoint-action.smoke.ts
+++ b/packages/core/smoke/endpoint-action.smoke.ts
@@ -33,6 +33,7 @@ import {
   type Receipt, type ReceiptEmissionWiring, type ReceiptStoreContext,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -70,8 +71,9 @@ c("the per-goal progress topic carries the caller identity for mint-time read co
     .endsWith(`.goal.u_abc.worker.${UID}.g1.progress`));
 
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-epact-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 
 try {
   let up = false;
@@ -488,6 +490,7 @@ try {
     if (broker.exitCode !== null || broker.signalCode !== null) resolve();
   });
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(`\nENDPOINT ACTION SMOKE ${fail === 0 ? "OK ✅ " : "FAILED ❌ "} (${ok} passed, ${fail} failed)`);

--- a/packages/core/smoke/endpoint-contract-store.smoke.ts
+++ b/packages/core/smoke/endpoint-contract-store.smoke.ts
@@ -27,6 +27,7 @@ import {
   type ContractStoreContext,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -60,8 +61,9 @@ await rejects("invalid UTF-8 bytes are never an artifact",
   () => assertCanonicalArtifactBytes(new Uint8Array([0x7b, 0xff, 0x7d]), "probe"), "contract-invalid");
 
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-epstore-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 try {
   let up = false;
   for (let i = 0; i < 50 && !up; i++) { up = await isReachable(`nats://127.0.0.1:${PORT}`); if (!up) await wait(100); }
@@ -365,6 +367,7 @@ try {
   broker.kill("SIGKILL");
   await new Promise<void>((resolve) => { broker.once("exit", () => resolve()); broker.once("error", () => resolve()); });
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 function HEXLIKE(s: string): boolean { return /^[0-9a-f]{64}$/.test(s); }

--- a/packages/core/smoke/endpoint-guard.smoke.ts
+++ b/packages/core/smoke/endpoint-guard.smoke.ts
@@ -27,6 +27,7 @@ import {
   type EpCaller, type GoalRef, type SignerAnchor, type AnchorResolver, type GuardCallSeam, type ActionContext,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -126,8 +127,9 @@ await rejects("the guard call and obligation verification share ONE gate budget 
 
 // ── the hold wiring over the checkpoint pause primitive (real broker) ──
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-epguard-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 try {
   let up = false;
   for (let i = 0; i < 50 && !up; i++) { up = await isReachable(`nats://127.0.0.1:${PORT}`); if (!up) await wait(100); }
@@ -459,6 +461,7 @@ try {
   broker.kill("SIGKILL");
   await new Promise<void>((resolve) => { broker.once("exit", () => resolve()); broker.once("error", () => resolve()); });
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(`\nENDPOINT GUARD SMOKE ${fail === 0 ? "OK ✅ " : "FAILED ❌ "} (${ok} passed, ${fail} failed)`);

--- a/packages/core/smoke/endpoint-journal.smoke.ts
+++ b/packages/core/smoke/endpoint-journal.smoke.ts
@@ -23,6 +23,7 @@ import {
   type AcceptanceFact, type RejectionFact, type QuarantineFact, type ParsedEpRequest, type EpCaller,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0, fail = 0;
 // A PASSING CELL PRINTS. It used to be silent, and silence is not free: `mutation-proof` counts
@@ -440,8 +441,9 @@ throws("size preflight refuses an acceptance that cannot fit", () => assertFactF
 
 // ── the decision CAS + plain appends (real broker) ──
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-epjrn-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 
 try {
   let up = false;
@@ -521,5 +523,6 @@ try {
   if (broker.pid) { try { process.kill(broker.pid, "SIGKILL"); } catch { /* gone */ } }
   await wait(200);
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
   process.exit(process.exitCode ?? 0);
 }

--- a/packages/core/smoke/endpoint-receipt.smoke.ts
+++ b/packages/core/smoke/endpoint-receipt.smoke.ts
@@ -27,6 +27,7 @@ import {
   type EpCaller, type ReceiptRef, type Receipt, type ReceiptStoreContext, type SignerAnchor, type AnchorResolver,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -224,8 +225,9 @@ await rejects("a non-positive verifyBudgetMs refuses",
 
 // ── create-only publication through the space-bonded context: one execution, one receipt ──
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-eprcpt-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 try {
   let up = false;
   for (let i = 0; i < 50 && !up; i++) { up = await isReachable(`nats://127.0.0.1:${PORT}`); if (!up) await wait(100); }
@@ -270,6 +272,7 @@ try {
   broker.kill("SIGKILL");
   await new Promise<void>((resolve) => { broker.once("exit", () => resolve()); broker.once("error", () => resolve()); });
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(`\nENDPOINT RECEIPT SMOKE ${fail === 0 ? "OK ✅ " : "FAILED ❌ "} (${ok} passed, ${fail} failed)`);

--- a/packages/core/smoke/endpoint-serve-gate.smoke.ts
+++ b/packages/core/smoke/endpoint-serve-gate.smoke.ts
@@ -48,6 +48,7 @@ import {
 } from "../src/index.js";
 import type { KV } from "@nats-io/kv";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -72,8 +73,9 @@ const mkServeRow = (credentialId: string): EpServeLedgerRow => ({
 });
 
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-epservegate-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 
 try {
   let up = false;
@@ -158,6 +160,7 @@ try {
 } finally {
   broker.kill("SIGKILL");
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(`\n${fail === 0 ? "ENDPOINT-SERVE GATE SMOKE OK ✅" : "ENDPOINT-SERVE GATE SMOKE FAILED"}  (${ok} passed, ${fail} failed)`);

--- a/packages/core/smoke/endpoint-serve.smoke.ts
+++ b/packages/core/smoke/endpoint-serve.smoke.ts
@@ -40,6 +40,7 @@ import {
 } from "../src/index.js";
 import type { KV } from "@nats-io/kv";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 /** READING THIS SUITE'S OUTPUT — the reporting is INVERTED and the inversion is a trap.
  *
@@ -269,8 +270,9 @@ const freezeErr = async (jsmStub: unknown): Promise<{ code?: string; message: st
 
 // ── live broker ──
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-epserve-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 
 try {
   let up = false;
@@ -1009,6 +1011,7 @@ try {
   broker.kill("SIGKILL");
   await new Promise<void>((resolve) => { broker.once("exit", () => resolve()); broker.once("error", () => resolve()); });
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(`\nENDPOINT SERVE SMOKE ${fail === 0 ? "OK ✅" : "FAILED ❌"}  (${ok} passed, ${fail} failed)`);

--- a/packages/core/smoke/endpoint-session.smoke.ts
+++ b/packages/core/smoke/endpoint-session.smoke.ts
@@ -48,6 +48,7 @@ import {
   type SignerAnchor, type AnchorResolver,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; console.log(`  ✓ ${n}`); } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -460,8 +461,9 @@ console.log("D. no standing EPS grant in any grant builder");
 // ---------- C. the rails over a real broker ----------
 console.log("C. rails: duplex windowed frames over a live broker");
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-epsession-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const broker = spawn("nats-server", ["-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 try {
   let up = false;
   for (let i = 0; i < 50 && !up; i++) { up = await isReachable(`nats://127.0.0.1:${PORT}`); if (!up) await wait(100); }
@@ -831,4 +833,5 @@ try {
 } finally {
   broker.kill("SIGKILL");
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/packages/core/smoke/endpoint-traits.smoke.ts
+++ b/packages/core/smoke/endpoint-traits.smoke.ts
@@ -43,6 +43,7 @@ import {
   type EpCommandDef, type EpServeGrant, type EpIssuanceBarrier, type EpServeContext,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -282,8 +283,9 @@ await rejects("an exotic container in a signed artifact (Map) refuses instead of
 
 // ── live broker: registration → serve grant → governed surface → the pre-effect gate ──
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-eptraits-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 
 try {
   let up = false;
@@ -933,6 +935,7 @@ try {
   broker.kill("SIGKILL");
   await new Promise((r) => broker.once("exit", r));
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(`\nENDPOINT TRAITS SMOKE ${fail === 0 ? "OK ✅" : "FAILED ❌"}  (${ok} passed, ${fail} failed)`);

--- a/packages/core/smoke/endpoint-verbs.smoke.ts
+++ b/packages/core/smoke/endpoint-verbs.smoke.ts
@@ -28,6 +28,7 @@ import {
   type EpRegistrationState,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -84,8 +85,9 @@ function respond(nc: NatsConnection, filter: string, batch: (req: ParsedEpReques
 
 // ── live broker ──
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-epverbs-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 
 try {
   let up = false;
@@ -461,5 +463,6 @@ try {
 } finally {
   broker.kill("SIGKILL");
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 if (fail > 0) process.exit(1);

--- a/packages/core/smoke/endpoint-virtual.smoke.ts
+++ b/packages/core/smoke/endpoint-virtual.smoke.ts
@@ -43,6 +43,7 @@ import {
   type ActivatorContext, type RestartHistoryEntry,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -66,8 +67,9 @@ const enc = (s: string) => new TextEncoder().encode(s);
 const td = new TextDecoder();
 
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-epvirtual-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 
 try {
   let up = false;
@@ -548,6 +550,7 @@ try {
   broker.kill("SIGKILL");
   await new Promise((r) => broker.once("exit", r));
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(fail === 0 ? `\nENDPOINT VIRTUAL SMOKE OK ✅  (${ok} passed, ${fail} failed)` : `\nENDPOINT VIRTUAL SMOKE FAILED ❌  (${ok} passed, ${fail} failed)`);

--- a/packages/core/smoke/frame-size.smoke.ts
+++ b/packages/core/smoke/frame-size.smoke.ts
@@ -56,6 +56,7 @@ import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import { CotalEndpoint, isReachable, mintLifecycleUid } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => {
@@ -65,10 +66,11 @@ const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 const MAXP = 4096;
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "frame-size-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const conf = join(sd, "nats.conf");
 writeFileSync(conf, `port: ${PORT}\nhost: "127.0.0.1"\nmax_payload: ${MAXP}\njetstream { store_dir: "${join(sd, "js")}" }\n`);
 const broker = spawn("nats-server", ["-c", conf], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 const SPACE = "framesize";
 const CH = "events.probe.s1";
 
@@ -194,6 +196,7 @@ try {
 } finally {
   broker.kill("SIGKILL");
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(`frame-size smoke: ${ok} passed, ${fail} failed`);


### PR DESCRIPTION
Mechanical adoption tranche, 15 of the 61 `packages/core` suites left after the corrective batch.
One suite per commit, no sweep.

Every suite keeps its existing `finally` teardown, which is correct and does the work on every
normal exit. Ownership only covers the path where the process is signalled and the `finally` never
unwinds. `release()` is the last statement of each teardown, so ownership is held until cleanup has
actually finished and an uncaught throw still exits with the broker owned.

## Counts, run before and after each edit

| suite | cells | | suite | cells |
| --- | --- | --- | --- | --- |
| `acl-cas` | 12 | | `endpoint-serve` | 136 |
| `artifact-store` | 21 | | `endpoint-serve-gate` | 24 |
| `cas-publish` | 37 | | `endpoint-session` | 113 |
| `endpoint-action` | 83 | | `endpoint-traits` | 112 |
| `endpoint-contract-store` | 57 | | `endpoint-verbs` | 76 |
| `endpoint-guard` | 71 | | `endpoint-virtual` | 94 |
| `endpoint-journal` | 115 | | `frame-size` | 16 |
| `endpoint-receipt` | 46 | | | |

Identical before and after in all 15. Box state around the runs: `nats-server` count 14 before and
14 after.

## Retired prefixes

Each suite's store dir prefix becomes the minted `cotal-smoke-broker-` token. That is not cosmetic:
a broker started through the helper stays recognisable after its owner is SIGKILLed, and one started
around it does not, so the token is the only evidence a later reaper can match. A suite that keeps
its own prefix stays unreapable even after adopting the helper.

**Fifteen greps are retired by this**, listed because a retired check is worse than a missing one:
it returns zero and reads as healthy while measuring nothing.

`cotal-aclcas-`, `cotal-artstore-`, `cas-publish-`, `cotal-epact-`, `cotal-epstore-`,
`cotal-epguard-`, `cotal-epjrn-`, `cotal-eprcpt-`, `cotal-epservegate-`, `cotal-epserve-`,
`cotal-epsession-`, `cotal-eptraits-`, `cotal-epverbs-`, `cotal-epvirtual-`, `frame-size-`.

## How these 15 were chosen

The edit is uniform, so it was applied by a small tool that performs the four changes on ONE file
and **refuses anything ambiguous** rather than guessing: it requires exactly one bound
`nats-server` spawn, exactly one `mkdtempSync` with a literal prefix, exactly one `rmSync` of that
directory, and a unique import anchor. Of the 61 remaining core suites it accepted 49 and refused 12
with reasons, and this tranche is the first 15 of the 49. Every accepted diff is 4 lines added and 1
changed, and each suite was still run individually and committed on its own.

The 12 refusals are not skipped work, they are the ones that need a person, and the split is exactly
what the tool printed rather than a characterisation of it: seven do not bind the spawn to a const,
so the tool cannot name the child to own; two spawn more than one broker, two and three
respectively; and three do their teardown inside a `process.on("exit")` handler rather than a
`finally`, so there is no `rmSync` of the store dir for the release to follow.

Worth recording about those three exit-handler suites, because it identifies the pattern that
already works: they kill the broker **and** remove the directory in the same handler, and they have
**zero** residue on a long lived box, against 64, 42 and 74 directories from the three suites fixed
in the corrective batch. An exit handler is not the problem. An exit handler that kills the broker
and leaves the directory is, which is exactly what the leaking suite had.

## Gates

- Every suite run before and after, identical cell counts (table above).
- `pnpm typecheck` rc=0.
- `pnpm smoke:core-boundary` green.
- No change to `bin/smoke/ci-suites.txt`, none under `docs/`, no manifest or lockfile change.

Test only; the changeset declares no release.
