### PR TITLE
fix(cli): give the shell back when the detach key wins the backoff race

### DIFF
--- a/.changeset/attach-detach-shell-back.md
+++ b/.changeset/attach-detach-shell-back.md
@@ -1,0 +1,14 @@
+---
+"@cotal-ai/cli": patch
+---
+
+`cotal attach`: pressing the detach key during a reconnect gives the shell back at once, instead of
+at the end of the backoff rung.
+
+The detach itself was always immediate: the terminal came back and `detached from <seat>` printed a
+moment after the press. The process then stayed alive until the backoff wait it had already
+abandoned ran out. Losing a `Promise.race` does not stop a `setTimeout`, and the timer is ref'd, so
+node kept the command open to the end of the rung. On the 30s rung that is half a minute of a shell
+that has said it detached and will not give the prompt back. Measured before the fix: 27.0s from
+press to exit with the next attempt 26.9s away, and 8.3s with it 8.1s away, tracking the rung rather
+than any work being done; 0.1s after it.

--- a/bin/smoke/mutations/attach-reconnect.json
+++ b/bin/smoke/mutations/attach-reconnect.json
@@ -60,7 +60,15 @@
     "Publishing to NATS is a buffer write; the FLUSH is the round trip that says the frame left. Cell B",
     "detaches while the link is still down, so it is the one cell that reaches the exit with a session",
     "genuinely unhandled, and its line was ABSENT on the buggy code. That absence is how the defect was",
-    "found, and mutation 8 is the same absence on demand."
+    "found, and mutation 8 is the same absence on demand.",
+    "",
+    "MUTATION 12 GRADES A DEFECT THIS SUITE SHIPPED WITH, found by measuring the cell it was hiding",
+    "behind. Cell J asserted a clean exit and got one: the detach was honoured immediately, the",
+    "terminal came back, `detached from` printed. What no assertion looked at was WHEN the process",
+    "ended. The backoff `sleep` lost its race and was never cleared, so node held the command open to",
+    "the end of the rung, up to 30 seconds of a shell that had already said it detached. A limit",
+    "measured after the work is no limit, so the assertion is bounded against the next attempt's own",
+    "position, which is the only clock the defect is expressed in."
   ],
   "mutations": [
     {
@@ -171,6 +179,16 @@
       "expectRed": "...saying NOTHING about a held session, because it handed the session back on the way out",
       "cell": "...saying NOTHING about a held session, because it handed the session back on the way out",
       "note": "The loop released before claiming the next session, which covers every exit that stays IN the loop and none that leaves it. An operator who detaches during the backoff is the ordinary case: the link may be back, one dial would free the slot, and returning straight out leaves it held and then reports that as though nothing could be done. Aimed at cell J, which heals the link and detaches during the 30s rung so the exit path, not a reconnect, is what has to do the freeing.",
+      "afterRestore": "pnpm --filter @cotal-ai/cli build"
+    },
+    {
+      "name": "the backoff timer is abandoned rather than cleared, so a detach holds the shell to the end of the rung",
+      "file": "implementations/cli/src/commands/agents.ts",
+      "find": "      const detached = await Promise.race([waited, watch.pressed.then(() => true)]);\n      clearTimeout(timer);",
+      "replace": "      const detached = await Promise.race([waited, watch.pressed.then(() => true)]);",
+      "expectRed": "...and it gives the shell back on the press, not when the rung it was waiting on expires",
+      "cell": "...and it gives the shell back on the press, not when the rung it was waiting on expires",
+      "note": "Losing a Promise.race does not stop a setTimeout. Without the clear, the detach is honoured at once and the terminal comes back, and then node keeps the process alive until the abandoned timer fires: measured at 27.0s with the next attempt 26.9s away and 8.3s with it 8.1s away, tracking the rung rather than any work. Aimed at cell J, which bounds the exit against where the next attempt actually falls rather than against a constant, because a constant loose enough for a slow runner is also loose enough for this.",
       "afterRestore": "pnpm --filter @cotal-ai/cli build"
     }
   ]

--- a/implementations/cli/src/commands/agents.ts
+++ b/implementations/cli/src/commands/agents.ts
@@ -332,7 +332,6 @@ export async function ps(args: ParsedArgs): Promise<void> {
  *  the terminal they walked away from being gone when they come back. */
 const RECONNECT_BACKOFF_MS = [1_000, 2_000, 5_000, 10_000, 30_000] as const;
 
-const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
 /** How long any single wait on a LINK may take before the loop stops waiting on it. Neither
  *  `flush()` nor `drain()` carries a deadline of its own, and `connect`'s `timeout` covers only the
@@ -610,10 +609,19 @@ async function runAttachLoop(
   for (;;) {
     if (!first) {
       // Back off BEFORE the attempt, and stay interruptible: the detach key must work while we
-      // wait, not only while a session is up.
-      const wait = RECONNECT_BACKOFF_MS[Math.min(attempt, RECONNECT_BACKOFF_MS.length - 1)];
+      // wait, not only while a session is up. The timer is CLEARED rather than left to the race,
+      // because losing a `Promise.race` does not stop a `setTimeout`: the detach is honoured at
+      // once, the terminal comes back and `detached from` prints, and then node holds the process
+      // open until the abandoned timer fires. On the 30s rung that is half a minute of a shell that
+      // has already said it detached and will not give the prompt back. Measured before this line
+      // existed: press to first output 0.1s, press to EXIT 27.0s with the next attempt 26.9s away,
+      // and 8.3s with it 8.1s away, tracking the rung rather than the work.
+      const ms = RECONNECT_BACKOFF_MS[Math.min(attempt, RECONNECT_BACKOFF_MS.length - 1)];
       const watch = watchDetachKey(key.byte);
-      const detached = await Promise.race([sleep(wait).then(() => false), watch.pressed.then(() => true)]);
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const waited = new Promise<boolean>((r) => { timer = setTimeout(() => r(false), ms); });
+      const detached = await Promise.race([waited, watch.pressed.then(() => true)]);
+      clearTimeout(timer);
       watch.stop();
       if (detached) return await done({ kind: "ended" });
       attempt++;

--- a/implementations/manager/smoke/_probe-cellj-timing.ts
+++ b/implementations/manager/smoke/_probe-cellj-timing.ts
@@ -25,7 +25,12 @@
  *   --arm today  the cell as it stood: wait 40s from the announcement, heal, press. `--lag` adds
  *                the observation offset a loaded runner contributes.
  *   --arm race   the failure on demand: heal on the first dial of an attempt instead of in the wait
- *                between two, so that attempt gets to use it. reconnected=true, every time.
+ *                between two, so that attempt gets to use it. The heal is triggered from inside the
+ *                proxy's connection handler, not from a poll that notices a knock afterwards: a
+ *                cluster of dials is over inside 100ms and a 200ms poll sees it too late, which
+ *                heals into the wait and produces a GREEN run. With the hook it is 3 runs out of 3;
+ *                with the poll it was 1 out of 2, which is the difference between a demonstration
+ *                and an anecdote.
  *   --arm sync   the cell owning its timing: wait for two knocks a rung apart, let that attempt
  *                finish dialling, heal, and confirm nothing re-established before pressing.
  *
@@ -122,9 +127,15 @@ const heal = (): Promise<void> =>
 /** Severed, but LOUD: the port keeps listening and destroys what it accepts, so every dial the
  *  client makes lands here with a timestamp. To the client this is a link that resets rather than
  *  one that refuses; a failed attempt either way. */
+let onKnock: (() => void) | undefined;
 const knockListener = (): Promise<void> =>
   new Promise((res, rej) => {
-    const s = createServer((sock) => { knocks.push(Date.now()); sock.destroy(); });
+    knocks.length = 0; // one outage, one measurement: a knock from the last one is not this schedule
+    const s = createServer((sock) => {
+      knocks.push(Date.now());
+      sock.destroy();
+      const hook = onKnock; onKnock = undefined; hook?.();
+    });
     s.on("error", rej);
     s.listen(PROXY_PORT, "127.0.0.1", () => { proxy = s; res(); });
   });
@@ -188,6 +199,7 @@ function attachUnderPty(root: string, seat: string): Attached {
 const QUIET = "rcquiet";
 let manager: InstanceType<typeof Manager> | undefined;
 let att: Attached | undefined;
+let failed = false;
 
 try {
   let up = false;
@@ -257,10 +269,18 @@ try {
     tHeal = Date.now();
   } else if (ARM === "race") {
     // The failure, on demand: heal in the MIDDLE of an attempt instead of in the wait between two.
-    // The first knock of a cluster says an attempt has just begun and will dial again in a few
-    // milliseconds, so a heal here is one the in-flight attempt gets to use. This is what a loaded
-    // runner does by accident when the offset walks the 40s wait onto a rung boundary.
-    await waitForLongRung();
+    // An attempt dials about five times inside a hundred milliseconds, so the heal has to ride the
+    // FIRST of those dials to be one the in-flight attempt can still use. A poll cannot: at 200ms
+    // it sees the cluster only once it is over, which is a heal in the wait and a green run. So the
+    // hook fires inside the connection handler itself, before the socket is even destroyed.
+    //
+    // Waiting for the ladder is a wait for SILENCE, not for a pair: the pair that proves the rung
+    // is the knock this arm has to act on, and by the time it exists the moment has passed.
+    while (Date.now() - (knocks.at(-1) ?? Date.now()) < 26_000) await wait(200);
+    let armed!: () => void;
+    const fired = new Promise<void>((r) => { armed = r; });
+    onKnock = () => { armed(); };
+    await fired;
     await closeLink();
     await heal();
     tHeal = Date.now();
@@ -318,9 +338,23 @@ try {
   console.log(reconnected
     ? `  VERDICT: the retry won the race. Cell J's premise assertion would be RED here.`
     : `  VERDICT: the press landed inside the wait. Cell J's premise assertion would be GREEN here.`);
+} catch (e) {
+  // Recorded rather than rethrown, because the finally below has to exit explicitly and an exit
+  // code of 0 on a probe that threw would be the quietest lie in this file.
+  failed = true;
+  console.error(`  PROBE FAILED: ${(e as Error).message}`);
 } finally {
   att?.kill();
+  onKnock = undefined;
   await closeLink();
   await manager?.stop().catch(() => {});
   releaseBroker();
+  // A reconnect leaves the manager's session plane holding sockets this file did not open, and the
+  // race arm always ends on one. `stop()` settles the manager's own work but node still has handles
+  // it will wait on, so the probe used to print its timeline and then sit there until something
+  // killed it. It reports and it leaves; nothing here is worth an ambiguous exit.
+  const held = (process as unknown as { getActiveResourcesInfo?: () => string[] }).getActiveResourcesInfo?.() ?? [];
+  const stray = held.filter((h) => h !== "TTYWrap" && h !== "Immediate" && h !== "TickObject");
+  if (stray.length > 0) console.log(`  (exiting on ${stray.length} handle(s) node would still have waited on: ${[...new Set(stray)].join(", ")})`);
+  process.exit(failed ? 1 : 0);
 }

--- a/implementations/manager/smoke/_probe-cellj-timing.ts
+++ b/implementations/manager/smoke/_probe-cellj-timing.ts
@@ -1,0 +1,326 @@
+/**
+ * Why cell J of `smoke:attach-reconnect` could be raced by the very retry it means to sit between,
+ * and what that turned up in the client. Run: pnpm probe:cellj-timing --arm race
+ *
+ * THE CELL'S PREMISE. Cell J presses the detach key while the reconnect loop is WAITING between
+ * attempts, on a link that has just come back, and asserts the attach never re-established. It used
+ * to get there by waiting 40s after the loss was announced and then healing, on the reasoning that
+ * "after 40s the backoff is on its 30s rung, so the heal lands mid-wait".
+ *
+ * WHY THAT WAS NOT A MARGIN. The 40s is measured from when the TEST sees the announcement come out
+ * of the pty; the ladder (1s, 2s, 5s, 10s, 30s) runs on the CLIENT's clock from the moment the link
+ * died. The offset between them is however long a loaded machine takes to push a line through a pty
+ * and a polling reader: 2.1s here, 7.1s on the runner that went red. Measured rather than modelled,
+ * the boundary after the wait falls at 50.2s and the cell acted at 42.1s, so the margin was 8.1s.
+ *
+ * WHAT ACTUALLY LOSES THE PRESS. Landing past a boundary is not enough on its own. `watchDetachKey`
+ * exists only for the duration of a wait, so a byte pressed while an ATTEMPT is running is not read:
+ * it sits in the stream, the attempt succeeds on the just-healed link, `[cotal: reconnected]` is
+ * printed, and the buffered byte then detaches the NEW session perfectly cleanly. Every other
+ * assertion passes and only the premise one fails, which is exactly what the CI log showed.
+ *
+ * HOW IT MEASURES. During the outage the proxy port stays open and destroys what it accepts, so
+ * every dial the client makes is a timestamped KNOCK: the client's schedule, read off the client.
+ *
+ *   --arm today  the cell as it stood: wait 40s from the announcement, heal, press. `--lag` adds
+ *                the observation offset a loaded runner contributes.
+ *   --arm race   the failure on demand: heal on the first dial of an attempt instead of in the wait
+ *                between two, so that attempt gets to use it. reconnected=true, every time.
+ *   --arm sync   the cell owning its timing: wait for two knocks a rung apart, let that attempt
+ *                finish dialling, heal, and confirm nothing re-established before pressing.
+ *
+ * WHAT IT FOUND BESIDES. Press-to-exit tracks the distance to the next attempt: 27.0s to exit with
+ * the boundary 26.9s away, 8.3s with it 8.1s away, while the terminal is restored and `detached
+ * from` printed 0.1s after the press either way. Losing a `Promise.race` does not stop a
+ * `setTimeout`, so the abandoned backoff timer held the process to the end of the rung. Fixed in
+ * the loop, and `--arm sync` reads 0.1s to exit now.
+ *
+ * It prints a timeline and grades nothing. The suite is where assertions live.
+ */import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { createServer, connect as netConnect, type AddressInfo, type Server, type Socket } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import * as pty from "@lydell/node-pty";
+import {
+  isReachable, createSpaceAuth, serverConfig, setupSpaceStreams, mintCreds, newIdentity,
+  registry, type Connector, type LaunchOpts, type LaunchSpec,
+} from "@cotal-ai/core";
+import { authDir, saveSpaceAuth } from "@cotal-ai/workspace";
+import { Manager } from "../src/manager.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "../../..");
+const BIN = join(repoRoot, "bin", "cotal.ts");
+const SEAT_STUB = join(here, "attach-reconnect-seat.mjs");
+const DETACH_BYTE = "\x1d";
+
+const argv = process.argv.slice(2);
+const argOf = (name: string, fallback: string): string => {
+  const i = argv.indexOf(`--${name}`);
+  return i >= 0 && argv[i + 1] ? String(argv[i + 1]) : fallback;
+};
+const ARM = argOf("arm", "today");
+const LAG_MS = Number(argOf("lag", "0"));
+if (!["today", "race", "sync"].includes(ARM)) throw new Error(`--arm must be today, race or sync, got ${ARM}`);
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const freePort = (): Promise<number> =>
+  new Promise((res, rej) => {
+    const s = createServer();
+    s.on("error", rej);
+    s.listen(0, "127.0.0.1", () => { const p = (s.address() as AddressInfo).port; s.close(() => res(p)); });
+  });
+
+const LIVE_HOST = "broker.cotal.ai";
+for (const k of ["COTAL_SERVERS", "COTAL_SERVER", "COTAL_CREDS", "COTAL_SPACE"]) delete process.env[k];
+for (const [k, v] of Object.entries(process.env))
+  if (typeof v === "string" && v.includes(LIVE_HOST)) throw new Error(`refusing to run: ${k} points at the live broker (${v})`);
+
+const BROKER_PORT = await freePort();
+const PROXY_PORT = await freePort();
+const BROKER = `nats://127.0.0.1:${BROKER_PORT}`;
+const PROXY = `nats://127.0.0.1:${PROXY_PORT}`;
+console.log(`broker-url guard: ${BROKER} (manager+seat) / ${PROXY} (attach client) are ephemeral loopback\n`);
+
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
+const home = join(dir, "home");
+mkdirSync(home, { recursive: true });
+process.env.COTAL_HOME = home;
+process.env.XDG_CONFIG_HOME = join(dir, "xdg");
+mkdirSync(process.env.XDG_CONFIG_HOME, { recursive: true });
+const space = `cellj-${randomUUID().slice(0, 8)}`;
+const auth = await createSpaceAuth(space);
+
+writeFileSync(
+  join(dir, "server.conf"),
+  serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: BROKER_PORT, storeDir: join(dir, "js") }) +
+    `\nping_interval: "2s"\nping_max: 1\n`,
+);
+const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
+
+// --- the faultable link, plus the state that makes the client's schedule observable -------------
+const liveSockets = new Set<Socket>();
+let proxy: Server | undefined;
+const knocks: number[] = [];
+const heal = (): Promise<void> =>
+  new Promise((res, rej) => {
+    const s = createServer((client) => {
+      const up = netConnect(BROKER_PORT, "127.0.0.1");
+      liveSockets.add(client); liveSockets.add(up);
+      const drop = () => { liveSockets.delete(client); liveSockets.delete(up); client.destroy(); up.destroy(); };
+      for (const ev of ["error", "close"] as const) { client.on(ev, drop); up.on(ev, drop); }
+      client.pipe(up); up.pipe(client);
+    });
+    s.on("error", rej);
+    s.listen(PROXY_PORT, "127.0.0.1", () => { proxy = s; res(); });
+  });
+/** Severed, but LOUD: the port keeps listening and destroys what it accepts, so every dial the
+ *  client makes lands here with a timestamp. To the client this is a link that resets rather than
+ *  one that refuses; a failed attempt either way. */
+const knockListener = (): Promise<void> =>
+  new Promise((res, rej) => {
+    const s = createServer((sock) => { knocks.push(Date.now()); sock.destroy(); });
+    s.on("error", rej);
+    s.listen(PROXY_PORT, "127.0.0.1", () => { proxy = s; res(); });
+  });
+const closeLink = (): Promise<void> =>
+  new Promise((res) => {
+    const s = proxy; proxy = undefined;
+    for (const sock of liveSockets) sock.destroy();
+    liveSockets.clear();
+    if (!s) return res();
+    s.close(() => res());
+  });
+
+const TICK_MS = 50;
+const envFor = (o: LaunchOpts): Record<string, string> => ({
+  COTAL_SPACE: o.space, COTAL_SERVERS: String(o.servers ?? BROKER), COTAL_CREDS: String(o.creds),
+  COTAL_ID: String(o.id), COTAL_NAME: o.name, PATH: process.env.PATH ?? "",
+  SEAT_TICK_MS: String(TICK_MS), SEAT_SILENT: "1",
+  ...(o.lifecycleUid ? { COTAL_LIFECYCLE_UID: o.lifecycleUid } : {}),
+});
+registry.register({
+  kind: "connector", name: "rc-seat-quiet", requires: ["node"],
+  buildLaunch: (o): LaunchSpec => ({ command: process.execPath, args: [SEAT_STUB], env: envFor(o) }),
+} as Connector);
+
+type Attached = {
+  seen: () => string;
+  write: (s: string) => void;
+  exit: () => { code: number; signal: number } | undefined;
+  waitFor: (re: RegExp, ms: number) => Promise<boolean>;
+  waitExit: (ms: number) => Promise<boolean>;
+  kill: () => void;
+};
+function attachUnderPty(root: string, seat: string): Attached {
+  const child = pty.spawn("npx", ["tsx", BIN, "attach", "--name", seat, "--space", space, "--server", PROXY], {
+    name: "xterm-256color", cols: 100, rows: 30, cwd: root,
+    env: { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME, COTAL_SPACE: "", COTAL_SERVERS: "", COTAL_CREDS: "" } as Record<string, string>,
+  });
+  let buf = "";
+  let exited: { code: number; signal: number } | undefined;
+  child.onData((d) => { buf += d; });
+  child.onExit((e) => { exited = { code: e.exitCode, signal: e.signal ?? 0 }; });
+  const seen = () => buf;
+  return {
+    seen,
+    write: (s) => child.write(s),
+    exit: () => exited,
+    kill: () => { try { child.kill("SIGKILL"); } catch { /* already gone */ } },
+    waitFor: async (re, ms) => {
+      const deadline = Date.now() + ms;
+      while (Date.now() < deadline) { if (re.test(seen())) return true; await wait(100); }
+      return re.test(seen());
+    },
+    waitExit: async (ms) => {
+      const deadline = Date.now() + ms;
+      while (Date.now() < deadline) { if (exited) return true; await wait(100); }
+      return exited !== undefined;
+    },
+  };
+}
+
+const QUIET = "rcquiet";
+let manager: InstanceType<typeof Manager> | undefined;
+let att: Attached | undefined;
+
+try {
+  let up = false;
+  for (let i = 0; i < 60; i++) { if (await isReachable(BROKER)) { up = true; break; } await wait(200); }
+  if (!up) throw new Error(`nats-server did not come up on ${BROKER_PORT}`);
+  await setupSpaceStreams({ servers: BROKER, space, creds: await mintCreds(auth, newIdentity(), "provisioner") });
+  await heal();
+
+  const root = join(dir, "ws");
+  mkdirSync(join(root, ".cotal", "agents"), { recursive: true });
+  writeFileSync(join(root, ".cotal", "agents", `${QUIET}.md`), `---\nname: ${QUIET}\nrole: worker\n---\n`);
+  saveSpaceAuth(authDir(root), auth);
+  const { recordMesh } = await import("@cotal-ai/workspace");
+  recordMesh({ space, server: BROKER, root, mode: "auth", ts: new Date().toISOString() });
+
+  manager = new Manager({ space, servers: BROKER, runtime: "pty", workspaceRoot: root });
+  await manager.start();
+  const q = await manager.startAgent({ name: QUIET, agent: "rc-seat-quiet", cwd: repoRoot });
+  if (!q.ok) throw new Error(`quiet seat did not start: ${JSON.stringify(q)}`);
+  const live = (): number => (manager as unknown as { sessionPlane?: { liveSessions: number } }).sessionPlane?.liveSessions ?? -1;
+
+  const base = live();
+  att = attachUnderPty(root, QUIET);
+  if (!await att.waitFor(new RegExp(`attached to ${QUIET}`), 90_000)) throw new Error(`attach never came up: ${att.seen().slice(-400)}`);
+  console.log(`arm=${ARM} lag=${LAG_MS}ms   sessions before: ${base} -> with the attach: ${live()}`);
+
+  // The link dies. From here the client's ladder runs on its own clock and the knocks below are
+  // the only view of it this file has that does not go through the pty.
+  await closeLink();
+  await knockListener();
+  const tSever = Date.now();
+  const announced = await att.waitFor(/\[cotal: connection lost, reconnecting\]/, 30_000);
+  const tSeen = Date.now();
+  console.log(`  sever at +0ms; loss announced through the pty at +${tSeen - tSever}ms (announced=${announced})`);
+
+  /** Wait until two knocks land at least 25s apart. Only the 30s rung can produce that, so the
+   *  later knock is the first dial of an attempt made from the top of a 30s wait: the schedule
+   *  measured off the client's own dials rather than modelled from the ladder. */
+  const waitForLongRung = async (): Promise<number> => {
+    const deadline = Date.now() + 180_000;
+    for (;;) {
+      // Scan the whole run, not just the newest pair: an attempt dials several times in a few
+      // milliseconds, so the pair that carries the rung is buried the moment the rest of its
+      // cluster lands and a poll that only looks at the tail will never see it.
+      for (let i = knocks.length - 1; i > 0; i--) if (knocks[i] - knocks[i - 1] >= 25_000) return knocks[i];
+      if (Date.now() > deadline) throw new Error(`never observed a 25s rung in ${knocks.length} knocks`);
+      await wait(200);
+    }
+  };
+  /** The attempt is over when it has stopped dialling. */
+  const waitForQuiet = async (ms: number): Promise<void> => {
+    for (;;) {
+      const last = knocks[knocks.length - 1] ?? 0;
+      if (Date.now() - last >= ms) return;
+      await wait(200);
+    }
+  };
+  let tHeal = 0;
+  let redone = 0;
+  if (ARM === "today") {
+    // The cell as it stands: the wait starts when the TEST saw the line, and `--lag` is the extra
+    // offset a loaded runner adds between the client's clock and this one.
+    await wait(LAG_MS);
+    await wait(40_000);
+    await closeLink();
+    await heal();
+    tHeal = Date.now();
+  } else if (ARM === "race") {
+    // The failure, on demand: heal in the MIDDLE of an attempt instead of in the wait between two.
+    // The first knock of a cluster says an attempt has just begun and will dial again in a few
+    // milliseconds, so a heal here is one the in-flight attempt gets to use. This is what a loaded
+    // runner does by accident when the offset walks the 40s wait onto a rung boundary.
+    await waitForLongRung();
+    await closeLink();
+    await heal();
+    tHeal = Date.now();
+  } else {
+    // The cell owning its timing. Wait for the rung, let the attempt that proved it finish failing,
+    // heal, and then VERIFY the premise before acting on it: if a reconnect announces itself, the
+    // heal landed on an attempt after all, so sever and take the next rung instead of asserting
+    // against a scenario that did not happen.
+    for (;;) {
+      await waitForLongRung();
+      await waitForQuiet(1_500);
+      await closeLink();
+      await heal();
+      tHeal = Date.now();
+      await wait(1_500);
+      if (!/\[cotal: reconnected\]/.test(att.seen())) break;
+      if (++redone > 3) throw new Error("could not land a heal inside the wait in 4 tries");
+      console.log(`  (heal ${redone} landed on an attempt, not in the wait: severing and taking the next rung)`);
+      const losses = (att.seen().match(/\[cotal: connection lost, reconnecting\]/g) ?? []).length;
+      await closeLink();
+      await knockListener();
+      const byWhen = Date.now() + 30_000;
+      while (Date.now() < byWhen && (att.seen().match(/\[cotal: connection lost, reconnecting\]/g) ?? []).length === losses) await wait(200);
+    }
+  }
+  const lenAtPress = att.seen().length;
+  att.write(DETACH_BYTE);
+  const tPress = Date.now();
+  // When does the press produce ANY output? If the wait is interruptible, the terminal moves within
+  // a moment of the press; if it is not, nothing happens until the rung expires.
+  let tGrew = 0;
+  void (async () => {
+    while (Date.now() - tPress < 90_000) {
+      if (att && att.seen().length !== lenAtPress) { tGrew = Date.now(); return; }
+      await wait(100);
+    }
+  })();
+
+  const exited = await att.waitExit(60_000);
+  const tExit = Date.now();
+  const lastKnock = knocks[knocks.length - 1] ?? tSever;
+  const rel = (t: number) => `${((t - tSever) / 1000).toFixed(1)}s`;
+  console.log(`  knocks (client dials, relative to sever): ${knocks.map((k) => rel(k)).join(", ")}`);
+  const gaps = knocks.slice(1).map((k, i) => ((k - knocks[i]) / 1000).toFixed(1));
+  console.log(`  gaps between knocks: ${gaps.join(", ")}`);
+  console.log(`  heal at ${rel(tHeal)}, press at ${rel(tPress)}, exit at ${rel(tExit)} (exited=${exited}, code=${att.exit()?.code})`);
+  console.log(`  press landed ${((tPress - lastKnock) / 1000).toFixed(1)}s after the last observed attempt; exit ${((tExit - lastKnock) / 1000).toFixed(1)}s after it`);
+  console.log(`  press to first output: ${tGrew ? `${((tGrew - tPress) / 1000).toFixed(1)}s` : "none seen"}; press to exit: ${((tExit - tPress) / 1000).toFixed(1)}s; next attempt was due ${((lastKnock + 30_000 - tPress) / 1000).toFixed(1)}s after the press`);
+  console.log(`  transcript tail: ${JSON.stringify(att.seen().slice(-260))}`);
+  const reconnected = /\[cotal: reconnected\]/.test(att.seen());
+  const held = /the manager still holds/.test(att.seen());
+  console.log(`  RESULT: reconnected=${reconnected} (the cell asserts false) held-notice=${held} (the cell asserts false)`);
+  const settled = live();
+  console.log(`  sessions after: ${settled} (base ${base})`);
+  console.log(reconnected
+    ? `  VERDICT: the retry won the race. Cell J's premise assertion would be RED here.`
+    : `  VERDICT: the press landed inside the wait. Cell J's premise assertion would be GREEN here.`);
+} finally {
+  att?.kill();
+  await closeLink();
+  await manager?.stop().catch(() => {});
+  releaseBroker();
+}

--- a/implementations/manager/smoke/_probe-cellj-timing.ts
+++ b/implementations/manager/smoke/_probe-cellj-timing.ts
@@ -43,7 +43,7 @@
  * It prints a timeline and grades nothing. The suite is where assertions live.
  */import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createServer, connect as netConnect, type AddressInfo, type Server, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -226,6 +226,16 @@ try {
   if (!await att.waitFor(new RegExp(`attached to ${QUIET}`), 90_000)) throw new Error(`attach never came up: ${att.seen().slice(-400)}`);
   console.log(`arm=${ARM} lag=${LAG_MS}ms   sessions before: ${base} -> with the attach: ${live()}`);
 
+  // COUNTED, never tested. `seen()` only ever grows, so "has it said it?" goes false to true once and
+  // stays there: every question this file asks about a reconnect is really "did it say it AGAIN,
+  // after the moment I care about", and that is a count against a baseline. The retry below asked it
+  // the monotone way and could therefore never come back green, which is the same defect the cell
+  // this probe justifies was fixed for.
+  const tx = att;
+  const RECONNECTED = /\[cotal: reconnected\]/g;
+  const LOST = /\[cotal: connection lost, reconnecting\]/g;
+  const said = (re: RegExp): number => (tx.seen().match(re) ?? []).length;
+
   // The link dies. From here the client's ladder runs on its own clock and the knocks below are
   // the only view of it this file has that does not go through the pty.
   await closeLink();
@@ -292,21 +302,23 @@ try {
     for (;;) {
       await waitForLongRung();
       await waitForQuiet(1_500);
+      const before = said(RECONNECTED);
       await closeLink();
       await heal();
       tHeal = Date.now();
       await wait(1_500);
-      if (!/\[cotal: reconnected\]/.test(att.seen())) break;
+      if (said(RECONNECTED) === before) break;
       if (++redone > 3) throw new Error("could not land a heal inside the wait in 4 tries");
       console.log(`  (heal ${redone} landed on an attempt, not in the wait: severing and taking the next rung)`);
-      const losses = (att.seen().match(/\[cotal: connection lost, reconnecting\]/g) ?? []).length;
+      const losses = said(LOST);
       await closeLink();
       await knockListener();
       const byWhen = Date.now() + 30_000;
-      while (Date.now() < byWhen && (att.seen().match(/\[cotal: connection lost, reconnecting\]/g) ?? []).length === losses) await wait(200);
+      while (Date.now() < byWhen && said(LOST) === losses) await wait(200);
     }
   }
   const lenAtPress = att.seen().length;
+  const reconnectsAtPress = said(RECONNECTED);
   att.write(DETACH_BYTE);
   const tPress = Date.now();
   // When does the press produce ANY output? If the wait is interruptible, the terminal moves within
@@ -330,9 +342,9 @@ try {
   console.log(`  press landed ${((tPress - lastKnock) / 1000).toFixed(1)}s after the last observed attempt; exit ${((tExit - lastKnock) / 1000).toFixed(1)}s after it`);
   console.log(`  press to first output: ${tGrew ? `${((tGrew - tPress) / 1000).toFixed(1)}s` : "none seen"}; press to exit: ${((tExit - tPress) / 1000).toFixed(1)}s; next attempt was due ${((lastKnock + 30_000 - tPress) / 1000).toFixed(1)}s after the press`);
   console.log(`  transcript tail: ${JSON.stringify(att.seen().slice(-260))}`);
-  const reconnected = /\[cotal: reconnected\]/.test(att.seen());
+  const reconnected = said(RECONNECTED) > reconnectsAtPress;
   const held = /the manager still holds/.test(att.seen());
-  console.log(`  RESULT: reconnected=${reconnected} (the cell asserts false) held-notice=${held} (the cell asserts false)`);
+  console.log(`  RESULT: reconnected-after-the-press=${reconnected} (the cell asserts false) held-notice=${held} (the cell asserts false)`);
   const settled = live();
   console.log(`  sessions after: ${settled} (base ${base})`);
   console.log(reconnected
@@ -348,6 +360,13 @@ try {
   onKnock = undefined;
   await closeLink();
   await manager?.stop().catch(() => {});
+  // Order is the whole of it, and the suite states the rule: kill and remove FIRST, release LAST.
+  // `releaseBroker` does not stop anything, it hands ownership BACK (`owned.delete(entry)`), and
+  // the reap that runs on exit only touches what it still owns. Releasing before exiting therefore
+  // leaves a live `nats-server` and its store dir behind on a clean exit 0, which is a worse
+  // failure than the hang the explicit exit was added to fix.
+  srv.kill("SIGKILL");
+  rmSync(dir, { recursive: true, force: true });
   releaseBroker();
   // A reconnect leaves the manager's session plane holding sockets this file did not open, and the
   // race arm always ends on one. `stop()` settles the manager's own work but node still has handles

--- a/implementations/manager/smoke/attach-reconnect.smoke.ts
+++ b/implementations/manager/smoke/attach-reconnect.smoke.ts
@@ -581,34 +581,46 @@ try {
     }
     check("the link is back with the loop WAITING rather than dialling, which is this cell's premise",
       landed, { knocks: knocks.length, tail: b.seen().slice(-300) });
-    // The next attempt is a full rung away from the knock that proved the rung, so the margin below
-    // is measured against where the boundary actually is rather than against a stopwatch.
-    const nextAttemptDue = (longRungAt() ?? Date.now()) + 30_000;
-    const reconnectsAtPress = saidReconnected(b);
-    const tPress = Date.now();
-    b.write(DETACH_BYTE);
-    check("the detach key ends the attach during the backoff", await b.waitExit(30_000), b.seen().slice(-300));
-    const tExit = Date.now();
-    check("...exiting clean", b.exit()?.code === 0, b.exit());
-    // Counted from the press, for the same reason the premise is: on a first-try landing this is
-    // "never reconnected" and says so, and after a miss it is the only form that can still be true
-    // of the run the cell actually set up.
-    check("...without re-establishing after the press, so this is the backoff path and not a reconnect",
-      saidReconnected(b) === reconnectsAtPress, { reconnectsAtPress, now: saidReconnected(b), tail: b.seen().slice(-600) });
-    // The shell comes back with the press, not with the rung. Losing a `Promise.race` does not stop
-    // a `setTimeout`, so before this was asserted the loop honoured the detach at once, printed
-    // `detached from`, and then held the process open until the abandoned backoff timer fired: 27.0s
-    // measured with the next attempt 26.9s away, and 8.3s with it 8.1s away. Bounded against the
-    // BOUNDARY rather than against a constant, because the defect is exactly a wait that runs to
-    // the boundary and a constant would have to be chosen loose enough to allow it on a slow runner.
-    check("...and it gives the shell back on the press, not when the rung it was waiting on expires",
-      tExit <= nextAttemptDue - 10_000,
-      { pressToExitMs: tExit - tPress, boundaryInMs: nextAttemptDue - tPress, spareMs: nextAttemptDue - tExit });
-    check("...saying NOTHING about a held session, because it handed the session back on the way out",
-      !/the manager still holds/.test(b.seen()), b.seen().slice(-600));
-    const freed = await settle(baseJ, 20_000);
-    check("...and the manager is back to the count it started with, with no slot left behind",
-      freed === baseJ, { baseJ, freed });
+    if (!landed) {
+      // Four tries and the scenario never happened. What this must NOT do is press anyway. The link
+      // is severed here, so a press lands on an outage, which is cell B's scenario, not this one:
+      // the client cannot hand the session back over a dead link, so it says the manager still
+      // holds it and the count stays up. Both are correct behaviour, and both would be recorded as
+      // failures of a hand-back that is not broken. Six assertions painting a defect that is not
+      // there is worse than no measurement, so the premise red above is the whole finding and the
+      // rest of the cell is not graded. It stays RED rather than being skipped quietly: a cell that
+      // cannot reach its own scenario in four tries is a broken cell and has to be seen as one.
+      console.log("    (premise never landed in 4 tries: NOT grading the 6 assertions that follow, on a severed link they would describe cell B)");
+    } else {
+      // The next attempt is a full rung away from the knock that proved the rung, so the margin below
+      // is measured against where the boundary actually is rather than against a stopwatch.
+      const nextAttemptDue = (longRungAt() ?? Date.now()) + 30_000;
+      const reconnectsAtPress = saidReconnected(b);
+      const tPress = Date.now();
+      b.write(DETACH_BYTE);
+      check("the detach key ends the attach during the backoff", await b.waitExit(30_000), b.seen().slice(-300));
+      const tExit = Date.now();
+      check("...exiting clean", b.exit()?.code === 0, b.exit());
+      // Counted from the press, for the same reason the premise is: on a first-try landing this is
+      // "never reconnected" and says so, and after a miss it is the only form that can still be true
+      // of the run the cell actually set up.
+      check("...without re-establishing after the press, so this is the backoff path and not a reconnect",
+        saidReconnected(b) === reconnectsAtPress, { reconnectsAtPress, now: saidReconnected(b), tail: b.seen().slice(-600) });
+      // The shell comes back with the press, not with the rung. Losing a `Promise.race` does not stop
+      // a `setTimeout`, so before this was asserted the loop honoured the detach at once, printed
+      // `detached from`, and then held the process open until the abandoned backoff timer fired: 27.0s
+      // measured with the next attempt 26.9s away, and 8.3s with it 8.1s away. Bounded against the
+      // BOUNDARY rather than against a constant, because the defect is exactly a wait that runs to
+      // the boundary and a constant would have to be chosen loose enough to allow it on a slow runner.
+      check("...and it gives the shell back on the press, not when the rung it was waiting on expires",
+        tExit <= nextAttemptDue - 10_000,
+        { pressToExitMs: tExit - tPress, boundaryInMs: nextAttemptDue - tPress, spareMs: nextAttemptDue - tExit });
+      check("...saying NOTHING about a held session, because it handed the session back on the way out",
+        !/the manager still holds/.test(b.seen()), b.seen().slice(-600));
+      const freed = await settle(baseJ, 20_000);
+      check("...and the manager is back to the count it started with, with no slot left behind",
+        freed === baseJ, { baseJ, freed });
+    }
   }
 
   // ---------------------------------------------------------------------------------------------

--- a/implementations/manager/smoke/attach-reconnect.smoke.ts
+++ b/implementations/manager/smoke/attach-reconnect.smoke.ts
@@ -190,6 +190,10 @@ const severLoud = (): Promise<void> =>
  *  the client's schedule MEASURED rather than modelled from the ladder and a stopwatch. The whole
  *  run is scanned, not just the newest pair: an attempt dials several times within a few
  *  milliseconds, so the pair carrying the rung is buried the moment the rest of its cluster lands. */
+/** How many times this attach has announced each thing. Counted rather than searched: every one of
+ *  these lines stays in the transcript, so "has it ever" is not a question a retry can act on. */
+const saidReconnected = (a: { seen: () => string }): number => (a.seen().match(/\[cotal: reconnected\]/g) ?? []).length;
+const saidLost = (a: { seen: () => string }): number => (a.seen().match(/\[cotal: connection lost, reconnecting\]/g) ?? []).length;
 const longRungAt = (): number | undefined => {
   for (let i = knocks.length - 1; i > 0; i--) if (knocks[i] - knocks[i - 1] >= 25_000) return knocks[i];
   return undefined;
@@ -556,19 +560,23 @@ try {
       while (longRungAt() === undefined && Date.now() < rungDeadline) await wait(200);
       const quietUntil = Date.now() + 20_000;
       while (Date.now() - (knocks.at(-1) ?? 0) < 1_500 && Date.now() < quietUntil) await wait(200);
+      // COUNTED, not searched. A miss leaves `[cotal: reconnected]` in the transcript forever, so a
+      // later try asking "has this attach ever reconnected" can only ever answer yes, and a retry
+      // that cannot come back green is worse than no retry: it reads as resilience and is not.
+      const before = saidReconnected(b);
       await sever();
       await heal();
       await wait(1_500);
-      landed = !/\[cotal: reconnected\]/.test(b.seen());
+      landed = saidReconnected(b) === before;
       if (!landed) {
         // The heal was used by an attempt that was already running. Sever and take the next rung:
         // the cell reports the miss rather than asserting against the scenario it did not get.
         console.log(`    (heal ${tries} landed on an attempt rather than in the wait; taking the next rung)`);
-        const losses = (b.seen().match(/\[cotal: connection lost, reconnecting\]/g) ?? []).length;
+        const losses = saidLost(b);
         await sever();
         await severLoud();
         const again = Date.now() + 60_000;
-        while (Date.now() < again && (b.seen().match(/\[cotal: connection lost, reconnecting\]/g) ?? []).length === losses) await wait(200);
+        while (Date.now() < again && saidLost(b) === losses) await wait(200);
       }
     }
     check("the link is back with the loop WAITING rather than dialling, which is this cell's premise",
@@ -576,13 +584,17 @@ try {
     // The next attempt is a full rung away from the knock that proved the rung, so the margin below
     // is measured against where the boundary actually is rather than against a stopwatch.
     const nextAttemptDue = (longRungAt() ?? Date.now()) + 30_000;
+    const reconnectsAtPress = saidReconnected(b);
     const tPress = Date.now();
     b.write(DETACH_BYTE);
     check("the detach key ends the attach during the backoff", await b.waitExit(30_000), b.seen().slice(-300));
     const tExit = Date.now();
     check("...exiting clean", b.exit()?.code === 0, b.exit());
-    check("...without ever re-establishing, so this is the backoff path and not a reconnect",
-      !/\[cotal: reconnected\]/.test(b.seen()), b.seen().slice(-600));
+    // Counted from the press, for the same reason the premise is: on a first-try landing this is
+    // "never reconnected" and says so, and after a miss it is the only form that can still be true
+    // of the run the cell actually set up.
+    check("...without re-establishing after the press, so this is the backoff path and not a reconnect",
+      saidReconnected(b) === reconnectsAtPress, { reconnectsAtPress, now: saidReconnected(b), tail: b.seen().slice(-600) });
     // The shell comes back with the press, not with the rung. Losing a `Promise.race` does not stop
     // a `setTimeout`, so before this was asserted the loop honoured the detach at once, printed
     // `detached from`, and then held the process open until the abandoned backoff timer fired: 27.0s

--- a/implementations/manager/smoke/attach-reconnect.smoke.ts
+++ b/implementations/manager/smoke/attach-reconnect.smoke.ts
@@ -40,6 +40,10 @@
  *      failure mark, the refusal's own remedy, and no reconnect it was never going to make.
  *   H. a reconnect hands the abandoned session back to the manager. Against a SILENT seat, which
  *      is the one nothing on the serving side reaps, so the count is the client's doing or nobody's.
+ *   I. a link that stays UP and carries nothing ends the attach cleanly and says what it could not
+ *      hand back, rather than aborting the command on a wait that never returns.
+ *   J. a detach pressed in the wait BETWEEN attempts, on a link that came back, hands the session
+ *      back and gives the shell straight back rather than at the end of the rung.
  *   F. the four classifications the loop turns on, as functions.
  *
  * ON CELL F. It builds its inputs by hand, so on its own it would prove only that the suite
@@ -132,13 +136,21 @@ const releaseBroker = teardownOnSignal(srv, dir);
 // --- the faultable link -------------------------------------------------------------------------
 const liveSockets = new Set<Socket>();
 let proxy: Server | undefined;
-// The link has THREE states, not two. Severed is a socket that is gone, which the client's NATS
+// The link has FOUR states, not two. Severed is a socket that is gone, which the client's NATS
 // layer notices at once. HELD is a socket that is still up and carries nothing, which is what a
 // sleeping laptop or a black-holing middlebox actually looks like from the client: the connection
 // is not closed, so anything that asks "is this link alive?" says yes, and only a round trip that
 // fails to come back tells the truth. Data handlers behind a flag, because `pipe` cannot be paused
 // without also pausing the socket the flag is meant to keep looking healthy.
+//
+// The fourth is severed but LOUD: the port keeps listening and destroys what it accepts, so every
+// dial the client makes lands here with a timestamp. To the client that is a link that resets
+// instead of one that refuses, a failed attempt either way. It exists because a cell that has to
+// act BETWEEN two re-establishment attempts cannot get there by waiting: the backoff ladder runs on
+// the client's clock from the moment the link died, and everything this file observes arrives
+// through a pty and a polling reader, offset by however loaded the machine is (issue #582).
 let holding = false;
+const knocks: number[] = [];
 const hold = (): void => { holding = true; };
 const unhold = (): void => { holding = false; };
 const heal = (): Promise<void> =>
@@ -164,6 +176,24 @@ const sever = (): Promise<void> =>
     if (!s) return res();
     s.close(() => res());
   });
+/** Severed, and every dial timestamped. `sever()` first: this takes the same port. */
+const severLoud = (): Promise<void> =>
+  new Promise((res, rej) => {
+    holding = false;
+    knocks.length = 0; // one outage, one measurement: a knock from the last one is not this schedule
+    const s = createServer((sock) => { knocks.push(Date.now()); sock.destroy(); });
+    s.on("error", rej);
+    s.listen(PROXY_PORT, "127.0.0.1", () => { proxy = s; res(); });
+  });
+/** The time of the first dial of an attempt that was made from the top of a 30s wait, or undefined
+ *  while the ladder is still climbing. Two knocks 25s apart can come from no other rung, so this is
+ *  the client's schedule MEASURED rather than modelled from the ladder and a stopwatch. The whole
+ *  run is scanned, not just the newest pair: an attempt dials several times within a few
+ *  milliseconds, so the pair carrying the rung is buried the moment the rest of its cluster lands. */
+const longRungAt = (): number | undefined => {
+  for (let i = knocks.length - 1; i > 0; i--) if (knocks[i] - knocks[i - 1] >= 25_000) return knocks[i];
+  return undefined;
+};
 
 // The seat ticks FAST. The manager's stall watchdog only arms once the 64-frame send window is
 // full, so at 50ms the window fills in about 3s and the serving side is dead by about 33s: that is
@@ -503,23 +533,65 @@ try {
     // action rather than an exotic one: the link dies, the client records the session it could not
     // hand back, the link comes back, and the operator presses the detach key during the wait
     // before the next attempt. Exiting there without dialling would leave a slot held that a single
-    // connection would have freed, and would then say so as though nothing could be done. The wait
-    // below is long enough that the detach cannot be raced by the next attempt: after 40s of failed
-    // attempts the backoff is on its 30s rung, so the heal lands mid-wait rather than mid-attempt.
+    // connection would have freed, and would then say so as though nothing could be done.
+    //
+    // Getting there is the hard part, and waiting will not do it (#582). `watchDetachKey` exists
+    // only for the duration of a wait, so a press that lands while an ATTEMPT is running is not
+    // read: it sits in the stream, the attempt succeeds on the link this cell just healed, and the
+    // buffered byte then detaches the NEW session perfectly cleanly. Every assertion below still
+    // passes and the premise is gone. So the cell measures where the wait is instead of assuming
+    // it: knock timing puts it on the 30s rung, it lets that attempt finish dialling, heals, and
+    // then CONFIRMS no reconnect announced itself before it presses anything.
     const baseJ = live();
     const b = attachUnderPty(root, [], QUIET); started.push(b);
     check("the attach comes up", await b.waitFor(new RegExp(`attached to ${QUIET}`), 90_000), b.seen().slice(-400));
     check("...and the manager counts one more live session", live() === baseJ + 1, { baseJ, now: live() });
 
     await sever();
+    await severLoud();
     check("the reconnect is under way", await b.waitFor(/\[cotal: connection lost, reconnecting\]/, 30_000), b.seen().slice(-400));
-    await wait(40_000);
-    await heal();
+    let landed = false;
+    for (let tries = 1; tries <= 4 && !landed; tries++) {
+      const rungDeadline = Date.now() + 150_000;
+      while (longRungAt() === undefined && Date.now() < rungDeadline) await wait(200);
+      const quietUntil = Date.now() + 20_000;
+      while (Date.now() - (knocks.at(-1) ?? 0) < 1_500 && Date.now() < quietUntil) await wait(200);
+      await sever();
+      await heal();
+      await wait(1_500);
+      landed = !/\[cotal: reconnected\]/.test(b.seen());
+      if (!landed) {
+        // The heal was used by an attempt that was already running. Sever and take the next rung:
+        // the cell reports the miss rather than asserting against the scenario it did not get.
+        console.log(`    (heal ${tries} landed on an attempt rather than in the wait; taking the next rung)`);
+        const losses = (b.seen().match(/\[cotal: connection lost, reconnecting\]/g) ?? []).length;
+        await sever();
+        await severLoud();
+        const again = Date.now() + 60_000;
+        while (Date.now() < again && (b.seen().match(/\[cotal: connection lost, reconnecting\]/g) ?? []).length === losses) await wait(200);
+      }
+    }
+    check("the link is back with the loop WAITING rather than dialling, which is this cell's premise",
+      landed, { knocks: knocks.length, tail: b.seen().slice(-300) });
+    // The next attempt is a full rung away from the knock that proved the rung, so the margin below
+    // is measured against where the boundary actually is rather than against a stopwatch.
+    const nextAttemptDue = (longRungAt() ?? Date.now()) + 30_000;
+    const tPress = Date.now();
     b.write(DETACH_BYTE);
     check("the detach key ends the attach during the backoff", await b.waitExit(30_000), b.seen().slice(-300));
+    const tExit = Date.now();
     check("...exiting clean", b.exit()?.code === 0, b.exit());
     check("...without ever re-establishing, so this is the backoff path and not a reconnect",
       !/\[cotal: reconnected\]/.test(b.seen()), b.seen().slice(-600));
+    // The shell comes back with the press, not with the rung. Losing a `Promise.race` does not stop
+    // a `setTimeout`, so before this was asserted the loop honoured the detach at once, printed
+    // `detached from`, and then held the process open until the abandoned backoff timer fired: 27.0s
+    // measured with the next attempt 26.9s away, and 8.3s with it 8.1s away. Bounded against the
+    // BOUNDARY rather than against a constant, because the defect is exactly a wait that runs to
+    // the boundary and a constant would have to be chosen loose enough to allow it on a slow runner.
+    check("...and it gives the shell back on the press, not when the rung it was waiting on expires",
+      tExit <= nextAttemptDue - 10_000,
+      { pressToExitMs: tExit - tPress, boundaryInMs: nextAttemptDue - tPress, spareMs: nextAttemptDue - tExit });
     check("...saying NOTHING about a held session, because it handed the session back on the way out",
       !/the manager still holds/.test(b.seen()), b.seen().slice(-600));
     const freed = await settle(baseJ, 20_000);

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "smoke:attach-reconnect": "tsx implementations/manager/smoke/attach-reconnect.smoke.ts",
     "probe:attach-reconnect": "tsx implementations/manager/smoke/_probe-attach-reconnect.ts",
     "probe:session-leak": "tsx implementations/manager/smoke/_probe-session-leak.ts",
+    "probe:cellj-timing": "tsx implementations/manager/smoke/_probe-cellj-timing.ts",
     "smoke:manager-console": "pnpm --filter @cotal-ai/manager... build && tsx implementations/manager/smoke/console-assets.smoke.ts",
     "smoke:windows": "tsx implementations/manager/smoke/windows-launch.smoke.ts",
     "smoke:secret-fs": "tsx packages/core/smoke/secret-fs.smoke.ts",


### PR DESCRIPTION
Closes #582.

Cell J of `smoke:attach-reconnect` went red on CI run 32115572662 (shard 3, tip `9f8a2dd4`, a PR touching none of this code), with only its premise assertion failing and everything the cell exists to prove still green. That shape is the tell: the cell graded a scenario it had not set up. Reproducing it turned up a real defect in the shipped client alongside the test one, so this PR carries both.

## The repro, before either fix

The client's schedule was made observable: during the outage the proxy keeps listening and destroys what it accepts, so every dial the CLI makes is a timestamped knock. `probe:cellj-timing`, on the laptop:

```
knocks (relative to the sever): 2.0s  3.1s  5.1s  10.2s  20.2s  50.2s
gaps:                                1     2     5      10     30
```

The cell waited 40s from the moment the TEST saw `[cotal: connection lost, reconnecting]` come out of the pty, then healed and pressed. That wait runs on this side's clock; the ladder runs on the client's, from when the link died. The offset between them is however long a loaded machine takes to push a line through a pty and a polling reader: 2.1s here, 7.1s on the runner that went red. So the boundary falls at 50.2s, the cell acts at 42.1s, and the margin is 8.1s rather than the rung the comment claimed.

Landing past a boundary is not what loses the press. `watchDetachKey` exists only for the duration of a wait, so a byte pressed while an attempt is RUNNING is not read: it sits in the stream, the attempt succeeds on the link the cell just healed, `[cotal: reconnected]` prints, and the buffered byte then detaches the new session cleanly. Every other assertion passes.

`--arm race` heals on the first dial of an attempt instead of in the wait between two. **Predicted `reconnected=true`; actual `reconnected=true`**, exit 0.3s later, every other assertion green: the CI failure on demand rather than by waiting for load.

## The defect the repro found in the client

Instrumenting press-to-exit, on the code as shipped:

```
press to first output: 0.1s     terminal restored, "detached from rcquiet" printed
press to exit:        27.0s     next attempt due 26.9s after the press
press to exit:         8.3s     next attempt due  8.1s after the press
```

Two different boundary distances, the exit tracking each. Losing a `Promise.race` does not stop a `setTimeout`, and the timer is ref'd, so node held the command open to the end of the rung: up to half a minute of a shell that had already said it detached and would not give the prompt back. Clearing the timer takes it to 0.1s with the boundary still 26.8s away.

The docs needed no change, and that is the point rather than an omission: `docs/cli.md` already says the detach key is read during the waits so a reconnect never traps you. It was the code that did not keep that promise.

## The cell, fixed

The link gains a fourth state, severed but loud: the port keeps listening and timestamps every dial. Two knocks 25s apart can come from no rung but the 30s one, so the cell waits for that pair, lets the attempt that produced it finish dialling, heals, and then confirms nothing re-established before pressing anything. A heal that does land on an attempt is printed and retried on the next rung rather than asserted through. **Margin 27s measured, against 8.1s assumed.**

Four tries that all miss end the cell there. The premise assertion stays red, because a cell that cannot reach its own scenario is broken and has to be seen as one, but the six assertions after it are not graded and a printed line says why. Pressing on a link that is still severed is cell B's scenario: the client cannot hand the session back over a dead link, so it correctly reports the session held and the count stays up, and both were being recorded as failures of a hand-back that is not broken. That was measured, on a control arm forced to miss four times: predicted 2 reds, actual 4.

Cell J gains two assertions: that the loop was waiting rather than dialling when the link came back (its premise, now checked instead of assumed), and that the shell comes back on the press. The second is bounded against where the next attempt actually falls, not against a constant, because a constant loose enough for a slow runner is also loose enough to admit the defect.

## Predicted versus actual

- `smoke:attach-reconnect`: predicted 72 passed 0 failed (70 before, plus the two new assertions); actual **72 passed, 0 failed**, with no retry line printed on an unloaded laptop.
- `probe:cellj-timing --arm sync` after the client fix: predicted press-to-exit under 2s; actual **0.1s**, next attempt still 26.9s away, no reconnect after the press.
- `probe:cellj-timing --arm race`: predicted a reconnect after the press; actual **one**, boundary knock at 50.2s off a 30.0s gap, exit 0. The cell's premise assertion would be red here, which is the point of the arm.
- Both arms leave no broker and no store dir behind. The check was positive-controlled first, because the obvious form of it (`find -newermt` under `2>/dev/null`, where this laptop's `find` rejects that timestamp) reports a clean machine while checking nothing.

## Scope

- `implementations/cli/src/commands/agents.ts`: clear the backoff timer when the detach wins the race; the now-unused `sleep` helper goes with it.
- `implementations/manager/smoke/attach-reconnect.smoke.ts`: the fourth link state, cell J rewritten to measure the schedule, two new assertions, and the header's cell list extended to cover I and J.
- `implementations/manager/smoke/_probe-cellj-timing.ts` plus `probe:cellj-timing`: the instrument, with all three arms kept. Its teardown follows the same contract the suites do, kill, remove the store dir, release ownership LAST, because `releaseBroker` hands the kill duty back rather than doing it and releasing first left a live broker behind on a clean exit 0. Its reconnect checks are counted against a baseline for the same reason the cell's are.
- `bin/smoke/mutations/attach-reconnect.json`: mutation 12 restores the abandoned timer and must redden the shell-back assertion by name.
- Changeset: patch on `@cotal-ai/cli`.
- `bin/smoke/ci-suites.txt` untouched: no new suite, and the cell runs where it already ran.
- SPEC.md untouched. Nothing on the wire changes; this is the client's own timer and the suite's own clock.

## The arithmetic behind the new bound, stated rather than left to be derived

`tExit <= nextAttemptDue - 10_000`, with the press landing about 3s after the boundary knock, allows the honest exit path about 17s. That path is a dial, a publish, a flush and a close, each bounded by `LINK_DEADLINE_MS` (5s), so its theoretical worst case is about 20s: 5s dial, 5s flush, 5s drain, 5s close. Measured it is 0.1s, because the link in this cell was healed a second earlier and is loopback.

The 20s case is not reachable here without a different assertion firing first. Every one of those bounds is hit only by a link that is dead or half open, and a hand-back over a dead link is exactly what makes `flushed` return false, which throws, which keeps the session on the abandoned list, which prints the held-session notice the next assertion forbids. A world where this bound is exceeded honestly is a world where the cell is already red for a better reason.

## Adjacent, filed rather than folded in

Review of this PR executed two findings about stdin ownership during a reconnect, both pre-existing and neither introduced nor addressed here: keystrokes typed while an attempt is ESTABLISHING are buffered and replayed into the seat when the session opens (including `Ctrl-C`, which reaches the agent as a signal), and a detach byte that arrives in the same read as another byte is discarded by both readers, which test `d.length === 1`. Filed as #585 with the executed evidence, because closing them is a behaviour change with its own repro and its own cells.

`teardownOnSignal` in `packages/smoke-kit` is filed as #587: its `release` hands the kill duty back silently, so a call site that releases first leaks a broker and exits 0. All 134 call sites were audited and none has that order, which makes it a trap for a file written from scratch rather than a live leak. The issue carries the measurement showing why the obvious guard cannot work: on the line after `kill("SIGKILL")`, where every correct site calls release, the child still reports `exitCode=null` and `kill(pid, 0)` still succeeds.

