### PR TITLE
test(lang): floor the dry-run corpus so its central identities cannot hold at zero

### DIFF
--- a/packages/lang/smoke/dryrun.smoke.ts
+++ b/packages/lang/smoke/dryrun.smoke.ts
@@ -43,6 +43,16 @@ const SCRIPT = {
   checkpoints: { "approve-plan": { status: "resolved", value: true, by: "sim" } },
 } as const;
 
+/**
+ * What PROGRAM does under SCRIPT: spawn, spawn, turn, checkpoint, turn, sleep. Four kinds.
+ *
+ * Stated here rather than inline because two sections below compare one derived list against
+ * another, and a comparison between two lists that shrink together is true when both are empty. The
+ * number is what stops those comparisons from passing over a run that did nothing.
+ */
+const EFFECTS = 6;
+const KINDS = 4;
+
 // ---- 1) the report answers the questions a dry run exists to answer -----------------------------
 
 const realStart = Date.now();
@@ -112,12 +122,11 @@ const realMs = Date.now() - realStart;
   // is `"[]" === "[]"`. A run that journalled nothing would pass the two cells this file calls the
   // ones that matter, and the drift they exist to catch is exactly the drift they would miss in the
   // case where it is total. `report.agents` and `report.checkpoints` are pinned above but they are
-  // built from the recorder's own arrays, not from the journal, so they floor nothing here. Pin the
-  // corpus itself: six effects, and all four kinds the program uses.
+  // built from the recorder's own arrays, not from the journal, so they floor nothing here.
   const realKinds = new Set(real.journal.entries().map((e) => e.kind));
   ok(
-    "the real run journalled the program's six effects, across all four of its kinds",
-    realKeys.length === 6 && realKinds.size === 4,
+    "the real run journalled every effect the program has, across all of its kinds",
+    realKeys.length === EFFECTS && realKinds.size === KINDS,
     { keys: realKeys, kinds: [...realKinds] },
   );
 
@@ -165,10 +174,10 @@ const realMs = Date.now() - realStart;
   const rec = new RecordingHandler(inner);
   ok("the recorder delegates the clock rather than owning one", rec.now() === inner.now());
   const r = await run(PROGRAM, { runId: "dry-run", handler: rec });
-  // Another identity, floored transitively: section 4 pins `realKeys` at six and then equates it to
-  // `planKeys`, so `report.effects` is non-empty by the time this line runs, or the suite is already
-  // red. If section 4's floor is ever removed, this cell goes unfloored with it.
-  ok("a run through the recorder behaves identically", r.journal.entries().length === report.effects.length, {
+  // Same identity, same reason, and floored here rather than left to section 4: a floor one section
+  // away is an ordering someone can change, and a comment saying so is a claim rather than a term.
+  ok("a run through the recorder behaves identically",
+    r.journal.entries().length === report.effects.length && report.effects.length === EFFECTS, {
     through: r.journal.entries().length,
     plan: report.effects.length,
   });

--- a/packages/lang/smoke/dryrun.smoke.ts
+++ b/packages/lang/smoke/dryrun.smoke.ts
@@ -118,11 +118,13 @@ const realMs = Date.now() - realStart;
     .map((e) => `${e.scope}/${e.kind}${e.name === "" ? "" : `:${e.name}`}#${e.occurrence}`);
   const planKeys = report.effects.map((e) => e.step);
 
-  // Both comparisons below are identities, and an identity holds at zero: `0 === 0` is true, and so
-  // is `"[]" === "[]"`. A run that journalled nothing would pass the two cells this file calls the
-  // ones that matter, and the drift they exist to catch is exactly the drift they would miss in the
-  // case where it is total. `report.agents` and `report.checkpoints` are pinned above but they are
-  // built from the recorder's own arrays, not from the journal, so they floor nothing here.
+  // The floor and the two comparisons below catch DIFFERENT failures, and neither replaces the
+  // other. Empty `report.effects` alone and the comparisons go red at `{plan: 0, real: 6}` while the
+  // floor passes: that is reporter drift, the failure named at the top of this section, and the
+  // comparisons are the right instrument for it. Stop the run journalling and BOTH sides fall to
+  // zero together — `0 === 0` and `"[]" === "[]"` are true, and the comparisons see nothing at all.
+  // That second one is the floor's, and `report.agents` / `report.checkpoints` do not cover it: they
+  // are pinned above but built from the recorder's own arrays rather than from the journal.
   const realKinds = new Set(real.journal.entries().map((e) => e.kind));
   ok(
     "the real run journalled every effect the program has, across all of its kinds",

--- a/packages/lang/smoke/dryrun.smoke.ts
+++ b/packages/lang/smoke/dryrun.smoke.ts
@@ -108,6 +108,19 @@ const realMs = Date.now() - realStart;
     .map((e) => `${e.scope}/${e.kind}${e.name === "" ? "" : `:${e.name}`}#${e.occurrence}`);
   const planKeys = report.effects.map((e) => e.step);
 
+  // Both comparisons below are identities, and an identity holds at zero: `0 === 0` is true, and so
+  // is `"[]" === "[]"`. A run that journalled nothing would pass the two cells this file calls the
+  // ones that matter, and the drift they exist to catch is exactly the drift they would miss in the
+  // case where it is total. `report.agents` and `report.checkpoints` are pinned above but they are
+  // built from the recorder's own arrays, not from the journal, so they floor nothing here. Pin the
+  // corpus itself: six effects, and all four kinds the program uses.
+  const realKinds = new Set(real.journal.entries().map((e) => e.kind));
+  ok(
+    "the real run journalled the program's six effects, across all four of its kinds",
+    realKeys.length === 6 && realKinds.size === 4,
+    { keys: realKeys, kinds: [...realKinds] },
+  );
+
   ok("the plan has an entry for every effect the real run performed", planKeys.length === realKeys.length, {
     plan: planKeys.length,
     real: realKeys.length,
@@ -152,6 +165,9 @@ const realMs = Date.now() - realStart;
   const rec = new RecordingHandler(inner);
   ok("the recorder delegates the clock rather than owning one", rec.now() === inner.now());
   const r = await run(PROGRAM, { runId: "dry-run", handler: rec });
+  // Another identity, floored transitively: section 4 pins `realKeys` at six and then equates it to
+  // `planKeys`, so `report.effects` is non-empty by the time this line runs, or the suite is already
+  // red. If section 4's floor is ever removed, this cell goes unfloored with it.
   ok("a run through the recorder behaves identically", r.journal.entries().length === report.effects.length, {
     through: r.journal.entries().length,
     plan: report.effects.length,


### PR DESCRIPTION
Section 4 of `packages/lang/smoke/dryrun.smoke.ts` compares the dry-run plan against a real
execution, key by key. The file's own comment calls it the test that matters, and gives the reason:

> Everything above could pass while the reporter drifts from the interpreter, because every line of
> a drifted report still looks plausible.

Both of its comparisons are identities:

```ts
planKeys.length === realKeys.length
JSON.stringify(planKeys) === JSON.stringify(realKeys)
```

`0 === 0` is true, and so is `"[]" === "[]"`. A run that journalled nothing passes both while
proving nothing at all — the section misses the drift it exists to catch in exactly the case where
that drift is total.

Nothing in the file floored either side. The two pinned counts above it look like they might:

```ts
ok("it lists the agents that would be spawned", report.agents.length === 2, …);
ok("it lists the checkpoints a person would face", report.checkpoints.length === 1, …);
```

They do not. `dryRun` builds `agents` and `checkpoints` from the recorder's own arrays
(`recorder.spawns`, `recorder.checkpointsAsked`) but builds `effects` from `result.journal.entries()`
— the same source the real run's keys come from. One change at that source empties both sides of the
identity at once and leaves the two pinned counts untouched.

## Two terms, two failures — neither is redundant

The identities are not the defect, and an earlier draft of this branch's comment implied they were.
Emptying `report.effects` alone, leaving the real run untouched:

```
ok  the real run journalled every effect the program has, across all of its kinds
FAIL: the plan has an entry for every effect the real run performed - {"plan":0,"real":6}
```

**That is reporter drift — the failure this section was written for — and the identities catch it
while the floor does not.** The floor catches the other one: a run that journals nothing, where both
sides fall to zero together and the identities see nothing.

So each term survives a mutation the other does not, and deleting either as redundant trades one
real failure for the other.

## The proof

Mutation: `Journal.entries()` returns `[]`. It is coarse on purpose — it is precisely the corpus
collapse the floor claims to catch.

| | section 4 | first red |
|---|---|---|
| mutant, before this change | **all three cells green** | `and the taken branch is still there`, one section later |
| mutant, with this change | red on the new cell | `the real run journalled the program's six effects, across all four of its kinds` |

Before: `the plan has an entry for every effect the real run performed` ✓,
`in the same order, with the same journal keys` ✓, `and the same step count` ✓ — under a journal
returning nothing. What eventually noticed was an unrelated positive assertion in section 5, about
branch pruning rather than about drift. (Section 5's *negative* cell,
`a branch the script does not take is absent from the plan`, also passed vacuously.)

After: the suite stops on the new cell, and it is the only red.

## The change

`EFFECTS` and `KINDS` next to the program they describe, one floor cell before the section-4
identities, and the same floor as a term on the section-6 recorder identity
(`r.journal.entries().length === report.effects.length`), which is the same shape and was equally
bare.

The section-6 term went in as a term rather than a comment on purpose, and it is the one part of
this change with **no mutant, by construction**: any mutation that would empty its corpus reddens
section 4 and then section 5 first, so the cell is never reached. It is not provable here and the
claim for it is narrower — it removes an ordering dependency, so the cell does not rely on a floor
one section away that a later change can move.

Restore verified: tree clean after the mutation, `packages/lang` suite green on the restored tree.

## Verification

- `packages/lang` suite: 9/9 suites, 286 checks, rc=0. `dryrun.smoke` 22 → 23.
- Root `pnpm typecheck`: rc=0.
- The smoke directory is not covered by `packages/lang`'s `typecheck` script on this base, so rc=0
  above does not speak for the edited file. Checked it separately under a config that includes
  `smoke`, and compared the error sets by set difference rather than by reading: 36 errors on the
  base, 36 with this commit, **0 new and 0 gone**. All 36 pre-date this change.

No changeset: this is test-only and ships no behaviour change.