### PR TITLE
test(core): sweep remote manager EPS grants

### DIFF
--- a/packages/core/smoke/eps-grant-sweep.smoke.ts
+++ b/packages/core/smoke/eps-grant-sweep.smoke.ts
@@ -75,6 +75,11 @@ const PRODUCERS: Record<Profile, () => string[]> = {
   observer: via("observer"),
   admin: via("admin"),
   supervisor: via("supervisor"),
+  "remote-manager": () => {
+    const actor = `manager_${IID}`;
+    return rowsOf(permissionsFor("remote-manager", SPACE,
+      { ...pr, actor }, { remoteManager: { instanceId: IID, owner: DEV_OWNER, actor } }));
+  },
   provisioner: via("provisioner"),
   deprovisioner: via("deprovisioner", { deprovisionTarget: { principal: `${DEV_OWNER}.worker`, lifecycleUid: UID } }),
   "retirement-requester": via("retirement-requester", { retirementRequester: { owner: DEV_OWNER, actor: "manager", uid: UID, target: { owner: DEV_OWNER, actor: "worker", lifecycleUid: UID } } }),

--- a/packages/core/smoke/eps-grant-sweep.smoke.ts
+++ b/packages/core/smoke/eps-grant-sweep.smoke.ts
@@ -75,11 +75,9 @@ const PRODUCERS: Record<Profile, () => string[]> = {
   observer: via("observer"),
   admin: via("admin"),
   supervisor: via("supervisor"),
-  "remote-manager": () => {
-    const actor = `manager_${IID}`;
-    return rowsOf(permissionsFor("remote-manager", SPACE,
-      { ...pr, actor }, { remoteManager: { instanceId: IID, owner: DEV_OWNER, actor } }));
-  },
+  "remote-manager": () => [`manager_${IID}`, `manager_exec_${IID}`].flatMap((actor) =>
+    rowsOf(permissionsFor("remote-manager", SPACE,
+      { ...pr, actor }, { remoteManager: { instanceId: IID, owner: DEV_OWNER, actor } }))),
   provisioner: via("provisioner"),
   deprovisioner: via("deprovisioner", { deprovisionTarget: { principal: `${DEV_OWNER}.worker`, lifecycleUid: UID } }),
   "retirement-requester": via("retirement-requester", { retirementRequester: { owner: DEV_OWNER, actor: "manager", uid: UID, target: { owner: DEV_OWNER, actor: "worker", lifecycleUid: UID } } }),


### PR DESCRIPTION
## Summary

- add a valid `remote-manager` producer to the exhaustive EPS grant sweep
- construct the producer with its authorized owner, instance, and server-selected manager actor
- exercise its real permission rows against foreign session rails

## Verification

- `pnpm smoke:eps-grant-sweep`
- mutation proof: injected a foreign `remote-manager` EPS `in` rail and confirmed only the section B foreign-rail cell failed, then restored and reran green

Closes #894 (item 1 only).