### PR TITLE
test(core): own nested brokers, and mint the reapable token for the exit-handler suites

### DIFF
--- a/.changeset/broker-teardown-core-t5.md
+++ b/.changeset/broker-teardown-core-t5.md
@@ -1,0 +1,6 @@
+---
+---
+
+Test-only: finishes the `packages/core` broker teardown adoption apart from the live suite, covering
+the nested-broker and exit-handler shapes the adoption tool refused. No shipped behaviour changes,
+so no release.

--- a/packages/core/smoke/endpoint-binding.smoke.ts
+++ b/packages/core/smoke/endpoint-binding.smoke.ts
@@ -44,6 +44,7 @@ import {
   assertFactRetentionFloor, IDEMPOTENCY_HORIZON_MS_DEFAULT, RECEIPT_RETENTION_MS_DEFAULT,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0, fail = 0;
 // A PASSING CELL PRINTS: `mutation-proof` counts `✓` marks to tell "the mutation applied and no
@@ -521,8 +522,9 @@ throws("a fractional fact age is refused (a wire duration is a safe integer)",
 
 // ── the resources + live behaviors (real broker) ──
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-epbind-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 
 try {
   let up = false;
@@ -728,7 +730,7 @@ try {
   // the body-selected EPW read.
   {
     const SPORT = await pickFreePort();
-    const sd2 = mkdtempSync(join(tmpdir(), "cotal-epbind-auth-"));
+    const sd2 = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
     const canonRows = canonicalizerWorkGrants(SPACE, "manager");
     writeFileSync(join(sd2, "server.conf"), [
       `port: ${SPORT}`,
@@ -743,6 +745,9 @@ try {
       "}",
     ].join("\n"));
     const broker2 = spawn("nats-server", ["-c", join(sd2, "server.conf")], { stdio: "ignore" });
+    // The nested broker is owned separately, with its OWN store dir. A signalled run that reaped
+    // the outer one and left this one would read as cleaned up while a second broker held a port.
+    const releaseBroker2 = teardownOnSignal(broker2, sd2);
     try {
       let up2 = false;
       for (let i = 0; i < 50 && !up2; i++) { up2 = await isReachable(`nats://127.0.0.1:${SPORT}`); if (!up2) await wait(100); }
@@ -824,6 +829,7 @@ try {
       if (broker2.pid) { try { process.kill(broker2.pid, "SIGKILL"); } catch { /* gone */ } }
       await wait(200);
       rmSync(sd2, { recursive: true, force: true });
+      releaseBroker2(); // last for the nested broker
     }
   }
 
@@ -837,5 +843,6 @@ try {
   if (broker.pid) { try { process.kill(broker.pid, "SIGKILL"); } catch { /* gone */ } }
   await wait(200);
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
   process.exit(process.exitCode ?? 0);
 }

--- a/packages/core/smoke/evict-live-auth.smoke.ts
+++ b/packages/core/smoke/evict-live-auth.smoke.ts
@@ -42,6 +42,7 @@ import {
   deriveOwnerToken, grantActor, revokeActor, ledgerAclResolver, ledgerAuthorizeConnect,
 } from "@cotal-ai/auth";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -72,12 +73,13 @@ const observerCreds = await mintMembershipObserverCreds(auth, observerId);
 const evictorCreds = await mintConnectionEvictorCreds(auth, evictorId);
 
 const callout = await createCalloutAuth({ space, operatorSeed: auth.operator.seed, accountPub: auth.account.pub });
-const dir = mkdtempSync(join(tmpdir(), "cotal-evictlive-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(
   join(dir, "server.conf"),
   serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js"), extraAccounts: [{ pub: callout.account.pub, jwt: callout.account.jwt }] }),
 );
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 const awaitExit = (proc: ReturnType<typeof spawn>, timeoutMs = 3000): Promise<void> =>
   new Promise((resolve) => {
     if (proc.exitCode !== null || proc.signalCode !== null) return resolve();
@@ -341,7 +343,7 @@ try {
   {
     const pA = 21000 + Math.floor(Math.random() * 20000);
     const [pB, cA, cB] = [pA + 1, pA + 2, pA + 3];
-    const cdir = mkdtempSync(join(tmpdir(), "cotal-evictlive-cluster-"));
+    const cdir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
     const conf = (name: string, port: number, cport: number, routes: string) => [
       `port: ${port}`, `server_name: ${name}`,
       `cluster { name: livetest, listen: 127.0.0.1:${cport} ${routes} }`,
@@ -352,6 +354,10 @@ try {
     writeFileSync(join(cdir, "b.conf"), conf("evclB", pB, cB, `, routes: [ "nats-route://127.0.0.1:${cA}" ]`));
     const srvA = spawn("nats-server", ["-c", join(cdir, "a.conf")], { stdio: "ignore" });
     const srvB = spawn("nats-server", ["-c", join(cdir, "b.conf")], { stdio: "ignore" });
+    // BOTH cluster nodes are owned, with their shared cluster dir. Owning one of two would leave
+    // the other holding its port after a signal, while the run read as cleaned up.
+    const releaseA = teardownOnSignal(srvA, cdir);
+    const releaseB = teardownOnSignal(srvB, cdir);
     let sysNc: NatsConnection | undefined;
     try {
       let upA = false;
@@ -369,6 +375,8 @@ try {
       await awaitExit(srvA);
       await awaitExit(srvB);
       rmSync(cdir, { recursive: true, force: true });
+      releaseA();
+      releaseB(); // last for the nested cluster
     }
   }
 
@@ -383,6 +391,7 @@ try {
   srv.kill("SIGKILL"); // exact PID — never pkill nats-server
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
   rmSync(ledgerDir, { recursive: true, force: true });
 }
 process.exit(process.exitCode ?? 0);

--- a/packages/core/smoke/inst-route-enforce.smoke.ts
+++ b/packages/core/smoke/inst-route-enforce.smoke.ts
@@ -45,6 +45,7 @@ import {
   type EpCapability,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -57,10 +58,14 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 };
 
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-instenf-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
-process.on("exit", () => { try { srv.kill("SIGKILL"); } catch { /* gone */ } rmSync(dir, { recursive: true, force: true }); });
+// This suite's exit handler already kills the broker AND removes the store dir, which is the
+// complete pattern: measured, it leaves zero residue on a long lived box. Ownership adds the
+// case that handler cannot reach, a runner that terminates without running `exit` handlers.
+const releaseBroker = teardownOnSignal(srv, dir);
+process.on("exit", () => { try { srv.kill("SIGKILL"); } catch { /* gone */ } rmSync(dir, { recursive: true, force: true }); releaseBroker(); });
 
 /** The broker's verdict on ONE subject under ONE credential. Three outcomes; a timeout is not one
  *  of the two arms and must never be counted as either. */

--- a/packages/core/smoke/manager-lease-grant.smoke.ts
+++ b/packages/core/smoke/manager-lease-grant.smoke.ts
@@ -52,6 +52,7 @@ import {
   principalKey, DEV_OWNER,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -64,10 +65,14 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 };
 
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-leasegrant-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
-process.on("exit", () => { try { srv.kill("SIGKILL"); } catch { /* gone */ } rmSync(dir, { recursive: true, force: true }); });
+// This suite's exit handler already kills the broker AND removes the store dir, which is the
+// complete pattern: measured, it leaves zero residue on a long lived box. Ownership adds the
+// case that handler cannot reach, a runner that terminates without running `exit` handlers.
+const releaseBroker = teardownOnSignal(srv, dir);
+process.on("exit", () => { try { srv.kill("SIGKILL"); } catch { /* gone */ } rmSync(dir, { recursive: true, force: true }); releaseBroker(); });
 
 const enc = (o: unknown) => new TextEncoder().encode(JSON.stringify(o));
 const holder = principalKey(DEV_OWNER, "sup").key;

--- a/packages/core/smoke/manager-lease-probe.smoke.ts
+++ b/packages/core/smoke/manager-lease-probe.smoke.ts
@@ -37,6 +37,7 @@ import { jetstreamManager } from "@nats-io/jetstream";
 import { Kvm } from "@nats-io/kv";
 import { CotalEndpoint, isReachable, managerBucket, managerLeaseKey, MANAGER_LEASE_KEY } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 // An OS-assigned port, not a fixed one. A hard-coded port silently hands the suite whatever broker
 // already owns it: the first run of this file bound nothing, talked to a leftover AUTHED server, and
@@ -45,7 +46,7 @@ import { pickFreePort } from "./_free-port.js";
 const PORT = await pickFreePort();
 const SERVER = `nats://127.0.0.1:${PORT}`;
 const SPACE = "leaseprobe";
-const store = mkdtempSync(join(tmpdir(), "cotal-leaseprobe-"));
+const store = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 let pass = 0;
 const check = (name: string, cond: boolean, extra?: unknown) => {
   assert.ok(cond, `${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
@@ -54,7 +55,11 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 };
 
 const srv = spawn("nats-server", ["-p", String(PORT), "-js", "-sd", store], { stdio: "ignore" });
-process.on("exit", () => { try { srv.kill("SIGKILL"); } catch { /* gone */ } rmSync(store, { recursive: true, force: true }); });
+// This suite's exit handler already kills the broker AND removes the store dir, which is the
+// complete pattern: measured, it leaves zero residue on a long lived box. Ownership adds the
+// case that handler cannot reach, a runner that terminates without running `exit` handlers.
+const releaseBroker = teardownOnSignal(srv, store);
+process.on("exit", () => { try { srv.kill("SIGKILL"); } catch { /* gone */ } rmSync(store, { recursive: true, force: true }); releaseBroker(); });
 
 const enc = (o: unknown) => new TextEncoder().encode(JSON.stringify(o));
 const lease = (instanceId: string) => ({ instanceId, holder: `HOLDER_${instanceId}`, pid: 1, root: "/tmp", runtime: "pty", since: Date.now() });


### PR DESCRIPTION
The last five `packages/core` suites the adoption tool refused, in two shapes. One commit each.
Running total: **63 of the 134** census, and 63 of the 64 in `packages/core`. Only `backup-live`
remains here, held out because live suites get their own handling.

## Nested brokers: `endpoint-binding`, `evict-live-auth`

Each runs a second broker inside an inner scope, with its own store dir and its own `finally`.
`evict-live-auth`'s inner scope is a two node cluster. Owning the outer broker alone would leave the
inner one holding a port after a signal, while the run read as cleaned up.

Ownership is taken once per live broker, each with the store dir it actually writes to, and released
at the end of the scope that owns it. Every prefix becomes the minted token, the nested ones
included, so no broker either suite starts is left unreapable after a SIGKILL.

## Exit-handler suites: `inst-route-enforce`, `manager-lease-grant`, `manager-lease-probe`

These do their whole teardown inside `process.on("exit")`, killing the broker **and** removing the
store dir in the same place. That is the complete pattern and it is measurably correct: **zero**
directories on a long lived box, against 64, 42 and 74 from the three suites whose handlers killed
the broker and left the tree behind, fixed in #507.

So the change here is deliberately small. Ownership adds the one case the handler cannot reach, a
runner that terminates without running `exit` handlers at all. The part that actually buys something
is the token: after a SIGKILL no handler runs, and the minted prefix is the only evidence a later
reaper can match.

## Counts, run before and after each edit

| suite | shape | cells |
| --- | --- | --- |
| `endpoint-binding` | outer plus one nested broker | 165 |
| `evict-live-auth` | outer plus a nested two node cluster | 27 |
| `inst-route-enforce` | exit handler, already complete | 6 |
| `manager-lease-grant` | exit handler, already complete | 6 |
| `manager-lease-probe` | exit handler, already complete | 8 |

Identical before and after in all five. Box state: `nats-server` count 14 before and 14 after.

## One baseline that failed, and why it was not a defect

`evict-live-auth` failed its first baseline run in a fresh worktree with:

```
ERR_MODULE_NOT_FOUND: Cannot find module '.../node_modules/@cotal-ai/auth/dist/index.js'
```

That is an **absent build**, not a broken suite: a fresh worktree has no `dist/`, and this is the
one suite in the set that imports a built first-party package rather than source. `pnpm build` first,
and the baseline is 27 passed. Recorded rather than quietly re-run, because the failure reads like a
suite defect and is a build-state fact, and because it is the same resolution hazard that argues for
the smoke kit having no `dist` at all.

Bound worth stating with it: the earlier tranches' baselines were taken in fresh worktrees without a
build. They all passed, so none of them needed one, but that is an observation about those suites
rather than a property of the method.

## Retired prefixes

`cotal-epbind-`, `cotal-epbind-auth-`, `cotal-evictlive-`, `cotal-evictlive-cluster-`,
`cotal-instenf-`, `cotal-leasegrant-`, `cotal-leaseprobe-`. Seven more greps that now match nothing
by construction, listed because a retired check returns zero and reads as healthy while measuring
nothing.

## Gates

- Every suite run before and after, identical counts.
- `pnpm typecheck` rc=0.
- `pnpm smoke:core-boundary` green.
- No change to `bin/smoke/ci-suites.txt`, none under `docs/`, no manifest or lockfile change.

Test only; the changeset declares no release.
