### PR TITLE
test(ci): gate cited smoke evidence

### DIFF
--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -572,3 +572,13 @@ smoke:renewal-terminal-race
 # and every real CLI subprocess, and resolves the repository's actual bin/cotal.ts entry. Concurrent
 # runs therefore share neither port nor state. Appended to preserve every existing shard assignment.
 smoke:send
+# These seven self-contained suites are cited by the shipped plan as executable evidence. Each owns
+# or needs no broker, passed serially and in six-way shard-like overlap, and was previously run by
+# nothing. Appended as one debt slice so every existing shard assignment remains unchanged.
+smoke:channel-attention
+smoke:channel-attention:auth
+smoke:install
+smoke:manifest-launch
+smoke:members
+smoke:presence-scrub
+smoke:start-model

--- a/bin/smoke/gate-inventory.smoke.ts
+++ b/bin/smoke/gate-inventory.smoke.ts
@@ -99,16 +99,15 @@ const UNGATED: Record<string, string> = {
   "smoke": "UNTRIAGED",
   // Untriaged debt. These are the ones that should shrink.
   "smoke:attention": "UNTRIAGED",
-  "smoke:attention:auth": "UNTRIAGED", "smoke:channel-attention": "UNTRIAGED",
-  "smoke:channel-attention:auth": "UNTRIAGED", "smoke:delivery-boot-retry:auth": "UNTRIAGED",
+  "smoke:attention:auth": "UNTRIAGED",
+ "smoke:delivery-boot-retry:auth": "UNTRIAGED",
   "smoke:delivery-broker-coupling": "UNTRIAGED", "smoke:delivery-old-manager": "UNTRIAGED",
-  "smoke:feedback": "UNTRIAGED", "smoke:install": "UNTRIAGED",
-  "smoke:lifecycle-files": "UNTRIAGED", "smoke:manager-console": "UNTRIAGED", "smoke:manifest-launch": "UNTRIAGED",
-  "smoke:members": "UNTRIAGED", "smoke:membership": "UNTRIAGED",
+  "smoke:feedback": "UNTRIAGED",
+  "smoke:lifecycle-files": "UNTRIAGED", "smoke:manager-console": "UNTRIAGED",
+ "smoke:membership": "UNTRIAGED",
   "smoke:plane3-activation:auth": "UNTRIAGED",
-  "smoke:plane3-gate:auth": "UNTRIAGED", "smoke:presence-scrub": "UNTRIAGED",
+  "smoke:plane3-gate:auth": "UNTRIAGED",
   "smoke:self-serve-join-coverage:auth": "UNTRIAGED",
-  "smoke:start-model": "UNTRIAGED",
 };
 
 /**


### PR DESCRIPTION
## Summary

- gate seven self-contained smoke suites already cited by the shipped plan as executable evidence
- remove their stale `UNTRIAGED` exemptions
- append all seven after the complete current smoke chain so existing shard assignments remain unchanged

## Verification

- full workspace build
- all seven suites passed concurrently after build
- `pnpm smoke:gate-inventory` — CI suites 393→400, untriaged 20→13, cited-but-unrun 10→3, BROKEN 0
- `pnpm smoke:ci-suites`
- exact origin/main prefix guard