### PR TITLE
test(web): authenticate guarded smoke suites

### DIFF
--- a/implementations/web/smoke/body-cap.smoke.ts
+++ b/implementations/web/smoke/body-cap.smoke.ts
@@ -99,21 +99,26 @@ try {
   webChild.stdout?.on("data", (d: Buffer) => { log += d.toString(); });
   webChild.stderr?.on("data", (d: Buffer) => { log += d.toString(); });
 
-  let served = false;
-  for (let i = 0; i < 200; i++) {
-    const r = await fetch(`http://127.0.0.1:${WEB_PORT}/api/roster`).catch(() => undefined);
-    if (r?.status === 200) { served = true; break; }
+  let launchUrl: string | undefined;
+  for (let i = 0; i < 200 && launchUrl === undefined; i++) {
+    launchUrl = log.match(/http:\/\/127\.0\.0\.1:\d+\/\?k=[A-Za-z0-9_-]+/)?.[0];
     await wait(250);
   }
+  const exchange = launchUrl === undefined ? undefined : await fetch(launchUrl, { redirect: "manual" }).catch(() => undefined);
+  const session = /(?:^|,\s*)cotal_web_session=([^;]+)/.exec(exchange?.headers.get("set-cookie") ?? "")?.[1];
+  const authed = { cookie: `cotal_web_session=${session}` };
+  const ready = session === undefined ? undefined
+    : await fetch(`http://127.0.0.1:${WEB_PORT}/api/roster`, { headers: authed }).catch(() => undefined);
+  const served = exchange?.status === 302 && session !== undefined && ready?.status === 200;
 
   const post = async (payload: string): Promise<{ status: number; text: string }> => {
     const r = await fetch(`http://127.0.0.1:${WEB_PORT}/api/channel/delete`, {
-      method: "POST", headers: { "content-type": "application/json" }, body: payload,
+      method: "POST", headers: { ...authed, "content-type": "application/json" }, body: payload,
     });
     return { status: r.status, text: await r.text() };
   };
   const stillThere = async (ch: string): Promise<boolean> =>
-    (await (await fetch(`http://127.0.0.1:${WEB_PORT}/api/channels/${ch}/history?limit=20`)).text()).includes(MSG);
+    (await (await fetch(`http://127.0.0.1:${WEB_PORT}/api/channels/${ch}/history?limit=20`, { headers: authed })).text()).includes(MSG);
 
   /** A raw socket, because the two facts that matter most here are how many bytes the CALLER got
    *  out before it was cut off, and whether a body with no `content-length` at all is still
@@ -149,7 +154,8 @@ try {
       setTimeout(() => { sock.destroy(); done(); }, 25_000);
     });
 
-  const CHUNKED_HEAD = "POST /api/channel/delete HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\n" +
+  const COOKIE = `Cookie: ${authed.cookie}\r\n`;
+  const CHUNKED_HEAD = "POST /api/channel/delete HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\n" + COOKIE +
     "Connection: close\r\nTransfer-Encoding: chunked\r\n\r\n";
   const asChunks = (b: Buffer): Buffer =>
     Buffer.concat([Buffer.from(b.length.toString(16) + "\r\n"), b, Buffer.from("\r\n")]);
@@ -228,7 +234,7 @@ try {
     // sends a few bytes and stops. The streaming count never reaches the cap, so a server that
     // only counts what arrives waits for bytes that are not coming, and the caller learns nothing
     // until something else times out. Refusing on the announcement is the difference.
-    const head = "POST /api/channel/delete HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\n" +
+    const head = "POST /api/channel/delete HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\n" + COOKIE +
       `Connection: close\r\nContent-Length: ${20_000_000}\r\n\r\n`;
     const r = await raw(head, Buffer.from('{"channel":"a', "utf8"));
     ok("5.0 a body ANNOUNCED as oversized is refused on the announcement, without waiting for bytes the caller never sends",
@@ -237,7 +243,7 @@ try {
   {
     // Declared: refused before the body is read at all.
     const body = Buffer.alloc(20_000_000, 0x61);
-    const head = "POST /api/channel/delete HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\n" +
+    const head = "POST /api/channel/delete HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\n" + COOKIE +
       `Connection: close\r\nContent-Length: ${body.length}\r\n\r\n`;
     const r = await raw(head, body);
     ok("5.1 a DECLARED oversize is refused and the caller never finishes the body it announced, so the read did not run to the end",
@@ -344,7 +350,7 @@ try {
       KEEPALIVE.includes("keep-alive") && !KEEPALIVE.includes("close"));
 
     const oversizedOverKeepAlive = async (declared: boolean): Promise<{ resp: string; closedAfterMs: number | null; afterClose: string; sent: number }> => {
-      const head = "POST /api/channel/delete HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\n" + KEEPALIVE +
+      const head = "POST /api/channel/delete HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\n" + COOKIE + KEEPALIVE +
         (declared ? "Content-Length: 20000000\r\n\r\n" : "Transfer-Encoding: chunked\r\n\r\n");
       let resp = "", sent = 0;
       const piece = Buffer.alloc(65536, 0x61);
@@ -403,7 +409,7 @@ try {
     // on the SAME socket.
     const req = (ch: string): string => {
       const b = JSON.stringify({ channel: ch });
-      return "POST /api/channel/delete HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\n" +
+      return "POST /api/channel/delete HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\n" + COOKIE +
         `Connection: keep-alive\r\nContent-Length: ${Buffer.byteLength(b)}\r\n\r\n${b}`;
     };
     let resp = "";

--- a/implementations/web/smoke/channel-alias.smoke.ts
+++ b/implementations/web/smoke/channel-alias.smoke.ts
@@ -92,20 +92,25 @@ try {
   webChild.stdout?.on("data", (d: Buffer) => { log += d.toString(); });
   webChild.stderr?.on("data", (d: Buffer) => { log += d.toString(); });
 
-  let served = false;
-  for (let i = 0; i < 200; i++) {
-    const r = await fetch(`http://127.0.0.1:${WEB_PORT}/api/roster`).catch(() => undefined);
-    if (r?.status === 200) { served = true; break; }
+  let launchUrl: string | undefined;
+  for (let i = 0; i < 200 && launchUrl === undefined; i++) {
+    launchUrl = log.match(/http:\/\/127\.0\.0\.1:\d+\/\?k=[A-Za-z0-9_-]+/)?.[0];
     await wait(250);
   }
+  const exchange = launchUrl === undefined ? undefined : await fetch(launchUrl, { redirect: "manual" }).catch(() => undefined);
+  const session = /(?:^|,\s*)cotal_web_session=([^;]+)/.exec(exchange?.headers.get("set-cookie") ?? "")?.[1];
+  const authed = { cookie: `cotal_web_session=${session}` };
+  const ready = session === undefined ? undefined
+    : await fetch(`http://127.0.0.1:${WEB_PORT}/api/roster`, { headers: authed }).catch(() => undefined);
+  const served = exchange?.status === 302 && session !== undefined && ready?.status === 200;
 
   const get = async (p: string): Promise<{ status: number; body: Buffer }> => {
-    const r = await fetch(`http://127.0.0.1:${WEB_PORT}${p}`);
+    const r = await fetch(`http://127.0.0.1:${WEB_PORT}${p}`, { headers: authed });
     return { status: r.status, body: Buffer.from(await r.arrayBuffer()) };
   };
   const del = async (channel: string): Promise<{ status: number; body: Buffer }> => {
     const r = await fetch(`http://127.0.0.1:${WEB_PORT}/api/channel/delete`, {
-      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ channel }),
+      method: "POST", headers: { ...authed, "content-type": "application/json" }, body: JSON.stringify({ channel }),
     });
     return { status: r.status, body: Buffer.from(await r.arrayBuffer()) };
   };

--- a/implementations/web/smoke/echo-escaping.smoke.ts
+++ b/implementations/web/smoke/echo-escaping.smoke.ts
@@ -354,12 +354,17 @@ try {
   webChild.stdout?.on("data", (d: Buffer) => { log += d.toString(); });
   webChild.stderr?.on("data", (d: Buffer) => { log += d.toString(); });
 
-  let served = false;
-  for (let i = 0; i < 200; i++) {
-    const r = await fetch(`http://127.0.0.1:${WEB_PORT}/api/roster`).catch(() => undefined);
-    if (r?.status === 200) { served = true; break; }
+  let launchUrl: string | undefined;
+  for (let i = 0; i < 200 && launchUrl === undefined; i++) {
+    launchUrl = log.match(/http:\/\/127\.0\.0\.1:\d+\/\?k=[A-Za-z0-9_-]+/)?.[0];
     await wait(250);
   }
+  const exchange = launchUrl === undefined ? undefined : await fetch(launchUrl, { redirect: "manual" }).catch(() => undefined);
+  const session = /(?:^|,\s*)cotal_web_session=([^;]+)/.exec(exchange?.headers.get("set-cookie") ?? "")?.[1];
+  const authed = { cookie: `cotal_web_session=${session}` };
+  const ready = session === undefined ? undefined
+    : await fetch(`http://127.0.0.1:${WEB_PORT}/api/roster`, { headers: authed }).catch(() => undefined);
+  const served = exchange?.status === 302 && session !== undefined && ready?.status === 200;
 
   console.log("1. the shipped routes echo the value, and what they echo is readable");
   ok("1.0 the shipped `web` entry point serves at all", served, log.slice(-300));
@@ -377,7 +382,7 @@ try {
   /** One refusal: the 400 body as BYTES and the operator line it wrote. */
   const refuse = async (queryValue: string): Promise<{ status: number; body: Buffer; line: string }> => {
     log = "";
-    const res = await fetch(`http://127.0.0.1:${WEB_PORT}/api/activity?limit=${queryValue}`);
+    const res = await fetch(`http://127.0.0.1:${WEB_PORT}/api/activity?limit=${queryValue}`, { headers: authed });
     const body = Buffer.from(await res.arrayBuffer());
     await wait(150);
     return { status: res.status, body, line: log };
@@ -455,7 +460,7 @@ try {
   // percent-encodes for you and would answer a question this cell is not asking.
   const rawTarget = (target: Buffer): Promise<string> => new Promise((resolve) => {
     const sock = net.connect(WEB_PORT, "127.0.0.1", () => {
-      sock.write(Buffer.concat([Buffer.from("GET "), target, Buffer.from(" HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n")]));
+      sock.write(Buffer.concat([Buffer.from("GET "), target, Buffer.from(` HTTP/1.1\r\nHost: 127.0.0.1\r\nCookie: ${authed.cookie}\r\nConnection: close\r\n\r\n`)]));
     });
     let out = "";
     sock.on("data", (d) => { out += d.toString("latin1"); });
@@ -498,14 +503,14 @@ try {
   // refused by name, so the third site has a real input and 3.3 is that input.
   {
     log = "";
-    const res = await fetch(`http://127.0.0.1:${WEB_PORT}/api/channels/%zz/history`);
+    const res = await fetch(`http://127.0.0.1:${WEB_PORT}/api/channels/%zz/history`, { headers: authed });
     const body = await res.text();
     await wait(150);
     ok("3.1 the channel-name refusal is a 400 that NAMES the segment it could not decode",
       res.status === 400 && body.includes("%zz") && body.includes("percent-encoded"),
       { status: res.status, body: body.slice(0, 120) });
     ok("3.2 CONTROL: a well-formed name that simply does not exist is NOT a 400, so 3.1 is about the decode",
-      (await fetch(`http://127.0.0.1:${WEB_PORT}/api/channels/nosuchchannel/history`)).status === 200);
+      (await fetch(`http://127.0.0.1:${WEB_PORT}/api/channels/nosuchchannel/history`, { headers: authed })).status === 200);
   }
 
   {
@@ -513,7 +518,7 @@ try {
     const unnamed: string[] = [];
     for (const [name, n] of [["RLO U+202E", 0x202e], ["ALM U+061C", 0x61c], ["TAG U+E0001", 0xe0001]] as [string, number][]) {
       log = "";
-      const res = await fetch(`http://127.0.0.1:${WEB_PORT}/api/channels/abc${pct(n)}/history`);
+      const res = await fetch(`http://127.0.0.1:${WEB_PORT}/api/channels/abc${pct(n)}/history`, { headers: authed });
       const body = Buffer.from(await res.arrayBuffer());
       await wait(150);
       if (res.status !== 400 || body.includes(Buffer.from(cp(n), "utf8"))) raw.push(name + " (status " + res.status + ")");

--- a/implementations/web/smoke/history-limit.smoke.ts
+++ b/implementations/web/smoke/history-limit.smoke.ts
@@ -85,12 +85,12 @@ function slowLink(o: { listen: number; target: number; oneWayMs: number; bytesPe
  *  and a run that dies on the harness timeout reports an unknown instead of reddening the assertion
  *  that names the rule. `null` here means "did not answer", which is the finding, not an error. */
 type Answer = { status: number; body: string; ms: number } | null;
-const get = async (url: string, ms: number): Promise<Answer> => {
+const get = async (url: string, ms: number, cookie: string): Promise<Answer> => {
   const ac = new AbortController();
   const t = setTimeout(() => ac.abort(), ms);
   const t0 = Date.now();
   try {
-    const r = await fetch(url, { signal: ac.signal });
+    const r = await fetch(url, { headers: { cookie }, signal: ac.signal });
     return { status: r.status, body: await r.text(), ms: Date.now() - t0 };
   } catch { return null; } finally { clearTimeout(t); }
 };
@@ -127,14 +127,24 @@ try {
   await seed.stop();
 
   const runWeb = fileURLToPath(new URL("./run-web.mts", import.meta.url));
-  const bootWeb = async (port: number, broker: string): Promise<ReturnType<typeof spawn>> => {
+  const bootWeb = async (port: number, broker: string): Promise<{ child: ReturnType<typeof spawn>; cookie: string }> => {
     const ch = spawn(process.execPath, ["--import", "tsx", runWeb, "--space", SPACE, "--server", broker,
       "--port", String(port), "--no-open"], { stdio: ["ignore", "pipe", "pipe"] });
-    ch.stdout?.on("data", () => {}); ch.stderr?.on("data", () => {});
-    for (let i = 0; i < 200; i++) { const r = await fetch(`http://127.0.0.1:${port}/api/meta`).catch(() => undefined); if (r?.ok) break; await wait(250); }
-    return ch;
+    let log = "";
+    ch.stdout?.on("data", (d: Buffer) => { log += d.toString(); });
+    ch.stderr?.on("data", (d: Buffer) => { log += d.toString(); });
+    let launchUrl: string | undefined;
+    for (let i = 0; i < 200 && launchUrl === undefined; i++) {
+      launchUrl = log.match(/http:\/\/127\.0\.0\.1:\d+\/\?k=[A-Za-z0-9_-]+/)?.[0];
+      await wait(250);
+    }
+    const exchange = launchUrl === undefined ? undefined : await fetch(launchUrl, { redirect: "manual" }).catch(() => undefined);
+    const session = /(?:^|,\s*)cotal_web_session=([^;]+)/.exec(exchange?.headers.get("set-cookie") ?? "")?.[1];
+    if (exchange?.status !== 302 || session === undefined) throw new Error(`web launch failed: ${log.slice(-300)}`);
+    return { child: ch, cookie: `cotal_web_session=${session}` };
   };
-  fastWeb = await bootWeb(FAST, SERVER);
+  const fast = await bootWeb(FAST, SERVER);
+  fastWeb = fast.child;
   const F = `http://127.0.0.1:${FAST}`;
 
   // ── 1. ONE PARSE, AND ALL THREE ROUTES OBEY IT ───────────────────────────────────────────────
@@ -145,38 +155,38 @@ try {
   // Without it that branch has no cell and a mutation of it cannot be graded.
   const BAD = ["abc", "Infinity", "1e999", "2.5", "-3", " 5", "5abc", "1e3", "99999999999999999999"];
   for (const bad of BAD) {
-    const answers = await Promise.all(ROUTES.map((r) => get(`${F}${r}?limit=${encodeURIComponent(bad)}`, CEILING_MS)));
+    const answers = await Promise.all(ROUTES.map((r) => get(`${F}${r}?limit=${encodeURIComponent(bad)}`, CEILING_MS, fast.cookie)));
     ok(`1.1 ?limit=${JSON.stringify(bad)} is refused by ALL THREE routes, and every one of them ANSWERS`,
       answers.every((a) => a !== null && a.status === 400), { bad, got: answers.map((a) => a?.status ?? "no answer") });
     ok(`1.2 the refusal of ${JSON.stringify(bad)} NAMES the parameter and the value it received`,
       answers.every((a) => !!a && a.body.includes("limit") && a.body.includes(bad)), answers[0]?.body);
     ok(`1.3 the refusal of ${JSON.stringify(bad)} carries no data`, answers.every((a) => len(a) <= 0), answers.map(len));
   }
-  const five = await get(`${F}/api/channels/ch0/history?limit=5`, CEILING_MS);
+  const five = await get(`${F}/api/channels/ch0/history?limit=5`, CEILING_MS, fast.cookie);
   ok("1.4 a whole number is honoured exactly", five?.status === 200 && len(five) === 5, { status: five?.status, n: len(five) });
-  const zero = await get(`${F}/api/channels/ch0/history?limit=0`, CEILING_MS);
+  const zero = await get(`${F}/api/channels/ch0/history?limit=0`, CEILING_MS, fast.cookie);
   ok("1.5 ZERO STILL MEANS ZERO: the value #699 claimed returns everything returns an empty page",
     zero?.status === 200 && len(zero) === 0, { status: zero?.status, n: len(zero) });
-  const absent = await get(`${F}/api/channels/ch0/history`, CEILING_MS);
-  const empty = await get(`${F}/api/channels/ch0/history?limit=`, CEILING_MS);
+  const absent = await get(`${F}/api/channels/ch0/history`, CEILING_MS, fast.cookie);
+  const empty = await get(`${F}/api/channels/ch0/history?limit=`, CEILING_MS, fast.cookie);
   ok("1.6 an absent limit is the route's own default, and an EMPTY limit is the same as absent",
     absent?.status === 200 && empty?.status === 200 && len(absent) === PER && len(empty) === PER,
     { absent: len(absent), empty: len(empty), expected: PER });
   // A caller error and a server fault are different facts; before the split they shared a status.
   ok("1.7 a malformed request is a 400, NEVER the 500 that means the dashboard broke",
-    (await get(`${F}/api/dms?limit=abc`, CEILING_MS))?.status === 400);
+    (await get(`${F}/api/dms?limit=abc`, CEILING_MS, fast.cookie))?.status === 400);
   // The same law one level up. The channel name is percent-decoded out of the path, and a decode
   // that cannot succeed is the caller having typed a bad escape, not the server having broken. It
   // reached the frame as a bare URIError, which is not a BadRequest, so it was reported 500 by the
   // very split 1.7 asserts. A rule that holds for the query and not for the path is not the rule.
-  const badEscape = await get(`${F}/api/channels/%zz/history`, CEILING_MS);
+  const badEscape = await get(`${F}/api/channels/%zz/history`, CEILING_MS, fast.cookie);
   ok("1.8 a channel name that cannot be percent-decoded is the CALLER's error, so 400 and not 500",
     badEscape?.status === 400, { status: badEscape?.status, body: badEscape?.body?.slice(0, 120) });
   ok("1.9 and that refusal says what was wrong with the name, not just that something failed",
     !!badEscape && /channel name/i.test(badEscape.body), badEscape?.body?.slice(0, 160));
   // A well formed name that simply is not there stays a 200 empty read, so 1.8 cannot pass by
   // turning every unknown channel into a refusal.
-  const absentChan = await get(`${F}/api/channels/no-such-channel/history?limit=5`, CEILING_MS);
+  const absentChan = await get(`${F}/api/channels/no-such-channel/history?limit=5`, CEILING_MS, fast.cookie);
   ok("1.10 a well formed name for a channel with nothing in it still READS, it is not refused",
     absentChan?.status === 200, { status: absentChan?.status });
 
@@ -193,9 +203,10 @@ try {
   // the refusal to be the correct ending. Slowing it further costs no wall clock: once the deadline
   // fires the arm returns at the deadline whatever the link does, so the margin is free.
   link = slowLink({ listen: PROXY, target: PORT, oneWayMs: 80, bytesPerSec: 6 * 1024 });
-  slowWeb = await bootWeb(SLOW, `nats://127.0.0.1:${PROXY}`);
+  const slow = await bootWeb(SLOW, `nats://127.0.0.1:${PROXY}`);
+  slowWeb = slow.child;
   const S = `http://127.0.0.1:${SLOW}`;
-  const slowRead = await get(`${S}/api/channels/ch0/history?limit=${PER}`, CEILING_MS);
+  const slowRead = await get(`${S}/api/channels/ch0/history?limit=${PER}`, CEILING_MS, slow.cookie);
   console.log(`   the slow arm answered ${slowRead?.status ?? "not at all"} in ${slowRead?.ms ?? CEILING_MS}ms`);
   ok("3.1 it ANSWERS on a link where it used to run past the deadline unbounded", slowRead !== null,
     "no answer within three deadlines");
@@ -214,7 +225,7 @@ try {
     { ms: slowRead?.ms, deadline: AGGREGATION_DEADLINE_MS });
   // The arm is only meaningful if the link is genuinely the cost, so prove the same read is fine
   // without it. Without this, a 503 could be a broken route and the cell would call it a success.
-  const fastRead = await get(`${F}/api/channels/ch0/history?limit=${PER}`, CEILING_MS);
+  const fastRead = await get(`${F}/api/channels/ch0/history?limit=${PER}`, CEILING_MS, fast.cookie);
   ok("3.4 control: the identical read with no link cost returns the full page, so 3.3 is the link",
     fastRead?.status === 200 && len(fastRead) === PER, { status: fastRead?.status, n: len(fastRead) });
 } finally {


### PR DESCRIPTION
## Summary

- spend each web console launch link once in the four remaining guarded smoke suites
- reuse the minted `cotal_web_session` cookie for fetch and raw-socket requests
- preserve every existing behavior predicate while restoring the routes each suite measures

## Verification

- `pnpm build`
- `pnpm typecheck`
- `pnpm smoke:web-history-limit` (39 cells)
- `pnpm smoke:web-echo-escaping` (29 cells)
- `pnpm smoke:web-channel-alias` (11 cells)
- `pnpm smoke:web-body-cap` (30 cells)

All commands ran with `COTAL_*` variables scrubbed.

## Discrimination proof

Each named cell was deliberately made red by changing only its request, then restored and rerun green:

- history limit: `3.4 control: the identical read with no link cost returns the full page, so 3.3 is the link`
- echo escaping: `3.3 a channel name that DECODES but the wire would rewrite is refused 400 with the offending codepoint escaped, never raw`
- channel alias: `2.1 a name the wire would rewrite is REFUSED at the history route, rather than quietly reading the channel it aliases onto`
- body cap: `5.2 a body with NO declared length is still refused, so the cap is enforced on the bytes as they arrive and not only on what the caller admits to`
