### PR TITLE
test(auth): own spawned brokers across the auth smokes

### DIFF
--- a/.changeset/broker-teardown-auth.md
+++ b/.changeset/broker-teardown-auth.md
@@ -1,0 +1,5 @@
+---
+---
+
+Test-only: adopts the smoke broker teardown helper across the `implementations/auth` suites, so a
+signalled run takes its broker and scratch tree with it. No shipped behaviour changes, so no release.

--- a/implementations/auth/package.json
+++ b/implementations/auth/package.json
@@ -34,6 +34,7 @@
     "@nats-io/kv": "^3.4.0"
   },
   "devDependencies": {
+    "@cotal-ai/smoke-kit": "workspace:*",
     "better-auth": "^1.6.23"
   },
   "files": [

--- a/implementations/auth/smoke/admission-mediator.smoke.ts
+++ b/implementations/auth/smoke/admission-mediator.smoke.ts
@@ -34,6 +34,7 @@ import { registryStores } from "../src/lifecycle-registry.js";
 import { makeRecordsScannerOverConnection } from "../src/records-scanner.js";
 import type { CommitValue } from "../src/admission-mediator.js";
 import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -73,7 +74,7 @@ const mkReq = (cc: { owner: string; actor: string; uid: string }): MediatedReque
   mediatedRequestFromSubject(`cotal.${SPACE}.epj.${EP}.admit.${cc.owner}.${cc.actor}.${cc.uid}`);
 
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-medsmoke-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(sd, "server.conf"), `
 port: ${PORT}
 listen: 127.0.0.1:${PORT}
@@ -81,6 +82,7 @@ jetstream { store_dir: ${JSON.stringify(sd)} }
 accounts { APP: { jetstream: enabled, users = [ { user: "auth", password: "pw" } ] } }
 `);
 const broker = spawn("nats-server", ["-c", join(sd, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 
 let nc: NatsConnection | undefined;
 try {
@@ -495,6 +497,7 @@ try {
   broker.kill("SIGKILL"); // exact PID — never pkill nats-server
   await new Promise((r) => broker.once("exit", r));
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(fail === 0 ? `\nADMISSION MEDIATOR SMOKE OK ✅  (${ok} passed, ${fail} failed)` : `\nADMISSION MEDIATOR SMOKE FAILED ❌  (${ok} passed, ${fail} failed)`);

--- a/implementations/auth/smoke/auth-admin.smoke.ts
+++ b/implementations/auth/smoke/auth-admin.smoke.ts
@@ -44,6 +44,7 @@ import { ensureRootCredential } from "../src/root-credential.js";
 import { openLifecycleRegistry, readLifecycleHeadForOperation } from "../src/lifecycle-registry.js";
 import type { EvictPrincipal } from "../src/credential-ledger.js";
 import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -53,11 +54,12 @@ const check = (name: string, cond: boolean, extra?: unknown) => { if (cond) { pa
 
 const space = `aadm-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const tmp = mkdtempSync(join(tmpdir(), "cotal-aadm-"));
+const tmp = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const dir = join(tmp, "state");
 mkdirSync(dir, { recursive: true });
 writeFileSync(join(tmp, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(tmp, "js") }));
 const srv = spawn("nats-server", ["-c", join(tmp, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, tmp);
 const awaitExit = (proc: ReturnType<typeof spawn>, timeoutMs = 3000): Promise<void> =>
   new Promise((resolve) => {
     if (proc.exitCode !== null || proc.signalCode !== null) return resolve();
@@ -437,5 +439,6 @@ try {
   srv.kill("SIGTERM"); // exact PID — never pkill nats-server
   await awaitExit(srv);
   rmSync(tmp, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 process.exit(process.exitCode ?? 0);

--- a/implementations/auth/smoke/auth-callout.smoke.ts
+++ b/implementations/auth/smoke/auth-callout.smoke.ts
@@ -34,6 +34,7 @@ import { fromPublic, fromSeed } from "@nats-io/nkeys";
 import { createSpaceAuth, isReachable, newIdentity, serverConfig } from "@cotal-ai/core";
 import { createCalloutAuth, deriveOwnerToken, startAuthCallout, USER_TOKEN_VER } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -48,12 +49,13 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 const space = `callout-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
 const callout = await createCalloutAuth({ space, operatorSeed: auth.operator.seed, accountPub: auth.account.pub });
-const dir = mkdtempSync(join(tmpdir(), "cotal-callout-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(
   join(dir, "server.conf"),
   serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js"), extraAccounts: [{ pub: callout.account.pub, jwt: callout.account.jwt }] }),
 );
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 const awaitExit = (proc: ReturnType<typeof spawn>, timeoutMs = 3000): Promise<void> =>
   new Promise((resolve) => {
     if (proc.exitCode !== null || proc.signalCode !== null) return resolve();
@@ -212,5 +214,6 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 process.exit(process.exitCode ?? 0);

--- a/implementations/auth/smoke/barrier-plane.smoke.ts
+++ b/implementations/auth/smoke/barrier-plane.smoke.ts
@@ -38,6 +38,7 @@ import { credRowKey, enumerateOperationIntents, parseLedgerRow, runAgentTakeover
 import { runAgentRetirementBarrier, type RetirementDeps } from "../src/retirement-barrier.js";
 import { makeLedgerScannerOverConnection } from "../src/ledger-scanner.js";
 import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -55,11 +56,12 @@ const rejects = async (fn: () => Promise<unknown>): Promise<string> => { try { a
 
 const space = `barpl-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const tmp = mkdtempSync(join(tmpdir(), "cotal-barpl-"));
+const tmp = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const dir = join(tmp, "state");
 mkdirSync(dir, { recursive: true });
 writeFileSync(join(tmp, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(tmp, "js") }));
 const srv = spawn("nats-server", ["-c", join(tmp, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, tmp);
 
 const OWNER = deriveOwnerToken("s".repeat(32), "better-auth|human-1");
 const dataAccount = { pub: auth.account.pub, signingSeed: auth.account.signingSeed };
@@ -461,4 +463,5 @@ try {
   srv.kill();
   await awaitExit(srv);
   rmSync(tmp, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/implementations/auth/smoke/callout-deny.smoke.ts
+++ b/implementations/auth/smoke/callout-deny.smoke.ts
@@ -20,6 +20,7 @@ import { createSpaceAuth, isReachable, serverConfig, mintLifecycleUid } from "@c
 const smokeUid = mintLifecycleUid();
 import { createCalloutAuth, calloutPermissions, deriveOwnerToken, startAuthCallout, USER_TOKEN_VER } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -35,9 +36,10 @@ const check = (name: string, cond: boolean, extra?: unknown) => { if (cond) { pa
 const space = `deny-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
 const callout = await createCalloutAuth({ space, operatorSeed: auth.operator.seed, accountPub: auth.account.pub });
-const dir = mkdtempSync(join(tmpdir(), "cotal-deny-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js"), extraAccounts: [{ pub: callout.account.pub, jwt: callout.account.jwt }] }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 const { publicKey, privateKey } = await generateKeyPair("EdDSA");
 const ISS = "https://auth.cotal.test";
@@ -127,4 +129,5 @@ try {
   try { await calloutNc?.close(); } catch { /* */ }
   srv.kill("SIGKILL");
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/implementations/auth/smoke/connect-reader-acl.smoke.ts
+++ b/implementations/auth/smoke/connect-reader-acl.smoke.ts
@@ -27,6 +27,7 @@ import { openLifecycleRegistry, registryStores } from "../src/lifecycle-registry
 import { credRowKey, parseLedgerRow } from "../src/credential-ledger.js";
 import type { ValidatedUserToken } from "../src/token.js";
 import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -43,9 +44,10 @@ const throwsSync = (fn: () => unknown): boolean => { try { fn(); return false; }
 
 const space = `rdacl-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const tmp = mkdtempSync(join(tmpdir(), "cotal-rdacl-"));
+const tmp = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(tmp, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(tmp, "js") }));
 const srv = spawn("nats-server", ["-c", join(tmp, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, tmp);
 
 const OWNER = deriveOwnerToken("s".repeat(32), "better-auth|human-1");
 const dataAccount = { pub: auth.account.pub, signingSeed: auth.account.signingSeed };
@@ -149,4 +151,5 @@ try {
   srv.kill();
   await awaitExit(srv);
   rmSync(tmp, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/implementations/auth/smoke/credential-ledger.smoke.ts
+++ b/implementations/auth/smoke/credential-ledger.smoke.ts
@@ -47,6 +47,7 @@ import {
   type EvictPrincipal, type ReconcileSessionPair,
 } from "../src/credential-ledger.js";
 import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -70,7 +71,7 @@ const enc = new TextEncoder();
 const dec = new TextDecoder();
 
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-credledger-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 // A conf broker with a REAL system account (CONNZ + KICK live) and an APP account holding the
 // trusted-auth user plus two victim users whose usernames are principal NAME-forms — CONNZ
 // surfaces a static user's name as `authorized_user`, which `principalFromConnz` resolves to
@@ -95,6 +96,7 @@ accounts {
 }
 `);
 const broker = spawn("nats-server", ["-c", join(sd, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 
 let nc: NatsConnection | undefined, sysObserver: NatsConnection | undefined, sysEvictor: NatsConnection | undefined,
   victim1: NatsConnection | undefined, victim2: NatsConnection | undefined, servingConn: NatsConnection | undefined, wedgeConn: NatsConnection | undefined;
@@ -541,6 +543,7 @@ try {
   broker.kill("SIGKILL"); // exact PID — never pkill nats-server
   await new Promise((r) => broker.once("exit", r));
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(fail === 0 ? `\nCREDENTIAL LEDGER SMOKE OK ✅  (${ok} passed, ${fail} failed)` : `\nCREDENTIAL LEDGER SMOKE FAILED ❌  (${ok} passed, ${fail} failed)`);

--- a/implementations/auth/smoke/deny-new.smoke.ts
+++ b/implementations/auth/smoke/deny-new.smoke.ts
@@ -35,6 +35,7 @@ import { credRowKey, finalizeAgentMint, markLedgerRowRevoked, stageAgentMint } f
 import { authorityWriterGrants, openAuthorityClient } from "../src/authority-client.js";
 import { ROOT_CREDENTIAL_TTL_MS } from "../src/root-credential.js";
 import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -59,10 +60,11 @@ async function rejects(name: string, fn: () => Promise<unknown>, needle?: string
 const space = `denynew-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
 const callout = await createCalloutAuth({ space, operatorSeed: auth.operator.seed, accountPub: auth.account.pub });
-const tmp = mkdtempSync(join(tmpdir(), "cotal-denynew-"));
+const tmp = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const dir = join(tmp, "state");
 writeFileSync(join(tmp, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(tmp, "js"), extraAccounts: [{ pub: callout.account.pub, jwt: callout.account.jwt }] }));
 const srv = spawn("nats-server", ["-c", join(tmp, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, tmp);
 
 const ISS = "https://auth.cotal.test";
 const OWNER = deriveOwnerToken("s".repeat(32), "better-auth|human-1");
@@ -184,4 +186,5 @@ try {
   srv.kill();
   await awaitExit(srv);
   rmSync(tmp, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/implementations/auth/smoke/descendant-deny.smoke.ts
+++ b/implementations/auth/smoke/descendant-deny.smoke.ts
@@ -34,6 +34,7 @@ import {
 import { openAuthorityClient } from "../src/authority-client.js";
 import { ROOT_CREDENTIAL_TTL_MS } from "../src/root-credential.js";
 import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -51,10 +52,11 @@ const check = (name: string, cond: boolean, extra?: unknown) => { if (cond) { pa
 const space = `descdeny-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
 const callout = await createCalloutAuth({ space, operatorSeed: auth.operator.seed, accountPub: auth.account.pub });
-const tmp = mkdtempSync(join(tmpdir(), "cotal-descdeny-"));
+const tmp = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const dir = join(tmp, "state");
 writeFileSync(join(tmp, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(tmp, "js"), extraAccounts: [{ pub: callout.account.pub, jwt: callout.account.jwt }] }));
 const srv = spawn("nats-server", ["-c", join(tmp, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, tmp);
 
 const ISS = "https://auth.cotal.test";
 const OWNER = deriveOwnerToken("s".repeat(32), "better-auth|human-1");
@@ -155,4 +157,5 @@ try {
   srv.kill();
   await awaitExit(srv);
   rmSync(tmp, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/implementations/auth/smoke/drain-repair.smoke.ts
+++ b/implementations/auth/smoke/drain-repair.smoke.ts
@@ -28,6 +28,7 @@ import { contractDigest, createSpaceAuth, ensureAuthorityStores, epfStreamName, 
 import { openAuthorityClient } from "../src/authority-client.js";
 import { assertAppliableCommitKey, assertEffectsCancelSubject, assertPoolRepairSubject, drainApplierGrants, drainCancellerGrants, drainReconcilerGrants, makeDrainRepairers } from "../src/drain-repair.js";
 import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -91,9 +92,10 @@ console.log("B. the closed pool-repair subject");
 console.log("C. live exact-coordinate confinement over the real JWT broker");
 const space = `drrp-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const tmp = mkdtempSync(join(tmpdir(), "cotal-drrp-"));
+const tmp = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(tmp, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(tmp, "js") }));
 const srv = spawn("nats-server", ["-c", join(tmp, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, tmp);
 const dataAccount = { pub: auth.account.pub, signingSeed: auth.account.signingSeed };
 const awaitExit = (proc: ReturnType<typeof spawn>, timeoutMs = 3000): Promise<void> =>
   new Promise((resolve) => {
@@ -225,6 +227,7 @@ try {
   srv.kill("SIGTERM"); // exact PID — never pkill nats-server
   await awaitExit(srv);
   rmSync(tmp, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(fail === 0 ? `\nDRAIN-REPAIR SMOKE OK ✅  (${pass} passed, ${fail} failed)` : `\nDRAIN-REPAIR SMOKE FAILED ❌  (${pass} passed, ${fail} failed)`);

--- a/implementations/auth/smoke/lifecycle-registry.smoke.ts
+++ b/implementations/auth/smoke/lifecycle-registry.smoke.ts
@@ -40,6 +40,7 @@ import {
   observeGate, createGateFrozen, freezeGate, reopenGate, retireGate,
 } from "../src/lifecycle-registry.js";
 import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -57,7 +58,7 @@ const headKey = (o: string, a: string) => recordAtomicKey(LIFECYCLE_HEAD, [o, a]
 const uidKey = (u: string) => recordAtomicKey(UID_RESERVATION, [u]);
 
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-lifereg-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 // A conf broker with a full ADMIN user, a SCOPED mapping-reader user (records leader read +
 // the bind-time STREAM.INFO shape proof, §13.9; a CONNECTION-scoped inbox, never the
 // account-wide default), and a SCOPED minting-profile WRITER user (the registry's real
@@ -88,6 +89,7 @@ authorization {
 }
 `);
 const broker = spawn("nats-server", ["-c", join(sd, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 
 try {
   let up = false;
@@ -408,6 +410,7 @@ try {
   broker.kill("SIGKILL");
   await new Promise((r) => broker.once("exit", r));
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(fail === 0 ? `\nLIFECYCLE REGISTRY SMOKE OK ✅  (${ok} passed, ${fail} failed)` : `\nLIFECYCLE REGISTRY SMOKE FAILED ❌  (${ok} passed, ${fail} failed)`);

--- a/implementations/auth/smoke/mediator-confinement.smoke.ts
+++ b/implementations/auth/smoke/mediator-confinement.smoke.ts
@@ -40,6 +40,7 @@ import { makeRecordsScannerOverConnection } from "../src/records-scanner.js";
 import { openLifecycleRegistry, activateLifecycle } from "../src/lifecycle-registry.js";
 import { runExactPoolCleaner } from "../src/retirement-barrier.js";
 import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -75,7 +76,7 @@ const fp = (tag: string): string => contractDigest({ fp: tag });
 const enc = new TextEncoder();
 
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-confine-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 // The connection-scoped inbox nonces (SPEC 13.9: never the account-wide `_INBOX.>` default). The
 // mediator holds NO records-stream consumer grant (site 3): its drain enumerates through the sealed
 // records scanner, so there is no per-mediator enumeration consumer name to bind.
@@ -98,6 +99,7 @@ writeFileSync(join(sd, "server.conf"), [
   "}",
 ].join("\n"));
 const broker = spawn("nats-server", ["-c", join(sd, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 
 let nc: NatsConnection | undefined, medNc: NatsConnection | undefined, clnNc: NatsConnection | undefined;
 try {
@@ -375,6 +377,7 @@ try {
   broker.kill("SIGKILL"); // exact PID — never pkill nats-server
   await new Promise((r) => broker.once("exit", r));
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(fail === 0 ? `\nMEDIATOR/CLEANER CONFINEMENT SMOKE OK ✅  (${ok} passed, ${fail} failed)` : `\nMEDIATOR/CLEANER CONFINEMENT SMOKE FAILED ❌  (${ok} passed, ${fail} failed)`);

--- a/implementations/auth/smoke/plane-claim.smoke.ts
+++ b/implementations/auth/smoke/plane-claim.smoke.ts
@@ -36,6 +36,7 @@ import { acquirePlaneClaim, parsePlaneClaimRow, scannerDeathCopy, PLANE_CLAIM_KE
 import { openAuthAuthorityPlane } from "../src/service.js";
 import type { EvictPrincipal } from "../src/credential-ledger.js";
 import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -46,9 +47,10 @@ const rejects = async (fn: () => Promise<unknown>): Promise<string> => { try { a
 
 const space = `plcl-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const tmp = mkdtempSync(join(tmpdir(), "cotal-plcl-"));
+const tmp = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(tmp, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(tmp, "js") }));
 const srv = spawn("nats-server", ["-c", join(tmp, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, tmp);
 const dataAccount = { pub: auth.account.pub, signingSeed: auth.account.signingSeed };
 const quiet = () => {};
 
@@ -294,6 +296,7 @@ try {
   srv.kill("SIGTERM");
   if (srv.exitCode === null && srv.signalCode === null) await new Promise<void>((resolve) => { srv.once("exit", () => resolve()); setTimeout(resolve, 3000); });
   rmSync(tmp, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(fail === 0 ? `\nPLANE-CLAIM SMOKE OK ✅  (${pass} passed, ${fail} failed)` : `\nPLANE-CLAIM SMOKE FAILED ❌  (${pass} passed, ${fail} failed)`);

--- a/implementations/auth/smoke/retirement-barrier.smoke.ts
+++ b/implementations/auth/smoke/retirement-barrier.smoke.ts
@@ -34,6 +34,7 @@ import { runAgentRetirementBarrier, resumeAgentRetirement, settlementForIntent, 
 import { drainRepairPrincipals } from "../src/drain-repair.js";
 import { workPoolContext } from "@cotal-ai/core";
 import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -71,7 +72,7 @@ const PORT = await pickFreePort();
 // about to close the frontier; the drain-repair fence must cluster-verified-evict it first.
 const OP_H = "h".repeat(26);
 const APPLIER_USER = drainRepairPrincipals(OP_H)[0]!.principal.replace(".", "-"); // local.epapl_<hash> -> local-epapl_<hash>
-const sd = mkdtempSync(join(tmpdir(), "cotal-retire-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(sd, "server.conf"), `
 port: ${PORT}
 listen: 127.0.0.1:${PORT}
@@ -92,6 +93,7 @@ accounts {
 }
 `);
 const broker = spawn("nats-server", ["-c", join(sd, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 
 let nc: NatsConnection | undefined, sysObserver: NatsConnection | undefined, sysEvictor: NatsConnection | undefined,
   victim: NatsConnection | undefined;
@@ -712,6 +714,7 @@ try {
   broker.kill("SIGKILL"); // exact PID — never pkill nats-server
   await new Promise((r) => broker.once("exit", r));
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(fail === 0 ? `\nRETIREMENT BARRIER SMOKE OK ✅  (${ok} passed, ${fail} failed)` : `\nRETIREMENT BARRIER SMOKE FAILED ❌  (${ok} passed, ${fail} failed)`);

--- a/implementations/auth/smoke/retirement-cleaner-confinement.smoke.ts
+++ b/implementations/auth/smoke/retirement-cleaner-confinement.smoke.ts
@@ -34,6 +34,7 @@ import { openAuthorityClient } from "../src/authority-client.js";
 import { jetstream } from "@nats-io/jetstream";
 import type { NatsConnection } from "@nats-io/transport-node";
 import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; console.log(`  ✓ ${n}`); } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -50,10 +51,11 @@ const SERVERS = `nats://127.0.0.1:${PORT}`;
 const SPACE = `rclean-${randomUUID().slice(0, 8)}`;
 const EP = "jobsrv", EP2 = "mgrjob", POOL_A = "pa", POOL_B = "pb";
 const enc = new TextEncoder();
-const tmp = mkdtempSync(join(tmpdir(), "cotal-rclean-"));
+const tmp = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const auth = await createSpaceAuth(SPACE);
 writeFileSync(join(tmp, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(tmp, "js") }));
 const srv = spawn("nats-server", ["-c", join(tmp, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, tmp);
 const dataAccount = { pub: auth.account.pub, signingSeed: auth.account.signingSeed };
 const quiet = () => {};
 
@@ -263,6 +265,7 @@ try {
   if (srv.exitCode === null && srv.signalCode === null)
     await new Promise<void>((resolve) => { srv.once("exit", () => resolve()); srv.once("error", () => resolve()); });
   rmSync(tmp, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(`\nRETIREMENT CLEANER CONFINEMENT ${fail === 0 ? "OK ✅" : "FAILED ❌"}  (${ok} passed, ${fail} failed)`);

--- a/implementations/auth/smoke/session-ledger.smoke.ts
+++ b/implementations/auth/smoke/session-ledger.smoke.ts
@@ -43,6 +43,7 @@ import { makeLedgerScannerOverConnection } from "../src/ledger-scanner.js";
 import { parseLedgerRow } from "../src/credential-ledger.js";
 import { tryReserveUid, createGateFrozen, reopenGate } from "../src/lifecycle-registry.js";
 import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -91,8 +92,9 @@ const PRESENTER = { id: HOLDER_ID, lifecycleUid: HOLDER_UID };
 const sid = (n: number) => `${"q".repeat(20)}${String(n).padStart(4, "0")}`;
 
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-sessadapter-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 
 try {
   let up = false;
@@ -551,6 +553,7 @@ try {
   broker.kill("SIGKILL");
   await new Promise((r) => broker.once("exit", r));
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(fail === 0 ? `\nSESSION ADAPTER SMOKE OK ✅  (${ok} passed, ${fail} failed)` : `\nSESSION ADAPTER SMOKE FAILED ❌  (${ok} passed, ${fail} failed)`);

--- a/implementations/auth/smoke/storage-authority-confinement.smoke.ts
+++ b/implementations/auth/smoke/storage-authority-confinement.smoke.ts
@@ -43,6 +43,7 @@ import {
   type EpCapability,
 } from "@cotal-ai/core";
 import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0, fail = 0;
 const c = (n: string, v: boolean, extra?: unknown) => { if (v) { ok++; } else { fail++; console.log("  ✗ FAIL:", n, extra ?? ""); } };
@@ -91,7 +92,7 @@ const cap: EpCapability = { endpoint: EP, command: "spawn", target: { mode: "own
 const callerRows = epCallerGrantRows(S, [cap], { owner: "u_abc", actor: "cli", uid: UID });
 
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-stauth-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(sd, "server.conf"), [
   `port: ${PORT}`,
   `jetstream { store_dir: ${JSON.stringify(join(sd, "js"))} }`,
@@ -110,6 +111,7 @@ writeFileSync(join(sd, "server.conf"), [
   "}",
 ].join("\n"));
 const broker = spawn("nats-server", ["-c", join(sd, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 
 const conns: NatsConnection[] = [];
 try {
@@ -291,6 +293,7 @@ try {
   broker.kill("SIGKILL");
   await new Promise((r) => broker.once("exit", r));
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(fail === 0 ? `\nSTORAGE-AUTHORITY CONFINEMENT OK ✅  (${ok} passed, ${fail} failed)` : `\nSTORAGE-AUTHORITY CONFINEMENT FAILED ❌  (${ok} passed, ${fail} failed)`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,6 +338,9 @@ importers:
         specifier: ^6.2.3
         version: 6.2.3
     devDependencies:
+      '@cotal-ai/smoke-kit':
+        specifier: workspace:*
+        version: link:../../packages/smoke-kit
       better-auth:
         specifier: ^1.6.23
         version: 1.6.23(@opentelemetry/api@1.9.0)(react@19.2.7)


### PR DESCRIPTION
Seventeen `implementations/auth` smokes now own the `nats-server` they spawn, so it dies when the
suite is signalled and not only when the suite returns and its `finally` runs. Each takes ownership
at the spawn and releases it last, after its own teardown has already finished, so the existing
normal path is unchanged and the helper never touches a broker the suite has handled itself.

Scratch prefixes move to the shared minted token, the only evidence that survives SIGKILL, and the one
case ownership cannot cover.

| suite | cells |
| --- | --- |
| admission-mediator | 61 |
| auth-admin | 24 |
| auth-callout | 10 |
| barrier-plane | 60 |
| callout-deny | 4 |
| connect-reader-acl | 20 |
| credential-ledger | 78 |
| deny-new | 15 |
| descendant-deny | 9 |
| drain-repair | 45 |
| lifecycle-registry | 79 |
| mediator-confinement | 52 |
| plane-claim | 41 |
| retirement-barrier | 61 |
| retirement-cleaner-confinement | 35 |
| session-ledger | 81 |
| storage-authority-confinement | 40 |

715 cells, every count identical before and after, all seventeen exit 0, `pnpm typecheck` clean.

Six of the package's twenty-three broker-spawning suites are not here: two mint more than one
scratch dir or none, and four bind no single broker to a name. Those need reading rather than a
mechanical edit and are not in this change.

This is the first package in the migration that needed the dependency declared, so it carries a
manifest commit: the kit is private, source-only and has no dependencies of its own, so the
lockfile grows by three lines and nothing is pulled in. It is a devDependency, and a boundary suite
already enforces that no `src/` file may import it.

