### PR TITLE
test(connector-core): own spawned brokers in four attention smokes

### DIFF
--- a/.changeset/broker-teardown-connector-core.md
+++ b/.changeset/broker-teardown-connector-core.md
@@ -1,0 +1,6 @@
+---
+---
+
+Test-only: adopts the smoke broker teardown helper in the four `extensions/connector-core`
+attention suites, so a signalled run takes its broker and scratch tree with it. No shipped
+behaviour changes, so no release.

--- a/extensions/connector-core/smoke/attention-auth.smoke.ts
+++ b/extensions/connector-core/smoke/attention-auth.smoke.ts
@@ -31,6 +31,7 @@ import { MeshAgent } from "../src/agent.js";
 import type { AgentConfig } from "../src/config.js";
 import type { InboxItem } from "../src/agent.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const servers = `nats://127.0.0.1:${PORT}`;
@@ -43,10 +44,11 @@ const awaitExit = (proc: ReturnType<typeof spawn>, timeoutMs = 3000): Promise<vo
     setTimeout(resolve, timeoutMs);
   });
 
-const dir = mkdtempSync(join(tmpdir(), "cotal-attn-auth-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const auth = await createSpaceAuth(space);
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 let pass = 0;
 const check = (name: string, cond: boolean, extra?: unknown) => {
   assert.ok(cond, `${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
@@ -174,5 +176,6 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 process.exit(0);

--- a/extensions/connector-core/smoke/attention.smoke.ts
+++ b/extensions/connector-core/smoke/attention.smoke.ts
@@ -18,6 +18,7 @@ import { MeshAgent } from "../src/agent.js";
 import type { AgentConfig } from "../src/config.js";
 import type { InboxItem } from "../src/agent.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const servers = `nats://127.0.0.1:${PORT}`;
@@ -30,8 +31,9 @@ const awaitExit = (proc: ReturnType<typeof spawn>, timeoutMs = 3000): Promise<vo
     setTimeout(resolve, timeoutMs);
   });
 
-const dir = mkdtempSync(join(tmpdir(), "cotal-attn-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const srv = spawn("nats-server", ["-js", "-p", String(PORT), "-sd", join(dir, "js")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 let pass = 0;
 const check = (name: string, cond: boolean, extra?: unknown) => {
   assert.ok(cond, `${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
@@ -117,5 +119,6 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 process.exit(0);

--- a/extensions/connector-core/smoke/per-channel-attention-auth.smoke.ts
+++ b/extensions/connector-core/smoke/per-channel-attention-auth.smoke.ts
@@ -35,6 +35,7 @@ import { MeshAgent } from "../src/agent.js";
 import type { AgentConfig } from "../src/config.js";
 import type { InboxItem } from "../src/agent.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const servers = `nats://127.0.0.1:${PORT}`;
@@ -47,10 +48,11 @@ const awaitExit = (proc: ReturnType<typeof spawn>, timeoutMs = 3000): Promise<vo
     setTimeout(resolve, timeoutMs);
   });
 
-const dir = mkdtempSync(join(tmpdir(), "cotal-chanattn-auth-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const auth = await createSpaceAuth(space);
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 let pass = 0;
 const check = (name: string, cond: boolean, extra?: unknown) => {
   assert.ok(cond, `${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
@@ -184,5 +186,6 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 process.exit(0);

--- a/extensions/connector-core/smoke/per-channel-attention.smoke.ts
+++ b/extensions/connector-core/smoke/per-channel-attention.smoke.ts
@@ -26,6 +26,7 @@ import { MeshAgent } from "../src/agent.js";
 import type { AgentConfig } from "../src/config.js";
 import type { InboxItem } from "../src/agent.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const servers = `nats://127.0.0.1:${PORT}`;
@@ -38,8 +39,9 @@ const awaitExit = (proc: ReturnType<typeof spawn>, timeoutMs = 3000): Promise<vo
     setTimeout(resolve, timeoutMs);
   });
 
-const dir = mkdtempSync(join(tmpdir(), "cotal-chanattn-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const srv = spawn("nats-server", ["-js", "-p", String(PORT), "-sd", join(dir, "js")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 let pass = 0;
 const check = (name: string, cond: boolean, extra?: unknown) => {
   assert.ok(cond, `${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
@@ -297,5 +299,6 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 process.exit(0);


### PR DESCRIPTION
Four connector-core smokes now own the `nats-server` they spawn, so it dies when the suite is
signalled and not only when the suite returns and its `finally` runs. Each takes ownership at the
spawn and releases it last, after its own teardown has already finished, so the existing normal
path is unchanged and the helper never touches a broker the suite has handled itself.

Their scratch prefixes move to the shared minted token. That token is the only evidence that
survives SIGKILL, which ownership cannot cover: parentage covers the case the helper fixes, the
token covers the case it cannot, and neither covers both.

| suite | checks |
| --- | --- |
| attention | 13 |
| attention-auth | 13 |
| per-channel-attention | 45 |
| per-channel-attention-auth | 14 |

Every count is identical before and after, all four exit 0, and `pnpm typecheck` is clean. Across
the eight runs that produced those numbers, no broker scratch directory was left behind.

Six suites in this package spawn a broker. One was already migrated in an earlier change. One is
held: it spawns two brokers, neither bound to a name the mechanical edit can key on, so where
ownership belongs is a question about that suite's lifecycle rather than a substitution, so it gets
read rather than swept. The remaining four are here, one commit each, and each is the same four
lines: the import, the token, the ownership, the release.

No manifest or dependency changes: the dev dependency this needs was already declared.
