### PR TITLE
test(claude): grade overlap protection without redelivery timing

### DIFF
--- a/extensions/connector-claude-code/smoke/mutations/wake-overlap-refcount.json
+++ b/extensions/connector-claude-code/smoke/mutations/wake-overlap-refcount.json
@@ -1,0 +1,33 @@
+{
+  "suite": "extensions/connector-claude-code/smoke/wake-path.smoke.ts",
+  "guard": "overlapping hook frames count ownership of the same surfaced ids so one delivery verdict cannot release another frame's protection",
+  "command": "pnpm --filter @cotal-ai/connector-claude-code... build && pnpm smoke:claude-wake",
+  "proveWith": "node scripts/mutation-proof.mjs --config extensions/connector-claude-code/smoke/mutations/wake-overlap-refcount.json",
+  "why": [
+    "The old cell inferred a refcount property from later overflow eviction and JetStream redelivery timing. It failed nondeterministically on unrelated branches because the selected live-inbox batch could change during redelivery.",
+    "The replacement drives the MeshAgent hold/release state machine directly with a unique synthetic id. Existing boolean observability is sufficient: after two holds, the first release must leave the id protected and the second must release it.",
+    "W1 restores boolean-set behavior: the second frame no longer increments an existing hold. W2 makes the first verdict delete the hold regardless of the second frame. Both must red at the surviving-protection cell."
+  ],
+  "mutations": [
+    {
+      "name": "W1 a second overlapping frame does not increment the existing hold",
+      "file": "extensions/connector-core/src/agent.ts",
+      "find": "    for (const id of ids) this.inFlightIds.set(id, (this.inFlightIds.get(id) ?? 0) + 1);",
+      "replace": "    for (const id of ids) this.inFlightIds.set(id, 1);",
+      "expectRed": "one frame's verdict does not unprotect the overlapping id",
+      "cell": "one frame's verdict does not unprotect the overlapping id",
+      "afterRestore": "pnpm --filter @cotal-ai/connector-claude-code... build",
+      "note": "Recreates the boolean hold that let one frame's verdict speak for another."
+    },
+    {
+      "name": "W2 the first frame verdict releases an id another frame still holds",
+      "file": "extensions/connector-core/src/agent.ts",
+      "find": "      if (held <= 1) this.inFlightIds.delete(id);\n      else this.inFlightIds.set(id, held - 1);",
+      "replace": "      this.inFlightIds.delete(id);",
+      "expectRed": "one frame's verdict does not unprotect the overlapping id",
+      "cell": "one frame's verdict does not unprotect the overlapping id",
+      "afterRestore": "pnpm --filter @cotal-ai/connector-claude-code... build",
+      "note": "Recreates the premature release the counted hold prevents."
+    }
+  ]
+}

--- a/extensions/connector-claude-code/smoke/wake-path.smoke.ts
+++ b/extensions/connector-claude-code/smoke/wake-path.smoke.ts
@@ -521,42 +521,20 @@ try {
   // meant the FIRST verdict unpinned ids the SECOND was still delivering, and an arrival in between
   // acked one. Same permanent loss as §7, reached through the concurrency the keying deliberately
   // allows, so the hold has to be counted rather than flagged.
-  // Driven through the SHIPPED handler directly (as §3b does) rather than by racing two relay
-  // processes: the interleaving is the whole point, so it has to be exact rather than probable. An
-  // earlier version raced two real relays, and a mutation that removed the refcount still passed it —
-  // the overlap simply had not happened. A check that survives deleting the thing it tests is worth
-  // nothing, so this drives the two verdicts by hand.
-  await waitFor("a full inbox to overflow against", () => agent.inboxCount("automatic") >= FILL, 60_000);
-  const twoFrameOldest = agent.peekInbox("automatic")[0].text.slice(0, 20);
-  const overlapA = { hook_event_name: "UserPromptSubmit" };
-  const overlapBFrame = { hook_event_name: "UserPromptSubmit" };
-  await claude.handle(agent, overlapA); // frame A surfaces and holds every id
-  await claude.handle(agent, overlapBFrame); // frame B surfaces and holds the SAME ids
-  claude.onReply(overlapA, false); // A's verdict lands first — B is still in flight
-  await dmOtto("dm-seven-b-overflow: arrives between the two verdicts");
-  await waitFor("the overflow arrival to land", () => stillPending("dm-seven-b-overflow"), 15_000);
-  // The precondition, asserted rather than assumed. An earlier version checked `inboxCount <= FILL`,
-  // which `buffer()` enforces unconditionally and which was already true before the arrival — a
-  // tautology wearing a precondition's label, so the grade below could have been handed out for an
-  // ordering that never happened. What actually has to be true is that the arrival evicted THE ID
-  // FRAME B IS STILL DELIVERING: gone from the buffer while its delivery is still open.
-  check("the arrival evicted the very id the second frame is still delivering", !stillPending(twoFrameOldest), {
-    oldest: twoFrameOldest,
-    automatic: agent.inboxCount("automatic"),
-  });
-  claude.onReply(overlapBFrame, false); // ...and only now does B report
-  await sleep(300);
-  const twoFrameBack = async (): Promise<boolean> => {
-    for (let i = 0; i < (ACK_WAIT_MS + 8_000) / 250 && !stillPending(twoFrameOldest); i++) await sleep(250);
-    return stillPending(twoFrameOldest);
-  };
-  const twoFrameRecovered = await twoFrameBack();
-  console.log(`    (overlapping frames: ${twoFrameOldest} recoverable: ${twoFrameRecovered})`);
-  check(
-    "one frame's verdict does not unprotect ids another frame is still delivering",
-    twoFrameRecovered,
-    { oldest: twoFrameOldest, buffered: agent.inboxCount("automatic") },
-  );
+  //
+  // Grade that refcount state machine directly with a synthetic id. The product property is entirely
+  // inside MeshAgent: two frames acquire the same id, the first verdict releases only its ownership,
+  // and the second releases the last ownership. Routing this cell through the live inbox or hook
+  // handler made the selected batch depend on unrelated redelivery timing — the flake this fix is
+  // removing. The public boolean observer is enough to distinguish a real refcount from a set.
+  const overlapId = "synthetic-overlap-hold";
+  check("the first overlapping frame acquires the id", agent.holdInFlight([overlapId]));
+  check("the second overlapping frame acquires the same id", agent.holdInFlight([overlapId]));
+  check("the overlapping id is protected while both frames are open", agent.isInFlight(overlapId));
+  agent.releaseInFlight([overlapId]); // frame A's verdict lands first — B is still in flight
+  check("one frame's verdict does not unprotect the overlapping id", agent.isInFlight(overlapId));
+  agent.releaseInFlight([overlapId]); // ...and only now does B report
+  check("the final frame's verdict releases the overlapping id", !agent.isInFlight(overlapId));
 
   // ---- 7c. at the hold ceiling, DECLINE to surface rather than surface unprotected --------------
   // Found by review, after §7b's refcount shipped. The cap protected existing holds but let a NEW


### PR DESCRIPTION
## Summary

Make the overlapping-frame delivery test grade the actual reference-count invariant instead of inferring it from inbox eviction and JetStream redelivery timing.

The old cell was nondeterministic on clean `main` and on unrelated branches. It could fail before eviction, or after eviction while waiting for broker redelivery, even though the counted in-flight implementation was unchanged.

## Change

- Drive the existing hold/release state machine with one unique synthetic id.
- Assert that two acquisitions keep the id protected after the first release and free it only after the second.
- Add two mutations that restore boolean hold behavior and premature release.

No product code or delivery behavior changes. This is a test-only correction.

## Verification

- Exact-tip repeated `pnpm smoke:claude-wake`, mutation proof, and `pnpm typecheck` are being re-derived after the final test-only amendment.
- CI and independent exact-SHA review are in progress.