### PR TITLE
chore(git): union-merge the CI gate registry so append-only entries stop colliding

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# The CI gate registry is append-only: every PR that adds a smoke suite writes a comment block
+# and its suite name at the tail, so any two such PRs collide there. Both sides are always
+# additive and the resolution is always "keep both", which makes the conflict pure overhead -
+# and worse, a conflict resolved identically every time stops being read. A resolver in a hurry
+# drops the other side's entry and the result is a silently ungated suite: the file still parses,
+# CI still passes, and only a hand grep notices. Union merge keeps both sides automatically.
+#
+# Verified: union preserves block adjacency, so a multi-line comment stays attached to the suite
+# line beneath it rather than being interleaved away from it.
+bin/smoke/ci-suites.txt merge=union


### PR DESCRIPTION
## The problem

`bin/smoke/ci-suites.txt` is append-only by convention: every PR that adds a smoke suite writes a comment block explaining the defect it defends, then the suite name, at the tail. That convention is good - the file reads as a history of what went wrong and why each gate exists.

The cost is that **every** such PR writes to the same final lines, so any two are guaranteed to conflict, and merging one makes the other DIRTY immediately.

This session hit it **six times across five PRs**: #784 against #748's entry, then #792/#793/#794 all going DIRTY when #784 merged, then #792/#794 again when #793 merged.

## Why it is not merely annoying

Both sides are always additive and the resolution is always "keep both". There is no judgement involved - which is exactly what makes it dangerous. **A conflict resolved identically every time stops being read.**

A resolver in a hurry drops the other side's entry, and the result is a **silently ungated suite**: the file still parses, CI still passes, and `smoke:gate-inventory` only catches it if the suite exists but nothing runs it. During this session every resolution had to be verified by hand with a grep that the neighbouring PR's entry survived.

## The fix

```
bin/smoke/ci-suites.txt merge=union
```

Union merge keeps both sides automatically. It matches the file's semantics exactly: an append-only registry where both sides are always wanted.

## Verified, not assumed

#797 raised the concern that entries are **multi-line** - a comment block followed by its suite name - so union must preserve block adjacency rather than interleaving a comment away from the suite it describes.

Tested in a scratch repo, then on the real file: two simulated PRs each appending a two-line comment plus a suite name, merged.

```
# second line of A
smoke:sim-a
# second line of B
smoke:sim-b
```

Both entries present, each comment still attached to its own suite line, zero conflict markers, `GATE INVENTORY OK`. The simulation commits were reset out; this PR is the single `.gitattributes` addition.

## Note

`.gitattributes` did not exist in the repo before this, so this creates it.

Closes #797.