### PR TITLE
fix(attach): recover terminal state after backpressure

### DIFF
--- a/.changeset/attach-backpressure-repaint.md
+++ b/.changeset/attach-backpressure-repaint.md
@@ -1,0 +1,9 @@
+---
+"@cotal-ai/cli": patch
+"@cotal-ai/manager": patch
+---
+
+`cotal attach` now coalesces rapid wheel input and PTY redraw bursts, waits for local stdout drain
+before returning session credit, and automatically repaints the canonical terminal snapshot after an
+explicit backpressure drop. Session teardown also lets the distinct terminal reason drain before the
+unsequenced close control can overtake it. The bounded 64-frame rail window is unchanged.

--- a/implementations/cli/src/lib/attach-client.ts
+++ b/implementations/cli/src/lib/attach-client.ts
@@ -65,6 +65,10 @@ const ALT_LEAVE_SEQ = "\x1b[?1049l"; // leave alt-screen — alt-scroll is inert
 const MOUSE_ON = "\x1b[?1002h\x1b[?1006h"; // button+drag tracking, SGR encoding
 const PAGE_UP = "\x1b[5~";
 const PAGE_DOWN = "\x1b[6~";
+/** Collapse a wheel burst to at most one page command per display frame. Each raw wheel report used
+ *  to become a separate session frame and TUI redraw; rapid scrolling could fill the 64-frame rail
+ *  before the caller returned credit, even though the operator only intended one continuous scroll. */
+const WHEEL_COALESCE_MS = 16;
 // Enter/leave the alternate screen: xterm `?1049`, plus the older `?1047`/`?47`.
 const ALT_ENTER = /\x1b\[\?(?:1049|1047|47)h/g;
 const ALT_LEAVE = /\x1b\[\?(?:1049|1047|47)l/g;
@@ -87,8 +91,9 @@ const lastIndexOfRe = (re: RegExp, s: string): number => {
 export interface TerminalTransport {
   /** Fires once the transport is connected and ready to carry the terminal. */
   onReady(cb: () => void): void;
-  /** Remote → local: terminal output bytes. */
-  onData(cb: (bytes: Buffer) => void): void;
+  /** Remote → local: terminal output bytes. The transport awaits an async consumer before returning
+   *  credit, so a slow local stdout applies real backpressure instead of acknowledging unread bytes. */
+  onData(cb: (bytes: Buffer) => void | Promise<void>): void;
   /** The session ended: `err` on a transport error (rejects), else a clean detach/close (resolves),
    *  with the peer's distinct end `reason` when it sent one. */
   onEnd(cb: (err?: Error, reason?: string) => void): void;
@@ -152,6 +157,23 @@ function swallowStdoutPipeErrors(): void {
   if (stdoutErrorSwallowed) return;
   stdoutErrorSwallowed = true;
   process.stdout.on("error", () => {});
+}
+
+/** Resolve when stdout accepted a write. A destroyed pipe is a terminal that no longer consumes, not
+ *  a reason to wedge the mesh rail forever; `error`/`close` therefore release the wait like `drain`. */
+function writeStdout(bytes: Buffer): void | Promise<void> {
+  if (process.stdout.write(bytes) || process.stdout.destroyed) return;
+  return new Promise<void>((resolve) => {
+    const done = (): void => {
+      process.stdout.off("drain", done);
+      process.stdout.off("error", done);
+      process.stdout.off("close", done);
+      resolve();
+    };
+    process.stdout.once("drain", done);
+    process.stdout.once("error", done);
+    process.stdout.once("close", done);
+  });
 }
 
 /**
@@ -239,6 +261,27 @@ export function attachClient(transport: TerminalTransport, hold?: TerminalHold, 
     // into the agent by the NEXT session's resume. Cell O of `smoke:attach-stdin` is that window.
     let tookStdin = false;
     let mouseBuf = "";
+    let wheelDelta = 0;
+    let wheelTimer: ReturnType<typeof setTimeout> | undefined;
+    const flushWheel = (): void => {
+      if (wheelTimer) clearTimeout(wheelTimer);
+      wheelTimer = undefined;
+      const delta = wheelDelta;
+      wheelDelta = 0;
+      if (delta === 0) return;
+      transport.send(Buffer.from(delta > 0 ? PAGE_DOWN : PAGE_UP, "latin1"));
+    };
+    const clearWheel = (): void => {
+      if (wheelTimer) clearTimeout(wheelTimer);
+      wheelTimer = undefined;
+      wheelDelta = 0;
+    };
+    const queueWheel = (delta: number): void => {
+      wheelDelta = Math.max(-8, Math.min(8, wheelDelta + delta));
+      if (wheelTimer) return;
+      wheelTimer = setTimeout(flushWheel, WHEEL_COALESCE_MS);
+      wheelTimer.unref?.();
+    };
     // Carry the tail of the previous output frame so an alt-screen escape split across ws frames
     // (e.g. `ESC[?10` then `49h`) is still detected; 16 bytes covers these private-mode sequences.
     // Acting only on state *change* below makes re-scanning the carried bytes idempotent.
@@ -260,6 +303,7 @@ export function attachClient(transport: TerminalTransport, hold?: TerminalHold, 
         // Leaving alt-screen mid-session: undo the mouse modes WE enabled so the terminal stops
         // reporting the wheel/clicks and native scrollback works again — don't wait for detach.
         mouseBuf = "";
+        clearWheel();
         if (process.stdout.isTTY) process.stdout.write(MOUSE_OFF);
       }
     };
@@ -268,6 +312,7 @@ export function attachClient(transport: TerminalTransport, hold?: TerminalHold, 
       transport.resize(process.stdout.columns ?? 80, process.stdout.rows ?? 24);
     const onInput = (d: Buffer) => {
       if (d.length === 1 && d[0] === detach.byte) {
+        clearWheel();
         transport.close();
         return;
       }
@@ -277,8 +322,20 @@ export function attachClient(transport: TerminalTransport, hold?: TerminalHold, 
         return;
       }
       // Full-screen child: rewrite wheel reports to PageUp/PageDown, pass everything else through.
+      // Wheel reports are coalesced ACROSS stdin reads; raw input flushes the pending wheel first so
+      // keyboard/mouse ordering remains exact.
       mouseBuf += d.toString("latin1");
       let out = "";
+      const flushOut = (): void => {
+        if (!out) return;
+        transport.send(Buffer.from(out, "latin1"));
+        out = "";
+      };
+      const appendRaw = (raw: string): void => {
+        if (!raw) return;
+        flushWheel();
+        out += raw;
+      };
       for (;;) {
         const i = mouseBuf.indexOf("\x1b[<");
         if (i === -1) {
@@ -287,11 +344,11 @@ export function attachClient(transport: TerminalTransport, hold?: TerminalHold, 
           // Escape key and must forward at once (e.g. OpenCode's interrupt); the rarer `ESC`|`[<…`
           // split stays raw by design.
           const keep = mouseBuf.endsWith("\x1b[") ? 2 : 0;
-          out += mouseBuf.slice(0, mouseBuf.length - keep);
+          appendRaw(mouseBuf.slice(0, mouseBuf.length - keep));
           mouseBuf = mouseBuf.slice(mouseBuf.length - keep);
           break;
         }
-        out += mouseBuf.slice(0, i);
+        appendRaw(mouseBuf.slice(0, i));
         const rest = mouseBuf.slice(i);
         const m = SGR_MOUSE.exec(rest);
         if (!m) {
@@ -299,19 +356,22 @@ export function attachClient(transport: TerminalTransport, hold?: TerminalHold, 
           // anything else can't become an SGR mouse report, so pass it straight through.
           if (/^\x1b\[<[\d;]*$/.test(rest)) mouseBuf = rest;
           else {
-            out += rest;
+            appendRaw(rest);
             mouseBuf = "";
           }
           break;
         }
         const btn = Number(m[1]);
-        if (btn & 0x40) out += btn & 1 ? PAGE_DOWN : PAGE_UP; // wheel: 64=up, 65=down
-        else out += m[0]; // other mouse (click/drag): forward raw so the TUI still gets it
+        if (btn & 0x40) {
+          flushOut();
+          queueWheel(btn & 1 ? 1 : -1); // wheel: 64=up, 65=down
+        } else appendRaw(m[0]); // other mouse (click/drag): forward raw so the TUI still gets it
         mouseBuf = rest.slice(m[0].length);
       }
-      if (out) transport.send(Buffer.from(out, "latin1"));
+      flushOut();
     };
     const cleanup = () => {
+      clearWheel();
       stdin.off("data", onInput);
       process.stdout.off("resize", sendResize);
       // Undo terminal modes the (still-running) agent's TUI enabled — it won't restore us on detach.
@@ -351,10 +411,10 @@ export function attachClient(transport: TerminalTransport, hold?: TerminalHold, 
       process.stdout.on("resize", sendResize);
       stdin.on("data", onInput);
     });
-    transport.onData((data) => {
+    transport.onData(async (data) => {
       carried = true;
       trackAltScreen(data);
-      process.stdout.write(data);
+      await writeStdout(data);
     });
     transport.onEnd((err, reason) => {
       cleanup();
@@ -377,26 +437,45 @@ export function attachClient(transport: TerminalTransport, hold?: TerminalHold, 
  * reason. No `127.0.0.1`, no bearer URL — the grant is holder-bound.
  */
 export function meshSessionTransport(nc: NatsConnection, grant: SessionGrant): TerminalTransport {
-  let onDataCb: ((bytes: Buffer) => void) | undefined;
+  let onDataCb: ((bytes: Buffer) => void | Promise<void>) | undefined;
   let onEndCb: ((err?: Error, reason?: string) => void) | undefined;
   let onReadyCb: (() => void) | undefined;
   let ended = false;
+  let repaintTimer: ReturnType<typeof setTimeout> | undefined;
+  let rail!: ReturnType<typeof openSessionRail>;
   const fireEnd = (err?: Error, reason?: string): void => {
     if (ended) return;
     ended = true;
+    if (repaintTimer) clearTimeout(repaintTimer);
+    repaintTimer = undefined;
     onEndCb?.(err, reason);
   };
+  // Schedule after the rail's async handler returns so the reverse data frame piggybacks the NEW
+  // receive watermark, including the drop notice itself. That ack reopens the serving window before
+  // the repeat `ready` asks for a fresh canonical screen snapshot.
+  const requestRepaint = (): void => {
+    if (ended || repaintTimer) return;
+    repaintTimer = setTimeout(() => {
+      repaintTimer = undefined;
+      if (ended) return;
+      try { rail.send({ k: "ready" }); } catch { /* broken/full: the rail fault path ends the session */ }
+    }, 0);
+    repaintTimer.unref?.();
+  };
 
-  const rail = openSessionRail({
+  rail = openSessionRail({
     nc,
     grant,
     role: "caller",
-    onData: (data) => {
+    onData: async (data) => {
       let frame;
       try { frame = decodeTerminalFrame(data); } catch { return; } // garbled: the rail already surfaced it
-      if (frame.k === "data") onDataCb?.(Buffer.from(terminalFrameBytes(frame)));
+      if (frame.k === "data") await onDataCb?.(Buffer.from(terminalFrameBytes(frame)));
       else if (frame.k === "end") fireEnd(undefined, frame.reason);
-      else if (frame.k === "drop") onDataCb?.(Buffer.from(`\r\n[cotal: ${frame.bytes} bytes dropped - backpressure]\r\n`));
+      else if (frame.k === "drop") {
+        await onDataCb?.(Buffer.from(`\r\n[cotal: ${frame.bytes} bytes dropped - backpressure]\r\n`));
+        requestRepaint();
+      }
     },
     onClose: () => fireEnd(undefined, "peer-closed"),
     // The fault NAME rides alongside the error. It used to live only inside the message, where the

--- a/implementations/manager/smoke/attach-repaint.smoke.ts
+++ b/implementations/manager/smoke/attach-repaint.smoke.ts
@@ -110,6 +110,8 @@ async function driveDetach(snapshot: string, marker: string): Promise<string> {
   let captured = "";
   const realWrite = process.stdout.write;
   const realTTY = process.stdout.isTTY;
+  const realDetach = process.env.COTAL_DETACH_KEY;
+  delete process.env.COTAL_DETACH_KEY;
   Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
   process.stdout.write = ((chunk: string | Buffer): boolean => {
     captured += Buffer.isBuffer(chunk) ? chunk.toString("latin1") : String(chunk);
@@ -126,6 +128,8 @@ async function driveDetach(snapshot: string, marker: string): Promise<string> {
   } finally {
     process.stdout.write = realWrite;
     Object.defineProperty(process.stdout, "isTTY", { value: realTTY, configurable: true });
+    if (realDetach === undefined) delete process.env.COTAL_DETACH_KEY;
+    else process.env.COTAL_DETACH_KEY = realDetach;
   }
   return captured;
 }
@@ -142,10 +146,91 @@ async function testDetachLeavesAltScreen(): Promise<void> {
   console.log("  ✓ attach client leaves the alt-screen on detach only when the child entered it");
 }
 
+async function testWheelCoalescing(): Promise<void> {
+  let onEndCb: ((err?: Error, reason?: string) => void) | undefined;
+  const sent: string[] = [];
+  const transport: TerminalTransport = {
+    onReady: (cb) => { queueMicrotask(cb); },
+    onData: (cb) => { queueMicrotask(() => { void cb(Buffer.from("\x1b[?1049h\x1b[HSCROLL-VIEW", "latin1")); }); },
+    onEnd: (cb) => { onEndCb = cb; },
+    send: (bytes) => { sent.push(bytes.toString("latin1")); },
+    resize: () => {},
+    close: () => { onEndCb?.(undefined, "detached"); },
+  };
+
+  let captured = "";
+  const realWrite = process.stdout.write;
+  const realTTY = process.stdout.isTTY;
+  const realDetach = process.env.COTAL_DETACH_KEY;
+  delete process.env.COTAL_DETACH_KEY;
+  Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+  process.stdout.write = ((chunk: string | Buffer): boolean => {
+    captured += Buffer.isBuffer(chunk) ? chunk.toString("latin1") : String(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    const done = attachClient(transport);
+    for (let i = 0; i < 200 && !captured.includes("SCROLL-VIEW"); i++) await sleep(5);
+    assert.ok(captured.includes("SCROLL-VIEW"), "C: alternate-screen snapshot painted before wheel input");
+    const up = Buffer.from("\x1b[<64;40;12M", "latin1");
+    for (let i = 0; i < 100; i++) process.stdin.emit("data", up);
+    await sleep(5);
+    assert.strictEqual(sent.filter((x) => x === "\x1b[5~").length, 0, "C: burst is held for coalescing, not emitted per report");
+    await sleep(30);
+    assert.strictEqual(sent.filter((x) => x === "\x1b[5~").length, 1, "C: 100 wheel reports become one PageUp command");
+
+    process.stdin.emit("data", Buffer.from("\x1b[<65;40;12M", "latin1"));
+    process.stdin.emit("data", Buffer.from("a"));
+    assert.deepStrictEqual(sent.slice(-2), ["\x1b[6~", "a"], "C: raw input flushes the pending wheel first and preserves order");
+    process.stdin.emit("data", Buffer.from([0x1d]));
+    await done;
+  } finally {
+    process.stdout.write = realWrite;
+    Object.defineProperty(process.stdout, "isTTY", { value: realTTY, configurable: true });
+    if (realDetach === undefined) delete process.env.COTAL_DETACH_KEY;
+    else process.env.COTAL_DETACH_KEY = realDetach;
+  }
+  console.log("  ✓ rapid wheel reports coalesce across stdin reads without reordering keyboard input");
+}
+
+async function testStdoutDrainBackpressure(): Promise<void> {
+  let onDataCb: ((bytes: Buffer) => void | Promise<void>) | undefined;
+  let onEndCb: ((err?: Error, reason?: string) => void) | undefined;
+  const transport: TerminalTransport = {
+    onReady: (cb) => { queueMicrotask(cb); },
+    onData: (cb) => { onDataCb = cb; },
+    onEnd: (cb) => { onEndCb = cb; },
+    send: () => {},
+    resize: () => {},
+    close: () => { onEndCb?.(undefined, "detached"); },
+  };
+  const realWrite = process.stdout.write;
+  process.stdout.write = (() => false) as typeof process.stdout.write;
+  try {
+    const done = attachClient(transport);
+    for (let i = 0; i < 100 && !onDataCb; i++) await sleep(1);
+    assert.ok(onDataCb, "D: attach registered its output consumer");
+    let accepted = false;
+    const pending = Promise.resolve(onDataCb!(Buffer.from("SLOW-STDOUT"))).then(() => { accepted = true; });
+    await sleep(10);
+    assert.strictEqual(accepted, false, "D: a false stdout.write holds transport acceptance and therefore rail credit");
+    process.stdout.emit("drain");
+    await pending;
+    assert.strictEqual(accepted, true, "D: stdout drain releases transport acceptance");
+    transport.close();
+    await done;
+  } finally {
+    process.stdout.write = realWrite;
+  }
+  console.log("  ✓ receiver credit waits for local stdout drain instead of acknowledging unread bytes");
+}
+
 async function main(): Promise<void> {
   await testPtyReconstruction();
   await testDetachLeavesAltScreen();
-  console.log("\nATTACH REPAINT SMOKE OK ✅  (2 tests)");
+  await testWheelCoalescing();
+  await testStdoutDrainBackpressure();
+  console.log("\nATTACH REPAINT SMOKE OK ✅  (4 tests)");
 }
 
 main()

--- a/implementations/manager/smoke/mesh-attach-plane.smoke.ts
+++ b/implementations/manager/smoke/mesh-attach-plane.smoke.ts
@@ -211,10 +211,14 @@ const s3 = h3.attach();
 const r3 = await plane.establishAttach({ ...CALLER, uid: "e".repeat(26) }, { name: "worker-3", lifecycleUid: "y".repeat(26) }, s3);
 const ncCaller3: NatsConnection = await connect({ servers: `nats://127.0.0.1:${PORT}` });
 let end3: string | undefined;
+let close3 = false;
+let fault3: string | undefined;
 const rx3: Buffer[] = [];
 const rail3 = openSessionRail({
   nc: ncCaller3, grant: r3.grant, role: "caller",
   onData: (data) => { const p = decodeTerminalFrame(data); if (p.k === "data") rx3.push(Buffer.from(p.b, "base64")); else if (p.k === "end") end3 = p.reason; },
+  onClose: () => { close3 = true; },
+  onProtocolError: (reason) => { fault3 = reason; },
 });
 await ncCaller3.flush();
 rail3.send({ k: "ready" } satisfies TerminalFrame);
@@ -223,7 +227,7 @@ c("the caller is live (echo confirms the pty is alive before the kill)", await u
 // Kill the child DIRECTLY (bypass endForTarget + handle.stop) — the agent process exits on its own.
 if (h3.pid === undefined) throw new Error("the pty handle reported no pid; there is nothing to kill");
 process.kill(h3.pid, "SIGKILL");
-c("a natural pty exit surfaces `process-exit` to the live caller (NO zombie session)", await until(() => end3 === "process-exit"), { end3, handleStatus: h3.status() });
+c("a natural pty exit surfaces `process-exit` to the live caller (NO zombie session)", await until(() => end3 === "process-exit"), { end3, close3, fault3, rail: rail3.stats(), handleStatus: h3.status() });
 c("the plane drops the naturally-exited session", await until(() => plane.liveSessions === 0));
 await ncCaller3.close();
 

--- a/implementations/manager/smoke/mesh-attach-plane.smoke.ts
+++ b/implementations/manager/smoke/mesh-attach-plane.smoke.ts
@@ -279,14 +279,46 @@ rail5.send({ k: "ready" } satisfies TerminalFrame);
 c("a session over an already-dead pty surfaces `process-exit` (never a zombie)", await until(() => end5 === "process-exit"), { end5, status: h5.status() });
 await ncCaller5.close();
 
+// --------------------------------------------------------------------------------------------
+// `close` is an unsequenced rail control frame. If the serving bridge closes immediately after
+// sending `end`, it can overtake data still inside the caller's async consumer: the rail closes,
+// the queued end frame is discarded, and the CLI reports `peer-closed` instead of the real reason.
+console.log("I. an async caller accepts queued output before the distinct serving end");
+const h6 = createRuntime("pty", "mesh-plane-smoke6").spawn("worker-6", ECHO_CHILD, process.cwd());
+const s6 = h6.attach();
+const target6 = { name: "worker-6", lifecycleUid: "6".repeat(26) };
+const r6 = await plane.establishAttach({ ...CALLER, uid: "h".repeat(26) }, target6, s6);
+const ncCaller6: NatsConnection = await connect({ servers: `nats://127.0.0.1:${PORT}` });
+const transport6 = meshSessionTransport(ncCaller6, r6.grant);
+let end6: string | undefined;
+let slowEntered6 = false;
+let releaseSlow6!: () => void;
+const slowGate6 = new Promise<void>((resolve) => { releaseSlow6 = resolve; });
+transport6.onData(async (bytes) => {
+  if (!bytes.toString("utf8").includes("ENDORDER6")) return;
+  slowEntered6 = true;
+  await slowGate6;
+});
+transport6.onEnd((_error, reason) => { end6 = reason; });
+await ncCaller6.flush();
+transport6.send(Buffer.from("ENDORDER6\n", "utf8"));
+c("the async caller handler is holding output before the serving end", await until(() => slowEntered6));
+plane.endForTarget(target6.name, target6.lifecycleUid, "target-despawn");
+await wait(500);
+c("an unsequenced close does not overtake output still inside the async caller handler", end6 === undefined, { end6 });
+releaseSlow6();
+c("the queued distinct end reason arrives after async output acceptance", await until(() => end6 === "target-despawn"), { end6 });
+await ncCaller6.close();
+h6.stop({ graceful: false });
+
 // ---------------------------------------------------------------------------------------------
 // A per-session connection that LEAKS is a worse bug than the standing wildcard it replaces, so
 // prove the connections actually close rather than trusting that teardown was called. `drain`
 // awaits every in-flight teardown; after it, every connection this run opened must be closed and
 // every ledger row terminal.
-console.log("I. teardown really closes every per-session connection and terminalizes every row");
+console.log("J. teardown really closes every per-session connection and terminalizes every row");
 const openedCount = opened.length;
-c("the run opened one connection PER SESSION (not one shared connection)", openedCount >= 5, openedCount);
+c("the run opened one connection PER SESSION (not one shared connection)", openedCount >= 6, openedCount);
 await plane.drain("closed");
 c("the plane reports no live sessions after drain", plane.liveSessions === 0, plane.liveSessions);
 c("EVERY per-session connection is closed (no leak)", opened.every((x) => x.isClosed()), opened.map((x) => x.isClosed()));

--- a/implementations/manager/smoke/mesh-attach.smoke.ts
+++ b/implementations/manager/smoke/mesh-attach.smoke.ts
@@ -53,6 +53,7 @@ import {
   type TerminalFrame,
 } from "../src/session/index.js";
 import { launchEnv } from "@cotal-ai/connector-core"; // dev-only smoke import: the OS env allow-list a real connector supplies
+import { meshSessionTransport } from "../../cli/src/lib/attach-client.js"; // dev-only cross-impl smoke import: the real CLI caller consumer
 
 // A portable pty echo child: it pipes stdin straight back to stdout, so a keystroke the caller
 // sends comes back as output — a genuine duplex byte stream over the two eps rails. `process.execPath`
@@ -286,17 +287,13 @@ await ncServing.close();
 handle.stop({ graceful: false });
 
 // ---------------------------------------------------------------------------------------------
-console.log("D. backpressure DROP-NOTICE (bounded window, never silent loss)");
+console.log("D. burst coalescing + overflow recovery (bounded, explicit, canonical repaint)");
 {
   const ncS: NatsConnection = await connect({ servers: `nats://127.0.0.1:${PORT}` });
   const ncC: NatsConnection = await connect({ servers: `nats://127.0.0.1:${PORT}` });
   const g = mintAttachOffer(
-    { space: SPACE, serving: SERVING, holder: HOLDER, target: TARGET, ttlMs: 60_000, signer: { keyId: "sk1", keyPair: mgrSigner }, window: 2 },
+    { space: SPACE, serving: SERVING, holder: HOLDER, target: TARGET, ttlMs: 60_000, signer: { keyId: "sk1", keyPair: mgrSigner }, window: 8 },
   ).grant;
-
-  // A controllable session: the window counts FRAMES, so proving backpressure needs DISCRETE chunks
-  // emitted on demand (real pty output chunking is nondeterministic). Everything else — the rail,
-  // the broker, the framing — is real.
   let onOut: ((c: Buffer) => void) | undefined;
   const fake: AttachSession = {
     cols: 80, rows: 24,
@@ -308,26 +305,65 @@ console.log("D. backpressure DROP-NOTICE (bounded window, never silent loss)");
   };
   const br = serveSessionBridge({ nc: ncS, grant: g, session: fake });
   await ncS.flush();
-  // A caller that NEVER credits (onData drops on the floor, stall/idle timers off): the window fills
-  // after `window` frames and stays full.
-  const notices: number[] = [];
-  const stalledRail = openSessionRail({
-    nc: ncC, grant: g, role: "caller", stallTimeoutMs: 0, idleCreditMs: 0,
-    onData: (data) => { const p = decodeTerminalFrame(data); if (p.k === "drop") notices.push(p.bytes); },
-  });
+  const caller = openSessionRail({ nc: ncC, grant: g, role: "caller", onData: () => {} });
   await ncC.flush();
-  stalledRail.send({ k: "ready" } satisfies TerminalFrame);
+  caller.send({ k: "ready" } satisfies TerminalFrame);
   await until(() => br.stats().live, 4000);
 
-  // Emit more discrete chunks than the window: the first `window` land, the rest are DROPPED and
-  // COUNTED (never buffered unboundedly, never silently lost).
-  for (let i = 0; i < 12; i++) onOut?.(Buffer.from(`chunk-${i};`));
-  const dropped = await until(() => br.stats().droppedBytes > 0, 4000);
-  c("a full window DROPS output and records the byte count (bounded, never buffered unboundedly)", dropped, br.stats());
-  c("nothing is silently lost: the drop is accounted for in droppedBytes", br.stats().droppedBytes > 0);
-  void notices;
+  for (let i = 0; i < 200; i++) onOut?.(Buffer.from("x"));
+  c("a 200-chunk redraw burst coalesces into one bounded output frame", await until(() => br.stats().sent === 1), br.stats());
+  c("coalescing stays below the frame window without dropping bytes", br.stats().droppedBytes === 0 && br.stats().inFlight <= 1, br.stats());
+  c("the coalescer's memory stays bounded after the flush", br.stats().queuedBytes === 0, br.stats());
 
-  stalledRail.close();
+  caller.close();
+  br.end("closed");
+  await ncC.close();
+  await ncS.close();
+}
+{
+  const ncS: NatsConnection = await connect({ servers: `nats://127.0.0.1:${PORT}` });
+  const ncC: NatsConnection = await connect({ servers: `nats://127.0.0.1:${PORT}` });
+  const g = mintAttachOffer(
+    { space: SPACE, serving: SERVING, holder: HOLDER, target: TARGET, ttlMs: 60_000, signer: { keyId: "sk1", keyPair: mgrSigner }, window: 2 },
+  ).grant;
+  let onOut: ((c: Buffer) => void) | undefined;
+  let canonical = "\x1b[?1049h\x1b[2J\x1b[HINITIAL-CANONICAL-SCREEN";
+  let backlogCalls = 0;
+  const fake: AttachSession = {
+    cols: 80, rows: 24,
+    backlog: () => { backlogCalls++; return Buffer.from(canonical, "latin1"); },
+    onData: (fn) => { onOut = fn; return () => { onOut = undefined; }; },
+    onExit: () => () => {},
+    write: () => {},
+    resize: () => {},
+  };
+  // A one-byte test ceiling deliberately disables batching so the two-frame window can be saturated
+  // deterministically. Production keeps the 64-KiB ceiling and 8-ms coalescing above.
+  const br = serveSessionBridge({ nc: ncS, grant: g, session: fake, outputBatchBytes: 1, outputBatchMs: 0 });
+  await ncS.flush();
+  const received: Buffer[] = [];
+  let ready = false;
+  const transport = meshSessionTransport(ncC, g);
+  transport.onReady(() => { ready = true; });
+  transport.onData((bytes) => { received.push(bytes); });
+  transport.onEnd(() => {});
+  c("the real CLI transport opens the overflow-control session", await until(() => ready && backlogCalls >= 1));
+  c("the initial canonical alternate-screen snapshot lands", await until(() => Buffer.concat(received).toString("latin1").includes("INITIAL-CANONICAL-SCREEN")));
+
+  received.length = 0;
+  for (let i = 0; i < 24; i++) onOut?.(Buffer.from(String(i % 10)));
+  canonical = "\x1b[?1049h\x1b[2J\x1b[HFINAL-CANONICAL-SCREEN";
+  const recovered = await until(() => {
+    const text = Buffer.concat(received).toString("latin1");
+    return text.includes("bytes dropped - backpressure") && text.includes("FINAL-CANONICAL-SCREEN") && backlogCalls >= 2;
+  }, 6000);
+  const recoveredText = Buffer.concat(received).toString("latin1");
+  c("overflow is explicit and automatically requests a fresh canonical repaint", recovered, { backlogCalls, stats: br.stats() });
+  c("the drop notice precedes the final repaint", recoveredText.indexOf("bytes dropped - backpressure") < recoveredText.indexOf("FINAL-CANONICAL-SCREEN"));
+  c("the recovered image re-enters and clears the alternate screen", recoveredText.includes("\x1b[?1049h\x1b[2J\x1b[HFINAL-CANONICAL-SCREEN"));
+  c("recovery drains bounded bridge memory and clears the accounted loss", await until(() => br.stats().queuedBytes === 0 && br.stats().droppedBytes === 0), br.stats());
+
+  transport.close();
   br.end("closed");
   await ncC.close();
   await ncS.close();

--- a/implementations/manager/smoke/mutations/attach-end-order.json
+++ b/implementations/manager/smoke/mutations/attach-end-order.json
@@ -1,0 +1,22 @@
+{
+  "suite": "implementations/manager/smoke/mesh-attach-plane.smoke.ts",
+  "guard": "the serving bridge does not let its unsequenced close control overtake a distinct end frame while an earlier output frame is still inside the caller's async consumer",
+  "command": "pnpm smoke:mesh-attach-plane",
+  "completionMarker": "mesh-attach-plane 6b:",
+  "proveWith": "node scripts/mutation-proof.mjs --config implementations/manager/smoke/mutations/attach-end-order.json",
+  "why": [
+    "The defect requires three real pieces at once: the serving bridge queues terminal output and an end frame, the CLI mesh transport awaits an async output consumer, and the core rail receives an unsequenced close control. Synchronous frame observers cannot witness it because they accept the earlier output before close can overtake anything.",
+    "",
+    "The smoke holds a real PTY echo frame inside meshSessionTransport.onData, ends the serving bridge while that handler is pending, and first proves no close-derived reason appears during the hold. After release it requires the queued target-despawn reason. Restoring immediate close makes peer-closed win and reddens the named cell."
+  ],
+  "mutations": [
+    {
+      "name": "close the serving rail immediately, discarding a queued distinct end behind async caller output",
+      "file": "implementations/manager/src/session/bridge.ts",
+      "find": "    void (async () => {\n      try { await opts.nc.flush(); } catch { /* connection already gone */ }\n      if (endSeq !== undefined) {\n        const deadline = Date.now() + Math.max(END_ACK_GRACE_MS, (opts.idleCreditMs ?? 1_000) + 500);\n        while (rail.stats().ackedThrough < endSeq && Date.now() < deadline)\n          await new Promise<void>((resolve) => setTimeout(resolve, 10));\n      }\n      rail.close();\n      opts.onEnd?.(reason);\n    })();",
+      "replace": "    void endSeq;\n    rail.close();\n    opts.onEnd?.(reason);",
+      "expectRed": "an unsequenced close does not overtake output still inside the async caller handler",
+      "cell": "an unsequenced close does not overtake output still inside the async caller handler"
+    }
+  ]
+}

--- a/implementations/manager/src/session/bridge.ts
+++ b/implementations/manager/src/session/bridge.ts
@@ -7,14 +7,13 @@
  *    then sends `ready`; the bridge replays the pty's byte-exact backlog snapshot (which can rebuild
  *    a full-screen TUI's alternate-screen buffer) and only then streams live output — so a late or
  *    third attach paints correctly without the child having to repaint. Live output that arrives
- *    while the snapshot is being built is buffered and flushed after it, in order (no chunk slips
- *    ahead of, or is lost before, the image);
- *  - duplex byte flow: pty output → `b` frames (serving → caller); caller `b` frames → pty
- *    keystrokes; `resize` frames → pty geometry;
+ *    after the snapshot boundary is buffered within a hard cap and flushed after it, in order;
+ *  - duplex byte flow: pty output → bounded, coalesced `b` frames (serving → caller); caller `b`
+ *    frames → pty keystrokes; `resize` frames → pty geometry;
  *  - BACKPRESSURE (item-6 pin: never silent loss): the core rail's window is bounded and refuses
  *    (`resource-exhausted`) rather than buffer; on refusal the bridge DROPS the chunk, accumulates
- *    the dropped-byte count, and prepends an explicit `drop` notice to the next frame the reopened
- *    window accepts — the caller always learns output was lost;
+ *    the dropped-byte count, retries an explicit `drop` notice when credit reopens, and the caller
+ *    automatically requests a fresh canonical snapshot so a full-screen TUI cannot stay corrupt;
  *  - TERMINATION (item-6 pin 4): every teardown surfaces a DISTINCT end reason (`process-exit` /
  *    `closed` / `expired` / `target-despawn` / `manager-restart`) as an `end` frame before the rail
  *    closes, so the client can tell "the agent exited" from "you were detached" from "the manager
@@ -33,6 +32,12 @@ import {
  *  incarnation advanced its epoch (the successor refuses old-epoch sessions, §13.6). */
 export type AttachEndReason = "process-exit" | "closed" | "expired" | "target-despawn" | "manager-restart";
 
+const OUTPUT_BATCH_MS = 8;
+const OUTPUT_BATCH_BYTES = 64 * 1024;
+const REPAINT_BUFFER_BYTES = 256 * 1024;
+const DROP_RETRY_MS = 25;
+const END_ACK_GRACE_MS = 1_500;
+
 export interface ServeSessionBridgeOpts {
   /** A connection scoped to this session's two eps rails (the serving side's per-session credential,
    *  or — static mode — the manager's instrument connection whose rows cover the subtree). */
@@ -46,6 +51,10 @@ export interface ServeSessionBridgeOpts {
   /** Passthrough rail timer knobs (testability). */
   idleCreditMs?: number;
   stallTimeoutMs?: number;
+  /** Output coalescing knobs. Production defaults batch one display frame up to 64 KiB; smokes use
+   *  the byte ceiling to force deterministic frame-window overflow. */
+  outputBatchMs?: number;
+  outputBatchBytes?: number;
 }
 
 export interface SessionBridge {
@@ -55,16 +64,25 @@ export interface SessionBridge {
   /** In-memory observability (smoke assertions): the rail's window stats, the dropped-byte count
    *  (backpressure), the dropped-FRAME count (caller frames the codec rejected), and whether the
    *  reconstruction handshake has gone live. */
-  stats(): { sent: number; ackedThrough: number; delivered: number; inFlight: number; droppedBytes: number; droppedFrames: number; live: boolean };
+  stats(): { sent: number; ackedThrough: number; delivered: number; inFlight: number; droppedBytes: number; droppedFrames: number; queuedBytes: number; live: boolean; repainting: boolean };
 }
 
 export function serveSessionBridge(opts: ServeSessionBridgeOpts): SessionBridge {
   const { session } = opts;
+  const outputBatchMs = Math.max(0, opts.outputBatchMs ?? OUTPUT_BATCH_MS);
+  const outputBatchBytes = Math.max(1, opts.outputBatchBytes ?? OUTPUT_BATCH_BYTES);
   let live = false; // has `ready` been received (backlog replayed, streaming live)?
+  let repainting = false;
+  let repaintQueued = false;
   let ended = false;
   let droppedBytes = 0;
   let droppedFrames = 0; // caller frames the codec rejected (observability; NOT a silent black hole)
-  const preReadyBuffer: Buffer[] = [];
+  let pendingOutput: Buffer[] = [];
+  let pendingOutputBytes = 0;
+  let outputTimer: ReturnType<typeof setTimeout> | undefined;
+  let repaintBuffer: Buffer[] = [];
+  let repaintBufferBytes = 0;
+  let dropRetryTimer: ReturnType<typeof setTimeout> | undefined;
   let rail!: SessionRail;
 
   // Send an application payload down the serving rail. Returns true on success; false when the
@@ -81,37 +99,127 @@ export function serveSessionBridge(opts: ServeSessionBridgeOpts): SessionBridge 
     }
   };
 
-  // Forward one pty output chunk, honoring backpressure with an explicit drop-notice. A pending
-  // drop count is flushed FIRST (the caller must learn output was lost before the resumed stream),
-  // and only if that notice lands does the actual chunk go — otherwise the chunk's bytes join the
-  // drop count. Nothing is ever buffered unboundedly: a chunk the window can't take is DROPPED,
-  // counted, and surfaced, never queued.
-  const forwardOutput = (chunk: Buffer): void => {
-    if (ended) return;
+  // A drop notice must not depend on the child producing one more byte. Retry the CONTROL frame
+  // until caller credit reopens the bounded window; the caller responds with a repeat `ready`, whose
+  // piggybacked ack gives this side room for the canonical repaint snapshot.
+  const scheduleDropNotice = (): void => {
+    if (ended || droppedBytes === 0 || dropRetryTimer) return;
+    dropRetryTimer = setTimeout(() => {
+      dropRetryTimer = undefined;
+      if (ended || droppedBytes === 0) return;
+      const bytes = droppedBytes;
+      if (railSend({ k: "drop", bytes })) droppedBytes -= bytes;
+      else scheduleDropNotice();
+    }, DROP_RETRY_MS);
+    dropRetryTimer.unref?.();
+  };
+
+  // Forward one bounded output frame. A pending drop count is flushed FIRST, so the caller learns
+  // that its screen is stale before any resumed stream; a refused chunk is counted and discarded.
+  const forwardOutput = (chunk: Buffer): boolean => {
+    if (ended || chunk.length === 0) return false;
     if (droppedBytes > 0) {
-      if (railSend({ k: "drop", bytes: droppedBytes })) droppedBytes = 0;
-      else { droppedBytes += chunk.length; return; }
+      const bytes = droppedBytes;
+      if (railSend({ k: "drop", bytes })) droppedBytes -= bytes;
+      else {
+        droppedBytes += chunk.length;
+        scheduleDropNotice();
+        return false;
+      }
     }
-    if (!railSend(encodeTerminalData(chunk))) droppedBytes += chunk.length;
+    if (railSend(encodeTerminalData(chunk))) return true;
+    droppedBytes += chunk.length;
+    scheduleDropNotice();
+    return false;
+  };
+
+  const forwardBytes = (bytes: Buffer): void => {
+    for (let offset = 0; offset < bytes.length; offset += outputBatchBytes) {
+      const part = bytes.subarray(offset, Math.min(bytes.length, offset + outputBatchBytes));
+      if (forwardOutput(part)) continue;
+      const remaining = bytes.length - offset - part.length;
+      if (remaining > 0) droppedBytes += remaining;
+      scheduleDropNotice();
+      return;
+    }
+  };
+  const flushOutput = (): void => {
+    if (outputTimer) clearTimeout(outputTimer);
+    outputTimer = undefined;
+    if (pendingOutputBytes === 0) return;
+    const bytes = Buffer.concat(pendingOutput, pendingOutputBytes);
+    pendingOutput = [];
+    pendingOutputBytes = 0;
+    forwardBytes(bytes);
+  };
+  const discardPendingOutput = (): void => {
+    if (outputTimer) clearTimeout(outputTimer);
+    outputTimer = undefined;
+    pendingOutput = [];
+    pendingOutputBytes = 0;
+  };
+  const queueOutput = (chunk: Buffer): void => {
+    if (ended || chunk.length === 0) return;
+    if (chunk.length >= outputBatchBytes) {
+      flushOutput();
+      forwardBytes(chunk);
+      return;
+    }
+    if (pendingOutputBytes + chunk.length > outputBatchBytes) flushOutput();
+    pendingOutput.push(chunk);
+    pendingOutputBytes += chunk.length;
+    if (pendingOutputBytes >= outputBatchBytes || outputBatchMs === 0) {
+      flushOutput();
+      return;
+    }
+    if (!outputTimer) {
+      outputTimer = setTimeout(flushOutput, outputBatchMs);
+      outputTimer.unref?.();
+    }
+  };
+  const bufferDuringRepaint = (chunk: Buffer): void => {
+    const room = REPAINT_BUFFER_BYTES - repaintBufferBytes;
+    if (room > 0) {
+      const kept = chunk.length <= room ? chunk : chunk.subarray(0, room);
+      repaintBuffer.push(kept);
+      repaintBufferBytes += kept.length;
+    }
+    if (chunk.length > room) {
+      droppedBytes += chunk.length - Math.max(0, room);
+      scheduleDropNotice();
+    }
   };
 
   const offData = session.onData((chunk) => {
     if (ended) return;
-    if (live) forwardOutput(chunk);
-    else preReadyBuffer.push(chunk); // hold until the snapshot is replayed, then flush in order
+    if (repainting) bufferDuringRepaint(chunk);
+    else if (live) queueOutput(chunk);
+    // Before the first `ready`, the session's canonical backlog is the bounded source of truth. No
+    // raw pre-ready byte queue is needed: goLive snapshots it, then buffers only post-boundary bytes.
   });
-  // The pty exit surfaces `process-exit` — but DEFERRED until the caller is live if it exits before
-  // the `ready` handshake (a session established over an already-dead, or a just-dying, pty): EPS is
-  // at-most-once, so an `end` frame sent before the caller subscribed to `.out` is lost. goLive sends
-  // the deferred exit AFTER the backlog, so the caller always learns the agent exited.
+  // The pty exit surfaces `process-exit`, deferred through an opening/repaint snapshot so the caller
+  // receives the final canonical screen before the distinct terminal reason.
   let pendingExit = false;
-  const offExit = session.onExit(() => { if (live) end("process-exit"); else pendingExit = true; });
+  const offExit = session.onExit(() => {
+    if (live && !repainting) {
+      flushOutput();
+      end("process-exit");
+    } else pendingExit = true;
+  });
 
-  // The reconstruction handshake: replay the byte-exact backlog snapshot, then flush anything the
-  // pty emitted while we built it, then stream live. Subscribing to output BEFORE this (above)
-  // means no chunk is lost between the snapshot and going live. A repeat `ready` (an explicit
-  // repaint) re-sends a fresh snapshot without re-flushing the already-drained pre-ready buffer.
+  // Initial `ready` and repeat repaint use the same ordered cut: discard only UNSENT coalesced bytes
+  // (the terminal mirror already contains them), snapshot the canonical screen, then flush bytes that
+  // arrived after the snapshot boundary. Concurrent repeat-ready requests collapse to one more pass.
   const goLive = async (): Promise<void> => {
+    if (repainting) {
+      repaintQueued = true;
+      return;
+    }
+    repainting = true;
+    repaintQueued = false;
+    discardPendingOutput();
+    repaintBuffer = [];
+    repaintBufferBytes = 0;
     let snapshot: Buffer;
     try {
       snapshot = await session.backlog();
@@ -121,14 +229,22 @@ export function serveSessionBridge(opts: ServeSessionBridgeOpts): SessionBridge 
       return;
     }
     if (ended) return;
+    // A canonical snapshot is one atomic repaint frame, as before. Splitting it across the live-output
+    // batch ceiling can fill a small window halfway through the image and create a repaint loop.
     if (snapshot.length) forwardOutput(snapshot);
-    if (!live) {
-      for (const chunk of preReadyBuffer.splice(0)) forwardOutput(chunk);
-      live = true;
+    const afterSnapshot = Buffer.concat(repaintBuffer, repaintBufferBytes);
+    repaintBuffer = [];
+    repaintBufferBytes = 0;
+    if (afterSnapshot.length) forwardBytes(afterSnapshot);
+    live = true;
+    repainting = false;
+    if (droppedBytes > 0) scheduleDropNotice();
+    // The pty exited before/during reconstruction: surface the reason only after the final image.
+    if (pendingExit) {
+      end("process-exit");
+      return;
     }
-    // The pty exited before we went live (established over a dead/dying pty): surface `process-exit`
-    // NOW, after the backlog reconstruction, so the caller sees the final screen AND the honest end.
-    if (pendingExit) end("process-exit");
+    if (repaintQueued) void goLive();
   };
 
   const onCallerFrame = (data: unknown): void => {
@@ -166,15 +282,36 @@ export function serveSessionBridge(opts: ServeSessionBridgeOpts): SessionBridge 
   function end(reason: AttachEndReason): void {
     if (ended) return;
     ended = true;
+    if (outputTimer) clearTimeout(outputTimer);
+    if (dropRetryTimer) clearTimeout(dropRetryTimer);
+    outputTimer = undefined;
+    dropRetryTimer = undefined;
+    pendingOutput = [];
+    pendingOutputBytes = 0;
+    repaintBuffer = [];
+    repaintBufferBytes = 0;
     offData();
     offExit();
+    let endSeq: number | undefined;
     try {
-      rail.send({ k: "end", reason }); // best-effort distinct end-state notice (advisory; may window out)
+      endSeq = rail.send({ k: "end", reason });
     } catch {
       /* the ledger close/expiry is the authority; the notice is advisory (§13.6) */
     }
-    rail.close();
-    opts.onEnd?.(reason);
+    // `close` is an unsequenced control frame. Sending it immediately can overtake data already
+    // queued in the caller's async handler and make that handler discard the preceding `end` frame.
+    // Hold the serving connection until the end frame is acknowledged (stdout accepted it) or a
+    // bounded grace expires; then close/release regardless, because the ledger remains authoritative.
+    void (async () => {
+      try { await opts.nc.flush(); } catch { /* connection already gone */ }
+      if (endSeq !== undefined) {
+        const deadline = Date.now() + Math.max(END_ACK_GRACE_MS, (opts.idleCreditMs ?? 1_000) + 500);
+        while (rail.stats().ackedThrough < endSeq && Date.now() < deadline)
+          await new Promise<void>((resolve) => setTimeout(resolve, 10));
+      }
+      rail.close();
+      opts.onEnd?.(reason);
+    })();
   }
 
   rail = openSessionRail({
@@ -190,6 +327,13 @@ export function serveSessionBridge(opts: ServeSessionBridgeOpts): SessionBridge 
 
   return {
     end,
-    stats: () => ({ ...rail.stats(), droppedBytes, droppedFrames, live }),
+    stats: () => ({
+      ...rail.stats(),
+      droppedBytes,
+      droppedFrames,
+      queuedBytes: pendingOutputBytes + repaintBufferBytes,
+      live,
+      repainting,
+    }),
   };
 }


### PR DESCRIPTION
## Summary

- coalesce rapid wheel reports and PTY redraw chunks before they consume session-window frames
- wait for local stdout drain before acknowledging terminal output
- emit explicit drop accounting and automatically repaint from the canonical PTY snapshot after overflow
- let terminal end reasons drain before the unsequenced close control can overtake queued data
- keep the bounded session window at 64 frames

## Verification

- `pnpm typecheck`
- `pnpm smoke:attach-repaint` — 4/4
- `pnpm smoke:mesh-attach` — 26/26
- `pnpm smoke:mesh-attach-plane` — 25/25
- `env -u COTAL_DETACH_KEY pnpm smoke:attach-reconnect` — 72/72
- `env -u COTAL_DETACH_KEY pnpm smoke:attach-stdin` — 83/83
- `pnpm smoke:mutation-fixtures`
- `pnpm changeset status`