### PR TITLE
test(delivery): isolate the seed store in the adoption-doctor e2e smoke

### DIFF
--- a/.changeset/adoption-doctor-xdg-isolation.md
+++ b/.changeset/adoption-doctor-xdg-isolation.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only: `smoke:adoption-doctor-e2e` isolates `XDG_CONFIG_HOME` so it grades the code instead of the operator's connector seed store. No shipped package changes, so nothing to release.

--- a/implementations/delivery/smoke/adoption-doctor-e2e.smoke.ts
+++ b/implementations/delivery/smoke/adoption-doctor-e2e.smoke.ts
@@ -58,6 +58,15 @@ try {
   const evictor = await mintConnectionEvictorCreds(auth, newIdentity());
 
   const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
+  // The CONNECTOR SEED STORE lives under `globalConfigDir()`, so it is the operator's real
+  // `~/.config/cotal` unless XDG_CONFIG_HOME says otherwise. Every `cotal` command here — the
+  // delivery daemon and each `doctor auth` — runs the seed reconcile, which REFUSES outright when
+  // the store's generation is newer than the binary being run. On a box whose store was stamped by
+  // a later release than the tip under test, three cells red with "this cotal X is older than the
+  // seed store's generation Y", which looks exactly like a behaviour red and is not one. Isolated,
+  // the suite grades the code and nothing else.
+  process.env.XDG_CONFIG_HOME = join(dir, "xdg");
+  mkdirSync(process.env.XDG_CONFIG_HOME, { recursive: true });
   writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port, storeDir: join(dir, "js") }));
   const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
   // Owned, so a SIGNALLED run takes the broker and its store dir with it. `cleanups` drains in a


### PR DESCRIPTION
`smoke:adoption-doctor-e2e` had no `XDG_CONFIG_HOME` isolation, so it graded the operator's machine as much as the code.

The connector seed store does not live under `COTAL_HOME` — it sits under `globalConfigDir()`, which is the real `~/.config/cotal` unless `XDG_CONFIG_HOME` says otherwise. Every `cotal` invocation in this suite (the delivery daemon and each `doctor auth`) runs the seed reconcile, and that **refuses outright** when the store's generation is newer than the binary being run. On any box whose store was stamped by a later release than the tip under test, three cells red with `this cotal X is older than the seed store's generation Y` — which reads exactly like a behaviour failure and is not one.

Its sibling `implementations/manager/smoke/attach-reconnect.smoke.ts` already documents and applies this. This is the same guard, in the same shape.

**Evidence — red first, then green, against the same poisoned store.** The version premise did not hold on a plain run here (this box's store is stamped `0.28.2` and the branch is also `0.28.2`, so the refusal cannot fire, and the suite passed 3/3 un-isolated). Rather than fix an unreproduced failure, the condition was forced: a throwaway `XDG_CONFIG_HOME` containing `cotal/seed/stamp.json` at generation `99.0.0`, leaving the real store untouched.

- **Before**, with that store: `rc=1`, `✗ E2E DOCTOR-BINARY 7/10`, three cells carrying `this cotal 0.28.2 is older than the seed store's generation 99.0.0`.
- **After**, same store, same command: `rc=0`, `✓ E2E DOCTOR-BINARY 10/10`, zero refusal lines — 3 runs each way.

The count is asserted as 10/10, so a cell that silently stops running still reddens.

Test-only; no shipped package changes.
