### PR TITLE
fix(connector-jcode): version the package with its fixed group

### DIFF
--- a/extensions/connector-jcode/package.json
+++ b/extensions/connector-jcode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cotal-ai/connector-jcode",
   "description": "Cotal connector for Jcode: a host-mode mesh peer driven through Jcode's Harness API bridge.",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Main `ed0826dc` is red: #764 merged with `connector-jcode` at **0.25.0** while release #753 stamped the fixed changeset group at **0.26.0**. Both parents were honestly green — the skew exists only in the merged tree. The seed reconcile fails loud on a version-skewed payload (by design), so every suite that boots the CLI fails on main: all four smoke shards and `live`, with `connector "jcode" (@cotal-ai/connector-jcode) installed at version 0.25.0 but the seed generation is 0.26.0`.

**Change:** one line — bump `extensions/connector-jcode/package.json` to the group version 0.26.0. The lockfile references the package by workspace link, so nothing else moves.

**Proof it fails without / passes with:**
- Failing arm: CI at `ed0826dc` (runs 32512956967 and siblings) — `smoke:adoption-doctor-e2e` 7/10 with the exact skew string above.
- Passing arm: on this tree, `pnpm build` rc=0, `pnpm smoke:adoption-doctor-e2e` rc=0 (10/10), `pnpm typecheck` rc=0, `pnpm changeset status` rc=0.

**No changeset:** this aligns an unpublished tree with its own release stamp; the alternative cure is landing #766 (whose lockstep bump moves jcode to 0.27.0 and supersedes this line), but #766 currently carries its own unrelated shard-1 red (`smoke:delivery-renewal`, evictPrincipal cell). This PR unbreaks main independently of that.

Note for #759/#762/#763: their CI reds are inherited from this skew (identical failure string in their logs), not branch defects — they should re-run green once main is cured.