### PR TITLE
fix(smoke): bring the flag-inventory golden back in step with the declared flags

### DIFF
--- a/.changeset/flag-inventory-golden-drift.md
+++ b/.changeset/flag-inventory-golden-drift.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only: the flag-inventory golden is brought back in step with the flags the registry actually declares. No shipped package changes, so nothing to release.

--- a/bin/smoke/flag-inventory.smoke.ts
+++ b/bin/smoke/flag-inventory.smoke.ts
@@ -33,6 +33,10 @@ const GOLDEN: Record<string, { flags: string[]; positionals: boolean; rawArgs?: 
       "channels:string", "detach:boolean", "dry-run:boolean", "file:string:f", "host:string",
       "idp:string", "open:boolean", "runtime:string", "server:string", "space:string",
       // The optional PUBLIC remote-exchange face, threaded to the auth-service daemon.
+      // `--advertised-server` (2026-08): with --exchange-public-port, the broker address the public
+      // discovery bundle advertises - what participants dial, which is not the address the callout
+      // dials (--server is loopback/LAN and meaningless off the machine).
+      "advertised-server:string",
       "exchange-public-port:string", "exchange-public-url:string", "exchange-trusted-proxy:boolean",
       "restore:string", "restore-only:string", "accept-missing-source:boolean",
       // `--rotate-sys` (2026-08): the class-3 renewal, which rotates the system account and re-mints the
@@ -92,6 +96,9 @@ const GOLDEN: Record<string, { flags: string[]; positionals: boolean; rawArgs?: 
     flags: [
       ...TARGET, "force:boolean", "from:string", "model:string", "prompt:string", "role:string",
       "running:boolean", "verbose:boolean:v",
+      // `--subscribe` (2026-08, 53f66c25): `personas new` requires the persona to name the channels
+      // it reads ("" = none), so the flag it is passed through must be declared here too.
+      "subscribe:string",
     ],
     positionals: true,
   },
@@ -191,6 +198,9 @@ const GOLDEN: Record<string, { flags: string[]; positionals: boolean; rawArgs?: 
   },
   "auth-service": {
     flags: [
+      // `--advertised-server` (2026-08): rides the public bundle, so it is threaded from `up` to
+      // this daemon and must appear in both inventories.
+      "advertised-server:string",
       "exchange-public-port:string", "exchange-public-url:string", "exchange-trusted-proxy:boolean",
       "port:string", "server:string", "space:string",
     ],


### PR DESCRIPTION
## Why

`smoke:flag-inventory` is red on `main`. The CI chain aborts at the first failing suite, and this one sits at position **148 of 365** — so the **217 suites after it have not run on any branch rebased onto current main**. Every PR that rebases inherits the red, and inherits the blind spot behind it.

## What drifted

Three golden entries, from two separate features:

| command | missing from golden |
|---|---|
| `up` | `advertised-server:string` |
| `auth-service` | `advertised-server:string` |
| `personas` | `subscribe:string` |

`--advertised-server` rides the public discovery bundle and is threaded from `up` down to the auth-service daemon, so it is declared on **both** commands (`implementations/cli/src/commands/up.ts:166`, `implementations/auth/src/commands.ts:354`) and both inventories needed it. `--subscribe` came with `personas new` requiring a persona to name the channels it reads (53f66c25).

## The part worth reviewing

The suite asserts per command and **dies on the first mismatch**, so only `auth-service` was visible from the failure output. Fixing just that would have moved the failure to `up`, and fixing that would have moved it to `personas` — three sequential red runs, each looking like a fresh problem.

The actual sequence, stated exactly rather than tidied up:

1. The suite failed on `auth-service`. Grepping for the flag's declarations found `up` declares it too, so both entries were fixed together — one iteration avoided by reading the source rather than re-running.
2. Re-running surfaced `personas`, an unrelated feature. **That is one iteration that did happen.**
3. At that point the approach changed: rather than fix-and-re-run a third time, every registered command's declared flags were diffed against the golden in a single pass, to find out whether anything else was still hiding. That reported `TOTAL COMMANDS WITH DRIFT: 1 (of 43 registered)` — the `1` being `personas`, the only entry still unfixed at that moment, **not** a count of the original drift, which was three. The throwaway script was deleted and is not part of this change.

So: the set is closed by measurement rather than by the suite going quiet, and the `43` is the coverage the fixed suite reports. This is why the PR is three entries and not one.

## Verification

Red-first, at **unmodified** `main` (`bf40a164`):

```
AssertionError: flags of `auth-service` match golden
+ actual - expected
+   'advertised-server:string',
```

Green after:

```
✓ flag-inventory smoke passed (43 commands)
```

The suite states its own coverage (43 commands), so the pass is not a silent one.

## Scope

One test file. No shipped package changes, no behavior change, no flag added or removed — the golden is being brought back in step with flags that already shipped. The changeset is empty accordingly (`pnpm changeset status` demands a changeset for any changed package and is satisfied by the empty one; it reports no packages bumped at patch, minor, or major).

## Note on what this does not claim

This unblocks the chain at position 148. It does **not** assert that the 217 suites behind it are green — that is the next thing to find out, and it could not be found out while this suite was failing.
