### PR TITLE
chore: ignore pi-CLI task transcripts (.pi/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules/
 .pnpm-store/
 dist/
 .cotal/
+# pi-CLI task transcripts: per-developer working state, never committed
+.pi/
 *.log
 .DS_Store
 remotion/out/


### PR DESCRIPTION
pi-CLI task transcripts are per-developer working state and must never be committed. Box-local git excludes (`.git/info/exclude`) do not travel with the repo, so the ignore belongs in the tracked `.gitignore`.

One line, ignore-behaviour only. Verified on a fresh worktree off `main`:

- `git status` shows only the `.gitignore` edit; no tracked file is affected (tracked-file count unchanged, 1319 before and after).
- `git check-ignore` confirms `.pi/` is now ignored.
- Nothing under `.pi/` is tracked anywhere in the tree, so nothing is un-tracked by the change.
