### PR TITLE
test: own spawned brokers in the last mechanically-adoptable smokes

### DIFF
--- a/.changeset/broker-teardown-tail.md
+++ b/.changeset/broker-teardown-tail.md
@@ -1,0 +1,6 @@
+---
+---
+
+Test-only: adopts the smoke broker teardown helper in the remaining mechanically-adoptable suites
+across cli, connector-opencode, connector-codex, bin and connector-claude-code, and declares the
+private test kit in those five packages. No shipped behaviour changes, so no release.

--- a/bin/package.json
+++ b/bin/package.json
@@ -54,6 +54,7 @@
     "@cotal-ai/connector-hermes": "workspace:*",
     "@cotal-ai/connector-opencode": "workspace:*",
     "@cotal-ai/pi": "workspace:*",
+    "@cotal-ai/smoke-kit": "workspace:*",
     "@cotal-ai/web": "workspace:*",
     "@nats-io/jetstream": "^3.4.0",
     "@nats-io/transport-node": "^3.4.0"

--- a/bin/smoke/persona-announce.smoke.ts
+++ b/bin/smoke/persona-announce.smoke.ts
@@ -76,6 +76,7 @@ import { authDir, saveSpaceAuth } from "@cotal-ai/workspace";
 import { MeshAgent, cotalToolSpecs, type AgentConfig } from "@cotal-ai/connector-core";
 import { Manager } from "@cotal-ai/manager";
 import { PermissionViolationError } from "@nats-io/transport-node";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const freePort = (): Promise<number> =>
   new Promise((res, rej) => {
@@ -127,7 +128,7 @@ check(
 
 const space = `personaann-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-personaann-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const workspaceRoot = join(dir, "ws");
 mkdirSync(join(workspaceRoot, ".cotal", "agents"), { recursive: true });
 saveSpaceAuth(authDir(workspaceRoot), auth);
@@ -136,6 +137,7 @@ writeFileSync(
   serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }),
 );
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 /** The settle window. Cell 3 receives inside it on this same harness, which is what licenses cell 2
  *  to read an empty mailbox as silence rather than as impatience. */
@@ -513,4 +515,5 @@ try {
   await mgr.stop().catch(() => {});
   srv.kill("SIGKILL");
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/extensions/connector-claude-code/package.json
+++ b/extensions/connector-claude-code/package.json
@@ -27,8 +27,9 @@
     "@cotal-ai/core": ">=0.1.0"
   },
   "devDependencies": {
-    "@cotal-ai/core": "workspace:*",
     "@cotal-ai/connector-core": "workspace:*",
+    "@cotal-ai/core": "workspace:*",
+    "@cotal-ai/smoke-kit": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "esbuild": "^0.28.0",
     "tsx": "^4.22.4"

--- a/extensions/connector-claude-code/smoke/wake-path.smoke.ts
+++ b/extensions/connector-claude-code/smoke/wake-path.smoke.ts
@@ -42,6 +42,7 @@ import { createRequire } from "node:module";
 import { CotalEndpoint, seedChannelRegistry, isReachable } from "@cotal-ai/core";
 import { MeshAgent, startControlServer, type InboxItem } from "@cotal-ai/connector-core";
 import { createClaudeHandle, createWakePolicy } from "../src/hooks.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const here = fileURLToPath(new URL(".", import.meta.url));
 /** The real per-event hook entry Claude Code runs, and the loader that can execute its TS. */
@@ -75,9 +76,10 @@ const RETRY_DEADLINE_MS = 5_000;
 const NUDGE_RETRY_FIRST_MS = 1_000;
 const TOKEN = "wake-path-test-token";
 
-const dir = mkdtempSync(join(tmpdir(), "cotal-ccwake-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const socketPath = join(dir, "control.sock");
 const srv = spawn("nats-server", ["-js", "-p", String(PORT), "-sd", join(dir, "js")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 let pass = 0;
 const check = (name: string, cond: boolean, extra?: unknown) => {
@@ -674,5 +676,6 @@ try {
   srv.kill("SIGKILL");
   await sleep(200);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 process.exit(0);

--- a/extensions/connector-codex/package.json
+++ b/extensions/connector-codex/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@cotal-ai/connector-core": "workspace:*",
     "@cotal-ai/core": "workspace:*",
+    "@cotal-ai/smoke-kit": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@types/ws": "^8.18.1",
     "esbuild": "^0.28.0",

--- a/extensions/connector-codex/smoke/codex-host.smoke.ts
+++ b/extensions/connector-codex/smoke/codex-host.smoke.ts
@@ -31,6 +31,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { CotalEndpoint, seedChannelRegistry, isReachable } from "@cotal-ai/core";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 if (process.platform === "win32") {
   // Managed Codex agents are POSIX-only by design (the isolated CODEX_HOME symlinks the
@@ -61,7 +62,7 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
   console.log(`  ✓ ${name}`);
 };
 
-const dir = mkdtempSync(join(tmpdir(), "cotal-codexhost-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const FAKE = fileURLToPath(new URL("./fake-codex.mjs", import.meta.url));
 const BIN = join(dir, "fake-codex");
 writeFileSync(BIN, `#!/bin/sh\nexec "${process.execPath}" "${FAKE}" "$@"\n`);
@@ -101,6 +102,7 @@ async function waitFor<T>(name: string, get: () => T | undefined, timeoutMs = 20
 }
 
 const nats = spawn("nats-server", ["-js", "-p", String(PORT), "-sd", join(dir, "js")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(nats, dir);
 
 const operator = new CotalEndpoint({
   space,
@@ -1206,5 +1208,6 @@ try {
   nats.kill("SIGKILL");
   await sleep(200);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 process.exit(0);

--- a/extensions/connector-opencode/package.json
+++ b/extensions/connector-opencode/package.json
@@ -27,8 +27,9 @@
     "@cotal-ai/core": ">=0.1.0"
   },
   "devDependencies": {
-    "@cotal-ai/core": "workspace:*",
     "@cotal-ai/connector-core": "workspace:*",
+    "@cotal-ai/core": "workspace:*",
+    "@cotal-ai/smoke-kit": "workspace:*",
     "@opencode-ai/plugin": "^1.16.2",
     "esbuild": "^0.28.0",
     "tsx": "^4.22.4"

--- a/extensions/connector-opencode/smoke/boot-prompt.smoke.ts
+++ b/extensions/connector-opencode/smoke/boot-prompt.smoke.ts
@@ -28,6 +28,7 @@ import { join } from "node:path";
 import { seedChannelRegistry, isReachable } from "@cotal-ai/core";
 import { opencodeConnector } from "../src/extension.js";
 import { cotal } from "../src/plugin.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 let pass = 0;
@@ -89,8 +90,9 @@ async function freePort(): Promise<number> {
 const PORT = await freePort();
 const servers = `nats://127.0.0.1:${PORT}`;
 const space = "ocboot";
-const dir = mkdtempSync(join(tmpdir(), "cotal-ocboot-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const nats = spawn("nats-server", ["-js", "-p", String(PORT), "-sd", join(dir, "js")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(nats, dir);
 const auth = `Basic ${Buffer.from("opencode:test-secret").toString("base64")}`;
 
 // A fake OpenCode HTTP server: hand the plugin a session id and record every turn it drives.
@@ -195,5 +197,6 @@ try {
   oc.close();
   await sleep(150);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 process.exit(0);

--- a/extensions/connector-opencode/smoke/cooperative-stop.smoke.ts
+++ b/extensions/connector-opencode/smoke/cooperative-stop.smoke.ts
@@ -35,6 +35,7 @@ import {
 } from "@cotal-ai/core";
 import { opencodeConnector } from "../src/extension.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 // An OS-assigned free port (see _free-port.ts): a Windows-reserved port makes nats-server fail to bind.
 const PORT = await pickFreePort();
@@ -86,9 +87,10 @@ function sendShutdown(path: string, token: string): Promise<string> {
 
 const space = `oc-coop-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-oc-coop-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 let mgr: CotalEndpoint | undefined;
 let watcher: CotalEndpoint | undefined;
@@ -217,6 +219,7 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(`\n${fail === 0 ? "OPENCODE COOPERATIVE-STOP SMOKE OK ✅" : "OPENCODE COOPERATIVE-STOP SMOKE FAILED ❌"}  (${pass} passed, ${fail} failed)`);

--- a/extensions/connector-opencode/smoke/transcript-mirror.smoke.ts
+++ b/extensions/connector-opencode/smoke/transcript-mirror.smoke.ts
@@ -23,6 +23,7 @@ import { CotalEndpoint, seedChannelRegistry, isReachable } from "@cotal-ai/core"
 import type { CotalMessage, Delivery } from "@cotal-ai/core";
 import { transcriptChannel } from "@cotal-ai/connector-core";
 import { cotal } from "../src/plugin.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 async function freePort(): Promise<number> {
   const srv = createNetServer();
@@ -41,8 +42,9 @@ const NAME = "Otto";
 const CHAN = transcriptChannel(NAME); // "tr-otto" — the shared connector-core convention
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-const dir = mkdtempSync(join(tmpdir(), "cotal-octr-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const srv = spawn("nats-server", ["-js", "-p", String(PORT), "-sd", join(dir, "js")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 const auth = `Basic ${Buffer.from("opencode:test-secret").toString("base64")}`;
 let pass = 0;
 const check = (name: string, cond: boolean, extra?: unknown) => {
@@ -173,5 +175,6 @@ try {
   oc.close();
   await sleep(150);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 process.exit(0);

--- a/extensions/connector-opencode/smoke/turn-wedge.smoke.ts
+++ b/extensions/connector-opencode/smoke/turn-wedge.smoke.ts
@@ -26,6 +26,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CotalEndpoint, seedChannelRegistry, isReachable } from "@cotal-ai/core";
 import { cotal } from "../src/plugin.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 async function freePort(): Promise<number> {
   const srv = createNetServer();
@@ -42,8 +43,9 @@ const space = "ocwedge";
 const SID = "ses_test";
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-const dir = mkdtempSync(join(tmpdir(), "cotal-ocwedge-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const srv = spawn("nats-server", ["-js", "-p", String(PORT), "-sd", join(dir, "js")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 const auth = `Basic ${Buffer.from("opencode:test-secret").toString("base64")}`;
 let pass = 0;
 const check = (name: string, cond: boolean, extra?: unknown) => {
@@ -244,5 +246,6 @@ try {
   oc.close();
   await sleep(150);
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 process.exit(0);

--- a/implementations/cli/package.json
+++ b/implementations/cli/package.json
@@ -46,6 +46,7 @@
     "@eplightning/nats-server-win32-x64": "^2.14.0"
   },
   "devDependencies": {
+    "@cotal-ai/smoke-kit": "workspace:*",
     "@types/react": "^19.0.0",
     "@types/ws": "^8.18.1"
   },

--- a/implementations/cli/smoke/ep-rail-failure.smoke.ts
+++ b/implementations/cli/smoke/ep-rail-failure.smoke.ts
@@ -23,6 +23,7 @@ import {
 } from "@cotal-ai/core";
 import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
 import { askManager, epRailFailure } from "../src/lib/control.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let pass = 0, fail = 0;
 const c = (name: string, cond: boolean, extra?: unknown) => {
@@ -104,8 +105,9 @@ console.log("epRailFailure polarity (hand-built errors, one per producer shape):
 // ── Part 2: the public askManager path against a real broker (open mesh) ──
 console.log("askManager against a real broker:");
 const PORT = await pickFreePort();
-const sd = mkdtempSync(join(tmpdir(), "cotal-eprail-"));
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
 const SERVER = `nats://127.0.0.1:${PORT}`;
 const SPACE = "eprail";
 const enc = new TextEncoder(), dec = new TextDecoder();
@@ -159,6 +161,7 @@ try {
 } finally {
   broker.kill("SIGTERM");
   rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 
 console.log(`\n${fail === 0 ? "EP-RAIL-FAILURE POLARITY SMOKE OK ✅" : "EP-RAIL-FAILURE POLARITY SMOKE FAILED"}  (${pass} passed, ${fail} failed)`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       '@cotal-ai/pi':
         specifier: workspace:*
         version: link:../extensions/pi
+      '@cotal-ai/smoke-kit':
+        specifier: workspace:*
+        version: link:../packages/smoke-kit
       '@cotal-ai/web':
         specifier: workspace:*
         version: link:../implementations/web
@@ -171,6 +174,9 @@ importers:
       '@cotal-ai/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@cotal-ai/smoke-kit':
+        specifier: workspace:*
+        version: link:../../packages/smoke-kit
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
@@ -189,6 +195,9 @@ importers:
       '@cotal-ai/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@cotal-ai/smoke-kit':
+        specifier: workspace:*
+        version: link:../../packages/smoke-kit
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
@@ -253,6 +262,9 @@ importers:
       '@cotal-ai/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@cotal-ai/smoke-kit':
+        specifier: workspace:*
+        version: link:../../packages/smoke-kit
       '@opencode-ai/plugin':
         specifier: ^1.16.2
         version: 1.16.2
@@ -384,6 +396,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@cotal-ai/smoke-kit':
+        specifier: workspace:*
+        version: link:../../packages/smoke-kit
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.17


### PR DESCRIPTION
The last mechanically-adoptable smoke suites take ownership of the `nats-server` they spawn, so it
dies when the suite is signalled and not only when the suite returns and its `finally` runs. Each
takes ownership at the spawn and releases it last, after its own teardown has already finished, so
an existing normal path is unchanged and the helper never touches a broker the suite has handled
itself. Scratch prefixes move to the shared minted token, the only evidence that survives SIGKILL.

| suite | package | cells |
| --- | --- | --- |
| ep-rail-failure | cli | 23 |
| boot-prompt | connector-opencode | 9 |
| cooperative-stop | connector-opencode | 5 |
| transcript-mirror | connector-opencode | 9 |
| turn-wedge | connector-opencode | 18 |
| codex-host | connector-codex | 91 |
| persona-announce | bin | 60 |
| wake-path | connector-claude-code | 55 |

270 cells, every count identical before and after, all eight exit 0, `pnpm build` and
`pnpm typecheck` clean.

**Five packages in one change, deliberately.** Each needed the private test kit declared, and each
declaration touches `pnpm-lock.yaml`. Split across five pull requests they would have had to merge
one at a time purely to avoid colliding in that file, so the manifests and the lockfile move in a
single commit instead: 15 lockfile lines, nothing pulled in, and no dependency added to anything
shipped. The kit is a devDependency everywhere, and a boundary suite already refuses any `src`
import of it.

**`delivery` is not here.** All six of its broker-spawning suites were refused by the tool that
made these edits, so it has nothing mechanical to adopt and becomes hand work in a later change.

**Two suites are missing from this batch and it is worth saying why.** `codex-live` and
`codex-tui-live` gate on `COTAL_E2E_CODEX` before they reach their broker, so with that variable
unset they print SKIP and exit before the adopted lines ever run. Adopting them here would have
produced two rows reading identical-before-and-after next to eight rows where that means something,
which is not weak evidence but no evidence. They are held for a pass that can actually exercise
them. Neither is in the CI chain.
