### PR TITLE
test(core): make bare smoke self-contained

### DIFF
--- a/bin/smoke/ci-suites.mjs
+++ b/bin/smoke/ci-suites.mjs
@@ -33,7 +33,7 @@ export function parseCiSuites(raw, label = CI_SUITES_PATH) {
         `${label}:${i + 1}: drop the \`pnpm \` prefix - this file holds script NAMES, one per line: ` +
           `${JSON.stringify(s)}`,
       );
-    if (!/^smoke:[A-Za-z0-9:_-]+$/.test(s))
+    if (!/^smoke(?::[A-Za-z0-9:_-]+)?$/.test(s))
       throw new Error(`${label}:${i + 1}: not a smoke script name: ${JSON.stringify(s)}`);
     out.push(s);
   });

--- a/bin/smoke/ci-suites.mjs
+++ b/bin/smoke/ci-suites.mjs
@@ -33,7 +33,7 @@ export function parseCiSuites(raw, label = CI_SUITES_PATH) {
         `${label}:${i + 1}: drop the \`pnpm \` prefix - this file holds script NAMES, one per line: ` +
           `${JSON.stringify(s)}`,
       );
-    if (!/^smoke(?::[A-Za-z0-9:_-]+)?$/.test(s))
+    if (!/^smoke(?::[A-Za-z0-9_-]+(?::[A-Za-z0-9_-]+)*)?$/.test(s))
       throw new Error(`${label}:${i + 1}: not a smoke script name: ${JSON.stringify(s)}`);
     out.push(s);
   });

--- a/bin/smoke/ci-suites.smoke.ts
+++ b/bin/smoke/ci-suites.smoke.ts
@@ -61,6 +61,11 @@ check("an indented comment is still a comment", same(parse("   # note\nsmoke:a")
 check("a trailing space on an entry is trimmed, not carried into the script name", same(parse("smoke:a  "), ["smoke:a"]));
 check("a leading space on an entry is trimmed", same(parse("  smoke:a"), ["smoke:a"]));
 check("a carriage return does not survive into the name", same(parse("smoke:a\r\nsmoke:b"), ["smoke:a", "smoke:b"]));
+check(
+  "the bare root smoke script is a valid chain entry",
+  same(parse("smoke\nsmoke:a"), ["smoke", "smoke:a"]),
+  parse("smoke\nsmoke:a"),
+);
 
 // ---- A `pnpm ` prefix REFUSES: every line of the old chain looked like this ---------------------
 const pnpmPrefixed = parse("smoke:a\npnpm smoke:b");
@@ -101,7 +106,7 @@ check("a MISSING chain file throws at the reader rather than yielding an empty c
 const real = readCiSuites() as string[];
 check("the real chain file parses, and holds more than one suite", Array.isArray(real) && real.length > 1, real.length);
 
-const EXPECTED = 18;
+const EXPECTED = 19;
 check(
   `every cell ran - ${EXPECTED} expected, so a cell that stops existing is not mistaken for one that passed`,
   pass + fail === EXPECTED,

--- a/bin/smoke/ci-suites.smoke.ts
+++ b/bin/smoke/ci-suites.smoke.ts
@@ -78,7 +78,7 @@ check("the refusal says what to do about it", /drop the `pnpm ` prefix/.test(Str
 check("the refusal names the line number", /<fixture>:2:/.test(String(pnpmPrefixed)), pnpmPrefixed);
 
 // ---- Anything else that is not a script name refuses, with its line ------------------------------
-for (const bad of ["not-a-suite", "smoke:", "check", "&& pnpm smoke:a", "smoke:a && smoke:b"]) {
+for (const bad of ["not-a-suite", "smoke:", "smoke::", "smoke::a", "smoke:a:", "check", "&& pnpm smoke:a", "smoke:a && smoke:b"]) {
   check(`a line that is not a smoke script name is refused: ${JSON.stringify(bad)}`, String(parse(bad)).startsWith("THREW"));
 }
 // A malformed line must NOT be skipped: a chain that silently drops what it could not parse runs
@@ -116,7 +116,7 @@ check(
   realError || real?.length,
 );
 
-const EXPECTED = 19;
+const EXPECTED = 22;
 check(
   `every cell ran - ${EXPECTED} expected, so a cell that stops existing is not mistaken for one that passed`,
   pass + fail === EXPECTED,

--- a/bin/smoke/ci-suites.smoke.ts
+++ b/bin/smoke/ci-suites.smoke.ts
@@ -103,8 +103,18 @@ try {
 check("a MISSING chain file throws at the reader rather than yielding an empty chain", missingThrew);
 
 // ---- The real file is parsed by this same parser ------------------------------------------------
-const real = readCiSuites() as string[];
-check("the real chain file parses, and holds more than one suite", Array.isArray(real) && real.length > 1, real.length);
+let real: string[] | undefined;
+let realError = "";
+try {
+  real = readCiSuites() as string[];
+} catch (error) {
+  realError = (error as Error).message;
+}
+check(
+  "the real chain file parses, and holds more than one suite",
+  realError === "" && Array.isArray(real) && real.length > 1,
+  realError || real?.length,
+);
 
 const EXPECTED = 19;
 check(

--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -586,3 +586,8 @@ smoke:manifest-launch
 smoke:members
 smoke:presence-scrub
 smoke:start-model
+# The bare core smoke now owns an OS-assigned broker and a production-provisioned unique space. It
+# drives explicit live channels, lifecycle-scoped offline DM restart delivery, pre-activation DM
+# exclusion, presence, and open-mode membership semantics, then awaits broker teardown. Appended so
+# every existing shard assignment remains unchanged.
+smoke

--- a/bin/smoke/gate-inventory.smoke.ts
+++ b/bin/smoke/gate-inventory.smoke.ts
@@ -26,7 +26,6 @@ import ts from "typescript";
 import { readCiSuites, ciChainBody } from "./ci-suites.mjs";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
-const SCRIPT_RE = /(smoke:[A-Za-z0-9:_-]+)/g;
 
 /**
  * Suites deliberately not run by any automated path, each with the reason it is excluded.
@@ -275,8 +274,8 @@ for (const name of Object.keys(pkg.scripts))
       else if (!(target in scripts)) dangling.push([name, `${target} (absent from ${pkgName})`]);
       continue;
     }
-    for (const m of segment.matchAll(SCRIPT_RE))
-      if (m[1] !== name && !(m[1] in pkg.scripts)) dangling.push([name, m[1]]);
+    for (const target of suitesIn(segment))
+      if (target !== name && !(target in pkg.scripts)) dangling.push([name, target]);
   }
 if (dangling.length) {
   fail++;
@@ -292,8 +291,12 @@ if (dangling.length) {
 // gate quietly running less than it says. An empty chain is the sharp one: `smoke:ci` would exit 0
 // in seconds and every branch would read green.
 const chain = readCiSuites() as string[];
+const missingChainEntries = chain.filter((suite) => !(suite in pkg.scripts));
 const dupes = [...new Set(chain.filter((s, i) => chain.indexOf(s) !== i))].sort();
-if (chain.length < 2) {
+if (missingChainEntries.length) {
+  fail++;
+  console.log(`  ✗ FAIL: bin/smoke/ci-suites.txt names ${missingChainEntries.length} missing script(s): ${missingChainEntries.join(", ")}`);
+} else if (chain.length < 2) {
   fail++;
   console.log(`  ✗ FAIL: bin/smoke/ci-suites.txt holds ${chain.length} suite(s) — a chain that runs nothing exits 0`);
 } else if (dupes.length) {

--- a/bin/smoke/gate-inventory.smoke.ts
+++ b/bin/smoke/gate-inventory.smoke.ts
@@ -93,10 +93,6 @@ const UNGATED: Record<string, string> = {
   // subject. It is ungated because it needs a real user-auth broker plus a real callout, not because
   // it is obsolete. Deleting it would drop a security proof for shipped code.
   "smoke:ctl-trust:live": "needs a real user-auth broker + callout; pins the LIVE ctl.delivery rail",
-  // The bare `smoke` script — `tsx packages/core/smoke.ts`, documented in AGENTS.md as the core
-  // smoke entry point, and reached by nothing. Invisible to this file until the audited set stopped
-  // filtering on `smoke:`, and found by a second independent derivation rather than by this check.
-  "smoke": "UNTRIAGED",
   // Untriaged debt. These are the ones that should shrink.
   "smoke:attention": "UNTRIAGED",
   "smoke:attention:auth": "UNTRIAGED",

--- a/bin/smoke/mutations/ci-suites-bare-name.json
+++ b/bin/smoke/mutations/ci-suites-bare-name.json
@@ -13,10 +13,11 @@
     {
       "name": "restore the smoke-colon-only chain grammar",
       "file": "bin/smoke/ci-suites.mjs",
-      "find": "    if (!/^smoke(?::[A-Za-z0-9:_-]+)?$/.test(s))",
+      "find": "    if (!/^smoke(?::[A-Za-z0-9_-]+(?::[A-Za-z0-9_-]+)*)?$/.test(s))",
       "replace": "    if (!/^smoke:[A-Za-z0-9:_-]+$/.test(s))",
       "expectRed": "the bare root smoke script is a valid chain entry",
       "cell": "the bare root smoke script is a valid chain entry"
     }
-  ]
+  ],
+  "grades": "tool"
 }

--- a/bin/smoke/mutations/ci-suites-bare-name.json
+++ b/bin/smoke/mutations/ci-suites-bare-name.json
@@ -1,0 +1,22 @@
+{
+  "suite": "bin/smoke/ci-suites.smoke.ts",
+  "guard": "the shared CI-chain parser accepts the root package's bare smoke script as well as smoke:* names",
+  "command": "pnpm smoke:ci-suites",
+  "completionMarker": "SUITE COMPLETE",
+  "proveWith": "pnpm mutation-proof --config bin/smoke/mutations/ci-suites-bare-name.json",
+  "why": [
+    "The gate inventory has deliberately audited the bare smoke script since the audited set was repaired, but the one CI-chain parser accepted only smoke:* names. The suite was therefore visible as debt and impossible to add to the chain.",
+    "",
+    "The parser now accepts exactly smoke or smoke:<non-empty token grammar>; malformed near-misses, including smoke:, remain loud refusals."
+  ],
+  "mutations": [
+    {
+      "name": "restore the smoke-colon-only chain grammar",
+      "file": "bin/smoke/ci-suites.mjs",
+      "find": "    if (!/^smoke(?::[A-Za-z0-9:_-]+)?$/.test(s))",
+      "replace": "    if (!/^smoke:[A-Za-z0-9:_-]+$/.test(s))",
+      "expectRed": "the bare root smoke script is a valid chain entry",
+      "cell": "the bare root smoke script is a valid chain entry"
+    }
+  ]
+}

--- a/packages/core/smoke.ts
+++ b/packages/core/smoke.ts
@@ -1,180 +1,330 @@
 /**
- * End-to-end smoke test (no test runner) — run with: pnpm smoke
- * Requires a nats-server running locally (pnpm cotal up).
+ * Core open-mode end-to-end smoke — run with: pnpm smoke
+ *
+ * Owns an OS-assigned JetStream broker and a unique provisioned space, so the repository's bare
+ * smoke entry point is safe in CI and in concurrent checkouts. Open mode has no trusted Plane-3
+ * delivery daemon: channels are live-only and therefore create no durable membership rows. Direct
+ * messages are separately durable through the lifecycle-keyed DM consumer: a lifecycle that has
+ * connected once receives a message sent during a later offline gap, while a freshly activated
+ * lifecycle does not inherit messages published before its activation frontier.
  */
 import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { connect } from "@nats-io/transport-node";
 import { jetstreamManager } from "@nats-io/jetstream";
+import { killAndAwaitExit, SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 import {
   CotalEndpoint,
-  isReachable,
-  chatStream,
-  dmStream,
-  taskStream,
-  presenceBucket,
-  membersBucket,
-  openMembersRegistry,
-  principalKey,
   DEV_OWNER,
+  chatStream,
+  deleteSpace as deleteSpaceResources,
+  dmDurable,
+  dmStream,
+  isReachable,
+  mintLifecycleUid,
+  principalKey,
+  setupSpaceStreams,
   type CotalMessage,
   type Delivery,
 } from "./src/index.js";
+import { pickFreePort } from "./smoke/_free-port.js";
 
-const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const PORT = await pickFreePort();
+const SERVERS = `nats://127.0.0.1:${PORT}`;
+const SPACE = `core-smoke-${randomUUID().slice(0, 8)}`;
+const storeDir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
+const broker = spawn(
+  "nats-server",
+  ["-js", "-sd", storeDir, "-p", String(PORT), "-a", "127.0.0.1"],
+  { stdio: "ignore" },
+);
+const releaseBroker = teardownOnSignal(broker, storeDir);
+const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+const until = async (
+  condition: () => boolean | Promise<boolean>,
+  timeoutMs = 8_000,
+  stepMs = 50,
+): Promise<boolean> => {
+  const deadline = Date.now() + timeoutMs;
+  let current = await condition();
+  while (!current && Date.now() < deadline) {
+    await wait(stepMs);
+    current = await condition();
+  }
+  return current;
+};
+const textOf = (message: CotalMessage): string =>
+  message.parts.map((part) => (part.kind === "text" ? part.text : "")).join("");
 
-// Wait for NATS to be reachable (handles a just-started server).
-for (let i = 0; i < 50; i++) {
-  if (await isReachable()) break;
-  await wait(200);
+let pass = 0;
+let fail = 0;
+let unexpected = 0;
+const check = (name: string, condition: boolean, extra?: unknown): void => {
+  if (condition) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    fail++;
+    console.log(`  ✗ FAIL: ${name}`, extra ?? "");
+  }
+};
+
+const started = new Set<CotalEndpoint>();
+const startEndpoint = async (endpoint: CotalEndpoint): Promise<void> => {
+  started.add(endpoint);
+  await endpoint.start();
+};
+const stopEndpoint = async (endpoint: CotalEndpoint): Promise<void> => {
+  if (!started.delete(endpoint)) return;
+  await endpoint.stop();
+};
+
+let provisioned = false;
+try {
+  const ready = await until(() => isReachable(SERVERS), 5_000, 100);
+  check("owned broker is ready before the scenario", ready, SERVERS);
+  if (!ready) throw new Error("owned broker did not become reachable");
+
+  await setupSpaceStreams({ servers: SERVERS, space: SPACE });
+  provisioned = true;
+  let chatExists = false;
+  const setupProbe = await connect({ servers: SERVERS });
+  try {
+    await (await jetstreamManager(setupProbe)).streams.info(chatStream(SPACE));
+    chatExists = true;
+  } catch {
+    chatExists = false;
+  } finally {
+    await setupProbe.close();
+  }
+  check("the production setup seam provisions this unique space", chatExists);
+
+  const aliceActor = `alice_${randomUUID().replace(/-/g, "").slice(0, 16)}`;
+  const bobActor = `bob_${randomUUID().replace(/-/g, "").slice(0, 16)}`;
+  const alice = new CotalEndpoint({
+    space: SPACE,
+    servers: SERVERS,
+    lifecycleUid: mintLifecycleUid(),
+    card: { id: aliceActor, name: "alice", role: "planner", kind: "agent" },
+    channels: ["general"],
+    heartbeatMs: 300,
+    ttlMs: 1_500,
+  });
+  const bob = new CotalEndpoint({
+    space: SPACE,
+    servers: SERVERS,
+    lifecycleUid: mintLifecycleUid(),
+    card: { id: bobActor, name: "bob", role: "builder", kind: "agent" },
+    channels: ["general"],
+    heartbeatMs: 300,
+    ttlMs: 1_500,
+  });
+  alice.on("error", (error: Error) => console.error("  ! alice:", error.message));
+  bob.on("error", (error: Error) => console.error("  ! bob:", error.message));
+
+  const bobReceived: Array<{ kind: string; text: string }> = [];
+  let bobMentions: string[] | undefined;
+  bob.on("message", (message: CotalMessage, delivery: Delivery) => {
+    const kind = message.to ? "dm" : message.toService ? `any:${message.toService}` : `channel:${message.channel ?? ""}`;
+    const text = textOf(message);
+    bobReceived.push({ kind, text });
+    if (text === "hello team") bobMentions = message.mentions;
+    delivery.ack();
+  });
+
+  await startEndpoint(alice);
+  await startEndpoint(bob);
+  check(
+    "both explicit-channel peers become visible",
+    await until(
+      () => alice.getRoster().some((peer) => peer.card.id === bob.card.id)
+        && bob.getRoster().some((peer) => peer.card.id === alice.card.id),
+    ),
+  );
+
+  await alice.setStatus("working");
+  check(
+    "presence status propagates",
+    await until(() => bob.getRoster().find((peer) => peer.card.id === alice.card.id)?.status === "working"),
+    bob.getRoster().find((peer) => peer.card.id === alice.card.id)?.status,
+  );
+
+  const sent = await alice.multicast("hello team", {
+    channel: "general",
+    mentions: ["BOB", " bob ", "carol", ""],
+  });
+  const omitted = await alice.multicast("no ping", { channel: "general", mentions: [""] });
+  await alice.unicast(bob.card.id, "private hello");
+  await alice.anycast("builder", "build the thing");
+  await until(
+    () => bobReceived.some((entry) => entry.kind === "channel:general" && entry.text === "hello team")
+      && bobReceived.some((entry) => entry.kind === "dm" && entry.text === "private hello")
+      && bobReceived.some((entry) => entry.kind === "any:builder" && entry.text === "build the thing"),
+  );
+
+  check(
+    "multicast reaches the explicitly joined channel",
+    bobReceived.some((entry) => entry.kind === "channel:general" && entry.text === "hello team"),
+    bobReceived,
+  );
+  check(
+    "unicast reaches the addressed principal",
+    bobReceived.some((entry) => entry.kind === "dm" && entry.text === "private hello"),
+    bobReceived,
+  );
+  check(
+    "anycast reaches the builder role",
+    bobReceived.some((entry) => entry.kind === "any:builder" && entry.text === "build the thing"),
+    bobReceived,
+  );
+  check(
+    "mentions are normalized on the wire",
+    JSON.stringify(sent.mentions) === JSON.stringify(["bob", "carol"]),
+    sent.mentions,
+  );
+  check("empty mentions are omitted", omitted.mentions === undefined, omitted.mentions);
+  check("the recipient sees its normalized mention", bobMentions?.includes("bob") === true, bobMentions);
+
+  const carolActor = `carol_${randomUUID().replace(/-/g, "").slice(0, 16)}`;
+  const carolLifecycleUid = mintLifecycleUid();
+  const carol = new CotalEndpoint({
+    space: SPACE,
+    servers: SERVERS,
+    lifecycleUid: carolLifecycleUid,
+    card: { id: carolActor, name: "carol", role: "tester", kind: "agent" },
+    channels: [],
+    heartbeatMs: 300,
+    ttlMs: 1_500,
+  });
+  carol.on("error", (error: Error) => console.error("  ! carol:", error.message));
+  await startEndpoint(carol);
+
+  let carolDurableExists = false;
+  const durableProbe = await connect({ servers: SERVERS });
+  try {
+    await (await jetstreamManager(durableProbe)).consumers.info(
+      dmStream(SPACE),
+      dmDurable(DEV_OWNER, carolActor, carolLifecycleUid),
+    );
+    carolDurableExists = true;
+  } catch {
+    carolDurableExists = false;
+  } finally {
+    await durableProbe.close();
+  }
+  check("carol's lifecycle creates its DM durable before the offline gap", carolDurableExists);
+
+  await stopEndpoint(carol);
+  await alice.unicast(carol.card.id, "held during the offline gap");
+
+  const carolRestarted = new CotalEndpoint({
+    space: SPACE,
+    servers: SERVERS,
+    lifecycleUid: carolLifecycleUid,
+    card: { id: carolActor, name: "carol", role: "tester", kind: "agent" },
+    channels: [],
+    heartbeatMs: 300,
+    ttlMs: 1_500,
+  });
+  const carolReceived: string[] = [];
+  carolRestarted.on("error", (error: Error) => console.error("  ! carol restart:", error.message));
+  carolRestarted.on("message", (message: CotalMessage, delivery: Delivery) => {
+    carolReceived.push(textOf(message));
+    delivery.ack();
+  });
+  await startEndpoint(carolRestarted);
+  check(
+    "the same lifecycle receives a DM sent while it was offline",
+    await until(() => carolReceived.includes("held during the offline gap")),
+    carolReceived,
+  );
+
+  const daveActor = `dave_${randomUUID().replace(/-/g, "").slice(0, 16)}`;
+  await alice.unicast(principalKey(DEV_OWNER, daveActor).key, "published before activation");
+  const dave = new CotalEndpoint({
+    space: SPACE,
+    servers: SERVERS,
+    lifecycleUid: mintLifecycleUid(),
+    card: { id: daveActor, name: "dave", role: "tester", kind: "agent" },
+    channels: [],
+    heartbeatMs: 300,
+    ttlMs: 1_500,
+  });
+  const daveReceived: string[] = [];
+  dave.on("error", (error: Error) => console.error("  ! dave:", error.message));
+  dave.on("message", (message: CotalMessage, delivery: Delivery) => {
+    daveReceived.push(textOf(message));
+    delivery.ack();
+  });
+  await startEndpoint(dave);
+  await wait(600);
+  check(
+    "a fresh lifecycle does not inherit a pre-activation DM",
+    !daveReceived.includes("published before activation"),
+    daveReceived,
+  );
+
+  check(
+    "open live-only channels do not fabricate durable membership",
+    (await alice.channelMembers("general")).length === 0,
+  );
+  check(
+    "the no-arg durable-membership map is empty in open live-only mode",
+    (await alice.channelMembers()).size === 0,
+  );
+
+  await stopEndpoint(bob);
+  check(
+    "presence flips offline after a peer stops",
+    await until(() => alice.getRoster().find((peer) => peer.card.id === bob.card.id)?.status === "offline"),
+    alice.getRoster().find((peer) => peer.card.id === bob.card.id)?.status,
+  );
+} catch (error) {
+  unexpected++;
+  console.error("  ✗ scenario threw:", (error as Error).message);
+} finally {
+  for (const endpoint of [...started].reverse()) {
+    try {
+      await stopEndpoint(endpoint);
+    } catch (error) {
+      unexpected++;
+      console.error("  ✗ endpoint cleanup threw:", (error as Error).message);
+    }
+  }
+
+  let spaceDeleted = false;
+  let spaceDeleteError: unknown;
+  if (provisioned) {
+    try {
+      await deleteSpaceResources({ servers: SERVERS, space: SPACE });
+      spaceDeleted = true;
+    } catch (error) {
+      spaceDeleteError = error;
+    }
+  }
+  check("the production teardown seam removes the unique space", spaceDeleted, spaceDeleteError);
+
+  await killAndAwaitExit(broker);
+  check(
+    "the owned broker exits before its JetStream tree is removed",
+    broker.exitCode !== null || broker.signalCode !== null,
+  );
+  rmSync(storeDir, { recursive: true, force: true });
+  releaseBroker();
 }
 
-// Unique space per run → isolated streams, no cross-run history bleed, deterministic.
-const space = `smoke-${randomUUID().slice(0, 8)}`;
+const EXPECTED_BEFORE_COUNT = 18;
+check(
+  `every scenario cell ran — ${EXPECTED_BEFORE_COUNT} expected`,
+  pass + fail === EXPECTED_BEFORE_COUNT,
+  { pass, fail, unexpected, expected: EXPECTED_BEFORE_COUNT },
+);
 
-// Provision this run's members registry BEFORE any endpoint exists.
-//
-// `cotal up` creates the members bucket for the space IT provisions; this suite invents its own
-// (`smoke-<uuid>`), so nothing ever created the bucket that `channelMembers` reads. The read path
-// opens without creating (`openMembersRegistry`, `create` defaults false), so the call threw
-// StreamNotFoundError and killed the process at that line. That throw is why the final `ok` and its
-// `SMOKE FAILED` line were unreachable: the suite could not report on any assertion after it,
-// including the offline-DM durability one this file exists to exercise. Creating it here is what
-// lets the run reach its own verdict instead of dying before it.
-const provision = await connect();
-await openMembersRegistry(provision, space, { create: true });
-await provision.close();
-
-const a = new CotalEndpoint({
-  space,
-  card: { name: "alice", role: "planner", kind: "agent" },
-  heartbeatMs: 500,
-  ttlMs: 2000,
-});
-const b = new CotalEndpoint({
-  space,
-  card: { name: "bob", role: "builder", kind: "agent" },
-  heartbeatMs: 500,
-  ttlMs: 2000,
-});
-a.on("error", (e: Error) => console.error("! alice:", e.message));
-b.on("error", (e: Error) => console.error("! bob:", e.message));
-
-const got: string[] = [];
-let bobSawMentions: string[] | undefined;
-b.on("message", (m: CotalMessage, d: Delivery) => {
-  const text = m.parts.map((p) => (p.kind === "text" ? p.text : "")).join("");
-  const kind = m.to ? "DM" : m.toService ? "ANY:" + m.toService : "#" + (m.channel ?? "");
-  got.push(`${kind}:${m.from.name}:${text}`);
-  if (text === "hello team") bobSawMentions = m.mentions; // mentions ride the multicast payload
-  d.ack(); // recorded = surfaced
-});
-
-await a.start();
-await b.start();
-await wait(800);
-
-console.log("roster(a):", a.getRoster().map((p) => `${p.card.name}=${p.status}`));
-console.log("roster(b):", b.getRoster().map((p) => `${p.card.name}=${p.status}`));
-
-await a.setStatus("working");
-// Mentions ride the multicast payload: normalized (trim + lowercase + dedupe) on the wire,
-// and the field is omitted entirely when empty.
-const sent = await a.multicast("hello team", { channel: "general", mentions: ["BOB", " bob ", "carol", ""] });
-const omitted = await a.multicast("noping", { channel: "general", mentions: [""] });
-await wait(300);
-
-const bob = a.getRoster().find((p) => p.card.name === "bob");
-if (bob) await a.unicast(bob.card.id, "psst bob");
-await wait(300);
-
-// anycast to the "builder" service — bob (role: builder) should receive it
-await a.anycast("builder", "build the thing");
-await wait(300);
-
-// Durability: a DM sent to carol BEFORE she connects must still arrive.
-// NOTE: this case currently FAILS and the assertion below is left as it is on purpose. The
-// message is stored, but carol's durable is created past it, so she never sees it; the
-// authenticated sibling passes the same test only because it provisions her durable first.
-// Whether open mode is meant to deliver this at all is the open question in #534, and it is
-// not settled by editing the expectation here.
-// Addressed by PRINCIPAL (<owner>.<actor>), not by a bare id: the owner+actor cutover made a
-// bare id an invalid recipient, and the actor token must be dash-free to be a valid token.
-const carolActor = randomUUID().replace(/-/g, "");
-await a.unicast(principalKey(DEV_OWNER, carolActor).key, "stored while you were away");
-await wait(200);
-const carol = new CotalEndpoint({
-  space,
-  card: { id: carolActor, name: "carol", role: "tester", kind: "agent" },
-  heartbeatMs: 500,
-  ttlMs: 2000,
-});
-carol.on("error", (e: Error) => console.error("! carol:", e.message));
-const carolGot: string[] = [];
-carol.on("message", (m: CotalMessage, d: Delivery) => {
-  carolGot.push(m.parts.map((p) => (p.kind === "text" ? p.text : "")).join(""));
-  d.ack();
-});
-await carol.start();
-await wait(600);
-console.log("carol received (DM sent while offline):", carolGot);
-
-const aliceInB = b.getRoster().find((p) => p.card.name === "alice");
-console.log("bob received:", got);
-console.log("alice status seen by b:", aliceInB?.status);
-
-// Channel membership = broker truth (chat-stream consumers) ∩ presence liveness.
-// Pre-leave, #general has alice, bob, carol — all live. The no-arg form maps every channel.
-const preLeave = await a.channelMembers("general");
-const allChannels = await a.channelMembers();
-console.log("#general members (pre-leave):", preLeave.map((m) => `${m.name}=${m.live ? "live" : "stale"}`));
-console.log("channels → member count:", [...allChannels].map(([ch, ms]) => `${ch}:${ms.length}`));
-
-await b.stop();
-await wait(500);
-const bobInA = a.getRoster().find((p) => p.card.name === "bob");
-console.log("bob status seen by a after stop:", bobInA?.status);
-
-// Bob's chat durable lingers past his leave (reconnect grace), but presence flipped offline:
-// he stays visible as a STALE member (live:false), distinct from still-live alice.
-const afterLeave = await a.channelMembers("general");
-const bobMember = afterLeave.find((m) => m.name === "bob");
-const aliceMember = afterLeave.find((m) => m.name === "alice");
-console.log("#general members (post-leave):", afterLeave.map((m) => `${m.name}=${m.live ? "live" : "stale"}`));
-
-const mentionsNormalized = JSON.stringify(sent.mentions) === JSON.stringify(["bob", "carol"]);
-const emptyOmitted = omitted.mentions === undefined;
-const bobSawMention = bobSawMentions?.includes("bob") === true;
-console.log("mention wire:", { sent: sent.mentions, omitted: omitted.mentions, bobSaw: bobSawMentions });
-
-const membershipLive =
-  preLeave.some((m) => m.name === "alice" && m.live) &&
-  preLeave.some((m) => m.name === "bob" && m.live);
-const membershipMap = (allChannels.get("general") ?? []).some((m) => m.name === "alice");
-const membershipStale = bobMember?.live === false && aliceMember?.live === true;
-
-const ok =
-  got.some((g) => g.startsWith("#general")) &&
-  got.some((g) => g.startsWith("DM")) &&
-  got.some((g) => g.startsWith("ANY:builder")) &&
-  carolGot.some((g) => g.includes("stored while you were away")) &&
-  mentionsNormalized &&
-  emptyOmitted &&
-  bobSawMention &&
-  membershipLive &&
-  membershipMap &&
-  membershipStale &&
-  aliceInB?.status === "working" &&
-  bobInA?.status === "offline";
-
-console.log(ok ? "\nSMOKE OK ✅" : "\nSMOKE FAILED ❌");
-await carol.stop();
-await a.stop();
-
-// Tear down this run's (uniquely-named) streams + presence bucket — race-free, no litter.
-const cleanup = await connect();
-const jsm = await jetstreamManager(cleanup);
-for (const s of [chatStream(space), dmStream(space), taskStream(space), `KV_${presenceBucket(space)}`, `KV_${membersBucket(space)}`]) {
-  await jsm.streams.delete(s).catch(() => {});
-}
-await cleanup.close();
-process.exit(ok ? 0 : 1);
+const totalFail = fail + unexpected;
+console.log(
+  `\n${totalFail === 0 ? "SMOKE OK ✅" : "SMOKE FAILED ❌"}  (${pass} passed, ${totalFail} failed)`,
+);
+process.exit(totalFail === 0 ? 0 : 1);

--- a/packages/core/smoke.ts
+++ b/packages/core/smoke.ts
@@ -36,11 +36,16 @@ const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
 const SPACE = `core-smoke-${randomUUID().slice(0, 8)}`;
 const storeDir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
+let brokerLog = "";
 const broker = spawn(
   "nats-server",
   ["-js", "-sd", storeDir, "-p", String(PORT), "-a", "127.0.0.1"],
-  { stdio: "ignore" },
+  { stdio: ["ignore", "pipe", "pipe"] },
 );
+for (const stream of [broker.stdout, broker.stderr])
+  stream?.on("data", (chunk: Buffer | string) => {
+    brokerLog = (brokerLog + String(chunk)).slice(-8_000);
+  });
 const releaseBroker = teardownOnSignal(broker, storeDir);
 const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 const until = async (
@@ -72,6 +77,14 @@ const check = (name: string, condition: boolean, extra?: unknown): void => {
   }
 };
 
+const endpointErrors: Array<{ endpoint: string; message: string }> = [];
+const watchEndpointErrors = (endpoint: string, instance: CotalEndpoint): void => {
+  instance.on("error", (error: Error) => {
+    endpointErrors.push({ endpoint, message: error.message });
+    console.error(`  ! ${endpoint}:`, error.message);
+  });
+};
+
 const started = new Set<CotalEndpoint>();
 const startEndpoint = async (endpoint: CotalEndpoint): Promise<void> => {
   started.add(endpoint);
@@ -81,20 +94,49 @@ const stopEndpoint = async (endpoint: CotalEndpoint): Promise<void> => {
   if (!started.delete(endpoint)) return;
   await endpoint.stop();
 };
+const stopEndpointWithin = async (endpoint: CotalEndpoint, timeoutMs = 5_000): Promise<void> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      stopEndpoint(endpoint),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`stop timed out after ${timeoutMs}ms`)), timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+};
 
 let provisioned = false;
+const provisionedStreams = new Set<string>();
 try {
-  const ready = await until(() => isReachable(SERVERS), 5_000, 100);
-  check("owned broker is ready before the scenario", ready, SERVERS);
-  if (!ready) throw new Error("owned broker did not become reachable");
+  const reachable = await until(async () => {
+    if (broker.exitCode !== null || broker.signalCode !== null) return false;
+    return isReachable(SERVERS);
+  }, 5_000, 100);
+  if (reachable) await wait(200); // bind failures exit promptly; survive past that before trust
+  const ready = reachable
+    && broker.exitCode === null
+    && broker.signalCode === null
+    && await isReachable(SERVERS);
+  check("owned broker is ready before the scenario", ready, {
+    servers: SERVERS,
+    exitCode: broker.exitCode,
+    signalCode: broker.signalCode,
+    log: brokerLog,
+  });
+  if (!ready) throw new Error("owned broker did not survive bind and become reachable");
 
   await setupSpaceStreams({ servers: SERVERS, space: SPACE });
   provisioned = true;
   let chatExists = false;
   const setupProbe = await connect({ servers: SERVERS });
   try {
-    await (await jetstreamManager(setupProbe)).streams.info(chatStream(SPACE));
-    chatExists = true;
+    const setupManager = await jetstreamManager(setupProbe);
+    for await (const name of setupManager.streams.names()) provisionedStreams.add(name);
+    chatExists = provisionedStreams.has(chatStream(SPACE));
   } catch {
     chatExists = false;
   } finally {
@@ -122,8 +164,8 @@ try {
     heartbeatMs: 300,
     ttlMs: 1_500,
   });
-  alice.on("error", (error: Error) => console.error("  ! alice:", error.message));
-  bob.on("error", (error: Error) => console.error("  ! bob:", error.message));
+  watchEndpointErrors("alice", alice);
+  watchEndpointErrors("bob", bob);
 
   const bobReceived: Array<{ kind: string; text: string }> = [];
   let bobMentions: string[] | undefined;
@@ -199,7 +241,7 @@ try {
     heartbeatMs: 300,
     ttlMs: 1_500,
   });
-  carol.on("error", (error: Error) => console.error("  ! carol:", error.message));
+  watchEndpointErrors("carol", carol);
   await startEndpoint(carol);
 
   let carolDurableExists = false;
@@ -230,7 +272,7 @@ try {
     ttlMs: 1_500,
   });
   const carolReceived: string[] = [];
-  carolRestarted.on("error", (error: Error) => console.error("  ! carol restart:", error.message));
+  watchEndpointErrors("carol restart", carolRestarted);
   carolRestarted.on("message", (message: CotalMessage, delivery: Delivery) => {
     carolReceived.push(textOf(message));
     delivery.ack();
@@ -254,13 +296,18 @@ try {
     ttlMs: 1_500,
   });
   const daveReceived: string[] = [];
-  dave.on("error", (error: Error) => console.error("  ! dave:", error.message));
+  watchEndpointErrors("dave", dave);
   dave.on("message", (message: CotalMessage, delivery: Delivery) => {
     daveReceived.push(textOf(message));
     delivery.ack();
   });
   await startEndpoint(dave);
-  await wait(600);
+  await alice.unicast(dave.card.id, "published after activation");
+  check(
+    "the fresh lifecycle receives a post-activation DM sentinel",
+    await until(() => daveReceived.includes("published after activation")),
+    daveReceived,
+  );
   check(
     "a fresh lifecycle does not inherit a pre-activation DM",
     !daveReceived.includes("published before activation"),
@@ -286,37 +333,60 @@ try {
   unexpected++;
   console.error("  ✗ scenario threw:", (error as Error).message);
 } finally {
-  for (const endpoint of [...started].reverse()) {
-    try {
-      await stopEndpoint(endpoint);
-    } catch (error) {
-      unexpected++;
-      console.error("  ✗ endpoint cleanup threw:", (error as Error).message);
-    }
-  }
+  const endpointsToStop = [...started].reverse();
+  const stopResults = await Promise.allSettled(endpointsToStop.map((endpoint) => stopEndpointWithin(endpoint)));
+  stopResults.forEach((result, index) => {
+    if (result.status === "fulfilled") return;
+    unexpected++;
+    console.error(
+      `  ✗ endpoint cleanup for ${endpointsToStop[index]?.card.name ?? "unknown"} threw:`,
+      result.reason instanceof Error ? result.reason.message : String(result.reason),
+    );
+  });
+
+  check("the endpoints emitted no unexpected errors", endpointErrors.length === 0, endpointErrors);
 
   let spaceDeleted = false;
   let spaceDeleteError: unknown;
+  let remainingStreams: string[] = [];
   if (provisioned) {
     try {
       await deleteSpaceResources({ servers: SERVERS, space: SPACE });
-      spaceDeleted = true;
+      const deletionProbe = await connect({ servers: SERVERS });
+      try {
+        const deletionManager = await jetstreamManager(deletionProbe);
+        for await (const name of deletionManager.streams.names())
+          if (provisionedStreams.has(name)) remainingStreams.push(name);
+      } finally {
+        await deletionProbe.close();
+      }
+      spaceDeleted = provisionedStreams.size > 0 && remainingStreams.length === 0;
     } catch (error) {
       spaceDeleteError = error;
     }
   }
-  check("the production teardown seam removes the unique space", spaceDeleted, spaceDeleteError);
+  check("the production teardown seam removes the unique space", spaceDeleted, {
+    error: spaceDeleteError,
+    remainingStreams,
+    provisionedStreams: [...provisionedStreams],
+  });
 
   await killAndAwaitExit(broker);
-  check(
-    "the owned broker exits before its JetStream tree is removed",
-    broker.exitCode !== null || broker.signalCode !== null,
-  );
-  rmSync(storeDir, { recursive: true, force: true });
-  releaseBroker();
+  const brokerExited = broker.exitCode !== null || broker.signalCode !== null;
+  check("the owned broker exits before its JetStream tree is removed", brokerExited);
+  let storeRemoved = false;
+  let storeRemoveError: unknown;
+  try {
+    rmSync(storeDir, { recursive: true, force: true });
+    storeRemoved = true;
+  } catch (error) {
+    storeRemoveError = error;
+  }
+  check("the owned broker's JetStream tree is removed", storeRemoved, storeRemoveError);
+  if (brokerExited && storeRemoved) releaseBroker();
 }
 
-const EXPECTED_BEFORE_COUNT = 18;
+const EXPECTED_BEFORE_COUNT = 21;
 check(
   `every scenario cell ran — ${EXPECTED_BEFORE_COUNT} expected`,
   pass + fail === EXPECTED_BEFORE_COUNT,

--- a/packages/core/smoke/mutations/core-entry.json
+++ b/packages/core/smoke/mutations/core-entry.json
@@ -1,0 +1,62 @@
+{
+  "suite": "packages/core/smoke.ts",
+  "guard": "the repository's bare core smoke owns its broker and proves lifecycle-scoped open-mode delivery rather than borrowing ambient state",
+  "command": "pnpm smoke",
+  "completionMarker": "SMOKE ",
+  "proveWith": "pnpm mutation-proof --config packages/core/smoke/mutations/core-entry.json",
+  "why": [
+    "The previous bare entry point required an ambient broker, omitted every channel subscription after the no-implicit-general cut, read durable membership from a registry nobody populated, and expected a new lifecycle to inherit a DM published before its activation frontier.",
+    "",
+    "The repaired fixture provisions one unique space through the shipped setup seam, uses explicit live channels, and distinguishes same-lifecycle offline delivery from pre-activation exclusion before production teardown and an awaited broker exit."
+  ],
+  "mutations": [
+    {
+      "name": "skip production space provisioning",
+      "file": "packages/core/smoke.ts",
+      "find": "  await setupSpaceStreams({ servers: SERVERS, space: SPACE });",
+      "replace": "  void SPACE;",
+      "expectRed": "the production setup seam provisions this unique space",
+      "cell": "the production setup seam provisions this unique space"
+    },
+    {
+      "name": "remove bob's explicit general subscription",
+      "file": "packages/core/smoke.ts",
+      "find": "  const bob = new CotalEndpoint({\n    space: SPACE,\n    servers: SERVERS,\n    lifecycleUid: mintLifecycleUid(),\n    card: { id: bobActor, name: \"bob\", role: \"builder\", kind: \"agent\" },\n    channels: [\"general\"],",
+      "replace": "  const bob = new CotalEndpoint({\n    space: SPACE,\n    servers: SERVERS,\n    lifecycleUid: mintLifecycleUid(),\n    card: { id: bobActor, name: \"bob\", role: \"builder\", kind: \"agent\" },\n    channels: [],",
+      "expectRed": "multicast reaches the explicitly joined channel",
+      "cell": "multicast reaches the explicitly joined channel"
+    },
+    {
+      "name": "skip carol's first activation and durable creation",
+      "file": "packages/core/smoke.ts",
+      "find": "  await startEndpoint(carol);\n\n  let carolDurableExists = false;",
+      "replace": "  void carol;\n\n  let carolDurableExists = false;",
+      "expectRed": "carol's lifecycle creates its DM durable before the offline gap",
+      "cell": "carol's lifecycle creates its DM durable before the offline gap"
+    },
+    {
+      "name": "restart carol as a fresh lifecycle",
+      "file": "packages/core/smoke.ts",
+      "find": "  const carolRestarted = new CotalEndpoint({\n    space: SPACE,\n    servers: SERVERS,\n    lifecycleUid: carolLifecycleUid,",
+      "replace": "  const carolRestarted = new CotalEndpoint({\n    space: SPACE,\n    servers: SERVERS,\n    lifecycleUid: mintLifecycleUid(),",
+      "expectRed": "the same lifecycle receives a DM sent while it was offline",
+      "cell": "the same lifecycle receives a DM sent while it was offline"
+    },
+    {
+      "name": "send dave's control message after activation too",
+      "file": "packages/core/smoke.ts",
+      "find": "  await startEndpoint(dave);\n  await wait(600);",
+      "replace": "  await startEndpoint(dave);\n  await alice.unicast(dave.card.id, \"published before activation\");\n  await until(() => daveReceived.includes(\"published before activation\"));",
+      "expectRed": "a fresh lifecycle does not inherit a pre-activation DM",
+      "cell": "a fresh lifecycle does not inherit a pre-activation DM"
+    },
+    {
+      "name": "remove the awaited broker-exit barrier before JetStream tree removal",
+      "file": "packages/core/smoke.ts",
+      "find": "  await killAndAwaitExit(broker);",
+      "replace": "  broker.kill(\"SIGTERM\");",
+      "expectRed": "the owned broker exits before its JetStream tree is removed",
+      "cell": "the owned broker exits before its JetStream tree is removed"
+    }
+  ]
+}

--- a/packages/core/smoke/mutations/core-entry.json
+++ b/packages/core/smoke/mutations/core-entry.json
@@ -43,12 +43,20 @@
       "cell": "the same lifecycle receives a DM sent while it was offline"
     },
     {
-      "name": "send dave's control message after activation too",
-      "file": "packages/core/smoke.ts",
-      "find": "  await startEndpoint(dave);\n  await wait(600);",
-      "replace": "  await startEndpoint(dave);\n  await alice.unicast(dave.card.id, \"published before activation\");\n  await until(() => daveReceived.includes(\"published before activation\"));",
+      "name": "drop the fresh-lifecycle DM activation frontier",
+      "file": "packages/core/src/streams.ts",
+      "find": "      ? { deliver_policy: DeliverPolicy.StartSequence, opt_start_seq: frontier + 1 }",
+      "replace": "      ? { deliver_policy: DeliverPolicy.All }",
       "expectRed": "a fresh lifecycle does not inherit a pre-activation DM",
       "cell": "a fresh lifecycle does not inherit a pre-activation DM"
+    },
+    {
+      "name": "turn production space teardown into a no-op",
+      "file": "packages/core/smoke.ts",
+      "find": "      await deleteSpaceResources({ servers: SERVERS, space: SPACE });",
+      "replace": "      void SPACE;",
+      "expectRed": "the production teardown seam removes the unique space",
+      "cell": "the production teardown seam removes the unique space"
     },
     {
       "name": "remove the awaited broker-exit barrier before JetStream tree removal",
@@ -58,5 +66,6 @@
       "expectRed": "the owned broker exits before its JetStream tree is removed",
       "cell": "the owned broker exits before its JetStream tree is removed"
     }
-  ]
+  ],
+  "grades": "tool"
 }


### PR DESCRIPTION
## Summary
- replace the ambient bare core smoke with an OS-assigned owned broker and production-provisioned unique space
- prove explicit live channels, DM/anycast, presence, same-lifecycle offline DM delivery, fresh-lifecycle pre-activation exclusion, and open-mode membership semantics
- accept the bare `smoke` script in the shared CI-chain parser and gate it append-only

## Verification
- `pnpm smoke` — 19 passed, 0 failed
- four concurrent `pnpm smoke` runs — 4/4 green
- core smoke mutation proof — 6/6 killed
- CI parser mutation proof — 1/1 killed
- `pnpm smoke:ci-suites` — 20 passed, 0 failed
- `pnpm smoke:gate-inventory` — green at 402 suites, 11 UNTRIAGED, 0 BROKEN
- full 26-project workspace build — green