### PR TITLE
test(connector-core): own every broker in agui-retry-duplicate, and not its tree

### DIFF
--- a/.changeset/broker-teardown-agui.md
+++ b/.changeset/broker-teardown-agui.md
@@ -1,0 +1,6 @@
+---
+---
+
+Test-only: the agui retry/duplicate smoke now owns every broker it spawns rather than none, while
+deliberately leaving its scratch tree to its own stronger teardown. No shipped behaviour changes,
+so no release.

--- a/extensions/connector-core/smoke/agui-retry-duplicate.smoke.ts
+++ b/extensions/connector-core/smoke/agui-retry-duplicate.smoke.ts
@@ -65,6 +65,7 @@ import { CotalEndpoint, isReachable, mintLifecycleUid, type Part } from "@cotal-
 import { AguiEmitter, AguiEmitterHalted, aguiFrame, runFinished, runStarted } from "../src/agui.js";
 import { JsonlFileSource } from "../src/durable-source.js";
 import { EventWal } from "../src/event-wal.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 let ok = 0,
   fail = 0;
@@ -82,8 +83,25 @@ const OWNER = "local";
 const ACTOR = "aaa";
 const PRINCIPAL_KEY = `${OWNER}.${ACTOR}`;
 
-const root = mkdtempSync(join(tmpdir(), "agui-retry-dup-"));
+const root = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const procs: ChildProcess[] = [];
+// One release per broker, and NO store dir attached to any of them. That omission is the whole
+// decision, so it is written down rather than left to be inferred.
+//
+// This suite's own teardown is stronger than the helper's. It kills by pid, WAITS in a bounded
+// loop until every proc reports a terminal status, ASSERTS that as a cell, and only then removes
+// the tree, because the removal must not race a process still writing into it. The helper's reap
+// has no such wait: it kills and removes per entry in set order. So attaching `root` to any one
+// entry would let a signalled run delete the tree while later-iterated brokers are still dying,
+// reintroducing exactly the race the loop below exists to prevent. There is also no principled
+// choice of WHICH entry should carry it, and an arbitrary one is a design smell rather than a
+// detail.
+//
+// The consequence is deliberate: a signalled run kills every broker and LEAVES the tree. That is
+// not an oversight, it is the minted token doing its job. Ownership covers the processes; the
+// token covers the tree, by making it matchable to a reaper afterwards. Neither covers both, and
+// this suite is the one place where paying that price is cheaper than weakening the teardown.
+const releases: Array<() => void> = [];
 
 /**
  * Assert on the URL ACTUALLY DIALLED, before anything is dialled.
@@ -118,7 +136,9 @@ const startStandalone = async (tag: string): Promise<string> => {
   const port = await freePort();
   const conf = join(root, `${tag}.conf`);
   writeFileSync(conf, [`port: ${port}`, `server_name: ${tag}`, `jetstream { store_dir: "${join(root, tag)}" }`].join("\n"));
-  procs.push(spawn("nats-server", ["-c", conf], { stdio: "ignore" }));
+  const broker = spawn("nats-server", ["-c", conf], { stdio: "ignore" });
+  procs.push(broker);
+  releases.push(teardownOnSignal(broker));
   const url = `nats://127.0.0.1:${port}`;
   for (let i = 0; i < 200; i++) {
     if (await isReachable(url)) return url;
@@ -145,7 +165,9 @@ const startCluster = async (tag: string): Promise<string> => {
       `  port: ${routePorts[i]}`,
       `  routes: [${routes}] }`,
     ].join("\n"));
-    procs.push(spawn("nats-server", ["-c", conf], { stdio: "ignore" }));
+    const broker = spawn("nats-server", ["-c", conf], { stdio: "ignore" });
+    procs.push(broker);
+    releases.push(teardownOnSignal(broker));
   }
   const url = `nats://127.0.0.1:${ports[0]}`;
   let up = false;
@@ -357,6 +379,8 @@ try {
   const alive = procs.filter((p) => p.exitCode === null && p.signalCode === null).length;
   c("teardown: every broker this suite started is dead before its scratch dir is removed", alive === 0, alive);
   rmSync(root, { recursive: true, force: true });
+  // Last, after the verified kill and the removal above have both finished.
+  for (const release of releases) release();
 }
 
 console.log(`agui-retry-duplicate smoke: ${ok} passed, ${fail} failed`);


### PR DESCRIPTION
This suite spawns one broker in its standalone arm and three in its cluster arm, both inside loops,
so the broker count is dynamic and none of them was bound to a name. Every spawn is now bound,
owned, and its release collected, so a signalled run kills every broker it started rather than
whichever one happened to be reachable.

**The scratch tree is deliberately left out of that ownership, and that is the interesting part.**

This suite's own teardown is stronger than the shared helper's. It kills by pid, waits in a bounded
loop until every process reports a terminal status, asserts that as a cell, and only then removes
the tree, with a comment saying why: the removal must not race a process still writing into it.
That instinct was correct, and it was proved correct elsewhere while this change was being
prepared. A suite that removed its tree immediately after a graceful kill failed a CI shard on
`ENOTEMPTY` with every one of its cells already green.

The helper's reap has no such wait. It kills and removes per entry in set order. So attaching the
tree to any one owned entry would let a signalled run delete it while later-iterated brokers were
still dying, reintroducing the precise race this suite already prevents. There is also no
principled answer to which of the four entries should carry it, and when no placement is
principled the design is wrong rather than underspecified.

The consequence is stated rather than hidden: **a signalled run here kills every broker and leaves
the tree behind.** That is the minted scratch token doing its job, not an oversight. Ownership
covers the processes; the token covers the tree by making it matchable to a reaper afterwards;
neither covers both. Weakening a teardown that is better than the helper's, in order to adopt the
helper, would have been the wrong trade.

19 cells before, 19 after, `pnpm typecheck` clean, and no scratch directory left behind on either
run.
