### PR TITLE
test(ci): gate the repaired channels smoke

### DIFF
--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -559,3 +559,7 @@ smoke:hook-relay-startup
 # the infrastructure credential's exact subset is gated independently from the live restore cycle.
 # Appended so existing shard membership stays stable.
 smoke:isolated-infrastructure-scope
+# Channel registry/replay now uses OS-assigned ports, polls positive readiness, and awaits broker
+# teardown. Four concurrent real-broker runs pass without port collision or stale state; append to
+# preserve every existing shard assignment.
+smoke:channels

--- a/bin/smoke/gate-inventory.smoke.ts
+++ b/bin/smoke/gate-inventory.smoke.ts
@@ -78,9 +78,8 @@ const UNGATED: Record<string, string> = {
   // it shows up in production; and it shares no assumption with the redactor, which itself encodes
   // a belief about which fields matter and could be wrong in the same direction as the mapper.
   "smoke:agui-map:real": "names an operator's own uncommittable session JSONL (COTAL_AGUI_SESSION); the fixture arm is gated as smoke:agui-map",
-  // Known-red or documented flakes: debt with a fuse, counted as such. Gating them would make the
-  // gate lie; leaving them unmarked made the list unable to say how much debt it held.
-  "smoke:channels": `${BROKEN} documented timing flake + fixed-port cleanup leak`,
+  // Known-red suites: debt with a fuse, counted as such. Gating them would make the gate lie;
+  // leaving them unmarked made the list unable to say how much debt it held.
   // EXPECTED RED BY DESIGN. It reproduces an OPEN defect (renewManagedStaticCred reads the
   // terminal latch at entry, then does four awaits before two writes that retirement cleanup has
   // already deleted, leaving a valid credential and an `active` durable row for a retired


### PR DESCRIPTION
## Summary

- remove the stale BROKEN exemption for `smoke:channels`
- append the repaired suite to the smoke CI chain without changing existing shard assignments

## Verification

- `pnpm smoke:channels` — 29/29
- five additional sequential passes
- four concurrent real-broker passes
- `pnpm smoke:gate-inventory` — 461 scripts, 427 reached, 391 gated, one BROKEN suite remains
- `pnpm --filter @cotal-ai/core typecheck`
