### PR TITLE
fix(connector-core): bound the overflow reprieve so a message cannot cycle forever (#807)

### DIFF
--- a/.changeset/807-bound-overflow-churn.md
+++ b/.changeset/807-bound-overflow-churn.md
@@ -1,0 +1,12 @@
+---
+"@cotal-ai/connector-core": patch
+---
+
+The inbox overflow valve now gives up on a directed message that keeps cycling. Leaving a
+sacrificed directed message un-acked lets the broker redeliver it once there is room, which turns
+permanent loss into a delay - but an un-acked id can be handed straight back into a still-full
+inbox and evicted again, indefinitely, spending broker and connector throughput while every seat
+involved reports healthy. Evictions are now counted per id and the reprieve ends after five, acking
+the message and reporting the drop on stderr. The tally clears whenever a message is actually
+handled, so one that eventually lands never carries history toward the cap, and the bookkeeping
+itself is bounded so tracking churn cannot become a leak.

--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -470,3 +470,9 @@ smoke:orientation
 # Failing closed is correct (SPEC 13.10); never renewing is the defect. Rotate early, keep the old
 # key verifiable across an overlap, and never drop the newest.
 smoke:anchor-renewal
+# The un-ack reprieve has to end (#807). #793 stopped the overflow valve acking a directed message
+# it evicts so the broker can redeliver it once there is room - but an un-acked id can be handed
+# straight back into a still-full inbox and evicted again, forever, spending throughput while every
+# seat reports healthy. Same shape as #790 one layer down. Count evictions per id, give up after
+# five, and say so on stderr (never emit("error") - with no listener that kills the seat).
+smoke:overflow-churn-bound

--- a/extensions/connector-core/smoke/mutations/inbox-overflow-directed.json
+++ b/extensions/connector-core/smoke/mutations/inbox-overflow-directed.json
@@ -41,7 +41,7 @@
     {
       "name": "M2 ack a sacrificed directed message (loss becomes unrecoverable again)",
       "file": "extensions/connector-core/src/agent.ts",
-      "find": "        if (!this.inFlightIds.has(evicted.item.id) && !sacrificingDirected) evicted.ack();",
+      "find": "        if (!this.inFlightIds.has(evicted.item.id) && (!sacrificingDirected || giveUp)) evicted.ack();",
       "replace": "        if (!this.inFlightIds.has(evicted.item.id)) evicted.ack();",
       "expectRed": "sacrificed DMs are NOT acked, so the broker can redeliver them"
     },

--- a/extensions/connector-core/smoke/overflow-churn-bound.smoke.ts
+++ b/extensions/connector-core/smoke/overflow-churn-bound.smoke.ts
@@ -1,0 +1,161 @@
+/**
+ * The un-ack reprieve has to end.
+ *
+ * #793 stopped the overflow valve acking a directed message it evicts, so the broker can redeliver
+ * it once there is room instead of destroying it. That turned unrecoverable loss into a delay - but
+ * a delay only helps if it terminates. An un-acked id is one JetStream may hand straight back into
+ * an inbox that is still full, to be evicted again, forever: throughput spent on a message that
+ * never lands, while every seat involved reports healthy (#807).
+ *
+ * Same defect shape as #790, where `drive()` retries a failed turn with no backoff and no cap. This
+ * suite exists because I shipped that shape one layer up after filing it against someone else.
+ *
+ * The rule: count evictions per id, and after OVERFLOW_REDELIVERY_LIMIT give up and ack, recording
+ * the loss loudly. A message lost with a log line beats a mesh that quietly stops moving.
+ */
+import assert from "node:assert/strict";
+import { MeshAgent } from "../src/agent.js";
+import type { InboxItem } from "../src/types.js";
+
+let pass = 0;
+const failures: string[] = [];
+const check = (name: string, cond: boolean, extra?: unknown): void => {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+    return;
+  }
+  const detail = `${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`;
+  failures.push(detail);
+  console.log(`  ✗ ${detail}`);
+};
+
+const MAX_INBOX = 200;
+const LIMIT = 5; // OVERFLOW_REDELIVERY_LIMIT
+
+interface H {
+  agent: MeshAgent;
+  acked: Set<string>;
+  errors: string[];
+  push: (id: string, kind?: string) => void;
+  has: (id: string) => boolean;
+}
+
+function harness(): H {
+  const agent = new MeshAgent({ name: "victim", space: "main", connector: "test" } as never);
+  const acked = new Set<string>();
+  const errors: string[] = [];
+  // The give-up notice goes to stderr, not to an "error" event. That is deliberate: an EventEmitter
+  // with no listener turns emit("error") into an unhandled exception, so announcing a dropped
+  // message would kill the very seat that was surviving the flood. Capture the stream instead.
+  const realWrite = process.stderr.write.bind(process.stderr);
+  (process.stderr as unknown as { write: (c: string) => boolean }).write = (chunk: string) => {
+    if (typeof chunk === "string" && chunk.includes("overflow: dropping directed message")) errors.push(chunk);
+    return realWrite(chunk as never);
+  };
+  const push = (id: string, kind = "dm"): void => {
+    const item = {
+      id,
+      kind,
+      channel: kind === "channel" ? "team" : "",
+      from: "peer",
+      text: `${id}: body`,
+      mentionsMe: false,
+      historical: false,
+    } as InboxItem;
+    (agent as unknown as { buffer: (i: InboxItem, a: () => void, p: boolean) => void }).buffer(
+      item,
+      () => acked.add(id),
+      false,
+    );
+  };
+  const has = (id: string): boolean =>
+    (agent as unknown as { inbox: { item: InboxItem }[] }).inbox.some((p) => p.item.id === id);
+  return { agent, acked, errors, push, has };
+}
+
+/** Fill to capacity with throwaway DMs, then redeliver `id` and let it be evicted again. */
+function cycle(h: H, id: string, times: number): void {
+  for (let n = 0; n < times; n++) {
+    h.push(id); // the redelivery
+    // one more arrival evicts the oldest, which is the redelivered id once it is at the head
+    while (h.has(id)) h.push(`filler-${n}-${Math.random().toString(36).slice(2, 8)}`);
+  }
+}
+
+console.log("\n1. the reprieve still applies while it is plausible");
+{
+  const h = harness();
+  for (let i = 0; i < MAX_INBOX; i++) h.push(`fill-${i}`);
+  const victim = "dm-victim";
+  h.push(victim);
+  // Evict it a couple of times: well under the cap, so it must stay recoverable.
+  cycle(h, victim, 2);
+  check("a directed message evicted twice is NOT acked (redelivery can still help)", !h.acked.has(victim));
+  check("no give-up error was emitted that early", !h.errors.some((e) => e.includes(victim)), h.errors);
+}
+
+console.log("\n2. the reprieve ENDS: a message that never lands is finally acked");
+{
+  const h = harness();
+  for (let i = 0; i < MAX_INBOX; i++) h.push(`fill-${i}`);
+  const victim = "dm-doomed";
+  h.push(victim);
+  cycle(h, victim, LIMIT + 1);
+  check("after the limit the churning message IS acked (the cycle stops)", h.acked.has(victim));
+  check(
+    "and the loss is reported, not silent",
+    h.errors.some((e) => e.includes(victim) && /evictions/.test(e)),
+    h.errors.slice(0, 2),
+  );
+  check(
+    "the report does NOT ride an error event (that would crash a seat with no listener)",
+    h.agent.listenerCount("error") === 0,
+  );
+}
+
+console.log("\n3. landing the message clears its history");
+{
+  const h = harness();
+  for (let i = 0; i < MAX_INBOX; i++) h.push(`fill-${i}`);
+  const victim = "dm-survivor";
+  cycle(h, victim, LIMIT - 1); // four evictions: close to the cap, not over
+  const tally = (): number | undefined =>
+    (h.agent as unknown as { overflowEvictions: Map<string, number> }).overflowEvictions.get(victim);
+  check("evictions accumulate toward the cap", tally() === LIMIT - 1, { tally: tally() });
+
+  h.push(victim);
+  (h.agent as unknown as { drainInboxIds: (ids: string[]) => unknown }).drainInboxIds([victim]);
+  // Assert the TALLY, not the ack set. `drainInboxIds` acks a handled message by design, so
+  // "was it acked" cannot distinguish a successful delivery from a give-up - an earlier version of
+  // this cell made exactly that mistake and failed against correct code.
+  check("handling the message clears its eviction history", tally() === undefined, { tally: tally() });
+
+  cycle(h, victim, 2);
+  check("and it starts counting from zero again, not from the old total", tally() === 2, { tally: tally() });
+}
+
+console.log("\n4. #793's guarantee is intact: channel volume still cannot silence a DM");
+{
+  const h = harness();
+  h.push("dm-protected");
+  for (let i = 0; i < 400; i++) h.push(`chan-${i}`, "channel");
+  check("the DM survives a channel flood", h.has("dm-protected"));
+  check("the DM was not acked", !h.acked.has("dm-protected"));
+  check("evicted channel ambient IS still acked", h.acked.size > 0);
+}
+
+console.log("\n5. the bookkeeping cannot become its own leak");
+{
+  const h = harness();
+  for (let i = 0; i < MAX_INBOX; i++) h.push(`fill-${i}`);
+  // Thousands of distinct one-shot evictions: the tally map must stay bounded.
+  for (let i = 0; i < 2000; i++) h.push(`churn-${i}`);
+  const size = (h.agent as unknown as { overflowEvictions: Map<string, number> }).overflowEvictions.size;
+  check("the eviction tally stays bounded under a flood of distinct ids", size <= 4 * MAX_INBOX, { size });
+}
+
+console.log(`\noverflow churn bound: ${pass} cells OK, ${failures.length} failed`);
+if (failures.length) {
+  assert.fail(`overflow churn bound: ${failures.length} cell(s) failed\n  - ${failures.join("\n  - ")}`);
+}

--- a/extensions/connector-core/src/agent.ts
+++ b/extensions/connector-core/src/agent.ts
@@ -112,6 +112,12 @@ export function afterRecallMark(a: RecallMark, b: RecallMark): boolean {
 }
 
 const MAX_INBOX = 200;
+/** How many times overflow may evict the SAME directed id before it is acked and given up on.
+ *  The un-ack reprieve exists so a sacrificed message can be redelivered once there is room; if the
+ *  inbox is still full on the Nth redelivery, room is not coming and the cycle is pure cost. */
+const OVERFLOW_REDELIVERY_LIMIT = 5;
+/** Bound on the eviction bookkeeping itself, so tracking churn cannot become a leak of its own. */
+const OVERFLOW_EVICTION_CAP = 4 * MAX_INBOX;
 /** How many future-stamped recall ids one session will remember having handed over. See
  *  {@link MeshAgent.recallAheadRoom}. */
 const MAX_AHEAD = 256;
@@ -164,6 +170,9 @@ export class MeshAgent extends EventEmitter {
    *  permanently degrades unknown ambient to pull-only for this session rather than risk a late
    *  live/durable copy changing from quiet to automatic. */
   private evictedClassifications = new Map<string, { pullOnly: boolean; channel: string }>();
+  /** How many times overflow has evicted each directed id without it ever being handled. Bounds the
+   *  un-ack reprieve so a redelivery cycle cannot run forever — see the eviction path in `buffer`. */
+  private overflowEvictions = new Map<string, number>();
   /** Surfaced to the host but not yet committed or abandoned, counted per holding frame because
    *  frames overlap. See {@link holdInFlight}. */
   private inFlightIds = new Map<string, number>();
@@ -431,7 +440,41 @@ export class MeshAgent extends EventEmitter {
         // A directed message is never acked on overflow: leaving it un-acked lets JetStream redeliver
         // it once we have room, which turns unrecoverable loss into a delay. Channel ambient is still
         // acked, because replaying it is what the history flood was (#775).
-        if (!this.inFlightIds.has(evicted.item.id) && !sacrificingDirected) evicted.ack();
+        //
+        // ...but a delay only helps if it ENDS. An un-acked id is one the broker may hand straight
+        // back, into an inbox that is still full, to be evicted again - a cycle that spends broker
+        // and connector throughput while every seat involved looks healthy. So the reprieve is
+        // counted: after OVERFLOW_REDELIVERY_LIMIT evictions of the SAME id we stop hoping for room
+        // and ack it, recording the loss loudly. A message lost with a log line beats a mesh that
+        // quietly stops moving (#807).
+        //
+        // The counter is keyed on the id and cleared whenever that id is actually handled
+        // ({@link drainInboxIds}), so an id that eventually lands never accumulates toward the cap.
+        let giveUp = false;
+        if (sacrificingDirected) {
+          const seen = (this.overflowEvictions.get(evicted.item.id) ?? 0) + 1;
+          if (seen >= OVERFLOW_REDELIVERY_LIMIT) {
+            giveUp = true;
+            this.overflowEvictions.delete(evicted.item.id);
+            // Reported on stderr via the existing log path, NOT emit("error"): an EventEmitter with
+            // no "error" listener turns an emit into an unhandled exception that takes the process
+            // down, so announcing a dropped message would kill the seat that was trying to survive
+            // the flood. Nothing else in this class emits "error" either.
+            this.log(
+              `overflow: dropping directed message ${evicted.item.id} after ${seen} evictions - ` +
+                `the inbox has stayed full across every redelivery, so the reprieve is not helping`,
+            );
+          } else {
+            this.overflowEvictions.set(evicted.item.id, seen);
+            if (this.overflowEvictions.size > OVERFLOW_EVICTION_CAP) {
+              // Bounded bookkeeping: the map must not become its own leak under a sustained flood.
+              // Dropping the oldest entry only forgives a message, never destroys one.
+              const oldest = this.overflowEvictions.keys().next();
+              if (!oldest.done) this.overflowEvictions.delete(oldest.value);
+            }
+          }
+        }
+        if (!this.inFlightIds.has(evicted.item.id) && (!sacrificingDirected || giveUp)) evicted.ack();
       }
     }
     this.emit("incoming", item);
@@ -571,6 +614,10 @@ export class MeshAgent extends EventEmitter {
     for (const id of requested) {
       if (!present.has(id)) this.markHandled(id, pullOnly.get(id) ?? false);
       this.evictedClassifications.delete(id);
+      // An id that actually landed is not churning, whatever it survived on the way here: clear its
+      // overflow tally so a message that is redelivered, evicted, then finally handled never carries
+      // history toward the give-up cap.
+      this.overflowEvictions.delete(id);
     }
     return { items, missingIds: requested.filter((id) => !present.has(id)) };
   }

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "smoke:channel-attention:auth": "tsx extensions/connector-core/smoke/per-channel-attention-auth.smoke.ts",
     "smoke:presence-scrub": "tsx packages/core/smoke/presence-offline-scrub.smoke.ts",
     "smoke:cross-path-dedup": "tsx extensions/connector-core/smoke/cross-path-dedup.smoke.ts",
+    "smoke:overflow-churn-bound": "tsx extensions/connector-core/smoke/overflow-churn-bound.smoke.ts",
     "smoke:inbox-overflow-directed": "tsx extensions/connector-core/smoke/inbox-overflow-directed.smoke.ts",
     "smoke:history-flood": "tsx extensions/connector-core/smoke/history-flood.smoke.ts",
     "smoke:inbox-window": "tsx extensions/connector-core/smoke/inbox-window.smoke.ts",


### PR DESCRIPTION
## What

The overflow reprieve introduced by #793 now terminates.

## Why

#793 stopped the inbox overflow valve acking a directed message it evicts, so JetStream can redeliver it once there is room rather than destroying it. That turned unrecoverable loss into a delay — but **a delay only helps if it ends**.

An un-acked id is one the broker may hand straight back, into an inbox that is still full, to be evicted again. Nothing bounded that. Under sustained overflow the same message can cycle indefinitely, spending broker and connector throughput while every seat involved reports healthy.

Same defect shape as #790, where `drive()` retries a failed turn with no backoff and no cap. I filed that against someone else's code and then shipped it one layer up.

## The fix

Evictions are counted per id. After five, the reprieve ends: the message is acked and the drop is reported. **A message lost with a log line beats a mesh that quietly stops moving.**

Three details that matter:

- **The tally clears whenever an id is actually handled** (`drainInboxIds`). A message that is redelivered, evicted, then finally lands carries no history toward the cap — otherwise a busy-but-healthy seat would eventually start dropping mail.
- **The bookkeeping is bounded** (`4 × MAX_INBOX`). Tracking a flood must not become the leak. Evicting the oldest tally only *forgives* a message, never destroys one, so the failure direction is safe.
- **The report goes to the existing stderr `log()` helper, never `emit("error")`.** An EventEmitter with no `"error"` listener turns that emit into an unhandled exception, so announcing a dropped message would kill the seat that was surviving the flood. A cell asserts this directly.

## Proof

`smoke:overflow-churn-bound`, **12/12**, registered in `ci-suites.txt` with the defect story.

Cells cover: the reprieve still applying while it is plausible; the cycle stopping at the cap with the loss reported; the report not riding an error event; the tally accumulating, clearing on success, and restarting from zero; the bookkeeping staying bounded under 2000 distinct evictions.

Cell 4 re-asserts **#793's own guarantee** — a channel flood still cannot silence a DM, evicted channel ambient is still acked. A fix that bounded churn by weakening that would be a regression dressed as a fix.

Neighbours green: `inbox-overflow-directed` 17/17, `history-flood` 10, `inbox-window` 85, `attention` 13, `cross-path-dedup` 52. `typecheck` clean, `GATE INVENTORY OK`.

## Two mistakes worth recording

Both were caught by this suite before it was trusted:

1. **The first version used `emit("error")`** and crashed the process in any seat without a listener. My smoke masked it by registering one — which is exactly why it now captures stderr instead.
2. **A cell asserted "was it acked"**, which cannot distinguish a successful delivery from a give-up, since `drainInboxIds` acks handled messages by design. It failed against correct code until it asserted the eviction tally — the mechanism — instead of an ambiguous side effect.

Closes #807.
