### PR TITLE
test(connector-opencode): assert the event channel is core's derivation by identity, not one sampled value

### DIFF
--- a/extensions/connector-opencode/smoke/events-arm.smoke.ts
+++ b/extensions/connector-opencode/smoke/events-arm.smoke.ts
@@ -117,7 +117,7 @@ const HANDWRITTEN = eventChannel({ owner: "local", actor: "someone_elses_seat" }
   // that matters is that there is exactly one place the subject is decided. The value cell below would
   // pass a clone that returns the right string for `ollie`; only this fails the moment the assignment
   // is replaced by a re-implementation.
-  check("and the declared channel IS core's own derivation, not a re-implementation, so no clone can pass the value cell below",
+  check("and the declared channel IS core's own derivation, not a re-implementation: a clone that passes the value cell below still fails here",
     opencodeConnector.eventChannel === eventChannel);
   // BY VALUE, not by existence. A method that exists is another predicate proved against itself: it
   // says nothing about whether the channel the manager mints the grant for and the subject the

--- a/extensions/connector-opencode/smoke/events-arm.smoke.ts
+++ b/extensions/connector-opencode/smoke/events-arm.smoke.ts
@@ -112,6 +112,13 @@ const HANDWRITTEN = eventChannel({ owner: "local", actor: "someone_elses_seat" }
   // door because it never said it emits, which is what this connector did until it declared one.
   check("the connector DECLARES an event plane, which is what gets --events past the launch gate",
     typeof opencodeConnector.eventChannel === "function", typeof opencodeConnector.eventChannel);
+  // And it IS core's own derivation, not a second copy. By function identity rather than by output:
+  // two functions that agree on the sampled principal below can diverge on the next, and the property
+  // that matters is that there is exactly one place the subject is decided. The value cell below would
+  // pass a clone that returns the right string for `ollie`; only this fails the moment the assignment
+  // is replaced by a re-implementation.
+  check("and the declared channel IS core's own derivation, not a re-implementation, so no clone can pass the value cell below",
+    opencodeConnector.eventChannel === eventChannel);
   // BY VALUE, not by existence. A method that exists is another predicate proved against itself: it
   // says nothing about whether the channel the manager mints the grant for and the subject the
   // session publishes to are the same string. Compared against core's own derivation, on the
@@ -124,7 +131,7 @@ const HANDWRITTEN = eventChannel({ owner: "local", actor: "someone_elses_seat" }
 }
 
 // ---- Cell count, because a buildLaunch that threw on every input would DELETE cells, not fail them
-const EXPECTED = 14;
+const EXPECTED = 15;
 check(`every cell ran - ${EXPECTED} expected, a conditional cell that vanishes is invisible without this`,
   pass + fail === EXPECTED, `${pass + fail} cells reported`);
 


### PR DESCRIPTION
## What

The `events-arm` suite for the OpenCode connector asserted that the connector's
declared event channel matched core's derivation for one sample principal, by value:

```ts
// principal = { owner: "local", actor: "ollie" }
opencodeConnector.eventChannel?.(principal) === eventChannel(principal)
```

That is the right comparison at the wrong strength. A re-implementation of the
derivation that returned the correct string for `ollie` and diverged elsewhere would
pass the cell unchanged. What makes the property true in the shipped connector is not
the sampled value: it is that the connector's field IS core's function rather than a
copy, so the channel the manager mints the grant for and the subject the session
publishes to are decided in exactly one place.

This adds the function-identity assertion:

```ts
opencodeConnector.eventChannel === eventChannel
```

mirroring the assertion the codex `events-arm` suite already carries. The existing
by-value cell stays, because it additionally proves the derivation is keyed on the
principal rather than the display name.

Test-only. The property is already true; no behaviour changes. Closes #601.

## Proof

- Baseline: `smoke:opencode-events-arm` reports 16 passed, 0 failed.
- Mutation, cloning the assignment to `eventChannel: (p) => eventChannel(p)`: KILLED,
  red on the named assertion "not a re-implementation"; `mutation-proof` reports the
  suite discriminates.
- The gap shown directly: under that same clone, exactly one cell fails, the new
  identity cell, and the by-value cell is among the 15 that pass. The by-value cell
  alone could not have caught the clone; the new cell does.
- `pnpm typecheck` exits 0.

## Sibling gap, filed separately

The claude-code `events-arm` suite has the identical weakness (it asserts the declared
channel by value on one principal and no cell asserts function identity). Rather than
widen this PR past the issue it closes, that is filed as #713 so the weakness is on the
record with its reason, which is the disposition #601 itself argued for.
