### PR TITLE
fix(connector-jcode): resume the session a restarted seat left behind

### DIFF
--- a/.changeset/789-resume-session.md
+++ b/.changeset/789-resume-session.md
@@ -1,0 +1,13 @@
+---
+"@cotal-ai/connector-jcode": patch
+---
+
+A restarted jcode seat now resumes the session it left instead of silently starting blank. The host
+called `createSession` unconditionally, so `cotal stop` followed by `cotal spawn` forked a new
+session and orphaned the existing transcript: the seat came back looking healthy while remembering
+nothing, and the TUI, which is spawned with `--resume`, showed an attaching human the very history
+the agent could not recall. The host now looks for a prior session in the seat's own home and
+attaches it, choosing conservatively: the session must declare this seat's working directory, must
+not be archived, and must carry a non-empty transcript. When nothing is resumable it starts fresh
+and says so, and when it does resume it does not re-send the persona briefing into a transcript that
+already opens with it.

--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -436,3 +436,9 @@ smoke:inbox-overflow-directed
 # four-route allowlist, capless credential proof, loopback negative control, immediate revocation,
 # public-only view refusal, Origin/body hardening, peer isolation and bearer refresh after expiry.
 smoke:remote-exchange:live
+
+# A restarted seat must resume the session it left, not silently start blank (#789). The host called
+# createSession unconditionally, so stop+respawn forked a new session and orphaned the transcript:
+# a live seat answered NO PRIOR CONTEXT about work in its own 112 KB journal, while the TUI, spawned
+# with --resume, showed a human the history the agent could not recall.
+smoke:jcode-session-resume

--- a/extensions/connector-jcode/smoke/fake-jcode.mjs
+++ b/extensions/connector-jcode/smoke/fake-jcode.mjs
@@ -18,6 +18,9 @@ if (!socketPath) {
 }
 log({ ev: "argv", argv: process.argv.slice(2), env: Object.fromEntries(Object.entries(process.env).filter(([key]) => key.startsWith("COTAL_") || key.startsWith("JCODE_"))) });
 
+let attachedExisting;
+let createdFresh = false;
+
 const server = createServer((socket) => {
   let buffered = "";
   socket.setEncoding("utf8");
@@ -31,13 +34,29 @@ const server = createServer((socket) => {
       if (!line) continue;
       const frame = JSON.parse(line);
       log({ ev: "request", frame });
+      // Recorded so a test can assert WHICH path the host took, not merely that it started.
+      if (frame.req === "create_session" || frame.req === "attach_session") {
+        log({ ev: "session_path", req: frame.req, session_id: frame.session_id ?? null });
+      }
       const reply = (body) => socket.write(JSON.stringify({ v: 1, reply_to: frame.id, ...body }) + "\n");
       const event = (body) => socket.write(JSON.stringify({ v: 1, ...body }) + "\n");
       switch (frame.req) {
         case "hello":
           reply({ ev: "hello_ok", version: 1, server: "fake-jcode/1", capabilities: ["sessions", "streaming"] });
           break;
+        // A prior session is offered only when the harness is told to have one, so the same fake
+        // covers both a first launch (nothing to resume) and a restart (exactly one candidate).
+        case "list_sessions": {
+          const preset = process.env.FAKE_JCODE_SESSIONS;
+          reply({ ev: "sessions", sessions: preset ? JSON.parse(preset) : [] });
+          break;
+        }
+        case "attach_session":
+          attachedExisting = frame.session_id;
+          reply({ ev: "attached", session: { session_id: frame.session_id, working_dir: frame.working_dir, status: "idle" } });
+          break;
         case "create_session":
+          createdFresh = true;
           reply({ ev: "attached", session: { session_id: "fake-session", working_dir: frame.working_dir, status: "idle" } });
           break;
         case "set_model":

--- a/extensions/connector-jcode/smoke/mutations/session-resume.json
+++ b/extensions/connector-jcode/smoke/mutations/session-resume.json
@@ -15,7 +15,12 @@
     "because a seat that silently inherits another lane's context acts on it with full confidence.",
     "So the mutations attack both directions - the shipped defect (never resume), and each guard that",
     "keeps a resume honest (working dir, archived, empty transcript, richest-wins). An over-eager",
-    "resume that adopts a foreign or retired session is a security-shaped bug, not a convenience one."
+    "resume that adopts a foreign or retired session is a security-shaped bug, not a convenience one.",
+    "",
+    "M6 note: an earlier version of M6 rewrote `[...usable].sort` to `usable.sort`, and it SURVIVED.",
+    "That was a bad mutation rather than a coverage gap - `usable` is produced by `filter`, which",
+    "already returns a fresh array, so sorting it in place is unobservable and the spread is merely",
+    "defensive. M6 now sorts the CALLER's array, which is the defect shape the assertion exists for."
   ],
   "mutations": [
     {
@@ -54,10 +59,10 @@
       "expectRed": "the largest transcript is chosen"
     },
     {
-      "name": "M6 sort the caller's array in place (observable side effect)",
+      "name": "M6 sort the CALLER's array in place instead of the filtered copy",
       "file": "extensions/connector-jcode/src/session-resume.ts",
       "find": "  return [...usable].sort(",
-      "replace": "  return usable.sort(",
+      "replace": "  (candidates as ResumeCandidate[]).sort((x, y) => (y.transcript_bytes ?? 0) - (x.transcript_bytes ?? 0));\n  return [...usable].sort(",
       "expectRed": "the input list is not mutated (no in-place sort)"
     }
   ]

--- a/extensions/connector-jcode/smoke/mutations/session-resume.json
+++ b/extensions/connector-jcode/smoke/mutations/session-resume.json
@@ -1,0 +1,64 @@
+{
+  "suite": "extensions/connector-jcode/smoke/session-resume.smoke.ts",
+  "guard": "a restarting seat resumes its own prior session - same working dir, not archived, non-empty transcript, richest transcript wins - and otherwise starts fresh rather than adopting a session it cannot prove is its own",
+  "command": "pnpm smoke:jcode-session-resume",
+  "completionMarker": "session resume:",
+  "proveWith": "node scripts/mutation-proof.mjs --config extensions/connector-jcode/smoke/mutations/session-resume.json",
+  "why": [
+    "Found by dogfooding, not by a gate. A seat was stopped and respawned under the same name; it",
+    "returned to the same private home with its 112 KB journal intact, then answered NO PRIOR CONTEXT",
+    "when asked to recall from history alone a file it had written an hour earlier. The restart had",
+    "forked a 1.7 KB session and orphaned the real one, because the host called createSession",
+    "unconditionally while the SDK already offered listSessions and attachSession (#789).",
+    "",
+    "The rule is conservative on purpose: resuming the WRONG session is worse than starting clean,",
+    "because a seat that silently inherits another lane's context acts on it with full confidence.",
+    "So the mutations attack both directions - the shipped defect (never resume), and each guard that",
+    "keeps a resume honest (working dir, archived, empty transcript, richest-wins). An over-eager",
+    "resume that adopts a foreign or retired session is a security-shaped bug, not a convenience one."
+  ],
+  "mutations": [
+    {
+      "name": "M1 the shipped defect: never resume, always start blank",
+      "file": "extensions/connector-jcode/src/session-resume.ts",
+      "find": "  if (!candidates?.length) return undefined;",
+      "replace": "  if (!candidates?.length) return undefined;\n  return undefined;",
+      "expectRed": "a single matching prior session is resumed"
+    },
+    {
+      "name": "M2 adopt a session belonging to a different working directory",
+      "file": "extensions/connector-jcode/src/session-resume.ts",
+      "find": "      typeof c.working_dir === \"string\" &&\n      c.working_dir === cwd &&",
+      "replace": "      true &&",
+      "expectRed": "a foreign working_dir is refused"
+    },
+    {
+      "name": "M3 resume sessions the operator explicitly archived",
+      "file": "extensions/connector-jcode/src/session-resume.ts",
+      "find": "      c.archived !== true &&",
+      "replace": "      true &&",
+      "expectRed": "an archived session is never auto-resumed"
+    },
+    {
+      "name": "M4 treat an empty or unknown transcript as resumable memory",
+      "file": "extensions/connector-jcode/src/session-resume.ts",
+      "find": "      typeof c.transcript_bytes === \"number\" &&\n      c.transcript_bytes > 0,",
+      "replace": "      true,",
+      "expectRed": "a zero-byte transcript carries no memory and is skipped"
+    },
+    {
+      "name": "M5 pick the thinnest transcript - the restart's own stub outranks the real session",
+      "file": "extensions/connector-jcode/src/session-resume.ts",
+      "find": "      (b.transcript_bytes ?? 0) - (a.transcript_bytes ?? 0) || a.session_id.localeCompare(b.session_id),",
+      "replace": "      (a.transcript_bytes ?? 0) - (b.transcript_bytes ?? 0) || a.session_id.localeCompare(b.session_id),",
+      "expectRed": "the largest transcript is chosen"
+    },
+    {
+      "name": "M6 sort the caller's array in place (observable side effect)",
+      "file": "extensions/connector-jcode/src/session-resume.ts",
+      "find": "  return [...usable].sort(",
+      "replace": "  return usable.sort(",
+      "expectRed": "the input list is not mutated (no in-place sort)"
+    }
+  ]
+}

--- a/extensions/connector-jcode/smoke/session-resume.smoke.ts
+++ b/extensions/connector-jcode/smoke/session-resume.smoke.ts
@@ -98,12 +98,24 @@ console.log("\n6. an unusable session is skipped rather than trusted");
 
 console.log("\n7. selection is stable and side-effect free");
 {
-  const list = [s({ session_id: "a", transcript_bytes: 10 }), s({ session_id: "b", transcript_bytes: 20 })];
-  const frozen = JSON.stringify(list);
+  // Ordered so that sorting in place PROVABLY reorders: richest first means a descending sort must
+  // move elements. A two-element already-descending list would be a no-op and would let an in-place
+  // sort pass unnoticed (the first version of this test did exactly that, and a mutation caught it).
+  const list = [
+    s({ session_id: "a", transcript_bytes: 10 }),
+    s({ session_id: "c", transcript_bytes: 30 }),
+    s({ session_id: "b", transcript_bytes: 20 }),
+  ];
+  const orderBefore = list.map((c) => c.session_id).join(",");
   const first = chooseSessionToResume(list, cwd)?.session_id;
+  const orderAfter = list.map((c) => c.session_id).join(",");
   const second = chooseSessionToResume(list, cwd)?.session_id;
-  check("repeated selection returns the same session", first === second && first === "b");
-  check("the input list is not mutated (no in-place sort)", JSON.stringify(list) === frozen);
+  check("repeated selection returns the same session", first === second && first === "c");
+  check(
+    "the input list is not mutated (no in-place sort)",
+    orderAfter === orderBefore,
+    { orderBefore, orderAfter },
+  );
 }
 
 console.log(`\nsession resume: ${pass} cells OK, ${failures.length} failed`);

--- a/extensions/connector-jcode/smoke/session-resume.smoke.ts
+++ b/extensions/connector-jcode/smoke/session-resume.smoke.ts
@@ -1,0 +1,112 @@
+/**
+ * A restarted seat must come back to the session it left, not a blank one.
+ *
+ * Measured on a live seat before this suite existed: `cotal stop` then `cotal spawn` under the same
+ * name returned the seat to the same private home with its 112 KB journal still on disk, and the
+ * seat answered "NO PRIOR CONTEXT" when asked to recall, from history alone, a file it had written
+ * an hour earlier. The host called `createSession` unconditionally, forking a new 1.7 KB session and
+ * orphaning the real one. The TUI is spawned with `--resume`, so an attaching human saw a history
+ * the agent itself could not remember (#789).
+ *
+ * This grades the SELECTION RULE, which is where the bug lived - not the SDK, which already offered
+ * `listSessions` / `attachSession` and was simply never called.
+ */
+import assert from "node:assert/strict";
+import { chooseSessionToResume, type ResumeCandidate } from "../src/session-resume.js";
+
+let pass = 0;
+const failures: string[] = [];
+const check = (name: string, cond: boolean, extra?: unknown): void => {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+    return;
+  }
+  const detail = `${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`;
+  failures.push(detail);
+  console.log(`  ✗ ${detail}`);
+};
+
+const cwd = "/work/repo";
+const other = "/work/elsewhere";
+const s = (over: Partial<ResumeCandidate> & { session_id: string }): ResumeCandidate => ({
+  working_dir: cwd,
+  status: "idle",
+  transcript_bytes: 4096,
+  archived: false,
+  ...over,
+});
+
+console.log("\n1. the defect: a restart must not silently start blank");
+{
+  const prior = s({ session_id: "piglet", transcript_bytes: 112467 });
+  const picked = chooseSessionToResume([prior], cwd);
+  check("a single matching prior session is resumed", picked?.session_id === "piglet", picked);
+  check("resuming is preferred over forking a fresh session", picked !== undefined);
+}
+
+console.log("\n2. nothing to resume is a legitimate first launch, not a failure");
+{
+  check("an empty list yields no candidate", chooseSessionToResume([], cwd) === undefined);
+  check("undefined (the API refused or failed) yields no candidate", chooseSessionToResume(undefined, cwd) === undefined);
+}
+
+console.log("\n3. a session belonging to a different working dir is NOT ours");
+{
+  const foreign = s({ session_id: "foreign", working_dir: other });
+  check("a foreign working_dir is refused", chooseSessionToResume([foreign], cwd) === undefined, foreign);
+  const mixed = [foreign, s({ session_id: "mine" })];
+  check("ours is selected out of a mixed list", chooseSessionToResume(mixed, cwd)?.session_id === "mine");
+}
+
+console.log("\n4. archived sessions stay archived");
+{
+  const archived = s({ session_id: "old", archived: true, transcript_bytes: 999999 });
+  check("an archived session is never auto-resumed", chooseSessionToResume([archived], cwd) === undefined);
+  const mixed = [archived, s({ session_id: "live", transcript_bytes: 10 })];
+  check(
+    "a live session wins over a larger archived one",
+    chooseSessionToResume(mixed, cwd)?.session_id === "live",
+  );
+}
+
+console.log("\n5. the richest transcript wins, because that is the memory worth keeping");
+{
+  const list = [
+    s({ session_id: "thin", transcript_bytes: 1753 }),
+    s({ session_id: "fat", transcript_bytes: 112467 }),
+    s({ session_id: "middling", transcript_bytes: 40000 }),
+  ];
+  check("the largest transcript is chosen", chooseSessionToResume(list, cwd)?.session_id === "fat");
+  // The exact live shape: the restart's own fresh 1.7 KB session must never beat the real one.
+  check(
+    "a fresh stub does not outrank the session it would replace",
+    chooseSessionToResume([s({ session_id: "fox", transcript_bytes: 1753 }), s({ session_id: "piglet", transcript_bytes: 112467 })], cwd)
+      ?.session_id === "piglet",
+  );
+}
+
+console.log("\n6. an unusable session is skipped rather than trusted");
+{
+  const missingDir = { session_id: "nodir", status: "idle", transcript_bytes: 500 } as ResumeCandidate;
+  check("a session with no working_dir is refused (cannot prove it is ours)", chooseSessionToResume([missingDir], cwd) === undefined);
+  const empty = s({ session_id: "empty", transcript_bytes: 0 });
+  check("a zero-byte transcript carries no memory and is skipped", chooseSessionToResume([empty], cwd) === undefined);
+  const noBytes = s({ session_id: "unknown", transcript_bytes: undefined });
+  check("an unknown transcript size is not assumed rich", chooseSessionToResume([noBytes], cwd) === undefined);
+}
+
+console.log("\n7. selection is stable and side-effect free");
+{
+  const list = [s({ session_id: "a", transcript_bytes: 10 }), s({ session_id: "b", transcript_bytes: 20 })];
+  const frozen = JSON.stringify(list);
+  const first = chooseSessionToResume(list, cwd)?.session_id;
+  const second = chooseSessionToResume(list, cwd)?.session_id;
+  check("repeated selection returns the same session", first === second && first === "b");
+  check("the input list is not mutated (no in-place sort)", JSON.stringify(list) === frozen);
+}
+
+console.log(`\nsession resume: ${pass} cells OK, ${failures.length} failed`);
+if (failures.length) {
+  assert.fail(`session resume: ${failures.length} cell(s) failed\n  - ${failures.join("\n  - ")}`);
+}

--- a/extensions/connector-jcode/src/host.ts
+++ b/extensions/connector-jcode/src/host.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { JcodeClient, type ApiEvent } from "@1jehuang/jcode-sdk";
 import { hardenPrivate, loadAgentFile } from "@cotal-ai/core";
 import { mirrorJcodeCredentials, shortSocketHome } from "./private-state.js";
+import { chooseSessionToResume, type ResumeCandidate } from "./session-resume.js";
 import {
   MeshAgent,
   ORIENTATION_BOOTSTRAP,
@@ -329,11 +330,38 @@ export async function runJcodeHost(): Promise<void> {
       inheritLogins: false,
       env: { JCODE_DISABLE_CLAUDE_MCP: "1" },
     });
-    const session = await client.createSession(cwd);
+    // A restart must come back to the session it left. Calling createSession unconditionally forked
+    // a blank session and orphaned the real transcript, so a restarted seat reported for duty looking
+    // healthy while remembering nothing - and the TUI, spawned with --resume below, showed a human the
+    // very history the agent could not recall (#789). listSessions failing is not fatal: a seat that
+    // cannot enumerate still deserves to start, it just starts fresh and says so.
+    let prior: ResumeCandidate | undefined;
+    try {
+      prior = chooseSessionToResume(await client.listSessions(), cwd);
+    } catch (error) {
+      process.stderr.write(
+        `[cotal-jcode] could not list prior sessions, starting fresh: ${(error as Error).message}\n`,
+      );
+    }
+    let session;
+    if (prior) {
+      session = await client.attachSession(prior.session_id);
+      process.stderr.write(
+        `[cotal-jcode] resumed session ${prior.session_id} (${prior.transcript_bytes} bytes of transcript)\n`,
+      );
+    } else {
+      session = await client.createSession(cwd);
+      process.stderr.write(`[cotal-jcode] started a fresh session (no resumable prior session in this home)\n`);
+    }
+    const resumed = prior !== undefined;
     sessionId = session.session_id;
     agent.setContextId(sessionId);
     if (config.model) await client.setModel(sessionId, config.model);
-    await client.sendMessage(sessionId, instructions(config, def?.persona || undefined), { noReply: true });
+    // On a resume the persona/instructions are already the first thing in this transcript. Re-sending
+    // them would replay the whole briefing on every restart and grow the context without adding to it.
+    if (!resumed) {
+      await client.sendMessage(sessionId, instructions(config, def?.persona || undefined), { noReply: true });
+    }
     // Jcode registers MCP tools asynchronously. A first workload turn before its tools appear is
     // a silent mesh failure: the seat looks online yet cannot answer peers. Prove the exact cotal
     // surface is callable first. The Harness API exposes no MCP-ready event, so an absent call is

--- a/extensions/connector-jcode/src/session-resume.ts
+++ b/extensions/connector-jcode/src/session-resume.ts
@@ -1,0 +1,53 @@
+/**
+ * Which stored session, if any, a restarting seat should come back to.
+ *
+ * Kept apart from the host so the rule can be graded directly. The rule is deliberately
+ * conservative: resuming the WRONG session is worse than starting clean, because a seat that
+ * silently inherits another lane's context will act on it with full confidence.
+ */
+
+/** The subset of the SDK's `SessionInfo` this decision actually reads. */
+export interface ResumeCandidate {
+  session_id: string;
+  working_dir?: string;
+  status?: string;
+  transcript_bytes?: number;
+  archived?: boolean;
+}
+
+/**
+ * Pick the session to attach, or `undefined` to create a fresh one.
+ *
+ * A candidate must prove it is ours before it can be resumed:
+ *   - it declares a `working_dir`, and that dir is this seat's cwd (an undeclared dir cannot be
+ *     proven, so it is refused rather than assumed);
+ *   - it is not archived (archiving is an operator's explicit "retire this");
+ *   - it carries a transcript with actual bytes, since resuming an empty session buys nothing and
+ *     an unknown size is not assumed to be rich.
+ *
+ * Among survivors the largest transcript wins: that is the one holding the memory a restart would
+ * otherwise throw away, and it is what distinguishes the real session from the stub a previous
+ * buggy restart may have left behind.
+ */
+export function chooseSessionToResume(
+  candidates: readonly ResumeCandidate[] | undefined,
+  cwd: string,
+): ResumeCandidate | undefined {
+  if (!candidates?.length) return undefined;
+  const usable = candidates.filter(
+    (c) =>
+      typeof c.session_id === "string" &&
+      c.session_id.length > 0 &&
+      c.archived !== true &&
+      typeof c.working_dir === "string" &&
+      c.working_dir === cwd &&
+      typeof c.transcript_bytes === "number" &&
+      c.transcript_bytes > 0,
+  );
+  if (!usable.length) return undefined;
+  // Copy before sorting: the caller's list is not ours to reorder.
+  return [...usable].sort(
+    (a, b) =>
+      (b.transcript_bytes ?? 0) - (a.transcript_bytes ?? 0) || a.session_id.localeCompare(b.session_id),
+  )[0];
+}

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "smoke:jcode-args": "tsx extensions/connector-jcode/smoke/jcode-args.smoke.ts",
     "smoke:jcode-host": "tsx extensions/connector-jcode/smoke/jcode-host.smoke.ts",
     "smoke:jcode-private-state": "tsx extensions/connector-jcode/smoke/private-state.smoke.ts",
+    "smoke:jcode-session-resume": "tsx extensions/connector-jcode/smoke/session-resume.smoke.ts",
     "smoke:jcode-security": "tsx extensions/connector-jcode/smoke/jcode-security.smoke.ts",
     "smoke:jcode-live": "tsx extensions/connector-jcode/smoke/jcode-live.smoke.ts",
     "smoke:view": "tsx implementations/cli/smoke/view.smoke.ts",


### PR DESCRIPTION
## What

A restarted jcode seat now resumes its own prior session instead of silently starting blank.

## The failure

`cotal stop` then `cotal spawn` under the same name. The seat returns to the **same private home**, with its previous journal intact. Then:

> **operator:** answer from your own conversation history only: earlier you wrote a file for me under this directory and read it back. What was its exact filename and its two lines? If you have no memory of that, say exactly NO PRIOR CONTEXT.
>
> **seat:** NO PRIOR CONTEXT

It was being honest. It had nothing, while the work sat in a 112 KB journal beside it:

```
session_piglet_….json    112467 bytes   <- the actual work
session_fox_….json         1753 bytes   <- what the restart created
```

`host.ts` called `createSession` on every launch and never looked at what the home already held, though the SDK offers `listSessions` and `attachSession`. Twenty lines further down the same file spawns the TUI with `--resume`, so **an attaching human saw the history the agent itself could not recall**.

This is not an exotic path: it is how an operator applies a config change, recovers a wedged seat, or moves a lane, and a manager restart does it to the whole fleet at once. Every one of those silently amnesiaed every seat, and the seats reported for duty looking healthy. It is also why #783 (rolling PTY handoff) is worth less than it should be - a perfect handoff still hands off to a seat that forgot.

## The rule

The decision lives in `session-resume.ts` so it can be graded directly, and it is deliberately conservative, because **resuming the wrong session is worse than starting clean**: a seat that silently inherits another lane's context will act on it with full confidence. A candidate must prove it is ours:

- declares a `working_dir`, and it is this seat's cwd (undeclared cannot be proven, so it is refused)
- not archived (archiving is an operator's explicit retire)
- carries a non-empty transcript (an unknown size is not assumed rich)

Among survivors the largest transcript wins, which is what stops a previous buggy restart's 1.7 KB stub from outranking the real session.

Enumeration failure is not fatal - the seat starts fresh and says why. A resumed seat does not re-send the persona briefing into a transcript that already opens with it.

## Proof

- `smoke:jcode-session-resume` - new suite, **15/15**, covering the live shape exactly.
- `mutation-proof` - **6/6 KILLED**, each at its named assertion: never-resume (the shipped defect), adopt a foreign working dir, resume an archived session, treat an empty transcript as memory, prefer the thinnest transcript, and mutate the caller's array.
- Neighbours green through the real launch path: `jcode-host` 11 checks (including "mesh DM becomes a Harness API turn" and the MCP readiness turn), `jcode-args` 28, `jcode-security` 6.
- `typecheck` clean, `GATE INVENTORY OK`.
- `fake-jcode.mjs` gained `list_sessions`/`attach_session` and now logs which path the host took, so the harness can assert resume-vs-create rather than only that a seat started.

One honest note: the first M6 mutation **SURVIVED**, and that turned out to be the mutation being wrong rather than a coverage gap - `usable` comes from `filter`, which already returns a fresh array, so sorting it in place is unobservable. M6 now mutates the caller's array, which is the defect the assertion was actually written for. Recorded in the fixture's `why`.

Closes #789.