### PR TITLE
fix(ci): reject duplicate package keys

### DIFF
--- a/bin/smoke/gate-inventory.smoke.ts
+++ b/bin/smoke/gate-inventory.smoke.ts
@@ -21,6 +21,7 @@
 import { readFileSync, readdirSync, existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import ts from "typescript";
 // @ts-expect-error - plain .mjs helper, shared with bin/smoke/shard.mjs so the chain has one parser.
 import { readCiSuites, ciChainBody } from "./ci-suites.mjs";
 
@@ -144,7 +145,37 @@ const CITED_IN_PLAN = new Set([
   "smoke:user-spawn:live", "smoke:web-seed:live",
 ]);
 
-const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8")) as { scripts: Record<string, string> };
+const packagePath = join(ROOT, "package.json");
+const packageText = readFileSync(packagePath, "utf8");
+const packageSource = ts.parseJsonText(packagePath, packageText);
+
+/** JSON.parse silently keeps the final value of a duplicate object key. Walk TypeScript's JSON AST,
+ *  which preserves every property, so a duplicate script cannot hide behind the same parsed map the
+ *  inventory is auditing. Recurse through every object: the invariant belongs to the manifest, not
+ *  only today's `scripts` shape. */
+function duplicateObjectKeys(node: ts.Node, path = "$"): string[] {
+  if (ts.isArrayLiteralExpression(node))
+    return node.elements.flatMap((element, index) => duplicateObjectKeys(element, `${path}[${index}]`));
+  if (!ts.isObjectLiteralExpression(node)) return [];
+  const seen = new Set<string>();
+  const duplicates: string[] = [];
+  for (const property of node.properties) {
+    if (!ts.isPropertyAssignment(property)) continue;
+    const name =
+      ts.isStringLiteral(property.name) || ts.isNumericLiteral(property.name)
+        ? property.name.text
+        : property.name.getText(packageSource);
+    const next = `${path}.${name}`;
+    if (seen.has(name)) duplicates.push(next);
+    else seen.add(name);
+    duplicates.push(...duplicateObjectKeys(property.initializer, next));
+  }
+  return duplicates;
+}
+
+const rootExpression = (packageSource.statements[0] as ts.ExpressionStatement | undefined)?.expression;
+const duplicatePackageKeys = rootExpression ? duplicateObjectKeys(rootExpression) : [];
+const pkg = JSON.parse(packageText) as { scripts: Record<string, string> };
 // THE AUDITED SET INCLUDES THE BARE `smoke` SCRIPT. An earlier version filtered on `smoke:` and so
 // could not see `"smoke": "tsx packages/core/smoke.ts"` — a real suite that nothing runs, invisible
 // to the audit BY CONSTRUCTION. Found by a second, independent derivation, not by this file.
@@ -201,6 +232,15 @@ const staleAllowlist = Object.keys(UNGATED).filter((s) => !all.has(s) || reached
 
 let fail = 0;
 console.log(`gate inventory: ${all.size} smoke scripts, ${all.size - ungated.length} reached, ${ungated.length} not run by anything\n`);
+
+if (duplicatePackageKeys.length) {
+  fail++;
+  console.log(`  ✗ FAIL: root package JSON has ${duplicatePackageKeys.length} duplicate object key(s):`);
+  for (const key of duplicatePackageKeys) console.log(`      ${key}`);
+  console.log(`    JSON.parse keeps only the last value, so every downstream inventory sees a false unique map.`);
+} else {
+  console.log(`  ✓ root package JSON has no duplicate object keys`);
+}
 
 if (unexplained.length) {
   fail++;

--- a/bin/smoke/mutations/package-json-duplicate-keys.json
+++ b/bin/smoke/mutations/package-json-duplicate-keys.json
@@ -1,0 +1,22 @@
+{
+  "suite": "bin/smoke/gate-inventory.smoke.ts",
+  "guard": "the root package manifest contains no duplicate object keys, because JSON.parse silently hides every copy except the last",
+  "command": "pnpm smoke:gate-inventory",
+  "completionMarker": "GATE INVENTORY",
+  "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/package-json-duplicate-keys.json",
+  "why": [
+    "Every esbuild invocation warned that smoke:jcode-retry-policy appeared twice in package.json,",
+    "but the gate inventory parsed the manifest with JSON.parse and therefore saw a unique map: the",
+    "same instrument erased the defect before auditing it. TypeScript's JSON AST preserves every",
+    "property, so the gated inventory can now fail on the source manifest rather than its lossy map."
+  ],
+  "mutations": [
+    {
+      "name": "D1 restore the duplicate JCode retry-policy script",
+      "file": "package.json",
+      "find": "    \"smoke:jcode-provider-disconnect\": \"tsx extensions/connector-jcode/smoke/jcode-provider-disconnect.smoke.ts\",\n    \"smoke:jcode-live\": \"tsx extensions/connector-jcode/smoke/jcode-live.smoke.ts\",",
+      "replace": "    \"smoke:jcode-provider-disconnect\": \"tsx extensions/connector-jcode/smoke/jcode-provider-disconnect.smoke.ts\",\n    \"smoke:jcode-retry-policy\": \"tsx extensions/connector-jcode/smoke/retry-policy.smoke.ts\",\n    \"smoke:jcode-live\": \"tsx extensions/connector-jcode/smoke/jcode-live.smoke.ts\",",
+      "expectRed": "root package JSON has 1 duplicate object key(s)"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "smoke:jcode-lifecycle": "tsx extensions/connector-jcode/smoke/jcode-lifecycle.smoke.ts",
     "smoke:jcode-private-lifecycle": "tsx extensions/connector-jcode/smoke/private-lifecycle.smoke.ts",
     "smoke:jcode-provider-disconnect": "tsx extensions/connector-jcode/smoke/jcode-provider-disconnect.smoke.ts",
-    "smoke:jcode-retry-policy": "tsx extensions/connector-jcode/smoke/retry-policy.smoke.ts",
     "smoke:jcode-live": "tsx extensions/connector-jcode/smoke/jcode-live.smoke.ts",
     "smoke:view": "tsx implementations/cli/smoke/view.smoke.ts",
     "smoke:members": "tsx packages/core/smoke/members.smoke.ts",


### PR DESCRIPTION
## Summary

- detect duplicate object keys in the root package manifest before `JSON.parse` erases them
- remove the duplicate `smoke:jcode-retry-policy` script entry
- add a mutation ledger that restores the duplicate and requires the named inventory failure

## Verification

- `pnpm smoke:gate-inventory`
- `pnpm typecheck`
- `node scripts/mutation-proof.mjs --config bin/smoke/mutations/package-json-duplicate-keys.json` — 1/1 mutation killed
