### PR TITLE
fix(core): name the rejected property in closed-contract refusals

### DIFF
--- a/.changeset/648-name-rejected-property.md
+++ b/.changeset/648-name-rejected-property.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/core": patch
+---
+
+Name the rejected property in closed-contract validation refusals. An `additionalProperties: false` refusal printed only `/ must NOT have additional properties`; the rejected key rides AJV's `params.additionalProperty` and was dropped, so a caller/responder version skew (a newer CLI sending a key an older deployed manager's contract predates) surfaced as a guessing game. Both render sites (the invocation-time `bad-request` and the responder-side `internal`) now append the key: `/ must NOT have additional properties: "events"`.

--- a/packages/core/smoke/endpoint-envelope.smoke.ts
+++ b/packages/core/smoke/endpoint-envelope.smoke.ts
@@ -208,6 +208,25 @@ c("absent args validate against the void schema as null", assertArgsValid(voidVa
 rejects("present args against the void schema are bad-request", "bad-request",
   () => assertArgsValid(voidValidate, { any: 1 }));
 
+// A closed-contract refusal must NAME the offending property. AJV carries the rejected key only in
+// `params.additionalProperty`; dropping it prints "/ must NOT have additional properties" and
+// turns a caller/responder version skew (a newer caller sending a key an older deployed
+// responder's contract predates) into a guessing game: nothing says which key or which side is
+// stale. The args and output render sites share one helper, so both are asserted.
+{
+  const closed = compileContractSchema({ root: { type: "object", properties: { name: { type: "string" } }, required: ["name"], additionalProperties: false } });
+  let argsMsg = "";
+  try { assertArgsValid(closed, { name: "x", events: true }); } catch (e) { argsMsg = (e as Error).message; }
+  c("a closed-contract args refusal names the offending property", /additional properties: "events"/.test(argsMsg), argsMsg);
+  let outMsg = "";
+  try { assertOutputValid(closed, { name: "x", events: true }); } catch (e) { outMsg = (e as Error).message; }
+  c("a closed-contract output refusal names the offending property", /additional properties: "events"/.test(outMsg), outMsg);
+  // Control: the name is appended ONLY for the additionalProperties keyword, never fabricated.
+  let typeMsg = "";
+  try { assertArgsValid(closed, { name: 7 }); } catch (e) { typeMsg = (e as Error).message; }
+  c("a non-additionalProperties refusal does not grow a property name", !typeMsg.includes("additional properties:"), typeMsg);
+}
+
 // The §13.8 validation budget on the REQUEST path is REPORTED, not enforced. No available
 // instrument can justify refusing a caller on it: elapsed counts the machine (this budget refused
 // an 82ms cold-JIT validation of a small, schema-VALID object during a gate run), and process CPU

--- a/packages/core/smoke/endpoint-serve.smoke.ts
+++ b/packages/core/smoke/endpoint-serve.smoke.ts
@@ -617,6 +617,10 @@ try {
   const r3b = await send(oneSubj("status"), req({ args: { name: 42 } }));
   c("args violating the input schema are bad-request BEFORE any effect",
     r3b !== undefined && r3b.reply.error?.code === "bad-request");
+  const r3x = await send(oneSubj("status"), req({ args: { name: "x", events: true } }));
+  c("a closed-contract refusal names the offending property over the wire (skew diagnosis starts there)",
+    r3x !== undefined && r3x.reply.error?.code === "bad-request" && (r3x.reply.error?.message ?? "").includes('"events"'),
+    JSON.stringify(r3x?.reply.error));
   const r3n = await send(oneSubj("status"), req({ args: null }));
   c("explicit-null args on an OBJECT-input command are bad-request through the SCHEMA (not the parser)",
     r3n !== undefined && r3n.reply.error?.code === "bad-request", JSON.stringify(r3n?.reply));

--- a/packages/core/src/endpoint-envelope.ts
+++ b/packages/core/src/endpoint-envelope.ts
@@ -539,6 +539,17 @@ function reportValidateBudget(what: "args" | "output", startedCpu: NodeJS.CpuUsa
   );
 }
 
+/** The first AJV error as refusal prose: where (`instancePath`, root as "/"), its message, and -
+ *  when the keyword is `additionalProperties` - WHICH property was rejected, which AJV carries
+ *  only in `params.additionalProperty`. A closed-contract refusal that does not name the key turns
+ *  a caller/manager version skew into a guessing game: the operator cannot tell which key to drop
+ *  or which side to upgrade. Shared by the args and output sides so the two render in lockstep. */
+function firstErrorDetail(first: { instancePath?: string; message?: string; params?: Record<string, unknown> } | undefined | null): string {
+  if (!first) return "";
+  const extra = typeof first.params?.additionalProperty === "string" ? `: ${JSON.stringify(first.params.additionalProperty)}` : "";
+  return `: ${first.instancePath || "/"} ${first.message ?? ""}${extra}`;
+}
+
 /** Validate `args` against the command's compiled input schema BEFORE any effect: failure is the
  *  invocation-time `bad-request` (registration-time violations are `contract-invalid`,
  *  {@link import("./schema-profile.js").ContractInvalidError}). Against the void schema the
@@ -560,7 +571,7 @@ export function assertArgsValid(validate: ValidateFunction, args: Record<string,
   reportValidateBudget("args", startedCpu, started);
   if (!okValid) {
     const first = validate.errors?.[0];
-    fail("bad-request", `args do not validate against the input schema${first ? `: ${first.instancePath || "/"} ${first.message ?? ""}` : ""}`);
+    fail("bad-request", `args do not validate against the input schema${firstErrorDetail(first)}`);
   }
   return value;
 }
@@ -580,6 +591,6 @@ export function assertOutputValid(validate: ValidateFunction, data: unknown): vo
   reportValidateBudget("output", startedCpu, started);
   if (!okValid) {
     const first = validate.errors?.[0];
-    fail("internal", `output does not validate against the pinned output schema; an invalid reply is a responder bug, never success (SPEC 13.7)${first ? `: ${first.instancePath || "/"} ${first.message ?? ""}` : ""}`);
+    fail("internal", `output does not validate against the pinned output schema; an invalid reply is a responder bug, never success (SPEC 13.7)${firstErrorDetail(first)}`);
   }
 }


### PR DESCRIPTION
Refs #648 (the opaque-refusal half; the version-skew explanation half is tracked separately and not addressed here).

## What changed

A closed-contract (`additionalProperties: false`) refusal printed only
`/ must NOT have additional properties`. AJV carries the rejected key in
`params.additionalProperty` and both render sites dropped it, so a
caller/responder version skew (a newer CLI sending a key an older deployed
manager predates) could not be diagnosed from the refusal. Both sites now
append the key through one shared helper:

    args do not validate against the input schema: / must NOT have additional properties: "events"

Codes, throw paths, and the no-error empty suffix are unchanged; the only
delta is the appended quoted-key segment (JSON.stringify, so keys containing
quotes stay unambiguous).

## What was deliberately NOT built

- No skew detection/explanation machinery (contract-version negotiation,
  capability probing): the refusal now names the key, which is the
  diagnosis; the skew half is a separate change.
- No message catalog or localization layer: this is diagnostic prose; the
  machine contract is the error `code`, which is untouched.
- No changeset churn beyond one @cotal-ai/core patch entry.

## Evidence

Live repro against a published 0.20.1 manager (whose spawn contract predates
the `events` key) on an isolated mesh, driven by the current tree's CLI:
before/after shown in the issue. Mutation-proof x2 KILLED on the named
assertions; wire leg proves the name crosses to the caller; negative control
proves no name is fabricated for other keywords. Two cross-vendor review
lenses APPROVE at this sha.
