### PR TITLE
fix(manager): serialize renewal with terminalization

### DIFF
--- a/.changeset/serialize-static-renewal-terminal.md
+++ b/.changeset/serialize-static-renewal-terminal.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/manager": patch
+---
+
+Serialize managed-static credential renewal with lifecycle terminalization so an accepted renewal is drained before revocation and cleanup, while renewals arriving after the terminal latch are refused.

--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -563,3 +563,8 @@ smoke:isolated-infrastructure-scope
 # teardown. Four concurrent real-broker runs pass without port collision or stale state; append to
 # preserve every existing shard assignment.
 smoke:channels
+# A managed-static renewal accepted before terminalization publishes an in-flight barrier; the
+# terminal drains it before durable revocation and file cleanup, while arrivals after the latch are
+# refused. Four fresh lifecycles drive both orderings against a real JWT broker and journal.
+# Appended to preserve every existing shard assignment.
+smoke:renewal-terminal-race

--- a/bin/smoke/gate-inventory.smoke.ts
+++ b/bin/smoke/gate-inventory.smoke.ts
@@ -78,19 +78,6 @@ const UNGATED: Record<string, string> = {
   // it shows up in production; and it shares no assumption with the redactor, which itself encodes
   // a belief about which fields matter and could be wrong in the same direction as the mapper.
   "smoke:agui-map:real": "names an operator's own uncommittable session JSONL (COTAL_AGUI_SESSION); the fixture arm is gated as smoke:agui-map",
-  // Known-red suites: debt with a fuse, counted as such. Gating them would make the gate lie;
-  // leaving them unmarked made the list unable to say how much debt it held.
-  // EXPECTED RED BY DESIGN. It reproduces an OPEN defect (renewManagedStaticCred reads the
-  // terminal latch at entry, then does four awaits before two writes that retirement cleanup has
-  // already deleted, leaving a valid credential and an `active` durable row for a retired
-  // lifecycle). Gating a known red is how a chain teaches its readers to skim reds, which is the
-  // most expensive habit a gate can pick up.
-  //
-  // Originally written up as "a decision rather than debt", and it is marked BROKEN anyway. The
-  // decision is about not gating it TODAY; the entry still ends when the product defect is fixed,
-  // and its own reason says so. That is a fuse, and a fuse nobody counts is how the entry above it
-  // lasted six weeks. Being red for a good reason is still being red.
-  "smoke:renewal-terminal-race": `${BROKEN} reproduction of an open defect; gate when the fix lands`,
   // Full-stack live suites: boot a real broker + install tree, too slow/stateful for the PR gate.
   "smoke:manager-singleton:live": "full live stack", "smoke:seed-tarball:live": "packs a tarball",
   // `smoke:user-spawn:live` left this list when it was gated: it had thrown at section B1e on a

--- a/implementations/manager/smoke/mutations/renewal-terminal-serialization.json
+++ b/implementations/manager/smoke/mutations/renewal-terminal-serialization.json
@@ -1,0 +1,38 @@
+{
+  "suite": "implementations/manager/smoke/renewal-terminal-race.smoke.ts",
+  "guard": "a managed-static credential renewal accepted before terminalization is drained before the terminal revokes and cleans its family, while a later renewal is refused by the synchronous latch",
+  "command": "pnpm smoke:renewal-terminal-race",
+  "completionMarker": "RENEWAL-TERMINAL RACE SMOKE",
+  "proveWith": "pnpm mutation-proof --config implementations/manager/smoke/mutations/renewal-terminal-serialization.json",
+  "why": [
+    "The fixture uses four fresh aliases against a real JWT broker, the shipped manager, and the durable lifecycle journal. A SecretStore collaborator pauses the renewal after its row is appended but before materialization; despawn then latches terminalization, so the terminal must drain the accepted flight before it enumerates, revokes, and cleans.",
+    "",
+    "The independent late call occurs after the same synchronous terminal latch. It must be refused rather than join the accepted flight. Final cells enumerate the journal's own credential family and the real credential file, so a completed terminal with an active row or recreated material is red."
+  ],
+  "mutations": [
+    {
+      "name": "retirement no longer drains the renewal accepted before its latch",
+      "file": "implementations/manager/src/manager.ts",
+      "find": "    const acceptedRenewal = a.staticCredentialRenewal;\n    if (acceptedRenewal) await acceptedRenewal.catch(() => {});",
+      "replace": "    void a.staticCredentialRenewal;",
+      "expectRed": "the durable terminal does not pass an accepted renewal still in flight",
+      "cell": "the durable terminal does not pass an accepted renewal still in flight"
+    },
+    {
+      "name": "the accepted renewal is not published for terminalization to drain",
+      "file": "implementations/manager/src/manager.ts",
+      "find": "    a.staticCredentialRenewal = renewal;\n    return renewal;",
+      "replace": "    return renewal;",
+      "expectRed": "renewal publishes its accepted flight before returning",
+      "cell": "renewal publishes its accepted flight before returning"
+    },
+    {
+      "name": "a post-latch renewal joins the older accepted flight instead of refusing",
+      "file": "implementations/manager/src/manager.ts",
+      "find": "    if (a.terminalizing) throw new Error(\"renewManagedStaticCred: the lifecycle is terminalizing; no credential is minted after the terminal begins\");\n    if (a.staticCredentialRenewal) return a.staticCredentialRenewal;",
+      "replace": "    if (a.staticCredentialRenewal) return a.staticCredentialRenewal;\n    if (a.terminalizing) throw new Error(\"renewManagedStaticCred: the lifecycle is terminalizing; no credential is minted after the terminal begins\");",
+      "expectRed": "a renewal arriving after the terminal latch is refused",
+      "cell": "a renewal arriving after the terminal latch is refused"
+    }
+  ]
+}

--- a/implementations/manager/smoke/mutations/renewal-terminal-serialization.json
+++ b/implementations/manager/smoke/mutations/renewal-terminal-serialization.json
@@ -5,9 +5,9 @@
   "completionMarker": "RENEWAL-TERMINAL RACE SMOKE",
   "proveWith": "pnpm mutation-proof --config implementations/manager/smoke/mutations/renewal-terminal-serialization.json",
   "why": [
-    "The fixture uses four fresh aliases against a real JWT broker, the shipped manager, and the durable lifecycle journal. A SecretStore collaborator pauses the renewal after its row is appended but before materialization; despawn then latches terminalization, so the terminal must drain the accepted flight before it enumerates, revokes, and cleans.",
+    "The fixture uses a direct-renew/despawn lifecycle and a production-sweep/natural-exit lifecycle against a real JWT broker. An in-memory SecretStore collaborator pauses each renewal after a distinct credential id and active row are durably recorded but before materialization.",
     "",
-    "The independent late call occurs after the same synchronous terminal latch. It must be refused rather than join the accepted flight. Final cells enumerate the journal's own credential family and the real credential file, so a completed terminal with an active row or recreated material is red."
+    "The terminal must stay behind that accepted flight. After release, the smoke waits for the original hold to clear without re-driving it, then independently proves slot, gate, head, the renewal row, every row state, hosted-store deletion, and local-file deletion."
   ],
   "mutations": [
     {
@@ -59,10 +59,42 @@
       "cell": "no credential row remains active after retirement"
     },
     {
-      "name": "static retirement leaves the managed credential material in its secret store and file",
+      "name": "natural process exit no longer closes the terminal latch in freeSlot",
+      "file": "implementations/manager/src/manager.ts",
+      "find": "    a.terminalizing = true; // F5 latch (Unit B): also covers exit/reap paths that never rode stopHandle",
+      "replace": "    void a.terminalizing;",
+      "expectRed": "racer_exit: the terminal latch closes synchronously",
+      "cell": "racer_exit: the terminal latch closes synchronously"
+    },
+    {
+      "name": "renewal no longer records its credential id or active ledger row",
+      "file": "implementations/manager/src/manager.ts",
+      "find": "    await this.withLifecycleExecutor({ owner: DEV_OWNER, actor: a.id, lifecycleUid: a.lifecycleUid, alias: a.name }, async (t) => {\n      await recordSlotCredential(t, DEV_OWNER, a.name, a.lifecycleUid, credentialId);\n      await appendStaticCredentialRow(t, { lifecycleUid: a.lifecycleUid, credentialId, holderPrincipal: principalKey(DEV_OWNER, a.id).key, exp });\n    });",
+      "replace": "    void credentialId;",
+      "expectRed": "renewal records exactly one new credential id",
+      "cell": "renewal records exactly one new credential id"
+    },
+    {
+      "name": "the production renewal sweep no longer enters managed-static renewal",
+      "file": "implementations/manager/src/manager.ts",
+      "find": "            await this.renewManagedStaticCred(a);",
+      "replace": "            void a;",
+      "expectRed": "racer_exit: renewal records exactly one new credential id",
+      "cell": "racer_exit: renewal records exactly one new credential id"
+    },
+    {
+      "name": "static retirement leaves the hosted secret-store credential key intact",
       "file": "implementations/manager/src/manager.ts",
       "find": "    const cleanup = async (): Promise<void> => {\n      const secrets = this.secrets;\n      const files = a.secretPaths ?? agentLifecycleSecretFilePaths(this.workspaceRoot, a.name, a.lifecycleUid);\n      if (files.creds) {\n        await secrets.delete(agentSecretKeyForFile(files.creds));\n        rmSync(files.creds, { force: true });\n      }\n      await this.deprovisionBroker(a);\n    };",
-      "replace": "    const cleanup = async (): Promise<void> => {\n      await this.deprovisionBroker(a);\n    };",
+      "replace": "    const cleanup = async (): Promise<void> => {\n      const files = a.secretPaths ?? agentLifecycleSecretFilePaths(this.workspaceRoot, a.name, a.lifecycleUid);\n      if (files.creds) rmSync(files.creds, { force: true });\n      await this.deprovisionBroker(a);\n    };",
+      "expectRed": "the secret-store credential key is deleted",
+      "cell": "the secret-store credential key is deleted"
+    },
+    {
+      "name": "static retirement leaves the local credential materialization intact",
+      "file": "implementations/manager/src/manager.ts",
+      "find": "    const cleanup = async (): Promise<void> => {\n      const secrets = this.secrets;\n      const files = a.secretPaths ?? agentLifecycleSecretFilePaths(this.workspaceRoot, a.name, a.lifecycleUid);\n      if (files.creds) {\n        await secrets.delete(agentSecretKeyForFile(files.creds));\n        rmSync(files.creds, { force: true });\n      }\n      await this.deprovisionBroker(a);\n    };",
+      "replace": "    const cleanup = async (): Promise<void> => {\n      const secrets = this.secrets;\n      const files = a.secretPaths ?? agentLifecycleSecretFilePaths(this.workspaceRoot, a.name, a.lifecycleUid);\n      if (files.creds) await secrets.delete(agentSecretKeyForFile(files.creds));\n      await this.deprovisionBroker(a);\n    };",
       "expectRed": "no credential file remains after retirement",
       "cell": "no credential file remains after retirement"
     }

--- a/implementations/manager/smoke/mutations/renewal-terminal-serialization.json
+++ b/implementations/manager/smoke/mutations/renewal-terminal-serialization.json
@@ -23,8 +23,8 @@
       "file": "implementations/manager/src/manager.ts",
       "find": "    a.staticCredentialRenewal = renewal;\n    return renewal;",
       "replace": "    return renewal;",
-      "expectRed": "renewal publishes its accepted flight before returning",
-      "cell": "renewal publishes its accepted flight before returning"
+      "expectRed": "renewal publishes its accepted flight",
+      "cell": "renewal publishes its accepted flight"
     },
     {
       "name": "a post-latch renewal joins the older accepted flight instead of refusing",

--- a/implementations/manager/smoke/mutations/renewal-terminal-serialization.json
+++ b/implementations/manager/smoke/mutations/renewal-terminal-serialization.json
@@ -33,6 +33,38 @@
       "replace": "    if (a.staticCredentialRenewal) return a.staticCredentialRenewal;\n    if (a.terminalizing) throw new Error(\"renewManagedStaticCred: the lifecycle is terminalizing; no credential is minted after the terminal begins\");",
       "expectRed": "a renewal arriving after the terminal latch is refused",
       "cell": "a renewal arriving after the terminal latch is refused"
+    },
+    {
+      "name": "a settled renewal keeps occupying the per-agent single-flight slot forever",
+      "file": "implementations/manager/src/manager.ts",
+      "find": "      if (a.staticCredentialRenewal === renewal) a.staticCredentialRenewal = undefined;",
+      "replace": "      void a.staticCredentialRenewal;",
+      "expectRed": "a settled renewal releases its single-flight slot",
+      "cell": "a settled renewal releases its single-flight slot"
+    },
+    {
+      "name": "the synchronous terminal admission check is deleted",
+      "file": "implementations/manager/src/manager.ts",
+      "find": "    if (a.terminalizing) throw new Error(\"renewManagedStaticCred: the lifecycle is terminalizing; no credential is minted after the terminal begins\");",
+      "replace": "    void a.terminalizing;",
+      "expectRed": "a renewal arriving after the terminal latch is refused",
+      "cell": "a renewal arriving after the terminal latch is refused"
+    },
+    {
+      "name": "the active static terminal no longer revokes its recorded credential rows",
+      "file": "implementations/manager/src/static-lifecycle.ts",
+      "find": "  if (headNow.mapping.state !== \"retired\")\n    await headBeginRetirement(t, { owner: args.owner, actor: args.actor, lifecycleUid: args.lifecycleUid, opId: args.opId });\n  await revokeStaticCredentialRows(t, args.lifecycleUid, slot.row.credentialIds, hooks.log);\n  await hooks.cleanup();",
+      "replace": "  if (headNow.mapping.state !== \"retired\")\n    await headBeginRetirement(t, { owner: args.owner, actor: args.actor, lifecycleUid: args.lifecycleUid, opId: args.opId });\n  await hooks.cleanup();",
+      "expectRed": "no credential row remains active after retirement",
+      "cell": "no credential row remains active after retirement"
+    },
+    {
+      "name": "static retirement leaves the managed credential material in its secret store and file",
+      "file": "implementations/manager/src/manager.ts",
+      "find": "    const cleanup = async (): Promise<void> => {\n      const secrets = this.secrets;\n      const files = a.secretPaths ?? agentLifecycleSecretFilePaths(this.workspaceRoot, a.name, a.lifecycleUid);\n      if (files.creds) {\n        await secrets.delete(agentSecretKeyForFile(files.creds));\n        rmSync(files.creds, { force: true });\n      }\n      await this.deprovisionBroker(a);\n    };",
+      "replace": "    const cleanup = async (): Promise<void> => {\n      await this.deprovisionBroker(a);\n    };",
+      "expectRed": "no credential file remains after retirement",
+      "cell": "no credential file remains after retirement"
     }
   ]
 }

--- a/implementations/manager/smoke/renewal-terminal-race.smoke.ts
+++ b/implementations/manager/smoke/renewal-terminal-race.smoke.ts
@@ -1,96 +1,130 @@
 /**
- * RENEWAL-vs-TERMINAL RACE probe (control-surface v0.4, arbiter-recorded residual).
- * Run: pnpm smoke:renewal-terminal-race   (needs nats-server on PATH; boots its own broker)
+ * A renewal admitted before terminalization is drained before the static terminal revokes its
+ * credential family and deletes its material. A renewal arriving after the synchronous latch is
+ * refused. The test drives both orderings through the real manager, lifecycle journal, filesystem
+ * secret store, and JWT broker.
  *
- * THIS IS A REPRODUCTION, NOT A REGRESSION TEST YET. It is deliberately NOT in `smoke:ci`: it is
- * expected to FAIL while the defect stands, and it becomes the regression test once a fix lands.
- *
- * READ THIS BEFORE DESIGNING THE FIX. The shape resembles the session-capacity race (B1) and the
- * remedy is NOT the same. B1 took a RESERVATION because the correct outcome there was "admit exactly
- * N". Here the correct outcome is "NO CREDENTIAL" — so a reservation is wrong, and a retry is wrong,
- * because the right answer is not "a credential minted later". The shape is to make the writes
- * conditional on the same latch read the teardown orders against, so both cannot win.
- *
- * THE DEFECT. `renewManagedStaticCred` reads the terminal latch at ENTRY and then performs four
- * awaits before its writes:
- *
- *     if (a.terminalizing) throw …          <- the check
- *     await mintCreds(…)                     <- yield 1
- *     await withLifecycleExecutor(… recordSlotCredential, appendStaticCredentialRow …)   <- yield 2, DURABLE ROW
- *     await secrets.put(agentSecretKeyForFile(creds))                                     <- yield 3, WRITE 1
- *     await materializeSecretToFile(…, creds)                                             <- yield 4, WRITE 2
- *
- * The retirement cleanup deletes exactly those two artifacts, by the same key and the same path. So a
- * despawn landing inside that window latches `terminalizing`, cleanup deletes the credential, and an
- * in-flight renewal re-creates it afterwards — for a lifecycle whose terminal has begun.
- *
- * TWO GUARDS AT THE SAME POSITION ARE ONE GUARD: the renewal sweep filter also reads `terminalizing`,
- * and it also sits before the same four awaits. A reviewer counting guards finds two and stops.
- *
- * WHY THE DURABLE ROW IS THE ASSERTION AND THE FILE IS NOT. A stale file on disk is recoverable by
- * re-running cleanup. A static-credential ROW for a retired lifecycle is a claim IN THE JOURNAL that
- * the credential is legitimate, and the journal is the authority. The row is also a deterministic KV
- * read, where catching the file before cleanup is timing-dependent — so the probe asserts on the
- * artifact rather than on the interleaving.
- *
- * TWO THINGS A FIXER NEEDS, AND THEY DO NOT CANCEL EACH OTHER.
- *
- *  1. THE WINDOW IS WIDE ONCE ENTERED. It reproduced on the FIRST attempt that reached the race,
- *     with no help — no injected clock, no fake timers, no patched interleaving.
- *  2. HOW OFTEN PRODUCTION ENTERS IT IS UNMEASURED. This probe calls `renewManagedStaticCred`
- *     DIRECTLY. Production reaches it only through the renewal sweep, which filters on
- *     `health.state === "healthy"` and near-expiry (manager.ts ~:939/:944) — a gate this probe
- *     bypasses entirely. So the run says nothing about the RATE at which production arrives at the
- *     window, and "rare" is not established either way. Both halves belong in any prioritisation:
- *     overstating a hole misallocates attention exactly as reassuring copy does.
- *
- * THE DEFECT BLOCKS ITS OWN RE-TEST, so a rate cannot be read off repeated attempts here. After the
- * first hit, every later attempt is refused at spawn — "the name is reserved pending retirement" —
- * because the alias frees only when teardown completes, and the defect is that teardown does not
- * complete. TO MEASURE A RATE, USE A FRESH ALIAS PER ATTEMPT. Reporting hits-over-attempts from this
- * file as written would be a number that is not a count.
- *
- * CONCURRENCY IS STRUCTURAL, NOT AN UNLUCKY SCHEDULE: renewal is reached from a `setInterval` sweep
- * and despawn is caller-triggered from the ep door, so every `await` above is a yield point a
- * despawn can be scheduled into. This probe drives the same window directly rather than waiting for
- * the timer, and reports HITS OUT OF ATTEMPTS rather than a boolean — the window's width is the
- * thing a fixer needs, and one hit is enough to establish reachability.
+ * Run: pnpm smoke:renewal-terminal-race
  */
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { connect } from "@nats-io/transport-node";
+import { connect, type NatsConnection } from "@nats-io/transport-node";
 import { Kvm } from "@nats-io/kv";
 import {
-  createSpaceAuth, mintCreds, newIdentity, standaloneConnectOpts, registry, DEV_OWNER,
-  setupSpaceStreams, recordsBucket, epAuthBucket, parseLedgerRow, credRowKey,
+  createSpaceAuth, gateObserve, headCandidate, mintCreds, newIdentity, standaloneConnectOpts,
+  registry, DEV_OWNER, setupSpaceStreams, recordsBucket, epAuthBucket, parseLedgerRow, credRowKey,
   type AgentHandle, type Connector, type LaunchSpec, type Presence, type CredentialLedgerRow,
+  type LifecycleStateTransport, type SecretStore,
 } from "@cotal-ai/core";
-import {
-  staticLifecycleTransport, readStaticSlot,
-} from "../src/static-lifecycle.js";
-import { authDir, saveSpaceAuth } from "@cotal-ai/workspace";
+import { authDir, saveSpaceAuth, workspaceSecretStore } from "@cotal-ai/workspace";
+import { staticLifecycleTransport, readStaticSlot } from "../src/static-lifecycle.js";
 import { Manager } from "../src/manager.js";
 import { bootBroker } from "./_boot-broker.js";
 
-const ATTEMPTS = 12;
-let hitsRow = 0, hitsFile = 0, refused = 0, completed = 0;
+const ATTEMPTS = 4;
+const SCENARIO_CELLS = ATTEMPTS * 17;
+let pass = 0;
+let fail = 0;
+
+function check(label: string, ok: boolean, detail?: unknown): void {
+  if (ok) {
+    pass++;
+    console.log(`  ✓ ${label}`);
+  } else {
+    fail++;
+    console.error(`  ✗ ${label}${detail === undefined ? "" : ` — ${JSON.stringify(detail)}`}`);
+  }
+}
+
+async function until(predicate: () => boolean, timeoutMs = 5_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  return predicate();
+}
+
+async function untilAsync(predicate: () => Promise<boolean>, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  return predicate();
+}
+
+async function bounded<T>(promise: Promise<T>, timeoutMs: number): Promise<T | undefined> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<undefined>((resolve) => { timer = setTimeout(() => resolve(undefined), timeoutMs); }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+class PausingSecretStore implements SecretStore {
+  private pause?: {
+    reached: (key: string) => void;
+    release: Promise<void>;
+  };
+
+  constructor(private readonly base: SecretStore) {}
+
+  armNextPut(): { reached: Promise<string>; release: () => void } {
+    if (this.pause) throw new Error("a secret-store put is already paused");
+    let reached!: (key: string) => void;
+    let release!: () => void;
+    const reachedPromise = new Promise<string>((resolve) => { reached = resolve; });
+    const releasePromise = new Promise<void>((resolve) => { release = resolve; });
+    this.pause = { reached, release: releasePromise };
+    return {
+      reached: reachedPromise,
+      release: () => {
+        release();
+        this.pause = undefined;
+      },
+    };
+  }
+
+  get(key: string): Promise<string | undefined> {
+    return this.base.get(key);
+  }
+
+  async put(key: string, value: string): Promise<void> {
+    const pause = this.pause;
+    if (pause) {
+      pause.reached(key);
+      await pause.release;
+    }
+    await this.base.put(key, value);
+  }
+
+  delete(key: string): Promise<void> {
+    return this.base.delete(key);
+  }
+}
 
 const space = `renewal-race-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
-const { servers: SERVERS, stop: stopBroker } = await bootBroker(auth);
+const { servers, stop: stopBroker } = await bootBroker(auth);
 const workspaceRoot = mkdtempSync(join(tmpdir(), "cotal-renewal-race-"));
+const secrets = new PausingSecretStore(workspaceSecretStore(workspaceRoot));
+const aliases = Array.from({ length: ATTEMPTS }, (_, i) => `racer_${i + 1}`);
 mkdirSync(join(workspaceRoot, ".cotal", "agents"), { recursive: true });
-writeFileSync(
-  join(workspaceRoot, ".cotal", "agents", "racer.md"),
-  `---\nname: racer\nrole: worker\nsubscribe: [general]\nallowSubscribe: [general]\nallowPublish: [general]\n---\nbody\n`,
-);
+for (const name of aliases)
+  writeFileSync(
+    join(workspaceRoot, ".cotal", "agents", `${name}.md`),
+    `---\nname: ${name}\nrole: worker\nsubscribe: [general]\nallowSubscribe: [general]\nallowPublish: [general]\n---\nbody\n`,
+  );
 
-// `mgr.start()` reads the space auth from the workspace authDir — session-cap (the other suite that
-// calls start()) does this; static-lifecycle does not need it because it drives startAgent directly.
 saveSpaceAuth(authDir(workspaceRoot), auth);
-const mgr = new Manager({ space, servers: SERVERS, runtime: "pty", workspaceRoot });
+const mgr = new Manager({ space, servers, runtime: "pty", workspaceRoot, secretStore: secrets });
 (mgr as unknown as { auth: unknown }).auth = auth;
 const fakeSession = { cols: 80, rows: 24, backlog: () => Buffer.alloc(0), onData: () => () => {}, onExit: () => () => {}, write: () => {}, resize: () => {} };
 const fakeHandle = (name: string): AgentHandle => ({ name, kind: "fake", status: () => "running", stop: () => {}, interrupt: () => {}, attach: () => fakeSession });
@@ -101,76 +135,117 @@ const fakeHandle = (name: string): AgentHandle => ({ name, kind: "fake", status:
 };
 registry.register({ kind: "connector", name: "smoke-race", requires: ["node"], buildLaunch: () => ({ command: "true", args: [], env: {} }) } as Connector);
 
-type Agent = { id: string; name: string; lifecycleUid: string; terminalizing?: boolean; secretPaths?: { creds?: string } };
+type Agent = {
+  id: string;
+  name: string;
+  lifecycleUid: string;
+  terminalizing?: boolean;
+  staticCredentialRenewal?: Promise<void>;
+  secretPaths?: { creds?: string };
+};
+type RetirementHold = { lifecycleUid: string; lastError?: string };
 const M = mgr as unknown as {
   agents: Map<string, Agent>;
+  retiring: Map<string, RetirementHold>;
   renewManagedStaticCred(a: Agent): Promise<void>;
-  despawnAuthorized(a: Agent, graceful: boolean, wait: boolean): { ok: boolean };
+  despawnAuthorized(a: Agent, graceful: boolean, trackNonAdmin: boolean): { ok: boolean };
 };
 
-/** The journal's own view: every credential row the slot names, for one lifecycle. */
-async function credRowsFor(alias: string, actor: string, uid: string): Promise<CredentialLedgerRow[]> {
-  const creds = await mintCreds(auth, newIdentity(), "lifecycle-executor", { lifecycleExecutor: { owner: DEV_OWNER, actor, lifecycleUid: uid, alias } });
-  const nc = await connect({ servers: SERVERS, ...standaloneConnectOpts({ creds, tls: false }), maxReconnectAttempts: 0 });
-  try {
-    const kvm = new Kvm(nc);
-    const t = staticLifecycleTransport(await kvm.open(recordsBucket(space)), await kvm.open(epAuthBucket(space)));
-    const slot = await readStaticSlot(t, DEV_OWNER, alias);
-    const rows: CredentialLedgerRow[] = [];
-    for (const id of slot?.row.credentialIds ?? []) {
-      const e = await t.getAuth(credRowKey(uid, id));
-      if (e !== undefined) rows.push(parseLedgerRow(e.value, credRowKey(uid, id)));
-    }
-    return rows;
-  } finally {
-    await nc.drain().catch(() => nc.close());
-  }
+async function openLifecycleView(alias: string, actor: string, uid: string): Promise<{
+  nc: NatsConnection;
+  transport: LifecycleStateTransport;
+}> {
+  const creds = await mintCreds(auth, newIdentity(), "lifecycle-executor", {
+    lifecycleExecutor: { owner: DEV_OWNER, actor, lifecycleUid: uid, alias },
+  });
+  const nc = await connect({ servers, ...standaloneConnectOpts({ creds, tls: false }), maxReconnectAttempts: 0 });
+  const kvm = new Kvm(nc);
+  return {
+    nc,
+    transport: staticLifecycleTransport(await kvm.open(recordsBucket(space)), await kvm.open(epAuthBucket(space))),
+  };
 }
 
 try {
-  // The space streams the manager's own connection authorizes against. Omitting this is an
-  // Authorization Violation at `mgr.start()`, not a defect in anything under test.
-  await setupSpaceStreams({ servers: SERVERS, space, creds: await mintCreds(auth, newIdentity(), "provisioner") });
+  await setupSpaceStreams({ servers, space, creds: await mintCreds(auth, newIdentity(), "provisioner") });
   await mgr.start();
-  // The fake runtime's agent never joins the mesh, so the readiness wait would time out at 30s per
-  // spawn and every attempt would be SKIPPED — a probe that reports "not reproduced" having never
-  // reached the race. session-cap stubs this for the same reason.
   (mgr as unknown as { awaitReadiness(): Promise<{ ok: true }> }).awaitReadiness = async () => ({ ok: true });
-  console.log(`renewal-vs-terminal race probe — ${ATTEMPTS} attempts\n`);
 
-  for (let i = 0; i < ATTEMPTS; i++) {
-    const spawned = await mgr.startAgent({ name: "racer", agent: "smoke-race" });
-    if (!spawned.ok) { console.log(`  attempt ${i + 1}: spawn failed (${spawned.error}) — skipped`); continue; }
-    const a = M.agents.get("racer");
-    if (!a) { console.log(`  attempt ${i + 1}: no managed agent after spawn — skipped`); continue; }
-    const { id: actor, lifecycleUid: uid, secretPaths } = a;
-    const credsPath = secretPaths?.creds;
+  for (const name of aliases) {
+    console.log(`\n${name}: accepted renewal then terminal`);
+    const spawned = await mgr.startAgent({ name, agent: "smoke-race" });
+    check(`${name}: spawn succeeds`, spawned.ok, spawned);
+    const agent = M.agents.get(name);
+    check(`${name}: the spawned lifecycle is managed`, agent !== undefined);
+    if (!agent) throw new Error(`${name}: setup failed before the race`);
 
-    // THE RACE. Start the renewal and do NOT await it; despawn while it is between its latch read
-    // and its writes. Both are ordinary paths — no injection, no patched clock, no fake timers.
-    const renewal = M.renewManagedStaticCred(a).then(() => { completed++; return "completed" as const })
-      .catch((e) => { refused++; return `refused: ${(e as Error).message.slice(0, 60)}` as const });
-    M.despawnAuthorized(a, false, true);
-    const outcome = await renewal;
-    for (let w = 0; w < 100 && M.agents.has("racer"); w++) await new Promise((r) => setTimeout(r, 50));
+    const view = await openLifecycleView(name, agent.id, agent.lifecycleUid);
+    const pause = secrets.armNextPut();
+    try {
+      const credsPath = agent.secretPaths?.creds;
+      const accepted = M.renewManagedStaticCred(agent)
+        .then(() => "completed" as const)
+        .catch((error: Error) => `refused: ${error.message}` as const);
+      check(`${name}: renewal publishes its accepted flight before returning`, agent.staticCredentialRenewal !== undefined);
 
-    const rows = await credRowsFor("racer", actor, uid);
-    const active = rows.filter((r) => r.state === "active");
-    const fileBack = credsPath !== undefined && existsSync(credsPath);
-    if (active.length > 0) hitsRow++;
-    if (fileBack) hitsFile++;
-    console.log(`  attempt ${i + 1}: renewal ${outcome} · rows ${rows.length} (active ${active.length}) · creds file ${fileBack ? "PRESENT" : "gone"}`);
+      const pausedKey = await bounded(pause.reached, 5_000);
+      check(`${name}: renewal reaches the real secret-store put after journaling`, typeof pausedKey === "string" && pausedKey.endsWith(".creds"), pausedKey);
+
+      const stopped = M.despawnAuthorized(agent, false, true);
+      check(`${name}: despawn accepts the terminal`, stopped.ok, stopped);
+      check(`${name}: the terminal latch closes synchronously`, agent.terminalizing === true);
+      check(`${name}: terminalization registers the lifecycle hold`, M.retiring.get(name)?.lifecycleUid === agent.lifecycleUid, M.retiring.get(name));
+
+      let lateOutcome: string | undefined;
+      const late = M.renewManagedStaticCred(agent)
+        .then(() => { lateOutcome = "completed"; })
+        .catch((error: Error) => { lateOutcome = `refused: ${error.message}`; });
+      await until(() => lateOutcome !== undefined, 250);
+      check(`${name}: a renewal arriving after the terminal latch is refused`, lateOutcome?.startsWith("refused: renewManagedStaticCred: the lifecycle is terminalizing") === true, lateOutcome);
+
+      const terminalMovedWhilePaused = await untilAsync(async () => {
+        const slot = await readStaticSlot(view.transport, DEV_OWNER, name);
+        return slot?.row.phase !== "active";
+      }, 750);
+      check(`${name}: the durable terminal does not pass an accepted renewal still in flight`, !terminalMovedWhilePaused);
+
+      pause.release();
+      const acceptedOutcome = await accepted;
+      await late;
+      check(`${name}: the renewal accepted before terminalization settles before cleanup`, acceptedOutcome === "completed", acceptedOutcome);
+
+      const retired = await until(() => !M.retiring.has(name));
+      check(`${name}: retirement drains the accepted renewal and reaches its terminal`, retired, M.retiring.get(name));
+
+      const slot = await readStaticSlot(view.transport, DEV_OWNER, name);
+      const gate = await gateObserve(view.transport, agent.lifecycleUid);
+      const head = await headCandidate(view.transport, DEV_OWNER, agent.id);
+      check(`${name}: the durable slot is retired`, slot?.row.phase === "retired", slot?.row);
+      check(`${name}: the issuance gate is retired`, gate?.row.state === "retired", gate?.row);
+      check(`${name}: the lifecycle head is retired`, head?.mapping.state === "retired", head?.mapping);
+
+      const rows: CredentialLedgerRow[] = [];
+      for (const id of slot?.row.credentialIds ?? []) {
+        const entry = await view.transport.getAuth(credRowKey(agent.lifecycleUid, id));
+        if (entry !== undefined) rows.push(parseLedgerRow(entry.value, credRowKey(agent.lifecycleUid, id)));
+      }
+      check(`${name}: the journal exposes the credential family it retired`, rows.length > 0, rows);
+      check(`${name}: no credential row remains active after retirement`, rows.length > 0 && rows.every((row) => row.state === "revoked"), rows);
+      check(`${name}: no credential file remains after retirement`, credsPath !== undefined && !existsSync(credsPath), credsPath);
+    } finally {
+      pause.release();
+      await view.nc.drain().catch(() => view.nc.close());
+    }
   }
-
-  console.log(`\n── RESULT ──────────────────────────────────────────────`);
-  console.log(`  attempts                                   ${ATTEMPTS}`);
-  console.log(`  renewal REFUSED at the latch (correct)     ${refused}`);
-  console.log(`  renewal COMPLETED past the terminal        ${completed}`);
-  console.log(`  ACTIVE credential row for a retired uid    ${hitsRow}   <- the journal claims a live credential`);
-  console.log(`  credential FILE present after cleanup      ${hitsFile}`);
-  console.log(`\n  ${hitsRow > 0 ? "REPRODUCED" : "NOT reproduced in this run"} — one hit establishes reachability; zero does NOT establish absence.`);
 } finally {
   await mgr.stop().catch(() => {});
   await stopBroker();
+  rmSync(workspaceRoot, { recursive: true, force: true });
 }
-process.exit(0); // a probe reports; it does not gate
+
+check(`every scenario cell ran — ${SCENARIO_CELLS} expected`, pass + fail === SCENARIO_CELLS, { pass, fail, expected: SCENARIO_CELLS });
+if (fail) {
+  console.error(`\nRENEWAL-TERMINAL RACE SMOKE FAILED (${pass} passed, ${fail} failed)`);
+  process.exit(1);
+}
+console.log(`\nRENEWAL-TERMINAL RACE SMOKE OK ✅  (${pass} passed, 0 failed)`);

--- a/implementations/manager/smoke/renewal-terminal-race.smoke.ts
+++ b/implementations/manager/smoke/renewal-terminal-race.smoke.ts
@@ -1,8 +1,8 @@
 /**
- * A renewal admitted before terminalization is drained before the static terminal revokes its
- * credential family and deletes its material. A renewal arriving after the synchronous latch is
- * refused. The test drives both orderings through the real manager, lifecycle journal, filesystem
- * secret store, and JWT broker.
+ * Managed-static renewal and terminalization have one order: an admitted renewal drains before
+ * retirement enumerates, revokes, and cleans its credential family; a later renewal refuses. The
+ * fixture exercises both terminal entry paths (despawn and natural process exit), and reaches the
+ * renewal once directly and once through the production half-TTL sweep.
  *
  * Run: pnpm smoke:renewal-terminal-race
  */
@@ -13,18 +13,24 @@ import { join } from "node:path";
 import { connect, type NatsConnection } from "@nats-io/transport-node";
 import { Kvm } from "@nats-io/kv";
 import {
-  createSpaceAuth, gateObserve, headCandidate, mintCreds, newIdentity, standaloneConnectOpts,
-  registry, DEV_OWNER, setupSpaceStreams, recordsBucket, epAuthBucket, parseLedgerRow, credRowKey,
-  type AgentHandle, type Connector, type LaunchSpec, type Presence, type CredentialLedgerRow,
+  createSpaceAuth, gateObserve, headCandidate, mintCreds, newIdentity, principalKey, rawDigest,
+  standaloneConnectOpts, registry, DEV_OWNER, setupSpaceStreams, recordsBucket, epAuthBucket,
+  parseLedgerRow, credRowKey, type AgentHandle, type AttachSession,
+  type Connector, type LaunchSpec, type Presence, type CredentialLedgerRow,
   type LifecycleStateTransport, type SecretStore,
 } from "@cotal-ai/core";
-import { authDir, saveSpaceAuth, workspaceSecretStore } from "@cotal-ai/workspace";
-import { staticLifecycleTransport, readStaticSlot } from "../src/static-lifecycle.js";
+import { agentSecretKeyForFile, putSpaceAuth } from "@cotal-ai/workspace";
+import {
+  appendStaticCredentialRow, recordSlotCredential, staticLifecycleTransport, readStaticSlot,
+} from "../src/static-lifecycle.js";
 import { Manager } from "../src/manager.js";
 import { bootBroker } from "./_boot-broker.js";
 
-const ATTEMPTS = 4;
-const SCENARIO_CELLS = ATTEMPTS * 18;
+const SCENARIOS = [
+  { name: "racer_despawn", renewal: "direct", terminal: "despawn" },
+  { name: "racer_exit", renewal: "sweep", terminal: "natural-exit" },
+] as const;
+const SCENARIO_CELLS = SCENARIOS.length * 23;
 let pass = 0;
 let fail = 0;
 
@@ -38,16 +44,7 @@ function check(label: string, ok: boolean, detail?: unknown): void {
   }
 }
 
-async function until(predicate: () => boolean, timeoutMs = 5_000): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (predicate()) return true;
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-  return predicate();
-}
-
-async function untilAsync(predicate: () => Promise<boolean>, timeoutMs: number): Promise<boolean> {
+async function until(predicate: () => boolean | Promise<boolean>, timeoutMs = 5_000): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (await predicate()) return true;
@@ -68,13 +65,15 @@ async function bounded<T>(promise: Promise<T>, timeoutMs: number): Promise<T | u
   }
 }
 
-class PausingSecretStore implements SecretStore {
-  private pause?: {
-    reached: (key: string) => void;
-    release: Promise<void>;
-  };
+async function enterNextEpochSecond(): Promise<void> {
+  const second = Math.floor(Date.now() / 1_000);
+  await until(() => Math.floor(Date.now() / 1_000) > second, 1_500);
+}
 
-  constructor(private readonly base: SecretStore) {}
+class PausingSecretStore implements SecretStore {
+  private readonly values = new Map<string, string>();
+  private readonly deleted = new Set<string>();
+  private pause?: { reached: (key: string) => void; release: Promise<void> };
 
   armNextPut(): { reached: Promise<string>; release: () => void } {
     if (this.pause) throw new Error("a secret-store put is already paused");
@@ -93,7 +92,7 @@ class PausingSecretStore implements SecretStore {
   }
 
   get(key: string): Promise<string | undefined> {
-    return this.base.get(key);
+    return Promise.resolve(this.values.get(key));
   }
 
   async put(key: string, value: string): Promise<void> {
@@ -102,11 +101,61 @@ class PausingSecretStore implements SecretStore {
       pause.reached(key);
       await pause.release;
     }
-    await this.base.put(key, value);
+    this.deleted.delete(key);
+    this.values.set(key, value);
   }
 
   delete(key: string): Promise<void> {
-    return this.base.delete(key);
+    this.deleted.add(key);
+    this.values.delete(key);
+    return Promise.resolve();
+  }
+
+  wasDeleted(key: string): boolean {
+    return this.deleted.has(key);
+  }
+}
+
+class ControlledHandle implements AgentHandle {
+  readonly kind = "fake";
+  private state: "running" | "exited" = "running";
+  private readonly exitListeners = new Set<() => void>();
+  private readonly session: AttachSession;
+
+  constructor(readonly name: string) {
+    this.session = {
+      cols: 80,
+      rows: 24,
+      backlog: () => Buffer.alloc(0),
+      onData: () => () => {},
+      onExit: (listener) => {
+        this.exitListeners.add(listener);
+        return () => this.exitListeners.delete(listener);
+      },
+      write: () => {},
+      resize: () => {},
+    };
+  }
+
+  status(): "running" | "exited" {
+    return this.state;
+  }
+
+  stop(): void {
+    this.state = "exited";
+  }
+
+  interrupt(): void {}
+
+  attach(): AttachSession {
+    return this.session;
+  }
+
+  exitNaturally(): boolean {
+    this.state = "exited";
+    const listeners = [...this.exitListeners];
+    for (const listener of listeners) listener();
+    return listeners.length > 0;
   }
 }
 
@@ -114,21 +163,26 @@ const space = `renewal-race-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
 const { servers, stop: stopBroker } = await bootBroker(auth);
 const workspaceRoot = mkdtempSync(join(tmpdir(), "cotal-renewal-race-"));
-const secrets = new PausingSecretStore(workspaceSecretStore(workspaceRoot));
-const aliases = Array.from({ length: ATTEMPTS }, (_, i) => `racer_${i + 1}`);
+const secrets = new PausingSecretStore();
 mkdirSync(join(workspaceRoot, ".cotal", "agents"), { recursive: true });
-for (const name of aliases)
+for (const { name } of SCENARIOS)
   writeFileSync(
     join(workspaceRoot, ".cotal", "agents", `${name}.md`),
     `---\nname: ${name}\nrole: worker\nsubscribe: [general]\nallowSubscribe: [general]\nallowPublish: [general]\n---\nbody\n`,
   );
 
-saveSpaceAuth(authDir(workspaceRoot), auth);
+await putSpaceAuth(secrets, auth);
 const mgr = new Manager({ space, servers, runtime: "pty", workspaceRoot, secretStore: secrets });
 (mgr as unknown as { auth: unknown }).auth = auth;
-const fakeSession = { cols: 80, rows: 24, backlog: () => Buffer.alloc(0), onData: () => () => {}, onExit: () => () => {}, write: () => {}, resize: () => {} };
-const fakeHandle = (name: string): AgentHandle => ({ name, kind: "fake", status: () => "running", stop: () => {}, interrupt: () => {}, attach: () => fakeSession });
-(mgr as unknown as { runtime: { kind: string; spawn: (n: string, s: LaunchSpec) => AgentHandle } }).runtime = { kind: "fake", spawn: (name) => fakeHandle(name) };
+const handles = new Map<string, ControlledHandle>();
+(mgr as unknown as { runtime: { kind: string; spawn: (name: string, spec: LaunchSpec) => AgentHandle } }).runtime = {
+  kind: "fake",
+  spawn: (name) => {
+    const handle = new ControlledHandle(name);
+    handles.set(name, handle);
+    return handle;
+  },
+};
 (mgr as unknown as { ep: Record<string, unknown> }).ep = {
   ref: () => ({ id: "smoke-mgr" }), on: () => {}, off: () => {},
   waitForPresenceSnapshot: () => Promise.resolve(), getRoster: (): Presence[] => [],
@@ -139,6 +193,9 @@ type Agent = {
   id: string;
   name: string;
   lifecycleUid: string;
+  seed?: string;
+  role?: string;
+  launch: { allowSubscribe: string[]; allowPublish?: string[]; capabilities?: string[] };
   terminalizing?: boolean;
   staticCredentialRenewal?: Promise<void>;
   secretPaths?: { creds?: string };
@@ -147,8 +204,9 @@ type RetirementHold = { lifecycleUid: string; lastError?: string };
 const M = mgr as unknown as {
   agents: Map<string, Agent>;
   retiring: Map<string, RetirementHold>;
-  renewManagedStaticCred(a: Agent): Promise<void>;
-  despawnAuthorized(a: Agent, graceful: boolean, trackNonAdmin: boolean): { ok: boolean };
+  renewManagedStaticCred(agent: Agent): Promise<void>;
+  renewDaemonCreds(): Promise<void>;
+  despawnAuthorized(agent: Agent, graceful: boolean, trackNonAdmin: boolean): { ok: boolean };
 };
 
 async function openLifecycleView(alias: string, actor: string, uid: string): Promise<{
@@ -166,56 +224,113 @@ async function openLifecycleView(alias: string, actor: string, uid: string): Pro
   };
 }
 
+async function stageExpiringCredential(agent: Agent, transport: LifecycleStateTransport, key: string, path: string): Promise<number> {
+  if (!agent.seed) throw new Error(`${agent.name}: no static seed`);
+  const exp = Math.floor(Date.now() / 1_000) + 1;
+  const creds = await mintCreds(auth, { id: agent.id, seed: agent.seed }, "agent", {
+    allowSubscribe: agent.launch.allowSubscribe,
+    allowPublish: agent.launch.allowPublish,
+    role: agent.role,
+    capabilities: agent.launch.capabilities,
+    lifecycleUid: agent.lifecycleUid,
+    expiresAt: exp,
+  });
+  const credentialId = rawDigest(creds).replace("sha256:", "sha256-");
+  await recordSlotCredential(transport, DEV_OWNER, agent.name, agent.lifecycleUid, credentialId);
+  await appendStaticCredentialRow(transport, {
+    lifecycleUid: agent.lifecycleUid,
+    credentialId,
+    holderPrincipal: principalKey(DEV_OWNER, agent.id).key,
+    exp,
+  });
+  await secrets.put(key, creds);
+  writeFileSync(path, creds, { mode: 0o600 });
+  return exp;
+}
+
 try {
   await setupSpaceStreams({ servers, space, creds: await mintCreds(auth, newIdentity(), "provisioner") });
   await mgr.start();
   (mgr as unknown as { awaitReadiness(): Promise<{ ok: true }> }).awaitReadiness = async () => ({ ok: true });
 
-  for (const name of aliases) {
-    console.log(`\n${name}: accepted renewal then terminal`);
+  for (const scenario of SCENARIOS) {
+    const { name } = scenario;
+    console.log(`\n${name}: ${scenario.renewal} renewal then ${scenario.terminal}`);
     const spawned = await mgr.startAgent({ name, agent: "smoke-race" });
     check(`${name}: spawn succeeds`, spawned.ok, spawned);
     const agent = M.agents.get(name);
     check(`${name}: the spawned lifecycle is managed`, agent !== undefined);
     if (!agent) throw new Error(`${name}: setup failed before the race`);
 
+    const credsPath = agent.secretPaths?.creds;
+    if (!credsPath) throw new Error(`${name}: no managed credential path`);
+    const secretKey = agentSecretKeyForFile(credsPath);
     const view = await openLifecycleView(name, agent.id, agent.lifecycleUid);
-    const pause = secrets.armNextPut();
+    let pause: ReturnType<PausingSecretStore["armNextPut"]> | undefined;
     try {
-      const credsPath = agent.secretPaths?.creds;
-      const accepted = M.renewManagedStaticCred(agent)
+      if (scenario.renewal === "sweep") {
+        const exp = await stageExpiringCredential(agent, view.transport, secretKey, credsPath);
+        await until(() => Math.floor(Date.now() / 1_000) >= exp, 2_000);
+      } else {
+        await enterNextEpochSecond();
+      }
+      pause = secrets.armNextPut();
+
+      const beforeSlot = await readStaticSlot(view.transport, DEV_OWNER, name);
+      const beforeIds = beforeSlot?.row.credentialIds ?? [];
+      check(`${name}: the pre-renewal credential family is non-empty`, beforeIds.length > 0, beforeIds);
+
+      const accepted = (scenario.renewal === "sweep"
+        ? M.renewDaemonCreds()
+        : M.renewManagedStaticCred(agent))
         .then(() => "completed" as const)
         .catch((error: Error) => `refused: ${error.message}` as const);
-      check(`${name}: renewal publishes its accepted flight before returning`, agent.staticCredentialRenewal !== undefined);
 
       const pausedKey = await bounded(pause.reached, 5_000);
-      check(`${name}: renewal reaches the real secret-store put after journaling`, typeof pausedKey === "string" && pausedKey.endsWith(".creds"), pausedKey);
+      check(`${name}: renewal reaches the secret-store put after journaling`, pausedKey === secretKey, pausedKey);
+      check(`${name}: renewal publishes its accepted flight`, agent.staticCredentialRenewal !== undefined);
 
-      const stopped = M.despawnAuthorized(agent, false, true);
-      check(`${name}: despawn accepts the terminal`, stopped.ok, stopped);
+      const duringSlot = await readStaticSlot(view.transport, DEV_OWNER, name);
+      const duringIds = duringSlot?.row.credentialIds ?? [];
+      const newIds = duringIds.filter((id) => !beforeIds.includes(id));
+      check(`${name}: renewal records exactly one new credential id`, newIds.length === 1, { beforeIds, duringIds });
+      const newEntry = newIds[0] ? await view.transport.getAuth(credRowKey(agent.lifecycleUid, newIds[0])) : undefined;
+      const newRow = newEntry && newIds[0] ? parseLedgerRow(newEntry.value, credRowKey(agent.lifecycleUid, newIds[0])) : undefined;
+      check(`${name}: the newly recorded renewal row is active before terminalization`, newRow?.state === "active", newRow);
+
+      let terminalEntered = false;
+      if (scenario.terminal === "despawn")
+        terminalEntered = M.despawnAuthorized(agent, false, true).ok;
+      else
+        terminalEntered = handles.get(name)?.exitNaturally() === true && !M.agents.has(name);
+      check(`${name}: ${scenario.terminal} enters the terminal path`, terminalEntered);
       check(`${name}: the terminal latch closes synchronously`, agent.terminalizing === true);
       check(`${name}: terminalization registers the lifecycle hold`, M.retiring.get(name)?.lifecycleUid === agent.lifecycleUid, M.retiring.get(name));
 
       let lateOutcome: string | undefined;
       const late = M.renewManagedStaticCred(agent)
-        .then(() => { lateOutcome = "completed"; })
-        .catch((error: Error) => { lateOutcome = `refused: ${error.message}`; });
+        .then(() => "completed" as const)
+        .catch((error: Error) => `refused: ${error.message}` as const)
+        .then((outcome) => { lateOutcome = outcome; return outcome; });
       await until(() => lateOutcome !== undefined, 250);
       check(`${name}: a renewal arriving after the terminal latch is refused`, lateOutcome?.startsWith("refused: renewManagedStaticCred: the lifecycle is terminalizing") === true, lateOutcome);
+      const lateSettled = await bounded(late, 1_000);
+      check(`${name}: the post-latch renewal promise settles within its budget`, lateSettled !== undefined, lateOutcome);
 
-      const terminalMovedWhilePaused = await untilAsync(async () => {
+      const terminalMovedWhilePaused = await until(async () => {
         const slot = await readStaticSlot(view.transport, DEV_OWNER, name);
-        return slot?.row.phase !== "active";
-      }, 750);
-      check(`${name}: the durable terminal does not pass an accepted renewal still in flight`, !terminalMovedWhilePaused);
+        const hold = M.retiring.get(name);
+        return slot?.row.phase !== "active" || hold === undefined || hold.lastError !== undefined;
+      }, 3_000);
+      check(`${name}: the durable terminal does not pass an accepted renewal still in flight`, !terminalMovedWhilePaused, M.retiring.get(name));
 
       pause.release();
-      const acceptedOutcome = await accepted;
-      await late;
-      check(`${name}: the renewal accepted before terminalization settles before cleanup`, acceptedOutcome === "completed", acceptedOutcome);
-      check(`${name}: a settled renewal releases its single-flight slot`, agent.staticCredentialRenewal === undefined);
+      const acceptedOutcome = await bounded(accepted, 10_000);
+      check(`${name}: the accepted renewal entry settles before cleanup`, acceptedOutcome === "completed", acceptedOutcome);
+      const flightReleased = await until(() => agent.staticCredentialRenewal === undefined, 1_000);
+      check(`${name}: a settled renewal releases its single-flight slot`, flightReleased);
 
-      const retired = await until(() => !M.retiring.has(name));
+      const retired = await until(() => !M.retiring.has(name), 10_000);
       check(`${name}: retirement drains the accepted renewal and reaches its terminal`, retired, M.retiring.get(name));
 
       const slot = await readStaticSlot(view.transport, DEV_OWNER, name);
@@ -230,11 +345,12 @@ try {
         const entry = await view.transport.getAuth(credRowKey(agent.lifecycleUid, id));
         if (entry !== undefined) rows.push(parseLedgerRow(entry.value, credRowKey(agent.lifecycleUid, id)));
       }
-      check(`${name}: the journal exposes the credential family it retired`, rows.length > 0, rows);
+      check(`${name}: the retired family includes the renewal generation`, newIds.length === 1 && rows.some((row) => row.credentialId === newIds[0]), rows);
       check(`${name}: no credential row remains active after retirement`, rows.length > 0 && rows.every((row) => row.state === "revoked"), rows);
-      check(`${name}: no credential file remains after retirement`, credsPath !== undefined && !existsSync(credsPath), credsPath);
+      check(`${name}: the secret-store credential key is deleted`, secrets.wasDeleted(secretKey) && await secrets.get(secretKey) === undefined, secretKey);
+      check(`${name}: no credential file remains after retirement`, !existsSync(credsPath), credsPath);
     } finally {
-      pause.release();
+      pause?.release();
       await view.nc.drain().catch(() => view.nc.close());
     }
   }

--- a/implementations/manager/smoke/renewal-terminal-race.smoke.ts
+++ b/implementations/manager/smoke/renewal-terminal-race.smoke.ts
@@ -24,7 +24,7 @@ import { Manager } from "../src/manager.js";
 import { bootBroker } from "./_boot-broker.js";
 
 const ATTEMPTS = 4;
-const SCENARIO_CELLS = ATTEMPTS * 17;
+const SCENARIO_CELLS = ATTEMPTS * 18;
 let pass = 0;
 let fail = 0;
 
@@ -213,6 +213,7 @@ try {
       const acceptedOutcome = await accepted;
       await late;
       check(`${name}: the renewal accepted before terminalization settles before cleanup`, acceptedOutcome === "completed", acceptedOutcome);
+      check(`${name}: a settled renewal releases its single-flight slot`, agent.staticCredentialRenewal === undefined);
 
       const retired = await until(() => !M.retiring.has(name));
       check(`${name}: retirement drains the accepted renewal and reaches its terminal`, retired, M.retiring.get(name));

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -550,10 +550,12 @@ interface ManagedAgent {
   suppressCleanup?: boolean;
   /** The F5 TERMINALIZING latch (Unit B): flipped SYNCHRONOUSLY before the first await on every
    *  stop/despawn path (stopHandle + freeSlot are the chokepoints). Once set, this principal's
-   *  control ops refuse (the membership gate) and no further credential is minted for it
-   *  (renewal + the slot's own durable phase both refuse) — closing the freeSlot→retiring window
-   *  in-process, not just by `agents.delete` ordering. */
+   *  control ops refuse and no later renewal is admitted. A renewal already admitted drains before
+   *  the durable terminal begins, so its row and material are included in revocation and cleanup. */
   terminalizing?: boolean;
+  /** The one renewal admitted before terminalization. Retirement drains it before revocation and
+   *  cleanup; callers arriving after the latch never join it. */
+  staticCredentialRenewal?: Promise<void>;
 }
 
 
@@ -2328,7 +2330,8 @@ export class Manager {
    *  never swallowed silently. Being the single stop chokepoint, guarding here covers all callers at once. */
   private stopHandle(a: ManagedAgent, graceful: boolean): void {
     // The F5 TERMINALIZING latch (Unit B): flipped SYNCHRONOUSLY, before any await anywhere on
-    // this stop path — from here this principal's control ops refuse and no credential renews.
+    // this stop path — later renewals refuse, while an already-admitted renewal drains before the
+    // durable terminal begins.
     a.terminalizing = true;
     try {
       if (graceful && process.platform === "win32" && a.control) controlShutdown(a.control);
@@ -5645,7 +5648,12 @@ export class Manager {
    *  clears (ABA-guarded by uid). A PRE-UNIT-B lifecycle (no slot row — spawned before the
    *  durable registry existed) has nothing to terminalize: its footprint teardown runs directly
    *  and the hold clears, the honest upgrade path. */
-  private async driveStaticRetirement(a: { id: string; name: string; lifecycleUid: string; secretPaths?: ManagedAgent["secretPaths"] }): Promise<void> {
+  private async driveStaticRetirement(a: { id: string; name: string; lifecycleUid: string; secretPaths?: ManagedAgent["secretPaths"]; staticCredentialRenewal?: Promise<void> }): Promise<void> {
+    // A renewal that published its flight before the synchronous terminal latch is accepted work.
+    // Drain it before the durable terminal enumerates credential ids and before cleanup deletes its
+    // material; a failed renewal must not block retirement because it may still have staged an id.
+    const acceptedRenewal = a.staticCredentialRenewal;
+    if (acceptedRenewal) await acceptedRenewal.catch(() => {});
     const opId = retireOpId(a.lifecycleUid);
     const cleanup = async (): Promise<void> => {
       const secrets = this.secrets;
@@ -5686,42 +5694,28 @@ export class Manager {
    *  identity with the SAME scope (recorded on the managed row at spawn) and a fresh bounded
    *  exp, ledger the new credentialId (slot record first, then the row, then the file — a
    *  credential is never materialized before its ledger row exists), and re-sign the SAME
-   *  lifecycle-keyed file the agent endpoint's source seam re-reads. Never advances the epoch,
-   *  never routes through any barrier (renewal is the THIRD transition). */
+   *  lifecycle-keyed file the agent endpoint's source seam re-reads. Never advances the epoch;
+   *  renewal remains the THIRD transition. */
   private async renewManagedStaticCred(a: ManagedAgent): Promise<void> {
     if (!this.auth || !a.seed || !a.secretPaths?.creds) throw new Error("renewManagedStaticCred: not a renewable managed-static agent");
-    // THIS CHECK IS THE AUTHORITATIVE ONE. The renewal sweep's own `a.terminalizing` filter is an
-    // optimisation that has already-awaited by the time it matters; removing or weakening this line
-    // promotes that filter into the whole guard, with nothing failing at the moment of the change.
-    //
-    // CONFIRMED, OPEN, AND UNGATED. This check runs at ENTRY and there are FOUR awaits before the
-    // two writes below (`secrets.put` and `materializeSecretToFile`). A despawn landing in that
-    // window latches `terminalizing` and the retirement cleanup deletes exactly those two things —
-    // same secret key, same path — so an in-flight renewal RE-CREATES a valid bounded credential
-    // after teardown removed it, and `appendStaticCredentialRow` lands in the window too, which is
-    // the worse half: a stale file is recoverable by re-running cleanup, a durable credential row
-    // is the journal asserting the credential is legitimate.
-    //
-    // Reproduced by `smoke:renewal-terminal-race` (`renewal-terminal-race.smoke.ts`), which asserts
-    // the DURABLE ROW rather than the file — the file is timing-dependent, the row is a KV read.
-    // That suite is deliberately NOT in `smoke:ci`: it is expected RED until this is fixed, and
-    // gating a known red trains readers to treat the gate as noisy. So the absence of a red here
-    // is not evidence this is closed; run that suite.
-    //
-    // Reproduced on the FIRST attempt that reached the race, and that suite cannot produce a second:
-    // the alias frees only when teardown completes, and the defect is that teardown does not, so
-    // every later attempt is refused at spawn. That is a limit of the probe, NOT of the world — a
-    // FRESH ALIAS PER ATTEMPT makes a rate measurable. Do not read hits-over-attempts off that file
-    // as written; it is a number that is not a count.
-    //
-    // The fix is to make the WRITES conditional on the same latch the teardown orders against,
-    // never to retry: the correct outcome is "no credential", never "a credential minted later".
+    // Admission is synchronous. An accepted renewal publishes its flight before its first caller can
+    // terminalize the agent; terminalization rejects later callers and drains this flight before the
+    // durable terminal starts, giving renewal-before-terminal and terminal-before-renewal one order.
     if (a.terminalizing) throw new Error("renewManagedStaticCred: the lifecycle is terminalizing; no credential is minted after the terminal begins");
+    if (a.staticCredentialRenewal) return a.staticCredentialRenewal;
+    const renewal = this.driveManagedStaticCredRenewal(a).finally(() => {
+      if (a.staticCredentialRenewal === renewal) a.staticCredentialRenewal = undefined;
+    });
+    a.staticCredentialRenewal = renewal;
+    return renewal;
+  }
+
+  private async driveManagedStaticCredRenewal(a: ManagedAgent): Promise<void> {
     const exp = Math.floor(Date.now() / 1000) + MANAGED_STATIC_TTL_SEC;
     // The SAME permission scope the spawn minted (recorded on the managed row): allowSubscribe/
     // allowPublish/role/capabilities are the JWT-shaping inputs; `subscribe` (the active read
     // set) shapes durable membership only and is not a mint input.
-    const creds = await mintCreds(this.auth, { id: a.id, seed: a.seed }, "agent", {
+    const creds = await mintCreds(this.auth!, { id: a.id, seed: a.seed! }, "agent", {
       allowSubscribe: a.launch.allowSubscribe,
       allowPublish: a.launch.allowPublish,
       role: a.role,
@@ -5735,8 +5729,9 @@ export class Manager {
       await appendStaticCredentialRow(t, { lifecycleUid: a.lifecycleUid, credentialId, holderPrincipal: principalKey(DEV_OWNER, a.id).key, exp });
     });
     const secrets = this.secrets;
-    await secrets.put(agentSecretKeyForFile(a.secretPaths.creds), creds);
-    await materializeSecretToFile(secrets, agentSecretKeyForFile(a.secretPaths.creds), a.secretPaths.creds);
+    const credsPath = a.secretPaths!.creds!;
+    await secrets.put(agentSecretKeyForFile(credsPath), creds);
+    await materializeSecretToFile(secrets, agentSecretKeyForFile(credsPath), credsPath);
     console.error(`managed cred renewal ${a.name}: re-signed for the same identity (exp +${MANAGED_STATIC_TTL_SEC}s); the agent endpoint's source re-read adopts it`);
   }
 


### PR DESCRIPTION
## Summary

- serialize each managed-static credential renewal as a per-agent in-flight operation
- reject renewals arriving after terminalization, and drain an already-admitted renewal before durable retirement begins
- turn the known-red race probe into a counted broker-backed regression covering despawn, natural exit, direct renewal, and the production renewal sweep

## Verification

- `pnpm smoke:renewal-terminal-race` — 47 passed
- 11/11 renewal-terminal mutations killed by named cells
- `pnpm smoke:static-lifecycle` — 37/37
- `pnpm smoke:manager-reconcile-startup` — 4/4
- `pnpm smoke:lifecycle-e2e` — 30/30
- `pnpm --filter @cotal-ai/manager test`
- `pnpm --filter @cotal-ai/manager typecheck`
- `pnpm build`
- `pnpm smoke:ci-suites`
- `pnpm smoke:gate-inventory` — 0 BROKEN suites