### PR TITLE
fix(manager): request a retirement as the serve identity the gate names, not the endpoint identity

### DIFF
--- a/.changeset/retire-serve-principal.md
+++ b/.changeset/retire-serve-principal.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/manager": patch
+---
+
+A managed agent's retirement is now requested as the manager's SERVE identity, so it is authorized instead of being refused. The auth rail authorizes a `retireLifecycle` request by comparing the caller's `<owner>.<actor>` against the principal bound into the manager's serve issuance gate, and that gate is opened with the serve identity the manager registers with. The request was built from the manager's endpoint identity instead: a second, equally real identity of the same manager, and one the gate can never name. The comparison was therefore unsatisfiable on every user-auth mesh, so every despawn stopped the agent and then had its retirement refused as a full no-op, leaving the name held and the lifecycle un-retired. Both halves of the caller triple now come from the gate's own sources, the owner included, so a manager running under a user-shaped identity cannot re-open the mismatch in the owner half.

--- a/implementations/auth/smoke/auth-admin.smoke.ts
+++ b/implementations/auth/smoke/auth-admin.smoke.ts
@@ -34,8 +34,8 @@ import { connect, credsAuthenticator } from "@nats-io/transport-node";
 import {
   AUTH_ENDPOINT, EP_CMD_RETIRE_LIFECYCLE, epgateKey, epAuthBucket,
   epRequestSubject, epCallerReplyFilter, parseEpSubject,
-  createEndpointStreams, createSpaceAuth, ensureAuthorityStores, isReachable,
-  mintCreds, mintLifecycleUid, newIdentity, serverConfig, type EvictionResult,
+  createEndpointStreams, createSpaceAuth, ensureAuthorityStores, isReachable, DEV_OWNER,
+  mintCreds, mintLifecycleUid, newIdentity, principalKey, serverConfig, type EvictionResult,
 } from "@cotal-ai/core";
 import { deriveOwnerToken, openAuthAuthorityPlane } from "../src/index.js";
 import { openAuthorityClient } from "../src/authority-client.js";
@@ -86,9 +86,17 @@ const gatedEvictor: EvictPrincipal = async (principal) => {
   }
   return okEvictor(principal);
 };
-const MGR = { owner: "local", actor: "mgr0", uid: mintLifecycleUid() };
+// A manager holds TWO real identities, and Cotal #549 was the two being conflated: the nkey it
+// REGISTERS with (what its serve gate is bound to) and the nkey its ENDPOINT connects with. The
+// fixture models both, and derives each side of the rail's cross-check through the same expression
+// production uses on that side, from a different input. It used to spend ONE friendly literal on
+// both halves, so the cross-check was asserted against an equality this file had itself written:
+// a shape that cannot fail, teaches nothing, and let #549 through.
+const MGR_SERVE = newIdentity(); // registered; `gate.principal` is bound to this one
+const MGR_ENDPOINT = newIdentity(); // the endpoint's connection identity, never an authorization
+const MGR = { owner: DEV_OWNER, actor: MGR_SERVE.id, uid: mintLifecycleUid() };
 const spacePrefixLiteral = `cotal.${space}`;
-const MGR_KEY = `${MGR.owner}.${MGR.actor}`;
+const MGR_KEY = principalKey(DEV_OWNER, MGR_SERVE.id).key;
 // P2 item 3 (3b-3): the rail's holder check is now the serve-issuance GATE, not the manager lease.
 // The requester declares its serve identity; these are the defaults every green request rides (a test
 // overrides serveEpoch to model a superseded/deposed predecessor).
@@ -377,6 +385,40 @@ try {
     const rOwn = await request(MGR, { owner: OWNER, actor: "wforeign", lifecycleUid: uidF }, { opId: "f".repeat(26) });
     check("INVERSE CONTROL: the SAME caller naming its OWN serve registration SUCCEEDS (the cell grades the principal comparison, not a rail that refuses everything)",
       rOwn !== "no-reply" && rOwn.ok === true && (rOwn.data as { retired?: boolean })?.retired === true, rOwn);
+  }
+  // THE DIVERGENCE GUARD (Cotal #549). The cell above uses a foreign party, which reads as an
+  // outsider and is easy to get right. #549 was the hard shape: ONE manager process, TWO of its own
+  // real identities, and the requester speaking as the wrong one of them. Nothing about that looks
+  // like an intruder, which is why it survived every existing cell and shipped as "no user-mesh
+  // retirement ever completes". The registered identity authorizes; a second identity of the SAME
+  // process does not, whatever else it is entitled to do.
+  //
+  // WHAT THIS DOES AND DOES NOT PROVE. It fences the rail's side of the class: after this, a manager
+  // that speaks as anything other than its REGISTERED serve identity is refused here, deterministic
+  // and named. It cannot be red-before/green-after on its own, because the requester derivation the
+  // fix changes lives in the manager and `implementations/*` never import each other; that half is
+  // proved end-to-end over the real Manager in `user-spawn.smoke.ts`, with the mutation registered
+  // on it. This cell's job is that the FIXTURE can no longer agree with itself.
+  console.log("D. the divergence guard (#549: two identities of one manager)");
+  {
+    const uidD = mintLifecycleUid();
+    await ensureRootCredential(wreg, { owner: OWNER, actor: "wdiverge", lifecycleUid: uidD, managerInstance: "smoke" });
+    const target = { owner: OWNER, actor: "wdiverge", lifecycleUid: uidD };
+    // Same manager, same live registration, same epoch: the ONLY difference from the green path is
+    // which of its own identities the caller triple carries.
+    const rEp = await request({ owner: DEV_OWNER, actor: MGR_ENDPOINT.id, uid: MGR.uid }, target, { opId: "d".repeat(26) });
+    check("a manager speaking as its ENDPOINT identity is REFUSED against its own serve registration (both principals named, both derived, not literals)",
+      rEp !== "no-reply" && rEp.ok === false
+      && rEp.error?.includes(MGR_KEY) === true
+      && rEp.error?.includes(principalKey(DEV_OWNER, MGR_ENDPOINT.id).key) === true
+      && /FULL no-op/.test(rEp.error ?? ""), rEp);
+    check("...and that refusal left the target alive (an unauthorized request must not have acted)",
+      (await readLifecycleHeadForOperation(wreg, OWNER, "wdiverge"))?.mapping.state === "active");
+    // INVERSE CONTROL, on the SAME target and the SAME registration: the SERVE identity is accepted.
+    // Without it the cell above is satisfied by a rail that refuses every nkey-shaped principal.
+    const rServe = await request(MGR, target, { opId: "d".repeat(26) });
+    check("INVERSE CONTROL: the SERVE identity, on the same target and the same registration, IS authorized and retires it",
+      rServe !== "no-reply" && rServe.ok === true && (rServe.data as { retired?: boolean })?.retired === true, rServe);
   }
   // And the target is still intact after every refusal above.
   check("after every refusal face the target lifecycle is STILL active (refusals are complete no-ops)",

--- a/implementations/auth/smoke/user-spawn.smoke.ts
+++ b/implementations/auth/smoke/user-spawn.smoke.ts
@@ -91,10 +91,12 @@ type AddressInfo = import("node:net").AddressInfo;
 const {
   CotalEndpoint, createSpaceAuth, isReachable, mintCreds, newIdentity, serverConfig,
   setupSpaceStreams, principalKey, registry, spaceWildcard, clearChannel, mintLifecycleUid, eventChannel,
-  resolveService, invokeCommand, standaloneConnectOpts, EpEnvelopeError,
+  resolveService, invokeCommand, standaloneConnectOpts, EpEnvelopeError, epAuthBucket,
   mintMembershipObserverCreds, observePlaneLivenessWithCreds,
 } = await import("@cotal-ai/core");
 const { connect: rawConnect } = await import("@nats-io/transport-node");
+const { Kvm } = await import("@nats-io/kv");
+const { createHash } = await import("node:crypto");
 const { decodeJwt } = await import("jose");
 const { authDir, userAuthStateDir, saveSpaceAuth, recordMesh, assertUserAuthInfo, workspaceSecretStore, agentLifecycleSecretFilePaths } = await import("@cotal-ai/workspace");
 const {
@@ -626,11 +628,83 @@ try {
   // so a DIFFERENT actor under the same owner is a true sibling — not the spawner, not the manager.
   check("precondition: delta is live under the operator's owner", manager.list().some((a) => a.name === "delta"), manager.list().map((a) => a.name));
   const opsmate = await ctlCaller("opsmate", OWNER, ["spawn"]);
+  // delta's lifecycle uid, read off the same `inspect` the helper uses, so the retirement cells
+  // below key on the incarnation that is actually stopped rather than on a name.
+  const deltaInfo = await opsmate.invokeService("manager", "inspect", { name: "delta" });
+  const deltaUid = (deltaInfo.reply.data as { lifecycleUid: string }).lifecycleUid;
   const sibAttach = await epTargeted(opsmate, "attach", "delta");
   check("owner-domain: a spawn-scoped SIBLING actor attaches an agent under its owner (ep owner mode)", sibAttach.ok === true && typeof (sibAttach.data as { grant?: { sessionId?: string } })?.grant?.sessionId === "string", sibAttach);
   const sibStop = await epTargeted(opsmate, "stop", "delta");
   check("owner-domain: the same sibling actor stops it (stop travels with attach)", sibStop.ok === true, sibStop);
   check("delta is gone from the manager after the sibling stop", !manager.list().some((a) => a.name === "delta"), manager.list().map((a) => a.name));
+  // ---------- THE RETIREMENT IS AUTHORIZED AND ACTS (Cotal #549) ----------
+  // Read from STATE, never from the despawn's log copy. The defect this covers made the auth rail's
+  // principal cross-check unsatisfiable, because the gate is bound to `principalKey(DEV_OWNER,
+  // serveIdentity.id)` while the request used to carry the manager's ENDPOINT identity: two real
+  // identities of the same manager that can never be equal. Every user-mesh retirement was refused.
+  //
+  // WHY NOT ASSERT THE TERMINAL. `runAgentRetirementBarrier` cannot reach its terminal here: the
+  // final step needs `verifiedGone` from the delivery daemon's `evictPrincipal`, and this fixture
+  // runs no delivery daemon. Asserting "the name was released" would therefore be red for a reason
+  // that has nothing to do with authorization.
+  //
+  // WHY NOT ASSERT THE REFUSAL IS GONE. That is the wrong experiment, and it is the one I would
+  // most easily have run: a fix that only rewrote the refusal's wording would pass it. Measured on
+  // the broken tree, the string disappearing and the retirement working are genuinely different
+  // outcomes, because with the cross-check fixed the requests still fail further down.
+  //
+  // WHAT IS ASSERTED. The two durable facts the barrier writes BEFORE any of that, both of which a
+  // request refused at the cross-check never reaches: the operation intent row exists, and the
+  // agent's own issuance gate has moved from `open` to `frozen` under exactly that opId. The gate
+  // freeze is the load-bearing half: an intent row alone would only prove something was recorded,
+  // while the freeze proves the retirement began ACTING on the lifecycle.
+  //
+  // The opId is recomputed here rather than exported from the manager, because it is deterministic
+  // by contract (a stable op per retiring incarnation, so retries re-drive the same operation). If
+  // that derivation ever changes, this cell fails loudly rather than silently reading a stale key.
+  //
+  // FIXTURE HYGIENE. The freeze this cell waits for is real state left in the auth store, and a
+  // frozen gate is a known wedge class. It cannot wedge anything here: the row is `gate.<uid>` for
+  // delta's ONE stopped incarnation, `delta` is never spawned again below (the later cells use
+  // `alpha` and fresh names), and an issuance gate is keyed per lifecycle uid, so no later mint or
+  // registration reads it. The manager's OWN endpoint gate, which is the row whose freeze deadlocks
+  // a restart, is a different key family and is untouched.
+  {
+    const retireOpId = (uid: string): string => createHash("sha256").update(`retire:${uid}`).digest("hex").slice(0, 26);
+    // A `lifecycle-executor` pinned to delta. That profile is the one credential documented as able
+    // to READ (never write) other rows in the auth store for its one-shot lifetime, because its
+    // reads are body-selected `STREAM.MSG.GET` and a subject grant cannot see the requested key.
+    // It is used here rather than widening any production profile for a test, and it is pinned to
+    // exactly the incarnation under test.
+    const kvCreds = await mintCreds(auth, newIdentity(), "lifecycle-executor", {
+      lifecycleExecutor: { owner: OWNER, actor: "delta", lifecycleUid: deltaUid, alias: "delta" },
+    });
+    const kvNc = await rawConnect({ servers: SERVER, ...standaloneConnectOpts({ creds: kvCreds, tls: false }), maxReconnectAttempts: 0 });
+    try {
+      const authKv = await new Kvm(kvNc).open(epAuthBucket(SPACE));
+      // The retirement is single-flighted and driven off the despawn rather than awaited by it, so
+      // this polls to a deadline. A timeout leaves both observations at their last read, which is
+      // what the failure payload prints.
+      let intent: unknown, gateState: string | undefined, gateOp: string | undefined;
+      const deadline = Date.now() + 20_000;
+      while (Date.now() < deadline) {
+        const i = await authKv.get(`stage.${retireOpId(deltaUid)}`);
+        const g = await authKv.get(`gate.${deltaUid}`);
+        intent = i?.operation === "PUT" ? JSON.parse(new TextDecoder().decode(i.value)) as unknown : undefined;
+        const row = g?.operation === "PUT" ? JSON.parse(new TextDecoder().decode(g.value)) as { state?: string; op?: { opId?: string } } : undefined;
+        gateState = row?.state; gateOp = row?.op?.opId;
+        if (intent !== undefined && gateState === "frozen") break;
+        await wait(250);
+      }
+      check("the sibling stop's retirement was AUTHORIZED: the auth rail wrote its durable operation intent for delta's lifecycle",
+        (intent as { kind?: string; lifecycleUid?: string })?.kind === "retirement"
+        && (intent as { lifecycleUid?: string })?.lifecycleUid === deltaUid, { intent, deltaUid });
+      check("...and it ACTED: delta's own issuance gate is FROZEN under exactly that opId (an unauthorized request never reaches a gate)",
+        gateState === "frozen" && gateOp === retireOpId(deltaUid), { gateState, gateOp, expected: retireOpId(deltaUid) });
+    } finally {
+      await kvNc.close().catch(() => {});
+    }
+  }
   // THE SIBLING-WRITE VECTOR, executed on a real user mesh rather than argued from the mint table.
   // The two cells above are the reason it exists: on a user mesh the own-domain arm admits any seat
   // under the caller's owner, so `opsmate` attaches and stops an agent it never spawned. That is the

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -2602,10 +2602,21 @@ export class Manager {
   private async driveRetirement(a: { id: string; name: string; lifecycleUid: string }): Promise<void> {
     if (!this.auth) return; // guaranteed by requestRetirement; re-checked for the type narrowing below
     const held = this.retiring.get(a.name);
-    const me = parsePrincipalKey(this.ep.ref().id);
     const target = parsePrincipalKey(a.id);
-    if (!me || !target) {
-      if (held) held.lastError = "the manager or target principal could not be derived; the retirement was not requested";
+    if (!target) {
+      if (held) held.lastError = "the target principal could not be derived; the retirement was not requested";
+      return;
+    }
+    // The SERVE identity, not the endpoint identity, is who this request speaks as (#549). The field
+    // is declared `!:`, which asserts to the type system what the ordering happens to provide, so it
+    // is read here as what it actually is. On today's ordering this guard cannot fire: `start()`
+    // assigns the identity before it connects anything, and a retirement needs an agent that only a
+    // started manager can hold. It is kept as a fail-closed assertion rather than a live face,
+    // because the alternative is carrying `undefined` into the caller triple and surfacing the
+    // result as "the rail could not be reached", which would name the wrong cause.
+    const serveIdentity = this.managerServeIdentity as Identity | undefined;
+    if (!serveIdentity?.id) {
+      if (held) held.lastError = `the retirement was NOT requested: this manager has no serve identity yet, so it cannot speak as the registered serving instance. The despawn stopped "${a.name}" and the name stays held. NEXT: let the manager finish registering, then re-attempt the same-name spawn to re-drive the teardown.`;
       return;
     }
     const uncertain = (why: string) =>
@@ -2614,7 +2625,22 @@ export class Manager {
       // The caller triple and the TARGET are both grant-pinned now (#350): the `handle` target
       // rides the subject, so this ephemeral credential can ask to retire exactly this
       // incarnation and nothing else.
-      const caller = { owner: me.owner, actor: me.actor, uid: this.managerLifecycleUid };
+      //
+      // THE TRIPLE IS THE SERVE PRINCIPAL, and it has to be (#549). The auth rail authorizes this
+      // request by comparing the caller's `<owner>.<actor>` against the serve issuance gate's bound
+      // principal, and that gate is opened with `principalKey(DEV_OWNER, serveIdentity.id)` (see the
+      // registration block). Deriving the caller from `ep.ref().id` instead put the manager's
+      // ENDPOINT identity nkey on the wire, which is a different, equally real identity of the same
+      // manager, so the comparison was unsatisfiable and EVERY user-mesh retirement was refused as a
+      // full no-op. Measured before the fix: 8 refusals in one suite run across 5 agents, with the
+      // epoch and the instance id both matching and only the principal disagreeing.
+      //
+      // Both halves come from the gate's own sources rather than from `ep.ref()`: `DEV_OWNER` is
+      // hard-coded at the gate site, so taking the owner from `ep.ref().id` would re-open the same
+      // mismatch in the owner half the moment a manager ran under a user-shaped identity. This is
+      // also the more honest attribution: the authority being exercised is "I am the registered
+      // serving instance", which is exactly what the gate records.
+      const caller = { owner: DEV_OWNER, actor: serveIdentity.id, uid: this.managerLifecycleUid };
       const creds = await mintCreds(this.auth, newIdentity(), "retirement-requester", {
         retirementRequester: { ...caller, target: { owner: target.owner, actor: target.actor, lifecycleUid: a.lifecycleUid } },
       });


### PR DESCRIPTION
## What was wrong

On a user-auth mesh, no managed agent's lifecycle could be retired. Every despawn stopped the
child and then had its retirement refused, as a full no-op, so the name stayed held and the
lifecycle stayed un-retired.

The auth rail authorizes a `retireLifecycle` request by comparing the caller's `<owner>.<actor>`
against the principal bound into the manager's serve issuance gate. That gate is opened at
registration with `principalKey(DEV_OWNER, serveIdentity.id)`. `driveRetirement` built the caller
triple from `parsePrincipalKey(this.ep.ref().id)`, the manager's ENDPOINT identity: a second,
equally real identity of the same manager, and one the gate can never name. The comparison was
unsatisfiable, so the refusal was unconditional rather than conditional on anything an operator
could change.

Measured on the broken tree before writing the fix: 8 refusals in one suite run across 5 agents,
with the serve epoch and the serve instance id both matching and only the principal disagreeing.

## The fix

`driveRetirement` derives the caller triple from the serve identity, which is what the gate
records and what the request is actually claiming to be: "I am the registered serving instance".

Both halves come from the gate's own sources rather than from the endpoint reference. `DEV_OWNER`
is hard-coded at the gate site, so taking the owner from `ep.ref().id` would re-open the same
mismatch in the owner half the moment a manager ran under a user-shaped identity. That half is a
hardening rather than a currently-provable difference: the manager's endpoint card carries no
owner, so `CotalEndpoint` defaults it to `DEV_OWNER` and the two agree today by coincidence. This
change removes the coincidence instead of re-verifying it, which is the difference between fixing
the comparison and fixing this instance of it.

The pre-registration branch is a fail-closed assertion, not a live face. The serve identity field
is declared with a definite-assignment assertion, and reading it honestly means handling the
window the declaration papers over. On today's ordering it cannot fire: `start()` assigns the
identity before it connects anything, and a retirement needs an agent only a started manager can
hold. It is there because the alternative is carrying `undefined` into the caller triple and
surfacing the result as "the rail could not be reached", which names the wrong cause.

## Why nothing caught it

Two independent gaps, both closed here.

`auth-admin.smoke.ts` spent ONE friendly literal on both sides of the comparison it asserts: the
gate row was written with `principal: MGR_KEY` and the request was sent with `caller: MGR`, both
from the same object. A cross-check asserted against an equality the fixture itself wrote cannot
fail. It now models what a manager actually is: two real identities, the registered one and the
endpoint one, each side of the comparison derived through the expression production uses on that
side, from a different input.

`user-spawn.smoke.ts` drove a real despawn through the real manager against the real rail and
asserted nothing about the outcome, so the refusal was invisible.

## What is proved, and how

The end-to-end cell reads STATE, never the despawn's log copy. It asserts the two durable facts
the retirement barrier writes before anything else, both of which a request refused at the
cross-check never reaches: the auth rail's operation intent row exists for the stopped
incarnation, and that incarnation's own issuance gate has moved to `frozen` under exactly the
derived opId. The freeze is the load-bearing half: an intent row alone would prove only that
something was recorded, while the freeze proves the retirement began acting on the lifecycle.

The state is read with a `lifecycle-executor` credential, minted by the test harness from the
space signing key and pinned to the stopped incarnation, because that is the one profile
documented as able to read another principal's auth-store rows. No production grant was widened to
make the cell possible. One precision about that profile, since the cell depends on it: its
lifecycle pin confines WRITES, not reads, so it should not be described as a least-authority
read-only credential in isolation. It carries lifecycle write authority for the incarnation it
names, and this cell exercises only its reads.

Two experiments were deliberately not run. Asserting the terminal (the name released for reuse)
would put an absent oracle in the path of a cell about a principal comparison: the barrier's final
step needs `verifiedGone` from a delivery daemon this fixture does not run, so a red would not
have meant what it said. Asserting that the refusal string is gone is satisfied by a fix that only
rewrites the wording, and measured on the broken tree the two outcomes genuinely differ, because
with the cross-check fixed the requests still fail further down.

Mutation, registered before the run: reverting the caller derivation to the endpoint identity,
verbatim as it shipped. KILLED on the named cell, 88 progress marks against a baseline of 90, so
exactly the two new cells reddened and nothing else. The mutation config builds the manager
package before the run and rebuilds it after the restore, because the suite loads the manager from
`dist` and would otherwise never see the mutant, and the tree would otherwise keep a `dist` built
from it.

The foreign-caller property was re-proved at this tip rather than inherited: a requester credential
cannot publish as a foreign caller triple or re-aim at a different incarnation (both broker-denied,
with a positive control), and a caller naming a foreign principal's serve registration is still
refused by the cross-check, with its inverse control. The new divergence cell carries its own
inverse control on the same target and the same registration.

The class has an independent occupant, found by a different lane's harness in a different suite
while this fix was in review, which reported the identical refusal verbatim: the serve registration
named for a manager belongs to one principal and not to the requesting one. That matters here
because the fixture this repository already had built the equality it asserted, so a reasonable
reader could ask whether the defect was an artifact of how the suite was written. A second,
independently constructed occurrence answers that: the comparison is unsatisfiable in the code, not
in one test's setup.

## Scope note

This cell proves the retirement is authorized and begins acting. It deliberately does not prove
the terminal, which needs a delivery daemon in the fixture and is its own change. Two downstream
faces become observable only once the cross-check stops refusing everything, and both are filed
separately rather than pulled in here.

Closes #549


