### PR TITLE
test(core): retarget the declared-empty mutation after the writer guard

### DIFF
--- a/packages/core/smoke/mutations/agent-file-policy-roundtrip.json
+++ b/packages/core/smoke/mutations/agent-file-policy-roundtrip.json
@@ -39,13 +39,13 @@
   ],
   "mutations": [
     {
-      "name": "the read set reverts to emit-only-when-non-empty",
+      "name": "the writer turns a declared-empty read set back into inherited general",
       "file": "packages/core/src/agent-file.ts",
       "find": "  if (def.subscribe) fm.subscribe = def.subscribe;",
-      "replace": "  if (def.subscribe?.length) fm.subscribe = def.subscribe;",
+      "replace": "  if (def.subscribe) fm.subscribe = def.subscribe.length ? def.subscribe : [\"general\"];",
       "expectRed": "a empty subscribe survives a save",
       "cell": "a empty subscribe survives a save",
-      "note": "The exact pre-fix condition. A declared-empty read set is dropped on save and reads back as undefined."
+      "note": "The writer must state the declared empty set now that omission is refused. Reintroducing the old inherited channel keeps the file well-formed and the run complete, but widens a deliberate no-channel policy to general; the empty round-trip cell names it."
     },
     {
       "name": "the post ACL reverts to emit-only-when-non-empty",


### PR DESCRIPTION
Closes the mutation-proof regression introduced by the interaction between #811 and #812.

`saveAgentFile` now correctly refuses an omitted `subscribe`, so the old mutation that dropped an explicit empty list no longer reached the suite's completion marker: it failed loud at the new writer guard and mutation-proof reported INCONCLUSIVE instead of a clean named red.

Retarget the mutation to the remaining product failure: turn a declared-empty read set back into inherited `general`. The file remains valid, the run completes, and the existing empty-round-trip cell names the widened policy.

## Verification

- Before: exact current `main` `90cf3e34` — mutation-proof rc 1, M1 INCONCLUSIVE, 4/5 killed.
- After: `node scripts/mutation-proof.mjs --config packages/core/smoke/mutations/agent-file-policy-roundtrip.json` — rc 0, all 5 killed; M1 red on `a empty subscribe survives a save` (35 marks vs baseline 37).
- `pnpm smoke:mutation-fixtures` — rc 0, 160 files / 984 anchors, zero dead or ambiguous anchors.
- `pnpm typecheck` — rc 0.

No product code, package surface, or release note changes. This is the smallest complete fix: one mutation entry is retargeted; no new harness or test machinery is added.