### PR TITLE
feat(core)!: remove the implicit general channel floor

### DIFF
--- a/.changeset/no-general-floor.md
+++ b/.changeset/no-general-floor.md
@@ -1,0 +1,34 @@
+---
+"@cotal-ai/core": minor
+"@cotal-ai/cli": minor
+"@cotal-ai/manager": minor
+"@cotal-ai/connector-core": minor
+---
+
+Remove the implicit `general` channel floor: undeclared access now grants nothing
+
+An agent that declared no channel access used to fall back to `["general"]` for its
+active read set and read ACL. That floor was applied in seven places — the provisioner,
+the agent-file loader, the manager's spawn path, the CLI's `spawn`, the connector's
+config resolver, and the endpoint's own channel list — so an agent with no frontmatter
+silently joined a channel nobody had granted it.
+
+The fallback also could not see the credentials it was guessing against. On a manifest
+spawn the materialized persona carries no access frontmatter, so the connector fell back
+to `general` while the minted creds allowed only the manifest's channels; the broker then
+refused the subscription and the agent joined nothing, with no error naming the cause.
+`COTAL_SUBSCRIBE` forwarding was added to paper over exactly this.
+
+Undeclared read is now empty, matching the repo's no-fallbacks rule and the existing
+default-deny on `allowPublish`. `Endpoint.send()` throws instead of defaulting to
+`general` when the endpoint is on no concrete channel — a caller that never declared a
+channel now gets a loud error rather than a message delivered somewhere it never asked
+for.
+
+The seeded personas change with it: `default_agent` no longer auto-subscribes to
+`general` and no longer carries a wildcard post ACL (`allowPublish: [">"]` → `[]`,
+default-deny), and the demo personas move to their own `welcome` channel. Channels are
+implicit — created on first use — so no channel provisioning is required.
+
+Breaking for anyone relying on the implicit floor: an agent that read `general` without
+declaring it must now declare it.

--- a/extensions/connector-core/src/config.ts
+++ b/extensions/connector-core/src/config.ts
@@ -251,7 +251,7 @@ export function configFromEnv(env: NodeJS.ProcessEnv = process.env): AgentConfig
   if (!name)
     throw new Error("COTAL_NAME, COTAL_AGENT_FILE or COTAL_LINK is required — a Cotal session needs an explicit identity from its launcher");
   const subscribe = splitList(env.COTAL_SUBSCRIBE);
-  const resolvedSubscribe = subscribe.length ? subscribe : (def?.subscribe ?? link?.channels ?? ["general"]);
+  const resolvedSubscribe = subscribe.length ? subscribe : (def?.subscribe ?? link?.channels ?? []);
   const allowSub = splitList(env.COTAL_ALLOW_SUBSCRIBE);
   const resolvedAllowSub = allowSub.length ? allowSub : (def?.allowSubscribe ?? resolvedSubscribe);
   // Fail loud on an inconsistent env override (the agent-file loader already checks the file): the

--- a/implementations/cli/src/commands/setup.ts
+++ b/implementations/cli/src/commands/setup.ts
@@ -588,7 +588,7 @@ function writeDemoAgent(path: string, body: string): void {
  *  then the user's to shape. Unlike the demo team it's never refreshed (seed-if-absent), so any
  *  edits stand; deleting it just means the next `cotal setup` writes a fresh copy.
  *
- *  Read scope is split intentionally: the ACTIVE set (`subscribe`) is just `general`, so a fresh
+ *  Read scope is split intentionally: the ACTIVE set (`subscribe`) is EMPTY, so a fresh
  *  agent isn't firehosed every channel on the mesh at boot, while the read ACL (`allowSubscribe:
  *  [">"]`) still PERMITS it to read anything — it just has to `cotal_join` a channel to start
  *  receiving it. (`subscribe: [">"]` would auto-subscribe to every channel, the old behavior.) */
@@ -597,9 +597,9 @@ name: default_agent
 role: default
 description: An agent on the mesh
 tags: []
-subscribe: [general]
+subscribe: []
 allowSubscribe: [">"]
-allowPublish: [">"]
+allowPublish: []
 capabilities: [spawn]
 ---
 
@@ -639,8 +639,8 @@ name: david
 role: cotal-tech
 description: "the engineer: how Cotal works (the wire, NATS, connectors, integration)."
 tags: [cotal, technical, help]
-subscribe: [general]
-allowPublish: [general]
+subscribe: [welcome]
+allowPublish: [welcome]
 ---
 
 You are david, Cotal's engineer, live on the web for agents with the operator who just set Cotal
@@ -661,8 +661,8 @@ name: sven
 role: cotal-guide
 description: "the guide: what to build with Cotal (examples, setups, getting the most out of it)."
 tags: [cotal, examples, help]
-subscribe: [general]
-allowPublish: [general]
+subscribe: [welcome]
+allowPublish: [welcome]
 ---
 
 You are sven, Cotal's guide, live on the web for agents with the operator who just set Cotal up.
@@ -681,8 +681,8 @@ name: me
 role: operator
 description: "your own session on the Cotal mesh."
 tags: [cotal]
-subscribe: [general]
-allowPublish: [general]
+subscribe: [welcome]
+allowPublish: [welcome]
 capabilities: [spawn]
 ---
 

--- a/implementations/cli/src/commands/spawn.ts
+++ b/implementations/cli/src/commands/spawn.ts
@@ -680,7 +680,7 @@ async function provisionUserForeground(
       owner,
       actor: name,
       scope: (opts.capabilities ?? []).filter((s) => s === "spawn" || s === "admin" || /^role:[A-Za-z0-9_-]+$/.test(s)),
-      allowSubscribe: opts.allowSubscribe?.length ? opts.allowSubscribe : (opts.subscribe?.length ? opts.subscribe : ["general"]),
+      allowSubscribe: opts.allowSubscribe?.length ? opts.allowSubscribe : (opts.subscribe ?? []),
       allowPublish: publish,
       role: opts.role,
       parent: `${owner}.cli`,

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -3361,7 +3361,7 @@ export class Manager {
       subscribe = opts.subscribe ?? def.subscribe;
       // Defaulted the same way the loader/provisioner do — minted into the creds (the broker
       // boundary); runtime durable joins are re-authorized against the committed ACL by the daemon.
-      allowSubscribe = opts.allowSubscribe ?? def.allowSubscribe ?? subscribe ?? ["general"];
+      allowSubscribe = opts.allowSubscribe ?? def.allowSubscribe ?? subscribe ?? [];
       allowPublish = opts.allowPublish ?? def.allowPublish;
       capabilities = def.capabilities;
       // #651: fold the persona's model into the launch record, mirroring the variant line below

--- a/packages/core/src/agent-file.ts
+++ b/packages/core/src/agent-file.ts
@@ -158,7 +158,7 @@ export function loadAgentFile(path: string): AgentDef {
     }
   // Invariant (fail-loud at load): the active read set must be within the read ACL. Defaults:
   // subscribe ⇒ [general]; allowSubscribe ⇒ subscribe (read exactly what you subscribe to).
-  const effSubscribe = subscribe?.length ? subscribe : ["general"];
+  const effSubscribe = subscribe ?? [];
   const effAllow = allowSubscribe?.length ? allowSubscribe : effSubscribe;
   for (const ch of effSubscribe)
     if (!channelInAllow(effAllow, ch))

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -607,7 +607,7 @@ export class CotalEndpoint extends EventEmitter {
     this.user = opts.user;
     this.pass = opts.pass;
     this.tls = opts.tls ?? false;
-    this.channels = opts.channels ?? ["general"];
+    this.channels = opts.channels ?? [];
     this.heartbeatMs = opts.heartbeatMs ?? 2000;
     this.ttlMs = opts.ttlMs ?? 6000;
     this.doRegister = opts.registerPresence ?? true;
@@ -1243,7 +1243,11 @@ export class CotalEndpoint extends EventEmitter {
     // Publish must target a concrete sub-channel — you can't broadcast to a
     // wildcard. Default to the first concrete channel we're on (channels[0] may
     // itself be a wildcard subscription like `team.>`).
-    const channel = opts?.channel ?? this.channels.find(isConcreteChannel) ?? "general";
+    const channel = opts?.channel ?? this.channels.find(isConcreteChannel);
+    if (!channel)
+      throw new Error(
+        "send() needs a channel: this endpoint is on no concrete channel, so there is no default to fall back to - pass opts.channel",
+      );
     if (!isConcreteChannel(channel))
       throw new Error(`cannot publish to wildcard channel "${channel}" - pick a concrete sub-channel`);
     const msg: CotalMessage = {

--- a/packages/core/src/provision.ts
+++ b/packages/core/src/provision.ts
@@ -740,7 +740,7 @@ export async function provisionAgentDurables(
   opts: ProvisionOpts = {},
 ): Promise<string[]> {
   const uid = assertLifecycleToken(pr.lifecycleUid); // hard cut: every provisioned footprint is lifecycle-keyed (SPEC 13.1)
-  const subscribe = opts.subscribe?.length ? opts.subscribe : ["general"];
+  const subscribe = opts.subscribe ?? [];
   const allowSubscribe = opts.allowSubscribe?.length ? opts.allowSubscribe : subscribe;
   // Reject channel names the wire layer would rewrite (the pre-created filter rides token() too).
   for (const ch of [...subscribe, ...allowSubscribe]) assertValidChannel(ch);
@@ -1078,7 +1078,7 @@ export function permissionsFor(
   if (profile !== "agent")
     throw new Error(`permissionsFor: unhandled profile "${profile}" - add an explicit arm, do not fall through to agent`);
   const allowPublish = opts.allowPublish ?? []; // post ACL — DEFAULT-DENY (publish must be declared)
-  const allowSubscribe = opts.allowSubscribe?.length ? opts.allowSubscribe : ["general"]; // read ACL
+  const allowSubscribe = opts.allowSubscribe ?? []; // read ACL — no floor: undeclared reads nothing
   // Re-assert at the mint chokepoint (covers mint/spawn paths that bypass the file loader): a policy
   // channel must equal its wire token, or the minted grant would alias the logical ACL.
   for (const ch of [...allowSubscribe, ...allowPublish]) assertValidChannel(ch);


### PR DESCRIPTION
## What

An agent that declared no channel access fell back to `["general"]` for its active read set and read ACL. This removes that floor: **undeclared access now grants nothing.**

The floor was applied in seven places — the provisioner (×2), the agent-file loader, the manager's spawn path, the CLI's `spawn`, the connector's config resolver, and the endpoint's own channel list.

## Why

Two independent problems.

**1. It granted access nobody declared.** An agent with no frontmatter silently joined a channel it was never given. That contradicts the repo's own no-fallbacks rule, and it is inconsistent with `allowPublish`, which has always been default-deny on the grounds that "publishing is the dangerous verb."

**2. It guessed against credentials it could not see.** On a manifest spawn the materialized persona carries no access frontmatter, so the connector fell back to `general` while the minted creds allowed only the manifest's channels. The broker then refused the subscription and the agent joined **nothing**, with no error naming the cause. `COTAL_SUBSCRIBE` forwarding exists to paper over exactly this — the code comments in `connector.ts:31`, `manager.ts:3647` and `launch.ts:197` all document the failure.

## Changes

- undeclared `subscribe` / `allowSubscribe` resolve to `[]` rather than `["general"]`
- `Endpoint.send()` **throws** when the endpoint is on no concrete channel, instead of silently publishing to `general`
- `default_agent` no longer auto-subscribes to `general`, and its post ACL drops from the wildcard `[">"]` to `[]` (default-deny)
- the demo personas (`david`, `sven`, `nova`) move to their own `welcome` channel

Channels are implicit — created on first use — so no channel provisioning is needed.

## Breaking

Anything relying on the implicit floor must now declare `general` explicitly. Packages are 0.x, so this is a minor per the changeset policy.

## Verification

- `pnpm typecheck` clean across all packages
- `pnpm changeset status` clean
- no `general` fallback remains in any access-granting path; the four surviving references are send-target/display defaults in `join.ts`, `console/commands.ts`, `tool-specs.ts` and `pi/tools.ts`, which grant nothing