### PR TITLE
fix(smoke): typecheck the manager smoke tree

### DIFF
--- a/implementations/manager/smoke/attach-stdin.smoke.ts
+++ b/implementations/manager/smoke/attach-stdin.smoke.ts
@@ -431,8 +431,14 @@ function attachFromFile(root: string, contents: string, extra: readonly string[]
   });
   let buf = "";
   let code: number | undefined;
-  child.stdout.on("data", (d) => { buf += String(d); });
-  child.stderr.on("data", (d) => { buf += String(d); });
+  // The sibling spawn above passes a literal ["pipe","pipe","pipe"], which node's overloads type as
+  // non-null streams; a file descriptor on 0 drops this call to the general signature, where both
+  // are nullable even though 1 and 2 are still pipes. A `?.` here would swallow a genuinely absent
+  // stream and leave `buf` silently empty, so the absence throws instead.
+  const { stdout, stderr } = child;
+  if (stdout === null || stderr === null) throw new Error("the attach child was spawned with piped stdout and stderr");
+  stdout.on("data", (d) => { buf += String(d); });
+  stderr.on("data", (d) => { buf += String(d); });
   child.on("close", (c) => { code = c ?? 0; });
   const p: Piped = {
     seen: () => buf,

--- a/implementations/manager/smoke/console-ws-duplex.smoke.ts
+++ b/implementations/manager/smoke/console-ws-duplex.smoke.ts
@@ -17,6 +17,7 @@ import { wsconnect, credsAuthenticator } from "@nats-io/nats-core";
 import {
   isReachable, createSpaceAuth, serverConfig, setupSpaceStreams, mintCreds, newIdentity, mintLifecycleUid,
   registry, openSessionRail, encodeTerminalData, decodeTerminalFrame, terminalFrameBytes,
+  type Connector,
 } from "@cotal-ai/core";
 import { authDir, saveSpaceAuth } from "@cotal-ai/workspace";
 import { Manager } from "../src/manager.js";
@@ -41,7 +42,8 @@ writeFileSync(join(workspaceRoot, ".cotal", "agents", "echo1.md"), "---\nname: e
 // A portable line-echo pty. `process.execPath` needs no PATH resolution and `launchEnv()` is the OS
 // allow-list a real connector supplies — a ConPTY child inherits nothing but `spec.env`, and on
 // Windows a node child without `SystemRoot` aborts at startup. (This was `cat`, absent on Windows.)
-registry.register({ kind: "connector", name: "echo", requires: [], buildLaunch: () => ({ command: process.execPath, args: ["-e", "process.stdin.pipe(process.stdout)"], env: launchEnv() }) });
+const echoCon: Connector = { kind: "connector", name: "echo", requires: [], buildLaunch: () => ({ command: process.execPath, args: ["-e", "process.stdin.pipe(process.stdout)"], env: launchEnv() }) };
+registry.register(echoCon);
 
 const kids: ChildProcess[] = [];
 let mgr: InstanceType<typeof Manager> | undefined;

--- a/implementations/manager/smoke/events-grant-acl.smoke.ts
+++ b/implementations/manager/smoke/events-grant-acl.smoke.ts
@@ -149,8 +149,10 @@ const base = {
     return { command: "true", args: [], env: {} };
   },
 };
-registry.register({ ...base, name: "smoke-emitter", eventChannel } satisfies Connector);
-registry.register({ ...base, name: "smoke-silent" } satisfies Connector); // no eventChannel → cannot emit
+const emitterCon: Connector = { ...base, name: "smoke-emitter", eventChannel };
+const silentCon: Connector = { ...base, name: "smoke-silent" }; // no eventChannel → cannot emit
+registry.register(emitterCon);
+registry.register(silentCon);
 
 const credsDir = join(workspaceRoot, ".cotal", "auth", "creds");
 

--- a/implementations/manager/smoke/goal-sibling-race.smoke.ts
+++ b/implementations/manager/smoke/goal-sibling-race.smoke.ts
@@ -103,7 +103,9 @@ try {
   conns.push(tapNc);
   const readNc = await connect({ servers: SERVER, maxReconnectAttempts: 0 });
   conns.push(readNc);
-  const rctx: ActionContext = await actionContext(readNc, SPACE, { resolveExecutorEpoch: () => A.serviceServe?.grant.epoch ?? 0 });
+  // The result subject carries no epoch token, so the read context takes no epoch resolver: a
+  // terminal is judged against the goal's OWN accepted epoch, never the current one.
+  const rctx: ActionContext = await actionContext(readNc, SPACE);
   const goalRef = (goalId: string): GoalRef => ({ endpoint: MANAGER_ENDPOINT, caller, goalId });
 
   // Capture the request frame A is about to receive. Replaying real bytes keeps the duplicate a

--- a/implementations/manager/smoke/instrument-instance-pin.smoke.ts
+++ b/implementations/manager/smoke/instrument-instance-pin.smoke.ts
@@ -50,6 +50,7 @@ import {
   isRepeatSafeCommand, MANAGER_ADMIN_COMMANDS, parseEpSubject,
   type EpCaller,
   type ResolvedService,
+  type EpError,
 } from "@cotal-ai/core";
 import { authDir, saveSpaceAuth, recordMesh } from "@cotal-ai/workspace";
 import { Manager } from "../src/manager.js";
@@ -143,7 +144,7 @@ const requestsSent = (ep: CotalEndpoint): ((endpoint: string, command: string) =
  * reply); a lost effect reported as success breaks it; a refusal after the handler ran breaks it.
  */
 const dispositionAgrees = (
-  reply: { ok?: boolean; error?: { code?: string; details?: { kind: string }[] } } | undefined,
+  reply: { ok?: boolean; error?: EpError } | undefined,
   ranDelta: number,
 ): boolean => ranDelta === (replyRefusedBeforeEffect(reply?.error) ? 0 : 1);
 
@@ -469,7 +470,7 @@ try {
       const readSplitsBefore = ep.splitRecoveryCount;
       const psBefore = totalRuns("ps");
       let readThrew: unknown;
-      let readLanded: { reply?: { ok?: boolean; error?: { code?: string; details?: { kind: string }[] } } } | undefined;
+      let readLanded: { reply?: { ok?: boolean; error?: EpError } } | undefined;
       try { readLanded = await ep.invokeService(MANAGER_ENDPOINT, "ps"); } catch (e) { readThrew = e; }
       const afterRead = cache.get(MANAGER_ENDPOINT)?.responder.instanceId;
       check("a READ with the same forced split self-heals inside ONE call: the guard did not widen",
@@ -584,7 +585,7 @@ try {
       // reports a correctly repaired call and a duplicated one identically. It is replaced by a
       // count taken where the effect is applied, which is the property itself rather than a proxy
       // for it.
-      const purgeReply = (returned as { reply?: { ok?: boolean; error?: { code?: string; details?: { kind: string }[] } } } | undefined)?.reply;
+      const purgeReply = (returned as { reply?: { ok?: boolean; error?: EpError } } | undefined)?.reply;
       check("a DESTRUCTIVE non-creating command is NEVER purged twice across the split (handler entries, not publishes)",
         totalRuns("purge") - purgedBefore <= 1, { ran: totalRuns("purge") - purgedBefore, threw });
       check("...and its disposition matches its effect: refused ⇒ nothing was purged, answered ⇒ purged once",
@@ -791,7 +792,7 @@ try {
         // the fence the re-issue is the repair and the publish count can no longer separate a
         // repaired call from a duplicated one — only the handler-entry count can.
         const delta = totalRuns(command) - ranBefore;
-        const reply = (res as { reply?: { ok?: boolean; error?: { code?: string; details?: { kind: string }[] } } } | undefined)?.reply;
+        const reply = (res as { reply?: { ok?: boolean; error?: EpError } } | undefined)?.reply;
         const refused = replyRefusedBeforeEffect(reply?.error)
           || (err instanceof EpEnvelopeError && replyRefusedBeforeEffect(err.toEpError()));
         // REACHED means the request got as far as a responder: it either ran, or came back refused

--- a/implementations/manager/smoke/manager-service-ops.smoke.ts
+++ b/implementations/manager/smoke/manager-service-ops.smoke.ts
@@ -45,7 +45,7 @@ import {
   type Connector, type ControlReply, type EpCaller, type LaunchOpts, type LaunchSpec,
 } from "@cotal-ai/core";
 import { authDir, saveSpaceAuth } from "@cotal-ai/workspace";
-import { Manager } from "../src/manager.js";
+import { Manager, type SpawnHooks } from "../src/manager.js";
 import { MANAGER_ENDPOINT, MANAGER_CONTRACTS } from "../src/manager-service-contract.js";
 import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
@@ -111,7 +111,9 @@ const mgr = new Manager({ space, servers: SERVERS, runtime: "pty", workspaceRoot
 const M = mgr as unknown as {
   managerInstanceId: string;
   agents: Map<string, { id: string; lifecycleUid: string; secretPaths?: { creds?: string } }>;
-  startAgent: (opts: Record<string, unknown>, spawner?: string) => Promise<ControlReply>;
+  // The real signature takes the spawn hooks as a third parameter; this hand-written view had
+  // only two, so the mock below could pass `hooks` that the type said would never arrive.
+  startAgent: (opts: Record<string, unknown>, spawner?: string, hooks?: SpawnHooks) => Promise<ControlReply>;
 };
 
 /** A caller instrument: mint an agent cred with the given ep capabilities (+ ctl privileged via
@@ -161,7 +163,7 @@ try {
   let launchInputDigest: string | undefined;
   {
     const replies: unknown[] = [];
-    const sub = A.nc.subscribe(epCallerReplyFilter(space, A.caller), { callback: (_e, m) => replies.push(JSON.parse(dec.decode(m.data))) });
+    const sub = A.nc.subscribe(epCallerReplyFilter(space, A.caller), { callback: (_e, m) => { replies.push(JSON.parse(dec.decode(m.data))); } });
     const subj = epRequestSubject(space, { route: { mode: "one" }, endpoint: MANAGER_ENDPOINT, command: "describe", caller: A.caller, nonce: `n${String(Date.now()).padStart(23, "0")}` });
     A.nc.publish(subj, enc.encode(JSON.stringify({ v: 1, id: "d1", op: { endpoint: MANAGER_ENDPOINT, command: "describe" }, class: "ephemeral", replyExpected: true, deadlineMs: 5000, from: { id: A.principal, name: "smoke" } })));
     await A.nc.flush();

--- a/implementations/manager/smoke/manager-service.smoke.ts
+++ b/implementations/manager/smoke/manager-service.smoke.ts
@@ -39,7 +39,7 @@ import {
   epcredFamilyPrefix, parseLedgerRow, rawDigest, recordSpecKey, RECORD_KINDS,
   epCall, epRequestSubject, epCallerReplyFilter, EpEnvelopeError,
   serveIssuanceGateKv,
-  type EpServeLedgerRow,
+  type CredentialLedgerRow,
 } from "@cotal-ai/core";
 import { authDir, saveSpaceAuth } from "@cotal-ai/workspace";
 import { Manager } from "../src/manager.js";
@@ -103,8 +103,10 @@ try {
   const recKv = await kvm.open(recordsBucket(space));
   const gateKey = epgateKey(MANAGER_ENDPOINT, iid);
   const readGate = async () => parseEndpointGate((await authKv.get(gateKey))!.value, gateKey);
-  const credRows = async (): Promise<EpServeLedgerRow[]> => {
-    const rows: EpServeLedgerRow[] = [];
+  // `parseLedgerRow` returns a CredentialLedgerRow; the annotation named the serve-grant row type,
+  // which is a different shape.
+  const credRows = async (): Promise<CredentialLedgerRow[]> => {
+    const rows: CredentialLedgerRow[] = [];
     const it = await authKv.keys(`${epcredFamilyPrefix(MANAGER_ENDPOINT, iid)}.>`);
     for await (const k of it) rows.push(parseLedgerRow((await authKv.get(k))!.value, k));
     return rows;
@@ -177,7 +179,7 @@ try {
   {
     const replies: unknown[] = [];
     const sub = callerNc.subscribe(epCallerReplyFilter(space, caller), {
-      callback: (_e, m) => replies.push(JSON.parse(dec.decode(m.data))),
+      callback: (_e, m) => { replies.push(JSON.parse(dec.decode(m.data))); },
     });
     const n = `n${String(Date.now()).padStart(23, "0")}`;
     const subj = epRequestSubject(space, { route: { mode: "one" }, endpoint: MANAGER_ENDPOINT, command: "describe", caller, nonce: n });

--- a/implementations/manager/smoke/manifest-launch.smoke.ts
+++ b/implementations/manager/smoke/manifest-launch.smoke.ts
@@ -46,6 +46,11 @@ function check(label: string, cond: boolean, extra?: unknown): void {
   console.log(`${cond ? "✓" : "✗"} ${label}${cond ? "" : ` — ${extra ?? ""}`}`);
   if (!cond) failures++;
 }
+
+/** `ControlReply.data` is `unknown` on the wire, so the identity a reply reports is read through
+ *  one narrow view rather than four spot casts. */
+const replyName = (r: { data?: unknown }): string | undefined =>
+  (r.data as { name?: string } | undefined)?.name;
 function throws(label: string, fn: () => unknown): void {
   try {
     fn();
@@ -144,7 +149,7 @@ registry.register(recCon);
   check("launchAgentToStartOpts forwards the apply-time owner", launchAgentToStartOpts(resolved, personaPath, OWNER).owner === OWNER);
   const reply = await mgr.startAgent(startOpts);
   check("resolved spawn succeeds with no persona file in .cotal/agents", reply.ok === true, JSON.stringify(reply));
-  check("identity is the resolved name", reply.ok && reply.data?.name === "scout", reply.ok && reply.data?.name);
+  check("identity is the resolved name", reply.ok && replyName(reply) === "scout", reply.ok && replyName(reply));
   check("variant is forwarded to the connector", seenVariant === "high", seenVariant);
   check("launchOptions forwarded to the connector (via resolved)", JSON.stringify(seenLaunchOptions) === JSON.stringify({ temperature: "0.2" }), seenLaunchOptions);
   check("manifest kickoff prompt forwarded to the connector (via resolved)", seenPrompt === "Kick off: post your research plan in #general.", seenPrompt);
@@ -265,7 +270,7 @@ function writeSpec(name: string, body: unknown): string {
   // there would have silently deleted all of them.
   const reply = await op({ runId: runId2, name: "ranger" });
   check("opLaunch boots the resolved agent", reply.ok === true, reply.error);
-  check("reply.name is the declared name, taken exactly (no numbering when nothing collides)", reply.ok && reply.data?.name === "ranger", reply.ok && reply.data?.name);
+  check("reply.name is the declared name, taken exactly (no numbering when nothing collides)", reply.ok && replyName(reply) === "ranger", reply.ok && replyName(reply));
   check("reply carries the manifest requested name", reply.ok && reply.data?.requested === "ranger");
   check("reply carries runId + resolved hash for the ledger", reply.ok && reply.data?.runId === runId2 && reply.data?.hash === "abc123");
   check("reply carries the spawned nkey id", reply.ok && typeof reply.data?.id === "string" && (reply.data.id as string).length > 0);

--- a/implementations/manager/smoke/mesh-attach-plane.smoke.ts
+++ b/implementations/manager/smoke/mesh-attach-plane.smoke.ts
@@ -221,6 +221,7 @@ rail3.send({ k: "ready" } satisfies TerminalFrame);
 rail3.send(encodeTerminalData(Buffer.from("ALIVE3\n", "utf8")));
 c("the caller is live (echo confirms the pty is alive before the kill)", await until(() => Buffer.concat(rx3).toString("utf8").includes("ALIVE3")));
 // Kill the child DIRECTLY (bypass endForTarget + handle.stop) — the agent process exits on its own.
+if (h3.pid === undefined) throw new Error("the pty handle reported no pid; there is nothing to kill");
 process.kill(h3.pid, "SIGKILL");
 c("a natural pty exit surfaces `process-exit` to the live caller (NO zombie session)", await until(() => end3 === "process-exit"), { end3, handleStatus: h3.status() });
 c("the plane drops the naturally-exited session", await until(() => plane.liveSessions === 0));
@@ -258,6 +259,7 @@ h4.stop({ graceful: false });
 // onExit must too).
 console.log("H. establishing over an already-dead pty surfaces `process-exit` (no zombie)");
 const h5 = createRuntime("pty", "mesh-plane-smoke5").spawn("worker-5", ECHO_CHILD, process.cwd());
+if (h5.pid === undefined) throw new Error("the pty handle reported no pid; there is nothing to kill");
 process.kill(h5.pid, "SIGKILL");
 await until(() => h5.status() === "exited");
 const s5 = h5.attach(); // attach over the DEAD pty

--- a/implementations/manager/smoke/persona-identity-acl.smoke.ts
+++ b/implementations/manager/smoke/persona-identity-acl.smoke.ts
@@ -32,6 +32,11 @@ function check(label: string, cond: boolean, extra?: unknown): void {
   if (!cond) failures++;
 }
 
+/** `ControlReply.data` is `unknown` on the wire, so the identity a reply reports is read through
+ *  one narrow view rather than four spot casts. */
+const replyName = (r: { data?: unknown }): string | undefined =>
+  (r.data as { name?: string } | undefined)?.name;
+
 // Decode the `nats` permission block out of a minted creds file (the JWT is the first line after the
 // BEGIN marker; its middle segment is base64url JSON).
 function credAcl(path: string): { sub: string[]; pub: string[] } {
@@ -88,7 +93,7 @@ try {
   {
     const reply = await mgr.startAgent({ name: "review-critic", agent: "smoke-rec2" });
     check("spawn by filename succeeds", reply.ok === true, reply);
-    check("identity is the file's name: (socrates), not the filename", reply.ok && reply.data?.name === "socrates", reply.ok && reply.data?.name);
+    check("identity is the file's name: (socrates), not the filename", reply.ok && replyName(reply) === "socrates", reply.ok && replyName(reply));
 
     // Lifecycle-keyed cred file (`<name>.<uid>.creds`) — the reply's uid names this incarnation's file.
     const socratesUid = reply.ok ? String((reply.data as { lifecycleUid?: string }).lifecycleUid ?? "") : "";
@@ -107,7 +112,7 @@ try {
   // 3 — A second spawn of the same persona auto-numbers the IDENTITY (socrates → socrates-2).
   {
     const reply = await mgr.startAgent({ name: "review-critic", agent: "smoke-rec2" });
-    check("second spawn auto-numbers the identity", reply.ok && reply.data?.name === "socrates-2", reply.ok && reply.data?.name);
+    check("second spawn auto-numbers the identity", reply.ok && replyName(reply) === "socrates-2", reply.ok && replyName(reply));
   }
 } finally {
   await stopBroker();

--- a/implementations/manager/smoke/preserve-state.smoke.ts
+++ b/implementations/manager/smoke/preserve-state.smoke.ts
@@ -17,7 +17,7 @@ import {
   type LaunchSpec,
 } from "@cotal-ai/core";
 import { authDir, agentLifecycleSecretFilePaths } from "@cotal-ai/workspace";
-import { Manager, type ManagerResumeAgent, type ManagerResumeInventory } from "../src/manager.js";
+import { Manager, type ManagerResumeIdentity, type ManagerResumeAgent, type ManagerResumeInventory } from "../src/manager.js";
 import { MAX_RESUME_CONTROL_BYTES } from "../src/resume.js";
 
 let failures = 0;
@@ -232,7 +232,12 @@ function managed(name: string, id: string, handle: AgentHandle, source: "manifes
   };
 }
 
+// The connector callback below is what assigns this, and the checker cannot follow a call into
+// a registered extension. A bare `x = undefined` reset therefore narrows the binding to
+// `undefined` for the rest of the block and every later read reports on `never`, so the reset
+// goes through a call, which leaves the declared type in place. Runtime behaviour is identical.
 let capturedLaunch: LaunchOpts | undefined;
+const resetCapturedLaunch = () => { capturedLaunch = undefined; };
 const connector: Connector = {
   kind: "connector",
   name: "preserve-connector",
@@ -258,7 +263,11 @@ let retainedAuthority = {
   role: "worker",
   parent: undefined as string | undefined,
 };
-registry.register({
+// The registry takes a whole AuthProvider; this stub implements only what the resume path calls.
+// A cast AFTER the literal gives its members no contextual type, which is why the validator's
+// parameter was implicitly `any`; annotating the subset types the callback from the contract, and
+// the widening happens once, at the register call.
+const preserveAuth: Pick<AuthProvider, "kind" | "name" | "agentBearerCommand" | "validateRetainedAgent" | "grantAgent"> = {
   kind: "auth-provider",
   name: "preserve-auth",
   agentBearerCommand: "agent-bearer",
@@ -273,19 +282,21 @@ registry.register({
     retainedGrantCalls++;
     throw new Error("grantAgent must not run during resume");
   },
-} as unknown as AuthProvider);
+};
+registry.register(preserveAuth as unknown as AuthProvider);
 
 // Fence and drain: an accepted async control request completes before children stop, while later
 // lifecycle work is rejected immediately. The exit watcher fires from stop() but must not clean up.
 {
   let releaseModels!: () => void;
   const modelsGate = new Promise<void>((resolve) => { releaseModels = resolve; });
-  registry.register({
+  const slowModelsCon: Connector = {
     kind: "connector",
     name: "preserve-slow-models",
     listModels: async () => { await modelsGate; return { models: [] }; },
     buildLaunch: () => ({ command: "true", args: [] }),
-  } satisfies Connector);
+  };
+  registry.register(slowModelsCon);
   const manager = managerWith((name) => fakeHandle(name));
   const handle = fakeHandle("worker");
   const map = (manager as unknown as { agents: Map<string, unknown> }).agents;
@@ -456,6 +467,9 @@ let openInventory: ManagerResumeAgent;
       runtime: "fake",
       cwd: root,
       source: { kind: "manifest", runId: "r1", requested: "worker", hash: "abc123", configPath: runPersonaPath, configSha256: digest(runPersonaPath), manifestSha256: digest(join(runDir, "r1.json")) },
+      // Required by ManagerResumeAgent and omitted here, so the resume read `undefined` and treated
+      // this run as event-less. `false` is that same behaviour, stated.
+      events: false,
       subscribe: ["general"],
       allowSubscribe: ["general"],
       allowPublish: [],
@@ -465,7 +479,7 @@ let openInventory: ManagerResumeAgent;
     startedAt: new Date().toISOString(),
   };
   const manager = managerWith((name) => fakeHandle(name));
-  capturedLaunch = undefined;
+  resetCapturedLaunch();
   const result = await manager.resumePreserved(inventoryOf(openInventory));
   const reply = result.agents[0]?.reply;
   check("open resume succeeds under the exact retained name", result.ok && reply?.ok && (reply.data as { name?: string })?.name === "worker", JSON.stringify(result));
@@ -548,7 +562,7 @@ let openInventory: ManagerResumeAgent;
   // (manager-service-ops); a merely spawn-capable caller is broker-denied before the handler. There
   // is no in-handler tier reject to assert here anymore, so this section drives the admin path only.
   check("no resume launched before the admin call", spawns === 0, spawns);
-  capturedLaunch = undefined;
+  resetCapturedLaunch();
   const resumed = await control(manager, "admin", "resumePreserved", args);
   check("admin wire resume succeeds", resumed.ok, resumed.error);
   check("wire resume uses the exact retained principal", capturedLaunch?.id === "open_principal_resume", capturedLaunch?.id);
@@ -822,7 +836,7 @@ let openInventory: ManagerResumeAgent;
     launch: { ...openInventory.launch, source: { kind: "persona", ref: "worker", configPath: personaPath, configSha256: digest(personaPath) } },
     dependencies: [personaPath],
   };
-  capturedLaunch = undefined;
+  resetCapturedLaunch();
   const ok = await manager.resumePreserved(inventoryOf(entry));
   check("static resume accepts matching retained credential", ok.ok && capturedLaunch?.id === identity.id && capturedLaunch?.creds === credsPath, ok);
   check("static resume threads the recovered incarnation uid into launch", capturedLaunch?.lifecycleUid === uidFor(identity.id), capturedLaunch?.lifecycleUid);
@@ -888,7 +902,9 @@ let openInventory: ManagerResumeAgent;
   const healthPath = join(credsDir, "worker.auth-health.json");
   writeFileSync(actorTokenPath, "retained-token", { mode: 0o600 });
   writeFileSync(sentinelPath, "retained-sentinel", { mode: 0o600 });
-  const entry: ManagerResumeAgent = {
+  // Annotated with the user arm pinned: `ManagerResumeAgent` widens `identity` to the whole union,
+  // and the cells below read owner/actor and rebuild the identity, which only one arm carries.
+  const entry: ManagerResumeAgent & { identity: Extract<ManagerResumeIdentity, { mode: "user" }> } = {
     ...openInventory,
     identity: {
       mode: "user",
@@ -902,12 +918,12 @@ let openInventory: ManagerResumeAgent;
   };
   retainedValidationCalls = 0;
   retainedGrantCalls = 0;
-  capturedLaunch = undefined;
+  resetCapturedLaunch();
   const result = await manager.resumePreserved(inventoryOf(entry));
   check("user resume validates retained authority at preflight and immediately before spawn", result.ok && retainedValidationCalls === 2, `${result.error} / calls=${retainedValidationCalls}`);
   check("provider receives retained token and sentinel contents", lastRetainedInput?.actorToken === "retained-token" && lastRetainedInput?.sentinelCreds === "retained-sentinel", lastRetainedInput);
   check("user resume never calls grantAgent", retainedGrantCalls === 0, retainedGrantCalls);
-  check("user resume reuses exact owner/actor in launch", capturedLaunch?.userAuth?.owner === entry.identity.owner && capturedLaunch.userAuth.actor === entry.identity.actor, capturedLaunch?.userAuth);
+  check("user resume reuses exact owner/actor in launch", capturedLaunch?.userAuth?.owner === entry.identity.owner && capturedLaunch?.userAuth?.actor === entry.identity.actor, capturedLaunch?.userAuth);
   check("user resume threads the recovered incarnation uid into launch", capturedLaunch?.lifecycleUid === uidFor("userworker"), capturedLaunch?.lifecycleUid);
   check("user bearer command is reconstructed from provider command", capturedLaunch?.userAuth?.bearerCmd.includes("agent-bearer") === true, capturedLaunch?.userAuth?.bearerCmd);
 

--- a/implementations/manager/smoke/sibling-mint-fence.smoke.ts
+++ b/implementations/manager/smoke/sibling-mint-fence.smoke.ts
@@ -130,7 +130,7 @@ try {
   };
   const openGate = async (): Promise<void> => {
     const g = await readGate();
-    const { op: _op, ...rest } = g.row as Record<string, unknown>;
+    const { op: _op, ...rest } = g.row;
     void _op;
     await authKv.update(gateKey, enc.encode(JSON.stringify({ ...rest, state: "open" })), g.revision);
   };
@@ -141,7 +141,7 @@ try {
   const supersedeGate = async (): Promise<void> => {
     await freezeGate();
     const g = await readGate();
-    const { op: _op, ...rest } = g.row as Record<string, unknown>;
+    const { op: _op, ...rest } = g.row;
     void _op;
     await authKv.update(gateKey, enc.encode(JSON.stringify({ ...rest, state: "open", generation: g.row.generation + 1 })), g.revision);
   };

--- a/implementations/manager/smoke/spawn-action-auth.smoke.ts
+++ b/implementations/manager/smoke/spawn-action-auth.smoke.ts
@@ -162,10 +162,12 @@ try {
     const gwReadCreds = await mintCreds(auth, newIdentity(), "goal-writer", { goalWriter: { endpoint: MANAGER_ENDPOINT } });
     const readNc = await connect({ servers: SERVERS, ...standaloneConnectOpts({ creds: gwReadCreds, tls: false }), maxReconnectAttempts: 0 });
     conns.push(readNc);
-    // Reading an EXECUTOR-PINNED goal terminal resolves the executor's CURRENT epoch (item 3's (i)
-    // fence): after the synthetic takeover the gate is at epoch obs+1, so the reader looks at
-    // result.<obs+1> and the corpse's fenced (old-epoch) attempt is invisible → no terminal.
-    const rctx = await actionContext(readNc, space, { resolveExecutorEpoch: (execIid) => (execIid === iid ? obs!.processEpoch + 1 : null) });
+    // The terminal subject carries NO epoch token (endpoint-action.ts): an earlier revision scoped
+    // the result by executor epoch, and that is precisely the defect it removed, because judging a
+    // terminal against the CURRENT epoch hid a legitimate pre-restart winner. So the read takes no
+    // epoch resolver, and the absence below is the corpse having written no fact at all rather than
+    // a fact filed under a superseded epoch the reader declined to look at.
+    const rctx = await actionContext(readNc, space);
     const result = await readGoalResult(rctx, ref);
     check("FENCE (a) the superseded corpse never committed a terminal (own-gate currency refused — no wrong terminal)", result === undefined, result);
   }

--- a/implementations/manager/smoke/spawn-action.smoke.ts
+++ b/implementations/manager/smoke/spawn-action.smoke.ts
@@ -160,12 +160,10 @@ try {
   // the reconcile index directly off the broker, so the successor's reconcile is observed at the source.
   const readNc = await connect({ servers: SERVER, maxReconnectAttempts: 0 });
   conns.push(readNc);
-  // Reads of an EXECUTOR-PINNED goal terminal (item 3's (i) fence, now in production) resolve the
-  // executor's CURRENT epoch. The predecessor serves at epoch 0; after the M5 restart the SAME logical
-  // instance re-registers at epoch 1 and the successor settles the orphan there, so the reader tracks
-  // the current serving epoch (0 before the restart, the successor's epoch after).
-  let readerExecEpoch = 0;
-  const rctx: ActionContext = await actionContext(readNc, SPACE, { resolveExecutorEpoch: () => readerExecEpoch });
+  // The result subject carries no epoch token, so one read context covers the whole suite: the
+  // predecessor's and the successor's terminals are addressed identically, and a fact stays valid
+  // however far the process epoch advances after it was committed.
+  const rctx: ActionContext = await actionContext(readNc, SPACE);
   const goalRef = (goalId: string): GoalRef => ({ endpoint: MANAGER_ENDPOINT, caller, goalId });
   const idxKv = await new Kvm(readNc).open(recordsBucket(SPACE));
 
@@ -350,9 +348,6 @@ try {
     (mgr2 as unknown as { readinessTimeoutMs: number }).readinessTimeoutMs = 2_000;
     await mgr2.start();
     mgr = mgr2;
-    // The successor re-registered the SAME logical instance at an ADVANCED epoch; the reader now
-    // resolves that current epoch so it sees the successor's settle (result.<successorEpoch>).
-    readerExecEpoch = (mgr2 as unknown as { serviceServe?: { grant?: { epoch?: number } } }).serviceServe?.grant?.epoch ?? 0;
     const successorIid = (mgr2 as unknown as { managerLifecycleUid: string }).managerLifecycleUid;
     check("M5 the successor is a FRESH incarnation (a new process, advanced epoch)", successorIid !== managerIid, { successorIid, managerIid });
     const after = await pollResult(ref, 4_000);

--- a/implementations/manager/smoke/start-model-preflight.smoke.ts
+++ b/implementations/manager/smoke/start-model-preflight.smoke.ts
@@ -106,7 +106,12 @@ const agentCount = () => agentsMap().size;
 // A recording connector that requires `node` (present whenever this smoke runs) — captures the
 // LaunchOpts the manager hands it, so we can assert the model threads through verbatim. Declares
 // `supportsResume` so a resume request passes the pre-mint preflight and reaches buildLaunch.
+// The connector callback below is what assigns this, and the checker cannot follow a call into
+// a registered extension. A bare `x = undefined` reset therefore narrows the binding to
+// `undefined` for the rest of the block and every later read reports on `never`, so the reset
+// goes through a call, which leaves the declared type in place. Runtime behaviour is identical.
 let lastOpts: LaunchOpts | undefined;
+const resetOpts = () => { lastOpts = undefined; };
 const recCon: Connector = {
   kind: "connector",
   name: "smoke-rec",
@@ -118,7 +123,12 @@ registry.register(recCon);
 
 // A twin that passes the harness preflight (node present) but does NOT support resume — used to prove
 // the pre-mint resume preflight rejects BEFORE reaching buildLaunch (its buildLaunch must never run).
-let noResumeBuilt = false;
+// Only buildLaunch below assigns this, and the checker cannot follow a call into a registered
+// connector. An initialised flag reset with a bare assignment narrows to that literal, so a later
+// `=== true` reads as a comparison that cannot hold. Declared unset and reset through a call, the
+// binding keeps its declared type and the cells state the same claims.
+let noResumeBuilt: boolean | undefined;
+const resetNoResumeBuilt = () => { noResumeBuilt = undefined; };
 const recNoResumeCon: Connector = {
   kind: "connector",
   name: "smoke-norsm",
@@ -144,19 +154,19 @@ registry.register(recNoResumeCon);
 
 // 2 — Model THREADING through the manager into LaunchOpts (PATH restored → `node` present again).
 {
-  lastOpts = undefined;
+  resetOpts();
   const reply = await mgr.startAgent({ name: "rec1", agent: "smoke-rec", model: "sonnet" });
   check("present-binary connector passes preflight + spawns", reply.ok === true, reply);
   check("--model threads into LaunchOpts.model verbatim", lastOpts?.model === "sonnet", lastOpts?.model);
   check("built spec was captured (success path ran)", lastSpec?.command === "true");
 
-  lastOpts = undefined;
+  resetOpts();
   await mgr.startAgent({ name: "rec2", agent: "smoke-rec" });
   check("no --model → LaunchOpts.model undefined", lastOpts?.model === undefined, lastOpts?.model);
 
   // ACL threading: the resolved read/post set must reach the connector via LaunchOpts (the bug —
   // it was minted into creds but never handed to buildLaunch, so the connector fell back to general).
-  lastOpts = undefined;
+  resetOpts();
   await mgr.startAgent({ name: "rec3", agent: "smoke-rec" });
   check("persona subscribe threads into LaunchOpts.subscribe", JSON.stringify(lastOpts?.subscribe) === '["team"]', lastOpts?.subscribe);
   check("persona allowSubscribe threads into LaunchOpts", JSON.stringify(lastOpts?.allowSubscribe) === '["team","team.>"]', lastOpts?.allowSubscribe);
@@ -287,10 +297,10 @@ registry.register(recNoResumeCon);
     check(`${con.name}: no resume → builds normally`, built);
   }
   // MANAGER THREADING: startAgent({resume}) → LaunchOpts.resume verbatim, and absent → undefined.
-  lastOpts = undefined;
+  resetOpts();
   await mgr.startAgent({ name: "rrec1", agent: "smoke-rec", resume: "sess-thread" });
   check("startAgent resume threads into LaunchOpts.resume", lastOpts?.resume === "sess-thread", lastOpts?.resume);
-  lastOpts = undefined;
+  resetOpts();
   await mgr.startAgent({ name: "rrec2", agent: "smoke-rec" });
   check("no resume → LaunchOpts.resume undefined", lastOpts?.resume === undefined, lastOpts?.resume);
 }
@@ -304,16 +314,16 @@ registry.register(recNoResumeCon);
   check("hermes supportsResume falsy", !hermesConnector.supportsResume, hermesConnector.supportsResume);
 
   // REJECT: smoke-norsm passes the node PATH check but declares no resume support.
-  noResumeBuilt = false;
+  resetNoResumeBuilt();
   const before = agentCount();
   const reply = await mgr.startAgent({ name: "norsm1", agent: "smoke-norsm", resume: "sess-x" });
   check("unsupported-connector resume rejected", reply.ok === false, reply);
   check("reject names 'does not support resuming'", /does not support resuming/.test(reply.error ?? ""), reply.error);
-  check("reject BEFORE buildLaunch (no spec built)", noResumeBuilt === false);
+  check("reject BEFORE buildLaunch (no spec built)", noResumeBuilt !== true);
   check("reject BEFORE side effect (no agent recorded)", agentCount() === before);
 
   // …but no resume → the same connector spawns normally (the preflight doesn't over-fire).
-  noResumeBuilt = false;
+  resetNoResumeBuilt();
   const ok = await mgr.startAgent({ name: "norsm2", agent: "smoke-norsm" });
   check("no resume → unsupported-resume connector still spawns", ok.ok === true, ok);
   check("no resume → buildLaunch reached", noResumeBuilt === true);

--- a/implementations/manager/smoke/start-overrides.smoke.ts
+++ b/implementations/manager/smoke/start-overrides.smoke.ts
@@ -65,7 +65,12 @@ const fakeHandle = (name: string): AgentHandle => ({
   getRoster: () => [...(mgr as unknown as { agents: Map<string, { id: string; name: string; lifecycleUid: string }> }).agents.values()].map((a) => ({ card: { id: principalKey(DEV_OWNER, a.id).key, name: a.name }, status: "idle", lifecycleUid: a.lifecycleUid })),
 };
 
+// The connector callback below is what assigns this, and the checker cannot follow a call into
+// a registered extension. A bare `x = undefined` reset therefore narrows the binding to
+// `undefined` for the rest of the block and every later read reports on `never`, so the reset
+// goes through a call, which leaves the declared type in place. Runtime behaviour is identical.
 let lastOpts: LaunchOpts | undefined;
+const resetOpts = () => { lastOpts = undefined; };
 const recCon: Connector = {
   kind: "connector",
   name: "smoke-ov",
@@ -78,7 +83,7 @@ const j = (v: unknown) => JSON.stringify(v);
 
 // 1 — ACL overrides win over the persona file (flags > file, foreground-parity precedence).
 {
-  lastOpts = undefined;
+  resetOpts();
   const reply = await mgr.startAgent({
     name: "team",
     agent: "smoke-ov",
@@ -94,7 +99,7 @@ const j = (v: unknown) => JSON.stringify(v);
 
 // 2 — no overrides → the persona file still rules (regression guard on the new precedence code).
 {
-  lastOpts = undefined;
+  resetOpts();
   await mgr.startAgent({ name: "team", agent: "smoke-ov" });
   check("no override → file subscribe", j(lastOpts?.subscribe) === j(["team"]), lastOpts?.subscribe);
   check("no override → file allowPublish", j(lastOpts?.allowPublish) === j(["team"]), lastOpts?.allowPublish);
@@ -102,30 +107,30 @@ const j = (v: unknown) => JSON.stringify(v);
 
 // 3 — allowSubscribe defaults from the OVERRIDDEN subscribe (one source feeds creds + connector).
 {
-  lastOpts = undefined;
+  resetOpts();
   await mgr.startAgent({ name: "plain", agent: "smoke-ov", subscribe: ["ops"] });
   check("allowSubscribe defaults from overridden subscribe", j(lastOpts?.allowSubscribe) === j(["ops"]), lastOpts?.allowSubscribe);
 }
 
 // 4 — prompt threads verbatim.
 {
-  lastOpts = undefined;
+  resetOpts();
   await mgr.startAgent({ name: "plain", agent: "smoke-ov", prompt: "hello team" });
   check("prompt threads into LaunchOpts.prompt", lastOpts?.prompt === "hello team", lastOpts?.prompt);
-  lastOpts = undefined;
+  resetOpts();
   await mgr.startAgent({ name: "plain", agent: "smoke-ov" });
   check("no --prompt → LaunchOpts.prompt undefined", lastOpts?.prompt === undefined, lastOpts?.prompt);
 }
 
 // 5 — share-tools selection narrows the declared servers; `none` = none; absent = all; unknown fails.
 {
-  lastOpts = undefined;
+  resetOpts();
   await mgr.startAgent({ name: "plain", agent: "smoke-ov" });
   check("absent shareTools → all declared servers", j(Object.keys(lastOpts?.mcpServers ?? {})) === j(["alpha", "beta"]), lastOpts?.mcpServers);
-  lastOpts = undefined;
+  resetOpts();
   await mgr.startAgent({ name: "plain", agent: "smoke-ov", shareTools: "alpha" });
   check("named selection → that server only", j(Object.keys(lastOpts?.mcpServers ?? {})) === j(["alpha"]), lastOpts?.mcpServers);
-  lastOpts = undefined;
+  resetOpts();
   await mgr.startAgent({ name: "plain", agent: "smoke-ov", shareTools: "none" });
   check("shareTools none → no servers", j(Object.keys(lastOpts?.mcpServers ?? {})) === j([]), lastOpts?.mcpServers);
   const bad = await mgr.startAgent({ name: "plain", agent: "smoke-ov", shareTools: "gamma" });
@@ -135,12 +140,12 @@ const j = (v: unknown) => JSON.stringify(v);
 // 6 — the identity override (`--name` alongside a ref) wins over the file's `name:` and threads
 // into both the reply and LaunchOpts (foreground's `requested = values.name ?? def.name` parity).
 {
-  lastOpts = undefined;
+  resetOpts();
   const r = await mgr.startAgent({ name: "team", agent: "smoke-ov", identity: "scout" });
   check("identity override spawns", r.ok === true, r);
   check("identity override wins over file name:", (r.data as { name?: string })?.name === "scout", r.data);
   check("identity threads into LaunchOpts.name", lastOpts?.name === "scout", lastOpts?.name);
-  lastOpts = undefined;
+  resetOpts();
   await mgr.startAgent({ name: "plain", agent: "smoke-ov" });
   // Earlier sections spawned `plain` repeatedly — uniqueName auto-numbers, so match the series.
   check("no identity override → file name: (auto-numbered)", /^plain(-\d+)?$/.test(lastOpts?.name ?? ""), lastOpts?.name);
@@ -169,7 +174,7 @@ const j = (v: unknown) => JSON.stringify(v);
   const prev = process.env.COTAL_DEFAULT_AGENT;
   process.env.COTAL_DEFAULT_AGENT = "smoke-ov";
   try {
-    lastOpts = undefined;
+    resetOpts();
     const r = await mgr.startAgent({ name: "plain" });
     check("COTAL_DEFAULT_AGENT spawn succeeds", r.ok === true, r);
     check("COTAL_DEFAULT_AGENT used as manager default", (r.data as { agent?: string })?.agent === "smoke-ov", r.data);

--- a/implementations/manager/smoke/static-lifecycle.smoke.ts
+++ b/implementations/manager/smoke/static-lifecycle.smoke.ts
@@ -280,7 +280,7 @@ try {
   crashLaunch = true;
   const spawnC = await mgr.startAgent({ name: "crashy", agent: "smoke-sl" });
   crashLaunch = false;
-  check("a spawn that throws at buildLaunch fails WITH the injected crash (not an earlier refusal)", spawnC.ok === false && /injected buildLaunch crash/.test(spawnC.ok ? "" : spawnC.error), spawnC);
+  check("a spawn that throws at buildLaunch fails WITH the injected crash (not an earlier refusal)", spawnC.ok === false && /injected buildLaunch crash/.test(spawnC.error ?? ""), spawnC);
   const cSettled = await until(async () => (await readSlotOnly("crashy"))?.phase === "retired", 30_000, "the crashed spawn's rollback terminal");
   check("the crashed spawn's slot reached RETIRED (no active orphan — F3)", cSettled);
   const cSlot = await readSlotOnly("crashy");
@@ -347,7 +347,7 @@ try {
 
   // ── 8. F2: endpointCapabilities refusal ────────────────────────────────────
   const spawnEp = await mgr.startAgent({ name: "epcap", agent: "smoke-sl", ...({ endpointCapabilities: [{ endpoint: "x", verb: "call" }] } as Record<string, unknown>) });
-  check("a static spawn carrying endpointCapabilities is REFUSED (F2, fail-closed in code)", spawnEp.ok === false && /endpointCapabilities/.test(spawnEp.ok ? "" : spawnEp.error), spawnEp);
+  check("a static spawn carrying endpointCapabilities is REFUSED (F2, fail-closed in code)", spawnEp.ok === false && /endpointCapabilities/.test(spawnEp.error ?? ""), spawnEp);
 } finally {
   await (mgr as unknown as { stop?: () => Promise<void> }).stop?.().catch(() => {});
   await stopBroker();

--- a/implementations/manager/smoke/windows-launch.smoke.ts
+++ b/implementations/manager/smoke/windows-launch.smoke.ts
@@ -173,7 +173,10 @@ function launchCapture(command: string, args: string[], env: NodeJS.ProcessEnv, 
   return new Promise((resolve) => {
     let h: ReturnType<ReturnType<typeof createRuntime>["spawn"]>;
     try {
-      h = createRuntime("pty", "winsmoke").spawn("winsmoke", { command, args, env }, cwd);
+      // `process.env` values are `string | undefined`; a LaunchSpec carries only the defined ones,
+      // which is also what the child would receive, since node drops an undefined entry.
+      const defined = Object.fromEntries(Object.entries(env).filter((e): e is [string, string] => e[1] !== undefined));
+      h = createRuntime("pty", "winsmoke").spawn("winsmoke", { command, args, env: defined }, cwd);
     } catch (e) {
       resolve(`THREW:${(e as Error).message}`);
       return;


### PR DESCRIPTION
Fifth slice of the smoke-tree typecheck repair, stacked on #653. `implementations/manager` goes from
97 type errors across 18 files to 0, and the tree total from 205 to 108. Test trees only; no shipped
source is touched.

## Scope

**Two thirds of the count were one control-flow shape.** A suite records what a connector was handed
by assigning a module-scoped binding inside `buildLaunch`, then resets it between blocks with a bare
`lastOpts = undefined`. The checker cannot follow a call into a registered extension, so it takes the
reset at its word: from there the binding is `undefined`, `lastOpts?.subscribe` narrows to `never`,
and every later read of the recorder is an error. Runtime was always correct. Routing the resets
through a one-line helper leaves the declared type in place and closes 60 errors across three files
with four added lines. Those three files carry 67 errors between them, and the other seven, all in
`preserve-state`, are closed by that file's other hunks rather than by the helper. `start-model-preflight` needed one step more: an initialised `let
noResumeBuilt = false` narrows to the literal, so `=== true` read as a comparison that cannot hold.
Declared unset and reset through a call, its two cells state the same claims.

**Three suites passed an argument to a function that does not take one.** `actionContext(nc, space)`
has two parameters; `spawn-action`, `spawn-action-auth` and `goal-sibling-race` each called it with a
third `{ resolveExecutorEpoch }` object that JavaScript discarded on every run. One carried a live
variable, `readerExecEpoch`, assigned for no other purpose.

The comments above those calls are the part worth reading. They describe the reader resolving the
executor's current epoch and looking at `result.<epoch>`, so a superseded corpse's attempt is
invisible. That is the epoch-scoped read `endpoint-action.ts` removed as non-conformant: scoping a
terminal by epoch hid a legitimate pre-restart winner behind a later epoch, and the subject now
carries no epoch token at all. `packages/core/smoke/goal-epoch-fence.smoke.ts` says exactly that and
exists to catch the regression. So three suites documented the removed defect as the mechanism behind
their passing cells. The cells are honest, a terminal was never committed, but the stated reason was
three revisions stale. The dead argument is gone and the comments state the mechanism that holds.

**Four fixtures or local views disagreed with the code.**

| file | what it said | what is true |
| --- | --- | --- |
| `manager-service-ops` | its hand-written `Manager` view declared `startAgent(opts, spawner?)` | the real method takes the spawn hooks as a third parameter, which the mock in that same block passes |
| `manager-service` | its ledger reader returned `EpServeLedgerRow[]` | `parseLedgerRow` returns `CredentialLedgerRow`, a different shape |
| `preserve-state` | the open-resume fixture omitted `events` | `ManagerResumeAgent` requires it; the resume read `undefined` and treated the run as event-less, so `events: false` is that behaviour stated |
| `preserve-state` | the auth-provider stub was cast after its literal | a cast at that position gives the members no contextual type, which is why the retained validator's parameter was implicitly `any` |

**A nullable stream read as non-null.** `attach-stdin` read `child.stdout.on` on a child spawned with
a file descriptor on stdin. Its sibling block passes a literal `["pipe","pipe","pipe"]`, which node's
overloads type as non-null; a descriptor drops the call to the general signature, where the streams
are nullable even though 1 and 2 are still pipes. A `?.` there would swallow a genuinely absent
stream and leave the captured output silently empty, so the absence throws instead.

**The rest is drift.** `registry.register` takes an `Extension`, so a fresh connector literal is
excess-property-checked against `kind` and `name` alone; three now bind to a `Connector` first, as the
other suites already do. A pty handle's `pid` is optional and two `process.kill` calls needed the
absence to be loud. `ControlReply.error` is optional, so a refusal message reaches a regex through
`?? ""`. `ControlReply.data` is `unknown`, so the identity a reply reports is read through one narrow
view per file instead of four spot casts. `EndpointGateRow.op` is declared, so stripping it needs no
cast. `instrument-instance-pin` spelled its own error shape at four sites where `EpError` is the type.
`process.env` values are `string | undefined` and a `LaunchSpec` carries only the defined ones, which
is what a child receives anyway. Two subscription callbacks leaked `Array.push`'s number into a
handler that returns void.

## Verification

All eighteen affected suites run locally and pass: `attach-stdin` 77, `static-lifecycle` 37,
`instrument-instance-pin` 55, `manager-service-ops` 52, `manager-spawn-action` 35, `manager-service`
25, `mesh-attach-plane` 25, `sibling-mint-fence` 24, `goal-sibling-race` 9,
`manager-spawn-action-auth` 7, `console-ws-duplex` 6, plus `preserve-state`, `manifest-launch`,
`persona-acl`, `events-grant`, `start-model`, `start-overrides` and `windows`, each reporting no
failures.

`bin/smoke/ci-suites.txt` is untouched by this branch. No suite is added, removed or reordered.

Three of the eighteen do not reach CI through `ci-suites.txt`, and it is worth saying which route
each takes rather than leaving the list to imply one. `smoke:start-model` runs through
`implementations/manager`'s own `test` script, which the unit job invokes as `pnpm test`.
`smoke:windows` runs in the Windows workflow. `smoke:manifest-launch` runs nowhere: it is a root
script named by no `ci-suites.txt` entry, no workflow and no package `test`, and it has never been
listed. That is a gap this slice reports rather than closes, because gating a suite is a change with
its own runtime and failure surface and does not belong in a typecheck repair. It is now type-clean
either way, which is the part this slice owns.

On the absolutes: the tree totals in the first paragraph were measured before this branch's tip
advanced into a merge. Read the delta, which is the slice's own 97 to 0, and re-derive any absolute
you intend to rely on at the tip you are reading.

## Deliberately not built

No shipped source is changed. `Manager.startAgent`'s third parameter is described in a test-local
view rather than re-exported; `actionContext` is not given the options parameter three suites assumed
it had, because the design removed that concept on purpose. No `@ts-expect-error`, no `any`, and no
non-null assertion is introduced to silence an error: every repair either states the type the value
actually has or fixes the fixture. No suite is added and no existing cell is deleted. The CI job that
would hold the count at zero is still not here; it belongs in the final slice, once the last area
reaches zero, so it lands measuring a real floor rather than a moving one.


