### PR TITLE
fix(smoke): wait for a broker to exit before removing the tree it is flushing into

### DIFF
--- a/.changeset/smoke-teardown-await-broker-exit.md
+++ b/.changeset/smoke-teardown-await-broker-exit.md
@@ -1,0 +1,6 @@
+---
+---
+
+Test-only: the smoke teardown helper now waits for a broker to exit before its scratch tree is
+removed, fixing an ENOTEMPTY that failed a CI shard after every cell had passed. Only smoke suites
+and the private test kit change, so no release.

--- a/packages/core/smoke/bind-fence.smoke.ts
+++ b/packages/core/smoke/bind-fence.smoke.ts
@@ -42,7 +42,7 @@ import {
 } from "../src/index.js";
 import type { KV } from "@nats-io/kv";
 import { pickFreePort } from "./_free-port.js";
-import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+import { SMOKE_BROKER_TOKEN, killAndAwaitExit, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let pass = 0, fail = 0;
 /** A cell RECORDS its verdict and never throws: one throwing cell would take every cell below it
@@ -353,7 +353,10 @@ try {
   await Promise.all(served.map((s) => s.stop()));
 } finally {
   await nc.drain().catch(() => nc.close());
-  broker.kill("SIGTERM");
+  // WAIT for it, do not just ask. SIGTERM makes nats-server flush JetStream on its way out, and
+  // removing the tree on the next line walked into what it was still writing: this suite went red
+  // in CI on ENOTEMPTY over .../KV_cotal_records_bindfence/msgs with every cell already passed.
+  await killAndAwaitExit(broker, "SIGTERM");
   rmSync(sd, { recursive: true, force: true });
   // LAST, deliberately. Releasing before the lines above would hand the broker back while cleanup
   // could still throw, which is the exact case ownership exists to catch; held until here, an

--- a/packages/core/smoke/broker-teardown.smoke.ts
+++ b/packages/core/smoke/broker-teardown.smoke.ts
@@ -13,6 +13,7 @@
  * partial mitigation that reads as a solved problem is worse than a stated one.
  */
 import { spawnSync, spawn, type ChildProcess } from "node:child_process";
+import { killAndAwaitExit } from "@cotal-ai/smoke-kit";
 import { existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
@@ -187,6 +188,32 @@ try {
     check("wrapper killed: the broker is still torn down, by the exit handler", !alive(s.brokerPid), `pid ${s.brokerPid}`);
     check("wrapper killed: the fixture exited rather than being signalled", how.signal === null, JSON.stringify(how));
     reapOwn(s.brokerPid, s.storeDir);
+  }
+  // 7. `killAndAwaitExit` must not return until the child is ACTUALLY gone. This is the contract the
+  //    ENOTEMPTY failure in CI was missing: `bind-fence` sent SIGTERM and removed its tree on the
+  //    next line, and the recursive walk met a broker still flushing JetStream on its way out.
+  //
+  //    The assertion is deterministic even though the race it prevents is not. It does not try to
+  //    reproduce a timing window; it states the property that makes the window impossible — when this
+  //    resolves, the child reports a terminal status — so deleting the wait turns it red every time
+  //    rather than one run in ten.
+  //
+  //    The fixture ignores SIGTERM for 400ms before exiting, standing in for the graceful shutdown
+  //    that flushes state, so a helper that merely SENT the signal would return while it still runs.
+  {
+    const child = spawn(process.execPath, ["-e",
+      `process.on("SIGTERM", () => setTimeout(() => process.exit(0), 400)); setInterval(() => {}, 1000);`,
+    ], { stdio: "ignore" });
+    await wait(200); // let it install the handler, or SIGTERM lands on the default disposition
+    const t0 = Date.now();
+    await killAndAwaitExit(child, "SIGTERM");
+    const elapsed = Date.now() - t0;
+    check("killAndAwaitExit: the child reports a terminal status by the time it resolves",
+      child.exitCode !== null || child.signalCode !== null, { exitCode: child.exitCode, signalCode: child.signalCode });
+    check("killAndAwaitExit: it is really gone at the OS level, not just per the handle", !alive(child.pid!), `pid ${child.pid}`);
+    // Stated as a bound, not asserted as a deadline: it must have WAITED out the 400ms shutdown, which
+    // is what tells a reader this is a wait and not a sleep that happens to be long enough.
+    check("killAndAwaitExit: it waited for the shutdown rather than returning on the signal", elapsed >= 350, `${elapsed}ms`);
   }
 } finally {
   // Nothing to release: every cell reaps its own broker above, including the two that leak on purpose.

--- a/packages/core/smoke/channels-auth.smoke.ts
+++ b/packages/core/smoke/channels-auth.smoke.ts
@@ -3,7 +3,7 @@ import { writeFileSync, mkdirSync, mkdtempSync, openSync, readFileSync, rmSync }
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
-import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+import { SMOKE_BROKER_TOKEN, killAndAwaitExit, teardownOnSignal } from "@cotal-ai/smoke-kit";
 import { pickFreePort } from "./_free-port.js";
 import {
   createSpaceAuth, serverConfig, mintCreds, newIdentity, isReachable,
@@ -146,12 +146,15 @@ await dlv.stop();
 await poster.stop();
 await sup.stop();
 await mgr.stop();
-child.kill("SIGTERM");
 // The store dir goes too. Its absence here is the whole reason this suite leaked: it passed, said
-// so, and left a directory behind on every green run. The pause is the same one `_boot-broker` uses:
-// removing the tree while the broker is still flushing JetStream state leaves files behind it
-// recreates, so the directory survives the removal that was supposed to take it.
-await sleep(200);
+// so, and left a directory behind on every green run.
+//
+// The 200ms pause that used to stand here was a GUESS at how long a graceful shutdown takes, and the
+// guess was too small: modelled on a fixture that flushes JetStream for 250ms after SIGTERM, removing
+// the tree after a fixed 200ms still walked into live writes. `bind-fence` proved the same window is
+// real in CI, dying on ENOTEMPTY with every cell already green. Waiting for the exit is not a longer
+// pause, it is the end of guessing.
+await killAndAwaitExit(child, "SIGTERM");
 rmSync(dir, { recursive: true, force: true });
 releaseBroker(); // last: ownership is held until this teardown has actually finished
 process.exit(0);

--- a/packages/core/smoke/fixtures/broker-teardown.mutations.json
+++ b/packages/core/smoke/fixtures/broker-teardown.mutations.json
@@ -37,6 +37,14 @@
       "replace": "  void entry;",
       "expectRed": "✗ FAIL: SIGTERM: the owned broker is gone",
       "cell": "✗ FAIL: SIGTERM: the owned broker is gone"
+    },
+    {
+      "name": "killAndAwaitExit sends the signal but does not wait, which is the shape that failed in CI",
+      "file": "packages/smoke-kit/src/broker-teardown.ts",
+      "find": "  if ((await Promise.race([exited.then(() => \"exited\" as const), after(timeoutMs)])) === \"timeout\") {",
+      "replace": "  if (false as boolean) {",
+      "expectRed": "✗ FAIL: killAndAwaitExit: the child reports a terminal status by the time it resolves",
+      "cell": "✗ FAIL: killAndAwaitExit: the child reports a terminal status by the time it resolves"
     }
   ]
 }

--- a/packages/core/smoke/probe-teardown.smoke.ts
+++ b/packages/core/smoke/probe-teardown.smoke.ts
@@ -28,7 +28,7 @@ import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { isReachable, probeConnect } from "../src/endpoint.js";
-import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+import { SMOKE_BROKER_TOKEN, killAndAwaitExit, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REFUSING = "nats://127.0.0.1:1"; // closed loopback port: answers RST
@@ -200,7 +200,10 @@ try {
     child.signal === null && child.status === 0, { status: child.status, signal: child.signal, stderr: child.stderr?.slice(0, 400) });
 } finally {
   const comm = spawnSync("ps", ["-p", String(BROKER_PID), "-o", "comm="], { encoding: "utf8" }).stdout.trim();
-  if (comm === "nats-server") process.kill(BROKER_PID, "SIGTERM");
+  // Same wide window as bind-fence: SIGTERM asks for a graceful shutdown, which flushes JetStream
+  // into the very tree the next line walks. The pid check stays — it is what proves the process
+  // under this pid is still the broker — and the handle is what we wait on.
+  if (comm === "nats-server") await killAndAwaitExit(broker, "SIGTERM");
   rmSync(scratch, { recursive: true, force: true });
   releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/packages/smoke-kit/src/broker-teardown.ts
+++ b/packages/smoke-kit/src/broker-teardown.ts
@@ -47,6 +47,52 @@ import { rmSync } from "node:fs";
  *  SIGKILLed; a broker started around it is not, so a reaper is only ever as complete as migration. */
 export const SMOKE_BROKER_TOKEN = "cotal-smoke-broker-";
 
+/**
+ * Kill a broker and DO NOT RETURN until it is actually gone, so the caller's `rmSync` cannot race a
+ * process still writing into the tree it is walking.
+ *
+ * This exists because that race is not theoretical. `bind-fence` sent SIGTERM and removed its tree on
+ * the next line; in CI the recursive walk hit a directory nats-server had just written back into and
+ * the suite died on `ENOTEMPTY: directory not empty, rmdir
+ * '/tmp/cotal-smoke-broker-LilWsp/jetstream/$G/streams/KV_cotal_records_bindfence/msgs'` after every
+ * one of its cells had passed.
+ *
+ * SIGTERM is the reason the window is wide: it asks nats-server to shut down GRACEFULLY, and a
+ * graceful shutdown FLUSHES JetStream state to disk. So the signal that is polite to the broker is
+ * precisely the one that keeps it writing while the removal walks. Modelled on a fixture that flushes
+ * for 250ms after SIGTERM, removing straight away failed 4 times out of 4; waiting for the exit first
+ * succeeded 4 out of 4.
+ *
+ * A NOTE ON WHAT DOES NOT WORK, so nobody re-derives it from the docs. Node's own retry options on
+ * `rmSync` (`maxRetries`/`retryDelay`) name ENOTEMPTY explicitly and look like the native answer. They
+ * are not: measured on the same fixture they failed 4 out of 4 while burning 5.7 seconds, because the
+ * retry re-attempts the failed `rmdir` and never re-walks the directory, so files created during the
+ * first walk are never removed and the `rmdir` can never succeed. Waiting is the fix; retrying is not.
+ *
+ * Never throws — it runs on the teardown path, where a throw would replace the real cause of death.
+ * If the broker ignores the first signal it is escalated to SIGKILL rather than waited on forever.
+ */
+export async function killAndAwaitExit(child: ChildProcess, signal: NodeJS.Signals = "SIGTERM", timeoutMs = 10_000): Promise<void> {
+  const dead = (): boolean => child.exitCode !== null || child.signalCode !== null;
+  if (dead()) return;
+  const exited = new Promise<void>((resolve) => child.once("exit", () => resolve()));
+  const after = (ms: number): Promise<"timeout"> => new Promise((r) => setTimeout(() => r("timeout"), ms).unref());
+  try {
+    child.kill(signal);
+  } catch {
+    return; // already gone; `exit` may never fire, and there is nothing left to wait for
+  }
+  if ((await Promise.race([exited.then(() => "exited" as const), after(timeoutMs)])) === "timeout") {
+    // It ignored the polite signal. Escalate rather than hang the suite's teardown forever.
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      return;
+    }
+    await Promise.race([exited, after(2_000)]);
+  }
+}
+
 interface Owned {
   readonly child: ChildProcess;
   readonly storeDir?: string;

--- a/packages/smoke-kit/src/index.ts
+++ b/packages/smoke-kit/src/index.ts
@@ -13,4 +13,4 @@
  * pointing straight at `.ts`, so there is no build step, no build ordering, and no second copy that
  * can disagree with this one.
  */
-export { SMOKE_BROKER_TOKEN, teardownOnSignal } from "./broker-teardown.js";
+export { SMOKE_BROKER_TOKEN, killAndAwaitExit, teardownOnSignal } from "./broker-teardown.js";


### PR DESCRIPTION
A CI shard failed on `smoke:bind-fence` after every one of its cells had passed:

```
Error: ENOTEMPTY: directory not empty, rmdir
'/tmp/cotal-smoke-broker-LilWsp/jetstream/$G/streams/KV_cotal_records_bindfence/msgs'
```

The suite sent SIGTERM and removed its scratch tree on the next line. SIGTERM asks nats-server to
shut down **gracefully**, and a graceful shutdown flushes JetStream state to disk, so the polite
signal is exactly the one that keeps the broker writing while the recursive removal walks the tree.

`killAndAwaitExit` does not return until the child reports a terminal status, so the removal can no
longer race a live writer. It never throws, because it runs on the teardown path where a throw
replaces the real cause of death, and it escalates to SIGKILL rather than waiting forever on a
broker that ignores the first signal.

**Scope is three suites, not sixty.** Only `bind-fence`, `probe-teardown` and `channels-auth` send
the graceful signal before removing. The other 59 migrated suites send SIGKILL, which has no flush
window. `channels-auth` also loses a fixed 200ms pause that was a guess at how long a shutdown
takes, measurably too small, since the modelled shutdown runs 250ms.

**What does not work, recorded so nobody re-derives it from the docs.** Node's `maxRetries` and
`retryDelay` on `rmSync` name ENOTEMPTY explicitly and look like the native answer. Measured against
a fixture that flushes for 250ms after SIGTERM:

| teardown | result | time |
| --- | --- | --- |
| kill, then remove immediately (what shipped) | ENOTEMPTY 4/4 | ~150ms |
| kill, then remove with `maxRetries:10, retryDelay:100` | ENOTEMPTY 4/4 | ~5.7s |
| kill, wait for exit, then remove | removed 4/4 | ~470ms |

The retry option re-attempts the failed `rmdir` and never re-walks the directory, so files written
during the first walk are never removed and the `rmdir` can never succeed. It converts a fast
failure into a slow one.

**The new cell asserts the property, not the race.** A timing window reproduces one run in ten and
would make a flaky guard; the cell instead states what makes the window impossible: when the helper
resolves, the child reports a terminal status and is gone at the OS level, and bounds the elapsed
time to prove it waited out the shutdown rather than returning on the signal. `pnpm mutation-proof`
kills both mutations on their named assertions: removing ownership reddens the SIGTERM cell (12
marks of 17), and making the helper send-without-waiting reddens the new cell (14 of 17).

Suites run green after the change: broker-teardown 17, bind-fence 28, probe-teardown 20,
channels-auth passing. `pnpm typecheck` clean.