### PR TITLE
fix(core): let a caller hear its own goal's terminal, and say so when it cannot

### DIFF
--- a/.changeset/goal-follow-denied-subscription.md
+++ b/.changeset/goal-follow-denied-subscription.md
@@ -11,3 +11,9 @@ already settled. Both branches now fold `sub` in. Independently, a subscription 
 path was discarded, which made a denied subscription indistinguishable from an empty one; it now
 surfaces at once as a distinct refusal naming the subject, stating the goal is unaffected, and
 telling the operator not to retry.
+
+Every subscription error is surfaced, not only the permission one: whether the subscription failed
+is knowable from the error being present, so narrowing that decision by error class would return
+every other class to the silent timeout. What does key on the class is the diagnosis. A broker
+refusal reports `permission-denied` and asks for the grant row; any other failure reports
+`unavailable`, names the class, and says plainly that changing ACLs is the wrong remedy.

--- a/.changeset/goal-follow-denied-subscription.md
+++ b/.changeset/goal-follow-denied-subscription.md
@@ -1,0 +1,13 @@
+---
+"@cotal-ai/core": minor
+---
+
+Let a caller hear its own goal's terminal, and say so distinctly when it cannot. `epCallerGrantRows`
+returns `{pub, sub}` and documents its `sub` as the per-goal progress row that lets a caller follow
+its own goal to terminal, but the `spawn` and `admin` mint branches took `.pub` alone, so a
+spawn-capable credential could submit a goal and not hear it: the broker refused the follow, the
+manager committed the terminal on time, and the caller reported a timeout about a goal that had
+already settled. Both branches now fold `sub` in. Independently, a subscription error in the follow
+path was discarded, which made a denied subscription indistinguishable from an empty one; it now
+surfaces at once as a distinct refusal naming the subject, stating the goal is unaffected, and
+telling the operator not to retry.

--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -335,3 +335,4 @@ smoke:agui-opencode-map
 smoke:agui-opencode-source
 smoke:opencode-events-arm
 smoke:opencode-events-reset
+smoke:goal-follow

--- a/bin/smoke/goal-follow.smoke.ts
+++ b/bin/smoke/goal-follow.smoke.ts
@@ -1,0 +1,78 @@
+/**
+ * The goal-follow subscription contract (#610): a caller that is REFUSED its per-goal progress
+ * subscription must be told so, distinctly, and must never be handed a timeout.
+ *
+ * WHY A HAND-BUILT CELL, STATED RATHER THAN LEFT TO A READER. This drives
+ * {@link submitAndFollowGoal} against a stub connection whose subscribe answers with an error,
+ * because the failure it grades cannot be minted through the public API any more: since the
+ * companion fix in `provision.ts`, a spawn-capable credential CARRIES the progress row, so the
+ * denial this cell needs is no longer reachable from a real credential. That is the right outcome
+ * for the product and it leaves this branch testable only by construction. It therefore proves the
+ * BRANCH, not that a real door reaches it; `smoke:user-spawn:live` carries the end-to-end half
+ * (a spawn-scope caller following its own goal to terminal over a real authed mesh).
+ *
+ * The distinction matters because the two failures want opposite responses from an operator: a
+ * timeout invites a retry, and a retry submits a second goal and duplicates the effect (#605
+ * records one duplicate created exactly that way). A denial wants a grant.
+ *
+ * Run: pnpm smoke:goal-follow
+ */
+import { submitAndFollowGoal } from "@cotal-ai/core";
+
+let pass = 0;
+const ok = (name: string, cond: boolean, extra?: unknown) => {
+  if (!cond) throw new Error(`FAIL: ${name}${extra !== undefined ? ` - ${JSON.stringify(extra)}` : ""}`);
+  pass++;
+  console.log(`  ✓ ${name}`);
+};
+
+const CALLER = { owner: "u_probe", actor: "cli", uid: "0123456789abcdefghijklmnopqrst" };
+const GOAL = "goal-follow-probe";
+const DENIAL = 'permission denied: cannot subscription "cotal.s.epe.manager.*.*.goal.u_probe.cli.0123456789abcdefghijklmnopqrst.>"';
+
+/** A connection whose subscribe is REFUSED: the callback is handed an error and no message ever
+ *  arrives, which is exactly what a broker-denied subscription looks like from inside the client. */
+const deniedConn = {
+  subscribe: (_subject: string, opts: { callback: (err: Error | null, m: unknown) => void }) => {
+    queueMicrotask(() => opts.callback(new Error(DENIAL), undefined));
+    return { unsubscribe: () => {} };
+  },
+};
+
+/** A connection whose subscribe succeeds and never delivers: the ordinary "no terminal yet" case,
+ *  which must keep reporting a DEADLINE and must not be reworded by this change. */
+const silentConn = {
+  subscribe: (_subject: string, _opts: { callback: (err: Error | null, m: unknown) => void }) => ({ unsubscribe: () => {} }),
+};
+
+const acceptance = () => Promise.resolve({
+  reply: { ok: true as const, data: { goalId: GOAL } },
+  instanceId: "i1",
+  epoch: 0,
+});
+
+console.log("A. a REFUSED progress subscription is reported as a refusal, not as a timeout");
+{
+  const t0 = Date.now();
+  const r = await submitAndFollowGoal(deniedConn as never, "s", "manager", CALLER, 20_000, acceptance as never);
+  const elapsed = Date.now() - t0;
+  const msg = r.reply.error?.message ?? "";
+  // THE ASSERTION THIS FIX EXISTS FOR. Before it, the denial was discarded at the callback
+  // (`if (err) return;`) and this call sat until its deadline and then blamed the goal.
+  ok("the reply is a refusal, not a deadline", r.reply.error?.code === "permission-denied", r.reply.error);
+  ok("...naming the denied subscription so the remedy is findable", msg.includes("per-goal progress subscription"), msg);
+  ok("...stating the goal is unaffected rather than failed", msg.includes("THE GOAL IS UNAFFECTED"), msg);
+  ok("...and telling the operator NOT to retry (a retry duplicates the effect)", msg.includes("Do NOT retry"), msg);
+  // A denial is knowable the moment it arrives, so the caller must not be held to its deadline:
+  // 20s budget, and this has to come back immediately.
+  ok(`...returned at once rather than after the deadline (${elapsed}ms of 20000ms)`, elapsed < 5_000, elapsed);
+}
+
+console.log("B. an ordinary silent wait still reports a DEADLINE (the change is narrow)");
+{
+  const r = await submitAndFollowGoal(silentConn as never, "s", "manager", CALLER, 300, acceptance as never);
+  ok("a subscribed-but-silent follow still times out", r.reply.error?.code === "deadline-exceeded", r.reply.error);
+  ok("...and still says the timeout is about the WAIT, not the work", (r.reply.error?.message ?? "").includes("timeout on the WAIT"), r.reply.error?.message);
+}
+
+console.log(`\ngoal-follow smoke passed (${pass} checks)`);

--- a/bin/smoke/goal-follow.smoke.ts
+++ b/bin/smoke/goal-follow.smoke.ts
@@ -18,6 +18,7 @@
  * Run: pnpm smoke:goal-follow
  */
 import { submitAndFollowGoal } from "@cotal-ai/core";
+import { PermissionViolationError } from "@nats-io/transport-node";
 
 let pass = 0;
 const ok = (name: string, cond: boolean, extra?: unknown) => {
@@ -34,10 +35,32 @@ const DENIAL = 'permission denied: cannot subscription "cotal.s.epe.manager.*.*.
  *  arrives, which is exactly what a broker-denied subscription looks like from inside the client. */
 const deniedConn = {
   subscribe: (_subject: string, opts: { callback: (err: Error | null, m: unknown) => void }) => {
-    queueMicrotask(() => opts.callback(new Error(DENIAL), undefined));
+    // The REAL class the client delivers here, not a stand-in Error. The reply's diagnosis now keys
+    // on it, so a fixture carrying a plain Error would assert the branch while quietly assuming the
+    // shape, and would keep passing if the client ever stopped delivering this class.
+    queueMicrotask(() => opts.callback(new PermissionViolationError(DENIAL), undefined));
     return { unsubscribe: () => {} };
   },
 };
+
+/** A connection whose subscribe fails for a reason that is NOT a grant refusal. The subscription is
+ *  just as dead, so this must be just as loud, but the cause and the remedy differ and the reply
+ *  must not claim the broker refused a grant. */
+const brokenConn = {
+  subscribe: (_subject: string, opts: { callback: (err: Error | null, m: unknown) => void }) => {
+    queueMicrotask(() => opts.callback(new Error("connection closed while subscribing"), undefined));
+    return { unsubscribe: () => {} };
+  },
+};
+
+/** Acceptance REFUSED at submit, paired with a connection already denied: the ordering question.
+ *  The refusal must survive unchanged, because a subscription denial says nothing about a goal that
+ *  was never accepted, and claiming acceptance there would strand a goal that never ran. */
+const refuseAtAccept = () => Promise.resolve({
+  reply: { ok: false as const, data: undefined, error: { code: "failed-precondition", message: "refused at accept" } },
+  instanceId: "i1",
+  epoch: 0,
+});
 
 /** A connection whose subscribe succeeds and never delivers: the ordinary "no terminal yet" case,
  *  which must keep reporting a DEADLINE and must not be reworded by this change. */
@@ -73,6 +96,32 @@ console.log("B. an ordinary silent wait still reports a DEADLINE (the change is 
   const r = await submitAndFollowGoal(silentConn as never, "s", "manager", CALLER, 300, acceptance as never);
   ok("a subscribed-but-silent follow still times out", r.reply.error?.code === "deadline-exceeded", r.reply.error);
   ok("...and still says the timeout is about the WAIT, not the work", (r.reply.error?.message ?? "").includes("timeout on the WAIT"), r.reply.error?.message);
+}
+
+console.log("C. a NON-permission subscription failure is just as loud, with a truthful cause");
+{
+  const t0 = Date.now();
+  const r = await submitAndFollowGoal(brokenConn as never, "s", "manager", CALLER, 20_000, acceptance as never);
+  const elapsed = Date.now() - t0;
+  const msg = r.reply.error?.message ?? "";
+  // The SURFACE must not narrow with the diagnosis: if only the permission class were surfaced,
+  // every other class would fall back through to the deadline, which is this defect again in
+  // miniature.
+  ok("a non-permission subscription failure is NOT swallowed into a deadline", r.reply.error?.code !== "deadline-exceeded", r.reply.error);
+  ok("...and is not mislabelled a grant refusal", r.reply.error?.code === "unavailable", r.reply.error);
+  ok("...says plainly that ACLs are the wrong remedy", msg.includes("NOT a grant refusal"), msg);
+  ok("...still states the goal is unaffected and forbids the retry", msg.includes("THE GOAL IS UNAFFECTED") && msg.includes("Do NOT retry"), msg);
+  ok(`...and is knowable at once, like the denial (${elapsed}ms of 20000ms)`, elapsed < 5_000, elapsed);
+}
+
+console.log("D. a subscription denial NEVER manufactures an acceptance (the pre-accept ordering)");
+{
+  // The refusal text asserts "the goal was accepted" and says not to retry. If that branch were
+  // reachable when submit had NOT been accepted, the same sentence would strand a goal that never
+  // ran. The denial here is already pending before submit answers.
+  const r = await submitAndFollowGoal(deniedConn as never, "s", "manager", CALLER, 20_000, refuseAtAccept as never);
+  ok("a refusal at accept survives the pending subscription denial unchanged", r.reply.error?.code === "failed-precondition", r.reply.error);
+  ok("...and no acceptance is claimed for a goal that was never accepted", !(r.reply.error?.message ?? "").includes("was accepted"), r.reply.error?.message);
 }
 
 console.log(`\ngoal-follow smoke passed (${pass} checks)`);

--- a/bin/smoke/goal-follow.smoke.ts
+++ b/bin/smoke/goal-follow.smoke.ts
@@ -29,7 +29,8 @@ const ok = (name: string, cond: boolean, extra?: unknown) => {
 
 const CALLER = { owner: "u_probe", actor: "cli", uid: "0123456789abcdefghijklmnopqrst" };
 const GOAL = "goal-follow-probe";
-const DENIAL = 'permission denied: cannot subscription "cotal.s.epe.manager.*.*.goal.u_probe.cli.0123456789abcdefghijklmnopqrst.>"';
+const SUBJECT = "cotal.s.epe.manager.*.*.goal.u_probe.cli.0123456789abcdefghijklmnopqrst.>";
+const DENIAL = `permission denied: cannot subscription "${SUBJECT}"`;
 
 /** A connection whose subscribe is REFUSED: the callback is handed an error and no message ever
  *  arrives, which is exactly what a broker-denied subscription looks like from inside the client. */
@@ -38,7 +39,7 @@ const deniedConn = {
     // The REAL class the client delivers here, not a stand-in Error. The reply's diagnosis now keys
     // on it, so a fixture carrying a plain Error would assert the branch while quietly assuming the
     // shape, and would keep passing if the client ever stopped delivering this class.
-    queueMicrotask(() => opts.callback(new PermissionViolationError(DENIAL), undefined));
+    queueMicrotask(() => opts.callback(new PermissionViolationError(DENIAL, "subscription", SUBJECT), undefined));
     return { unsubscribe: () => {} };
   },
 };

--- a/bin/smoke/mutations/goal-follow-subscription.json
+++ b/bin/smoke/mutations/goal-follow-subscription.json
@@ -31,11 +31,11 @@
     {
       "name": "the subscription error is discarded again, so a denied caller is handed a timeout",
       "file": "packages/core/src/endpoint-invoke.ts",
-      "find": "      if (err) {\n        // Keep the FIRST error (later ones are consequences) and wake every waiter: once this\n        // subscription is refused, no further waiting can change the answer.\n        subError ??= err instanceof Error ? err : new Error(String(err));\n        for (const wake of waiters.values()) wake();\n        return;\n      }",
-      "replace": "      if (err) return;",
+      "find": "        subError ??= err instanceof Error ? err : new Error(String(err));\n        for (const wake of waiters.values()) wake();\n        return;",
+      "replace": "        return;",
       "expectRed": "the reply is a refusal, not a deadline",
       "cell": "the reply is a refusal, not a deadline",
-      "note": "The defect exactly as shipped, in one line. A denied subscription becomes indistinguishable from an empty one, and the caller blames the goal for a terminal that was committed on time. The broker's own wording for this is that a denied peer looks absent; this line is what made the client believe it.",
+      "note": "The defect exactly as shipped: the error is discarded and a denied subscription becomes indistinguishable from an empty one, so the caller blames the goal for a terminal that was committed on time. The broker's own wording for this is that a denied peer looks absent; discarding the error is what made the client believe it. Anchored on the three code lines rather than on the `if (err) {` line above them, because the comment between the two is prose a tidying commit could move, and a guard that a docs change can disarm is not a guard.",
       "afterRestore": "pnpm --filter @cotal-ai/core build"
     },
     {

--- a/bin/smoke/mutations/goal-follow-subscription.json
+++ b/bin/smoke/mutations/goal-follow-subscription.json
@@ -1,0 +1,54 @@
+{
+  "suite": "bin/smoke/goal-follow.smoke.ts + implementations/auth/smoke/user-spawn.smoke.ts (cell B1f)",
+  "guard": "a caller can hear its own goal's terminal, and when it genuinely cannot it is told so distinctly instead of being handed a timeout",
+  "command": "pnpm --filter @cotal-ai/core build && pnpm smoke:goal-follow",
+  "completionMarker": "A. a REFUSED progress subscription is reported as a refusal, not as a timeout",
+  "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/goal-follow-subscription.json",
+  "why": [
+    "TWO HALVES OF ONE DEFECT, AND EITHER ALONE LEAVES IT HALF ALIVE. The fold is the repair for",
+    "this illegitimate absence; the surfacing fix is the safety net for every FUTURE legitimately",
+    "absent grant. A mutation per half, each aimed at the assertion its half exists for.",
+    "",
+    "THE LIVE OCCUPANT, so neither is hypothetical. Measured on an authed mesh: the manager bound",
+    "the goal, earned ownership, committed a terminal and emitted it, while the caller sat with a",
+    "broker-refused subscription and then printed a timeout. #605 records a duplicate agent created",
+    "by an operator who read exactly that timeout as failure and re-issued.",
+    "",
+    "WHY MUTATION 1 IS AIMED AT A HAND-BUILT CELL, and what that does and does not prove. Since the",
+    "fold landed, a spawn-capable credential CARRIES the progress row, so a real credential can no",
+    "longer produce the denial this branch handles. The cell therefore builds the refusal by hand and",
+    "proves the BRANCH. Mutation 2 is the pair: it is aimed end to end at a real authed spawn over a",
+    "real broker, which is what shows a production door reaches the follow path at all.",
+    "",
+    "BUILD FIRST, REBUILD ON RESTORE: both suites read `@cotal-ai/core` through `dist/`, so a mutation",
+    "on `src` is invisible without a build, and `dist/` is gitignored so git cannot be the recovery.",
+    "",
+    "THE COMPLETION MARKER IS A LINE PRINTED BEFORE THE ASSERTION, not the suite summary: both suites",
+    "throw on their first failed assertion, so a mutant run can never reach a final line, and keying",
+    "the gate there reports a real kill as INCONCLUSIVE (measured on this lane's previous config)."
+  ],
+  "mutations": [
+    {
+      "name": "the subscription error is discarded again, so a denied caller is handed a timeout",
+      "file": "packages/core/src/endpoint-invoke.ts",
+      "find": "      if (err) {\n        // Keep the FIRST error (later ones are consequences) and wake every waiter: once this\n        // subscription is refused, no further waiting can change the answer.\n        subError ??= err instanceof Error ? err : new Error(String(err));\n        for (const wake of waiters.values()) wake();\n        return;\n      }",
+      "replace": "      if (err) return;",
+      "expectRed": "the reply is a refusal, not a deadline",
+      "cell": "the reply is a refusal, not a deadline",
+      "note": "The defect exactly as shipped, in one line. A denied subscription becomes indistinguishable from an empty one, and the caller blames the goal for a terminal that was committed on time. The broker's own wording for this is that a denied peer looks absent; this line is what made the client believe it.",
+      "afterRestore": "pnpm --filter @cotal-ai/core build"
+    },
+    {
+      "name": "the spawn mint branch drops the `sub` half again, so a spawn-capable credential may submit a goal it cannot hear",
+      "file": "packages/core/src/provision.ts",
+      "find": "  if (opts.capabilities?.includes(\"spawn\")) {\n    const rows = epCallerGrantRows(space, spawnCallerCapabilities(pr.owner), epCaller);\n    pubAllow.push(...rows.pub);\n    for (const s of rows.sub) if (!epSub.includes(s)) epSub.push(s);\n  }",
+      "replace": "  if (opts.capabilities?.includes(\"spawn\"))\n    pubAllow.push(...epCallerGrantRows(space, spawnCallerCapabilities(pr.owner), epCaller).pub);",
+      "expectRed": "a spawn-scope caller HEARS its own goal's terminal",
+      "cell": "a spawn-scope caller HEARS its own goal's terminal (not a deadline, not a denied subscription)",
+      "note": "The shipped shape: `.pub` taken, `.sub` discarded, one property access short of the credential. Aimed END TO END at a real authed spawn, which is what shows a production door reaches this. Under the mutation the caller is refused its follow and now reports the DISTINCT refusal rather than a timeout, because mutation 1's fix is still in place: the two halves are visible separately, which is the point of grading them separately.",
+      "command": "pnpm --filter @cotal-ai/core build && pnpm smoke:user-spawn:live",
+      "completionMarker": "B1f) a spawn-scope caller follows its own goal to a terminal",
+      "afterRestore": "pnpm --filter @cotal-ai/core build"
+    }
+  ]
+}

--- a/bin/smoke/mutations/goal-follow-subscription.json
+++ b/bin/smoke/mutations/goal-follow-subscription.json
@@ -66,6 +66,42 @@
       "command": "pnpm --filter @cotal-ai/core build && pnpm smoke:user-spawn:live",
       "completionMarker": "D1) an admin-scope caller follows its own goal to a terminal",
       "afterRestore": "pnpm --filter @cotal-ai/core build"
+    },
+    {
+      "name": "the short-circuit is removed, so a knowable denial is still waited out to the deadline",
+      "file": "packages/core/src/endpoint-invoke.ts",
+      "find": "    const terminal = terminals.get(goalId) ?? (subError !== undefined ? undefined : await new Promise<{ state: string; data?: unknown } | undefined>((resolve) => {",
+      "replace": "    const terminal = terminals.get(goalId) ?? (await new Promise<{ state: string; data?: unknown } | undefined>((resolve) => {",
+      "expectRed": "returned at once rather than after the deadline",
+      "cell": "...returned at once rather than after the deadline",
+      "note": "The half of this fix that a correct MESSAGE hides. The first version of the fix produced exactly the right refusal text and still consumed 20004ms of a 20000ms budget, because the error arrived before the waiter was registered and nothing checked for it beforehand. Without this mutation the timing assertion, which is the one that caught that, is itself ungraded: a guard nobody has proven guards.",
+      "command": "pnpm --filter @cotal-ai/core build && pnpm smoke:goal-follow",
+      "completionMarker": "A. a REFUSED progress subscription is reported as a refusal, not as a timeout",
+      "afterRestore": "pnpm --filter @cotal-ai/core build"
+    },
+    {
+      "name": "the diagnosis stops discriminating, so a transport failure is reported as a grant refusal",
+      "file": "packages/core/src/endpoint-invoke.ts",
+      "find": "      const refused = subError instanceof PermissionViolationError;",
+      "replace": "      const refused = true;",
+      "expectRed": "is not mislabelled a grant refusal",
+      "cell": "...and is not mislabelled a grant refusal",
+      "note": "A confidently wrong remedy is worse than a vague one: this mutation makes a closed connection report that the BROKER REFUSED A GRANT and that the fix is to grant a row, which sends an operator to the ACLs for a fault that is not there. Measured on the real class before the narrowing landed: a genuine transport error was labelled permission-denied.",
+      "command": "pnpm --filter @cotal-ai/core build && pnpm smoke:goal-follow",
+      "completionMarker": "C. a NON-permission subscription failure is just as loud, with a truthful cause",
+      "afterRestore": "pnpm --filter @cotal-ai/core build"
+    },
+    {
+      "name": "the SURFACE narrows to the permission class, so every other subscription error becomes a timeout again",
+      "file": "packages/core/src/endpoint-invoke.ts",
+      "find": "        subError ??= err instanceof Error ? err : new Error(String(err));",
+      "replace": "        if (!(err instanceof PermissionViolationError)) return;\n        subError ??= err;",
+      "expectRed": "a non-permission subscription failure is NOT swallowed into a deadline",
+      "cell": "a non-permission subscription failure is NOT swallowed into a deadline",
+      "note": "THE TEMPTING WRONG FIX, graded so it cannot be made quietly. Narrowing the surface rather than the diagnosis looks like precision and is this whole defect again in miniature: a non-permission subscription error stops being surfaced, falls through to the wait, and is reported as a deadline about a goal that may have settled on time. Whether the subscription failed is knowable from `err` being present; only the CAUSE and the REMEDY may key on its class.",
+      "command": "pnpm --filter @cotal-ai/core build && pnpm smoke:goal-follow",
+      "completionMarker": "C. a NON-permission subscription failure is just as loud, with a truthful cause",
+      "afterRestore": "pnpm --filter @cotal-ai/core build"
     }
   ]
 }

--- a/bin/smoke/mutations/goal-follow-subscription.json
+++ b/bin/smoke/mutations/goal-follow-subscription.json
@@ -25,7 +25,12 @@
     "",
     "THE COMPLETION MARKER IS A LINE PRINTED BEFORE THE ASSERTION, not the suite summary: both suites",
     "throw on their first failed assertion, so a mutant run can never reach a final line, and keying",
-    "the gate there reports a real kill as INCONCLUSIVE (measured on this lane's previous config)."
+    "the gate there reports a real kill as INCONCLUSIVE (measured on this lane's previous config).",
+    "",
+    "BOTH FOLD BRANCHES ARE GRADED, because only one of them used to be. `permissionsFor` folds the",
+    "row on `spawn` AND on `admin`, and every cell that followed a goal was minted with `spawn`, so a",
+    "revert of the admin branch alone was invisible. Mutation 3 is aimed at cell D1, which mints an",
+    "admin-scope caller carrying no `spawn` at all."
   ],
   "mutations": [
     {
@@ -48,6 +53,18 @@
       "note": "The shipped shape: `.pub` taken, `.sub` discarded, one property access short of the credential. Aimed END TO END at a real authed spawn, which is what shows a production door reaches this. Under the mutation the caller is refused its follow and now reports the DISTINCT refusal rather than a timeout, because mutation 1's fix is still in place: the two halves are visible separately, which is the point of grading them separately.",
       "command": "pnpm --filter @cotal-ai/core build && pnpm smoke:user-spawn:live",
       "completionMarker": "B1f) a spawn-scope caller follows its own goal to a terminal",
+      "afterRestore": "pnpm --filter @cotal-ai/core build"
+    },
+    {
+      "name": "the admin mint branch drops the `sub` half, so an admin-capable credential may submit a goal it cannot hear",
+      "file": "packages/core/src/provision.ts",
+      "find": "      const rows = epCallerGrantRows(space, operatorInstrumentCapabilities(\"admin\", pr.owner), epCaller);\n      pubAllow.push(...rows.pub);\n      for (const s of rows.sub) if (!epSub.includes(s)) epSub.push(s);",
+      "replace": "      pubAllow.push(...epCallerGrantRows(space, operatorInstrumentCapabilities(\"admin\", pr.owner), epCaller).pub);",
+      "expectRed": "an admin-scope caller HEARS its own goal's terminal",
+      "cell": "an admin-scope caller HEARS its own goal's terminal (the admin mint branch folds the progress row too)",
+      "note": "The SECOND branch that folds the row. Until cell D1 existed this mutation SURVIVED: every cell that followed a goal was minted with `spawn`, which supplies the same row, so reverting the admin branch alone reddened nothing. D1 mints an admin-scope caller with no `spawn` in its ledger row, which is a real ledger shape, and follows a goal-bearing command to its terminal. Measured on the unmutated tree: the terminal arrives at 3915ms of a 20000ms budget with no broker refusal on the connection.",
+      "command": "pnpm --filter @cotal-ai/core build && pnpm smoke:user-spawn:live",
+      "completionMarker": "D1) an admin-scope caller follows its own goal to a terminal",
       "afterRestore": "pnpm --filter @cotal-ai/core build"
     }
   ]

--- a/implementations/auth/smoke/user-spawn.smoke.ts
+++ b/implementations/auth/smoke/user-spawn.smoke.ts
@@ -720,6 +720,32 @@ try {
   const adminInput = await epTargeted(auditor, "input", "alpha");
   check("cross-owner seat input with ledger admin passes, and reports the bytes it wrote",
     adminInput.ok === true && (adminInput.data as { bytes?: number })?.bytes === 8, adminInput);
+  // ---------- D1. an ADMIN-scope caller HEARS ITS OWN GOAL'S TERMINAL (#610, the admin fold) ----------
+  // `permissionsFor` folds the per-goal progress row on TWO branches, `spawn` and `admin`, and B1f
+  // covers only the first. Every other cell that follows a goal is minted with `spawn`, which
+  // supplies the same row, so reverting the admin branch alone left the whole suite green. This is
+  // the assertion that branch is missing: an admin-scope caller with NO `spawn` in its ledger row
+  // submits a goal-bearing command and hears its terminal, rather than being refused the follow.
+  console.log("D1) an admin-scope caller follows its own goal to a terminal (#610)");
+  {
+    const adminFollower = await ctlCaller("adminfollower", OWNER_B, ["admin"]);
+    const followErrors: string[] = [];
+    adminFollower.on("error", (e: unknown) => followErrors.push((e as Error)?.message ?? String(e)));
+    const t0 = Date.now();
+    const r = await adminFollower.invokeService("manager", "spawn", { name: "beta", agent: "e2e" }, { deadlineMs: 20_000, follow: true });
+    const elapsed = Date.now() - t0;
+    const code = r.reply.ok === true ? "ok" : (r.reply.error?.code ?? "?");
+    console.log(`   [D1 observed] code=${code} elapsed=${elapsed} msg=${(r.reply.error?.message ?? "").slice(0, 140)} errs=${JSON.stringify(followErrors)}`);
+    check("an admin-scope caller HEARS its own goal's terminal (the admin mint branch folds the progress row too)",
+      code === "ok" || code === "failed", { code, elapsed, message: r.reply.error?.message?.slice(0, 160), followErrors });
+    check(`...on the goal's own timing, not at the caller's budget (${elapsed}ms of 20000ms)`, elapsed < 15_000, elapsed);
+    check("...with no broker refusal on the admin follower's connection", followErrors.length === 0, followErrors);
+    if (r.reply.ok === true) {
+      const spawned = (r.reply.data as { name?: string })?.name ?? "beta";
+      await adminFollower.invokeService("manager", "despawn", { name: spawned, owner: OWNER_B }).catch(() => undefined);
+    }
+  }
+
   // Narrow the auditor back to [spawn] (upsert) — its NEXT exchange mints owner-mode-only rows, so a
   // cross-owner op loses the any-mode reach (the callout re-reads the ledger per exchange).
   await cotalAuthProvider.grantAgent({ store, dir, space: SPACE, owner: OWNER_B, actor: "auditor", scope: ["spawn"], allowSubscribe: [], allowPublish: [], lifecycleUid: mintLifecycleUid() });

--- a/implementations/auth/smoke/user-spawn.smoke.ts
+++ b/implementations/auth/smoke/user-spawn.smoke.ts
@@ -399,6 +399,46 @@ try {
   const listed = manager.list().find((a) => a.name === "alpha");
   check("manager ps lists alpha under its principal id, mesh live", listed?.id === alphaPrincipal && listed?.mesh !== "absent", listed);
 
+  // ---------- B1f. a spawn-scope caller HEARS ITS OWN GOAL'S TERMINAL (#610) ----------
+  // The end-to-end half of the goal-follow contract. `epCallerGrantRows` returns `{pub, sub}` and
+  // documents its `sub` as the row that lets "the caller may follow its OWN goal to terminal", but
+  // the `spawn` mint branch took `.pub` alone, so a spawn-capable credential could SUBMIT a goal
+  // and not HEAR it: the broker refused the follow, the manager committed the terminal on time, and
+  // the caller reported a timeout about a goal that had already settled. An operator reads that as
+  // failure and re-issues, which mints a duplicate.
+  //
+  // The spawn under test is REFUSED by design (persona `beta` carries `role: worker`, which the cli
+  // actor's `[spawn]` scope may not delegate), so the manager commits a `failed` terminal promptly
+  // and no child is created. What is asserted is not the refusal - it is that this caller HEARS it.
+  console.log("B1f) a spawn-scope caller follows its own goal to a terminal (#610)");
+  {
+    const claims = JSON.parse(Buffer.from(opCreds.bearer.split(".")[1], "base64url").toString("utf8")) as { act: { lifecycleUid: string } };
+    const follower = new CotalEndpoint({
+      space: SPACE, servers: SERVER, bearer: opCreds.bearer, sentinelCreds: opCreds.sentinelCreds,
+      lifecycleUid: claims.act.lifecycleUid,
+      channels: [], consume: false, registerPresence: false, watchPresence: false,
+      card: { name: "goal-follower", kind: "endpoint" },
+    });
+    // Surface rather than swallow: a broker refusal on this connection is the defect itself, and a
+    // swallowed one is indistinguishable from silence (the product had the same bug).
+    const connErrors: string[] = [];
+    follower.on("error", (e: unknown) => connErrors.push((e as Error)?.message ?? String(e)));
+    await follower.start();
+    ctlEps.push(follower);
+    const t0 = Date.now();
+    const r = await follower.invokeService("manager", "spawn", { name: "beta", agent: "e2e" }, { deadlineMs: 20_000, follow: true });
+    const elapsed = Date.now() - t0;
+    const code = r.reply.ok === true ? "ok" : (r.reply.error?.code ?? "?");
+    // THE ASSERTION THE FIX EXISTS FOR: a real terminal, not a deadline and not a refusal to listen.
+    check("a spawn-scope caller HEARS its own goal's terminal (not a deadline, not a denied subscription)",
+      code === "failed", { code, elapsed, message: r.reply.error?.message?.slice(0, 160), connErrors });
+    check("...and the terminal carries the refusal's own reason, so the caller learns WHY",
+      (r.reply.error?.message ?? "").includes("would exceed its spawner's grant"), r.reply.error?.message?.slice(0, 200));
+    check(`...delivered on the goal's own timing, well inside the caller's budget (${elapsed}ms of 20000ms)`,
+      elapsed < 15_000, elapsed);
+    check("...with no broker refusal on the follower's connection", connErrors.length === 0, connErrors);
+  }
+
   // ---------- B1e. the v0.4 ep rails under a USER bearer (1c.2c) ----------
   // The manager REGISTERS its service on this user mesh (the mode-neutral 1c.2c flip), the cli
   // actor's callout-minted rows carry the spawn set + baseline, and the bearer's ledger lifecycle

--- a/package.json
+++ b/package.json
@@ -353,6 +353,7 @@
     "smoke:launch-parity": "tsx bin/smoke/launch-parity.smoke.ts",
     "smoke:broker-disclosure": "tsx bin/smoke/broker-disclosure.smoke.ts",
     "smoke:spawn-detach:live": "tsx bin/smoke/spawn-detach-live.smoke.ts",
+    "smoke:goal-follow": "tsx bin/smoke/goal-follow.smoke.ts",
     "smoke:readiness:live": "tsx bin/smoke/readiness-window-live.smoke.ts",
     "smoke:setup-pure:live": "pnpm --filter @cotal-ai/workspace... build && tsx bin/smoke/setup-pure-live.smoke.ts",
     "smoke:up-stack:live": "tsx bin/smoke/up-stack-live.smoke.ts",

--- a/packages/core/src/endpoint-invoke.ts
+++ b/packages/core/src/endpoint-invoke.ts
@@ -476,11 +476,23 @@ export async function submitAndFollowGoal(
       const t = setTimeout(() => resolve(terminals.get(goalId)), deadlineMs);
       waiters.set(goalId, () => { clearTimeout(t); resolve(terminals.get(goalId)); });
     }));
-    if (terminal === undefined && subError !== undefined)
+    if (terminal === undefined && subError !== undefined) {
       // THE DISTINCT, ACTIONABLE FAILURE (#610). Deliberately NOT the deadline message below: this
       // caller was never listening, so "no terminal arrived" would be a statement about the goal
-      // when the true statement is about this credential. The remedy is a grant, never a retry.
-      return { ...attributed, reply: { ...attributed.reply, ok: false, data: undefined, error: { code: "permission-denied", message: `the goal "${goalId}" was accepted, but this caller is NOT PERMITTED to hear its outcome: the broker refused the per-goal progress subscription "${progressSubject}" (${subError.message}). THE GOAL IS UNAFFECTED - it may already have succeeded, and its terminal may have been committed on time; what failed is this credential's ability to observe it. Do NOT retry: a retry submits a second goal and duplicates the effect, and it will be just as unobservable. Read the outcome with 'ps'/'inspect', and grant this caller the per-goal progress read row so a following call can hear its own goal (SPEC 13.6)` } } };
+      // when the true statement is about this credential.
+      //
+      // SURFACING IS FOR EVERY ERROR; ONLY THE DIAGNOSIS IS NARROWED. Whether the subscription
+      // failed is knowable from `err` being present, so that decision must never key on the error's
+      // class: narrowing the SURFACE would re-create this very defect for every other class, which
+      // would fall back through to the silent timeout. What may key on the class is the CAUSE and
+      // the REMEDY, because "the broker refused your grant, ask for the row" is a specific claim
+      // and it is false for a transport failure. So an unrecognized class stays loud and says less,
+      // and never degrades to silence.
+      const refused = subError instanceof PermissionViolationError;
+      return { ...attributed, reply: { ...attributed.reply, ok: false, data: undefined, error: refused
+        ? { code: "permission-denied", message: `the goal "${goalId}" was accepted, but this caller is NOT PERMITTED to hear its outcome: the broker refused the per-goal progress subscription "${progressSubject}" (${subError.message}). THE GOAL IS UNAFFECTED - it may already have succeeded, and its terminal may have been committed on time; what failed is this credential's ability to observe it. Do NOT retry: a retry submits a second goal and duplicates the effect, and it will be just as unobservable. Read the outcome with 'ps'/'inspect', and grant this caller the per-goal progress read row so a following call can hear its own goal (SPEC 13.6)` }
+        : { code: "unavailable", message: `the goal "${goalId}" was accepted, but this caller's per-goal progress subscription "${progressSubject}" FAILED, so it cannot hear the outcome (${subError.name}: ${subError.message}). THE GOAL IS UNAFFECTED - it may already have succeeded, and its terminal may have been committed on time; what failed is this connection's ability to observe it. This is NOT a grant refusal, so changing ACLs is the wrong remedy. Do NOT retry: a retry submits a second goal and duplicates the effect. Read the outcome with 'ps'/'inspect' (SPEC 13.6)` } } };
+    }
     if (terminal === undefined)
       // WHAT THIS PROVED: nothing about the goal. The goal was ACCEPTED (the submit above returned
       // ok); only its terminal did not arrive here in time, which a slow runtime or a dropped

--- a/packages/core/src/endpoint-invoke.ts
+++ b/packages/core/src/endpoint-invoke.ts
@@ -437,9 +437,25 @@ export async function submitAndFollowGoal(
 ): Promise<EpAttributedReply> {
   const terminals = new Map<string, { state: string; data?: unknown }>();
   const waiters = new Map<string, () => void>();
-  const sub = nc.subscribe(epGoalProgressGrantRow(space, endpoint, caller), {
+  const progressSubject = epGoalProgressGrantRow(space, endpoint, caller);
+  // A SUBSCRIPTION ERROR IS NOT ABSENCE OF NEWS, AND IT MUST NOT BE DISCARDED. If the broker
+  // refuses this subscription the caller can never hear ANY terminal for this goal - success as
+  // readily as failure - so waiting out the deadline reports "no terminal arrived" about a goal
+  // whose terminal may have been committed on time. Measured (#610): the manager bound the goal,
+  // earned ownership, committed the terminal and emitted it, while the caller sat denied and then
+  // printed a timeout. The broker's own wording for this is "a denied peer looks absent", which is
+  // exactly the confusion, and the operator response to the two is opposite: a timeout invites a
+  // retry (which duplicates the effect), a denial requires a grant.
+  let subError: Error | undefined;
+  const sub = nc.subscribe(progressSubject, {
     callback: (err, m) => {
-      if (err) return;
+      if (err) {
+        // Keep the FIRST error (later ones are consequences) and wake every waiter: once this
+        // subscription is refused, no further waiting can change the answer.
+        subError ??= err instanceof Error ? err : new Error(String(err));
+        for (const wake of waiters.values()) wake();
+        return;
+      }
       let ev: { goalId?: unknown; phase?: unknown; state?: unknown; data?: unknown };
       try { ev = JSON.parse(dec.decode(m.data)); } catch { return; }
       if (ev && ev.phase === "terminal" && typeof ev.goalId === "string") {
@@ -453,10 +469,18 @@ export async function submitAndFollowGoal(
     if (attributed.reply.ok !== true) return attributed; // refuse at accept — surface as-is
     const goalId = (attributed.reply.data as { goalId?: unknown } | undefined)?.goalId;
     if (typeof goalId !== "string") return attributed; // not an action reply — pass through
-    const terminal = terminals.get(goalId) ?? await new Promise<{ state: string; data?: unknown } | undefined>((resolve) => {
+    // A denial that has ALREADY arrived must not be waited out: it is knowable now, and holding the
+    // caller to its deadline is what turns a grant problem into a retry (the cell that caught this
+    // measured 20004ms of a 20000ms budget with the right message attached to it).
+    const terminal = terminals.get(goalId) ?? (subError !== undefined ? undefined : await new Promise<{ state: string; data?: unknown } | undefined>((resolve) => {
       const t = setTimeout(() => resolve(terminals.get(goalId)), deadlineMs);
       waiters.set(goalId, () => { clearTimeout(t); resolve(terminals.get(goalId)); });
-    });
+    }));
+    if (terminal === undefined && subError !== undefined)
+      // THE DISTINCT, ACTIONABLE FAILURE (#610). Deliberately NOT the deadline message below: this
+      // caller was never listening, so "no terminal arrived" would be a statement about the goal
+      // when the true statement is about this credential. The remedy is a grant, never a retry.
+      return { ...attributed, reply: { ...attributed.reply, ok: false, data: undefined, error: { code: "permission-denied", message: `the goal "${goalId}" was accepted, but this caller is NOT PERMITTED to hear its outcome: the broker refused the per-goal progress subscription "${progressSubject}" (${subError.message}). THE GOAL IS UNAFFECTED - it may already have succeeded, and its terminal may have been committed on time; what failed is this credential's ability to observe it. Do NOT retry: a retry submits a second goal and duplicates the effect, and it will be just as unobservable. Read the outcome with 'ps'/'inspect', and grant this caller the per-goal progress read row so a following call can hear its own goal (SPEC 13.6)` } } };
     if (terminal === undefined)
       // WHAT THIS PROVED: nothing about the goal. The goal was ACCEPTED (the submit above returned
       // ok); only its terminal did not arrive here in time, which a slow runtime or a dropped

--- a/packages/core/src/provision.ts
+++ b/packages/core/src/provision.ts
@@ -1165,15 +1165,32 @@ export function permissionsFor(
   const baseline = epBaselineGrantRows(space, epCaller);
   pubAllow.push(...baseline.pub);
   const epSub: string[] = [...baseline.sub];
-  if (opts.capabilities?.includes("spawn"))
-    pubAllow.push(...epCallerGrantRows(space, spawnCallerCapabilities(pr.owner), epCaller).pub);
+  // BOTH HALVES OF THE ROLLUP, NOT JUST `pub`. `epCallerGrantRows` returns `{pub, sub}` and its
+  // `sub` is the per-goal progress row its own docblock promises: "a goal-bearing capability
+  // (spawn/launch) adds ONE per-endpoint epGoalProgressGrantRow - the caller may follow its OWN
+  // goal to terminal". Taking `.pub` alone minted a credential that may SUBMIT a goal and may not
+  // HEAR it, so the broker refused the follow and the caller reported a timeout about a goal whose
+  // terminal had already been committed (#610). `spawn` is goal-bearing, so this `sub` is never
+  // empty here - the row was computed correctly and discarded one property access short of the
+  // credential.
+  if (opts.capabilities?.includes("spawn")) {
+    const rows = epCallerGrantRows(space, spawnCallerCapabilities(pr.owner), epCaller);
+    pubAllow.push(...rows.pub);
+    for (const s of rows.sub) if (!epSub.includes(s)) epSub.push(s);
+  }
   if (opts.capabilities?.includes("admin"))
     // The admin capability's ep mirror (the 1c grant-migration table): the v0.3 `ctl.<admin>`
     // subject above grants the FULL admin-tier op reach, so its holder gets the admin instrument
     // set on the ep rails — any-mode despawn/attach + the `manager.admin` family + the reads. In
     // user mode this is the ledger `admin` scope arriving via the callout, the broker-enforced
     // half of the tier; the manager's ledger-derived per-op admin flag stays on top of it.
-    pubAllow.push(...epCallerGrantRows(space, operatorInstrumentCapabilities("admin", pr.owner), epCaller).pub);
+    {
+      // Same `{pub, sub}` contract as the spawn branch above: an admin instrument's set carries the
+      // goal-bearing lifecycle commands, so it earns the same follow row.
+      const rows = epCallerGrantRows(space, operatorInstrumentCapabilities("admin", pr.owner), epCaller);
+      pubAllow.push(...rows.pub);
+      for (const s of rows.sub) if (!epSub.includes(s)) epSub.push(s);
+    }
   if (opts.endpointCapabilities?.length) {
     if (opts.lifecycleUid !== undefined && assertLifecycleToken(opts.lifecycleUid) !== uid)
       throw new Error(`permissionsFor: opts.lifecycleUid "${opts.lifecycleUid}" disagrees with the principal's lifecycleUid "${uid}" - one credential names ONE incarnation on the caller rail (SPEC 13.1/13.2)`);


### PR DESCRIPTION
Fixes the branch of #610 that mints duplicates: a caller could submit a goal and then be unable to
hear its outcome, and was handed a timeout instead of being told so.

Two halves, in one PR, because either alone leaves the defect half alive. The fold is the repair for
this illegitimate absence; the surfacing fix is the safety net for every future legitimate one.

## The mechanism, not a correlation

`epCallerGrantRows` returns `{pub, sub}`, and its `sub` is the per-goal progress row. Its own
docblock says what that row is for:

> A goal-bearing capability (`GOAL_BEARING_COMMANDS`: spawn/launch) adds ONE per-endpoint
> `epGoalProgressGrantRow` **the caller may follow its OWN goal to terminal** (P2 item 2, Q1); it is
> the one read an invoke implies, because the subject pins the caller's own triple.

Two mint branches in `provision.ts` took `.pub` and dropped `.sub`, while a third folded it in:

```js
// :1169  the SPAWN capability
pubAllow.push(...epCallerGrantRows(space, spawnCallerCapabilities(pr.owner), epCaller).pub);   // .pub only
// :1176  the ADMIN capability
pubAllow.push(...epCallerGrantRows(space, operatorInstrumentCapabilities("admin", ...), epCaller).pub); // .pub only

// :1180  the endpointCapabilities branch
const rows = epCallerGrantRows(space, opts.endpointCapabilities, epCaller);
pubAllow.push(...rows.pub);
for (const s of rows.sub) if (!epSub.includes(s)) epSub.push(s);                                // .sub folded in
```

`spawn` is in `SPAWN_CREATE_COMMANDS` and `GOAL_BEARING_COMMANDS` is `["spawn", "launch"]`, so the
discarded `sub` is never empty for a spawn-capable credential. The row was computed correctly and
thrown away one property access short of the credential. The broker then refused the caller the very
subscription that function had just granted it.

That asymmetry is also why the failure looked credential-dependent in the field rather than random.
It is not a pattern in the data, it is these two branches: a credential minted with the `spawn`
capability loses its `sub` and cannot hear terminals, while one minted through `endpointCapabilities`
keeps it and can. Partitioning observed events by which string they printed separates cleanly along
exactly that line:

| caller surface | string printed | class |
| --- | --- | --- |
| MCP / connector credential (`capabilities: ["spawn"]`) | `accepted but produced no terminal within Nms` | this defect: never subscribed |
| installed CLI / operator credential (`endpointCapabilities`) | `the success signal did not arrive within the readiness deadline` | heard its terminal; a host boot floor, #605 mechanism 1 |
| open mesh, either door | verdict delivered at the window | working, no ACL to deny |

## The second half: a refusal is not an absence

The follow path's subscription callback opened with `if (err) return;`, so a broker refusal was
discarded and became indistinguishable from an empty subscription. Measured on an authed mesh: the
manager bound the goal, earned ownership, committed a `failed` terminal and emitted it, while the
caller sat denied and then printed a timeout about a goal that had already settled.

The broker's own wording for this is that a denied peer looks "absent", and the two states want
opposite responses from an operator. A timeout invites a retry, and a retry submits a second goal and
duplicates the effect. A denial wants a grant. The refusal now surfaces at once, naming the subject,
stating the goal is unaffected, and saying not to retry.

## No SPEC surface moves

The subject, the grammar, and the caller's right to follow its own goal were already specified. What
was broken was a mint discarding half of a `{pub, sub}` contract, against a docblock that states the
opposite. That contradiction, quoted above, is the one-line proof that this is a wiring bug rather
than a change to what any credential is entitled to.

## Evidence

Three cells, deliberately of different kinds:

- `bin/smoke/goal-follow.smoke.ts` (14 checks) proves the **branches**. A refused subscription is
  reported as a refusal, immediately (0 ms against a 20000 ms budget, where the same case previously
  consumed 20004 ms). An ordinary subscribed-but-silent wait still reports a deadline, so the change
  stays narrow. A non-permission failure is just as loud, is not mislabelled a grant refusal, and
  says plainly that changing ACLs is the wrong remedy. And a denial that is already pending when the
  submit is refused leaves that refusal unchanged, so no acceptance is ever manufactured for a goal
  that was never accepted. It builds its inputs by hand, and says so in its header, because since
  the fold a real credential can no longer produce this denial. Its denial carries a real
  `PermissionViolationError`, constructed with the operation and subject the class requires, rather
  than a stand-in `Error`.
- `implementations/auth/smoke/user-spawn.smoke.ts` cell **B1f** proves a real **door** reaches it: a
  spawn-scope caller over a real broker on a real authed mesh hears its own goal's terminal in 637 ms
  against a 20000 ms budget, carrying the refusal's own reason. The spawn under test is refused by
  design, so no child is created; what is asserted is not the refusal but that the caller hears it.
- Cell **D1** covers the other fold branch, which nothing reached before: an **admin**-scope caller
  carrying no `spawn` at all in its ledger row follows a goal-bearing command to its terminal, on the
  goal's own timing (3915 ms of a 20000 ms budget) with no broker refusal on its connection.
  `admin` without `spawn` is a real ledger shape, and until this cell existed a mutation reverting
  the `admin` branch alone survived, because every cell that followed a goal was minted with `spawn`
  and `spawn` supplies the same row.

A note on how the hermetic fixture was checked, so nobody cites the wrong gate for it: `pnpm
typecheck` does NOT cover it. `bin/tsconfig.json` includes only `cotal.ts` and `run.ts`, so no smoke
file under `bin/` is typechecked by the repo gate, and a clean `pnpm typecheck` says nothing about
this file. It was checked with a direct `tsc --noEmit` run instead, which caught a real error in it
(the denial fixture constructed its error with one argument against a five-parameter constructor)
and reports that error on a copy that still carries the old form. The broader gap is filed
separately as #622 and is not fixed here.

`bin/smoke/mutations/goal-follow-subscription.json` grades all of it: **6 of 6 KILLED**, each red on
the assertion named before the run.

| mutation | red on | marks |
| --- | --- | --- |
| discard the subscription error again | the reply is a refusal, not a deadline | 0 of 14 |
| `spawn` mint drops the `sub` half | a spawn-scope caller hears its own goal's terminal | 92 of 95 |
| `admin` mint drops the `sub` half | an admin-scope caller hears its own goal's terminal | 93 of 95 |
| remove the short-circuit | returned at once rather than after the deadline | 4 of 14 |
| diagnosis stops discriminating | is not mislabelled a grant refusal | 8 of 14 |
| narrow the SURFACE, not the diagnosis | a non-permission failure is not swallowed into a deadline | 7 of 14 |

The four hermetic mutants die at four different points against the same baseline of 14, which is
what distinguishes four aimed mutants from four mutants all tripping the first assertion. The two
mint mutants run the authed suite, whose unmutated baseline is the live gate: `smoke:user-spawn:live`
green at 95 progress marks before either mutation was applied.

The last row deserves its own sentence, because it grades a fix that was never written. Narrowing
the surface to the permission class instead of narrowing the diagnosis looks like precision and is
this defect again in miniature: every other subscription error would stop being surfaced and fall
back through to the timeout. That mutation exists so the tempting version cannot be introduced
quietly later.

One process note, since it bears on how much the numbers above are worth. An earlier run of this
config was contaminated: a suite edit landed while it was in flight, under three mutants that run
that suite, so it was grading a file it had not started with. Killing it left one mutation
half-applied, which `git status` showed and `git checkout --` restored; the fold was verified back
by counting its occurrences, and `@cotal-ai/core` was rebuilt, because a killed run leaves `dist/`
compiled from the mutant and `dist/` is gitignored, so git is not the recovery for it. The result
above is from a rerun started on a verified-clean tree, which the tool also enforces by refusing a
dirty one. No number from the contaminated run is reported here or anywhere else.

## The same defect on a live credential

The two cells above are built. This one was not. An audit of a credential in ordinary use on an
authed mesh, minted by the unfixed code, shows the whole mechanism on real material.

Decoding that credential's JWT:

- `pub.allow` carries `cotal.main.ep.one.manager.spawn.<owner>.<uid>.*`, so it may submit the goal.
- `sub.allow` carries four rows in total, and not one of them contains `.goal.`. The row that
  `epGoalProgressGrantRow` builds, `<space>.epe.<endpoint>.*.*.goal.<callerBlock>.>`, is absent.
- The connector requests the follow regardless: `extensions/connector-core/src/agent.ts:764` invokes
  `spawn` with `follow: true` and a 40000 ms deadline.

Submit permitted, follow not permitted, follow requested anyway. Two spawns through that credential
each printed `accepted but produced no terminal within 40000ms` at the full budget, and both spawns
had in fact succeeded: the agents came up, and `ps` confirmed them running.

The credential, rather than the timing, is what makes this conclusive. With no `.goal.` row present
the subscription could not have been permitted at any timing, so host slowness cannot account for it;
slowness would explain a late terminal, never an unhearable one. This is the first row of the
partition table above, observed rather than predicted.

That credential carries the `spawn` capability, so it was minted through the first of the two
branches fixed here. After the fold, the same mint carries the row.

## Merging this does not repair credentials already issued

The fix acts at mint time. It stops new deaf credentials from being issued; it does not add the row
to credentials the unfixed code already issued, and those stay unable to hear their own goals until
they are renewed or re-minted. Anyone running spawn-capable credentials should expect to roll them.
That is deliberately not scoped into this PR, being an operational step rather than a code change.

## Also closes #620

Closes #620.

#620 was filed from this PR when the `admin` fold was found to have no cell: every cell that
followed a goal was minted with `spawn`, which supplies the same row, so a mutation reverting the
`admin` branch alone survived. It asked for a cell that mints `["admin"]` with no `"spawn"`, follows
a goal-bearing command, and asserts the terminal arrives, so that a mutation on the `admin` branch
has a target. Cell D1 and the third mutation are exactly that, and the mutation kills.

What does not land here, and is a localization rather than a missing guarantee: an assertion made
directly against the decoded minted credential, rather than against the follow it enables. D1 proves
the whole ledger to mint to connect to follow path, which is the stronger claim; a decoded-credential
assertion would fail faster and point more precisely when it does. Worth adding, not worth blocking
on, and nothing behavioral is uncovered without it.

## Also closes #547

Closes #547.

#547 reports the same defect from the other end: a caller whose credential carries only the `spawn`
capability invokes `spawn` with `follow: true` and gets the "accepted but produced no terminal"
timeout, including on a spawn that succeeded and produced a live agent. Its own first candidate
cause, "whether the goal terminal's subject is inside the capability set a `spawn` grant mints", is
exactly the discarded `sub` half fixed here.

Its second candidate, that following might require a consumer the endpoint does not create when
built without a channel set, was not the cause: the endpoint subscribes on the caller's own
connection, and the subscription was refused rather than missing.

#547 has no separate `ps`/`inspect` facet to leave behind. Its repro shape is a caller built exactly
as `ctlCaller(actor, owner, ["spawn"], acl)`, which is the shape cell B1f now drives to a terminal,
so what it asks for is what the fold restores and what mutation 2 grades. The tier boundary that
keeps `ps` broker-dropped for a spawn-scope caller is unchanged and is asserted as correct by the
sibling cell.

## What this does not do

It does not address the readiness window itself, which is host-dependent and answered separately in
#605. It does not claim to explain every readiness false negative observed in the field: which
credential path minted a given caller decides which of the two strings above it prints, and that is a
check to run per event rather than an inference.





