### PR TITLE
fix(connector-opencode): the plugin bundle exports only the plugin

### DIFF
--- a/.changeset/opencode-plugin-single-export.md
+++ b/.changeset/opencode-plugin-single-export.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/connector-opencode": patch
+---
+
+The published OpenCode plugin bundle exports exactly one symbol: the `cotal` plugin. OpenCode's loader treats every export of a plugin module as a plugin factory, so the log-marker constants `src/plugin.ts` exports for the smokes broke plugin loading when that file was bundled directly. The bundle now builds from a thin entry (`src/plugin.entry.ts`) that re-exports only `cotal`; the constants remain exported from the source module for the smokes.

--- a/extensions/connector-opencode/package.json
+++ b/extensions/connector-opencode/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "node -e \"require('node:fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json --emitDeclarationOnly && pnpm run bundle",
-    "bundle": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/index.js --external:@cotal-ai/core && esbuild src/plugin.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/plugin.bundle.js && esbuild src/serve.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/serve.js",
+    "bundle": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/index.js --external:@cotal-ai/core && esbuild src/plugin.entry.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/plugin.bundle.js && esbuild src/serve.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/serve.js",
     "prepublishOnly": "pnpm run build"
   },
   "peerDependencies": {

--- a/extensions/connector-opencode/src/plugin.entry.ts
+++ b/extensions/connector-opencode/src/plugin.entry.ts
@@ -1,0 +1,5 @@
+/** The plugin *bundle* entry (esbuild → `dist/plugin.bundle.js`). OpenCode's loader treats every
+ *  export of a plugin module as a plugin factory and calls it, so the bundle must export exactly
+ *  one symbol: the plugin. The log-marker constants stay exported from `./plugin.ts` for the
+ *  smokes, which import the source — they must never reach this surface. */
+export { cotal } from "./plugin.js";


### PR DESCRIPTION
OpenCode's loader treats every export of a plugin module as a plugin factory. `src/plugin.ts` exports four log-marker constants (`SESSION_RETIRED`, `SETTLE_ABANDONED`, `WAL_REAPED`, `WAL_KEPT`) for the smokes, so bundling it directly as `dist/plugin.bundle.js` gave the published bundle five exports and broke plugin loading.

The bundle now builds from a thin entry (`src/plugin.entry.ts`) that re-exports only `cotal`. The constants stay exported from the source module, which is what the smokes import (`../src/plugin.js`) — no smoke changes needed.

Verified: built bundle's export block is exactly `export { cotal }`; package typecheck clean. This is the first rider for the 0.30.1 patch release.