### PR TITLE
test(cli): stabilize component health diagnostics

### DIFF
--- a/implementations/cli/smoke/component-health.smoke.ts
+++ b/implementations/cli/smoke/component-health.smoke.ts
@@ -67,6 +67,16 @@ function cli(...args: string[]) {
   return spawnSync(TSX, [CLI, ...args], { cwd: root, env, encoding: "utf8", timeout: 30_000 });
 }
 
+/** The old-surface fact under comparison, excluding unrelated process-wide advisories whose
+ * presence depends on whether this particular subprocess crossed an approximate CPU threshold. */
+function oldManagerAnswer(text: string): string | undefined {
+  return text
+    .replace(/\x1b\[[0-9;]*m/g, "")
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => /failed-precondition: the service registry for "manager"|no manager reachable/i.test(line));
+}
+
 async function waitForFile(path: string): Promise<void> {
   for (let i = 0; i < 100 && !existsSync(path); i++) await sleep(50);
   assert.ok(existsSync(path), `fixture never wrote ${path}`);
@@ -157,7 +167,15 @@ try {
   const oldAbsentText = `${oldAbsent.stdout}${oldAbsent.stderr}`;
   check("REPRO control: existing ps gives the same manager-service answer when absent",
     oldAbsent.status !== 0 && /service registry.*stream not found|no manager reachable/i.test(oldAbsentText), oldAbsentText);
-  check("REPRO is indistinguishable on the old surface", oldPresent.status === oldAbsent.status && oldPresentText === oldAbsentText, { oldPresentText, oldAbsentText });
+  const oldPresentAnswer = oldManagerAnswer(oldPresentText);
+  const oldAbsentAnswer = oldManagerAnswer(oldAbsentText);
+  check(
+    "REPRO is indistinguishable on the old surface",
+    oldPresent.status === oldAbsent.status &&
+      oldPresentAnswer !== undefined &&
+      oldPresentAnswer === oldAbsentAnswer,
+    { oldPresentAnswer, oldAbsentAnswer, oldPresentText, oldAbsentText },
+  );
 
   const absent = cli("status", "--components", "--space", SPACE, "--server", server);
   const absentText = `${absent.stdout}${absent.stderr}`;

--- a/implementations/cli/smoke/fixtures/component-health.mutations.json
+++ b/implementations/cli/smoke/fixtures/component-health.mutations.json
@@ -1,6 +1,6 @@
 {
   "command": "pnpm smoke:component-health",
-  "progressPattern": "✓",
+  "progressPattern": "\u2713",
   "minTicks": 13,
   "mutations": [
     {
@@ -9,7 +9,8 @@
       "find": "if (!noService) return { name: \"manager\", verdict: \"refused\", facts };\n    const liveRecord = record.kind === \"live\";\n    const hasLease = facts.some((fact) => fact.startsWith(\"lease holder \"));\n    return { name: \"manager\", verdict: liveRecord || hasLease ? \"not-serving\" : \"absent\", facts };",
       "replace": "if (!noService) return { name: \"manager\", verdict: \"refused\", facts };\n    return { name: \"manager\", verdict: \"serving\", facts };",
       "expectRed": "live lease-holder that never serves exits present-not-serving (2)",
-      "cell": "live lease-holder that never serves exits present-not-serving (2)"
+      "cell": "live lease-holder that never serves exits present-not-serving (2)",
+      "afterRestore": "pnpm --filter @cotal-ai/cli build"
     },
     {
       "name": "a confirmed stale-or-missing manager process is reported as present-but-not-serving instead of component-absent",
@@ -17,7 +18,8 @@
       "find": "if (record.kind === \"absent\" || record.kind === \"dead\") return \"absent\";",
       "replace": "if (record.kind === \"absent\" || record.kind === \"dead\") return \"not-serving\";",
       "expectRed": "no manager process exits component-absent (1)",
-      "cell": "no manager process exits component-absent (1)"
+      "cell": "no manager process exits component-absent (1)",
+      "afterRestore": "pnpm --filter @cotal-ai/cli build"
     },
     {
       "name": "a delivery lease that has not reached ready is reported as healthy",
@@ -25,7 +27,8 @@
       "find": "return { name: \"delivery\", verdict: lease.ready ? \"serving\" : \"not-serving\", facts };",
       "replace": "return { name: \"delivery\", verdict: \"serving\", facts };",
       "expectRed": "delivery ready lease and renewal adoption report independently from its own surfaces",
-      "cell": "delivery ready lease and renewal adoption report independently from its own surfaces"
+      "cell": "delivery ready lease and renewal adoption report independently from its own surfaces",
+      "afterRestore": "pnpm --filter @cotal-ai/cli build"
     },
     {
       "name": "a live pid whose command is not the web dashboard is guessed onto the default port instead of refused",
@@ -33,7 +36,8 @@
       "find": "if (!portMatch && !isWebCommand)\n    return { name: \"web\", verdict: \"refused\", facts: [...facts, \"port probe refused (recorded PID is not a web command)\"] };",
       "replace": "",
       "expectRed": "a live non-web pidfile is a probe refusal (3), never a healthy default-port guess",
-      "cell": "a live non-web pidfile is a probe refusal (3), never a healthy default-port guess"
+      "cell": "a live non-web pidfile is a probe refusal (3), never a healthy default-port guess",
+      "afterRestore": "pnpm --filter @cotal-ai/cli build"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -230,7 +230,7 @@
     "smoke:ledger": "tsx implementations/cli/smoke/ledger.smoke.ts",
     "smoke:spawn-manifest:live": "tsx implementations/cli/smoke/spawn-manifest-live.smoke.ts",
     "smoke:manager-singleton:live": "tsx implementations/cli/smoke/manager-singleton-live.smoke.ts",
-    "smoke:component-health": "pnpm --filter @cotal-ai/cli build && tsx implementations/cli/smoke/component-health.smoke.ts",
+    "smoke:component-health": "pnpm --filter cotal-ai... build && tsx implementations/cli/smoke/component-health.smoke.ts",
     "smoke:connect": "tsx implementations/cli/smoke/connect.smoke.ts",
     "smoke:web-seed:live": "tsx implementations/cli/smoke/web-seed-live.smoke.ts",
     "smoke:delivery-cred:auth": "tsx packages/core/smoke/delivery-cred-confinement.smoke.ts",


### PR DESCRIPTION
## Summary

- compare the semantic manager-service diagnostic instead of complete subprocess output, so a nondeterministic schema CPU advisory cannot make equivalent old-surface answers look different
- build the full `cotal-ai` composition dependency closure before the component-health smoke
- rebuild CLI `dist` after every component-health mutation restore

## Validation

- `pnpm smoke:component-health` — 13/13
- component-health mutation proof — 4/4 named kills
- `pnpm smoke:mutation-fixtures` — 203 fixtures, 1,127 anchors, zero failures
- `git diff --check`
