### PR TITLE
fix(core): require a persona to name the channels it reads

### DIFF
--- a/.changeset/persona-declare-scope.md
+++ b/.changeset/persona-declare-scope.md
@@ -1,0 +1,14 @@
+---
+"@cotal-ai/core": minor
+"@cotal-ai/cli": minor
+"@cotal-ai/manager": minor
+---
+
+Saving a persona now requires it to name the channels it reads. `saveAgentFile` refuses a
+definition with no `subscribe`, `cotal personas new` takes a required `--subscribe` (pass
+an empty value for an agent reachable only by direct message and anycast), and a persona
+defined over the wire is created with an empty read set, since that path deliberately
+accepts no policy from its caller. Previously a saved persona with no read set inherited
+whatever default was current, so a file could grant a channel its author never chose and a
+later reader could not tell a deliberate silence from a forgotten field. An empty list is
+written rather than filled in, so the two stay distinguishable.

--- a/.changeset/persona-declare-scope.md
+++ b/.changeset/persona-declare-scope.md
@@ -8,7 +8,8 @@ Saving a persona now requires it to name the channels it reads. `saveAgentFile` 
 definition with no `subscribe`, `cotal personas new` takes a required `--subscribe` (pass
 an empty value for an agent reachable only by direct message and anycast), and a persona
 defined over the wire is created with an empty read set, since that path deliberately
-accepts no policy from its caller. Previously a saved persona with no read set inherited
+accepts no policy from its caller, and records that the caller was never offered the
+choice so a reader can tell it apart from a persona whose author chose no channels. Previously a saved persona with no read set inherited
 whatever default was current, so a file could grant a channel its author never chose and a
 later reader could not tell a deliberate silence from a forgotten field. An empty list is
 written rather than filled in, so the two stay distinguishable.

--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -170,6 +170,13 @@ smoke:spawn-args
 smoke:own-agent-control
 smoke:views
 smoke:agent-file
+
+# Every persona this repo SHIPS declares the channels it reads, and the set of code paths that write
+# into the persona catalog is enumerated by output path rather than by function name. The writer
+# refuses a definition with no read set, but setup writes its personas as literal template strings
+# and never reaches it, so a template that forgot the field would ship an agent whose read set is
+# whatever the current default happens to be.
+smoke:persona-templates
 smoke:card-host
 smoke:attach-auth
 smoke:attach-host-persistence

--- a/implementations/cli/smoke/persona-templates.smoke.ts
+++ b/implementations/cli/smoke/persona-templates.smoke.ts
@@ -1,0 +1,113 @@
+/** Every persona this repo SHIPS declares the channels it reads.
+ *
+ *  The writer refuses a definition with no read set, which binds every caller that builds an
+ *  AgentDef and saves it. Setup does not: it writes its persona files as literal template strings,
+ *  so the writer's guard cannot see them and a template that omits the field would ship a persona
+ *  whose read set is a guess. This suite is the other half of that coverage.
+ *
+ *  It also enumerates the writers by OUTPUT PATH rather than by function name. Name-based searches
+ *  missed setup twice, because a writer can call any helper it likes but must eventually name the
+ *  directory it writes into. A new writer that appears here is not assumed wrong; it has to be
+ *  listed deliberately, which is the point.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse as parseYaml } from "yaml";
+
+let pass = 0;
+let fail = 0;
+const ok = (name: string, cond: boolean, extra?: unknown) => {
+  if (!cond) {
+    fail++;
+    console.log(`  ✗ FAIL: ${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
+    return;
+  }
+  pass++;
+  console.log(`  ✓ ${name}`);
+};
+
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const setupSrc = readFileSync(join(repoRoot, "implementations/cli/src/commands/setup.ts"), "utf8");
+
+// Every frontmatter block in setup's template literals. Anchored on the fences and on a `name:`
+// line ANYWHERE inside, not on the block starting with one: the managed-marker comment precedes
+// `name:` in the guided team's templates, and anchoring on the first line silently matched only
+// the one template that happens to start with it.
+const blocks = [...setupSrc.matchAll(/---\n([\s\S]*?)\n---/g)]
+  .map((m) => m[1])
+  .filter((b) => /^name: /m.test(b));
+ok("setup ships at least the default persona plus the guided team", blocks.length >= 4, blocks.length);
+
+for (const raw of blocks) {
+  // Drop the `${MANAGED_MARKER}` interpolation line: it is a source-level expression, not YAML, and
+  // becomes a `#` comment only once the template is rendered. Reading the source means reading it
+  // before interpolation, so the suite has to skip what the file will not contain at runtime.
+  const block = raw
+    .split("\n")
+    .filter((l) => !l.includes("${") && !l.trimStart().startsWith("#"))
+    .join("\n");
+  let fm: Record<string, unknown>;
+  try {
+    fm = parseYaml(block) as Record<string, unknown>;
+  } catch (e) {
+    ok(`a shipped template parses as YAML`, false, String(e).slice(0, 120));
+    continue;
+  }
+  const name = String(fm.name ?? "(unnamed)");
+  ok(`${name} declares the channels it reads`, Array.isArray(fm.subscribe), fm.subscribe);
+  // allowSubscribe defaults to subscribe and allowPublish is default-deny, so neither is required;
+  // what must not happen is a shipped persona whose READ SET is left to a default.
+}
+
+// The writer enumeration, by output path. Each entry is a file that names an agents directory AND
+// writes to it. Readers and path helpers are not listed. A new one fails this cell until someone
+// decides which half of the coverage it belongs to: the writer guard, or a template assertion.
+const KNOWN_WRITERS = [
+  "packages/core/src/agent-file.ts", // saveAgentFile — guards itself
+  "implementations/cli/src/commands/setup.ts", // literal templates — asserted above
+];
+const searched = ["packages/core/src", "packages/workspace/src", "implementations", "extensions", "bin"];
+const found = new Set<string>();
+const walk = (dir: string) => {
+  let entries;
+  try {
+    entries = readdirSync(join(repoRoot, dir), { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const e of entries) {
+    const rel = `${dir}/${e.name}`;
+    if (e.isDirectory()) {
+      if (e.name === "node_modules" || e.name === "dist" || e.name === "smoke") continue;
+      walk(rel);
+      continue;
+    }
+    if (!e.name.endsWith(".ts") || e.name.endsWith(".generated.ts")) continue;
+    const src = readFileSync(join(repoRoot, rel), "utf8");
+    // A writer NAMES a catalog path and WRITES on the same expression. Testing the two conditions
+    // file-wide instead flags any file that mentions the catalog anywhere and writes anything
+    // anywhere - which is how a persona READER that happens to write an unrelated file, or a caller
+    // that delegates the write to saveAgentFile, was counted as a writer. Match the call itself.
+    const lines = src.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      const window = lines.slice(i, i + 3).join("\n");
+      const isWrite = /\bwriteFileSync\(/.test(window);
+      if (!isWrite) continue;
+      // `agent-file.ts` writes the path it was HANDED, so the call site names no directory. It is
+      // the shared writer every other caller routes through, so match it by what it is rather than
+      // failing to see the one file the whole guard rests on.
+      const target =
+        /["'`]agents["'`]|\.cotal\/agents|agentFilePath\(|cotalPath\("agents"/.test(window) ||
+        /export function saveAgentFile/.test(src);
+      if (target) found.add(rel);
+    }
+  }
+};
+for (const d of searched) walk(d);
+const unexpected = [...found].filter((f) => !KNOWN_WRITERS.includes(f));
+ok("no unlisted writer into the persona catalog", unexpected.length === 0, unexpected);
+for (const w of KNOWN_WRITERS) ok(`${w} is still a writer (the search still finds it)`, found.has(w));
+
+console.log(`\npersona templates: ${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/implementations/cli/src/commands/personas.ts
+++ b/implementations/cli/src/commands/personas.ts
@@ -35,7 +35,7 @@ const NAME_RE = /^[A-Za-z0-9_-]+$/;
 
 export async function personas(args: ParsedArgs): Promise<void> {
   const positionals = args.positionals;
-  const values = args.values as { role?: string; model?: string; prompt?: string; from?: string; verbose?: boolean; force?: boolean; running?: boolean; space?: string; server?: string; creds?: string };
+  const values = args.values as { role?: string; model?: string; prompt?: string; from?: string; subscribe?: string; verbose?: boolean; force?: boolean; running?: boolean; space?: string; server?: string; creds?: string };
 
   switch (positionals[0] ?? "list") {
     case "list":
@@ -61,6 +61,7 @@ export function personasComplete(argv: string[]): CompletionResult {
     { name: "model", type: "string" },
     { name: "prompt", type: "string" },
     { name: "from", type: "string" },
+    { name: "subscribe", type: "string" },
     { name: "verbose", type: "boolean", short: "v" },
     { name: "running", type: "boolean" },
     { name: "force", type: "boolean" },
@@ -179,7 +180,7 @@ function edit(name?: string): void {
   console.log(c.green(`✓ saved "${name}"`));
 }
 
-function create(name: string | undefined, v: { role?: string; model?: string; prompt?: string; from?: string; force?: boolean }): void {
+function create(name: string | undefined, v: { role?: string; model?: string; prompt?: string; from?: string; subscribe?: string; force?: boolean }): void {
   if (!name) return usage();
   if (!NAME_RE.test(name)) {
     console.error(c.red(`invalid persona name "${name}": use letters, digits, "_" or "-"`));
@@ -208,7 +209,17 @@ function create(name: string | undefined, v: { role?: string; model?: string; pr
     process.exit(1);
   }
 
-  const def: AgentDef = { name, role: v.role, model: v.model, persona };
+  // The channels it reads are stated, never guessed: `--subscribe a,b` or `--subscribe ""` for an
+  // agent that reads none. There is no default, because the two possible ones are both wrong - a
+  // channel the author did not ask for, or an empty set indistinguishable from forgetting to say.
+  if (v.subscribe === undefined) {
+    console.error(c.red("--subscribe is required: name the channels this persona reads"));
+    console.error(c.dim('e.g. --subscribe general   or   --subscribe "" for an agent reachable only by direct message'));
+    process.exit(1);
+  }
+  const subscribe = v.subscribe.split(",").map((s) => s.trim()).filter(Boolean);
+
+  const def: AgentDef = { name, role: v.role, model: v.model, persona, subscribe };
   saveAtomic(path, def);
   console.log(c.green(`✓ wrote persona "${name}"`));
   console.log(c.dim(`${path}\nspawn it:  cotal spawn ${name}${v.role ? ` --role ${v.role}` : ""}`));
@@ -253,7 +264,7 @@ function usage(): never {
   console.error(
     c.red(
       "usage: cotal personas <list [--verbose] [--running] | show <name> | edit <name> | " +
-        'new <name> (--prompt <text> | --from <file|->) [--role <r>] [--model <m>] [--force] | rm <name> --force>',
+        'new <name> (--prompt <text> | --from <file|->) --subscribe <a,b|""> [--role <r>] [--model <m>] [--force] | rm <name> --force>',
     ),
   );
   process.exit(1);

--- a/implementations/manager/smoke/manager-service-ops.smoke.ts
+++ b/implementations/manager/smoke/manager-service-ops.smoke.ts
@@ -38,6 +38,7 @@ import { connect } from "@nats-io/transport-node";
 import {
   isReachable, createSpaceAuth, serverConfig, setupSpaceStreams, mintCreds, newIdentity,
   mintLifecycleUid, standaloneConnectOpts, principalKey, DEV_OWNER,
+  loadAgentFile, saveAgentFile,
   epCall, epRequestSubject, epCallerReplyFilter, EpEnvelopeError,
   contractStoreContext, fetchContractClosure, contractRefToHex, compileContract,
   resolveService, invokeCommand,
@@ -300,9 +301,27 @@ try {
   {
     const rDef = await A.call("define-persona", { name: "eppersona", persona: "You are the ep persona.", model: "m9" });
     check("definePersona creates the persona (content-only write)", rDef.reply.ok === true && existsSync(join(workspaceRoot, ".cotal", "agents", "eppersona.md")), rDef.reply);
+    // The tool takes no scope argument by design, so a peer cannot name its own channels here. The
+    // persona is therefore created reading nothing, and records WHY: everywhere else an empty read
+    // set is a choice, and on this path the caller was never offered one. Without the marker a
+    // census cannot tell the two apart and credits this path with an intent nobody expressed.
+    const defined = loadAgentFile(join(workspaceRoot, ".cotal", "agents", "eppersona.md"));
+    check("a wire-defined persona reads no channels", JSON.stringify(defined.subscribe) === "[]", defined.subscribe);
+    check("and records that the caller could not choose", defined.meta?.scope_source === "wire-default", defined.meta);
+
     const rDefB = await B.call("define-persona", { name: "eppersona", persona: "takeover" });
     check("a FOREIGN redefine refuses (ownership preserved through the ep door)",
       rDefB.reply.ok === false && String(rDefB.reply.error?.message ?? "").includes("not authorized to redefine"), rDefB.reply);
+    // A marker that outlives its condition is worse than none. Once an operator gives the persona a
+    // real read set, the claim "scope was never chosen" is false, so a later redefine drops it.
+    const eppPath = join(workspaceRoot, ".cotal", "agents", "eppersona.md");
+    saveAgentFile(eppPath, { ...loadAgentFile(eppPath), subscribe: ["general"], allowSubscribe: ["general"] });
+    const rDefC = await A.call("define-persona", { name: "eppersona", persona: "widened by the operator, redefined after" });
+    const widened = loadAgentFile(eppPath);
+    check("a redefine drops the marker once the persona has a real read set",
+      rDefC.reply.ok === true && widened.meta?.scope_source === undefined, { meta: widened.meta, reply: rDefC.reply });
+    check("and leaves the operator's read set alone", JSON.stringify(widened.subscribe) === '["general"]', widened.subscribe);
+
     const rModels = await A.call("models", {});
     const catalogs = (rModels.reply.data as { catalogs: Array<{ agent: string; supported: boolean }> })?.catalogs;
     check("models answers the NORMALIZED catalog list (stub connector: supported=false)",

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -5692,6 +5692,10 @@ export class Manager {
       // if an operator has since given it a real read set, the marker is a stale claim about a state
       // that no longer holds, and a marker that outlives its condition is worse than none: it tells
       // a census the scope was never chosen when someone chose it.
+      //
+      // The condition is the READ SET specifically, not any channel field. `allowSubscribe` alone is
+      // a ceiling on what the agent may read, not the set it reads, so a persona given only that
+      // still reads nothing and the marker still describes it correctly.
       if (def.meta?.scope_source === "wire-default" && def.subscribe?.length) {
         const { scope_source: _dropped, ...rest } = def.meta;
         def.meta = Object.keys(rest).length ? rest : undefined;

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -5688,6 +5688,14 @@ export class Manager {
       // PATCH content: overwrite model only when provided, so a persona-only redefine can't wipe an existing model.
       if (model !== undefined) def.model = model;
       def.persona = persona;
+      // A redefine cannot change scope, so a file that still has no channels keeps its marker. But
+      // if an operator has since given it a real read set, the marker is a stale claim about a state
+      // that no longer holds, and a marker that outlives its condition is worse than none: it tells
+      // a census the scope was never chosen when someone chose it.
+      if (def.meta?.scope_source === "wire-default" && def.subscribe?.length) {
+        const { scope_source: _dropped, ...rest } = def.meta;
+        def.meta = Object.keys(rest).length ? rest : undefined;
+      }
     } else {
       // Fresh name: create with content + owner = caller. The privileged tier suffices (creating a
       // brand-new persona isn't admin-only); the creator becomes its owner.
@@ -5698,7 +5706,13 @@ export class Manager {
       // safe scope for a peer-created persona is none, and an operator widens it afterwards. It is
       // written explicitly so the file states it, instead of being an omission a later default
       // could reinterpret.
-      def = { name, model, persona, owner: caller, subscribe: [] };
+      //
+      // `scope_source` records WHY it is empty. Everywhere else an empty read set means the author
+      // chose none; here the author was never offered the choice, and the two are indistinguishable
+      // in the file without this. A reader counting deliberate empties would otherwise credit this
+      // path with an intent nobody expressed. An operator setting a real read set should drop the
+      // marker, and `cotal personas edit` re-validates on save.
+      def = { name, model, persona, owner: caller, subscribe: [], meta: { scope_source: "wire-default" } };
     }
     try {
       saveAgentFile(path, def);

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -5691,7 +5691,14 @@ export class Manager {
     } else {
       // Fresh name: create with content + owner = caller. The privileged tier suffices (creating a
       // brand-new persona isn't admin-only); the creator becomes its owner.
-      def = { name, model, persona, owner: caller };
+      //
+      // The read set is EMPTY, and that is a policy decision made here rather than a field left
+      // blank. A peer cannot name its own channels through this path by design (see CONTENT vs
+      // POLICY above): letting it would make defining a persona a way to grant reads. So the only
+      // safe scope for a peer-created persona is none, and an operator widens it afterwards. It is
+      // written explicitly so the file states it, instead of being an omission a later default
+      // could reinterpret.
+      def = { name, model, persona, owner: caller, subscribe: [] };
     }
     try {
       saveAgentFile(path, def);

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "smoke:self-serve-join-coverage:auth": "tsx packages/core/smoke/self-serve-join-coverage-auth.smoke.ts",
     "smoke:e2e:acl": "tsx packages/core/smoke/e2e-acl.smoke.ts",
     "smoke:agent-file": "tsx packages/core/smoke/agent-file.smoke.ts",
+    "smoke:persona-templates": "tsx implementations/cli/smoke/persona-templates.smoke.ts",
     "smoke:control-auth": "tsx packages/core/smoke/control-auth.smoke.ts",
     "smoke:manager-split": "tsx packages/core/smoke/manager-split-auth.smoke.ts",
     "smoke:cred-lifetime": "tsx packages/core/smoke/cred-lifetime-auth.smoke.ts",

--- a/packages/core/smoke/agent-file.smoke.ts
+++ b/packages/core/smoke/agent-file.smoke.ts
@@ -184,5 +184,18 @@ let emptyOk = true;
 try { saveAgentFile(join(dir, "declared-none.md"), { name: "declarednone", persona: "x", subscribe: [] }); } catch { emptyOk = false; }
 ok("declaring an empty read set is accepted", emptyOk);
 
+// 8) An unmodelled frontmatter key survives a round trip. Callers record provenance this way (the
+//    manager marks a persona it created with no read set, because that path cannot offer its caller
+//    the choice), and nothing in those callers can tell whether the key still survives: they hand it
+//    to the writer and never see it again. If the meta sweep were ever narrowed to an allowlist,
+//    every such record would vanish silently and the file would go back to being ambiguous with no
+//    test anywhere going red. This is that test.
+const provenance = join(dir, "provenance.md");
+saveAgentFile(provenance, { name: "prov", persona: "x", subscribe: [], meta: { scope_source: "wire-default" } });
+const provBack = loadAgentFile(provenance);
+ok("an unmodelled key survives a save and reload", provBack.meta?.scope_source === "wire-default", provBack.meta);
+saveAgentFile(provenance, provBack);
+ok("and survives a second cycle, so a redefine cannot erode it", loadAgentFile(provenance).meta?.scope_source === "wire-default");
+
 console.log(`\nagent-file yaml smoke: ${pass} passed, ${fail} failed`);
 process.exit(fail === 0 ? 0 : 1);

--- a/packages/core/smoke/agent-file.smoke.ts
+++ b/packages/core/smoke/agent-file.smoke.ts
@@ -1,5 +1,5 @@
 /** Round-trip + safety proof for the yaml-backed agent-file parser (launchOptions map support). */
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadAgentFile, saveAgentFile, type AgentDef } from "../src/agent-file.js";
@@ -81,9 +81,13 @@ for (const [label, value] of [
   ok(`a ${label} allowPublish survives a save`, JSON.stringify(back.allowPublish) === JSON.stringify(value), back.allowPublish);
 }
 // An UNSET field stays unset: emitting on "is set" must not invent a field the author never wrote,
-// or every persona grows three keys and omitted stops being distinguishable from declared-empty.
-const bare = reread(join(dir, "policy-unset.md"), { name: "policy" });
-ok("an unset subscribe stays unset", bare.subscribe === undefined, bare.subscribe);
+// or every persona grows keys and omitted stops being distinguishable from declared-empty.
+//
+// Only `subscribe` is required. The other two have defaults that are answers rather than guesses:
+// allowSubscribe omitted means "exactly what it subscribes to", and allowPublish omitted means deny.
+// Neither can silently widen access, so neither needs to be spelled out. The read set had no such
+// answer, which is why it is the one field a saver must state.
+const bare = reread(join(dir, "policy-unset.md"), { name: "policy", subscribe: [] });
 ok("an unset allowSubscribe stays unset", bare.allowSubscribe === undefined, bare.allowSubscribe);
 ok("an unset allowPublish stays unset", bare.allowPublish === undefined, bare.allowPublish);
 
@@ -166,6 +170,19 @@ throws("launchOptions as scalar throws", "---\nname: x\nlaunchOptions: nope\n---
 throws("launchOptions as sequence throws", "---\nname: x\nlaunchOptions:\n  - a\n---\n");
 throws("renamed field 'channels' still fails loud", "---\nname: x\nchannels: [general]\n---\n");
 throws("malformed YAML fails loud", "---\nname: x\n  bad: : indent\n\t- weird\n---\n");
+
+// 7) Saving refuses a persona with no declared read set. The channels an agent reads must be said,
+//    because the two available defaults are both wrong: inheriting a channel grants one nobody
+//    chose, and filling in an empty list turns forgetting into a declaration and destroys the
+//    difference between them permanently. Refusing costs the caller one field and keeps the file
+//    honest about what its author meant.
+let refused = false;
+try { saveAgentFile(join(dir, "scopeless.md"), { name: "scopeless", persona: "x" }); } catch { refused = true; }
+ok("saving a persona with no read set is refused", refused);
+ok("the refusal writes no file", !existsSync(join(dir, "scopeless.md")));
+let emptyOk = true;
+try { saveAgentFile(join(dir, "declared-none.md"), { name: "declarednone", persona: "x", subscribe: [] }); } catch { emptyOk = false; }
+ok("declaring an empty read set is accepted", emptyOk);
 
 console.log(`\nagent-file yaml smoke: ${pass} passed, ${fail} failed`);
 process.exit(fail === 0 ? 0 : 1);

--- a/packages/core/smoke/mutations/agent-file-policy-roundtrip.json
+++ b/packages/core/smoke/mutations/agent-file-policy-roundtrip.json
@@ -69,10 +69,10 @@
       "name": "the redefine path is graded only through the writer, not through a real caller",
       "file": "packages/core/smoke/agent-file.smoke.ts",
       "find": "  saveAgentFile(file, d0);\n};\nredefine(live, \"Rewritten persona text.\");",
-      "replace": "  saveAgentFile(file, { ...d0, subscribe: d0.subscribe?.length ? d0.subscribe : undefined });\n};\nredefine(live, \"Rewritten persona text.\");",
+      "replace": "  saveAgentFile(file, { ...d0, subscribe: d0.subscribe?.length ? d0.subscribe : [\"general\"] });\n};\nredefine(live, \"Rewritten persona text.\");",
       "expectRed": "a redefine keeps the declared-empty read set",
       "cell": "a redefine keeps the declared-empty read set",
-      "note": "Plants the old behaviour INSIDE the replayed redefine sequence rather than in the writer, so the cell is shown to grade the caller's own path. Without this the redefine cells could pass for the writer's reasons alone."
+      "note": "Plants the pre-fix inherit INSIDE the replayed redefine rather than in the writer, so the cell is shown to grade the caller's path. It restores the old default rather than dropping the field, because dropping it now hits the writer's refusal and would crash the run instead of reddening this cell."
     },
     {
       "name": "the writer accepts a persona with no declared read set",

--- a/packages/core/smoke/mutations/agent-file-policy-roundtrip.json
+++ b/packages/core/smoke/mutations/agent-file-policy-roundtrip.json
@@ -29,7 +29,13 @@
     "depends on the mutated code; it cannot show that a real entry point reaches it. The redefine cells",
     "replay what the manager does when a persona is defined over an existing name, so that plant breaks",
     "the replay itself and leaves the writer correct, which is the only way to see the cells grade the",
-    "path rather than the function underneath it."
+    "path rather than the function underneath it.",
+    "",
+    "The read set is the one policy field a saver must state. The other two have defaults that answer",
+    "the question rather than guess at it: an omitted read ACL means exactly what the agent subscribes",
+    "to, and an omitted post ACL means deny. Neither can widen access by being absent. An omitted read",
+    "set had no such answer, so it was filled in by whatever default was current, and the file recorded",
+    "a channel nobody chose."
   ],
   "mutations": [
     {
@@ -51,13 +57,13 @@
       "note": "allowPublish is default-deny, so an explicit empty post ACL and an omitted one resolve alike today; the file must still record which one the author wrote."
     },
     {
-      "name": "the read set is emitted unconditionally, inventing a field the author never wrote",
+      "name": "the post ACL is emitted unconditionally, inventing a field the author never wrote",
       "file": "packages/core/src/agent-file.ts",
-      "find": "  if (def.subscribe) fm.subscribe = def.subscribe;",
-      "replace": "  fm.subscribe = def.subscribe ?? [];",
-      "expectRed": "an unset subscribe stays unset",
-      "cell": "an unset subscribe stays unset",
-      "note": "The overcorrection: every saved persona gains an empty read set that reads as a deliberate declaration. Same distinction lost, opposite direction."
+      "find": "  if (def.allowPublish) fm.allowPublish = def.allowPublish;",
+      "replace": "  fm.allowPublish = def.allowPublish ?? [];",
+      "expectRed": "an unset allowPublish stays unset",
+      "cell": "an unset allowPublish stays unset",
+      "note": "The overcorrection: every saved persona gains an empty post ACL that reads as a deliberate declaration. Same distinction lost, opposite direction. Aimed at allowPublish because subscribe is now required and cannot be unset."
     },
     {
       "name": "the redefine path is graded only through the writer, not through a real caller",
@@ -67,6 +73,15 @@
       "expectRed": "a redefine keeps the declared-empty read set",
       "cell": "a redefine keeps the declared-empty read set",
       "note": "Plants the old behaviour INSIDE the replayed redefine sequence rather than in the writer, so the cell is shown to grade the caller's own path. Without this the redefine cells could pass for the writer's reasons alone."
+    },
+    {
+      "name": "the writer accepts a persona with no declared read set",
+      "file": "packages/core/src/agent-file.ts",
+      "find": "  if (!def.subscribe)\n    throw new Error(",
+      "replace": "  if (false)\n    throw new Error(",
+      "expectRed": "saving a persona with no read set is refused",
+      "cell": "saving a persona with no read set is refused",
+      "note": "Removes the guard while leaving its message in place, so the suite cannot pass on the error text existing. A scopeless persona becomes writable again and the refusal cell names it."
     }
   ]
 }

--- a/packages/core/src/agent-file.ts
+++ b/packages/core/src/agent-file.ts
@@ -229,6 +229,19 @@ export function loadAgentFile(path: string): AgentDef {
 export function saveAgentFile(path: string, def: AgentDef): void {
   if (!def.name) throw new Error('saveAgentFile: "name" is required');
   assertValidName(def.name);
+  // The read set must be SAID, not inferred. A persona saved without one used to inherit a channel
+  // nobody chose, and the file gave a later reader no way to tell a deliberate silence from a
+  // forgotten field. Refusing here rather than filling in an empty list keeps that distinction:
+  // auto-filling would turn every omission into a declaration and destroy the difference for good.
+  //
+  // This is the writer, so it binds every caller that builds a definition and saves it, including
+  // ones added later. It cannot see a file written as literal text, which is why the shipped
+  // templates are asserted separately.
+  if (!def.subscribe)
+    throw new Error(
+      `saveAgentFile: "subscribe" is required for "${def.name}" - list the channels it reads, ` +
+        `or [] for none (an agent with no channels is still reachable by direct message and anycast)`,
+    );
   // Build the frontmatter mapping in read order, then serialize with the `yaml` library — it owns
   // all quoting/escaping (a value with a `:`/`#`/`[`/quote round-trips safely, which the old
   // hand-rolled writer had to special-case). `lineWidth: 0` keeps scalars on one line (no folding).


### PR DESCRIPTION
A persona saved with no read set inherited whatever default was current, so the stored file could carry a channel its author never chose, and a later reader had no way to tell a deliberate silence from a field someone forgot.

`saveAgentFile` now refuses a definition with no `subscribe`. Refusing at the writer binds every caller that builds a definition and saves it, including ones added later, which guarding each call site would not.

The refusal is deliberate rather than a filled-in empty list. Auto-filling would turn every omission into a declaration and destroy the distinction permanently, which is the opposite of what the field is for.

## Callers

- `cotal personas new` takes a required `--subscribe a,b`, or `--subscribe ""` for an agent reachable only by direct message and anycast. There is no default, because both candidates are wrong: a channel the author did not ask for, or an empty set indistinguishable from forgetting to say.
- A persona defined over the wire is created with an explicit empty read set. That path accepts no policy from its caller by design, since letting a peer name its own channels would make defining a persona a way to grant reads. An operator widens it afterwards.
- Setup writes its personas as literal template strings and never reaches the writer, so those are covered by assertion instead.

## Only the read set

`allowSubscribe` and `allowPublish` stay optional, because their defaults answer the question rather than guess at it: an omitted read ACL means exactly what the agent subscribes to, and an omitted post ACL means deny. Neither can widen access by being absent. An omitted read set had no such answer.

## Tests

New `smoke:persona-templates` covers what the writer cannot see:

- every persona template this repo ships declares the channels it reads
- the code paths that write into the persona catalog are enumerated by **output path**, not by function name, and an unlisted one fails the suite

The second cell exists because two separate name-based searches for writers missed the setup path, which uses its own path helper. A writer can call any function it likes, but it must eventually name the directory it writes into.

Both cells were driven to fail deliberately before being trusted: a template with the field removed reddens the first, and a new writer file reddens the second.

`smoke:agent-file` grows to 35 cells, and its mutation table to five, all killed on their named cells, including one that removes the new guard while leaving its error message in place so the suite cannot pass on the text existing.

Verified against the persona and spawn suites: `persona-acl`, `persona-input-closed`, `persona-announce`, `spawn-args`, `spawn-env-config`, `manifest-launch`, `manager-spawn-action`, `setup-failloud`.