### PR TITLE
test(delivery): own every broker the delivery suites spawn

### DIFF
--- a/.changeset/broker-teardown-delivery.md
+++ b/.changeset/broker-teardown-delivery.md
@@ -1,0 +1,6 @@
+---
+---
+
+Test-only: adopts the smoke broker teardown helper across the six `implementations/delivery` suites
+that spawn their own broker. All the changed files are smoke suites, so no shipped behaviour changes
+and no release.

--- a/implementations/delivery/package.json
+++ b/implementations/delivery/package.json
@@ -33,6 +33,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@cotal-ai/smoke-kit": "workspace:*",
     "@nats-io/transport-node": "^3.4.0"
   }
 }

--- a/implementations/delivery/smoke/adoption-doctor-e2e.smoke.ts
+++ b/implementations/delivery/smoke/adoption-doctor-e2e.smoke.ts
@@ -26,6 +26,7 @@ import {
   mintMembershipObserverCreds, newIdentity, serverConfig, setupSpaceStreams,
 } from "@cotal-ai/core";
 import { authDir, DELIVERY_CREDS_KEY, remintDaemonCreds, saveSpaceAuth, writeRenewalRecord } from "@cotal-ai/workspace";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 import { pickFreePort } from "./_free-port.js";
 
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -56,10 +57,16 @@ try {
   const obs = await mintMembershipObserverCreds(auth, newIdentity());
   const evictor = await mintConnectionEvictorCreds(auth, newIdentity());
 
-  const dir = mkdtempSync(join(tmpdir(), "cotal-e2e-doc-"));
+  const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
   writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port, storeDir: join(dir, "js") }));
   const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
-  cleanups.push(() => { srv.kill("SIGKILL"); rmSync(dir, { recursive: true, force: true }); });
+  // Owned, so a SIGNALLED run takes the broker and its store dir with it. `cleanups` drains in a
+  // `finally` and this suite registers no signal handler at all, so before this line a SIGINT left
+  // both behind. The SIGKILL below stays SIGKILL on purpose: measured on one fixture, 20 trials each,
+  // SIGTERM then an immediate rmSync hit ENOTEMPTY 3 times and SIGKILL zero, because SIGTERM asks for
+  // a graceful shutdown and a graceful shutdown flushes JetStream into the tree being walked.
+  const releaseBroker = teardownOnSignal(srv, dir);
+  cleanups.push(() => { srv.kill("SIGKILL"); rmSync(dir, { recursive: true, force: true }); releaseBroker(); });
   let up = false;
   for (let i = 0; i < 50; i++) { if (await isReachable(servers)) { up = true; break; } await wait(200); }
   if (!up) throw new Error("nats-server did not come up");

--- a/implementations/delivery/smoke/adoption-false-green.smoke.ts
+++ b/implementations/delivery/smoke/adoption-false-green.smoke.ts
@@ -51,6 +51,7 @@ import {
   serverConfig,
   setupSpaceStreams,
 } from "@cotal-ai/core";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 import { pickFreePort } from "./_free-port.js";
 
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -86,10 +87,17 @@ async function scenario(tag: string, rogueComponent: "delivery" | "membership"):
   const obsCreds = await mintMembershipObserverCreds(auth, newIdentity());
   const evictorCreds = await mintConnectionEvictorCreds(auth, newIdentity());
 
-  const dir = mkdtempSync(join(tmpdir(), `cotal-adopt-fg-${tag}-`));
+  // The token first so a reaper can still recognize this tree after a SIGKILLed run, the rail's tag
+  // kept after it so a leak that IS found still says which scenario made it.
+  const dir = mkdtempSync(join(tmpdir(), `${SMOKE_BROKER_TOKEN}${tag}-`));
   writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port, storeDir: join(dir, "js") }));
   const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
-  cleanups.push(() => { srv.kill("SIGKILL"); rmSync(dir, { recursive: true, force: true }); });
+  // Owned, so a SIGNALLED run takes the broker and its store dir with it: `cleanups` drains in a
+  // `finally` and this suite registers no signal handler, so before this line a SIGINT left both.
+  // SIGKILL stays SIGKILL: 20 trials each on one fixture, SIGTERM then an immediate rmSync hit
+  // ENOTEMPTY 3 times and SIGKILL zero, since only the graceful shutdown flushes JetStream.
+  const releaseBroker = teardownOnSignal(srv, dir);
+  cleanups.push(() => { srv.kill("SIGKILL"); rmSync(dir, { recursive: true, force: true }); releaseBroker(); });
 
   let up = false;
   for (let i = 0; i < 50; i++) { if (await isReachable(servers)) { up = true; break; } await wait(200); }

--- a/implementations/delivery/smoke/adoption-passive-preflight.smoke.ts
+++ b/implementations/delivery/smoke/adoption-passive-preflight.smoke.ts
@@ -29,6 +29,7 @@ import {
   CotalEndpoint, createSpaceAuth, isReachable, mintConnectionEvictorCreds, mintCreds,
   mintMembershipObserverCreds, newIdentity, serverConfig, setupSpaceStreams,
 } from "@cotal-ai/core";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 import { pickFreePort } from "./_free-port.js";
 
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -52,10 +53,15 @@ try {
   const obsCreds = await mintMembershipObserverCreds(auth, newIdentity());
   const evictorCreds = await mintConnectionEvictorCreds(auth, newIdentity());
 
-  const dir = mkdtempSync(join(tmpdir(), "cotal-adopt-pp-"));
+  const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
   writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port, storeDir: join(dir, "js") }));
   const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
-  cleanups.push(() => { srv.kill("SIGKILL"); rmSync(dir, { recursive: true, force: true }); });
+  // Owned, so a SIGNALLED run takes the broker and its store dir with it: `cleanups` drains in a
+  // `finally` and this suite registers no signal handler, so before this line a SIGINT left both.
+  // SIGKILL stays SIGKILL: 20 trials each on one fixture, SIGTERM then an immediate rmSync hit
+  // ENOTEMPTY 3 times and SIGKILL zero, since only the graceful shutdown flushes JetStream.
+  const releaseBroker = teardownOnSignal(srv, dir);
+  cleanups.push(() => { srv.kill("SIGKILL"); rmSync(dir, { recursive: true, force: true }); releaseBroker(); });
   let up = false;
   for (let i = 0; i < 50; i++) { if (await isReachable(servers)) { up = true; break; } await wait(200); }
   if (!up) throw new Error(`nats-server did not come up on ${port}`);

--- a/implementations/delivery/smoke/adoption-swap-strand.smoke.ts
+++ b/implementations/delivery/smoke/adoption-swap-strand.smoke.ts
@@ -26,6 +26,7 @@ import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { connect, type NatsConnection } from "@nats-io/transport-node";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 import { pickFreePort } from "./_free-port.js";
 
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -67,10 +68,15 @@ const cleanups: Array<() => void> = [];
 try {
   const port = await pickFreePort();
   const servers = `nats://127.0.0.1:${port}`;
-  const dir = mkdtempSync(join(tmpdir(), "cotal-adopt-strand-"));
+  const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
   writeFileSync(join(dir, "nats.conf"), `port: ${port}\n`);
   const srv = spawn("nats-server", ["-c", join(dir, "nats.conf")], { stdio: "ignore" });
-  cleanups.push(() => { srv.kill("SIGKILL"); rmSync(dir, { recursive: true, force: true }); });
+  // Owned, so a SIGNALLED run takes the broker and its store dir with it: `cleanups` drains in a
+  // `finally` and this suite registers no signal handler, so before this line a SIGINT left both.
+  // SIGKILL stays SIGKILL: 20 trials each on one fixture, SIGTERM then an immediate rmSync hit
+  // ENOTEMPTY 3 times and SIGKILL zero, since only the graceful shutdown flushes JetStream.
+  const releaseBroker = teardownOnSignal(srv, dir);
+  cleanups.push(() => { srv.kill("SIGKILL"); rmSync(dir, { recursive: true, force: true }); releaseBroker(); });
   let up: NatsConnection | undefined;
   for (let i = 0; i < 50; i++) { try { up = await connect({ servers, maxReconnectAttempts: 0 }); break; } catch { await wait(200); } }
   if (!up) throw new Error("nats-server did not come up");

--- a/implementations/delivery/smoke/delivery-broker-coupling.smoke.ts
+++ b/implementations/delivery/smoke/delivery-broker-coupling.smoke.ts
@@ -13,6 +13,7 @@ import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { isReachable, createSpaceAuth, mintCreds, serverConfig, newIdentity, setupSpaceStreams } from "@cotal-ai/core";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 import { pickFreePort } from "./_free-port.js";
 
 const PORT = await pickFreePort();
@@ -24,9 +25,15 @@ const check = (name: string, cond: boolean) => { if (cond) { pass++; console.log
 
 const space = `delivery-couple-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const dir = mkdtempSync(join(tmpdir(), "cotal-couple-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 let srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+// Owned, so a SIGNALLED run takes the broker and its store dir with it. The `finally` below is the
+// only teardown this suite has and no signal handler is registered, so before this line a SIGINT
+// left both behind. Killing the broker mid-test is this suite's SUBJECT, not its teardown: it proves
+// the daemon exits on its own once the broker is gone, and the ~10s wait for that is also why the
+// removal at the end of the `finally` is nowhere near the exit it follows.
+const releaseBroker = teardownOnSignal(srv, dir);
 const credsPath = join(dir, "delivery.creds");
 
 let daemon: ReturnType<typeof spawn> | undefined;
@@ -71,4 +78,5 @@ try {
   try { if (daemon && !daemonExited) daemon.kill("SIGKILL"); } catch { /* gone */ }
   try { srv.kill("SIGKILL"); } catch { /* gone */ }
   rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/implementations/delivery/smoke/delivery-cred-renewal.smoke.ts
+++ b/implementations/delivery/smoke/delivery-cred-renewal.smoke.ts
@@ -38,6 +38,7 @@ import {
   setupSpaceStreams,
   waitForDeliveryLease,
 } from "@cotal-ai/core";
+import { SMOKE_BROKER_TOKEN, killAndAwaitExit, teardownOnSignal } from "@cotal-ai/smoke-kit";
 import { pickFreePort } from "./_free-port.js";
 
 const PORT = await pickFreePort();
@@ -69,9 +70,12 @@ const space = `dlv-renew-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
 const obsCreds = await mintMembershipObserverCreds(auth, newIdentity()); // while the $SYS seed is in memory
 const evictorCreds = await mintConnectionEvictorCreds(auth, newIdentity()); // same in-memory-$SYS-only window
-const dir = mkdtempSync(join(tmpdir(), "cotal-dlv-renew-"));
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+// Owned, so a SIGNALLED run takes the broker and its store dir with it: the `finally` below is this
+// suite's only teardown and no signal handler is registered.
+const releaseBroker = teardownOnSignal(srv, dir);
 
 // The daemon's ISOLATED workspace root — findCotalRoot(cwd) lands here, so the membership feed's
 // creds/config come from THIS staging, never the developer's real .cotal.
@@ -206,12 +210,14 @@ try {
 } finally {
   try { await sup?.stop(); } catch { /* draining */ }
   try { if (daemon && !daemonExited) daemon.kill("SIGKILL"); } catch { /* gone */ }
-  srv.kill("SIGKILL");
-  await new Promise<void>((resolve) => {
-    if (srv.exitCode !== null || srv.signalCode !== null) return resolve();
-    srv.once("exit", () => resolve());
-    setTimeout(resolve, 3000);
-  });
+  // This suite had already worked out that the removal must not race a broker still writing, and
+  // hand-rolled the wait; the helper IS that wait, so the local copy goes. What it buys is small and
+  // worth naming rather than overstating: the copy resolved on a 3s timer whether or not the broker
+  // had exited, where the helper waits on the exit itself and only stops waiting after a bounded
+  // escalation. Since the signal here is already SIGKILL that escalation is a no-op, so this still
+  // returns unconfirmed if a broker somehow outlives it. Shared, not perfected.
+  await killAndAwaitExit(srv, "SIGKILL");
   rmSync(dir, { recursive: true, force: true });
   rmSync(root, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,6 +419,9 @@ importers:
         specifier: workspace:*
         version: link:../../packages/workspace
     devDependencies:
+      '@cotal-ai/smoke-kit':
+        specifier: workspace:*
+        version: link:../../packages/smoke-kit
       '@nats-io/transport-node':
         specifier: ^3.4.0
         version: 3.4.0


### PR DESCRIPTION
Six suites under `implementations/delivery` spawn their own `nats-server`. Each tears it down
correctly when it returns, and none of them registers a signal handler, so the entire teardown sits
in a `finally` that a SIGINT never reaches. They take ownership of the broker through the shared
smoke helper, which is the same adoption already applied to core, connector-core, manager and auth.

Reproduced on both sides before changing anything, same suite and same signal, with the broker
identified by parentage rather than by scanning for a name:

- on main, SIGINT during `adoption-passive-preflight` left the broker running and its JetStream
  tree on disk;
- with the change, the broker is reaped, the tree is removed, and the suite still exits 130, so a
  killed run still looks killed to whatever is reading its status.

The `SIGKILL` these suites already used is kept, and it is worth recording that it is the correct
signal here rather than a blunt one. Measured on one fixture at 20 trials each, `SIGTERM` followed
by an immediate `rmSync` hit `ENOTEMPTY` 3 times while `SIGKILL` hit it zero times, because only a
graceful shutdown flushes JetStream into the very tree the removal is walking. The change is
therefore ownership alone: none of the four synchronous cleanup closures was restructured into an
async one for a race there is no evidence they run.

`delivery-cred-renewal` had already diagnosed this and hand-rolled its own wait before removing the
tree. That copy is replaced by the shared one, which waits on the exit rather than resolving on a
3s timer whether or not the broker had gone. The comment there states what the shared version does
not fix as well as what it does.

Store dirs are minted through the shared token so that a broker orphaned by an uncatchable kill,
the case ownership cannot cover, is still identifiable afterwards. `adoption-false-green` keeps its
per-rail tag after the token, so a leak that is found still says which scenario produced it.

All six suites stay green with the same cell counts as before the change: 11, 19, 5, 4, 2 and 18.
Typecheck is clean. Every changed file is a smoke suite, so the changeset is a test-only no-release.

Two suites elsewhere were read for this sweep and deliberately not migrated, because neither can be
baselined on this machine and an unverifiable edit is worth less than an honest note:
`bin/smoke/herdr-e2e-live` skips entirely without the `herdr` binary and says so itself, and
`bin/smoke/backup-restore-live` is nondeterministically red on unmodified main, failing in three
different scenarios across three runs for reasons unrelated to teardown.