### PR TITLE
test(auth): own spawned brokers in three suites that needed reading

### DIFF
--- a/.changeset/broker-teardown-auth-hand.md
+++ b/.changeset/broker-teardown-auth-hand.md
@@ -1,0 +1,6 @@
+---
+---
+
+Test-only: adopts the smoke broker teardown helper in three more `implementations/auth` suites that
+needed reading rather than a mechanical edit, including one that bounces its broker and so hands
+ownership across the respawn. No shipped behaviour changes, so no release.

--- a/implementations/auth/smoke/ctl-trust.smoke.ts
+++ b/implementations/auth/smoke/ctl-trust.smoke.ts
@@ -48,6 +48,7 @@ import {
   deriveOwnerToken, grantActor, ledgerAclResolver, ledgerAuthorizeConnect,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -68,12 +69,16 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 const space = `ctltrust-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
 const callout = await createCalloutAuth({ space, operatorSeed: auth.operator.seed, accountPub: auth.account.pub });
-const dir = mkdtempSync(join(tmpdir(), "cotal-ctltrust-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(
   join(dir, "server.conf"),
   serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js"), extraAccounts: [{ pub: callout.account.pub, jwt: callout.account.jwt }] }),
 );
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+// The broker's own dir is owned. The ledger dir below is not a broker store, so it keeps its own
+// prefix and its own removal line: the minted token marks what a reaper must match, and marking
+// a directory no broker ever writes to would widen that match for nothing.
+const releaseBroker = teardownOnSignal(srv, dir);
 const awaitExit = (proc: ReturnType<typeof spawn>, timeoutMs = 3000): Promise<void> =>
   new Promise((resolve) => {
     if (proc.exitCode !== null || proc.signalCode !== null) return resolve();
@@ -247,5 +252,6 @@ try {
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true });
   rmSync(ledgerDir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }
 process.exit(process.exitCode ?? 0);

--- a/implementations/auth/smoke/endpoint-usermode.smoke.ts
+++ b/implementations/auth/smoke/endpoint-usermode.smoke.ts
@@ -22,6 +22,7 @@ import {
 const smokeUid = mintLifecycleUid();
 import { createCalloutAuth, calloutPermissions, deriveOwnerToken, startAuthCallout, USER_TOKEN_VER } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -42,9 +43,10 @@ const check = (name: string, cond: boolean, extra?: unknown) => { if (cond) { pa
 const space = `epuser-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
 const callout = await createCalloutAuth({ space, operatorSeed: auth.operator.seed, accountPub: auth.account.pub });
-const dir = mkdtempSync(join(tmpdir(), "cotal-epuser-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js"), extraAccounts: [{ pub: callout.account.pub, jwt: callout.account.jwt }] }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
 
 const { publicKey, privateKey } = await generateKeyPair("EdDSA");
 const ISS = "https://auth.cotal.test";
@@ -127,4 +129,5 @@ try {
   srv.kill("SIGKILL");
   await awaitExit(srv);
   rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/implementations/auth/smoke/shape-supervisor.smoke.ts
+++ b/implementations/auth/smoke/shape-supervisor.smoke.ts
@@ -27,6 +27,7 @@ import { Kvm } from "@nats-io/kv";
 import { assertAuthorityStreamShape, type AuthorityStreamCfg } from "../src/lifecycle-registry.js";
 import { openAuthorityClient, openSupervisedConnectReader } from "../src/authority-client.js";
 import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -51,10 +52,14 @@ function throwsSync(fn: () => void): boolean { try { fn(); return false; } catch
 
 const space = `shapesup-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const tmp = mkdtempSync(join(tmpdir(), "cotal-shapesup-"));
+const tmp = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 const conf = join(tmp, "server.conf");
 writeFileSync(conf, serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(tmp, "js") }));
 let srv = spawn("nats-server", ["-c", conf], { stdio: "ignore" });
+// Reassigned at the bounce below, so ownership is reassigned with it. Holding the FIRST handle
+// past the respawn would leave ownership pinned to a dead pid while the live broker was unowned,
+// which reads as handled and is worse than not owning it at all.
+let releaseBroker = teardownOnSignal(srv, tmp);
 
 const dataAccount = { pub: auth.account.pub, signingSeed: auth.account.signingSeed };
 const quiet = () => {};
@@ -108,7 +113,9 @@ try {
   await awaitExit(srv);
   const downDenied = await (async () => { for (let i = 0; i < 25; i++) { if (throwsSync(() => reader!.current())) return true; await wait(100); } return false; })();
   check("BLOCKER 1b: current() DENIES while the connection is down (unproved between binds)", downDenied);
+  releaseBroker();
   srv = spawn("nats-server", ["-c", conf], { stdio: "ignore" });
+  releaseBroker = teardownOnSignal(srv, tmp);
   for (let i = 0; i < 50; i++) { if (await isReachable(SERVERS)) break; await wait(200); }
   const reproved = await (async () => { for (let i = 0; i < 60; i++) { try { reader!.current(); return true; } catch { await wait(250); } } return false; })();
   check("BLOCKER 1b: current() SERVES again only after the rebind shape proof re-runs", reproved);
@@ -126,4 +133,5 @@ try {
   srv.kill();
   await awaitExit(srv);
   rmSync(tmp, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }


### PR DESCRIPTION
Three `implementations/auth` suites that a mechanical edit refused, migrated by reading them.

| suite | cells | shape |
| --- | --- | --- |
| ctl-trust | 6 | two scratch dirs, only the broker's is owned |
| endpoint-usermode | 6 | ordinary, refused only because its removal carries retry options |
| shape-supervisor | 12 | bounces its broker, so ownership moves across the respawn |

All three already kill their broker and wait for its exit before removing anything, so the normal
path is unchanged and no race was introduced or found. What they gain is the signal path, where
that teardown never runs, plus the minted token as the only evidence a reaper can match after
SIGKILL. Counts identical before and after, `pnpm typecheck` clean, no scratch directory left
behind on any run.

**`shape-supervisor` is the one worth reading.** It bounces its broker on the same port and store
dir to prove the supervised reader denies while the connection is down and re-proves the rebind
shape before serving again, so it holds two brokers over its lifetime and reassigns the handle
between them. Ownership is reassigned with it, released immediately before the respawn and retaken
on the new child. Holding the first handle past the bounce would have pinned ownership to a dead
pid while the live broker was unowned, which reads as handled in a diff and is worse than not
owning it at all.

**`ctl-trust` mints two directories and only one is owned.** The ledger dir is not a broker store,
so it keeps its own prefix and its own removal line. The minted token marks what a reaper must
match, and marking a tree no broker ever writes to would widen that match for nothing.

Three further suites in this package are still outstanding and are not here, because none of them
can reach a green baseline on this box for reasons unrelated to teardown. They are all live suites
and none is in the CI chain. Details are in the branch discussion rather than the tree.
