### PR TITLE
test(core): adopt the broker teardown helper in 17 more smoke suites

### DIFF
--- a/.changeset/broker-teardown-core-t2.md
+++ b/.changeset/broker-teardown-core-t2.md
@@ -1,0 +1,5 @@
+---
+---
+
+Test-only: adopts the smoke broker teardown helper in 17 more `packages/core` suites, and stops
+`history-recent` squatting a hardcoded port. No shipped behaviour changes, so no release.

--- a/packages/core/smoke/channels.smoke.ts
+++ b/packages/core/smoke/channels.smoke.ts
@@ -22,6 +22,7 @@ import {
   isReachable, chatSubject, DEV_OWNER, type CotalMessage, type Delivery, type MessageMeta,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 // Fresh OS-assigned port per run: a fixed port means a single leaked broker (from a crashed/failed
 // prior run) collides with — or serves stale JetStream state to — every subsequent run, which reads
@@ -55,8 +56,9 @@ function recorder(name: string, id: string, channels: string[]) {
 }
 const has = (got: Rec[], text: string) => got.filter((g) => g.text === text);
 
-const dir = mkdtempSync(join(tmpdir(), "cotal-chan-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const srv = spawn("nats-server", ["-js", "-p", String(PORT), "-sd", join(dir, "js")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 let pass = 0;
 const check = (name: string, cond: boolean, extra?: unknown) => {
   assert.ok(cond, `${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
@@ -246,5 +248,6 @@ try {
     setTimeout(resolve, 3000);
   });
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 process.exit(0);

--- a/packages/core/smoke/control-auth.smoke.ts
+++ b/packages/core/smoke/control-auth.smoke.ts
@@ -38,6 +38,7 @@ import {
   BASELINE_LIFECYCLE_ENDPOINT,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -62,9 +63,10 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 
 const space = `ctl-auth-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-ctlauth-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 /** Try to publish `subject` as a request from a fresh connection using `creds`. The error type
  *  classifies the outcome: an Authorization Violation ⇒ the server DENIED the publish; anything
@@ -163,4 +165,5 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/packages/core/smoke/cred-lifetime-auth.smoke.ts
+++ b/packages/core/smoke/cred-lifetime-auth.smoke.ts
@@ -28,6 +28,7 @@ import {
   STANDING_RENEWABLE_TTL_SEC,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -69,9 +70,10 @@ async function tryConnect(creds: string, id: string): Promise<"ok" | "rejected">
 
 const space = `cred-life-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-credlife-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 try {
   let up = false;
@@ -156,6 +158,7 @@ try {
   srv.kill();
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 if (fail) {

--- a/packages/core/smoke/cross-owner-auth.smoke.ts
+++ b/packages/core/smoke/cross-owner-auth.smoke.ts
@@ -24,6 +24,7 @@ import {
   principalKey, presenceBucket, spacePrefix,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -62,9 +63,10 @@ async function trySubscribe(creds: string, id: string, subject: string, graceMs 
 
 const space = `xowner-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-xowner-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 try {
   let up = false;
@@ -131,4 +133,5 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/packages/core/smoke/delivery-boot-retry.smoke.ts
+++ b/packages/core/smoke/delivery-boot-retry.smoke.ts
@@ -15,6 +15,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CotalEndpoint, isReachable, createSpaceAuth, mintCreds, provisionAgent, mintLifecycleUid, serverConfig, newIdentity, setupSpaceStreams } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -28,9 +29,10 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 
 const space = `delivery-boot-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-boot-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 let mgr: CotalEndpoint | undefined, daemon: CotalEndpoint | undefined, agent: CotalEndpoint | undefined;
 try {
@@ -80,4 +82,5 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/packages/core/smoke/delivery-cred-confinement.smoke.ts
+++ b/packages/core/smoke/delivery-cred-confinement.smoke.ts
@@ -42,6 +42,7 @@ import {
   leaseKey,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -151,9 +152,10 @@ async function tryKvGet(creds: string, id: string, bucket: string, key: string):
 
 const space = `delivery-cred-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-delivcred-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 try {
   let up = false;
@@ -219,4 +221,5 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/packages/core/smoke/delivery-lease.smoke.ts
+++ b/packages/core/smoke/delivery-lease.smoke.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CotalEndpoint, isReachable, createSpaceAuth, mintCreds, serverConfig, newIdentity, setupSpaceStreams } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -26,9 +27,10 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 
 const space = `delivery-lease-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-lease-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 const mkDaemon = async () =>
   new CotalEndpoint({
@@ -77,4 +79,5 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/packages/core/smoke/delivery-leave-tombstone.smoke.ts
+++ b/packages/core/smoke/delivery-leave-tombstone.smoke.ts
@@ -14,6 +14,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CotalEndpoint, isReachable, createSpaceAuth, mintCreds, provisionAgent, mintLifecycleUid, serverConfig, newIdentity, setupSpaceStreams, principalKey, DEV_OWNER } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -27,9 +28,10 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 
 const space = `delivery-leave-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-leave-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 let mgr: CotalEndpoint | undefined, daemon: CotalEndpoint | undefined, agent: CotalEndpoint | undefined;
 try {
@@ -90,4 +92,5 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/packages/core/smoke/delivery-reconnect.smoke.ts
+++ b/packages/core/smoke/delivery-reconnect.smoke.ts
@@ -15,6 +15,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CotalEndpoint, isReachable, createSpaceAuth, mintCreds, provisionAgent, mintLifecycleUid, serverConfig, newIdentity, setupSpaceStreams, principalKey, DEV_OWNER } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -26,9 +27,10 @@ const check = (name: string, cond: boolean, extra?: unknown) => { if (cond) { pa
 
 const space = `delivery-reconnect-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-reconnect-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 let mgr: CotalEndpoint | undefined, daemon: CotalEndpoint | undefined, agent: CotalEndpoint | undefined;
 try {
@@ -93,4 +95,5 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/packages/core/smoke/delivery-reply-injection.smoke.ts
+++ b/packages/core/smoke/delivery-reply-injection.smoke.ts
@@ -31,6 +31,7 @@ import {
   DEV_OWNER,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -50,9 +51,10 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 
 const space = `delivery-inject-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-inject-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 const noop = { commitAcl: async () => {}, reissueAcl: async () => {}, provisionDmInbox: async () => {}, provisionDlvInbox: async () => {}, provisionTaskQueue: async () => {} };
 let daemon: CotalEndpoint | undefined;
@@ -127,4 +129,5 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/packages/core/smoke/deprovision-agent-auth.smoke.ts
+++ b/packages/core/smoke/deprovision-agent-auth.smoke.ts
@@ -49,6 +49,7 @@ import {
   principalKey,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -73,9 +74,10 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 
 const space = `deprov-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-deprov-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 const localPrincipal = (actor: string) => principalKey(DEV_OWNER, actor).key;
 
 /** Does consumer `name` exist on `stream`? Opens a short-lived provisioner-cred jsm to check. */
@@ -322,4 +324,5 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/packages/core/smoke/e2e-acl.smoke.ts
+++ b/packages/core/smoke/e2e-acl.smoke.ts
@@ -30,6 +30,7 @@ import {
   type CotalMessage, type Delivery, type MessageMeta,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort(), SERVERS = `nats://127.0.0.1:${PORT}`, space = "e2eacl";
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -62,10 +63,11 @@ async function rawPubDenied(creds: string, id: string, subject: string): Promise
   }
 }
 
-const dir = mkdtempSync(join(tmpdir(), "cotal-e2e-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const auth = await createSpaceAuth(space);
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 /** Write a real agent file and load it back — exercises the file → AgentDef path the launcher uses. */
 function agentFile(name: string, fm: string) {
@@ -232,5 +234,6 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 process.exit(process.exitCode ?? (fail ? 1 : 0)); // force-exit: lingering endpoint reconnect timers keep the loop alive

--- a/packages/core/smoke/endpoint-serve-auth.smoke.ts
+++ b/packages/core/smoke/endpoint-serve-auth.smoke.ts
@@ -33,6 +33,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { connect, credsAuthenticator, type NatsConnection } from "@nats-io/transport-node";
 import type { KV } from "@nats-io/kv";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 import {
   isReachable, createSpaceAuth, mintCreds, serverConfig, newIdentity, EpEnvelopeError,
   serveEndpoint, compileContract, contractDigest, registerServiceInstance, authorizeServeGrant,
@@ -62,9 +63,10 @@ const UID = "c".repeat(26);
 const caller: EpCaller = { owner: "u_abc", actor: "worker", uid: UID };
 
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-epsauth-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 const contract = compileContract({ root: { type: "object", properties: { n: { type: "number" } }, additionalProperties: false } });
 const D = contract.closureDigest;
@@ -754,6 +756,7 @@ try {
   srv.kill("SIGKILL");
   await new Promise<void>((resolve) => { srv.once("exit", () => resolve()); setTimeout(resolve, 3000); });
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(`\nENDPOINT SERVE AUTH SMOKE ${fail === 0 ? "OK ✅" : "FAILED ❌"}  (${ok} passed, ${fail} failed)`);

--- a/packages/core/smoke/goal-epoch-fence.smoke.ts
+++ b/packages/core/smoke/goal-epoch-fence.smoke.ts
@@ -60,6 +60,7 @@ import {
   type EpCaller, type GoalRef, type ParsedEpRequest, type ActionContext,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -89,8 +90,9 @@ c("a goal's terminal subject is the ONE flat SPEC:1433 (§13.2 reserved subjects
   && !/\.result\.\d+$/.test(goalResultSubject(SPACE, ref("g1"))));
 
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-epfence-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 
 const newGoal = async (ctx: ActionContext, id: string, acceptedEpoch: number | undefined): Promise<GoalRef> => {
   const g = ref(id);
@@ -232,6 +234,7 @@ try {
 } finally {
   broker.kill("SIGKILL");
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(`${fail === 0 ? "GOAL TERMINAL ATTRIBUTION SMOKE OK ✅" : "GOAL TERMINAL ATTRIBUTION SMOKE FAILED ❌"}  (${ok} passed, ${fail} failed)`);

--- a/packages/core/smoke/history-recent.smoke.ts
+++ b/packages/core/smoke/history-recent.smoke.ts
@@ -20,11 +20,18 @@ import { join } from "node:path";
 import { jetstream, jetstreamManager } from "@nats-io/jetstream";
 import { connect } from "@nats-io/transport-node";
 import { CotalEndpoint, isReachable, newIdentity, setupSpaceStreams } from "../src/index.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+import { pickFreePort } from "./_free-port.js";
 
-const PORT = 14772;
+// An OS-assigned port, not the 14772 this suite used to hardcode. Two concurrent runs did not
+// collide loudly: the first to bind won, the second ATTACHED TO IT, both published 60 messages
+// into the same stream, and both then failed on `reads the whole channel back (120 of 60)`. That
+// reads like a duplicate-delivery bug in history backfill and is a port collision two causes
+// upstream. Reproduced before this line changed.
+const PORT = await pickFreePort();
 const SERVER = `nats://127.0.0.1:${PORT}`;
 const SPACE = "hist";
-const store = mkdtempSync(join(tmpdir(), "cotal-hist-"));
+const store = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 let pass = 0;
 const check = (name: string, cond: boolean, extra?: unknown) => {
   assert.ok(cond, `${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
@@ -34,6 +41,7 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 const srv = spawn("nats-server", ["-p", String(PORT), "-js", "-sd", store], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, store);
 try {
   let up = false;
   for (let i = 0; i < 60; i++) { if (await isReachable(SERVER)) { up = true; break; } await wait(150); }
@@ -233,5 +241,6 @@ try {
 } finally {
   srv.kill("SIGKILL");
   rmSync(store, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 process.exit(0);

--- a/packages/core/smoke/manager-split-auth.smoke.ts
+++ b/packages/core/smoke/manager-split-auth.smoke.ts
@@ -68,6 +68,7 @@ import {
   BASELINE_LIFECYCLE_ENDPOINT,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 import { assertEphemeralBroker } from "./_ephemeral-only.js";
 
 const PORT = await pickFreePort();
@@ -96,9 +97,10 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 
 const space = `mgr-split-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-mgrsplit-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 /** Publish `subject` as a request using `creds`. Auth Violation ⇒ DENIED; anything else (JS-API error,
  *  No-Responders, timeout) ⇒ ALLOWED (the publish itself was accepted). `inboxPrefix` matches the cred's
@@ -440,4 +442,5 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/packages/core/smoke/membership-auth.smoke.ts
+++ b/packages/core/smoke/membership-auth.smoke.ts
@@ -30,6 +30,7 @@ import {
 } from "../src/index.js";
 import type { Identity } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -75,9 +76,10 @@ async function canReadMembers(id: Identity, creds: string): Promise<boolean> {
 
 const space = `mem-auth-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-memauth-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 try {
   let up = false;
@@ -176,6 +178,7 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(


### PR DESCRIPTION
Mechanical adoption tranche 2, 17 suites, one commit each, no sweep. Running total against the
census: 3 corrective in #507, 15 in #509, 17 here, so 35 of the 134 broker spawning suites repo
wide, and 35 of the 64 in `packages/core`.

Every suite keeps its existing `finally` teardown, which is correct and does the work on every
normal exit. Ownership only covers the path where the process is signalled and the `finally` never
unwinds. `release()` is the last statement of each teardown.

## One suite is not mechanical, and its collision reads like a product bug

`history-recent` hardcoded port 14772. Two concurrent runs collided, and **the collision did not
surface as a collision**. The first to bind won; the second attached to it; both published 60
messages into the same stream; and both then failed on:

```
AssertionError: reads the whole channel back (120 of 60)
```

That reads like a duplicate delivery defect in history backfill. It is a port collision two causes
upstream. It is also worse than the same class in `channels-auth` (#507), which at least surfaced as
an `AuthorizationError` and so smelled like infrastructure: this one points straight at the code
under test. Reproduced before the line changed, both runs failing; after the fix both pass. It now
takes an OS assigned port from the same helper the rest of these suites use.

## One port left alone on purpose

`endpoint-serve-auth` picks `12000 + random(8000)`. That is the pattern `_free-port.ts` exists to
replace, and its docblock says why: a random range intermittently lands on a port the OS refuses.
But it is not a defect I can reproduce on demand, and the rule here is not to fix what has not been
reproduced. Changing it would be a refactor wearing a fix's clothes. Recorded, not touched, along
with `backup-live` which uses the same pattern and is excluded from this tranche for being a live
suite that wants its own handling.

## Counts, run before and after each edit

| suite | cells | | suite | cells |
| --- | --- | --- | --- | --- |
| `channels` | 29 | | `delivery-reply-injection` | 2 |
| `control-auth` | 13 | | `deprovision-agent-auth` | 24 |
| `cred-lifetime-auth` | 18 | | `e2e-acl` | 23 |
| `cross-owner-auth` | 24 | | `endpoint-serve-auth` | 99 |
| `delivery-boot-retry` | 2 | | `goal-epoch-fence` | 20 |
| `delivery-cred-confinement` | 17 | | `history-recent` | 23 |
| `delivery-lease` | 5 | | `manager-split-auth` | 135 |
| `delivery-leave-tombstone` | 3 | | `membership-auth` | 6 |
| `delivery-reconnect` | 5 | | | |

Identical before and after in all 17. Box state: `nats-server` count 14 before and 14 after.

## Retired prefixes

Each store dir prefix becomes the minted `cotal-smoke-broker-` token, which is the only evidence a
later reaper can match once an owner has been SIGKILLed. **Seventeen greps are retired by this**,
listed because a retired check returns zero and reads as healthy while measuring nothing:

`cotal-boot-`, `cotal-chan-`, `cotal-credlife-`, `cotal-ctlauth-`, `cotal-delivcred-`,
`cotal-deprov-`, `cotal-e2e-`, `cotal-epfence-`, `cotal-epsauth-`, `cotal-hist-`, `cotal-inject-`,
`cotal-lease-`, `cotal-leave-`, `cotal-memauth-`, `cotal-mgrsplit-`, `cotal-reconnect-`,
`cotal-xowner-`.

## Method

Same per-file tool as #509: it makes the four changes on one file and refuses anything ambiguous
rather than guessing, requiring exactly one bound `nats-server` spawn, one `mkdtempSync` with a
literal prefix, one `rmSync` of that directory, and a unique import anchor. Every accepted diff here
is 4 lines added and 1 changed. Each suite was still run individually and committed on its own, and
the one non-mechanical change was made by hand after the tool ran.

## Gates

- Every suite run before and after, identical cell counts.
- `history-recent` concurrency reproduced before and re-run after: two failures before, two passes
  after.
- `pnpm typecheck` rc=0.
- `pnpm smoke:core-boundary` green.
- No change to `bin/smoke/ci-suites.txt`, none under `docs/`, no manifest or lockfile change.

Test only; the changeset declares no release.
