### PR TITLE
test(core): own every broker the restart and cluster suites start, not just the first

### DIFF
--- a/.changeset/broker-teardown-core-t4.md
+++ b/.changeset/broker-teardown-core-t4.md
@@ -1,0 +1,6 @@
+---
+---
+
+Test-only: adopts the smoke broker teardown helper in the seven `packages/core` suites that restart
+or cluster their brokers, owning every live child rather than only the first. No shipped behaviour
+changes, so no release.

--- a/packages/core/smoke/cas-preflight-cluster.smoke.ts
+++ b/packages/core/smoke/cas-preflight-cluster.smoke.ts
@@ -50,6 +50,7 @@ import { connect } from "@nats-io/transport-node";
 import { jetstreamManager } from "@nats-io/jetstream";
 import { CotalEndpoint, chatStream, isReachable, mintLifecycleUid } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => {
@@ -57,8 +58,9 @@ const c = (n: string, v: boolean, extra?: unknown) => {
 };
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-const root = mkdtempSync(join(tmpdir(), "cas-preflight-cluster-"));
+const root = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const procs: ChildProcess[] = [];
+const releases: Array<() => void> = [];
 const ports: number[] = [];
 const cluster: number[] = [];
 
@@ -75,7 +77,11 @@ try {
       `  port: ${cluster[i]}`,
       `  routes: [${routes.split(",").map((r) => `"${r}"`).join(",")}] }`,
     ].join("\n"));
-    procs.push(spawn("nats-server", ["-c", conf], { stdio: "ignore" }));
+    // Every node of the cluster is owned, not just the first: a signalled run that reaped one
+    // of three and left two would read as cleaned up while two brokers held their ports.
+    const proc = spawn("nats-server", ["-c", conf], { stdio: "ignore" });
+    procs.push(proc);
+    releases.push(teardownOnSignal(proc, root));
   }
 
   let up = false;
@@ -167,6 +173,7 @@ try {
 } finally {
   for (const p of procs) p.kill("SIGKILL");
   rmSync(root, { recursive: true, force: true });
+  for (const release of releases) release(); // last: ownership held until cleanup has finished
 }
 
 console.log(`cas-preflight-cluster smoke: ${ok} passed, ${fail} failed`);

--- a/packages/core/smoke/cutover-restart-eviction-auth.smoke.ts
+++ b/packages/core/smoke/cutover-restart-eviction-auth.smoke.ts
@@ -22,6 +22,7 @@ import {
   serverConfig,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -94,10 +95,13 @@ async function staleConnectionUnusable(nc: NatsConnection, timeoutMs = 20_000): 
 
 const space = `cutover-evict-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-cutover-evict-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const conf = join(dir, "server.conf");
 writeFileSync(conf, serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 let srv = spawn("nats-server", ["-c", conf], { stdio: "ignore" });
+// Re-owned on every restart. Owning only the FIRST child would leave the LIVE broker unowned
+// after a respawn while the suite still read as migrated: ownership held on a dead pid.
+let releaseBroker = teardownOnSignal(srv, dir);
 
 try {
   await waitReachable();
@@ -122,7 +126,9 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   writeFileSync(conf, serverConfig(rotated, [rotated], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
+  releaseBroker();
   srv = spawn("nats-server", ["-c", conf], { stdio: "ignore" });
+  releaseBroker = teardownOnSignal(srv, dir);
   await waitReachable();
 
   check("already-live stale data-account connection is unusable after local cutover restart", await staleConnectionUnusable(oldDataNc));
@@ -138,6 +144,7 @@ try {
   srv.kill();
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 if (fail) {

--- a/packages/core/smoke/membership-rw-renewal.smoke.ts
+++ b/packages/core/smoke/membership-rw-renewal.smoke.ts
@@ -32,6 +32,7 @@ import {
   MEMBERSHIP_FEED_KEY, type MembershipFeedHandle,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const enc = (s: string) => new TextEncoder().encode(s);
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -46,9 +47,18 @@ const SERVERS = `nats://127.0.0.1:${PORT}`;
 const space = `member-rw-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
 const rogue = await createSpaceAuth(space); // a DIFFERENT operator, absent from server.conf → the broker refuses its signatures
-const dir = mkdtempSync(join(tmpdir(), "cotal-member-rw-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
-const startBroker = (): ChildProcess => spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+// Ownership lives INSIDE the factory, so every restart is covered by construction rather than by
+// each call site remembering. Owning only the first child would leave the LIVE broker unowned
+// after a restart while the suite still read as migrated: ownership held on a dead pid.
+let releaseBroker = (): void => {};
+const startBroker = (): ChildProcess => {
+  releaseBroker();
+  const p = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+  releaseBroker = teardownOnSignal(p, dir);
+  return p;
+};
 let srv = startBroker();
 
 const observerCreds = await mintMembershipObserverCreds(auth, newIdentity());
@@ -267,6 +277,7 @@ try {
   try { await feed?.stop(); } catch { /* draining */ }
   srv.kill("SIGKILL");
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
   await wait(200);
 }
 process.exit(fail ? 1 : 0);

--- a/packages/core/smoke/plane3-gate-auth.smoke.ts
+++ b/packages/core/smoke/plane3-gate-auth.smoke.ts
@@ -32,6 +32,7 @@ import {
   type Delivery,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -55,9 +56,12 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 
 const space = `plane3gate-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-plane3gate-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 let server = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+// Re-owned on every restart. Owning only the FIRST child would leave the LIVE broker unowned
+// after a respawn while the suite still read as migrated: ownership held on a dead pid.
+let releaseBroker = teardownOnSignal(server, dir);
 
 try {
   let up = false;
@@ -130,7 +134,9 @@ try {
   got.length = 0;
   server.kill("SIGKILL");
   await awaitExit(server); // the restart reuses PORT — the old broker must free the socket first
+  releaseBroker();
   server = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+  releaseBroker = teardownOnSignal(server, dir);
   let back = false;
   for (let i = 0; i < 50; i++) { if (await isReachable(SERVERS)) { back = true; break; } await wait(200); }
   if (!back) throw new Error("broker did not restart");
@@ -151,5 +157,6 @@ try {
   server.kill("SIGKILL");
   await awaitExit(server);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 process.exit(fail === 0 ? 0 : 1);

--- a/packages/core/smoke/self-serve-join-coverage-auth.smoke.ts
+++ b/packages/core/smoke/self-serve-join-coverage-auth.smoke.ts
@@ -42,6 +42,7 @@ import {
   type MessageMeta,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -72,9 +73,12 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 
 const space = `selfjoincov-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-selfjoincov-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 let server = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+// Re-owned on every restart. Owning only the FIRST child would leave the LIVE broker unowned
+// after a respawn while the suite still read as migrated: ownership held on a dead pid.
+let releaseBroker = teardownOnSignal(server, dir);
 
 try {
   let up = false;
@@ -252,7 +256,9 @@ try {
   await wait(300);
   server.kill("SIGKILL");
   await awaitExit(server);
+  releaseBroker();
   server = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+  releaseBroker = teardownOnSignal(server, dir);
   let back = false;
   for (let i = 0; i < 50; i++) { if (await isReachable(SERVERS)) { back = true; break; } await wait(200); }
   if (!back) throw new Error("broker did not restart");
@@ -292,7 +298,9 @@ try {
   check("manager-present joinChannel(ops.dual) reports durable:true (Plane-3)", dual.joined === true && dual.durable === true, dual);
   server.kill("SIGKILL");
   await awaitExit(server);
+  releaseBroker();
   server = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+  releaseBroker = teardownOnSignal(server, dir);
   let back2 = false;
   for (let i = 0; i < 50; i++) { if (await isReachable(SERVERS)) { back2 = true; break; } await wait(200); }
   if (!back2) throw new Error("broker did not restart (2)");
@@ -315,6 +323,7 @@ try {
   server.kill("SIGKILL");
   await awaitExit(server);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(`\nSELF-SERVE-JOIN COVERAGE SMOKE ${fail === 0 ? "OK ✅" : "FAILED ❌"}  (${pass} passed, ${fail} failed)`);

--- a/packages/core/smoke/signing-key-rotation-auth.smoke.ts
+++ b/packages/core/smoke/signing-key-rotation-auth.smoke.ts
@@ -23,6 +23,7 @@ import {
   stripSpaceAuth,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -78,10 +79,13 @@ function signingKeys(jwt: string): string[] {
 const space = `signing-rot-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
 const oldSigner = stripSpaceAuth(auth);
-const dir = mkdtempSync(join(tmpdir(), "cotal-signrot-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const conf = join(dir, "server.conf");
 writeFileSync(conf, serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 let srv = spawn("nats-server", ["-c", conf], { stdio: "ignore" });
+// Re-owned on every restart. Owning only the FIRST child would leave the LIVE broker unowned
+// after a respawn while the suite still read as migrated: ownership held on a dead pid.
+let releaseBroker = teardownOnSignal(srv, dir);
 
 try {
   await waitReachable();
@@ -101,7 +105,9 @@ try {
   srv.kill();
   await awaitExit(srv);
   writeFileSync(conf, serverConfig(rotated, [rotated], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
+  releaseBroker();
   srv = spawn("nats-server", ["-c", conf], { stdio: "ignore" });
+  releaseBroker = teardownOnSignal(srv, dir);
   await waitReachable();
 
   check("pre-rotation copied data-account user cred is denied after broker loads rotated account JWT", await tryConnect(oldCreds, oldUser.id) === "rejected");
@@ -118,6 +124,7 @@ try {
   srv.kill();
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 if (fail) {

--- a/packages/core/smoke/system-account-rotation-auth.smoke.ts
+++ b/packages/core/smoke/system-account-rotation-auth.smoke.ts
@@ -21,6 +21,7 @@ import {
   serverConfig,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -75,10 +76,13 @@ function systemAccount(jwt: string): string | undefined {
 
 const space = `sys-rot-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-sysrot-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const conf = join(dir, "server.conf");
 writeFileSync(conf, serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 let srv = spawn("nats-server", ["-c", conf], { stdio: "ignore" });
+// Re-owned on every restart. Owning only the FIRST child would leave the LIVE broker unowned
+// after a respawn while the suite still read as migrated: ownership held on a dead pid.
+let releaseBroker = teardownOnSignal(srv, dir);
 
 try {
   await waitReachable();
@@ -101,7 +105,9 @@ try {
   srv.kill();
   await awaitExit(srv);
   writeFileSync(conf, serverConfig(rotated, [rotated], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
+  releaseBroker();
   srv = spawn("nats-server", ["-c", conf], { stdio: "ignore" });
+  releaseBroker = teardownOnSignal(srv, dir);
   await waitReachable();
 
   check("pre-rotation membership-observer cred is denied after broker loads rotated system account", await tryConnect(oldObserverCreds, oldObserver.id) === "rejected");
@@ -116,6 +122,7 @@ try {
   srv.kill();
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 if (fail) {


### PR DESCRIPTION
The seven `packages/core` suites the adoption tool refused for having more than one live broker.
One commit each. Running total: **58 of the 134** census, and 58 of the 64 in `packages/core`.

## Why these were refused rather than swept

None of them starts one broker and keeps it. Five restart theirs mid-run (`let srv = spawn(...)`,
then `srv = spawn(...)` again after a config or account rotation), one starts them through a
factory called three times, and one runs a three node cluster.

Taking ownership of the first child and walking away would have left **the live broker unowned after
every respawn**, while the suite read as migrated. That is worse than not migrating it: ownership
held on a dead pid looks handled. It is exactly the failure this whole item exists to remove,
reintroduced by the migration itself, and it is the reason the tool refuses ambiguity instead of
guessing at it.

So ownership is taken once per live child and released before each replacement:

- **Five restart suites** own the first child, then release and re-own around each respawn.
- **`membership-rw-renewal`** puts ownership *inside* the factory, so every restart is covered by
  construction rather than by each of its three call sites remembering to.
- **`cas-preflight-cluster`** owns all three nodes. A signalled run that reaped one of three and
  left two would have read as cleaned up while two brokers held their ports.

`release()` is still the last statement of every teardown, and each suite's existing `finally` is
unchanged and still does the work on every normal exit.

## Counts, run before and after each edit

| suite | live brokers | cells |
| --- | --- | --- |
| `cas-preflight-cluster` | 3 at once | 11 |
| `cutover-restart-eviction-auth` | 2 in sequence | 8 |
| `membership-rw-renewal` | 3 in sequence | 28 of 28 |
| `plane3-gate-auth` | 2 in sequence | 3 |
| `self-serve-join-coverage-auth` | 3 in sequence | 17 |
| `signing-key-rotation-auth` | 2 in sequence | 9 |
| `system-account-rotation-auth` | 2 in sequence | 9 |

Identical before and after in all seven. `membership-rw-renewal` prints no cell counter, so its
terminal marker line is compared instead, which is stated rather than quietly substituted. Box
state: `nats-server` count 14 before and 14 after.

## Retired prefixes

`cas-preflight-cluster-`, `cotal-cutover-evict-`, `cotal-member-rw-`, `cotal-plane3gate-`,
`cotal-selfjoincov-`, `cotal-signrot-`, `cotal-sysrot-`. Each becomes the minted
`cotal-smoke-broker-` token, the only evidence a later reaper can match once an owner has been
SIGKILLed. Seven more greps retired, listed because a retired check returns zero and reads as
healthy while measuring nothing.

## What is left in `packages/core`

Six suites: three that do their whole teardown inside a `process.on("exit")` handler, one
`backup-live` held out for live handling, and two that need the same multi-broker treatment applied
by hand. The three exit-handler suites are the pattern that already works: they kill the broker
**and** remove the directory in the same handler, and they carry zero residue on a long lived box.

## Gates

- Every suite run before and after, identical counts.
- `pnpm typecheck` rc=0.
- `pnpm smoke:core-boundary` green.
- No change to `bin/smoke/ci-suites.txt`, none under `docs/`, no manifest or lockfile change.

Test only; the changeset declares no release.
