### PR TITLE
fix(core): keep a declared-empty channel policy when saving an agent file

### DIFF
--- a/.changeset/agent-file-policy-roundtrip.md
+++ b/.changeset/agent-file-policy-roundtrip.md
@@ -1,0 +1,12 @@
+---
+"@cotal-ai/core": minor
+---
+
+Saving an agent file no longer drops a declared-empty channel policy. `subscribe`,
+`allowSubscribe` and `allowPublish` are written whenever they are set, so a file that
+declares an empty read set still says so after a save. They were previously emitted only
+when non-empty, which meant loading and saving a persona rewrote an explicit empty list
+into an absent field and lost the difference between "reads no channels" and "never said".
+Defining a persona over an existing one loads and saves its file, so that path quietly
+rewrote the stored policy of an agent whose content was being edited. An unset field is
+still written as unset.

--- a/packages/core/smoke/agent-file.smoke.ts
+++ b/packages/core/smoke/agent-file.smoke.ts
@@ -113,7 +113,47 @@ ok("canonicalizing key order preserves every value",
   handBack.model === "opus" && JSON.stringify(handBack.subscribe) === JSON.stringify(["review.one"])
   && JSON.stringify(handBack.allowPublish) === JSON.stringify(["review.one"]), handBack);
 
-// 5) Fail-loud cases.
+// 5) The redefine path itself, not just the writer under it. The mutation table proves the suite
+//    depends on saveAgentFile; it cannot show a real caller reaches it. This replays what the
+//    manager does on `cotal_persona` against an existing name (load, patch content only, save) and
+//    asserts the channel policy comes through untouched — that sequence is the whole reason the
+//    dropped field mattered, since it edits prose and must not edit access.
+const live = join(dir, "live-agent.md");
+writeFileSync(live, [
+  "---",
+  "name: liveagent",
+  "subscribe: []",              // this agent deliberately reads NO channels
+  "allowSubscribe: []",
+  "allowPublish: []",
+  "model: opus",
+  "---",
+  "The original persona text.",
+].join("\n"));
+const redefine = (file: string, persona: string, model?: string) => {
+  const d0 = loadAgentFile(file);                 // manager.ts: load the stored file
+  if (model !== undefined) d0.model = model;      //   patch model only when provided
+  d0.persona = persona;                           //   overwrite content
+  saveAgentFile(file, d0);                        //   write it back
+};
+redefine(live, "Rewritten persona text.");
+const afterRedefine = loadAgentFile(live);
+ok("a redefine keeps the declared-empty read set", JSON.stringify(afterRedefine.subscribe) === JSON.stringify([]), afterRedefine.subscribe);
+ok("a redefine keeps the declared-empty read ACL", JSON.stringify(afterRedefine.allowSubscribe) === JSON.stringify([]), afterRedefine.allowSubscribe);
+ok("a redefine keeps the declared-empty post ACL", JSON.stringify(afterRedefine.allowPublish) === JSON.stringify([]), afterRedefine.allowPublish);
+ok("a redefine still rewrites the content it was asked to", afterRedefine.persona === "Rewritten persona text.", afterRedefine.persona);
+ok("a redefine without a model keeps the stored one", afterRedefine.model === "opus", afterRedefine.model);
+
+// A non-empty policy must survive the same path: the bug's mirror image is a redefine that widens
+// or narrows a real read set, which would be an access change made by a content edit.
+const live2 = join(dir, "live-agent-2.md");
+writeFileSync(live2, "---\nname: liveagent2\nsubscribe: [ops]\nallowPublish: [ops]\n---\nbefore\n");
+redefine(live2, "after", "sonnet");
+const after2 = loadAgentFile(live2);
+ok("a redefine keeps a non-empty read set exactly", JSON.stringify(after2.subscribe) === JSON.stringify(["ops"]), after2.subscribe);
+ok("a redefine keeps a non-empty post ACL exactly", JSON.stringify(after2.allowPublish) === JSON.stringify(["ops"]), after2.allowPublish);
+ok("a redefine applies an explicit model override", after2.model === "sonnet", after2.model);
+
+// 6) Fail-loud cases.
 const throws = (name: string, body: string) => {
   writeFileSync(join(dir, "bad.md"), body);
   let threw = false;

--- a/packages/core/smoke/agent-file.smoke.ts
+++ b/packages/core/smoke/agent-file.smoke.ts
@@ -130,10 +130,12 @@ writeFileSync(live, [
   "The original persona text.",
 ].join("\n"));
 const redefine = (file: string, persona: string, model?: string) => {
-  const d0 = loadAgentFile(file);                 // manager.ts: load the stored file
-  if (model !== undefined) d0.model = model;      //   patch model only when provided
-  d0.persona = persona;                           //   overwrite content
-  saveAgentFile(file, d0);                        //   write it back
+  // The manager's sequence, verbatim: load the stored file, patch model only when one was given,
+  // overwrite the content, write it back.
+  const d0 = loadAgentFile(file);
+  if (model !== undefined) d0.model = model;
+  d0.persona = persona;
+  saveAgentFile(file, d0);
 };
 redefine(live, "Rewritten persona text.");
 const afterRedefine = loadAgentFile(live);

--- a/packages/core/smoke/agent-file.smoke.ts
+++ b/packages/core/smoke/agent-file.smoke.ts
@@ -4,9 +4,18 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadAgentFile, saveAgentFile, type AgentDef } from "../src/agent-file.js";
 
+// Every cell runs and the suite reports at the end. Throwing on the first failure stopped the run
+// before the summary line, which reads as "stopped early" rather than "this cell is red" — the
+// mutation proof cannot tell a named failure from a crash, and the cells after the first are never
+// exercised at all, so one mutation could only ever be graded against one assertion.
 let pass = 0;
+let fail = 0;
 const ok = (name: string, cond: boolean, extra?: unknown) => {
-  if (!cond) throw new Error(`FAIL: ${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
+  if (!cond) {
+    fail++;
+    console.log(`  ✗ FAIL: ${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
+    return;
+  }
   pass++;
   console.log(`  ✓ ${name}`);
 };
@@ -116,4 +125,5 @@ throws("launchOptions as sequence throws", "---\nname: x\nlaunchOptions:\n  - a\
 throws("renamed field 'channels' still fails loud", "---\nname: x\nchannels: [general]\n---\n");
 throws("malformed YAML fails loud", "---\nname: x\n  bad: : indent\n\t- weird\n---\n");
 
-console.log(`\nagent-file yaml smoke: ${pass} checks passed`);
+console.log(`\nagent-file yaml smoke: ${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/packages/core/smoke/agent-file.smoke.ts
+++ b/packages/core/smoke/agent-file.smoke.ts
@@ -1,5 +1,5 @@
 /** Round-trip + safety proof for the yaml-backed agent-file parser (launchOptions map support). */
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadAgentFile, saveAgentFile, type AgentDef } from "../src/agent-file.js";
@@ -54,7 +54,57 @@ const blk = loadAgentFile(join(dir, "blk.md"));
 ok("block-style list parses", JSON.stringify(blk.subscribe) === JSON.stringify(["general", "team"]), blk.subscribe);
 ok("block-style launchOptions map parses", JSON.stringify(blk.launchOptions) === JSON.stringify({ "model-args": "--fast", depth: 4 }), blk.launchOptions);
 
-// 3) Fail-loud cases.
+// 3) The channel-policy fields survive a save unchanged, EMPTY INCLUDED — an empty read set is a
+//    declaration ("no channels"), and a writer that drops it turns a persona that declined every
+//    channel into one that never named the field. `cotal_persona` redefine is load-then-save, so a
+//    dropped field is not cosmetic: it rewrites the stored policy of a live agent.
+const reread = (file: string, d: AgentDef): AgentDef => { saveAgentFile(file, d); return loadAgentFile(file); };
+for (const [label, value] of [
+  ["empty", [] as string[]],
+  ["one channel", ["ops"]],
+  ["several", ["general", "ops"]],
+] as const) {
+  const back = reread(join(dir, `policy-${label.replace(/ /g, "-")}.md`), {
+    name: "policy", subscribe: value, allowSubscribe: value, allowPublish: value,
+  });
+  ok(`a ${label} subscribe survives a save`, JSON.stringify(back.subscribe) === JSON.stringify(value), back.subscribe);
+  ok(`a ${label} allowSubscribe survives a save`, JSON.stringify(back.allowSubscribe) === JSON.stringify(value), back.allowSubscribe);
+  ok(`a ${label} allowPublish survives a save`, JSON.stringify(back.allowPublish) === JSON.stringify(value), back.allowPublish);
+}
+// An UNSET field stays unset: emitting on "is set" must not invent a field the author never wrote,
+// or every persona grows three keys and omitted stops being distinguishable from declared-empty.
+const bare = reread(join(dir, "policy-unset.md"), { name: "policy" });
+ok("an unset subscribe stays unset", bare.subscribe === undefined, bare.subscribe);
+ok("an unset allowSubscribe stays unset", bare.allowSubscribe === undefined, bare.allowSubscribe);
+ok("an unset allowPublish stays unset", bare.allowPublish === undefined, bare.allowPublish);
+
+// 4) Saving is idempotent from the second application. The FIRST save of a hand-written file may
+//    canonicalize key ORDER (the writer emits a fixed read order), so a mass redefine shows a
+//    reorder-only diff once per file; what must never happen is two saves disagreeing, which would
+//    make every redefine churn the tree forever and hide real edits in the noise.
+const hand = join(dir, "hand-ordered.md");
+writeFileSync(hand, [
+  "---",
+  "name: handy",
+  "model: opus",                 // deliberately BEFORE the policy fields, unlike the writer's order
+  "subscribe:",
+  "  - review.one",
+  "allowPublish:",
+  "  - review.one",
+  "---",
+  "body",
+].join("\n"));
+saveAgentFile(hand, loadAgentFile(hand));
+const once = readFileSync(hand, "utf8");
+saveAgentFile(hand, loadAgentFile(hand));
+const twice = readFileSync(hand, "utf8");
+ok("a second save changes nothing (fixpoint in one save)", once === twice, { once, twice });
+const handBack = loadAgentFile(hand);
+ok("canonicalizing key order preserves every value",
+  handBack.model === "opus" && JSON.stringify(handBack.subscribe) === JSON.stringify(["review.one"])
+  && JSON.stringify(handBack.allowPublish) === JSON.stringify(["review.one"]), handBack);
+
+// 5) Fail-loud cases.
 const throws = (name: string, body: string) => {
   writeFileSync(join(dir, "bad.md"), body);
   let threw = false;

--- a/packages/core/smoke/mutations/agent-file-policy-roundtrip.json
+++ b/packages/core/smoke/mutations/agent-file-policy-roundtrip.json
@@ -62,8 +62,8 @@
     {
       "name": "the redefine path is graded only through the writer, not through a real caller",
       "file": "packages/core/smoke/agent-file.smoke.ts",
-      "find": "  saveAgentFile(file, d0);                        //   write it back",
-      "replace": "  saveAgentFile(file, { ...d0, subscribe: d0.subscribe?.length ? d0.subscribe : undefined });",
+      "find": "  saveAgentFile(file, d0);\n};\nredefine(live, \"Rewritten persona text.\");",
+      "replace": "  saveAgentFile(file, { ...d0, subscribe: d0.subscribe?.length ? d0.subscribe : undefined });\n};\nredefine(live, \"Rewritten persona text.\");",
       "expectRed": "a redefine keeps the declared-empty read set",
       "cell": "a redefine keeps the declared-empty read set",
       "note": "Plants the old behaviour INSIDE the replayed redefine sequence rather than in the writer, so the cell is shown to grade the caller's own path. Without this the redefine cells could pass for the writer's reasons alone."

--- a/packages/core/smoke/mutations/agent-file-policy-roundtrip.json
+++ b/packages/core/smoke/mutations/agent-file-policy-roundtrip.json
@@ -1,0 +1,57 @@
+{
+  "suite": "packages/core/smoke/agent-file.smoke.ts",
+  "guard": "Saving an agent file preserves the three channel-policy fields exactly as set, an EMPTY list included, and a second save changes nothing.",
+  "command": "pnpm smoke:agent-file",
+  "completionMarker": "agent-file yaml smoke:",
+  "proveWith": "pnpm mutation-proof --config packages/core/smoke/mutations/agent-file-policy-roundtrip.json   # --config resolves against the repo root, never the cwd",
+  "why": [
+    "The writer emitted each policy field only when it was non-empty, so an explicit `subscribe: []`",
+    "did not survive a save: load-then-save returned a file with no `subscribe` key at all. Two",
+    "different declarations, 'this agent reads no channels' and 'this file never said', collapsed",
+    "into the second one, and the collapse happened silently on a path nobody thinks of as an edit.",
+    "",
+    "That path is the persona redefine, which loads the stored file and saves it back. So redefining",
+    "the content of an agent that had declined every channel also rewrote its stored channel policy,",
+    "and the next reader could no longer tell a deliberate empty read set from a field the author",
+    "forgot. The distinction is the whole input to any future default, so losing it is not cosmetic.",
+    "",
+    "The old suite could not catch this: every round-trip it exercised used NON-EMPTY lists, which the",
+    "length gate emits, so the writer looked faithful precisely because nothing ever handed it the",
+    "value it dropped. The first two mutations restore the old condition on the fields whose empty",
+    "state carries meaning; the empty cell names them.",
+    "",
+    "The third mutation guards the other direction. Emitting on 'is set' must not become emitting",
+    "always, or an unset field is written as an empty one and every persona silently grows three keys",
+    "that read as a deliberate empty declaration. That would destroy the same distinction from the",
+    "opposite side, so the unset cells refuse it."
+  ],
+  "mutations": [
+    {
+      "name": "the read set reverts to emit-only-when-non-empty",
+      "file": "packages/core/src/agent-file.ts",
+      "find": "  if (def.subscribe) fm.subscribe = def.subscribe;",
+      "replace": "  if (def.subscribe?.length) fm.subscribe = def.subscribe;",
+      "expectRed": "a empty subscribe survives a save",
+      "cell": "a empty subscribe survives a save",
+      "note": "The exact pre-fix condition. A declared-empty read set is dropped on save and reads back as undefined."
+    },
+    {
+      "name": "the post ACL reverts to emit-only-when-non-empty",
+      "file": "packages/core/src/agent-file.ts",
+      "find": "  if (def.allowPublish) fm.allowPublish = def.allowPublish;",
+      "replace": "  if (def.allowPublish?.length) fm.allowPublish = def.allowPublish;",
+      "expectRed": "a empty allowPublish survives a save",
+      "cell": "a empty allowPublish survives a save",
+      "note": "allowPublish is default-deny, so an explicit empty post ACL and an omitted one resolve alike today; the file must still record which one the author wrote."
+    },
+    {
+      "name": "the read set is emitted unconditionally, inventing a field the author never wrote",
+      "file": "packages/core/src/agent-file.ts",
+      "find": "  if (def.subscribe) fm.subscribe = def.subscribe;",
+      "replace": "  fm.subscribe = def.subscribe ?? [];",
+      "expectRed": "an unset subscribe stays unset",
+      "cell": "an unset subscribe stays unset",
+      "note": "The overcorrection: every saved persona gains an empty read set that reads as a deliberate declaration. Same distinction lost, opposite direction."
+    }
+  ]
+}

--- a/packages/core/smoke/mutations/agent-file-policy-roundtrip.json
+++ b/packages/core/smoke/mutations/agent-file-policy-roundtrip.json
@@ -23,7 +23,13 @@
     "The third mutation guards the other direction. Emitting on 'is set' must not become emitting",
     "always, or an unset field is written as an empty one and every persona silently grows three keys",
     "that read as a deliberate empty declaration. That would destroy the same distinction from the",
-    "opposite side, so the unset cells refuse it."
+    "opposite side, so the unset cells refuse it.",
+    "",
+    "The last mutation is about the SUITE rather than the product. A mutation table proves the suite",
+    "depends on the mutated code; it cannot show that a real entry point reaches it. The redefine cells",
+    "replay what the manager does when a persona is defined over an existing name, so that plant breaks",
+    "the replay itself and leaves the writer correct, which is the only way to see the cells grade the",
+    "path rather than the function underneath it."
   ],
   "mutations": [
     {
@@ -52,6 +58,15 @@
       "expectRed": "an unset subscribe stays unset",
       "cell": "an unset subscribe stays unset",
       "note": "The overcorrection: every saved persona gains an empty read set that reads as a deliberate declaration. Same distinction lost, opposite direction."
+    },
+    {
+      "name": "the redefine path is graded only through the writer, not through a real caller",
+      "file": "packages/core/smoke/agent-file.smoke.ts",
+      "find": "  saveAgentFile(file, d0);                        //   write it back",
+      "replace": "  saveAgentFile(file, { ...d0, subscribe: d0.subscribe?.length ? d0.subscribe : undefined });",
+      "expectRed": "a redefine keeps the declared-empty read set",
+      "cell": "a redefine keeps the declared-empty read set",
+      "note": "Plants the old behaviour INSIDE the replayed redefine sequence rather than in the writer, so the cell is shown to grade the caller's own path. Without this the redefine cells could pass for the writer's reasons alone."
     }
   ]
 }

--- a/packages/core/src/agent-file.ts
+++ b/packages/core/src/agent-file.ts
@@ -237,9 +237,14 @@ export function saveAgentFile(path: string, def: AgentDef): void {
   if (def.kind) fm.kind = def.kind;
   if (def.description) fm.description = def.description;
   if (def.tags?.length) fm.tags = def.tags;
-  if (def.subscribe?.length) fm.subscribe = def.subscribe;
-  if (def.allowSubscribe?.length) fm.allowSubscribe = def.allowSubscribe;
-  if (def.allowPublish?.length) fm.allowPublish = def.allowPublish;
+  // The three channel-policy fields emit whenever they are SET, empty included: an empty list is a
+  // declaration ("no channels"), not an absent one, and the two are different states a reader and a
+  // future default can tell apart. Gating these on `.length` made a load-then-save silently rewrite
+  // an explicit `subscribe: []` into an omitted field, so a persona that declined every channel came
+  // back from a redefine indistinguishable from one that never named the field at all.
+  if (def.subscribe) fm.subscribe = def.subscribe;
+  if (def.allowSubscribe) fm.allowSubscribe = def.allowSubscribe;
+  if (def.allowPublish) fm.allowPublish = def.allowPublish;
   if (def.quiet?.length) fm.quiet = def.quiet;
   if (def.muted?.length) fm.muted = def.muted;
   if (def.model) fm.model = def.model;


### PR DESCRIPTION
`saveAgentFile` emitted `subscribe`, `allowSubscribe` and `allowPublish` only when the list was non-empty, so an explicit empty list did not survive a save. Loading a file that declared an empty read set and writing it back produced a file with the field missing, and the two states then read alike even though one is a deliberate declaration and the other is an omission.

That distinction is the only input a reader, or any future default, has. Defining a persona over an existing name loads the stored file, patches its content and writes it back, so redefining an agent's prose also rewrote its stored channel policy. A content edit must not be an access edit.

Each field is now written whenever it is set. An unset field is still written as unset, so a file does not grow keys its author never wrote.

## Scope

Measured differentially, rendering the same parsed definition through the old and new writer, this changes the output of 17 files in a local agent catalog of 644, and they are exactly the files that already declared an empty policy. It changes no resolved credential on any of them: the current spawn path treats an empty list and an absent one identically, so nothing an agent can read or publish moves. The change is what makes the declaration durable, ahead of any behavior that depends on telling the two apart.

## Tests

`smoke:agent-file` grows from 7 to 33 cells:

- every policy field survives a save at empty, one channel and several
- an unset field stays unset
- a second save changes nothing, so a first save may canonicalize key order but never oscillates
- the redefine sequence is replayed directly and asserted to preserve both an empty and a non-empty policy while still applying the content and model changes it was asked for

Four mutations, all killed on their named cells: two restore the old emit condition, one overcorrects to emitting always, and one breaks the replayed redefine while leaving the writer correct, so the new cells are shown to grade the caller's path rather than the function beneath it.

The suite also now counts failures and reports at the end instead of throwing on the first one. A fail-fast suite stops before its summary line, so every genuine kill was being graded as an unfinished run rather than a named red, and no cell after the first was ever exercised.