### PR TITLE
test(core): pick evict-live-auth's cluster ports from the OS, not a blind random range

### DIFF
--- a/.changeset/evict-live-cluster-ports.md
+++ b/.changeset/evict-live-cluster-ports.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only: evict-live-auth picks its cluster ports from the OS instead of a blind random range.

--- a/packages/core/smoke/evict-live-auth.smoke.ts
+++ b/packages/core/smoke/evict-live-auth.smoke.ts
@@ -341,8 +341,13 @@ try {
   // (nats-server sets it whenever clustering is configured), so the oracle refuses reclaim there.
   // If nats-server ever stopped declaring it, this check — not production — is what breaks.
   {
-    const pA = 21000 + Math.floor(Math.random() * 20000);
-    const [pB, cA, cB] = [pA + 1, pA + 2, pA + 3];
+    // OS-assigned and distinct. The old draw (21000 + random 20000, four consecutive, unchecked)
+    // overlapped the Linux ephemeral range 32768-60999 on 41% of picks, so a transient outbound
+    // socket could hold a cluster port with no other suite involved; the ten-second wait then
+    // reported the broker ("cluster node A did not come up"), not the taken port.
+    const picked = new Set<number>();
+    while (picked.size < 4) picked.add(await pickFreePort());
+    const [pA, pB, cA, cB] = [...picked];
     const cdir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
     const conf = (name: string, port: number, cport: number, routes: string) => [
       `port: ${port}`, `server_name: ${name}`,


### PR DESCRIPTION
Test-only. The evict-live-auth suite's cluster block drew a base port as \`21000 + random(20000)\` and claimed four consecutive ports from it, none checked before nats-server was told to bind. That range overlaps the Linux ephemeral range 32768-60999 on 8232 of the 20000 possible picks, so on 41% of runs the suite claims ports the kernel is simultaneously handing to transient outbound sockets, and it claims four of them. No second broker or leaked orphan is needed for a collision, which is why it has presented as a flake with no visible culprit.

When a collision lands, the ten-second wait reports \`cluster node A did not come up on <port>\`, which names the broker rather than the port that was already taken.

Reproduced in CI: smoke shard 3/4 at 2c0d42ae failed at this suite with \`cluster node A did not come up on 33330\`, a port inside the overlap, on a branch that does not touch this file.

The suite already imports \`pickFreePort\` and uses it for its main port; the cluster block now draws four distinct OS-assigned ports the same way. \`pickFreePort\` binds port 0, reads the assignment and closes, so a microsecond TOCTOU window survives, against a 41% blind draw.

Locally 27 passed, 0 failed at this tip, run after building dist because this suite imports the built \`@cotal-ai/auth\` (a fresh worktree without a build fails with ERR_MODULE_NOT_FOUND on that import, which is a dist-resolution fact, not a code verdict). Empty test-only changeset.

Not in scope: two other suites draw from \`12000 + random(8000)\`. That range sits entirely below the ephemeral floor, so their exposure is cross-run collision only, materially weaker; they are candidates for the same alignment but carry no repro.