### PR TITLE
chore(changesets): reword six pending changeset summaries to plain punctuation

### DIFF
--- a/.changeset/bind-fence.md
+++ b/.changeset/bind-fence.md
@@ -8,13 +8,13 @@ Refuse a class-queue split before the command runs, instead of reporting it afte
 An endpoint call resolves one incarnation and then invokes through a queue that may pick another.
 Until now the caller was the only party that noticed: the mismatch was detected on the reply, by
 which time the responder had already handled the request. That is why the error had to say it
-proved nothing about whether the command ran — a check that runs after the effect is a report, not
+proved nothing about whether the command ran: a check that runs after the effect is a report, not
 a guard. In a multi-manager space it is how one spawn becomes several: the effect lands on A, the
 caller bound to B is told the call failed, and the retry duplicates it.
 
 A request now carries the incarnation the caller resolved against (`bind`, a new optional
 `EndpointRequest` field), and a responder that is not that incarnation refuses at the pre-effect
-seam — before args validation, before target resolution, and before the governed gate that can
+seam, before args validation, before target resolution, and before the governed gate that can
 consume a one-use payment proof. The refusal carries `ai.cotal.ep.bind-refused` and states that
 the command did not run, so re-resolving and re-issuing is safe. `failed-precondition` when a
 different instance received it, `expired` when the same instance is at another epoch: the epoch is
@@ -22,14 +22,14 @@ carried even on the instance rail, where the subject grammar has no token for it
 incarnation would otherwise serve its predecessor's caller.
 
 The block confers nothing. It can only make a responder the subject already reached refuse, so it
-narrows and never widens, and attribution still comes from the reply subject — a refusal
+narrows and never widens, and attribution still comes from the reply subject: a refusal
 attributed to the very incarnation the caller bound is incoherent and is rejected rather than
 honored, so the marker cannot be used to claim an effect away. It is refused rather than ignored
 where it has no reading: on `describe`, which is what produces a bind, and on the scatter rail,
 which addresses every incarnation by construction.
 
 A long-lived client recovers from the refusal instead of stranding on it. `invokeService` caches
-its resolve, and its existing split recovery keyed on a thrown marker — which a refusal, being an
+its resolve, and its existing split recovery keyed on a thrown marker, which a refusal, being an
 ordinary reply, never raises. It now keys on the reply too, drops the stale bind, and re-issues
 the call **once for any command**, not only for one on the repeat-safe allowlist. That allowlist
 exists because a split used to be detected after the responder had handled the request, so core
@@ -38,7 +38,7 @@ removes the uncertainty rather than working around it, so the re-issue is a firs
 
 The allowlist still governs everything else, and that is the half that keeps this safe. A
 responder that predates the fence ignores the field and executes, so its reply proves nothing
-about whether the command ran — and re-issuing on it would duplicate the effect. The re-issue is
+about whether the command ran, and re-issuing on it would duplicate the effect. The re-issue is
 therefore withheld from every reply that does not carry the refusal, and the refusal is checked
 rather than believed: the bind it was computed against must be the one this request carried, and
 the incarnation it claims to be must be the one the reply subject attributes it to. Both halves
@@ -46,20 +46,20 @@ are derivable by the caller, and neither is something an unfenced responder can 
 accident. A refusal that fails either is `internal`, not a licence to try again.
 
 A re-issue that cannot be resolved surfaces the refusal, not the resolve. Re-resolving goes back
-to the registry, and an endpoint that has since retired answers nothing — so a stale handle used
+to the registry, and an endpoint that has since retired answers nothing, so a stale handle used
 to be met with a describe deadline ten seconds later, with the one fact that said the command had
 not run discarded on the way. The refusal now surfaces, carrying its marker, with the resolve
 failure named as the reason the repair could not be attempted.
 
 That recovery is counted, and the counter is the point. Handling a split makes it invisible, and
-the routing event is the only evidence the split exists at all — silence it and the split rate
+the routing event is the only evidence the split exists at all; silence it and the split rate
 becomes unmeasurable exactly as it becomes survivable. `CotalEndpoint.splitRecoveryCount` is
 always on and never behind a flag, and a `split-recovered` event carries the same fact for anyone
 listening; the event can be missed, the count cannot. On a live two-manager mesh, 5 of 6 unpinned
 class-anycast reads split, so this is not a rare-event counter.
 
 The caller-side check remains, and remains necessary: a responder that predates the fence ignores
-the field and executes, which leaves the older after-the-fact report — and the allowlist — as the
+the field and executes, which leaves the older after-the-fact report, and the allowlist, as the
 only protection in a skewed pair. That pair is now driven directly rather than argued about, by a
 hand-rolled responder that answers the class rail without a fence; `serveEndpoint` cannot produce
 the case, because its fence refuses a mismatched bind before the handler, so a request it executes

--- a/.changeset/hip-pots-shave.md
+++ b/.changeset/hip-pots-shave.md
@@ -7,8 +7,8 @@ under.
 
 `resolveMeshTarget` looks up the registry entry recorded for the current project root and honours its
 `server` and `mode`. That lookup compared roots with `resolve()`, which normalizes separators and
-`..`/`.` but does not collapse a symlink. A recorded root is whatever spelling the operator gave —
-`cotal meshes add --root <dir>` runs its root through `resolve()` too, never realpath — so a project
+`..`/`.` but does not collapse a symlink. A recorded root is whatever spelling the operator gave:
+`cotal meshes add --root <dir>` runs its root through `resolve()` too, never realpath, so a project
 recorded under one spelling of its directory and started under another read as *unrecorded*: its
 recorded server and mode were discarded and it was silently retargeted to the default server. A
 project started on `…:4333` resolved to `…:4222`, and a recorded open mesh minted credentials off

--- a/.changeset/journal-admission-conformance.md
+++ b/.changeset/journal-admission-conformance.md
@@ -19,7 +19,7 @@ never from the marker.
 
 `createEndpointStreams` now refuses a fact retention below the declared idempotency horizon. The
 horizon is realized by retention rather than by a clock, so a shorter age does not shorten a
-guarantee — it removes the mechanism, and a redelivered submission whose decision fact has been
+guarantee; it removes the mechanism, and a redelivered submission whose decision fact has been
 evicted is accepted as new work. The horizon is a declared option defaulting to the documented
 constant.
 

--- a/.changeset/strict-tool-input-seam.md
+++ b/.changeset/strict-tool-input-seam.md
@@ -7,15 +7,15 @@
 ---
 
 The `cotal_*` tools now refuse an argument they do not model instead of silently
-dropping it. A call carrying an unmodelled key — `owner` or `actor` alongside the
-real arguments — previously succeeded with that key stripped before the tool ran,
+dropping it. A call carrying an unmodelled key (`owner` or `actor` alongside the
+real arguments) previously succeeded with that key stripped before the tool ran,
 so the caller was told nothing and the tool did something other than what was
 asked. It is now refused by name, on every adapter and on every tool: the MCP
 renderers and pi publish a closed schema and the host rejects the call, while
 OpenCode and Hermes pass the caller's object through untouched and are closed at
-the connector's own dispatch. Tools that take no arguments are closed too — they
+the connector's own dispatch. Tools that take no arguments are closed too: they
 were previously published with no schema at all, so a host had nothing to check
-against and forwarded the extras to be dropped — as is `cotal_inbox`, whose
+against and forwarded the extras to be dropped, as is `cotal_inbox`, whose
 arguments four of the connectors replace with their own. Behaviourally breaking
 for any caller that was relying on extra keys being ignored. Every refusal names
 the rejected keys; where the connector is the one refusing it also lists the

--- a/.changeset/web-channel-authority.md
+++ b/.changeset/web-channel-authority.md
@@ -7,13 +7,13 @@ fix(web): route on the channel the broker policed, not the one the publisher cla
 
 The browser dashboard decided which channel a message belonged to by reading `msg.channel` off the
 payload. That field is written by the publisher, and the broker polices **subjects**, not payload
-fields — so a sender could put any channel name in a message body and have the dashboard file it
+fields, so a sender could put any channel name in a message body and have the dashboard file it
 into that channel's transcript, including a channel the sender had no permission to publish to.
 
 The verified channel was already available and was being discarded: the observer parses the subject
 to recover the authenticated sender, then dropped the rest of it. Routing now uses the channel
-derived from the subject the broker actually enforced. Where no authoritative channel exists —
-direct messages and anycast carry none — the publisher's claim is cleared rather than trusted, so a
+derived from the subject the broker actually enforced. Where no authoritative channel exists
+(direct messages and anycast carry none), the publisher's claim is cleared rather than trusted, so a
 forged value cannot survive into a transcript, a channel list, or an unread badge.
 
 Two rendering fixes ride along, because a message whose content vanishes is the same class of defect
@@ -22,7 +22,7 @@ a message with content displayed as a blank line; it now renders a marker naming
 part carrying data keeps that data instead of having it replaced by the marker. A surface that
 prints a marker while dropping the content looks like successful rendering, which is precisely the
 failure being removed. The two dashboard surfaces now share one parts renderer so they cannot drift
-apart on what a part looks like — that drift is how the original defect reached both of them.
+apart on what a part looks like; that drift is how the original defect reached both of them.
 
 **Limits worth stating.** The new suites drive the served JavaScript directly: they execute the
 shipped handler and backfill functions and assert message content and destination, but no cell opens

--- a/.changeset/web-membership-refusal.md
+++ b/.changeset/web-membership-refusal.md
@@ -7,7 +7,7 @@ fix(web): tell the browser a membership read failed instead of serving it as emp
 
 The dashboard's `/api/membership` route answered a failed read with `{asOf: undefined, members: []}`
 and a 200. `JSON.stringify` drops a key whose value is `undefined`, so those bytes are
-`{"members":[]}` — byte-identical to a successful read of a space where nobody is subscribed. The
+`{"members":[]}`, byte-identical to a successful read of a space where nobody is subscribed. The
 graph then reported the feed as `membership: traffic-only`, which asserts that the mesh publishes no
 membership feed, when the truth was that the read did not answer.
 


### PR DESCRIPTION
Prose-only edit of six pending changeset files (20 lines): replaces em-dashes with commas, colons, semicolons, and parentheses. No frontmatter, no bump-plan change, no package code. These summaries are copied into the generated CHANGELOGs at version time, so the release PR regenerates with clean prose after this lands.