### PR TITLE
test(core): adopt the broker teardown helper in the last 16 tool-eligible suites

### DIFF
--- a/.changeset/broker-teardown-core-t3.md
+++ b/.changeset/broker-teardown-core-t3.md
@@ -1,0 +1,5 @@
+---
+---
+
+Test-only: adopts the smoke broker teardown helper in the last 16 tool-eligible `packages/core`
+suites. No shipped behaviour changes, so no release.

--- a/packages/core/smoke/members.smoke.ts
+++ b/packages/core/smoke/members.smoke.ts
@@ -37,6 +37,7 @@ import {
   type MembershipRecord,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const servers = `nats://127.0.0.1:${PORT}`;
@@ -50,8 +51,9 @@ const OA = "local.ownera", OB = "local.ownerb";
 const A = "local.alice", B = "local.bob", CA = "local.carol", D = "local.dave", E = "local.eve";
 const Z = "local.zeta", AL = "local.al", BO = "local.bo", CY = "local.cy";
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-const dir = mkdtempSync(join(tmpdir(), "cotal-memreg-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const srv = spawn("nats-server", ["-js", "-p", String(PORT), "-sd", join(dir, "js")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 let pass = 0;
 const check = (name: string, cond: boolean, extra?: unknown) => {
@@ -213,5 +215,6 @@ main()
       setTimeout(resolve, 3000);
     });
     rmSync(dir, { recursive: true, force: true });
+    releaseBroker(); // last: ownership is held until this teardown has actually finished
     process.exit(process.exitCode ?? 0);
   });

--- a/packages/core/smoke/membership-feed-confinement.smoke.ts
+++ b/packages/core/smoke/membership-feed-confinement.smoke.ts
@@ -38,6 +38,7 @@ import {
   MEMBERSHIP_INBOX_PREFIX,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -107,9 +108,10 @@ async function tryKvGet(creds: string, id: string, bucket: string, key: string):
 
 const space = `membership-conf-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-memconf-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 try {
   let up = false;
@@ -167,4 +169,5 @@ try {
 } finally {
   srv.kill("SIGKILL");
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/packages/core/smoke/membership-feed.smoke.ts
+++ b/packages/core/smoke/membership-feed.smoke.ts
@@ -41,6 +41,7 @@ import {
 } from "../src/index.js";
 import type { ChannelMembership, MembershipRecord } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -58,9 +59,10 @@ const pkey = (id: string) => principalKey(DEV_OWNER, id).key;
 
 const space = `membership-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space); // sys.signingSeed lives in-memory here — mint the observer below
-const dir = mkdtempSync(join(tmpdir(), "cotal-membership-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 const conns: Array<Awaited<ReturnType<typeof connect>>> = [];
 let feed: Awaited<ReturnType<typeof startMembershipFeed>> | undefined;
@@ -227,4 +229,5 @@ try {
   for (const c of conns) { try { await c.drain(); } catch { /* already drained */ } }
   srv.kill("SIGKILL");
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/packages/core/smoke/plane3-activation-auth.smoke.ts
+++ b/packages/core/smoke/plane3-activation-auth.smoke.ts
@@ -42,6 +42,7 @@ import {
   type Delivery,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -65,9 +66,10 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 
 const space = `plane3act-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-plane3act-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 try {
   let up = false;
@@ -209,5 +211,6 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 process.exit(fail === 0 ? 0 : 1);

--- a/packages/core/smoke/plane3-auth.smoke.ts
+++ b/packages/core/smoke/plane3-auth.smoke.ts
@@ -42,6 +42,7 @@ import {
   type MessageMeta,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -80,9 +81,10 @@ const denied = async (fn: () => Promise<unknown>): Promise<boolean> => {
 
 const space = `plane3-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-plane3-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 try {
   let up = false;
@@ -359,5 +361,6 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 process.exit(fail === 0 ? 0 : 1);

--- a/packages/core/smoke/presence-offline-scrub.smoke.ts
+++ b/packages/core/smoke/presence-offline-scrub.smoke.ts
@@ -15,6 +15,7 @@ import { connect } from "@nats-io/transport-node";
 import { Kvm } from "@nats-io/kv";
 import { CotalEndpoint, isReachable, mintLifecycleUid, presenceBucket, principalKey, DEV_OWNER, type Presence } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const servers = `nats://127.0.0.1:${PORT}`;
@@ -28,8 +29,9 @@ const awaitExit = (proc: ReturnType<typeof spawn>, timeoutMs = 3000): Promise<vo
     setTimeout(resolve, timeoutMs);
   });
 
-const dir = mkdtempSync(join(tmpdir(), "cotal-scrub-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const srv = spawn("nats-server", ["-js", "-p", String(PORT), "-sd", join(dir, "js")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 let pass = 0;
 const check = (name: string, cond: boolean, extra?: unknown) => {
   assert.ok(cond, `${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
@@ -72,5 +74,6 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 process.exit(0);

--- a/packages/core/smoke/presence-ttl-expiry-open.smoke.ts
+++ b/packages/core/smoke/presence-ttl-expiry-open.smoke.ts
@@ -46,6 +46,7 @@ import { Kvm } from "@nats-io/kv";
 import { jetstreamManager } from "@nats-io/jetstream";
 import { isReachable, reconcileSpaceTtls, presenceBucket, deliveryBucket, managerBucket } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 import { assertEphemeralBroker, scrubAmbientBrokerEnv } from "./_ephemeral-only.js";
 
 // Fence layer 4 first: this environment carries the LIVE broker in COTAL_SERVERS, and this suite
@@ -60,9 +61,10 @@ const SERVERS = `nats://127.0.0.1:${PORT}`;
 assertEphemeralBroker(SERVERS);
 const space = `ttlexpiry-${randomUUID().slice(0, 8)}`;
 
-const dir = mkdtempSync(join(tmpdir(), "cotal-ttlexpiry-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), `port: ${PORT}\njetstream { store_dir: "${join(dir, "js")}" }\n`);
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 let pass = 0, fail = 0;
 const check = (n: string, v: boolean, x?: unknown) => { v ? (pass++, console.log(`  ✓ ${n}`)) : (fail++, console.log(`  ✗ FAIL: ${n}`, x ?? "")); };
 
@@ -109,5 +111,6 @@ try {
   srv.kill("SIGKILL");
   await sleep(200);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 process.exit(fail === 0 ? 0 : 1);

--- a/packages/core/smoke/presence-ttl-migration-auth.smoke.ts
+++ b/packages/core/smoke/presence-ttl-migration-auth.smoke.ts
@@ -28,6 +28,7 @@ import { Kvm } from "@nats-io/kv";
 import { jetstreamManager } from "@nats-io/jetstream";
 import { isReachable, createSpaceAuth, mintCreds, serverConfig, newIdentity, setupSpaceStreams, reconcileBucketTtl, standaloneConnectOpts, presenceBucket, deliveryBucket, managerBucket } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 import { assertEphemeralBroker } from "./_ephemeral-only.js";
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -41,9 +42,10 @@ const space = `ttlmig-${randomUUID().slice(0, 8)}`;
 const PRESENCE_MS = 6_000, DELIVERY_MS = 30_000, MANAGER_MS = 10_000;
 
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-ttlmig-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 let pass = 0;
 const check = (name: string, cond: boolean, extra?: unknown) => {
   assert.ok(cond, `${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
@@ -176,5 +178,6 @@ try {
   srv.kill("SIGKILL");
   await sleep(200);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 process.exit(0);

--- a/packages/core/smoke/probe-teardown.smoke.ts
+++ b/packages/core/smoke/probe-teardown.smoke.ts
@@ -28,6 +28,7 @@ import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { isReachable, probeConnect } from "../src/endpoint.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REFUSING = "nats://127.0.0.1:1"; // closed loopback port: answers RST
@@ -99,7 +100,7 @@ if (fail.length) { console.log("\nfixture preconditions failed — the rest woul
 // A dialable broker, for the inverse control. Own scratch dir; the pid is recorded AT CREATION and
 // is the only pid this file will ever signal.
 // ---------------------------------------------------------------------------
-const scratch = mkdtempSync(join(tmpdir(), "cotal-probe-teardown-"));
+const scratch = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const port = await new Promise<number>((resolve) => {
   const srv = createServer();
   srv.listen(0, "127.0.0.1", () => {
@@ -111,6 +112,7 @@ const DIALABLE = `nats://127.0.0.1:${port}`;
 writeFileSync(join(scratch, "nats.conf"),
   `host: "127.0.0.1"\nport: ${port}\nstore_dir: "${join(scratch, "store")}"\njetstream: enabled\n`);
 const broker = spawn("nats-server", ["-c", join(scratch, "nats.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, scratch);
 const BROKER_PID = broker.pid!;
 
 try {
@@ -200,6 +202,7 @@ try {
   const comm = spawnSync("ps", ["-p", String(BROKER_PID), "-o", "comm="], { encoding: "utf8" }).stdout.trim();
   if (comm === "nats-server") process.kill(BROKER_PID, "SIGTERM");
   rmSync(scratch, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(fail.length === 0

--- a/packages/core/smoke/read-acl-auth.smoke.ts
+++ b/packages/core/smoke/read-acl-auth.smoke.ts
@@ -41,6 +41,7 @@ import {
   DEV_OWNER,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -60,9 +61,10 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 
 const space = `read-acl-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-readacl-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 const CHAT = chatStream(space);
 const allowedFilter = chatSubject(space, "*", "*", "allowed"); // cotal.<space>.chat.*.*.allowed
@@ -189,4 +191,5 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/packages/core/smoke/read-history-auth.smoke.ts
+++ b/packages/core/smoke/read-history-auth.smoke.ts
@@ -46,6 +46,7 @@ import {
   type CotalMessage,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 /** A message's text lives in `parts`, not a `text` field. Asserting on `m.text` compares
  *  `undefined === undefined` for the empty case and silently passes a page that carries nothing. */
@@ -62,9 +63,10 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 
 const space = `read-history-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-readhist-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 let mgr: CotalEndpoint | undefined, daemon: CotalEndpoint | undefined;
 let poster: CotalEndpoint | undefined, reader: CotalEndpoint | undefined;
@@ -363,6 +365,7 @@ try {
   srv.kill("SIGKILL");
   await wait(200);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 console.log(fail === 0 ? `\nREAD-HISTORY SMOKE OK ✅  (${pass} passed, 0 failed)` : `\nREAD-HISTORY SMOKE FAILED ❌  (${pass} passed, ${fail} failed)`);
 process.exit(fail === 0 ? 0 : 1);

--- a/packages/core/smoke/reload-deadline-queue.smoke.ts
+++ b/packages/core/smoke/reload-deadline-queue.smoke.ts
@@ -29,6 +29,7 @@ import {
   serverConfig, setupSpaceStreams,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 const MANAGER_BOUND_MS = 15_000; // manager's requestDeliveryAdmin("reloadCreds") timeout
@@ -41,9 +42,10 @@ const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
 const space = `reload-dq-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-reload-dq-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 try {
   let up = false;
@@ -99,6 +101,7 @@ try {
 } finally {
   srv.kill("SIGKILL");
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
   await wait(200);
 }
 process.exit(fail ? 1 : 0);

--- a/packages/core/smoke/self-serve-join-auth.smoke.ts
+++ b/packages/core/smoke/self-serve-join-auth.smoke.ts
@@ -40,6 +40,7 @@ import {
   type Delivery,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 // Fresh OS-assigned port per run + await-exit on every broker kill (below): a fixed port plus a SIGKILL
 // that doesn't await the child's exit leaks the broker, and the next run collides with the squatter
@@ -76,9 +77,10 @@ const pkey = (id: string) => principalKey(DEV_OWNER, id).key;
 
 const space = `selfjoin-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-selfjoin-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 let server = srv; // mutable: the reconnect test restarts the broker and tracks the live process
 
 try {
@@ -372,6 +374,7 @@ try {
   server.kill("SIGKILL");
   await awaitExit(server); // await actual exit so a failed run never leaks the broker onto its port
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(`\nSELF-SERVE-JOIN SMOKE ${fail === 0 ? "OK ✅" : "FAILED ❌"}  (${pass} passed, ${fail} failed)`);

--- a/packages/core/smoke/standing-renewal-auth.smoke.ts
+++ b/packages/core/smoke/standing-renewal-auth.smoke.ts
@@ -23,6 +23,7 @@ import {
   setupSpaceStreams,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -53,9 +54,10 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 
 const space = `renewal-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-renewal-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 try {
   let up = false;
@@ -149,4 +151,5 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/packages/core/smoke/sub-acl-auth.smoke.ts
+++ b/packages/core/smoke/sub-acl-auth.smoke.ts
@@ -26,6 +26,7 @@ import {
   spacePrefix,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -90,9 +91,10 @@ async function trySubscribe(
 
 const space = `sub-acl-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-subacl-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 const noop = {
   commitAcl: async () => {},
@@ -184,4 +186,5 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/packages/core/smoke/wildcard-backfill.smoke.ts
+++ b/packages/core/smoke/wildcard-backfill.smoke.ts
@@ -26,6 +26,7 @@ import {
   type CotalMessage, type Delivery, type MessageMeta,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 // Fresh OS-assigned port per run: a fixed port lets a leaked broker from a crashed prior run serve
 // stale JetStream state to the next run (reads as a flaky gate). A fresh port isolates each run even
@@ -58,8 +59,9 @@ function recorder(name: string, id: string, channels: string[]) {
 }
 const has = (got: Rec[], text: string) => got.filter((g) => g.text === text);
 
-const dir = mkdtempSync(join(tmpdir(), "cotal-wbk-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const srv = spawn("nats-server", ["-js", "-p", String(PORT), "-sd", join(dir, "js")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 let pass = 0;
 const check = (name: string, cond: boolean, extra?: unknown) => {
   assert.ok(cond, `${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
@@ -155,5 +157,6 @@ try {
     setTimeout(resolve, 3000);
   });
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 process.exit(0);


### PR DESCRIPTION
Mechanical adoption tranche 3, 16 suites, one commit each. This finishes the tool-eligible half of
`packages/core`.

Running total against the census: 3 corrective in #507, 15 in #509, 17 in #511, 16 here, so **51 of
the 134** broker spawning suites repo wide and **51 of the 64** in `packages/core`.

Every suite keeps its existing `finally` teardown, which is correct and does the work on every
normal exit. Ownership only covers the path where the process is signalled and the `finally` never
unwinds. `release()` is the last statement of each teardown.

## Counts, run before and after each edit

| suite | cells | | suite | cells |
| --- | --- | --- | --- | --- |
| `membership-feed-confinement` | 15 | | `probe-teardown` | 20 |
| `membership-feed` | 15 | | `read-acl-auth` | 10 |
| `members` | 33 | | `read-history-auth` | 31 |
| `plane3-activation-auth` | 6 | | `reload-deadline-queue` | 6 of 6 |
| `plane3-auth` | 20 | | `self-serve-join-auth` | 23 |
| `presence-offline-scrub` | 2 | | `standing-renewal-auth` | 8 |
| `presence-ttl-expiry-open` | 5 | | `sub-acl-auth` | 9 |
| `presence-ttl-migration-auth` | 19 | | `wildcard-backfill` | 5 |

Identical before and after in all 16. `reload-deadline-queue` prints no cell counter, so its
terminal marker line is compared instead, which is stated rather than quietly substituted. Box
state: `nats-server` count 14 before and 14 after.

## Retired prefixes

Each store dir prefix becomes the minted `cotal-smoke-broker-` token, the only evidence a later
reaper can match once an owner has been SIGKILLed. **Sixteen greps are retired by this**, listed
because a retired check returns zero and reads as healthy while measuring nothing:

`cotal-memconf-`, `cotal-membership-`, `cotal-memreg-`, `cotal-plane3act-`, `cotal-plane3-`,
`cotal-scrub-`, `cotal-ttlexpiry-`, `cotal-ttlmig-`, `cotal-probe-teardown-`, `cotal-readacl-`,
`cotal-readhist-`, `cotal-reload-dq-`, `cotal-selfjoin-`, `cotal-renewal-`, `cotal-subacl-`,
`cotal-wbk-`.

## What is left in `packages/core` after this

13 suites, and none of them are tool-eligible, which is the point of the tool refusing rather than
guessing:

- **7** do not bind the spawn to a const, so there is no child to name for ownership.
- **2** spawn more than one broker, two and three respectively.
- **3** do their whole teardown inside a `process.on("exit")` handler rather than a `finally`, so
  there is no `rmSync` for the release to follow. Those three are also the ones with **zero**
  residue on a long lived box, because the handler kills the broker AND removes the directory. They
  are the pattern that already works, and they need the least.
- **1** is `backup-live`, held out because live suites get their own handling.

## Method

Same per-file tool as #509 and #511: four changes on one file, refusing anything ambiguous with a
printed reason. Every accepted diff is 4 lines added and 1 changed. Each suite was still run
individually and committed on its own.

## Gates

- Every suite run before and after, identical counts.
- `pnpm typecheck` rc=0.
- `pnpm smoke:core-boundary` green.
- No change to `bin/smoke/ci-suites.txt`, none under `docs/`, no manifest or lockfile change.

Test only; the changeset declares no release.
