### PR TITLE
fix(core): address the smoke's offline DM by principal, not by a bare id

### DIFF
--- a/.changeset/smoke-principal-recipient.md
+++ b/.changeset/smoke-principal-recipient.md
@@ -1,0 +1,5 @@
+---
+---
+
+Test-only: repairs the recipient addressing in the bare core smoke script and annotates one
+hand-built recipient in an auth smoke suite. No shipped code changes, so no release.

--- a/implementations/auth/smoke/user-spawn.smoke.ts
+++ b/implementations/auth/smoke/user-spawn.smoke.ts
@@ -694,6 +694,10 @@ try {
   // asserts on; a space-wide tap would be a silent sub violation and see nothing.
   godEye.tap((subject: string) => { tapped.push(subject); }, { subject: `cotal.${SPACE}.inst.>` });
   await wait(300); // let the tap subscription settle
+  // A written `<owner>.<actor>` literal, so it is a valid recipient by construction rather than
+  // by anything checking it here. Any future change to the principal grammar has to visit this
+  // line: it builds a recipient instead of borrowing one from a card, and this suite is not in
+  // the CI chain, so nothing would fail if it stopped being well formed.
   await opsmate.unicast(`${OWNER}.alpha`, "psst — a DM between two other principals");
   let sawDm = false;
   for (let i = 0; i < 20 && !sawDm; i++) { await wait(100); sawDm = tapped.some((s) => s.includes(".inst.")); }

--- a/packages/core/smoke.ts
+++ b/packages/core/smoke.ts
@@ -12,6 +12,8 @@ import {
   dmStream,
   taskStream,
   presenceBucket,
+  membersBucket,
+  openMembersRegistry,
   principalKey,
   DEV_OWNER,
   type Delivery,
@@ -27,6 +29,20 @@ for (let i = 0; i < 50; i++) {
 
 // Unique space per run → isolated streams, no cross-run history bleed, deterministic.
 const space = `smoke-${randomUUID().slice(0, 8)}`;
+
+// Provision this run's members registry BEFORE any endpoint exists.
+//
+// `cotal up` creates the members bucket for the space IT provisions; this suite invents its own
+// (`smoke-<uuid>`), so nothing ever created the bucket that `channelMembers` reads. The read path
+// opens without creating (`openMembersRegistry`, `create` defaults false), so the call threw
+// StreamNotFoundError and killed the process at that line. That throw is why the final `ok` and its
+// `SMOKE FAILED` line were unreachable: the suite could not report on any assertion after it,
+// including the offline-DM durability one this file exists to exercise. Creating it here is what
+// lets the run reach its own verdict instead of dying before it.
+const provision = await connect();
+await openMembersRegistry(provision, space, { create: true });
+await provision.close();
+
 const a = new CotalEndpoint({
   space,
   card: { name: "alice", role: "planner", kind: "agent" },
@@ -156,7 +172,7 @@ await a.stop();
 // Tear down this run's (uniquely-named) streams + presence bucket — race-free, no litter.
 const cleanup = await connect();
 const jsm = await jetstreamManager(cleanup);
-for (const s of [chatStream(space), dmStream(space), taskStream(space), `KV_${presenceBucket(space)}`]) {
+for (const s of [chatStream(space), dmStream(space), taskStream(space), `KV_${presenceBucket(space)}`, `KV_${membersBucket(space)}`]) {
   await jsm.streams.delete(s).catch(() => {});
 }
 await cleanup.close();

--- a/packages/core/smoke.ts
+++ b/packages/core/smoke.ts
@@ -12,6 +12,8 @@ import {
   dmStream,
   taskStream,
   presenceBucket,
+  principalKey,
+  DEV_OWNER,
   type Delivery,
 } from "./src/index.js";
 
@@ -72,13 +74,20 @@ await wait(300);
 await a.anycast("builder", "build the thing");
 await wait(300);
 
-// Durability: a DM sent to carol BEFORE she connects must still arrive (the stream holds it).
-const carolId = randomUUID();
-await a.unicast(carolId, "stored while you were away");
+// Durability: a DM sent to carol BEFORE she connects must still arrive.
+// NOTE: this case currently FAILS and the assertion below is left as it is on purpose. The
+// message is stored, but carol's durable is created past it, so she never sees it; the
+// authenticated sibling passes the same test only because it provisions her durable first.
+// Whether open mode is meant to deliver this at all is the open question in #534, and it is
+// not settled by editing the expectation here.
+// Addressed by PRINCIPAL (<owner>.<actor>), not by a bare id: the owner+actor cutover made a
+// bare id an invalid recipient, and the actor token must be dash-free to be a valid token.
+const carolActor = randomUUID().replace(/-/g, "");
+await a.unicast(principalKey(DEV_OWNER, carolActor).key, "stored while you were away");
 await wait(200);
 const carol = new CotalEndpoint({
   space,
-  card: { id: carolId, name: "carol", role: "tester", kind: "agent" },
+  card: { id: carolActor, name: "carol", role: "tester", kind: "agent" },
   heartbeatMs: 500,
   ttlMs: 2000,
 });


### PR DESCRIPTION
`pnpm smoke`, the bare core smoke script, has failed against any broker since early July. It sent a DM to a bare `randomUUID()`, and the owner and actor subject grammar made `unicast` split its recipient into `<owner>.<actor>` tokens and refuse anything that does not parse. Fixes #531. Fixes #535.

## What this changes

Two repairs to the suite's own setup, both in `packages/core/smoke.ts`.

**The recipient** is now built the way every other constructing caller builds one: a dash-free actor token, addressed as a principal. The bare id broke **two** lines, not one, and the second was invisible behind the first. `card.id` becomes the connection id, the connection id becomes the actor, and the principal builder rejects a dashed token, so constructing carol would have thrown the moment the unicast stopped throwing. Both are repaired by minting the actor token once and using it for the recipient and for her card.

**The members registry** is now provisioned for the run's own space. The suite mints a unique space per run, so nothing had ever created the bucket that `channelMembers` reads, and the read path opens without creating. That threw `StreamNotFoundError` and killed the process before the suite could compute or print its own verdict. The bucket is created at setup and torn down with the run's other streams. To be precise about what that teardown covers: the suite names five streams explicitly, and the members bucket now joins them. It does not remove the delivery stream, the inbox stream or the channel-registry bucket that the same run causes to exist, so those three are still left behind. That gap is pre-existing and is not touched here; it is filed as #543.

## The sweep, and the one annotation

Before treating this as a one-line repair, every `unicast` caller in the tree was swept. The useful instrument turned out not to be "which callers pass a valid recipient", which reports the tree healthy, but "which callers **build** a recipient rather than borrow one from an object that already holds a good key". A grammar change has to visit every constructing site; the borrowing ones were carried along by the object they read from.

That set has four members:

| site | builds via | gated in CI | state |
|---|---|---|---|
| `packages/core/smoke-auth.ts:198` | `principalKey(...)` | yes, `smoke:auth` | correct |
| `packages/core/smoke-auth.ts:206` | `principalKey(...)` | yes, `smoke:auth` | correct |
| `implementations/auth/smoke/user-spawn.smoke.ts:701` | a written literal | no, a `:live` script | well formed |
| `packages/core/smoke.ts:102` | `randomUUID()` | no | broken, repaired here |

The gating column separates them exactly. The constructing site CI runs is correct. Of the two it does not run, one was broken and the other is well formed only because a written `<owner>.<actor>` literal contains a dot by construction, not because anything verified it. Correct-by-luck and correct-by-check are indistinguishable from outside, so that fourth site gets a comment saying which one it is, so the next change to the grammar visits it instead of trusting it. That is the only change to that file.

## `pnpm smoke` still exits 1, and now it says so itself

Stated plainly because the title could be read as claiming otherwise.

Before this PR the run died on an uncaught throw, so the final `ok` and its `SMOKE FAILED` line were unreachable and the process exited 1 because of the error rather than because the suite graded itself. Grepping a log for `SMOKE FAILED` showed nothing. That is now repaired: the run reaches its own verdict, prints `SMOKE FAILED`, and exits 1 on the strength of its assertions.

It exits 1 for **four** assertions. None is introduced by this change; all four are revealed by it.

**One durability gap, filed as #534.** The recipient connects and receives `[ 'hello team', 'noping' ]`, the two multicasts published before it existed, and does not receive the DM published in the same window. The message is stored and its subject addresses the recipient correctly, but the recipient's durable is created with a start sequence past it, so it is never delivered. The authenticated sibling passes the same test only because it provisions the durable before the message is sent. **The assertion is deliberately left unchanged**, because whether open mode is meant to deliver this at all is a question about guarantees, not something settled by editing an expectation.

**Three membership assertions, filed as #540.** Against a fully provisioned mesh the three membership reads come back empty:

```
#general members (pre-leave): []
channels -> member count: []
#general members (post-leave): []
```

Presence is correct in the same run, so this is not a liveness problem. `channelMembers` resolves through the members registry, and a record is only written on the durable-join path; the suite's endpoints subscribe live and never durably join. Either membership became record-derived on purpose and this file's expectations are stale, or a subscribed live agent should still appear. #540 states both readings and asserts neither, because that is a question about intent.

Everything else in the suite passes: channel, direct and anycast receipt, mention normalization, the omitted-empty case, and both presence transitions.

## Verification

- Reproduced end to end on an unmodified checkout against a plain `nats-server -js`: same error, same file and line, after the two roster lines.
- Re-measured with the change on a real mesh brought up with `cotal up --open`, so broker, manager and delivery daemon rather than a bare server: the suite runs past both throws, reaches its own verdict, prints `SMOKE FAILED` and exits 1 for the four assertions above.
- The recipient key matches the connecting endpoint's own card id.
- `pnpm typecheck` rc=0.
- Changeset is empty on purpose: this touches only smoke scripts, so there is no release.

## Why it went unnoticed for six weeks

`pnpm smoke` is not in the CI chain. The property is more general than this one script: a suite that exercises a wire grammar is not gated on changes to that grammar. There are 30 `:live` scripts in `package.json` and 2 of them appear in the chain. That gap is deliberately not addressed here.


