### PR TITLE
fix(smoke): typecheck the core smoke tree

### DIFF
--- a/packages/core/smoke-auth.ts
+++ b/packages/core/smoke-auth.ts
@@ -36,6 +36,7 @@ import {
   mintLifecycleUid,
   principalKey,
   DEV_OWNER,
+  type CotalMessage,
   type Delivery,
 } from "./src/index.js";
 import { pickFreePort } from "./smoke/_free-port.js";
@@ -174,7 +175,7 @@ try {
 
   const got: string[] = [];
   let bobSawMentions: string[] | undefined;
-  b.on("message", (m, d: Delivery) => {
+  b.on("message", (m: CotalMessage, d: Delivery) => {
     const text = m.parts.map((p) => (p.kind === "text" ? p.text : "")).join("");
     const kind = m.to ? "DM" : m.toService ? "ANY:" + m.toService : "#" + (m.channel ?? "");
     got.push(`${kind}:${m.from.name}:${text}`);
@@ -217,7 +218,7 @@ try {
   });
   carol.on("error", (e: Error) => console.error("  ! carol:", e.message));
   const carolGot: string[] = [];
-  carol.on("message", (m, d: Delivery) => {
+  carol.on("message", (m: CotalMessage, d: Delivery) => {
     carolGot.push(m.parts.map((p) => (p.kind === "text" ? p.text : "")).join(""));
     d.ack();
   });

--- a/packages/core/smoke.ts
+++ b/packages/core/smoke.ts
@@ -16,6 +16,7 @@ import {
   openMembersRegistry,
   principalKey,
   DEV_OWNER,
+  type CotalMessage,
   type Delivery,
 } from "./src/index.js";
 
@@ -60,7 +61,7 @@ b.on("error", (e: Error) => console.error("! bob:", e.message));
 
 const got: string[] = [];
 let bobSawMentions: string[] | undefined;
-b.on("message", (m, d: Delivery) => {
+b.on("message", (m: CotalMessage, d: Delivery) => {
   const text = m.parts.map((p) => (p.kind === "text" ? p.text : "")).join("");
   const kind = m.to ? "DM" : m.toService ? "ANY:" + m.toService : "#" + (m.channel ?? "");
   got.push(`${kind}:${m.from.name}:${text}`);
@@ -109,7 +110,7 @@ const carol = new CotalEndpoint({
 });
 carol.on("error", (e: Error) => console.error("! carol:", e.message));
 const carolGot: string[] = [];
-carol.on("message", (m, d: Delivery) => {
+carol.on("message", (m: CotalMessage, d: Delivery) => {
   carolGot.push(m.parts.map((p) => (p.kind === "text" ? p.text : "")).join(""));
   d.ack();
 });

--- a/packages/core/smoke/artifact-store.smoke.ts
+++ b/packages/core/smoke/artifact-store.smoke.ts
@@ -36,6 +36,12 @@ import {
 import { pickFreePort } from "./_free-port.js";
 import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
+/** A one-chunk web stream. `ReadableStream.from` is Node's own and is absent from the lib types
+ *  the artifact store's `put` is declared against, so build the stream with the constructor both
+ *  sides agree on rather than reaching for an undeclared static. */
+const bytesStream = (bytes: Uint8Array): ReadableStream<Uint8Array> =>
+  new ReadableStream<Uint8Array>({ start(c) { c.enqueue(bytes); c.close(); } });
+
 const SPACE = "artstore";
 const PORT = await pickFreePort();
 const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
@@ -181,7 +187,7 @@ try {
   let putErr = "";
   try {
     const os = await new Objm(jetstream(fnc)).create(fb);
-    await os.put({ name: "probe" }, ReadableStream.from([new Uint8Array([1, 2, 3])]));
+    await os.put({ name: "probe" }, bytesStream(new Uint8Array([1, 2, 3])));
   } catch (e) { putErr = (e as Error).message; }
   await fnc.close();
   check("a rollup-denied store REJECTS every put (the consequence being guarded)",
@@ -206,7 +212,7 @@ try {
     retention: "limits" as never, allow_rollup_hdrs: true, max_age: 1_000_000_000,
   });
   const aos = await new Objm(jetstream(anc)).create(ab);
-  await aos.put({ name: "vanishing" }, ReadableStream.from([new Uint8Array([1, 2, 3])]));
+  await aos.put({ name: "vanishing" }, bytesStream(new Uint8Array([1, 2, 3])));
   await wait(1800);
   const aged_state = (await (await jetstreamManager(anc)).streams.info(objectStoreStream(ab))).state.messages;
   await anc.close();
@@ -230,9 +236,9 @@ try {
     retention: "limits" as never, allow_rollup_hdrs: true, max_msgs: 2,
   });
   const cos = await new Objm(jetstream(cnc)).create(cb);
-  await cos.put({ name: "first" }, ReadableStream.from([new Uint8Array([1])]));
+  await cos.put({ name: "first" }, bytesStream(new Uint8Array([1])));
   let secondErr = "";
-  try { await cos.put({ name: "second" }, ReadableStream.from([new Uint8Array([1])])); }
+  try { await cos.put({ name: "second" }, bytesStream(new Uint8Array([1]))); }
   catch (e) { secondErr = (e as Error).message; }
   await cnc.close();
   check("a message-capped store refuses a second artifact with the byte cap free",

--- a/packages/core/smoke/backup-live.smoke.ts
+++ b/packages/core/smoke/backup-live.smoke.ts
@@ -8,7 +8,7 @@ import { randomBytes, randomUUID } from "node:crypto";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { jetstream, jetstreamManager } from "@nats-io/jetstream";
+import { jetstream, jetstreamManager, type ConsumerInfo } from "@nats-io/jetstream";
 import { connect } from "@nats-io/transport-node";
 import {
   anycastSubject,
@@ -112,7 +112,7 @@ try {
   const taskProvisionerNc = await connect({ servers, ...standaloneConnectOpts({ creds: provisionerCreds, tls: false }) });
   const taskProvisionerManager = await jetstreamManager(taskProvisionerNc);
   const task = await taskProvisionerManager.consumers.add(taskStream(space), taskDurableConfig(space, "worker"));
-  const consumersByStream = Object.fromEntries(spaceBackupInventory(space).full.map((stream) => [stream, []]));
+  const consumersByStream: Record<string, ConsumerInfo[]> = Object.fromEntries(spaceBackupInventory(space).full.map((stream) => [stream, []]));
   consumersByStream[chatStream(space)] = [fanout];
   consumersByStream[taskStream(space)] = [task];
   const streamStates = Object.fromEntries(await Promise.all(spaceBackupInventory(space).full.map(async (stream) => [
@@ -168,7 +168,7 @@ try {
   const chunks: Uint8Array[] = [];
   const snapshot = await downloadStreamSnapshot(backupNc, chatStream(space), {
     deliverSubject: snapshotSubject,
-    onChunk: (chunk) => chunks.push(chunk),
+    onChunk: (chunk) => { chunks.push(chunk); },
   });
   validateCanonicalBackupStreamConfig(space, chatStream(space), snapshot.config);
   assert.ok(chunks.length >= 3, "snapshot payload spans multiple native chunks");
@@ -230,7 +230,7 @@ try {
     space,
     chatStream(space),
     canonicalBackupStreamConfig(space, chatStream(space)),
-    snapshot.state,
+    { ...snapshot.state }, // the door takes a raw blob and validates it itself
   );
   await restoreInitNc.drain();
 

--- a/packages/core/smoke/channels.smoke.ts
+++ b/packages/core/smoke/channels.smoke.ts
@@ -87,7 +87,7 @@ try {
     Object.hasOwn(specialReg.channels ?? {}, "__proto__")
       && specialReg.channels?.__proto__?.description === "Prototype token"
       && Object.hasOwn(specialReg.channels ?? {}, "constructor")
-      && specialReg.channels?.constructor?.description === "Constructor token");
+      && (specialReg.channels?.["constructor"] as { description?: string } | undefined)?.description === "Constructor token");
   check("registry read keeps the normal object prototype", Object.getPrototypeOf(specialReg.channels) === Object.prototype);
   assert.throws(() => validateChannelConfig({ description: "x".repeat(1000) }), /too long/);
   check("validation rejects oversize", true);
@@ -132,7 +132,9 @@ try {
   {
     const nc = await connect({ servers });
     const js = jetstream(nc);
-    const forged: CotalMessage = {
+    // Deliberately NOT annotated `CotalMessage`: the union is exclusive, and a frame carrying both
+    // `channel` and `to` is precisely the forgery under test. The wire is bytes; this is those bytes.
+    const forged = {
       id: randomUUID(),
       ts: Date.now(),
       space,

--- a/packages/core/smoke/cross-owner-auth.smoke.ts
+++ b/packages/core/smoke/cross-owner-auth.smoke.ts
@@ -80,7 +80,7 @@ try {
   // distinct lifecycle (SPEC §13.1): agent creds are lifecycle-keyed, so each mint carries its own uid.
   const idA1 = newIdentity(), idA2 = newIdentity(), idB1 = newIdentity();
   const uidA1 = mintLifecycleUid(), uidA2 = mintLifecycleUid(), uidB1 = mintLifecycleUid();
-  const grants = { allowSubscribe: ["general"], allowPublish: ["general"] } as const;
+  const grants = { allowSubscribe: ["general"], allowPublish: ["general"] };
   const a1 = await mintCreds(auth, idA1, "agent", { ...grants, principal: { owner: OWNER_A, actor: "actora1" }, lifecycleUid: uidA1 });
   await mintCreds(auth, idA2, "agent", { ...grants, principal: { owner: OWNER_A, actor: "actora2" }, lifecycleUid: uidA2 });
   await mintCreds(auth, idB1, "agent", { ...grants, principal: { owner: OWNER_B, actor: "actorb1" }, lifecycleUid: uidB1 });

--- a/packages/core/smoke/delivery-reply-injection.smoke.ts
+++ b/packages/core/smoke/delivery-reply-injection.smoke.ts
@@ -89,7 +89,7 @@ try {
 
   // Victim listens on its OWN reply subtree.
   const vnc = await connect({ servers: SERVERS, authenticator: credsAuthenticator(new TextEncoder().encode(vCreds)), inboxPrefix: `_INBOX_${victim.id}`, maxReconnectAttempts: 0 });
-  let victimGot = false;
+  let victimGot: boolean | undefined;
   const vsub = vnc.subscribe(`${controlServiceSubject(space, CONTROL_DELIVERY, DEV_OWNER, victim.id)}.>`, { callback: (err, m) => { if (!err && m) victimGot = true; } });
   await vnc.flush();
 
@@ -102,10 +102,10 @@ try {
   anc.publish(attackerReq, new TextEncoder().encode(body), { reply: forgedReply });
   await anc.flush();
   await wait(700);
-  check("forged reply target (peer's subtree) is NOT answered — no injection into the victim's lane", victimGot === false);
+  check("forged reply target (peer's subtree) is NOT answered — no injection into the victim's lane", victimGot !== true);
 
   // Control: a legitimate request with the reply under the attacker's OWN subtree IS answered.
-  let attackerGot = false;
+  let attackerGot: boolean | undefined;
   const legitReply = `${attackerReq}.reply.${randomUUID()}`;
   const asub = anc.subscribe(`${attackerReq}.>`, { callback: (err, m) => { if (!err && m) attackerGot = true; } });
   await anc.flush();

--- a/packages/core/smoke/delivery-reply-injection.smoke.ts
+++ b/packages/core/smoke/delivery-reply-injection.smoke.ts
@@ -102,7 +102,7 @@ try {
   anc.publish(attackerReq, new TextEncoder().encode(body), { reply: forgedReply });
   await anc.flush();
   await wait(700);
-  check("forged reply target (peer's subtree) is NOT answered — no injection into the victim's lane", victimGot !== true);
+  check("forged reply target (peer's subtree) is NOT answered: no injection into the victim's lane", victimGot !== true);
 
   // Control: a legitimate request with the reply under the attacker's OWN subtree IS answered.
   let attackerGot: boolean | undefined;

--- a/packages/core/smoke/endpoint-contract-store.smoke.ts
+++ b/packages/core/smoke/endpoint-contract-store.smoke.ts
@@ -156,7 +156,7 @@ try {
     const appended = await js.publish(epcSubject(SPACE_B, dHexB), enc("SHADOW-GARBAGE"), { headers: hb }).then((r) => r.seq).catch(() => 0);
     c("on an UN-HARDENED stream the raw append SUCCEEDS (seq 2) — the shadow is present", appended === 2, appended);
     const last = await jsm.direct.getMessage(epcStreamName(SPACE_B), { last_by_subj: epcSubject(SPACE_B, dHexB) });
-    c("last_by_subj now returns the SHADOW garbage (the DoS the read must defeat)", dec(last.data) === "SHADOW-GARBAGE");
+    c("last_by_subj now returns the SHADOW garbage (the DoS the read must defeat)", last !== null && dec(last.data) === "SHADOW-GARBAGE");
     const recovered = await fetchContractArtifact(ctxB, dHexB);
     c("fetchContractArtifact still returns the HONEST artifact (create-only-winner fallback defeats the shadow)", recovered !== undefined && dec(recovered) === '{"shadow":"honest-B"}', recovered && dec(recovered));
     // and a subject where BOTH the winner and the shadow are garbage stays loud (genuinely corrupt).

--- a/packages/core/smoke/endpoint-grammar.smoke.ts
+++ b/packages/core/smoke/endpoint-grammar.smoke.ts
@@ -105,7 +105,8 @@ c("retired control plane → null", parseEpSubject("cotal.demo.control.spawn.u_a
 c("v0 chat plane → null on this surface", parseEpSubject("cotal.demo.chat.u_abc.worker.general") === null);
 
 // ── reply derivation from the authenticated request (confused-deputy boundary) ──
-const derived = deriveReplySubject("demo", pInst!, { instanceId: IID, epoch: 7 });
+if (pInst?.plane !== "request") throw new Error("the inst fixture must parse as a request subject");
+const derived = deriveReplySubject("demo", pInst, { instanceId: IID, epoch: 7 });
 c("derived reply copies caller triple + nonce, pins responder identity",
   derived === `cotal.demo.ep.reply.manager.${IID}.7.u_abc.worker.${UID}.${NONCE}`);
 

--- a/packages/core/smoke/endpoint-grants.smoke.ts
+++ b/packages/core/smoke/endpoint-grants.smoke.ts
@@ -196,7 +196,8 @@ const OTHER_UID = "z".repeat(26);
 const prC7 = { owner: "u_abc", actor: "cli", connId: "connid01234567", lifecycleUid: UID };
 throws("permissionsFor fails loud when opts.lifecycleUid disagrees with the principal's (no dual-uid caller rail, C7)",
   () => permissionsFor("agent", "demo", prC7 as never, { endpointCapabilities: [spawnCap], lifecycleUid: OTHER_UID }));
-const agreed = permissionsFor("agent", "demo", prC7 as never, { endpointCapabilities: [spawnCap], lifecycleUid: UID });
+const agreed = permissionsFor("agent", "demo", prC7 as never, { endpointCapabilities: [spawnCap], lifecycleUid: UID }) as
+  { pub: { allow: string[] }; sub: { allow: string[] } };
 c("permissionsFor with an AGREEING opts.lifecycleUid mints, and every caller-rail row carries the ONE uid",
   agreed.pub.allow.concat(agreed.sub.allow).filter((r: string) => r.includes(".ep.")).every((r: string) => r.includes(`.${UID}.`) || r.includes(`.${UID}`))
   && !agreed.pub.allow.some((r: string) => r.includes(OTHER_UID)));

--- a/packages/core/smoke/endpoint-journal.smoke.ts
+++ b/packages/core/smoke/endpoint-journal.smoke.ts
@@ -199,8 +199,9 @@ c("c8 and the parsed value alone CANNOT show it — the duplicate is gone before
   && (JSON.parse(new TextDecoder().decode(dupRaw)) as { id: string }).id === "req-2");
 // Nested, so the scanner is not merely checking the top level.
 const dupNested = new TextEncoder().encode('{"id":"req-1","args":{"a":1,"a":2}}');
+const dupNestedOutcome = decideAdmission(dupNested, JSON.parse(new TextDecoder().decode(dupNested)), subj, CEIL);
 c("c8 a duplicate NESTED name is caught too",
-  decideAdmission(dupNested, JSON.parse(new TextDecoder().decode(dupNested)), subj, CEIL).cause === "no-canonical-form");
+  dupNestedOutcome.outcome === "quarantine" && dupNestedOutcome.cause === "no-canonical-form");
 // THE NEGATIVE SIDE, which is what stops the scanner degenerating into "refuse everything".
 // Each fixture below is BUILT and then serialised, never hand-escaped — my first attempt at writing
 // those escapes by hand produced invalid JSON.

--- a/packages/core/smoke/endpoint-serve-auth.smoke.ts
+++ b/packages/core/smoke/endpoint-serve-auth.smoke.ts
@@ -250,7 +250,7 @@ try {
     try { await mintCreds(auth, newIdentity(), profile, opts); return false; } catch { return true; }
   };
   c("a RAW unbranded serve value refuses at the mint",
-    await mintThrows({ principal: { owner: "u_op", actor: "mgr" }, endpointServe: { endpoint: "manager", instanceId: IID, epoch: EPOCH, commands: ["status"] } as EpServeGrant, serveIssuance: gate.seam }));
+    await mintThrows({ principal: { owner: "u_op", actor: "mgr" }, endpointServe: { endpoint: "manager", instanceId: IID, epoch: EPOCH, commands: ["status"] } as unknown as EpServeGrant, serveIssuance: gate.seam }));
   c("a STRUCTURAL COPY of the authorized artifact refuses at the mint",
     await mintThrows({ principal: { owner: "u_op", actor: "mgr" }, endpointServe: { ...serveGrant } as EpServeGrant, serveIssuance: gate.seam }));
   c("the AGENT profile refuses serve rows (a serve credential is never an agent-baseline cred)",
@@ -407,13 +407,13 @@ try {
     c("a mint that wins the CAS on an open, current gate commits its row (the positive fence path)",
       g.active() === 1 && g.revoked() === 0);
     const before = g.coord();
-    const token = g.freezeNow();
+    const token = await g.freezeNow();
     if (token === null) throw new Error("barrier freeze should win");
-    const family = g.barrier.enumerate();
-    for (const row of family) if (row.state === "active") g.barrier.revoke(row);
+    const family = await g.barrier.enumerate();
+    for (const row of family) if (row.state === "active") await g.barrier.revoke(row);
     for (const p of new Set(family.filter((r) => r.state === "revoked").map((r) => r.holderPrincipal)))
-      if (!g.barrier.evict(p)) throw new Error("evict should verify gone");
-    const reopened = g.barrier.reopen(token, { generation: before.generation + 1, processEpoch: before.processEpoch, registrationRevision: before.registrationRevision + 1, nameAuthorityRevision: before.nameAuthorityRevision });
+      if (!(await g.barrier.evict(p))) throw new Error("evict should verify gone");
+    const reopened = await g.barrier.reopen(token, { generation: before.generation + 1, processEpoch: before.processEpoch, registrationRevision: before.registrationRevision + 1, nameAuthorityRevision: before.nameAuthorityRevision });
     c("mint-wins→barrier enumerates→revokes→VERIFIED-evicts the released credential by holderPrincipal",
       family.length === 1 && family[0].holderPrincipal === "u_op.mgr" && g.active() === 0 && g.revoked() === 1 && g.evicted.includes("u_op.mgr"));
     c("…and the TOKEN-pinned reopen advanced the gate to the successor registrationRevision (a superseded re-mint would now lose)",
@@ -502,10 +502,10 @@ try {
   // stale/duplicate reopen with the same token loses and never clobbers the newer gate.
   {
     const g = makeGate({ endpoint: "manager", lifecycleUid: IID, generation: 1, processEpoch: EPOCH, registrationRevision: 5, nameAuthorityRevision: NAR });
-    const token = g.freezeNow();
+    const token = await g.freezeNow();
     if (token === null) throw new Error("freeze should win");
-    const first = g.barrier.reopen(token, { generation: 2, processEpoch: EPOCH, registrationRevision: 6, nameAuthorityRevision: NAR });
-    const stale = g.barrier.reopen(token, { generation: 99, processEpoch: EPOCH, registrationRevision: 999, nameAuthorityRevision: NAR });
+    const first = await g.barrier.reopen(token, { generation: 2, processEpoch: EPOCH, registrationRevision: 6, nameAuthorityRevision: NAR });
+    const stale = await g.barrier.reopen(token, { generation: 99, processEpoch: EPOCH, registrationRevision: 999, nameAuthorityRevision: NAR });
     c("reopen is token-pinned: the completing reopen wins, a STALE reopen with the same token loses and leaves the newer gate intact",
       first === true && stale === false && g.coord().registrationRevision === 6);
   }

--- a/packages/core/smoke/endpoint-serve.smoke.ts
+++ b/packages/core/smoke/endpoint-serve.smoke.ts
@@ -858,10 +858,10 @@ try {
   await nc.flush();
   for (let i = 0; i < 60 && gate === undefined; i++) await wait(25); // the handler is parked once gate is set
   c("the gated handler is in flight", gate !== undefined);
-  let stopped = false;
+  let stopped: boolean | undefined;
   const stopping = srvA.stop().then(() => { stopped = true; });
   await wait(400);
-  c("stop() does NOT report stopped while a handler is in flight", stopped === false);
+  c("stop() does NOT report stopped while a handler is in flight", stopped !== true);
   gate!();
   await stopping;
   c("stop() resolves once the in-flight handler finishes", stopped === true);

--- a/packages/core/smoke/endpoint-session.smoke.ts
+++ b/packages/core/smoke/endpoint-session.smoke.ts
@@ -281,7 +281,7 @@ function fakeHooks(over: Partial<SessionRedemptionHooks> = {}): { hooks: Session
   // A duplicate against a row still MID-ISSUE refuses: the retry exception applies only to active.
   const g = await verify(mint());
   const { hooks, st } = fakeHooks();
-  st.rows.set(g.sessionId, { sessionId: g.sessionId, endpoint: ENDPOINT, serving: SERVING, holder: { principal: HOLDER.id, lifecycleUid: HOLDER.lifecycleUid }, credCaller: "ccI", credServing: "csI", revoked: { caller: false, serving: false }, state: "issuing", exp: NOW + 60_000 });
+  st.rows.set(g.sessionId, { sessionId: g.sessionId, endpoint: ENDPOINT, serving: SERVING, holder: { principal: HOLDER.id, lifecycleUid: HOLDER.lifecycleUid }, grantSig: g.sig, credCaller: "ccI", credServing: "csI", revoked: { caller: false, serving: false }, state: "issuing", exp: NOW + 60_000 });
   await rejects("a duplicate against a still-issuing row refuses (one-use; the retry applies only to an active row)", () => redeemSession(g, PRESENTER, hooks), "permission-denied");
   c("…and released nothing", st.released.length === 0);
 }
@@ -304,7 +304,7 @@ function fakeHooks(over: Partial<SessionRedemptionHooks> = {}): { hooks: Session
   // retrieveServingCredential refuses on a non-active row (an issuing row confers nothing).
   const { hooks, st } = fakeHooks();
   const sid = mintSessionId();
-  st.rows.set(sid, { sessionId: sid, endpoint: ENDPOINT, serving: SERVING, holder: { principal: HOLDER.id, lifecycleUid: HOLDER.lifecycleUid }, credCaller: "ccX", credServing: "csX", revoked: { caller: false, serving: false }, state: "issuing", exp: NOW + 60_000 });
+  st.rows.set(sid, { sessionId: sid, endpoint: ENDPOINT, serving: SERVING, holder: { principal: HOLDER.id, lifecycleUid: HOLDER.lifecycleUid }, grantSig: "sigX", credCaller: "ccX", credServing: "csX", revoked: { caller: false, serving: false }, state: "issuing", exp: NOW + 60_000 });
   await rejects("serving retrieval on a non-active row refuses (issuing confers nothing)",
     () => retrieveServingCredential(sid, SERVING_PRESENTER, hooks), "failed-precondition");
 }
@@ -412,7 +412,7 @@ function fakeHooks(over: Partial<SessionRedemptionHooks> = {}): { hooks: Session
   // CRASH MID-ISSUE → the sweep collects: an `issuing` row past exp is transitioned expired
   // and BOTH recorded ids revoked + MARKED; a fully-collected terminal row is untouched.
   const { hooks, st } = fakeHooks();
-  const row: SessionLedgerRow = { sessionId: mintSessionId(), endpoint: ENDPOINT, serving: SERVING, holder: { principal: HOLDER.id, lifecycleUid: HOLDER.lifecycleUid }, credCaller: "ccX", credServing: "csX", revoked: { caller: false, serving: false }, state: "issuing", exp: NOW };
+  const row: SessionLedgerRow = { sessionId: mintSessionId(), endpoint: ENDPOINT, serving: SERVING, holder: { principal: HOLDER.id, lifecycleUid: HOLDER.lifecycleUid }, grantSig: "sigX", credCaller: "ccX", credServing: "csX", revoked: { caller: false, serving: false }, state: "issuing", exp: NOW };
   st.rows.set(row.sessionId, row);
   c("sweep collects a crashed half-issue past exp (row expired, BOTH ids revoked + marked)",
     (await sweepSessionRow(row, hooks, { now: NOW + 1 })) === true && st.rows.get(row.sessionId)!.state === "expired" && st.revoked.join() === "ccX,csX" && row.revoked.caller && row.revoked.serving, st);
@@ -431,7 +431,7 @@ function fakeHooks(over: Partial<SessionRedemptionHooks> = {}): { hooks: Session
     if (id === "csY" && failOnce) { failOnce = false; throw new Error("revocation outage"); }
     st.revoked.push(id);
   };
-  const row: SessionLedgerRow = { sessionId: mintSessionId(), endpoint: ENDPOINT, serving: SERVING, holder: { principal: HOLDER.id, lifecycleUid: HOLDER.lifecycleUid }, credCaller: "ccY", credServing: "csY", revoked: { caller: false, serving: false }, state: "issuing", exp: NOW };
+  const row: SessionLedgerRow = { sessionId: mintSessionId(), endpoint: ENDPOINT, serving: SERVING, holder: { principal: HOLDER.id, lifecycleUid: HOLDER.lifecycleUid }, grantSig: "sigY", credCaller: "ccY", credServing: "csY", revoked: { caller: false, serving: false }, state: "issuing", exp: NOW };
   st.rows.set(row.sessionId, row);
   c("sweep pass 1: row terminal; the FAILED revoke leaves its mark unset",
     (await sweepSessionRow(row, hooks, { now: NOW + 1 })) === true && st.rows.get(row.sessionId)!.state === "expired" && row.revoked.caller === true && row.revoked.serving === false, row);
@@ -475,8 +475,8 @@ try {
   {
     const gotB: unknown[] = []; const gotA: unknown[] = [];
     let aClosed = false;
-    const serving = openSessionRail({ nc: ncB, grant, role: "serving", onData: (d) => gotB.push(d) });
-    const caller = openSessionRail({ nc: ncA, grant, role: "caller", onData: (d) => gotA.push(d), onClose: () => { aClosed = true; } });
+    const serving = openSessionRail({ nc: ncB, grant, role: "serving", onData: (d) => { gotB.push(d); } });
+    const caller = openSessionRail({ nc: ncA, grant, role: "caller", onData: (d) => { gotA.push(d); }, onClose: () => { aClosed = true; } });
     await ncA.flush(); await ncB.flush();
 
     // Duplex, in order, MORE frames than the window (credits must cycle). A full window is
@@ -520,7 +520,7 @@ try {
     // and a credit overrun surface as protocol errors.
     const g3 = { ...grant, sessionId: mintSessionId() };
     const errs: string[] = []; const got: number[] = [];
-    const serving = openSessionRail({ nc: ncB, grant: g3, role: "serving", onData: (d) => got.push((d as { i: number }).i), onProtocolError: (r) => errs.push(r) });
+    const serving = openSessionRail({ nc: ncB, grant: g3, role: "serving", onData: (d) => { got.push((d as { i: number }).i); }, onProtocolError: (r) => errs.push(r) });
     await ncB.flush();
     const inSubj = epsSubject(SPACE, ENDPOINT, g3.sessionId, SERVING.epoch, "in");
     ncA.publish(inSubj, encodeSessionFrame({ t: "f", seq: 1, data: { i: 1 } }));
@@ -553,7 +553,7 @@ try {
     // the rail BEFORE the frame's data reaches onData.
     const gO = { ...grant, sessionId: mintSessionId() };
     const errs: string[] = []; const got: unknown[] = [];
-    const serving = openSessionRail({ nc: ncB, grant: gO, role: "serving", onData: (d) => got.push(d), onProtocolError: (r) => errs.push(r) });
+    const serving = openSessionRail({ nc: ncB, grant: gO, role: "serving", onData: (d) => { got.push(d); }, onProtocolError: (r) => errs.push(r) });
     await ncB.flush();
     ncA.publish(epsSubject(SPACE, ENDPOINT, gO.sessionId, SERVING.epoch, "in"), encodeSessionFrame({ t: "f", seq: 1, data: { evil: 1 }, ack: 99 }));
     await ncA.flush();

--- a/packages/core/smoke/plane3-activation-auth.smoke.ts
+++ b/packages/core/smoke/plane3-activation-auth.smoke.ts
@@ -39,6 +39,7 @@ import {
   commitMember,
   DEV_OWNER,
   type MembershipRecord,
+  type CotalMessage,
   type Delivery,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
@@ -126,7 +127,7 @@ try {
   });
   const got: string[] = [];
   a.on("error", () => {});
-  a.on("message", (m, d: Delivery) => { got.push(m.parts.map((p) => (p.kind === "text" ? p.text : "")).join("")); d.ack(); });
+  a.on("message", (m: CotalMessage, d: Delivery) => { got.push(m.parts.map((p) => (p.kind === "text" ? p.text : "")).join("")); d.ack(); });
   await a.start();
   await wait(400); // connect + boot-membership hydration round-trip
 
@@ -162,7 +163,6 @@ try {
     inboxPrefix: `_INBOX_${seedId.id}`,
     maxReconnectAttempts: 0,
   });
-  kvNc.on?.("error", () => {});
   const kv = await openMembersRegistry(kvNc, space);
   const pending: MembershipRecord = {
     channel: "review", owner: aPrincipal, lifecycleUid: uidA, state: "durable-active", joinCursor: 0,

--- a/packages/core/smoke/plane3-auth.smoke.ts
+++ b/packages/core/smoke/plane3-auth.smoke.ts
@@ -158,7 +158,7 @@ try {
   const agentErrors: string[] = [];
   a.on("error", (e: Error) => console.error("  ! alice", e.message));
   a.on("error", (e: Error) => agentErrors.push(e.message));
-  a.on("message", (m, d: Delivery, meta: MessageMeta) => {
+  a.on("message", (m: CotalMessage, d: Delivery, meta: MessageMeta) => {
     got.push({
       ch: m.channel, kind: meta.kind, durable: d.durable,
       text: m.parts.map((p) => (p.kind === "text" ? p.text : "")).join(""),
@@ -311,7 +311,6 @@ try {
     inboxPrefix: `_INBOX_${aId.id}`,
     maxReconnectAttempts: 0,
   });
-  aNc.on?.("error", () => {});
   const aJsm = await jetstreamManager(aNc);
   const aJs = jetstream(aNc);
   check(
@@ -340,7 +339,6 @@ try {
     inboxPrefix: `_INBOX_${bId.id}`,
     maxReconnectAttempts: 0,
   });
-  bNc.on?.("error", () => {});
   const bJs = jetstream(bNc);
   check(
     "a peer CANNOT bind another agent's dlv_<owner> durable (name-scoped grant)",

--- a/packages/core/smoke/plane3-gate-auth.smoke.ts
+++ b/packages/core/smoke/plane3-gate-auth.smoke.ts
@@ -29,6 +29,7 @@ import {
   newIdentity,
   setupSpaceStreams,
   DEV_OWNER,
+  type CotalMessage,
   type Delivery,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
@@ -115,7 +116,7 @@ try {
   });
   const got: string[] = [];
   a.on("error", () => {});
-  a.on("message", (m, d: Delivery) => { got.push(m.parts.map((p) => (p.kind === "text" ? p.text : "")).join("")); d.ack(); });
+  a.on("message", (m: CotalMessage, d: Delivery) => { got.push(m.parts.map((p) => (p.kind === "text" ? p.text : "")).join("")); d.ack(); });
   await a.start();
   await wait(300);
 

--- a/packages/core/smoke/read-acl-auth.smoke.ts
+++ b/packages/core/smoke/read-acl-auth.smoke.ts
@@ -114,7 +114,6 @@ try {
     inboxPrefix: `_INBOX_${id.id}`, // the agent's sub.allow is _INBOX_<id>.>
     maxReconnectAttempts: 0,
   });
-  ag.on?.("error" as any, () => {});
 
   const cfg = (filter: string) => ({
     stream_name: CHAT,

--- a/packages/core/smoke/run-journal.smoke.ts
+++ b/packages/core/smoke/run-journal.smoke.ts
@@ -725,8 +725,8 @@ const step = (run: string, n: number, ord: number) => ({ v: 1, kind: "step", run
       // is not the one WFJ stores.
       (replay.records as { record: RunJournalRecord; seq: number }[]).push(replay.records[0]!);
       const inner = replay.records[0]!.record as RunJournalActivation;
-      inner.holder = "impostor";
-      inner.n = 99;
+      (inner as { holder: string; n: number }).holder = "impostor";
+      (inner as { holder: string; n: number }).n = 99;
       const step0 = replay.records[1]!.record as { entry: { marker: string } };
       step0.entry.marker = "rewritten";
     },

--- a/packages/core/smoke/self-serve-join-auth.smoke.ts
+++ b/packages/core/smoke/self-serve-join-auth.smoke.ts
@@ -37,6 +37,7 @@ import {
   readMember,
   principalKey,
   DEV_OWNER,
+  type CotalMessage,
   type Delivery,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
@@ -145,7 +146,7 @@ try {
   });
   const got: string[] = [];
   const gotDurable: string[] = []; // keys delivered with durable:true (the Plane-3 backstop copy)
-  a.on("message", (m, d: Delivery) => {
+  a.on("message", (m: CotalMessage, d: Delivery) => {
     const key = `#${m.channel}:${m.parts.map((p) => (p.kind === "text" ? p.text : "")).join("")}`;
     got.push(key);
     if (d.durable) gotDurable.push(key);
@@ -305,7 +306,6 @@ try {
   // holds a members-bucket grant). Use a `delivery` cred with its own per-id inbox.
   const seedId = newIdentity();
   const kvNc = await connect({ servers: SERVERS, authenticator: credsAuthenticator(new TextEncoder().encode(await mintCreds(auth, seedId, "delivery"))), inboxPrefix: `_INBOX_${seedId.id}`, maxReconnectAttempts: 0 });
-  kvNc.on?.("error", () => {});
   const kv = await openMembersRegistry(kvNc, space);
   const opsRec = (await readMember(kv, "ops", pkey(aId.id), uidA))!.record;
   await commitMember(kv, { ...opsRec, activated: false });
@@ -339,7 +339,7 @@ try {
   });
   const gotB: string[] = [];
   b.on("error", () => {});
-  b.on("message", (m, d: Delivery) => { gotB.push(`#${m.channel}:${m.parts.map((p) => (p.kind === "text" ? p.text : "")).join("")}`); d.ack(); });
+  b.on("message", (m: CotalMessage, d: Delivery) => { gotB.push(`#${m.channel}:${m.parts.map((p) => (p.kind === "text" ? p.text : "")).join("")}`); d.ack(); });
   await b.start();
 
   // Poll for bob's boot self-join to hydrate (connect + daemon round-trip) rather than assume a fixed

--- a/packages/core/smoke/self-serve-join-coverage-auth.smoke.ts
+++ b/packages/core/smoke/self-serve-join-coverage-auth.smoke.ts
@@ -142,7 +142,8 @@ try {
     const raw = await connect({ servers: SERVERS, authenticator: credsAuthenticator(new TextEncoder().encode(posterCreds)), inboxPrefix: `_INBOX_${posterIdent.id}` });
     const rjs = jetstream(raw);
     // (a) forged payload `to: <alice>` with a VALID from=poster: must deliver, classified kind=channel by subject.
-    const forged: CotalMessage = {
+    // Deliberately NOT annotated `CotalMessage`: carrying both `channel` and `to` is the forgery.
+    const forged = {
       id: randomUUID(), ts: Date.now(), space, from: poster.ref(), channel: "rev.api",
       to: aId.id, parts: [{ kind: "text", text: "forged-to-probe" }],
     };


### PR DESCRIPTION
Fourth slice of the smoke-tree typecheck repair, stacked on #649. `packages/core` goes from 57 type
errors across 21 files to 0, and the tree total from 260 to 203. Test trees only; no shipped source
is touched anywhere in this PR.

## Scope

The root `tsconfig.json` covers the smoke trees, but nothing invokes it, so errors accumulated behind
a gate that never ran. This slice takes the fourth area to zero. What it fixes is not only type
noise: several cells were asserting less than they appeared to.

**Five dead lines that read as error handling.** Each was an `nc.on?.("error", () => {})` on a value
returned by `connect()`. `NatsConnection` has no `on`, verified at runtime rather than assumed:
`NatsConnectionImpl`'s prototype chain carries neither `on` nor `addListener`, only `closed()` and
`status()`. The optional call resolved to `undefined` and registered nothing. What each site does on
a real error is unchanged by the deletion:

| site | on a real error |
| --- | --- |
| `plane3-activation-auth` (`kvNc`) | backs `openMembersRegistry` and one `commitMember`; a transport or permission failure rejects that awaited call, leaves the suite's top-level `try`, the `finally` kills the broker, and the process exits non-zero with the stack |
| `plane3-auth` (`aNc`) | every use sits inside `denied(...)`, so an authorization refusal is the asserted outcome and is captured as a value; anything else rejects the awaited `jetstreamManager` call or publish and fails the suite |
| `plane3-auth` (`bNc`) | the same, around a consumer bind that must be refused |
| `read-acl-auth` (`ag`) | all traffic goes through `jsApi`, which returns a discriminated result, so a denial is a value the cells read; a transport failure rejects the awaited call |
| `self-serve-join-auth` (`kvNc`) | registry open, one `commitMember`, close, as above |

At none of the five can an EventEmitter `"error"` event exist to be swallowed. nats.js surfaces
connection failure through `closed()` resolving with an `Error`, through the `status()` async
iterable, and through rejected operation promises; all five connections set `maxReconnectAttempts:
0`, so a broker death ends them rather than retrying quietly.

**The barrier cells ran the issuance seam synchronously.** `EpIssuanceBarrier` declares every method
as `Promise<T> | T`, and the production caller in `endpoint-service.ts` awaits all of them.
`endpoint-serve-auth`'s fixture happens to be synchronous, so `freeze`, `enumerate`, `evict` and
`reopen` were called bare. The cells passed, but they proved the freeze/enumerate/revoke/evict/reopen
protocol only for a synchronous implementation. Against an async seam, which the contract permits,
`!barrier.evict(p)` is always false and `reopen(...) === true` is never true, so both guards would
have stopped discriminating in silence. Awaited, the cells hold for the contract as written, and
awaiting a non-promise is inert, so the fixture still passes at 99 checks.

**Three cells asserted less than they read.** `endpoint-journal` reached for `.cause` on
`decideAdmission`'s return without establishing which arm it had, and the admitted arm has no
`cause`, so the comparison could only ever be `undefined` against a string; it now asserts the
quarantine outcome and the cause together. `endpoint-contract-store` called `dec(last.data)` on a
nullable `direct.getMessage` result, which would have thrown rather than failed the cell.
`endpoint-grammar` derived a reply subject from `pInst!`, and the non-null assertion also hid that
nothing checked the fixture parses as a request subject, which is the precondition
`deriveReplySubject` is about; a throw-guard states both.

**A required field was missing from three fixtures.** `endpoint-session` built three
`SessionLedgerRow` values without `grantSig`. Where the grant is in scope the row now carries the
real signature.

**Two flow-analysis edges, not defects.** `let stopped = false` assigned only inside a callback still
narrows to `false` at the later use site, so `stopped === false` is reported as an unintentional
comparison. Declared without an initializer and phrased `!== true`, the claim is identical and no
longer depends on the compiler following a callback.

**The rest is drift.** `ReadableStream.from` is Node's own static and absent from the lib types the
artifact store's `put` is declared against. `channels.smoke` reads an own `constructor` key that
shadows the prototype's, where TypeScript sees only `Function`. Two forged frames are deliberately no
longer annotated `CotalMessage`, because carrying `channel` and `to` at once is exactly the forgery
under test and the union is exclusive. `run-journal` tampers with replayed records whose fields are
readonly, so the tampering goes through a mutable view. `backup-live`'s consumer map had no element
type, its `onChunk` arrow leaked `Array.push`'s number into a `void | Promise<void>` handler, and a
restore door that takes a raw blob was handed a typed one. `permissionsFor` returns a wider union
than the cell reads, an `as const` grants object produced readonly arrays, and nine message handlers
had no parameter types because nothing had ever checked them.

## Verification

Suites run locally, all green: `auth`, `artifact-store`, `channels`, `cross-owner:auth`,
`delivery-reply-injection:auth`, `ep-contract-store`, `ep-grammar`, `ep-grants`, `ep-journal`,
`ep-serve:auth`, `ep-serve`, `ep-session`, `plane3-activation:auth`, `plane3:auth`,
`plane3-gate:auth`, `read-acl:auth`, `run-journal`, `self-serve-join:auth`,
`self-serve-join-coverage:auth`.

`backup:live` runs too, and is green. It is named separately because it is not a root `smoke:*`
script: it is reachable only through `packages/core`'s own `smoke:backup:live`, so the list above,
which is the set of root scripts, does not contain it. Reading that list as the complete set of
suites this slice drives undercounts it by one.

The bare `pnpm smoke` is red in this environment and was red before this change: it needs the space
`cotal up` provisions rather than a bare broker, and running the file's previous version as a control
produces a byte-identical log. It is not one of the gated suites.

`bin/smoke/ci-suites.txt` is untouched by this branch (`git diff origin/main...HEAD` on that path is
empty). No suite is added, removed or reordered.

On the absolutes: the tree totals in the first paragraph were measured before this branch's tip
advanced into a merge, and re-measured at this tip they read 262 to 205. The offset is identical on
both ends, so the slice's own 57 to 0 is unaffected. Read the delta, and re-derive any absolute you
intend to rely on.

## Deliberately not built

No shipped source is changed, including where a type error points at a real API shape: those are
reported, not repaired here. No `@ts-expect-error` and no `any` is introduced to silence an error; every
repair either states the type the value actually has or fixes the fixture. No suite is added and no
existing cell is deleted. The CI job that would hold the count at zero is not in this PR; it belongs
in the final slice, after the remaining areas reach zero, so that it lands measuring a real floor
rather than a moving one.

