### PR TITLE
fix(auth): throttle a failed exchange, never one that would succeed (#802)

### DIFF
--- a/.changeset/802-throttle-after-credential.md
+++ b/.changeset/802-throttle-after-credential.md
@@ -1,0 +1,12 @@
+---
+"@cotal-ai/auth": patch
+---
+
+The public exchange face no longer refuses a request that would have succeeded. The
+refused-exchange throttle was enforced before the request body was read, so a full bucket denied
+every request from that peer key, including callers holding a valid IdP JWT or actor token. On
+the public face the default peer key is the socket address, so in the reverse-proxy topology the
+docs recommend, every client shares one bucket and thirty unauthenticated POSTs denied the
+public mint path for a rolling minute. The gate is now evaluated up front but enforced only on a
+genuine credential failure, so a throttled peer still mints with a valid credential while a
+failed exchange is answered 429 rather than its specific reason.

--- a/implementations/auth/smoke/remote-exchange.smoke.ts
+++ b/implementations/auth/smoke/remote-exchange.smoke.ts
@@ -408,6 +408,43 @@ try {
   }
   check("successful exchanges are never throttled (40/40 on one peer)", successes === 40, { successes });
 
+  // A VALID credential still mints while its own bucket is full.
+  //
+  // This is the cell the whole throttle depends on and it did not exist. The gate used to run
+  // before the body was read, so a full bucket refused every request from that peer key - valid
+  // ones included. On the public face the DEFAULT peer key is the socket address, so in the
+  // reverse-proxy topology `run-a-mesh.md` recommends (without --exchange-trusted-proxy) every
+  // client shares one bucket, and thirty unauthenticated garbage POSTs denied the public mint
+  // path for a rolling minute (#802). The cells above cannot see it: they only ever ask whether a
+  // throttled peer is refused, never whether a LEGITIMATE caller behind that same key still works.
+  //
+  // Throttling exists to slow probing, and a valid credential is not probing.
+  const victim = asPeer("203.0.113.44");
+  let victimThrottled = false;
+  for (let i = 0; i < 40; i++) {
+    const r = await post(`${PUBLIC}/exchange`, { ...agentBody2, actorToken: newActorToken().actorToken }, victim);
+    if (r.status === 429) { victimThrottled = true; break; }
+  }
+  check("a peer key is throttled after a refusal flood", victimThrottled);
+  const validWhileFull = await post(`${PUBLIC}/exchange`, agentBody2, victim);
+  check(
+    "A VALID TOKEN STILL MINTS (200) FROM A THROTTLED PEER KEY - a full bucket must not deny a request that would succeed",
+    validWhileFull.status === 200,
+    { status: validWhileFull.status, body: validWhileFull.body },
+  );
+  // ...and the budget still does its job: a FAILED exchange from that same throttled key is
+  // answered 429 rather than its specific reason, because the reason is what makes probing cheap.
+  const failedWhileFull = await post(
+    `${PUBLIC}/exchange`,
+    { ...agentBody2, actorToken: newActorToken().actorToken },
+    victim,
+  );
+  check(
+    "a FAILED exchange from a throttled key is answered 429, not the refusal reason",
+    failedWhileFull.status === 429,
+    { status: failedWhileFull.status, body: failedWhileFull.body },
+  );
+
   // ---------- H. refresh across expiry ----------
   console.log("H) agent-bearer-style refresh yields a fresh, later-expiring bearer");
   const first = await post(`${PUBLIC}/exchange`, { ...agentBody2, ttlSec: 1 });
@@ -429,7 +466,7 @@ try {
 }
 
 // Counts, not just "no failures": a cell that stops running stops protecting anything.
-const EXPECTED = 47;
+const EXPECTED = 50;
 console.log(`\nremote-exchange smoke: ${pass} passed, ${fail} failed`);
 if (pass + fail !== EXPECTED) {
   console.log(`  ✗ FAIL: expected ${EXPECTED} cells, ran ${pass + fail} - a cell was added or silently skipped`);

--- a/implementations/auth/src/service.ts
+++ b/implementations/auth/src/service.ts
@@ -766,9 +766,20 @@ async function handleExchange(req: IncomingMessage, res: ServerResponse, ctx: Ha
     }
   }
   // Refused-exchange rate limit (probing protection): count only FAILURES, on THIS face's budget.
+  //
+  // The gate is evaluated here but NOT enforced here. Enforcing before the body was read meant a
+  // full bucket refused every request from that peer key, including ones carrying a valid IdP JWT
+  // or actor token - and on the public face the default peer key is the socket address, so in the
+  // reverse-proxy topology `run-a-mesh.md` recommends, every client shares one bucket. Thirty
+  // unauthenticated garbage POSTs then denied the public mint path for a rolling minute (#802).
+  //
+  // Throttling exists to slow PROBING, and a valid credential is not probing. So a throttled peer
+  // still gets its credential evaluated: if it is good, it mints; if it is bad, the refusal arms
+  // below answer 429 instead of the specific reason, because the reason is what makes probing
+  // cheap and withholding it is the whole point of the budget. Nothing that would have succeeded
+  // is refused.
   const peer = policy.peerKey(req);
-  if (policy.throttled(ctx, peer))
-    return send(res, 429, { error: "too many refused exchanges - wait a minute and retry" });
+  const peerThrottled = policy.throttled(ctx, peer);
   const body = await readJsonBody(req);
   const { idpToken, actor, actorToken, owner, ttlSec, view } = body as {
     idpToken?: unknown;
@@ -824,6 +835,8 @@ async function handleExchange(req: IncomingMessage, res: ServerResponse, ctx: Ha
       policy.recordFailure(ctx, peer);
       const reason = e instanceof Error ? e.message : String(e);
       console.error(`auth-service: refused an agent exchange: ${reason}`);
+      if (peerThrottled)
+        return send(res, 429, { error: "too many refused exchanges - wait a minute and retry" });
       return send(res, 401, { error: reason });
     }
   }
@@ -840,6 +853,8 @@ async function handleExchange(req: IncomingMessage, res: ServerResponse, ctx: Ha
     policy.recordFailure(ctx, peer);
     const reason = e instanceof Error ? e.message : String(e);
     console.error(`auth-service: refused an exchange: ${reason}`);
+    if (peerThrottled)
+      return send(res, 429, { error: "too many refused exchanges - wait a minute and retry" });
     return send(res, 401, { error: reason });
   }
 }


### PR DESCRIPTION
## What

The public exchange face no longer refuses a request that would have succeeded.

## The defect

`implementations/auth/src/service.ts` enforced the refused-exchange throttle **before** reading the body, so it fired before any credential existed to evaluate:

```ts
if (policy.throttled(ctx, peer))
  return send(res, 429, { error: "too many refused exchanges - wait a minute and retry" });
const body = await readJsonBody(req);
```

The default peer key on the public face is the socket address, and `docs/run-a-mesh.md` tells the operator to front the listener with a reverse proxy while framing `--exchange-trusted-proxy` as an optional hazard. Follow that guidance without the flag and every client collapses into one bucket, so **30 unauthenticated garbage POSTs deny the public mint path for a rolling minute** — holders of valid IdP JWTs and actor tokens included. Loopback is unaffected, so local health looks fine while the published face is down.

Not a mint bypass: no token is issued that should not be. This is availability of the public identity plane, in the topology the docs recommend.

## The fix

Throttling exists to slow **probing**, and a valid credential is not probing. The gate is still evaluated up front (cheap, prunes the window) but enforced only where a credential actually failed:

- a throttled peer presenting a **valid** credential mints
- a throttled peer presenting a **bad** one is answered 429 instead of the specific reason, because the reason is what makes probing cheap

Nothing that would have succeeded is refused, and the budget still does its real job.

## Proof, red-first against a built defect

Both halves fail independently, so both were proven independently:

| Mutation | Result |
|---|---|
| enforce the throttle before `readJsonBody` (the shipped defect) | valid-token cell **RED**, 49/1 |
| strip the 429 short-circuit only | reason-withholding cell **RED**, 47/3 |
| fix in place | **50/0** |

That second mutation matters: without that assertion, "fixing" the DoS would silently gut the throttle, since a throttled peer would leak the refusal reason and probing becomes cheap again.

Note the proof required rebuilding between mutation and run — this suite imports the built `@cotal-ai/auth`, so a source-only mutation is invisible and grades everything green. My first attempt made exactly that mistake and reported false passes.

## Coverage this closes

Smoke G previously ran **only** with `--exchange-trusted-proxy`, so it asked whether a throttled peer is refused and whether other peers are isolated — never whether a legitimate caller behind that same key still works. That is why 47 green cells sat on top of an unauthenticated DoS. Two new cells cover it.

Partially addresses #799 (the suite's missing observed-failure evidence) for these cells specifically.

Closes #802.


---

**Base retargeted to `main`.** This PR was opened against `feat/remote-exchange` (old base tip `b91796c8`, previous head `4ceea934`). That branch is a strict ancestor of `main` with zero unique commits and sat 202 commits behind it, so grading this change against it measured a snapshot that no longer exists. The single commit was rebased onto `main` unchanged: the diff is still the same 3 files (+67/-3), and every added/removed line is byte-for-byte identical to the pre-rebase diff — only three hunk headers in `service.ts` shifted by 8 lines.

Also fixes the tail count this PR should have carried: it adds 3 cells to section G, so `EXPECTED` goes 47 → 50. `pnpm smoke:remote-exchange:live` reported `50 passed, 0 failed`.
