### PR TITLE
fix(web): name rejected history reads

### DIFF
--- a/.changeset/tidy-reads-refuse.md
+++ b/.changeset/tidy-reads-refuse.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/web": patch
+---
+
+Name failed direct-message and channel-history reads in dashboard 503 responses.

--- a/implementations/web/smoke/bounded-aggregation.smoke.ts
+++ b/implementations/web/smoke/bounded-aggregation.smoke.ts
@@ -168,6 +168,7 @@ const releaseBroker = teardownOnSignal(broker, store);
 let link: { close(): void } | undefined;
 let link2: { close(): void } | undefined;
 let webChild: ReturnType<typeof spawn> | undefined;
+let rejectingWebChild: ReturnType<typeof spawn> | undefined;
 try {
   let up = false;
   for (let i = 0; i < 80; i++) { if (await isReachable(SERVER)) { up = true; break; } await wait(150); }
@@ -336,7 +337,53 @@ try {
     ok("4.10 and it carries the underlying reason rather than replacing it", /timeout/.test(threw?.message ?? ""), threw?.message);
   }
 
-  // ── 5. THE ROUTE, NOT JUST THE FUNCTION ───────────────────────────────────────────────────────
+  // ── 5. BOTH ENDINGS OF EACH SINGLE-READ ROUTE ──────────────────────────────────────────────────
+  // A read can end before the outer deadline by REJECTING on its own timeout. Drive that ending
+  // without timing or load: the shipped entry point still owns the HTTP response, while its endpoint
+  // methods reject immediately with the exact bare reason that previously escaped as a 500.
+  {
+    const WEB_PORT = await freePort();
+    let log = "";
+    rejectingWebChild = spawn(process.execPath, [
+      "--import", "tsx", fileURLToPath(new URL("./run-web.mts", import.meta.url)),
+      "--server", SERVER, "--space", SPACE, "--port", String(WEB_PORT), "--no-open",
+    ], { stdio: ["ignore", "pipe", "pipe"], env: { ...process.env, COTAL_WEB_SMOKE_REJECT_HISTORY: "1" } });
+    rejectingWebChild.stdout?.on("data", (d: Buffer) => { log += d.toString(); });
+    rejectingWebChild.stderr?.on("data", (d: Buffer) => { log += d.toString(); });
+
+    let launchUrl: string | undefined;
+    for (let i = 0; i < 200 && launchUrl === undefined; i++) {
+      launchUrl = log.match(/http:\/\/127\.0\.0\.1:\d+\/\?k=[A-Za-z0-9_-]+/)?.[0];
+      await wait(50);
+    }
+    const exchange = launchUrl === undefined
+      ? undefined
+      : await fetch(launchUrl, { redirect: "manual" }).catch(() => undefined);
+    const session = /(?:^|,\s*)cotal_web_session=([^;]+)/.exec(exchange?.headers.get("set-cookie") ?? "")?.[1];
+    const authed = { cookie: `cotal_web_session=${session}` };
+    const ready = session === undefined
+      ? undefined
+      : await fetch(`http://127.0.0.1:${WEB_PORT}/api/roster`, { headers: authed }).catch(() => undefined);
+    ok("5.0 CONTROL: the rejection probe reaches the shipped web entry point",
+      exchange?.status === 302 && session !== undefined && ready?.status === 200, log.slice(-400));
+
+    const dRes = await fetch(`http://127.0.0.1:${WEB_PORT}/api/dms?limit=1`, { headers: authed });
+    const dBody = await dRes.json().catch(() => undefined);
+    ok("5.1 `/api/dms` names a read that REJECTS instead of returning the bare 500",
+      dRes.status === 503 && /direct messages: the read failed: timeout/.test(String(dBody?.error)),
+      { status: dRes.status, body: dBody });
+
+    const hRes = await fetch(`http://127.0.0.1:${WEB_PORT}/api/channels/team00/history?limit=1`, { headers: authed });
+    const hBody = await hRes.json().catch(() => undefined);
+    ok("5.2 `/api/channels/<name>/history` names a read that REJECTS instead of returning the bare 500",
+      hRes.status === 503 && /#team00: the read failed: timeout/.test(String(hBody?.error)),
+      { status: hRes.status, body: hBody });
+
+    rejectingWebChild.kill("SIGKILL");
+    rejectingWebChild = undefined;
+  }
+
+  // ── 6. THE DEADLINE ENDING, NOT JUST THE FUNCTION ──────────────────────────────────────────────
   // Everything above calls `activityBackfill` directly. That proves the aggregation behaves. It does
   // NOT prove the dashboard's ROUTE reaches it, and what the issue reports is a route answering 500.
   // So this section boots the SHIPPED `web()` entry point in its own process and reads its HTTP
@@ -377,7 +424,7 @@ try {
     const ready = session === undefined
       ? undefined
       : await fetch(`http://127.0.0.1:${WEB_PORT}/api/roster`, { headers: authed }).catch(() => undefined);
-    ok("5.0 the shipped `web` entry point serves across the link at all",
+    ok("6.0 the shipped `web` entry point serves across the link at all",
       exchange?.status === 302 && session !== undefined && ready?.status === 200, log.slice(-400));
 
     // CONTROL FIRST, on an idle link: a small route answers. Everything below is about what happens
@@ -385,7 +432,7 @@ try {
     // dashboard at all. It runs before the big reads because their abandoned work outlives them.
     const cRes = await fetch(`http://127.0.0.1:${WEB_PORT}/api/channels`, { headers: authed }).catch((e) => e as Error);
     const cBody = cRes instanceof Error ? undefined : await cRes.json().catch(() => undefined);
-    ok("5.1 CONTROL: a small route answers 200 across this link", !(cRes instanceof Error) && cRes.status === 200 && Array.isArray(cBody),
+    ok("6.1 CONTROL: a small route answers 200 across this link", !(cRes instanceof Error) && cRes.status === 200 && Array.isArray(cBody),
       cRes instanceof Error ? cRes.message : cRes.status);
 
     const t0 = Date.now();
@@ -395,12 +442,12 @@ try {
     const aMs = Date.now() - t0;
     const aBody = aRes instanceof Error ? undefined : await aRes.json().catch(() => undefined);
     const status = aRes instanceof Error ? 0 : aRes.status;
-    ok("5.2 `/api/activity` ANSWERS 200 where the shipped route answered 500", status === 200, { status, aMs });
-    ok("5.3 the body the browser receives is the aggregation's page, MARKED PARTIAL", aBody?.partial === true && aBody?.of === CHANNELS + 1,
+    ok("6.2 `/api/activity` ANSWERS 200 where the shipped route answered 500", status === 200, { status, aMs });
+    ok("6.3 the body the browser receives is the aggregation's page, MARKED PARTIAL", aBody?.partial === true && aBody?.of === CHANNELS + 1,
       { partial: aBody?.partial, read: aBody?.read, of: aBody?.of });
-    ok("5.4 and it NAMES the sources it left out, in the response itself", Array.isArray(aBody?.missing) && aBody.missing.length > 0
+    ok("6.4 and it NAMES the sources it left out, in the response itself", Array.isArray(aBody?.missing) && aBody.missing.length > 0
       && aBody.missing.every((m: string) => m === "direct messages" || names.some((n) => m === `#${n}`)), aBody?.missing?.slice(0, 3));
-    ok("5.5 the route answers inside the deadline it reports", aMs < AGGREGATION_DEADLINE_MS + 5000 && aBody?.deadlineMs === AGGREGATION_DEADLINE_MS,
+    ok("6.5 the route answers inside the deadline it reports", aMs < AGGREGATION_DEADLINE_MS + 5000 && aBody?.deadlineMs === AGGREGATION_DEADLINE_MS,
       { aMs, deadlineMs: aBody?.deadlineMs });
 
     // The single read. It cannot be partial, so its bound is a named refusal the browser can hold its
@@ -412,9 +459,9 @@ try {
     const dMs = Date.now() - t1;
     const dBody = dRes instanceof Error ? undefined : await dRes.json().catch(() => undefined);
     const dStatus = dRes instanceof Error ? 0 : dRes.status;
-    ok("5.6 `/api/dms` REFUSES at its deadline rather than answering long after the reader left", dStatus === 503, { dStatus, dMs });
-    ok("5.7 and the refusal names the deadline it exceeded", /did not finish within 8000ms/.test(String(dBody?.error)), dBody);
-    ok("5.8 bounded in wall time, not just in words", dMs < AGGREGATION_DEADLINE_MS + 5000, dMs);
+    ok("6.6 `/api/dms` REFUSES at its deadline rather than answering long after the reader left", dStatus === 503, { dStatus, dMs });
+    ok("6.7 and the refusal names the deadline it exceeded", /did not finish within 8000ms/.test(String(dBody?.error)), dBody);
+    ok("6.8 bounded in wall time, not just in words", dMs < AGGREGATION_DEADLINE_MS + 5000, dMs);
 
     // A NAMED LIMIT, DRIVEN RATHER THAN DESCRIBED. The deadline bounds the RESPONSE, not the broker
     // work: a JetStream read in flight has no cancel, so the read abandoned above keeps moving bytes
@@ -428,7 +475,7 @@ try {
     }).catch((e) => e as Error);
     const nBody = nRes instanceof Error ? undefined : await nRes.json().catch(() => undefined);
     const nStatus = nRes instanceof Error ? 0 : nRes.status;
-    ok("5.9 the request following a refused read either answers or REFUSES LEGIBLY, never with a bare broker word",
+    ok("6.9 the request following a refused read either answers or REFUSES LEGIBLY, never with a bare broker word",
       nStatus === 200
         ? nBody?.partial !== undefined
         : typeof nBody?.error === "string" && /channel list|did not finish|deadline/.test(nBody.error),
@@ -436,11 +483,12 @@ try {
 
     // The operator watching the server log is the one who can tell a slow link from a broken channel,
     // and the browser's marker never reaches them.
-    ok("5.10 the server SAYS in its own log that the page was short, and what it left out",
+    ok("6.10 the server SAYS in its own log that the page was short, and what it left out",
       /partial: \d+\/\d+ sources within \d+ms, missing /.test(log), log.split("\n").filter((l) => l.includes("partial")).slice(0, 2));
   }
 } finally {
   webChild?.kill("SIGKILL");
+  rejectingWebChild?.kill("SIGKILL");
   link?.close();
   link2?.close();
   releaseBroker();

--- a/implementations/web/smoke/fixtures/bounded-aggregation.mutations.json
+++ b/implementations/web/smoke/fixtures/bounded-aggregation.mutations.json
@@ -63,6 +63,20 @@
       "find": "const CEILING_MS = AGGREGATION_DEADLINE_MS * 3;",
       "replace": "const CEILING_MS = AGGREGATION_DEADLINE_MS / 2;",
       "expectRed": "2.0 the suite's own ceiling sits well above the deadline"
+    },
+    {
+      "name": "B10 the dms route stops naming an inner rejection and lets the broker's bare reason escape through the generic 500 again",
+      "file": "implementations/web/src/web.ts",
+      "find": "          ep.dmHistory({ limit }).catch((e: unknown) => {\n            throw new Error(`direct messages: the read failed: ${e instanceof Error ? e.message : String(e)}`);\n          }),",
+      "replace": "          ep.dmHistory({ limit }),",
+      "expectRed": "5.1 `/api/dms` names a read that REJECTS instead of returning the bare 500"
+    },
+    {
+      "name": "B11 the channel history route stops naming an inner rejection and lets the broker's bare reason escape through the generic 500 again",
+      "file": "implementations/web/src/web.ts",
+      "find": "          ep.channelHistory(name, { limit }).catch((e: unknown) => {\n            throw new Error(`#${name}: the read failed: ${e instanceof Error ? e.message : String(e)}`);\n          }),",
+      "replace": "          ep.channelHistory(name, { limit }),",
+      "expectRed": "5.2 `/api/channels/<name>/history` names a read that REJECTS instead of returning the bare 500"
     }
   ]
 }

--- a/implementations/web/smoke/run-web.mts
+++ b/implementations/web/smoke/run-web.mts
@@ -7,7 +7,13 @@
  *  ignored rather than guessed at.
  *
  *  Not shipped and not imported by shipped code: this file lives under `smoke/`. */
+import { CotalEndpoint } from "@cotal-ai/core";
 import { web } from "../src/web.js";
+
+if (process.env.COTAL_WEB_SMOKE_REJECT_HISTORY === "1") {
+  CotalEndpoint.prototype.dmHistory = async () => { throw new Error("timeout"); };
+  CotalEndpoint.prototype.channelHistory = async () => { throw new Error("timeout"); };
+}
 
 const raw = process.argv.slice(2);
 const values: Record<string, string | boolean> = {};

--- a/implementations/web/src/web.ts
+++ b/implementations/web/src/web.ts
@@ -961,10 +961,17 @@ export async function web(args: ParsedArgs): Promise<void> {
       const limit = historyLimit(query, 500);
       const clock = deadline(AGGREGATION_DEADLINE_MS);
       try {
-        const dms = await within(ep.dmHistory({ limit }), clock.until);
+        const dms = await within(
+          ep.dmHistory({ limit }).catch((e: unknown) => {
+            throw new Error(`direct messages: the read failed: ${e instanceof Error ? e.message : String(e)}`);
+          }),
+          clock.until,
+        );
         if (dms === LATE)
           return json(res, { error: `direct messages: the read did not finish within ${AGGREGATION_DEADLINE_MS}ms` }, 503);
         return json(res, dms);
+      } catch (e) {
+        return json(res, { error: e instanceof Error ? e.message : String(e) }, 503);
       } finally {
         clock.done();
       }
@@ -981,10 +988,17 @@ export async function web(args: ParsedArgs): Promise<void> {
       // channel holding the view open indefinitely.
       const clock = deadline(AGGREGATION_DEADLINE_MS);
       try {
-        const page = await within(ep.channelHistory(name, { limit }), clock.until);
+        const page = await within(
+          ep.channelHistory(name, { limit }).catch((e: unknown) => {
+            throw new Error(`#${name}: the read failed: ${e instanceof Error ? e.message : String(e)}`);
+          }),
+          clock.until,
+        );
         if (page === LATE)
           return json(res, { error: `#${name}: the read did not finish within ${AGGREGATION_DEADLINE_MS}ms` }, 503);
         return json(res, page);
+      } catch (e) {
+        return json(res, { error: e instanceof Error ? e.message : String(e) }, 503);
       } finally {
         clock.done();
       }


### PR DESCRIPTION
## Summary
- return named 503 refusals when direct-message history rejects before the aggregation deadline
- return named 503 refusals when channel history rejects before the aggregation deadline
- add deterministic route-level rejection coverage for both sibling endpoints and mutation cases for each

## Verification
- pre-fix: `/api/dms` returned `500 {"error":"timeout"}`
- pre-fix: `/api/channels/team00/history` returned `500 {"error":"timeout"}`
- post-fix: `pnpm smoke:web-bounded-aggregation` passed 43/43 cells
- `pnpm typecheck`
- targeted mutation proof killed both route mutations on their predicted isolated cells

Fixes #896
