### PR TITLE
fix(core,manager): renew the session signing key instead of letting it expire (#813)

### DIFF
--- a/.changeset/session-signing-key-renewal.md
+++ b/.changeset/session-signing-key-renewal.md
@@ -1,0 +1,14 @@
+---
+"@cotal-ai/core": patch
+"@cotal-ai/manager": patch
+---
+
+The manager's session signing key now renews itself instead of expiring after a day. It was minted
+once at startup with a flat 24-hour window and the same frozen anchor was returned for the life of
+the process, so any manager with more than a day of uptime lost its session plane permanently: every
+attach failed closed with "outside its validity window", and the only recovery was restarting the
+manager, which kills every live session. Failing closed on an expired key is correct and is
+unchanged; never renewing the key was the defect. The key now rotates once a third of its window has
+elapsed, the previous key stays verifiable for a ten-minute overlap so an artifact signed just
+before a swap is not orphaned, renewal is driven both by a timer and opportunistically before
+signing so a stalled timer alone cannot reintroduce the outage, and the newest key is never dropped.

--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -462,3 +462,11 @@ smoke:jcode-session-resume
 smoke:jcode-route-identity
 
 smoke:orientation
+
+# A signing key must not expire unattended. The manager minted its session key once at boot with a
+# flat 24h window and handed back that frozen anchor forever, so any manager with >24h uptime lost
+# its session plane: every attach failed closed with "outside its validity window", recoverable only
+# by restarting the manager, which kills every live session. It happened three times in one day.
+# Failing closed is correct (SPEC 13.10); never renewing is the defect. Rotate early, keep the old
+# key verifiable across an overlap, and never drop the newest.
+smoke:anchor-renewal

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -77,6 +77,8 @@ import {
   rawDigest,
   STANDING_RENEWABLE_TTL_SEC as MANAGED_STATIC_TTL_SEC,
   newArtifactSigner,
+  RotatingSigner,
+  generationAnchor,
   sessionsBucket,
   SESSION_GRANT_MAX_TTL_MS,
   type LifecycleStateTransport,
@@ -710,6 +712,9 @@ export class Manager {
    *  presents the refreshed cred on the next reconnect after a half-TTL renewal — the goal-writer
    *  precedent). Auth mode only; an open mesh runs the plane over a bare connection. */
   private sessionLedgerConn?: { nc: NatsConnection; creds?: string };
+  /** Renews the session signing key long before its window closes. A key that expires unattended
+   *  takes the whole session plane down until the manager is restarted, which kills live sessions. */
+  private sessionKeyRenewTimer?: ReturnType<typeof setInterval>;
   /** P2 item 6: credentialId → the nkey that credential was minted for, for the live per-session
    *  SERVING credentials. The §13.1 ledger row records the holder principal, and the row is written
    *  at stage time (after the mint), so the two steps need this one hop. Entries are dropped at
@@ -1627,6 +1632,7 @@ export class Manager {
   async stop(): Promise<void> {
     if (this.leaseTimer) clearInterval(this.leaseTimer);
     if (this.credRenewTimer) clearInterval(this.credRenewTimer);
+    if (this.sessionKeyRenewTimer) clearInterval(this.sessionKeyRenewTimer);
     if (this.maintenanceState === "active" && !this.resumeRequired) {
       await this.teardownManagedAgents(); // normal shutdown stays destructive (#159 B2)
     } else {
@@ -4901,12 +4907,32 @@ export class Manager {
     if (serveEpoch === undefined)
       throw new Error("the manager session plane needs the serve grant epoch; registerManagerService must run first");
     const ledgerKv = await openSessionLedgerKv(nc, sessionsBucket(this.space));
-    const signer = newArtifactSigner();
-    const keyId = `mgr-sessions-${identity.id.slice(0, 12)}`;
-    const anchor: SignerAnchor = {
-      keyId, publicKey: signer.publicKey, owner: MANAGER_ENDPOINT, roles: ["sessions"],
-      scope: { sessions: [MANAGER_ENDPOINT] }, validFrom: Date.now() - 60_000, validTo: Date.now() + SESSION_GRANT_MAX_TTL_MS,
-    };
+    // The session signing key ROTATES. It used to be minted once here with a flat 24h window and
+    // handed back frozen forever, so a manager that stayed up past 24h lost its session plane
+    // permanently: every attach failed closed with "outside its validity window", and the only
+    // recovery was restarting the manager, which kills every live session. It happened three times
+    // in one day. Failing closed on an expired key is correct (SPEC 13.10); the defect was that
+    // nothing ever renewed the key, so the correct refusal became permanent.
+    //
+    // Renewal is driven from two places on purpose - a timer below, and opportunistically before
+    // each signature. A timer alone stops if the loop is starved or the host suspends; an
+    // opportunistic check alone never fires on an idle plane that must sign after a long quiet
+    // period. Expiry now requires both to fail at once.
+    const rotating = new RotatingSigner((seq, now) => {
+      const kp = newArtifactSigner();
+      const keyId = seq === 0
+        ? `mgr-sessions-${identity.id.slice(0, 12)}`
+        : `mgr-sessions-${identity.id.slice(0, 12)}-g${seq}`;
+      return {
+        keyId,
+        keyPair: kp,
+        anchor: generationAnchor({
+          keyId, publicKey: kp.publicKey, owner: MANAGER_ENDPOINT, roles: ["sessions"],
+          scope: { sessions: [MANAGER_ENDPOINT] }, now, ttlMs: SESSION_GRANT_MAX_TTL_MS,
+        }),
+      };
+    }, Date.now());
+    const keyId = rotating.current().keyId;
     this.sessionPlane = new ManagerSessionPlane({
       space: this.space,
       // The session's serving identity is the persisted REGISTRATION instanceId (item 3), not the
@@ -4914,12 +4940,32 @@ export class Manager {
       // an ADVANCED epoch, so a client re-attaches by the same instance while the epoch fences the
       // old incarnation's sessions (item 6's restart-refusal composed with item 3's addressing).
       serving: { instanceId: this.managerInstanceId, epoch: serveEpoch },
-      signer: { keyId, keyPair: signer }, resolveAnchor: (id) => (id === keyId ? anchor : undefined),
+      // Read through the rotator on EVERY use rather than capturing a key: signing takes the newest
+      // generation, and resolution accepts any generation still inside its overlap so an artifact
+      // signed a moment before a swap is not orphaned a moment after it.
+      signer: {
+        get keyId() { rotating.maybeRenew(Date.now()); return rotating.current().keyId; },
+        keyPair: { sign: (input: Uint8Array) => rotating.current().keyPair.sign(input) },
+      },
+      resolveAnchor: (id) => rotating.resolve(id),
       ledgerKv, ttlMs: SESSION_GRANT_MAX_TTL_MS,
       servingCredential: this.sessionServingCredentials(),
       ...(this.maxSessions !== undefined ? { maxSessions: this.maxSessions } : {}),
     });
     this.sessionLedgerConn = sw;
+    // The belt to the signing path's braces: renew on a timer as well, so a plane that sits idle
+    // for longer than a window still holds a live key when work finally arrives. Checked well
+    // inside the renewal margin, unref'd so it never holds the process open.
+    const renewTimer = setInterval(() => {
+      const rotated = rotating.maybeRenew(Date.now());
+      if (rotated)
+        console.error(
+          `manager session signing key rotated to ${rotated} (previous generations stay verifiable ` +
+            `through their overlap; a key is never allowed to expire unattended)`,
+        );
+    }, 15 * 60 * 1000);
+    renewTimer.unref?.();
+    this.sessionKeyRenewTimer = renewTimer;
     console.error(`manager session plane standing (endpoint ${MANAGER_ENDPOINT}, epoch ${serveEpoch}, ${this.auth ? "scoped session-ledger cred, §13.1 family-staged" : "open/bare"})`);
   }
 

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "smoke:doctor-auth": "tsx implementations/cli/smoke/doctor-auth.smoke.ts",
     "smoke:sys-rotation": "tsx implementations/cli/smoke/sys-rotation.smoke.ts",
     "smoke:sys-rotation-e2e": "tsx implementations/cli/smoke/sys-rotation-e2e.smoke.ts",
+    "smoke:anchor-renewal": "tsx packages/core/smoke/anchor-renewal.smoke.ts",
     "smoke:signing-key-rotation": "tsx packages/core/smoke/signing-key-rotation-auth.smoke.ts",
     "smoke:system-account-rotation": "tsx packages/core/smoke/system-account-rotation-auth.smoke.ts",
     "smoke:cutover-restart-eviction": "tsx packages/core/smoke/cutover-restart-eviction-auth.smoke.ts",

--- a/packages/core/smoke/anchor-renewal.smoke.ts
+++ b/packages/core/smoke/anchor-renewal.smoke.ts
@@ -1,0 +1,141 @@
+/**
+ * A signing key must not expire unattended.
+ *
+ * The manager minted its session signing key once, at boot, with a flat 24h window:
+ *
+ *   validTo: Date.now() + SESSION_GRANT_MAX_TTL_MS
+ *
+ * and handed back that same frozen anchor forever. Past 24h of uptime every attach failed closed:
+ *
+ *   signing key mgr-sessions-UCZ2XFX524KR is outside its validity window at 1787489502074
+ *   (window 1787365061492..1787451521492)
+ *
+ * Decoded: a 24.02h window, and the failure landed 10.55h AFTER expiry. Restarting the client does
+ * nothing, because the dead window lives in the manager's anchor; the only recovery found was
+ * restarting the manager, which kills every live session. It happened three times in one day.
+ *
+ * Failing closed on an expired key is correct (SPEC 13.10) and is NOT what this suite questions.
+ * What it grades is that the key is renewed before it can expire, and that the old key stays
+ * verifiable long enough that an artifact signed a moment before a swap is not orphaned by it.
+ */
+import assert from "node:assert/strict";
+import {
+  OVERLAP_MS,
+  RENEW_AT_FRACTION,
+  RotatingSigner,
+  generationAnchor,
+  needsRenewal,
+  renewalDueAt,
+} from "../src/signing-key-rotation.js";
+
+let pass = 0;
+const failures: string[] = [];
+const check = (name: string, cond: boolean, extra?: unknown): void => {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+    return;
+  }
+  const detail = `${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`;
+  failures.push(detail);
+  console.log(`  ✗ ${detail}`);
+};
+
+const DAY = 24 * 60 * 60 * 1000;
+const T0 = 1_787_365_061_492; // the real mint time from the incident
+
+const mint = (seq: number, now: number) => ({
+  keyId: `mgr-sessions-gen${seq}`,
+  keyPair: { sign: () => new Uint8Array([seq]) },
+  anchor: generationAnchor({
+    keyId: `mgr-sessions-gen${seq}`,
+    publicKey: `pub-${seq}`,
+    owner: "ai.cotal.manager",
+    roles: ["sessions"],
+    scope: { sessions: ["ai.cotal.manager"] },
+    now,
+    ttlMs: DAY,
+  }),
+});
+
+console.log("\n1. THE INCIDENT: a manager past its window still signs");
+{
+  const s = new RotatingSigner(mint, T0);
+  const first = s.current().keyId;
+  // The exact failure time from the operator's paste: 34.5h after mint.
+  const atFailure = 1_787_489_502_074;
+  s.maybeRenew(atFailure);
+  const active = s.current().anchor;
+  check("the signing key is still inside its window at the moment that used to fail", atFailure <= active.validTo, {
+    at: atFailure,
+    validTo: active.validTo,
+  });
+  check("because it rotated rather than expiring", s.current().keyId !== first, { first, now: s.current().keyId });
+}
+
+console.log("\n2. renewal happens EARLY, with the window mostly unspent");
+{
+  const a = generationAnchor({ keyId: "k", publicKey: "p", owner: "o", roles: ["sessions"], scope: {}, now: T0, ttlMs: DAY });
+  const due = renewalDueAt(a);
+  check("renewal is due before the window is half gone", due < a.validFrom + (a.validTo - a.validFrom) / 2);
+  check("and not immediately at mint (that would rotate on every check)", due > a.validFrom);
+  check("the margin left after the renewal point is the majority of the window", a.validTo - due > (a.validTo - a.validFrom) / 2);
+  check("not yet due at mint", !needsRenewal(a, T0));
+  check("due once the fraction has elapsed", needsRenewal(a, a.validFrom + Math.ceil((a.validTo - a.validFrom) * RENEW_AT_FRACTION)));
+}
+
+console.log("\n3. the OLD key stays verifiable across the swap");
+{
+  const s = new RotatingSigner(mint, T0);
+  const old = s.current().keyId;
+  const swapAt = T0 + Math.ceil(DAY * RENEW_AT_FRACTION) + 1;
+  s.maybeRenew(swapAt);
+  check("a new generation is active", s.current().keyId !== old);
+  check("the OLD keyId still resolves right after the swap", s.resolve(old) !== undefined);
+  check("an artifact signed under the old key can still be verified", (s.resolve(old)?.validTo ?? 0) >= swapAt);
+}
+
+console.log("\n4. and it is eventually dropped, so retention is not a leak");
+{
+  const s = new RotatingSigner(mint, T0);
+  const old = s.current().keyId;
+  s.maybeRenew(T0 + Math.ceil(DAY * RENEW_AT_FRACTION) + 1);
+  const oldExpiry = s.resolve(old)!.validTo;
+  s.maybeRenew(oldExpiry + OVERLAP_MS + 1);
+  check("the superseded key is gone once its overlap has passed", s.resolve(old) === undefined);
+  check("retention stays bounded across many rotations", (() => {
+    const r = new RotatingSigner(mint, T0);
+    for (let i = 1; i <= 50; i++) r.maybeRenew(T0 + i * DAY);
+    return r.generations().length <= 3;
+  })());
+}
+
+console.log("\n5. the newest key is NEVER dropped, whatever the clock does");
+{
+  const s = new RotatingSigner(mint, T0);
+  // A clock jump far past every window: dropping everything would leave the plane unable to sign
+  // at all, which is worse than serving with a key a verifier will reject.
+  s.maybeRenew(T0 + 400 * DAY);
+  check("a generation still exists after an absurd clock jump", s.generations().length >= 1);
+  check("and it is signable", typeof s.current().keyPair.sign === "function");
+}
+
+console.log("\n6. renewal is idempotent - safe to call before every signature");
+{
+  const s = new RotatingSigner(mint, T0);
+  const before = s.current().keyId;
+  for (let i = 0; i < 100; i++) s.maybeRenew(T0 + 60_000);
+  check("100 checks inside the window rotate nothing", s.current().keyId === before);
+  check("and do not accumulate generations", s.generations().length === 1, { n: s.generations().length });
+}
+
+console.log("\n7. an unknown keyId still resolves to nothing (fail-closed is preserved)");
+{
+  const s = new RotatingSigner(mint, T0);
+  check("a key that was never minted does not resolve", s.resolve("mgr-sessions-forged") === undefined);
+}
+
+console.log(`\nsigning key rotation: ${pass} cells OK, ${failures.length} failed`);
+if (failures.length) {
+  assert.fail(`signing key rotation: ${failures.length} cell(s) failed\n  - ${failures.join("\n  - ")}`);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,7 @@ export * from "./session-terminal-frames.js";
 export * from "./endpoint-virtual.js";
 export * from "./endpoint-receipt.js";
 export * from "./endpoint-signing.js";
+export * from "./signing-key-rotation.js";
 export * from "./endpoint-traits.js";
 export * from "./safe-pattern.js";
 export * from "./resolve.js";

--- a/packages/core/src/signing-key-rotation.ts
+++ b/packages/core/src/signing-key-rotation.ts
@@ -1,0 +1,133 @@
+/**
+ * A signing key that outlives its own validity window.
+ *
+ * A signer minted at boot with `validTo: Date.now() + TTL` is correct for exactly TTL and then
+ * permanently broken. Nothing re-mints it, so a process that stays up past its window loses the
+ * plane that key serves - and no restart of the CLIENT helps, because the expiry is in the SERVER's
+ * frozen anchor. Observed three times in one day on a manager whose session key was minted at boot
+ * with a flat 24h window: at +34.5h every attach failed closed with "outside its validity window",
+ * and the only recovery anyone found was restarting the manager, which killed every live session.
+ *
+ * Failing closed on an expired key is correct (SPEC 13.10) and is not what this changes. What this
+ * changes is that the key stops expiring unattended: it is renewed well before the edge, and the
+ * previous key stays verifiable for an overlap so artifacts signed a moment before the swap do not
+ * become unverifiable a moment after it.
+ *
+ * The rule follows the auth issuer, which has had it all along: sign with the newest key, verify
+ * against any live key, drop a key only once nothing it signed can still be in flight.
+ */
+import type { AnchorRole, SignerAnchor } from "./endpoint-signing.js";
+
+/** Renew once this fraction of the window has elapsed. A third leaves two thirds of the window as
+ *  margin, so a renewal can fail and be retried many times before anything expires. */
+export const RENEW_AT_FRACTION = 1 / 3;
+/** How long a replaced key stays verifiable. It must exceed the longest artifact TTL that key can
+ *  sign, or a grant issued just before the swap outlives the ability to verify it. */
+export const OVERLAP_MS = 10 * 60 * 1000;
+
+/** A key that can sign, paired with the anchor a verifier resolves for it. */
+export interface KeyGeneration {
+  keyId: string;
+  keyPair: { sign(input: Uint8Array): Uint8Array };
+  anchor: SignerAnchor;
+}
+
+/** Mint a fresh generation. Supplied by the caller so this module never owns key material. */
+export type MintGeneration = (seq: number, now: number) => KeyGeneration;
+
+/**
+ * When the current generation should be replaced.
+ *
+ * Deliberately a fraction of the window rather than a fixed lead time: a short-lived key and a
+ * long-lived one both get proportional margin, and a caller cannot accidentally configure a lead
+ * time longer than the window itself (which would renew on every single check).
+ */
+export function renewalDueAt(anchor: Pick<SignerAnchor, "validFrom" | "validTo">): number {
+  const span = anchor.validTo - anchor.validFrom;
+  return anchor.validFrom + Math.floor(span * RENEW_AT_FRACTION);
+}
+
+/** Whether `now` has reached the renewal point for this anchor. */
+export function needsRenewal(anchor: Pick<SignerAnchor, "validFrom" | "validTo">, now: number): boolean {
+  return now >= renewalDueAt(anchor);
+}
+
+/**
+ * A rotating signing key: always signs with the newest generation, resolves any generation still
+ * inside its overlap, and drops the rest.
+ *
+ * The renewal is driven by {@link maybeRenew}, which the owner calls on a timer AND opportunistically
+ * before signing. Both matter: a timer alone stops if the event loop is starved or the process is
+ * suspended, and an opportunistic check alone never fires on an idle plane that then has to sign
+ * after a long quiet period. Together, an expired key requires both a dead timer and no signing.
+ */
+export class RotatingSigner {
+  #generations: KeyGeneration[] = [];
+  #seq = 0;
+  readonly #mint: MintGeneration;
+
+  constructor(mint: MintGeneration, now: number) {
+    this.#mint = mint;
+    this.#generations.push(this.#mint(this.#seq++, now));
+  }
+
+  /** The generation to sign with: always the newest. */
+  current(): KeyGeneration {
+    return this.#generations[this.#generations.length - 1];
+  }
+
+  /** Resolve an anchor by keyId across every generation still retained. A verifier must be able to
+   *  check an artifact signed just before a swap, which is the entire point of the overlap. */
+  resolve(keyId: string): SignerAnchor | undefined {
+    return this.#generations.find((g) => g.keyId === keyId)?.anchor;
+  }
+
+  /** Every generation currently retained, newest last. Observability for the owner's logs. */
+  generations(): readonly KeyGeneration[] {
+    return this.#generations;
+  }
+
+  /**
+   * Renew if the current generation has reached its renewal point, then drop generations whose
+   * overlap has passed. Idempotent and cheap: safe to call before every signature.
+   *
+   * Returns the new keyId when a rotation happened, so the owner can log a fact rather than a hope.
+   */
+  maybeRenew(now: number): string | undefined {
+    let rotated: string | undefined;
+    if (needsRenewal(this.current().anchor, now)) {
+      const next = this.#mint(this.#seq++, now);
+      this.#generations.push(next);
+      rotated = next.keyId;
+    }
+    // Never drop the newest, whatever the clock says: a plane with no signer cannot serve at all,
+    // and a key that is somehow already past its overlap is still better than nothing to sign with.
+    const newest = this.#generations[this.#generations.length - 1];
+    this.#generations = this.#generations.filter((g) => g === newest || now <= g.anchor.validTo + OVERLAP_MS);
+    return rotated;
+  }
+}
+
+/** Build the anchor for a generation. Kept here so every caller gets the same window shape. */
+export function generationAnchor(args: {
+  keyId: string;
+  publicKey: string;
+  owner: string;
+  roles: readonly AnchorRole[];
+  scope: SignerAnchor["scope"];
+  now: number;
+  ttlMs: number;
+  /** Tolerance for a verifier whose clock runs slightly behind this signer's. */
+  skewMs?: number;
+}): SignerAnchor {
+  const skew = args.skewMs ?? 60_000;
+  return {
+    keyId: args.keyId,
+    publicKey: args.publicKey,
+    owner: args.owner,
+    roles: args.roles,
+    scope: args.scope,
+    validFrom: args.now - skew,
+    validTo: args.now + args.ttlMs,
+  };
+}


### PR DESCRIPTION
## The report

```
cotal attach --name fm-orch-cotal
✗ signing key mgr-sessions-UCZ2XFX524KR is outside its validity window at 1787489502074
  (window 1787365061492..1787451521492); out-of-window use fails closed (SPEC 13.10)
```

Window: **24.02 hours**. Failure: **10.55 hours after it closed**. Third occurrence in one day on one host.

## Root cause

`manager.ts` `standUpSessionPlane()` computes the anchor **once**, at boot, and `resolveAnchor` returns that same frozen object for the life of the process:

```ts
validTo: Date.now() + SESSION_GRANT_MAX_TTL_MS,   // 24h, frozen
…
resolveAnchor: (id) => (id === keyId ? anchor : undefined),
```

Nothing re-mints it. A `grep` for `validTo` across `implementations/` finds exactly one non-test assignment — this one.

So **every manager with more than 24h uptime loses its session plane, permanently, by construction.** Restarting the client cannot help: the dead window lives in the manager's anchor. The only recovery is restarting the manager, which kills every live session.

## What this does not change

Failing closed on an out-of-window key is correct and required (SPEC 13.10). `resolveAnchorForUse` is untouched. The defect was that a **correct refusal became permanent**, because no renewal path existed at all.

## The fix

`RotatingSigner` in `packages/core/src/signing-key-rotation.ts`:

- **Renews at 1/3 of the window**, not a fixed lead time, so margin scales with the TTL and a lead can never exceed the window itself.
- **Keeps the previous key verifiable for a 10-minute overlap**, so a grant signed just before a swap is not orphaned just after it.
- **Two independent triggers**: a 15-minute timer *and* an opportunistic check before each signature. A timer alone stops when the loop is starved or the host suspends; an opportunistic check alone never fires on an idle plane. Expiry now needs both to fail at once.
- **Never drops the newest generation**, whatever the clock does — a plane with no signer is worse than one holding a key a verifier might reject.

The `implementations/auth` issuer has had this shape all along (rotate, verify any live kid, retire late). The session plane never got it.

## Proof

`smoke:anchor-renewal`, **17/17**. Cell 1 replays the operator's literal timestamp `1787489502074` and asserts the key is live at the moment that used to fail.

Red-first, each mutation reddening its own named cell:

| Mutation | Result |
|---|---|
| never renew (the shipped behaviour) | **RED** — `{"at":1787489502074,"validTo":1787451461492}`, the reported failure reproduced |
| renew but drop the old key immediately | **RED** on both overlap cells |
| restored | 17/17 |

Both halves matter: without the first the fix does nothing, and without the second it trades a 24-hour outage for a 10-minute one on every rotation — quieter, still broken.

`typecheck` clean, `GATE INVENTORY OK`, and the manager's renewal timer is `unref`'d and cleared on teardown alongside the existing `credRenewTimer`.

## One thing worth flagging for review

`smoke:signing-key-rotation` was **already taken** by a broker account-rotation suite. My first registration silently no-opped on that name and I ran the pre-existing suite, which passed and would have been reported as proof of this fix. Caught by reading the output (9 checks about account JWTs, not 17 about anchors) rather than the exit code. The new suite is `smoke:anchor-renewal`; the pre-existing one is untouched and still passes 9/9.

Closes #813.
