### PR TITLE
test(ci): gate smoke:jcode-private-lifecycle

### DIFF
--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -542,3 +542,4 @@ smoke:claude-launch-env
 smoke:web-console-auth
 smoke:no-implicit-general
 smoke:session-channels
+smoke:jcode-private-lifecycle


### PR DESCRIPTION
`smoke:jcode-private-lifecycle` is defined in `package.json` but absent from `bin/smoke/ci-suites.txt`,
so `smoke:gate-inventory` reds shard 1 on every run. This is half of #868.

#868 deliberately left the choice open — gate the suite, or remove it from the inventory's universe —
because it depended on whether the suite is actually CI-runnable. Some connector-jcode suites are
not: `smoke:jcode-host` hangs after its last cell (#874).

**This one is.** Run at this tree with `COTAL_*` scrubbed, it exits 0 in under a second:

```
$ pnpm smoke:jcode-private-lifecycle
PRIVATE LIFECYCLE SMOKE PASSED (status-1 failure for live PID stays loud)
rc=0
```

So the answer is to gate it, and `smoke:gate-inventory` passes with the entry appended
(`GATE INVENTORY OK`).

## Append-only, verified rather than assumed

`ci-suites.txt` is positional and auto-merges without a conflict marker, so a plain diff is not a
valid check on it. Verified by prefix comparison instead:

```
prefix preserved: True
appended only   : ['smoke:jcode-private-lifecycle']
no reordering   : True
```

384 real suites become 385. No existing index moves, so no suite changes shard.

## What this does NOT claim

It closes the inventory gap. It does **not** necessarily green shard 1, and I want that stated
rather than discovered.

`smoke:gate-inventory` sits at index 1, the second suite in shard 1, and a shard aborts at its first
failure. So it has been masking roughly 95 downstream shard-1 suites that have never been observed
on this baseline. Fixing it lets shard 1 run much further; whether it runs all the way green is
unknown, and some of those suites may fail for unrelated reasons.

This exact mistake was made once already this week: #888 repaired a shard-3 suite, shard 3 stayed
red, and the fix looked like a failure when it had actually worked and merely let the shard advance
to the next masked failure (#887). Treat any new shard-1 red after this as newly *revealed*, not
newly *caused*, and check it against the suite list before attributing it here.

The newly gated suite itself lands at index 384, which is shard 0. Shard 0 currently aborts earlier
at `smoke:artifact-store`, so it will not actually execute in CI until the other half of #868 is
fixed. That is a pre-existing condition, not a regression introduced here.

## Not addressed

The other half of #868, shard 0's `smoke:artifact-store`, is untouched. That one is not CI hygiene:
the suite is correctly reporting the #666 backup-inventory omissions (endpoint plane, session
ledger, workflow journal) and the #356 reap gap. It needs a product decision, not an append.
