### PR TITLE
fix(cli): the control family dials transport-aware, so ps/stop/attach work over wss

### DIFF
--- a/.changeset/control-dials-transport-aware.md
+++ b/.changeset/control-dials-transport-aware.md
@@ -1,0 +1,8 @@
+---
+"@cotal-ai/cli": patch
+---
+
+The control command family (`ps`, `stop`, `attach`, and the detached-session release) dials
+through `dialerFor`, so it works against a websocket broker (`wss://…`) instead of refusing
+with "'servers' node client doesn't support websockets, use the 'wsconnect' function
+instead" while `send` and foreground `spawn` — already routed through the dialer — worked.

--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -519,3 +519,6 @@ smoke:hermes-empty-id
 # a connectivity fact does not license. Four occurrences on the live space "main" reached the
 # neighbouring branch and survived only because the lease re-read answered.
 smoke:detach-not-teardown
+# Control commands resolve ws:// / wss:// meshes too. Exercise the real CLI against one broker's
+# websocket and TCP listeners so raw node-transport regressions name their `wsconnect` refusal.
+smoke:control-transport-dial

--- a/bin/smoke/control-transport-dial.smoke.ts
+++ b/bin/smoke/control-transport-dial.smoke.ts
@@ -1,0 +1,145 @@
+/**
+ * The CLI control family selects the transport from the resolved broker URL (#855).
+ *
+ * A real authenticated nats-server exposes the same account over nats:// and ws://, and the real CLI
+ * runs as a subprocess from a sandboxed COTAL_HOME. No manager runs: a successful dial reaches the
+ * ep-rails deadline, while the defect fails before that with the node transport's `wsconnect` refusal.
+ * The websocket cells discriminate on the pre-fix node-transport refusal naming `wsconnect`; the TCP
+ * cells are negative controls proving transport selection did not regress ordinary NATS dials.
+ */
+import { spawn as spawnProc, spawnSync, type ChildProcess } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const freePort = (): Promise<number> =>
+  new Promise((resolve, reject) => {
+    const server = createServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as AddressInfo).port;
+      server.close(() => resolve(port));
+    });
+  });
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const awaitExit = (child: ChildProcess, ms = 5_000): Promise<void> =>
+  new Promise((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) return resolve();
+    child.once("exit", () => resolve());
+    setTimeout(resolve, ms).unref?.();
+  });
+
+let pass = 0;
+let fail = 0;
+const ok = (name: string, condition: boolean, extra?: unknown): void => {
+  if (condition) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    fail++;
+    console.log(`  ✗ FAIL: ${name}${extra === undefined ? "" : ` - ${JSON.stringify(extra)}`}`);
+  }
+};
+const must = (name: string, condition: boolean, extra?: unknown): void => {
+  if (!condition) throw new Error(`FAIL (rig): ${name}${extra === undefined ? "" : ` - ${JSON.stringify(extra)}`}`);
+  pass++;
+  console.log(`  ✓ ${name}`);
+};
+
+const cleanEnv: NodeJS.ProcessEnv = { ...process.env };
+for (const key of Object.keys(cleanEnv)) if (key.startsWith("COTAL_")) delete cleanEnv[key];
+
+const home = mkdtempSync(join(tmpdir(), "cotal-control-dial-home-"));
+process.env.COTAL_HOME = home;
+const root = mkdtempSync(join(tmpdir(), "cotal-control-dial-root-"));
+const tcpPort = await freePort();
+const wsPort = await freePort();
+const tcpServer = `nats://127.0.0.1:${tcpPort}`;
+const wsServer = `ws://127.0.0.1:${wsPort}`;
+const space = "controldial";
+const cli = join(import.meta.dirname, "..", "cotal.ts");
+const kids: ChildProcess[] = [];
+
+const {
+  createSpaceAuth,
+  mintCreds,
+  newIdentity,
+  probeConnect,
+  serverConfig,
+  setupSpaceStreams,
+} = await import("@cotal-ai/core");
+const { authDir, recordMesh, saveSpaceAuth } = await import("@cotal-ai/workspace");
+
+const auth = await createSpaceAuth(space);
+saveSpaceAuth(authDir(root), auth);
+const conf = join(root, "server.conf");
+writeFileSync(
+  conf,
+  serverConfig(auth, [auth], {
+    transport: { kind: "plaintext" },
+    port: tcpPort,
+    host: "127.0.0.1",
+    wsPort,
+    wsHost: "127.0.0.1",
+    storeDir: join(root, "js"),
+  }),
+);
+
+const runCli = (args: string[], timeout = 60_000) => {
+  const result = spawnSync("npx", ["tsx", cli, ...args], {
+    cwd: root,
+    env: { ...cleanEnv, COTAL_HOME: home, XDG_CONFIG_HOME: join(home, "xdg"), COTAL_SKIP_CONNECTOR_SEED: "1", NO_COLOR: "1" },
+    encoding: "utf8",
+    timeout,
+  });
+  return {
+    status: result.status,
+    out: `${result.stdout ?? ""}${result.stderr ?? ""}`.replace(/\x1b\[[0-9;]*m/g, ""),
+  };
+};
+const reachedRails = (result: { status: number | null; out: string }): boolean =>
+  result.status !== 0 && /no manager reachable on the ep rails|no manager service is registered|service "manager" has no live registered instances/.test(result.out) &&
+  !/wsconnect|websocket connections must use/i.test(result.out);
+
+try {
+  const broker = spawnProc("nats-server", ["-c", conf], { stdio: "ignore" });
+  kids.push(broker);
+  let serving = false;
+  for (let i = 0; i < 80; i++) {
+    const probe = await probeConnect(tcpServer, { timeoutMs: 400 });
+    if (probe.ok || ("reason" in probe && probe.reason === "auth-required")) { serving = true; break; }
+    await sleep(100);
+  }
+  must("the authenticated broker is serving its TCP listener", serving, tcpServer);
+  await setupSpaceStreams({ servers: tcpServer, space, creds: await mintCreds(auth, newIdentity(), "provisioner") });
+
+  recordMesh({ space, server: wsServer, root, mode: "auth", ts: new Date().toISOString() });
+
+  const wsModels = runCli(["models", "--space", space]);
+  ok(
+    "A: models reaches the manager over ws:// through askManagerEp",
+    reachedRails(wsModels),
+    wsModels,
+  );
+
+  const wsPs = runCli(["ps", "--space", space]);
+  ok(
+    "B: ps reaches the manager over ws:// through the scatter connection",
+    reachedRails(wsPs),
+    wsPs,
+  );
+
+  recordMesh({ space, server: tcpServer, root, mode: "auth", ts: new Date().toISOString() });
+  const tcpModels = runCli(["models", "--space", space]);
+  ok("C: models still reaches the ep rails over nats://", reachedRails(tcpModels), tcpModels);
+  const tcpPs = runCli(["ps", "--space", space]);
+  ok("D: ps still reaches the ep rails over nats://", reachedRails(tcpPs), tcpPs);
+
+  console.log(`\ncontrol transport dial: ${pass} passed, ${fail} failed`);
+  if (fail) process.exitCode = 1;
+} finally {
+  await Promise.all(kids.map(async (child) => { if (child.exitCode === null) child.kill("SIGKILL"); await awaitExit(child); }));
+  rmSync(root, { recursive: true, force: true });
+  rmSync(home, { recursive: true, force: true });
+}

--- a/bin/smoke/mutations/control-transport-dial.json
+++ b/bin/smoke/mutations/control-transport-dial.json
@@ -1,0 +1,33 @@
+{
+  "suite": "bin/smoke/control-transport-dial.smoke.ts",
+  "guard": "CLI control dials select websocket transport from ws:// and preserve raw TCP behavior",
+  "command": "pnpm --filter @cotal-ai/cli build && pnpm smoke:control-transport-dial",
+  "completionMarker": "control transport dial:",
+  "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/control-transport-dial.json",
+  "why": [
+    "The websocket listener and CLI subprocess are real. With the shipped dialer, models reaches the endpoint rails and ps reaches the scatter's explicit empty-registry response. Replacing either dial with the raw node transport fails earlier with the refusal that names wsconnect, so the named cell turns red while the suite still reaches its completion banner.",
+    "The nats:// cells are negative controls. They prove selecting a dialer from the URL does not regress the node transport used for ordinary TCP brokers.",
+    "The attach session dial at agents.ts:577 requires a live manager and a redeemed session grant. That live workflow was independently validated for this PR, but this compact regression rig intentionally has no manager so it can use the endpoint-rails deadline as the discriminator. It is therefore not claimed by a mutation here.",
+    "releaseAbandonedSession at agents.ts:641 is reachable only after a live attached session loses its link mid-session. A deterministic discriminating cell would require fault injection that severs that one websocket after redemption while leaving the replacement route alive. No such rig exists here, so this fixture records the boundary honestly instead of registering a mutation that would SURVIVE."
+  ],
+  "mutations": [
+    {
+      "cell": "A",
+      "name": "askManagerEp uses raw TCP connect for a websocket URL",
+      "file": "implementations/cli/src/lib/control.ts",
+      "find": "async function askManagerEp(\n  space: string,\n  server: string,\n  op: string,\n  args: Record<string, unknown> | undefined,\n  auth: ControlAuth,\n  reach: ControlReach,\n  timeoutMs?: number,\n  pin?: ManagerPin,\n): Promise<ManagerReply> {\n  const instanceId = pin?.instanceId;\n  const mapped = EP_COMMANDS[op];\n  if (!mapped) return { ok: false, error: `unknown manager op \"${op}\" (no v0.4 command mapping)` };\n  const caller = auth.epCaller!;\n  // standaloneConnectOpts handles all three auth shapes: static creds, the user bearer + sentinel\n  // (client-chosen inbox nonce; the callout scopes the reply inbox on it), or BARE on an open\n  // mesh (no credential system; the broker enforces nothing).\n  // dialerFor, not the raw TCP connect: a user mesh reached through an HTTPS edge is a\n  // wss:// URL, and the node transport refuses those outright (\"use the 'wsconnect'\n  // function instead\") - which took `ps`/`stop`/`attach` down against every websocket\n  // broker while send and spawn (already routed through the dialer) worked.\n  const nc = await dialerFor(server)({\n    servers: server,",
+      "replace": "async function askManagerEp(\n  space: string,\n  server: string,\n  op: string,\n  args: Record<string, unknown> | undefined,\n  auth: ControlAuth,\n  reach: ControlReach,\n  timeoutMs?: number,\n  pin?: ManagerPin,\n): Promise<ManagerReply> {\n  const instanceId = pin?.instanceId;\n  const mapped = EP_COMMANDS[op];\n  if (!mapped) return { ok: false, error: `unknown manager op \"${op}\" (no v0.4 command mapping)` };\n  const caller = auth.epCaller!;\n  // standaloneConnectOpts handles all three auth shapes: static creds, the user bearer + sentinel\n  // (client-chosen inbox nonce; the callout scopes the reply inbox on it), or BARE on an open\n  // mesh (no credential system; the broker enforces nothing).\n  // dialerFor, not the raw TCP connect: a user mesh reached through an HTTPS edge is a\n  // wss:// URL, and the node transport refuses those outright (\"use the 'wsconnect'\n  // function instead\") - which took `ps`/`stop`/`attach` down against every websocket\n  // broker while send and spawn (already routed through the dialer) worked.\n  const nc = await (await import(\"@nats-io/transport-node\")).connect({\n    servers: server,",
+      "afterRestore": "pnpm --filter @cotal-ai/cli build",
+      "expectRed": "FAIL: A: models reaches the manager over ws:// through askManagerEp"
+    },
+    {
+      "cell": "B",
+      "name": "withControlConnection uses raw TCP connect for a websocket URL",
+      "file": "implementations/cli/src/lib/control.ts",
+      "find": "async function withControlConnection<T>(server: string, auth: ControlAuth, fn: (nc: NatsConnection) => Promise<T>): Promise<T> {\n  // dialerFor, not the raw TCP connect: a user mesh reached through an HTTPS edge is a\n  // wss:// URL, and the node transport refuses those outright (\"use the 'wsconnect'\n  // function instead\") - which took `ps`/`stop`/`attach` down against every websocket\n  // broker while send and spawn (already routed through the dialer) worked.\n  const nc = await dialerFor(server)({\n    servers: server,",
+      "replace": "async function withControlConnection<T>(server: string, auth: ControlAuth, fn: (nc: NatsConnection) => Promise<T>): Promise<T> {\n  // dialerFor, not the raw TCP connect: a user mesh reached through an HTTPS edge is a\n  // wss:// URL, and the node transport refuses those outright (\"use the 'wsconnect'\n  // function instead\") - which took `ps`/`stop`/`attach` down against every websocket\n  // broker while send and spawn (already routed through the dialer) worked.\n  const nc = await (await import(\"@nats-io/transport-node\")).connect({\n    servers: server,",
+      "afterRestore": "pnpm --filter @cotal-ai/cli build",
+      "expectRed": "FAIL: B: ps reaches the manager over ws:// through the scatter connection"
+    }
+  ]
+}

--- a/implementations/cli/src/commands/agents.ts
+++ b/implementations/cli/src/commands/agents.ts
@@ -1,6 +1,6 @@
-import { mintCreds, newIdentity, openSessionRail, standaloneConnectOpts, type CompletionResult, type FlagSpec, type FlagValues, type ParsedArgs, type SessionGrant } from "@cotal-ai/core";
+import { dialerFor, mintCreds, newIdentity, openSessionRail, standaloneConnectOpts, type CompletionResult, type FlagSpec, type FlagValues, type ParsedArgs, type SessionGrant } from "@cotal-ai/core";
 import { divergentCwdAnchor, loadMeshes, targetFlags } from "@cotal-ai/workspace";
-import { connect, type NatsConnection } from "@nats-io/transport-node";
+import { type NatsConnection } from "@nats-io/transport-node";
 import { c } from "../ui.js";
 import { askManager, scatterManager, failIfNotOk, resolveControlTarget, onInstanceOrExit, type ScatterInstanceLiveness } from "../lib/control.js";
 import { attachClient, detachKey, holdTerminal, isTransportEnd, meshSessionTransport, type TerminalHold } from "../lib/attach-client.js";
@@ -574,7 +574,7 @@ async function establishAttachSession(
   // with `gap`, or it stalled out and closed while this side was away, so nothing ever arrives
   // again). Owning re-establishment here means the link coming back produces a real session with a
   // real repaint, instead of a restored socket over a session that ended without us.
-  const nc = await connect({
+  const nc = await dialerFor(t.server)({
     servers: t.server,
     ...standaloneConnectOpts({ creds, tls: false }),
     inboxPrefix: `_INBOX_${id.id}`,
@@ -638,7 +638,7 @@ type Abandoned = { grant: SessionGrant; creds: string; inbox: string; server: st
  * minted from the credential the abandoned session already had.
  */
 async function releaseAbandonedSession(s: Abandoned): Promise<void> {
-  const nc = await connect({
+  const nc = await dialerFor(s.server)({
     servers: s.server,
     ...standaloneConnectOpts({ creds: s.creds, tls: false }),
     inboxPrefix: `_INBOX_${s.inbox}`,

--- a/implementations/cli/src/lib/control.ts
+++ b/implementations/cli/src/lib/control.ts
@@ -17,6 +17,7 @@ import {
   scatterCommand,
   mintLifecycleUid,
   newIdentity,
+  dialerFor,
   resolveService,
   standaloneConnectOpts,
   type ControlReply,
@@ -26,7 +27,7 @@ import {
   type Profile,
   type SpaceAuth,
 } from "@cotal-ai/core";
-import { PermissionViolationError, connect, type NatsConnection } from "@nats-io/transport-node";
+import { PermissionViolationError, type NatsConnection } from "@nats-io/transport-node";
 import { jetstreamManager } from "@nats-io/jetstream";
 import {
   authDir, endpointAuth, findCotalRoot, isWorkspaceTargetError, loadSpaceAuth, resolveMeshTarget,
@@ -217,7 +218,11 @@ async function askManagerEp(
   // standaloneConnectOpts handles all three auth shapes: static creds, the user bearer + sentinel
   // (client-chosen inbox nonce; the callout scopes the reply inbox on it), or BARE on an open
   // mesh (no credential system; the broker enforces nothing).
-  const nc = await connect({
+  // dialerFor, not the raw TCP connect: a user mesh reached through an HTTPS edge is a
+  // wss:// URL, and the node transport refuses those outright ("use the 'wsconnect'
+  // function instead") - which took `ps`/`stop`/`attach` down against every websocket
+  // broker while send and spawn (already routed through the dialer) worked.
+  const nc = await dialerFor(server)({
     servers: server,
     ...standaloneConnectOpts(auth.creds ? { creds: auth.creds, tls: auth.tls === true } : auth.bearer ? { bearer: auth.bearer, sentinelCreds: auth.sentinelCreds, tls: auth.tls === true } : { tls: auth.tls === true }),
     maxReconnectAttempts: 0,
@@ -436,7 +441,11 @@ export type ScatterReply = { ok: true; instances: ScatterInstanceReply[] } | { o
  *  the scatter's TWO connections cannot drift in their connect options: they differ in credential
  *  and in nothing else. */
 async function withControlConnection<T>(server: string, auth: ControlAuth, fn: (nc: NatsConnection) => Promise<T>): Promise<T> {
-  const nc = await connect({
+  // dialerFor, not the raw TCP connect: a user mesh reached through an HTTPS edge is a
+  // wss:// URL, and the node transport refuses those outright ("use the 'wsconnect'
+  // function instead") - which took `ps`/`stop`/`attach` down against every websocket
+  // broker while send and spawn (already routed through the dialer) worked.
+  const nc = await dialerFor(server)({
     servers: server,
     ...standaloneConnectOpts(auth.creds ? { creds: auth.creds, tls: auth.tls === true } : auth.bearer ? { bearer: auth.bearer, sentinelCreds: auth.sentinelCreds, tls: auth.tls === true } : { tls: auth.tls === true }),
     maxReconnectAttempts: 0,

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "smoke:mesh-attach": "tsx implementations/manager/smoke/mesh-attach.smoke.ts",
     "smoke:mesh-attach-plane": "tsx implementations/manager/smoke/mesh-attach-plane.smoke.ts",
     "smoke:attach-auth-root": "tsx bin/smoke/attach-auth-root.smoke.ts",
+    "smoke:control-transport-dial": "tsx bin/smoke/control-transport-dial.smoke.ts",
     "smoke:session-ledger-family": "tsx implementations/manager/smoke/session-ledger-family.smoke.ts",
     "smoke:session-cap": "tsx implementations/manager/smoke/session-cap.smoke.ts",
     "smoke:renewal-terminal-race": "tsx implementations/manager/smoke/renewal-terminal-race.smoke.ts",


### PR DESCRIPTION
The four control-path connects (askManager, withControlConnection, the attach re-establishment, and the abandoned-session release) called the node transport's connect() directly, which refuses ws/wss URLs outright — so `cotal ps` against a mesh published through an HTTPS edge died with "'servers' node client doesn't support websockets, use the 'wsconnect' function instead" while `send` and foreground `spawn`, already routed through `dialerFor` (2a383febc), worked.

This routes all four through `dialerFor`, which picks `wsconnect` for ws schemes and owns the transport options.

Verified against a live wss edge (hack.cotal.ai): the transport refusal is gone and `ps` proceeds to the exchange/manager path. Sibling of feedback f4ee818c.

Suites run: `@cotal-ai/cli` builds clean (`tsc -p`); live behavioral check as above. Not run: the full smoke battery — reviewer's call which cells this touches.