### PR TITLE
test(core): validate the backup inventory against broker truth in the gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -366,7 +366,7 @@
     "smoke:ext:live": "tsx bin/smoke/ext-live.smoke.ts",
     "smoke:dogfood:live": "tsx bin/smoke/dogfood-live.smoke.ts",
     "smoke:artifact-store": "tsx packages/core/smoke/artifact-store.smoke.ts",
-    "smoke:backup-inventory": "tsx packages/core/smoke/backup.smoke.ts",
+    "smoke:backup-inventory": "tsx packages/core/smoke/backup-inventory.smoke.ts",
     "smoke:backup-cli": "tsx implementations/cli/smoke/backup.smoke.ts",
     "smoke:backup-perms:live": "pnpm -F @cotal-ai/core smoke:backup:live",
     "smoke:backup-restore:live": "tsx bin/smoke/backup-restore-live.smoke.ts",

--- a/packages/core/smoke/backup-inventory.smoke.ts
+++ b/packages/core/smoke/backup-inventory.smoke.ts
@@ -1,0 +1,136 @@
+/**
+ * The backup inventory, validated against BROKER TRUTH, in the CI gate.
+ *
+ * WHY THIS SUITE EXISTS. #643: the gated backup smokes validated `spaceBackupInventory` against
+ * its own output, the same list on both sides of an exact set-equality, so the check passed even
+ * when a whole stream family was absent from the inventory. That is the mechanism that let the
+ * unenumerated authority stores (#356) sit undetected: nothing in the gate compared the inventory
+ * to a broker. A hand-pinned count cannot catch that class either, because it counts the
+ * inventory's own length, and a family the inventory never knew has nothing to count.
+ *
+ * So this suite does what the artifact-plane S2 suite (`smoke:artifact-store`) does: it provisions
+ * a real space on a real broker, enumerates what the broker ACTUALLY holds (its own stream list,
+ * never a name synthesized from `spaceBackupInventory()`), and runs `validateSpaceBackupInventory`
+ * against that. Exact set-equality against reality fails in BOTH directions: a stream created but
+ * unenumerated, and a stream enumerated but never created. That is the property the circular
+ * check could not have. It is GATED (ci-suites, `smoke:backup-inventory`); the hermetic
+ * `backup.smoke.ts` comparator unit tests remain in `pnpm test` under the core package.
+ *
+ * Run: pnpm smoke:backup-inventory   (needs nats-server on PATH; part of smoke:ci)
+ */
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { jetstreamManager } from "@nats-io/jetstream";
+import { connect } from "@nats-io/transport-node";
+import {
+  canonicalBackupStreamConfig,
+  dlvStream,
+  isReachable,
+  setupSpaceStreams,
+  validateSpaceBackupInventory,
+} from "../src/index.js";
+import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+
+const SPACE = "bkinv";
+const PORT = await pickFreePort();
+const sd = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
+const broker = spawn("nats-server", ["-js", "-sd", sd, "-p", String(PORT), "-a", "127.0.0.1"], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, sd);
+const servers = `nats://127.0.0.1:${PORT}`;
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+let ok = 0, fail = 0;
+const check = (name: string, pass: boolean, extra?: unknown) => {
+  if (pass) { ok++; } else { fail++; console.log("  ✗ FAIL:", name, extra ?? ""); }
+};
+
+// PRE-EXISTING GAP, NOT AN ACCEPTED ONE. `setupSpaceStreams` also creates the two SPEC 13.12
+// authority stores via `ensureAuthorityStores`, and they are in NEITHER the backup inventory NOR
+// `deleteSpace`'s explicit array (#356, owned by the control-surface lane). Subtracted HERE, by
+// prefix, exactly as `smoke:artifact-store` subtracts them: the gap is per-space, so every space
+// this suite creates leaks its own pair. This subtraction is why the equality below is "the
+// inventory matches the broker, bar the named pair" and not "the inventory matches the broker":
+// every OTHER family, on either side, still fails the check. When #356 enumerates them, DELETE
+// THIS BLOCK and the equality tightens automatically.
+const isUnenumeratedAuthority = (n: string) =>
+  n.startsWith("KV_cotal_auth_") || n.startsWith("KV_cotal_records_");
+const minusKnown = (names: string[]) => names.filter((n) => !isUnenumeratedAuthority(n));
+
+/** The broker's OWN stream list, on a fresh connection each call: a probe that mutates the broker
+ *  and re-validates must re-read it, or it grades a memory of the broker instead of the broker. */
+const readBrokerStreams = async (): Promise<string[]> => {
+  const c = await connect({ servers });
+  try {
+    const m = await jetstreamManager(c);
+    const names: string[] = [];
+    for await (const si of m.streams.list()) names.push(si.config.name);
+    return names;
+  } finally { await c.close(); }
+};
+
+/** Validate the broker's actual stream set for {@link SPACE}: "" on success, else the mismatch
+ *  message, the validator's own words, so a red names the stream it reddened for. */
+const validateAgainstBroker = async (): Promise<string> => {
+  const names = await readBrokerStreams();
+  try { validateSpaceBackupInventory(SPACE, minusKnown(names)); return ""; }
+  catch (e) { return (e as Error).message; }
+};
+
+try {
+  let up = false;
+  for (let i = 0; i < 50 && !up; i++) { up = await isReachable(servers); if (!up) await wait(100); }
+  if (!up) throw new Error(`broker never came up on ${PORT}`);
+
+  await setupSpaceStreams({ servers, space: SPACE });
+
+  // THE LOAD-BEARING CELL. Exact set-equality between what the broker holds and what the inventory
+  // declares, so a family created but unenumerated fails here, and one enumerated but never
+  // created fails here too. Both directions, one assertion. This is the check the circular
+  // `backup.smoke.ts` line could not be: remove a family from `spaceBackupInventory` and the
+  // broker's list still names it, so the validator throws `unexpected` here.
+  const equality = await validateAgainstBroker();
+  check("the broker's own stream set equals the backup inventory exactly", equality === "", equality);
+
+  // The named pair is the ONLY tolerance: prove the subtraction subtracts exactly the gap and
+  // nothing more, so the equality above cannot be quietly widened by a rename or a fourth store.
+  const raw = await readBrokerStreams();
+  check("the known-unenumerated pair is exactly the two authority stores",
+    raw.filter(isUnenumeratedAuthority).length === 2, raw);
+
+  // TEETH, BOTH DIRECTIONS, ON A REAL BROKER. The equality above is a claim that CAN fail; these
+  // cells make it fail on purpose, so the suite proves its own check is live rather than trusting
+  // the mutation rig to visit it. Each probe mutates the BROKER (never the inventory): the
+  // inventory under test stays the shipped one, and each probe is undone before the next cell
+  // reads the broker, so no cell grades a leftover of another.
+  const c0 = await connect({ servers });
+  await (await jetstreamManager(c0)).streams.delete(dlvStream(SPACE));
+  await c0.close();
+  const missingErr = await validateAgainstBroker();
+  check("a stream DELETED from the broker reddens the check as missing",
+    missingErr.includes("missing") && missingErr.includes(dlvStream(SPACE)), missingErr);
+
+  const c1 = await connect({ servers });
+  const jsm1 = await jetstreamManager(c1);
+  await jsm1.streams.add(canonicalBackupStreamConfig(SPACE, dlvStream(SPACE)));
+  await jsm1.streams.add({ name: "FOREIGN_PROBE", subjects: ["foreign.probe.>"] });
+  await c1.close();
+  const unexpectedErr = await validateAgainstBroker();
+  check("a stream the inventory does not know reddens the check as unexpected",
+    unexpectedErr.includes("unexpected") && unexpectedErr.includes("FOREIGN_PROBE"), unexpectedErr);
+
+  const c2 = await connect({ servers });
+  await (await jetstreamManager(c2)).streams.delete("FOREIGN_PROBE");
+  await c2.close();
+  const restored = await validateAgainstBroker();
+  check("the check is green again once the probes are undone", restored === "", restored);
+
+  console.log(`\nbackup inventory vs broker truth: ${ok} passed, ${fail} failed`);
+} finally {
+  broker.kill("SIGKILL");
+  rmSync(sd, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
+}
+process.exit(fail === 0 ? 0 : 1);

--- a/packages/core/smoke/backup.smoke.ts
+++ b/packages/core/smoke/backup.smoke.ts
@@ -42,6 +42,10 @@ assert.equal(inventory.full.length, 8);
 // LIFETIME, not durability - artifact bytes are transferable, not records. Its own `artifact`
 // class exists so this line cannot be read as "derived, therefore recomputable".
 assert.equal(inventory.excluded.length, 5);
+// Comparator mechanics ONLY: the list below is synthesized from the inventory itself, so this line
+// can never fail for a family the inventory lost or never knew. That is the #643 circularity; the claim
+// it used to carry (that the inventory agrees with a real broker) is proved by the GATED live
+// suite `smoke:backup-inventory` (backup-inventory.smoke.ts), which enumerates broker truth.
 assert.deepEqual(validateSpaceBackupInventory(space, [...inventory.full, ...inventory.excluded.map((s) => s.name)]), inventory);
 assert.throws(() => validateSpaceBackupInventory(space, inventory.full), /missing/);
 assert.throws(

--- a/packages/core/smoke/mutations/backup-inventory.json
+++ b/packages/core/smoke/mutations/backup-inventory.json
@@ -1,0 +1,51 @@
+{
+  "suite": "packages/core/smoke/backup-inventory.smoke.ts",
+  "guard": "The gated backup inventory check compares the inventory to BROKER TRUTH (its own stream list), not to the inventory's output. A family removed from either side must redden the check by name (#643).",
+  "command": "pnpm smoke:backup-inventory",
+  "completionMarker": "backup inventory vs broker truth:",
+  "proveWith": "pnpm mutation-proof --config packages/core/smoke/mutations/backup-inventory.json   # --config resolves against the repo root, never the cwd",
+  "why": [
+    "The gated smoke used to feed `spaceBackupInventory()` into `validateSpaceBackupInventory()`,",
+    "an exact set-equality with the same list on both sides, so it passed while a whole stream family",
+    "was missing from the inventory. That is how the unenumerated authority stores (#356) sat",
+    "undetected: the suites that would catch them did not run, and the suites that ran could not fail.",
+    "A hand-pinned count could not catch that class either; it counts the inventory's own length, and",
+    "a family the inventory never knew has nothing to count.",
+    "",
+    "The suite now provisions a real space and validates the broker's OWN enumeration against the",
+    "inventory (the artifact-plane S2 shape), so the check fails in both directions. Each mutation",
+    "below removes one family from one side and must redden the equality cell on the validator's own",
+    "words, which name the family. The three plants cover the three ways the circularity used to",
+    "hide: a backed-up family dropped, an excluded family dropped, and a family the broker holds that",
+    "the inventory never knew (the #356 direction, planted by refusing the named subtraction)."
+  ],
+  "mutations": [
+    {
+      "name": "a backed-up family (the ACL registry) is dropped from the inventory",
+      "file": "packages/core/src/backup-config.ts",
+      "find": "    { name: `KV_${aclBucket(space)}`, class: \"authorization\" },\n",
+      "replace": "",
+      "expectRed": "the broker's own stream set equals the backup inventory exactly",
+      "cell": "the broker's own stream set equals the backup inventory exactly",
+      "note": "The broker still creates the stream (driven by streams.ts, not the inventory), so it appears on the broker side only and the validator reports it as unexpected."
+    },
+    {
+      "name": "an excluded family (the presence bucket) is dropped from the inventory",
+      "file": "packages/core/src/backup-config.ts",
+      "find": "    { name: `KV_${presenceBucket(space)}`, class: \"transient\" },\n",
+      "replace": "",
+      "expectRed": "the broker's own stream set equals the backup inventory exactly",
+      "cell": "the broker's own stream set equals the backup inventory exactly",
+      "note": "Excluded streams are part of the validated set too: the space must account for every stream it owns, whether or not it enters the artifact."
+    },
+    {
+      "name": "the named #356 subtraction is widened to swallow every unexpected stream",
+      "file": "packages/core/smoke/backup-inventory.smoke.ts",
+      "find": "const isUnenumeratedAuthority = (n: string) =>\n  n.startsWith(\"KV_cotal_auth_\") || n.startsWith(\"KV_cotal_records_\");",
+      "replace": "  const isUnenumeratedAuthority = (n: string) => true;",
+      "expectRed": "the known-unenumerated pair is exactly the two authority stores",
+      "cell": "the known-unenumerated pair is exactly the two authority stores",
+      "note": "The subtraction is the check's only tolerance; a widened one is the circularity rebuilt one level up. The pair-count cell refuses it. This mutation plants the #356 direction: the broker holds families the inventory never knew, and the tolerance must not learn to ignore them."
+    }
+  ]
+}


### PR DESCRIPTION
The two gated backup smokes fed `spaceBackupInventory` back into `validateSpaceBackupInventory`, validating the produced inventory against itself. The check passed even when a whole stream family was missing, because a self-referential comparison cannot see an omission: the thing being validated and the thing it is validated against are the same object.

## Fix (circularity slice of #643)

`smoke:backup-inventory` now runs a live suite (`packages/core/smoke/backup-inventory.smoke.ts`) that provisions a real space, enumerates the broker's OWN stream list, and runs `validateSpaceBackupInventory` against that independent enumeration (the artifact-store S2 shape). The validator can now fail. The `§13.12` authority pair is subtracted by prefix with its removal instruction, pinned by a cell that refuses a wider tolerance so the subtraction cannot silently swallow more than the two authority stores.

`ci-suites.txt` has zero diff: `smoke:backup-inventory` was already a gated entry, so this repoints the existing gated check from the hermetic file to the live suite rather than adding a suite to the chain. The hermetic comparator tests stay under `pnpm test`, with the circular round-trip line annotated as mechanics-only.

## Proof

Before the fix, with the ACL family removed from `spaceBackupInventory`, the gated pair stayed effectively green for the validator: `smoke:backup-cli` green (blind), `smoke:backup-inventory` red only on a hand-pinned count, while the circular assertion itself still passed. The count cannot see the omission: it counts the inventory's own length. After the fix, the same plant reddens the named cell with the validator naming the family: `space backup inventory mismatch: missing [], unexpected [KV_cotal_acl_bkinv]`.

Mutation-proof 3/3 killed on named assertions (`packages/core/smoke/mutations/backup-inventory.json`): a backed-up family dropped and an excluded family dropped both redden "the broker's own stream set equals the backup inventory exactly"; a subtraction widened to swallow everything reddens "the known-unenumerated pair is exactly the two authority stores". `pnpm test` exit 0; `smoke:backup-cli`, `smoke:artifact-store`, `smoke:gate-inventory`, `smoke:core-boundary` green; no leaked brokers or store dirs.

## Deliberately not in scope

This is the circularity slice only. Bringing the broader live backup suites into a CI shard is left out; it waits on the inventory-reaping fix (#356) and the `backup-restore-live` repair, and is not addressed here. This change is test-only: `packages/core/src` is untouched and there is no changeset.

Refs #643.
