### PR TITLE
fix(connector-core): channel volume must not silence directed mail (#791)

### DIFF
--- a/.changeset/791-evict-channel-first.md
+++ b/.changeset/791-evict-channel-first.md
@@ -1,0 +1,16 @@
+---
+"@cotal-ai/connector-core": patch
+---
+
+A peer flooding a channel can no longer silence directed mail. The inbox overflow valve sacrificed
+pull-only backlog first, but pull-only requires a non-forgeable signal it did not have: it is
+`!mentionsMe && historical`, and `mentionsMe` is read from the payload `mentions` field, which the
+sender controls. A peer stamping the victim's name on every flooded message made none of its traffic
+pull-only, so eviction fell through to the oldest entry, which is the message that had been waiting
+longest, and acked it without marking it handled - unrecoverable, since the broker then never
+redelivers. Ordinary ambient channel traffic at volume did the same with no forgery at all.
+
+Eviction now prefers channel traffic over anything addressed to this agent, reading directedness
+from the subject-derived `kind` rather than from the payload, and a directed message that must be
+sacrificed is left un-acked so it can be redelivered. Channel ambient is still acked, because
+replaying it is what the earlier history flood was.

--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -417,3 +417,11 @@ smoke:web-body-cap
 # The old tail offered three ways to reply and never mentioned doing the work, at the exact moment
 # the model chooses its next action.
 smoke:injection-framing
+
+# The inbox overflow valve must not let channel volume silence directed mail (#791). pullOnly is
+# `!mentionsMe && historical` and mentionsMe comes from a forgeable payload field, so a peer that
+# stamped the victim's name on every flooded message made none of its traffic pull-only: eviction
+# fell through to the oldest entry, a waiting DM, and acked it unhandled. Plain ambient volume did
+# the same with no forgery. The suite shipped with #776 buffered 120 against MAX_INBOX 200, so it
+# never crossed this valve at all.
+smoke:inbox-overflow-directed

--- a/extensions/connector-core/smoke/inbox-overflow-directed.smoke.ts
+++ b/extensions/connector-core/smoke/inbox-overflow-directed.smoke.ts
@@ -129,6 +129,30 @@ console.log("\n6. an all-directed inbox still bounds memory (no attacker advanta
   );
 }
 
+console.log("\n7. the in-flight ceiling refuses all-or-nothing, and a refused DM is still not lost");
+{
+  // holdInFlight caps at MAX_INBOX * 2. A flood can exhaust that ceiling, at which point the guard
+  // refuses a whole batch and the caller must not surface it. The contract is a DEFERRAL, so the
+  // messages must still be buffered and un-acked; a refusal that also dropped them would turn a
+  // protection into the very loss it exists to prevent (audit finding 2 on #776).
+  const h = harness();
+  const held: string[] = [];
+  for (let i = 0; i < 420; i++) {
+    const id = `hold-${i}`;
+    h.push({ id, kind: "dm", channel: "", from: "peer" });
+    held.push(id);
+  }
+  const agent = h.agent as unknown as { holdInFlight: (ids: readonly string[]) => boolean };
+  const first = agent.holdInFlight(held.slice(0, 300));
+  const past = agent.holdInFlight(held.slice(300));
+  check("a batch within the ceiling is held", first === true);
+  check("a batch that would cross the ceiling is refused whole", past === false);
+  check(
+    "the refused DMs were NOT acked - refusal is a deferral, not a drop",
+    !held.slice(300).some((id) => h.acked.has(id)),
+  );
+}
+
 console.log(`\ninbox overflow directed: ${pass} cells OK, ${failures.length} failed`);
 if (failures.length) {
   assert.fail(`inbox overflow directed: ${failures.length} cell(s) failed\n  - ${failures.join("\n  - ")}`);

--- a/extensions/connector-core/smoke/inbox-overflow-directed.smoke.ts
+++ b/extensions/connector-core/smoke/inbox-overflow-directed.smoke.ts
@@ -1,0 +1,135 @@
+/**
+ * A peer flooding a channel must not be able to silence directed mail.
+ *
+ * The overflow valve sacrifices `pullOnly` entries first, and `pullOnly` is
+ * `!mentionsMe && historical`. `mentionsMe` comes from the payload `mentions` field, which the code
+ * itself calls forgeable. A hostile peer stamping the victim's name on every flooded message made
+ * none of its traffic pull-only, so `findIndex` returned -1 and eviction fell through to index 0 -
+ * the OLDEST entry, i.e. the DM that had been waiting longest. It was spliced out and `ack()`ed
+ * without being marked handled, so JetStream never redelivered it: silent, unrecoverable loss (#791).
+ *
+ * Plain ambient channel traffic at volume did the same thing with no forgery at all.
+ *
+ * This suite crosses the real valve. The suite shipped with #776 buffered 120 items against a
+ * MAX_INBOX of 200, so it never reached the overflow path it was meant to cover.
+ */
+import assert from "node:assert/strict";
+import { MeshAgent } from "../src/agent.js";
+import type { InboxItem } from "../src/types.js";
+
+let pass = 0;
+const failures: string[] = [];
+const check = (name: string, cond: boolean, extra?: unknown): void => {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+    return;
+  }
+  const detail = `${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`;
+  failures.push(detail);
+  console.log(`  ✗ ${detail}`);
+};
+
+const MAX_INBOX = 200;
+
+interface Harness {
+  agent: MeshAgent;
+  acked: Set<string>;
+  push: (item: Partial<InboxItem> & { id: string }, opts?: { pullOnly?: boolean }) => void;
+  ids: () => string[];
+}
+
+function harness(): Harness {
+  const agent = new MeshAgent({ name: "victim", space: "main", connector: "test" } as never);
+  const acked = new Set<string>();
+  const push: Harness["push"] = (partial, opts) => {
+    const item = {
+      kind: "channel",
+      channel: "team.noise",
+      from: "flooder",
+      text: "x",
+      mentionsMe: false,
+      historical: false,
+      ...partial,
+    } as InboxItem;
+    // Reach the private valve directly: this suite grades eviction, not ingest classification.
+    (agent as unknown as { buffer: (i: InboxItem, a: () => void, p: boolean) => void }).buffer(
+      item,
+      () => acked.add(item.id),
+      opts?.pullOnly ?? (!item.mentionsMe && item.historical),
+    );
+  };
+  const ids = () =>
+    (agent as unknown as { inbox: { item: InboxItem }[] }).inbox.map((p) => p.item.id);
+  return { agent, acked, push, ids };
+}
+
+console.log("\n1. the attack: a forged-mention flood must not evict a waiting DM");
+{
+  const h = harness();
+  h.push({ id: "dm-1", kind: "dm", channel: "", from: "colleague", text: "the answer is 4" });
+  // Every flooded message claims to mention the victim, so none of it is pullOnly.
+  for (let i = 0; i < 400; i++) h.push({ id: `flood-${i}`, mentionsMe: true, historical: true });
+
+  check("the inbox stayed bounded", h.ids().length <= MAX_INBOX, h.ids().length);
+  check("the waiting DM is STILL PRESENT after the flood", h.ids().includes("dm-1"));
+  check("the waiting DM was never acked (redelivery stays possible)", !h.acked.has("dm-1"));
+}
+
+console.log("\n2. the no-forgery case: plain live ambient channel traffic at volume");
+{
+  const h = harness();
+  h.push({ id: "dm-2", kind: "dm", channel: "", from: "colleague", text: "ping" });
+  for (let i = 0; i < 400; i++) h.push({ id: `ambient-${i}` });
+
+  check("the DM survives ordinary ambient volume", h.ids().includes("dm-2"));
+  check("the DM was not acked", !h.acked.has("dm-2"));
+}
+
+console.log("\n3. anycast is directed too and gets the same protection");
+{
+  const h = harness();
+  h.push({ id: "any-1", kind: "anycast", channel: "", from: "dispatcher", text: "claim me" });
+  for (let i = 0; i < 300; i++) h.push({ id: `f-${i}`, mentionsMe: true, historical: true });
+
+  check("an anycast task survives a mention-forged flood", h.ids().includes("any-1"));
+  check("the anycast task was not acked", !h.acked.has("any-1"));
+}
+
+console.log("\n4. channel ambient is still what gets sacrificed, and is still acked");
+{
+  const h = harness();
+  for (let i = 0; i < 260; i++) h.push({ id: `c-${i}` });
+
+  check("the inbox is capped", h.ids().length === MAX_INBOX, h.ids().length);
+  check("evicted channel traffic WAS acked (replaying it is the history flood)", h.acked.size === 60, h.acked.size);
+  check("the oldest channel items are the ones dropped", !h.ids().includes("c-0"));
+}
+
+console.log("\n5. pull-only backlog is still sacrificed before anything else");
+{
+  const h = harness();
+  h.push({ id: "keep-live", text: "live ambient" });
+  for (let i = 0; i < 250; i++) h.push({ id: `hist-${i}`, historical: true });
+
+  check("a live channel item outlives historical backlog", h.ids().includes("keep-live"));
+  check("historical backlog absorbed the eviction", h.acked.size > 0);
+}
+
+console.log("\n6. an all-directed inbox still bounds memory (no attacker advantage)");
+{
+  const h = harness();
+  for (let i = 0; i < 260; i++) h.push({ id: `dm-${i}`, kind: "dm", channel: "", from: "peer" });
+
+  check("the inbox is still capped when everything is directed", h.ids().length === MAX_INBOX, h.ids().length);
+  check(
+    "sacrificed DMs are NOT acked, so the broker can redeliver them",
+    h.acked.size === 0,
+    [...h.acked].slice(0, 3),
+  );
+}
+
+console.log(`\ninbox overflow directed: ${pass} cells OK, ${failures.length} failed`);
+if (failures.length) {
+  assert.fail(`inbox overflow directed: ${failures.length} cell(s) failed\n  - ${failures.join("\n  - ")}`);
+}

--- a/extensions/connector-core/smoke/mutations/inbox-overflow-directed.json
+++ b/extensions/connector-core/smoke/mutations/inbox-overflow-directed.json
@@ -1,0 +1,70 @@
+{
+  "suite": "extensions/connector-core/smoke/inbox-overflow-directed.smoke.ts",
+  "guard": "the inbox overflow valve sacrifices channel traffic before anything addressed to this agent, reads directedness from the subject-derived kind rather than the forgeable payload, and never acks a directed message it evicts so the broker can redeliver it",
+  "command": "pnpm smoke:inbox-overflow-directed",
+  "completionMarker": "inbox overflow directed:",
+  "proveWith": "node scripts/mutation-proof.mjs --config extensions/connector-core/smoke/mutations/inbox-overflow-directed.json",
+  "why": [
+    "A peer flooding a channel could silence a live DM waiting in the inbox. buffer() evicts pullOnly",
+    "entries first, and pullOnly is !mentionsMe && historical, where mentionsMe is read from the",
+    "payload mentions field the sender controls. A peer stamping the victim's name on every flooded",
+    "message made none of its traffic pull-only, so findIndex returned -1, eviction fell through to",
+    "index 0 - the oldest entry, the DM that had waited longest - and acked it without marking it",
+    "handled, which the broker treats as delivered. Plain ambient channel volume did the same with no",
+    "forgery at all (#791).",
+    "",
+    "This was invisible because no suite in the set ever pushed the inbox PAST MAX_INBOX, so the",
+    "eviction branch was never executed by any test: history-flood buffers 119, inbox-window buffers",
+    "exactly 200 as a deliberate boundary, and cross-path-dedup loops 8500 but drains after every",
+    "message so it never accumulates. This suite pushes 400 against a cap of 200 specifically to",
+    "execute that branch.",
+    "",
+    "The mutations restore the shipped defect and then attack each half of the fix independently,",
+    "because either half alone still loses mail: evicting the right victim but acking it is still",
+    "unrecoverable, and refusing to ack while still evicting DMs first still starves them."
+  ],
+  "mutations": [
+    {
+      "name": "M1 the shipped defect: no channel tier, so eviction falls through to the oldest entry",
+      "file": "extensions/connector-core/src/agent.ts",
+      "find": "        if (index < 0) index = this.inbox.findIndex((p) => p.item.kind === \"channel\");",
+      "replace": "",
+      "expectRed": "the waiting DM is STILL PRESENT after the flood"
+    },
+    {
+      "name": "M2 ack a sacrificed directed message (loss becomes unrecoverable again)",
+      "file": "extensions/connector-core/src/agent.ts",
+      "find": "        if (!this.inFlightIds.has(evicted.item.id) && !sacrificingDirected) evicted.ack();",
+      "replace": "        if (!this.inFlightIds.has(evicted.item.id)) evicted.ack();",
+      "expectRed": "the waiting DM was never acked (redelivery stays possible)"
+    },
+    {
+      "name": "M3 trust the forgeable payload instead of the subject-derived kind",
+      "file": "extensions/connector-core/src/agent.ts",
+      "find": "        if (index < 0) index = this.inbox.findIndex((p) => p.item.kind === \"channel\");",
+      "replace": "        if (index < 0) index = this.inbox.findIndex((p) => !p.item.mentionsMe);",
+      "expectRed": "the waiting DM is STILL PRESENT after the flood"
+    },
+    {
+      "name": "M4 stop acking evicted channel ambient (reopens the history flood)",
+      "file": "extensions/connector-core/src/agent.ts",
+      "find": "        const sacrificingDirected = evicted.item.kind !== \"channel\";",
+      "replace": "        const sacrificingDirected = true;",
+      "expectRed": "evicted channel traffic WAS acked (replaying it is the history flood)"
+    },
+    {
+      "name": "M5 sacrifice live channel traffic before pull-only backlog",
+      "file": "extensions/connector-core/src/agent.ts",
+      "find": "        let index = this.inbox.findIndex((p) => p.pullOnly);",
+      "replace": "        let index = -1;",
+      "expectRed": "a live channel item outlives historical backlog"
+    },
+    {
+      "name": "M6 let the in-flight ceiling hold a partial batch instead of refusing whole",
+      "file": "extensions/connector-core/src/agent.ts",
+      "find": "    if (this.inFlightIds.size + fresh > MAX_INBOX * 2) return false;",
+      "replace": "    if (this.inFlightIds.size + fresh > MAX_INBOX * 2) { for (const id of ids) this.inFlightIds.set(id, (this.inFlightIds.get(id) ?? 0) + 1); return true; }",
+      "expectRed": "a batch that would cross the ceiling is refused whole"
+    }
+  ]
+}

--- a/extensions/connector-core/smoke/mutations/inbox-overflow-directed.json
+++ b/extensions/connector-core/smoke/mutations/inbox-overflow-directed.json
@@ -21,7 +21,14 @@
     "",
     "The mutations restore the shipped defect and then attack each half of the fix independently,",
     "because either half alone still loses mail: evicting the right victim but acking it is still",
-    "unrecoverable, and refusing to ack while still evicting DMs first still starves them."
+    "unrecoverable, and refusing to ack while still evicting DMs first still starves them.",
+    "",
+    "M2 note: the ack half is only observable once the inbox is ENTIRELY directed. While any channel",
+    "item remains, the tier picks that instead, so the waiting DM in the flood scenarios is never",
+    "evicted and its ack assertion stays green under the mutation. An earlier fixture pointed M2 at",
+    "that assertion and the harness correctly reported WRONG-RED - the suite failed, but at a",
+    "different cell than claimed. The two halves protect different scenarios, which is exactly why",
+    "both scenarios have to exist."
   ],
   "mutations": [
     {
@@ -36,7 +43,7 @@
       "file": "extensions/connector-core/src/agent.ts",
       "find": "        if (!this.inFlightIds.has(evicted.item.id) && !sacrificingDirected) evicted.ack();",
       "replace": "        if (!this.inFlightIds.has(evicted.item.id)) evicted.ack();",
-      "expectRed": "the waiting DM was never acked (redelivery stays possible)"
+      "expectRed": "sacrificed DMs are NOT acked, so the broker can redeliver them"
     },
     {
       "name": "M3 trust the forgeable payload instead of the subject-derived kind",

--- a/extensions/connector-core/src/agent.ts
+++ b/extensions/connector-core/src/agent.ts
@@ -402,9 +402,24 @@ export class MeshAgent extends EventEmitter {
       // bounded local loss: evicted items are acked without being marked handled.
       let excess = this.inbox.length - MAX_INBOX;
       while (excess-- > 0) {
+        // Eviction order, weakest claim first. The tiers below `pullOnly` exist because `pullOnly`
+        // is `!mentionsMe && historical`, and `mentionsMe` derives from the payload `mentions` field
+        // — forgeable by the sender. A peer that stamps every flooded message with the victim's name
+        // makes none of its traffic pull-only, so `findIndex` returned -1, the old code fell through
+        // to index 0, and index 0 is the OLDEST entry: a directed message waiting to be handled. It
+        // was spliced out and acked unhandled, which is unrecoverable (#791). Ambient channel chatter
+        // at volume did the same thing with no forgery at all.
+        //
+        // So directedness decides who gets sacrificed, and directedness is read from `kind`, which is
+        // derived from the delivering subject and broker-policed rather than from the payload.
         let index = this.inbox.findIndex((p) => p.pullOnly);
+        // Channel traffic before anything addressed to us specifically, forged mentions included.
+        if (index < 0) index = this.inbox.findIndex((p) => p.item.kind === "channel");
+        // Only when the whole buffer is directed mail does the oldest lose, and that case carries no
+        // attacker advantage: a peer cannot force DMs it is not authorised to send.
         if (index < 0) index = 0;
         const [evicted] = this.inbox.splice(index, 1);
+        const sacrificingDirected = evicted.item.kind !== "channel";
         this.rememberEvicted(evicted);
         // ...but NOT an id that is mid-delivery. Overflow prefers the oldest, which is exactly what a
         // surfaced batch is made of, so without this an arrival can ack a message a host is still
@@ -412,7 +427,11 @@ export class MeshAgent extends EventEmitter {
         // unrecoverable — gone from the buffer, never marked handled, no longer redeliverable. Left
         // un-acked it redelivers; and if the delivery does succeed, {@link drainInboxIds} marks the
         // now-missing id handled so that redelivery is silently acked.
-        if (!this.inFlightIds.has(evicted.item.id)) evicted.ack();
+        //
+        // A directed message is never acked on overflow: leaving it un-acked lets JetStream redeliver
+        // it once we have room, which turns unrecoverable loss into a delay. Channel ambient is still
+        // acked, because replaying it is what the history flood was (#775).
+        if (!this.inFlightIds.has(evicted.item.id) && !sacrificingDirected) evicted.ack();
       }
     }
     this.emit("incoming", item);

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "smoke:channel-attention:auth": "tsx extensions/connector-core/smoke/per-channel-attention-auth.smoke.ts",
     "smoke:presence-scrub": "tsx packages/core/smoke/presence-offline-scrub.smoke.ts",
     "smoke:cross-path-dedup": "tsx extensions/connector-core/smoke/cross-path-dedup.smoke.ts",
+    "smoke:inbox-overflow-directed": "tsx extensions/connector-core/smoke/inbox-overflow-directed.smoke.ts",
     "smoke:history-flood": "tsx extensions/connector-core/smoke/history-flood.smoke.ts",
     "smoke:inbox-window": "tsx extensions/connector-core/smoke/inbox-window.smoke.ts",
     "smoke:feedback": "tsx extensions/connector-core/smoke/feedback.smoke.ts",


### PR DESCRIPTION
## The defect

**A peer flooding a channel you subscribe to could silence a live DM waiting in your inbox** - dropped and acked unhandled, so the broker never redelivered it. Silent, unrecoverable loss of directed mail.

`buffer()` bounds the inbox at `MAX_INBOX = 200` by evicting `pullOnly` entries first:

```ts
let index = this.inbox.findIndex((p) => p.pullOnly);
if (index < 0) index = 0;   // <- the OLDEST entry: the waiting DM
```

`pullOnly` is `!mentionsMe && historical`, and `mentionsMe` derives from the payload `mentions` field - which `agent.ts` itself labels payload-forgeable. A hostile peer sets `mentions: ["<victim>"]` on every flooded message, so none of its traffic is ever pull-only, the shield never engages, and eviction walks to index 0. The code's own comment already names acking as the step that makes loss unrecoverable.

The worst vector needs **no forgery at all**: plain ambient channel chatter at volume evicts directed mail the same way.

## The fix

Directedness decides who gets sacrificed, and it is read from `kind` - derived from the delivering subject and broker-policed - not from the payload:

1. pull-only backlog first (unchanged)
2. then **channel** traffic, forged mentions included
3. only an all-directed inbox falls back to the oldest, and that carries no attacker advantage since a peer cannot force DMs it is not authorised to send

A directed message that must be sacrificed is **left un-acked**, turning unrecoverable loss into a delay: JetStream redelivers once there is room. Channel ambient is still acked, because replaying it is exactly what the #775 history flood was.

## Proof

New suite `smoke:inbox-overflow-directed`, **14/14**, and it crosses the real valve - 400 messages against `MAX_INBOX = 200`.

Reproduced the defect independently rather than trusting the report: with the fix reverted in place, the suite goes **7 red**, naming each vector.

```
✗ the waiting DM is STILL PRESENT after the flood
✗ the waiting DM was never acked (redelivery stays possible)
✗ the DM survives ordinary ambient volume
✗ the DM was not acked
✗ an anycast task survives a mention-forged flood
✗ the anycast task was not acked
✗ sacrificed DMs are NOT acked  — ["dm-0","dm-1","dm-2"]
```

Restored: 14/14, `git diff` clean.

Coverage the suite adds, beyond the attack: channel ambient is still evicted **and still acked**; pull-only backlog is still sacrificed before live traffic; an all-directed inbox still bounds memory; anycast gets the same protection as DMs.

Neighbours green (216 checks): `history-flood` 10, `inbox-window` 85, `attention` 13, `channel-attention` 45, `cross-path-dedup` 52, `control-reply` 11. `typecheck` clean, `GATE INVENTORY OK`.

## Provenance, and a coverage gap worth stating

Found by the **post-merge security audit of #776**, which merged on an explicit CI waiver and therefore never got a panel. The audit drove seven scenarios and reported that the seam I asked about genuinely holds; this was the finding it turned up alongside.

It is **pre-existing, not a #776 regression** - the auditor proved that by reverting the shipped line and re-running: 4 of 4 vectors silenced the DM before #776, 3 of 4 after. #776 closed one vector and opened none.

The audit also caught that the smoke shipped with #776 buffers at most 120 items against a `MAX_INBOX` of 200, so **it never crossed the overflow valve it was meant to cover**. That gap is what this suite closes.

Closes #791.