### PR TITLE
test(web): strip COTAL_ before the rejection arm's env spread

### DIFF
--- a/implementations/web/smoke/bounded-aggregation.smoke.ts
+++ b/implementations/web/smoke/bounded-aggregation.smoke.ts
@@ -344,10 +344,18 @@ try {
   {
     const WEB_PORT = await freePort();
     let log = "";
+    // STRIP `COTAL_` BEFORE THE SPREAD. Whatever runs this suite may be a managed agent session, so
+    // an unfiltered `...process.env` hands the child a live credential and a live broker URL — the
+    // child would then talk to the operator's mesh instead of this suite's throwaway one.
+    // `smoke:suite-ambient-env` is the census that enforces this; it named this file when the
+    // rejection arm was added.
+    const childEnv: NodeJS.ProcessEnv = { ...process.env };
+    for (const key of Object.keys(childEnv)) if (key.startsWith("COTAL_")) delete childEnv[key];
+    childEnv.COTAL_WEB_SMOKE_REJECT_HISTORY = "1";
     rejectingWebChild = spawn(process.execPath, [
       "--import", "tsx", fileURLToPath(new URL("./run-web.mts", import.meta.url)),
       "--server", SERVER, "--space", SPACE, "--port", String(WEB_PORT), "--no-open",
-    ], { stdio: ["ignore", "pipe", "pipe"], env: { ...process.env, COTAL_WEB_SMOKE_REJECT_HISTORY: "1" } });
+    ], { stdio: ["ignore", "pipe", "pipe"], env: childEnv });
     rejectingWebChild.stdout?.on("data", (d: Buffer) => { log += d.toString(); });
     rejectingWebChild.stderr?.on("data", (d: Buffer) => { log += d.toString(); });
 


### PR DESCRIPTION
Main is red on shard 2 at `smoke:suite-ambient-env`, and #898 caused it. This is the repair.

## What broke

The rejection arm #898 added spawns the web child with an unfiltered spread:

```ts
env: { ...process.env, COTAL_WEB_SMOKE_REJECT_HISTORY: "1" }
```

`smoke:suite-ambient-env` exists to refuse exactly that, and it named the file on main at
`a268c8dbe` (run 32977375051, shard 2, job 98205295502):

```
AssertionError [ERR_ASSERTION]: these suite files spread the ambient environment into a child
without stripping COTAL_ first:
  implementations/web/smoke/bounded-aggregation.smoke.ts
```

The census's own wording is the reason it matters: whatever runs a suite may be a managed agent
session, so the spread hands the child a live credential and a live broker URL, and the child talks
to the operator's mesh instead of the suite's throwaway one.

## The fix

Strip `COTAL_` from the copy before the spread, using the idiom the compliant suites already use
(`attach-auth-root.smoke.ts:107`, `control-transport-dial.smoke.ts:51`,
`discovery-bundle-consumable.smoke.ts:89`), then set the one flag the arm needs. Not added to
`REVIEWED` and not to `FROZEN` — the census is explicit that `FROZEN` is a baseline rather than a
place for new entries, and this child genuinely should not inherit connection material.

## Verification

- `smoke:suite-ambient-env`: **PASS**, with the file now listed under `strips COTAL_ before the
  spread` rather than in the assertion.
- `smoke:web-bounded-aggregation`: **43 passed, 0 failed** — the same count as before the change, so
  no cell was lost and #898's rejection cells still hold.

## Why it got through

Worth recording rather than just fixing, because this is the second time the same census has caught
the same class from the same direction. #454 did it with `console-auth.smoke.ts`; this is
`bounded-aggregation.smoke.ts`. Both times a web smoke gained a child-spawning arm, and both times
the review checked the sibling web suites and not the census that governs child spawning. The
sibling suites cannot catch it — only `smoke:suite-ambient-env` can, and it lives on a different
shard.

The durable form: **a change that gives any suite a new child process must run
`smoke:suite-ambient-env` before merge**, regardless of what else passes.
