### PR TITLE
fix(connector-jcode): name the provider carrying a seat's model, and refuse a prefixed model id (#785)

### DIFF
--- a/.changeset/785-route-identity.md
+++ b/.changeset/785-route-identity.md
@@ -1,0 +1,12 @@
+---
+"@cotal-ai/connector-jcode": patch
+---
+
+A jcode seat now records which provider is actually carrying its model, and refuses a
+provider-prefixed model id at the launch boundary. The connector already refused to join under a
+model label it did not receive, but that guarantee stopped at the model: a seat could be truthfully
+labelled while its traffic was carried by a component nobody named, and `RuntimeInfo` already
+carried the provider and routes in the same response the model check reads. A `provider/model`
+specifier was forwarded verbatim to an endpoint that expects a bare id, so the refusal came back as
+`model_not_found` naming neither the connector nor the prefix; it is now refused where the accepted
+form can be named.

--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -436,3 +436,10 @@ smoke:inbox-overflow-directed
 # four-route allowlist, capless credential proof, loopback negative control, immediate revocation,
 # public-only view refusal, Origin/body hardening, peer isolation and bearer refresh after expiry.
 smoke:remote-exchange:live
+
+# A seat must name the provider actually carrying its model, and refuse a provider-prefixed model id
+# at the boundary (#785). Measured: one route reported three identities - requested gemini-3.7-flash
+# under a cliproxy default, logged as prv:OpenRouter, died in a cursor_plugin_error - and none of the
+# three appeared in the roster, the spawn confirmation, or the manager exit line. RuntimeInfo already
+# carried provider and routes in the response the model check reads; they were discarded.
+smoke:jcode-route-identity

--- a/extensions/connector-jcode/smoke/mutations/route-identity.json
+++ b/extensions/connector-jcode/smoke/mutations/route-identity.json
@@ -1,0 +1,68 @@
+{
+  "suite": "extensions/connector-jcode/smoke/route-identity.smoke.ts",
+  "guard": "a seat names the provider actually serving its model, preferring the matching route over the session default, reports an unknown route rather than guessing or going quiet, and refuses a provider-prefixed model id at the boundary while naming the accepted bare form",
+  "command": "pnpm smoke:jcode-route-identity",
+  "completionMarker": "route identity:",
+  "proveWith": "node scripts/mutation-proof.mjs --config extensions/connector-jcode/smoke/mutations/route-identity.json",
+  "why": [
+    "Measured on a dying seat. One route carried three provider identities: requested as",
+    "gemini-3.7-flash through a config whose default provider was cliproxy, logged every line as",
+    "prv:OpenRouter, and died inside a cursor_plugin_error. None of the three appeared in the roster,",
+    "the spawn confirmation, or the manager's exit line, so establishing which was true meant reading",
+    "the seat's private log by hand (#785).",
+    "",
+    "The connector already refuses to join under a model label it did not receive, and that guarantee",
+    "stopped at the model: a seat can be truthfully labelled while its traffic is carried by a",
+    "component nobody named. RuntimeInfo already carried provider and routes in the same response the",
+    "model check reads, so this was a reporting gap, not a discovery problem.",
+    "",
+    "The mutations attack each way the report can go wrong: reporting the session default instead of",
+    "the route serving this model (the exact confusion that produced three stories), going silent on",
+    "an unknown route (silence is what made it expensive), dropping the api_method, ignoring an",
+    "unavailable route, and forwarding a prefixed specifier instead of refusing it."
+  ],
+  "mutations": [
+    {
+      "name": "M1 report the session default instead of the route serving this model",
+      "file": "extensions/connector-jcode/src/route-identity.ts",
+      "find": "  const provider = matched?.provider ?? runtime?.provider;",
+      "replace": "  const provider = runtime?.provider ?? matched?.provider;",
+      "expectRed": "names the provider actually serving THIS model"
+    },
+    {
+      "name": "M2 go quiet when the route is unknown",
+      "file": "extensions/connector-jcode/src/route-identity.ts",
+      "find": "  if (!provider) return `model ${model} is served by an unreported provider (the Harness API named none)`;",
+      "replace": "  if (!provider) return \"\";",
+      "expectRed": "no routes and no provider says so explicitly"
+    },
+    {
+      "name": "M3 drop the api method, losing the wire shape",
+      "file": "extensions/connector-jcode/src/route-identity.ts",
+      "find": "  const via = matched?.api_method ? ` via ${matched.api_method}` : \"\";",
+      "replace": "  const via = \"\";",
+      "expectRed": "names the api method, so the wire shape is on the record"
+    },
+    {
+      "name": "M4 ignore a route that reports itself unavailable",
+      "file": "extensions/connector-jcode/src/route-identity.ts",
+      "find": "  const unavailable = matched && matched.available === false ? \" (route reports itself UNAVAILABLE)\" : \"\";",
+      "replace": "  const unavailable = \"\";",
+      "expectRed": "an unavailable route is flagged"
+    },
+    {
+      "name": "M5 accept a provider-prefixed id and forward it into a model_not_found",
+      "file": "extensions/connector-jcode/src/route-identity.ts",
+      "find": "  if (slash <= 0 || slash === model.length - 1) return { ok: true };",
+      "replace": "  return { ok: true };\n  if (slash <= 0 || slash === model.length - 1) return { ok: true };",
+      "expectRed": "a provider-prefixed id is refused"
+    },
+    {
+      "name": "M6 treat a trailing slash as a prefix (refusing a legitimate id)",
+      "file": "extensions/connector-jcode/src/route-identity.ts",
+      "find": "  if (slash <= 0 || slash === model.length - 1) return { ok: true };",
+      "replace": "  if (slash <= 0) return { ok: true };",
+      "expectRed": "a trailing slash is not a prefix"
+    }
+  ]
+}

--- a/extensions/connector-jcode/smoke/route-identity.smoke.ts
+++ b/extensions/connector-jcode/smoke/route-identity.smoke.ts
@@ -1,0 +1,96 @@
+/**
+ * A seat must be able to say which provider is actually carrying its model.
+ *
+ * Measured: a seat requested as `gemini-3.7-flash` through a config whose default provider was
+ * `cliproxy` logged every line as `prv:OpenRouter` and died with a `cursor_plugin_error`. Three
+ * provider identities for one route, and none of them appeared in the roster, the spawn
+ * confirmation, or the manager's exit line - establishing the truth meant reading the seat's private
+ * log by hand (#785).
+ *
+ * Separately, `--model cliproxy/gemini-3.7-flash` was forwarded verbatim to an endpoint that wants a
+ * bare id and came back `model_not_found`, naming neither the connector nor the prefix.
+ */
+import assert from "node:assert/strict";
+import { bareModelId, describeRoute, type RuntimeIdentity } from "../src/route-identity.js";
+
+let pass = 0;
+const failures: string[] = [];
+const check = (name: string, cond: boolean, extra?: unknown): void => {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+    return;
+  }
+  const detail = `${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`;
+  failures.push(detail);
+  console.log(`  ✗ ${detail}`);
+};
+
+console.log("\n1. the measured case: the route's provider, not the session default");
+{
+  // The live shape: session default says one thing, the route serving this model says another.
+  const runtime: RuntimeIdentity = {
+    provider: "cliproxy",
+    model: "gemini-3.7-flash",
+    providers: ["cliproxy", "OpenRouter"],
+    routes: [
+      { model: "other-model", provider: "cliproxy", api_method: "responses" },
+      { model: "gemini-3.7-flash", provider: "OpenRouter", api_method: "chat_completions" },
+    ],
+  };
+  const line = describeRoute(runtime, "gemini-3.7-flash");
+  check("names the provider actually serving THIS model", line.includes("OpenRouter"), line);
+  check("does not report the session default as the carrier", !line.includes("provider cliproxy"), line);
+  check("names the api method, so the wire shape is on the record", line.includes("chat_completions"), line);
+  check("names the model it is describing", line.includes("gemini-3.7-flash"), line);
+}
+
+console.log("\n2. an unknown route is REPORTED, never guessed or silently skipped");
+{
+  check(
+    "no routes and no provider says so explicitly",
+    describeRoute({ routes: [] }, "m").includes("unreported provider"),
+    describeRoute({ routes: [] }, "m"),
+  );
+  check("undefined runtime does not throw", describeRoute(undefined, "m").includes("unreported provider"));
+  check(
+    "a session provider is used when no route matches",
+    describeRoute({ provider: "cliproxy", routes: [{ model: "elsewhere", provider: "x" }] }, "m").includes(
+      "provider cliproxy",
+    ),
+  );
+}
+
+console.log("\n3. a route that reports itself unavailable says so");
+{
+  const line = describeRoute(
+    { routes: [{ model: "m", provider: "p", api_method: "chat", available: false }] },
+    "m",
+  );
+  check("an unavailable route is flagged", line.includes("UNAVAILABLE"), line);
+  const ok = describeRoute({ routes: [{ model: "m", provider: "p", available: true }] }, "m");
+  check("an available route is not flagged", !ok.includes("UNAVAILABLE"), ok);
+}
+
+console.log("\n4. the prefixed specifier is caught at the boundary, not forwarded");
+{
+  const bad = bareModelId("cliproxy/gemini-3.7-flash");
+  check("a provider-prefixed id is refused", bad.ok === false);
+  check("it reports the accepted bare form", bad.ok === false && bad.bare === "gemini-3.7-flash", bad);
+  check("it names the prefix that was stripped", bad.ok === false && bad.prefix === "cliproxy", bad);
+  check("a bare id passes", bareModelId("gemini-3.7-flash").ok === true);
+}
+
+console.log("\n5. edge shapes are not mistaken for a prefix");
+{
+  check("a leading slash is not a prefix", bareModelId("/model").ok === true);
+  check("a trailing slash is not a prefix", bareModelId("provider/").ok === true);
+  check("an empty string is not a prefix", bareModelId("").ok === true);
+  const nested = bareModelId("a/b/c");
+  check("only the first segment is treated as the prefix", nested.ok === false && nested.bare === "b/c", nested);
+}
+
+console.log(`\nroute identity: ${pass} cells OK, ${failures.length} failed`);
+if (failures.length) {
+  assert.fail(`route identity: ${failures.length} cell(s) failed\n  - ${failures.join("\n  - ")}`);
+}

--- a/extensions/connector-jcode/src/host.ts
+++ b/extensions/connector-jcode/src/host.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { JcodeClient, type ApiEvent } from "@1jehuang/jcode-sdk";
 import { hardenPrivate, loadAgentFile } from "@cotal-ai/core";
 import { mirrorJcodeCredentials, shortSocketHome } from "./private-state.js";
+import { bareModelId, describeRoute } from "./route-identity.js";
 import {
   MeshAgent,
   ORIENTATION_BOOTSTRAP,
@@ -332,6 +333,16 @@ export async function runJcodeHost(): Promise<void> {
     const session = await client.createSession(cwd);
     sessionId = session.session_id;
     agent.setContextId(sessionId);
+    // A `provider/model` specifier was forwarded verbatim to an endpoint that wants a bare id, and
+    // the refusal came back as `model_not_found` naming neither the connector nor the prefix as the
+    // cause. Refuse it here, where the accepted form can actually be named (#785).
+    if (config.model) {
+      const spec = bareModelId(config.model);
+      if (!spec.ok)
+        throw new Error(
+          `jcode connector: model ${JSON.stringify(config.model)} carries a provider prefix, but the Harness API expects a bare model id — pass ${JSON.stringify(spec.bare)} (the ${JSON.stringify(spec.prefix)} provider is selected by configuration, not by the model id)`,
+        );
+    }
     if (config.model) await client.setModel(sessionId, config.model);
     await client.sendMessage(sessionId, instructions(config, def?.persona || undefined), { noReply: true });
     // Jcode registers MCP tools asynchronously. A first workload turn before its tools appear is
@@ -366,6 +377,12 @@ export async function runJcodeHost(): Promise<void> {
         throw new Error(
           `jcode connector: requested model ${JSON.stringify(config.model)} but the Harness API reports ${JSON.stringify(runtime.model)} — refusing a mislabelled mesh seat`,
         );
+      // The model is checked above; the PROVIDER carrying it was fetched in the same response and
+      // then thrown away. That gap cost real time: a seat requested as one model logged under a
+      // second provider's name and died inside a third component, and establishing which was true
+      // meant reading the seat's private log by hand. RuntimeInfo already knows, so record it where
+      // an operator looks first (#785).
+      process.stderr.write(`[cotal-jcode] ${describeRoute(runtime, config.model)}\n`);
     }
 
     initialized = true;

--- a/extensions/connector-jcode/src/route-identity.ts
+++ b/extensions/connector-jcode/src/route-identity.ts
@@ -1,0 +1,59 @@
+/**
+ * Say which provider is actually carrying a seat's model.
+ *
+ * The connector already refuses to join under a model label it did not receive, and that guarantee
+ * stopped at the model. A seat could be truthfully labelled with the model an operator asked for
+ * while its traffic was carried by a component nobody named: one seat was requested as a given
+ * model, logged every line under a different provider's name, and died inside a third component's
+ * plugin. Nothing in the roster, the spawn confirmation, or the manager's exit line named the route,
+ * so establishing it meant reading the seat's private log by hand (#785).
+ *
+ * `RuntimeInfo` carries `provider` and `routes` in the same response the model check already reads,
+ * so this is a reporting gap, not a discovery problem.
+ */
+
+/** The route fields this description reads; a subset of the SDK's `ModelRouteInfo`. */
+export interface RouteInfo {
+  model: string;
+  provider: string;
+  api_method?: string;
+  available?: boolean;
+}
+
+/** The subset of the SDK's `RuntimeInfo` needed to describe a route. */
+export interface RuntimeIdentity {
+  provider?: string;
+  model?: string;
+  providers?: string[];
+  routes?: RouteInfo[];
+}
+
+/**
+ * One line naming the effective route for `model`.
+ *
+ * The route matching the requested model wins, because `runtime.provider` is the session default and
+ * can differ from the provider actually serving this model. When neither is known the line says so
+ * explicitly rather than guessing or going quiet: an unknown route is itself worth reporting, since
+ * silence is what made this expensive to diagnose.
+ */
+export function describeRoute(runtime: RuntimeIdentity | undefined, model: string): string {
+  const matched = runtime?.routes?.find((r) => r?.model === model);
+  const provider = matched?.provider ?? runtime?.provider;
+  if (!provider) return `model ${model} is served by an unreported provider (the Harness API named none)`;
+  const via = matched?.api_method ? ` via ${matched.api_method}` : "";
+  const unavailable = matched && matched.available === false ? " (route reports itself UNAVAILABLE)" : "";
+  return `model ${model} is served by provider ${provider}${via}${unavailable}`;
+}
+
+/**
+ * Reject a `provider/model` specifier at the boundary instead of forwarding it.
+ *
+ * An operator passing `--model <provider>/<model>` had it sent verbatim to an endpoint that wants a
+ * bare id, and the resulting `model_not_found` named neither the connector nor the prefix as the
+ * cause. Returns the accepted form so the caller can say what to use instead.
+ */
+export function bareModelId(model: string): { ok: true } | { ok: false; bare: string; prefix: string } {
+  const slash = model.indexOf("/");
+  if (slash <= 0 || slash === model.length - 1) return { ok: true };
+  return { ok: false, bare: model.slice(slash + 1), prefix: model.slice(0, slash) };
+}

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "smoke:jcode-args": "tsx extensions/connector-jcode/smoke/jcode-args.smoke.ts",
     "smoke:jcode-host": "tsx extensions/connector-jcode/smoke/jcode-host.smoke.ts",
     "smoke:jcode-private-state": "tsx extensions/connector-jcode/smoke/private-state.smoke.ts",
+    "smoke:jcode-route-identity": "tsx extensions/connector-jcode/smoke/route-identity.smoke.ts",
     "smoke:jcode-security": "tsx extensions/connector-jcode/smoke/jcode-security.smoke.ts",
     "smoke:jcode-live": "tsx extensions/connector-jcode/smoke/jcode-live.smoke.ts",
     "smoke:view": "tsx implementations/cli/smoke/view.smoke.ts",


### PR DESCRIPTION
## What

Two related gaps in how a jcode seat reports the route it is actually running on.

## The failure

The connector already refuses to join under a model label it did not receive. That guarantee **stops at the model**, so a seat can be truthfully labelled while its traffic is carried by a component nobody named.

One dying seat produced three provider identities for a single route:

| | |
|---|---|
| requested | `gemini-3.7-flash`, resolved through a config whose `default_provider = "cliproxy"` |
| self-reported in every log line | `prv:OpenRouter` |
| failing component at death | `cursor_plugin_error` |

None of the three appeared in `cotal ps`, the spawn confirmation, or the manager's exit line. Establishing which was true meant reading the seat's private jcode log by hand.

## Why this was a reporting bug, not a research problem

The host **already** calls `getRuntimeInfo(sessionId)` and checks `.model` against the requested one. The same response carries `.provider` and `.routes` - and both were discarded, one line from the check that was already there.

```ts
const runtime = await client.getRuntimeInfo(sessionId);
if (runtime.model !== config.model) throw …   // model: verified
// provider and routes: dropped on the floor
```

## The design decision worth reviewing

`describeRoute` prefers **the route serving the requested model** over `runtime.provider`, because those are exactly the two fields that disagreed in the incident: the session default said `cliproxy` while the route carrying gemini said `OpenRouter`. Reporting the session default would reproduce the original confusion with more confidence than before, which is worse than silence.

An unknown route is **reported as unknown** rather than guessed or skipped - silence is what made this expensive to diagnose in the first place. A route that declares itself unavailable is flagged.

## Second half: the prefixed specifier

`--model cliproxy/gemini-3.7-flash` was forwarded verbatim to an endpoint that wants a bare id:

```
{"error":{"message":"unknown provider for model cliproxy/gemini-3.7-flash","code":"model_not_found"}}
```

The refusal named neither the connector nor the prefix as the cause. It is now refused at launch, naming the accepted bare form and stating that the provider is selected by configuration rather than by the model id.

## Proof

- `smoke:jcode-route-identity` - new suite, **17/17**, built from the measured shape (session default and route provider deliberately disagreeing).
- `mutation-proof` - **6/6 KILLED first attempt**, each at its named assertion: report the session default instead of the matching route, go quiet on an unknown route, drop the api method, ignore an unavailable route, accept a prefixed id, and treat a trailing slash as a prefix.
- Neighbours green through the real launch path: `jcode-host` 11, `jcode-args` 28, `jcode-security` 6, `jcode-private-state` 8.
- `typecheck` clean, `check:docsbundle` PASS, `GATE INVENTORY OK` with the suite registered and its reason recorded.

## Scope

Deliberately **not** included: the third ask on #785, surfacing the last provider error in the manager's exit report. That is manager code, not connector code, and folding it in would mix two review surfaces. It stays open on the issue.

Related: #781 (a provider stream stall kills the seat), #789/#792 (restart amnesia).