### PR TITLE
test(cli): repair web seed live proof

### DIFF
--- a/implementations/cli/smoke/fixtures/web-seed-live.mutations.json
+++ b/implementations/cli/smoke/fixtures/web-seed-live.mutations.json
@@ -1,0 +1,20 @@
+{
+  "suite": "implementations/cli/smoke/web-seed-live.smoke.ts",
+  "guard": "The live web seed-drop proof writes chat history through a self-scoped operator credential, not a provisioner credential whose least-privilege grant has no chat publish row.",
+  "command": "pnpm --filter @cotal-ai/core... build && pnpm smoke:web-seed:live",
+  "minTicks": 4,
+  "proveWith": "node scripts/mutation-proof.mjs --config implementations/cli/smoke/fixtures/web-seed-live.mutations.json",
+  "why": [
+    "The provisioner still creates streams and registry state, but it deliberately cannot publish chat. Seeding history with it crashes on a broker permission violation before the purge behavior is tested.",
+    "The operator profile is the production self-scoped message surface. The named cell waits for asynchronous permission errors so this distinction fails legibly rather than as an unhandled event."
+  ],
+  "mutations": [
+    {
+      "name": "W1 seed history with a provisioner credential that cannot publish chat",
+      "file": "implementations/cli/smoke/web-seed-live.smoke.ts",
+      "find": "  const publisherCreds = await mintCreds(auth, newIdentity(), \"operator\");",
+      "replace": "  const publisherCreds = await mintCreds(auth, newIdentity(), \"provisioner\");",
+      "expectRed": "operator publisher seeds #ops without broker permission violations"
+    }
+  ]
+}

--- a/implementations/cli/smoke/fixtures/web-seed-live.mutations.json
+++ b/implementations/cli/smoke/fixtures/web-seed-live.mutations.json
@@ -2,7 +2,6 @@
   "suite": "implementations/cli/smoke/web-seed-live.smoke.ts",
   "guard": "The live web seed-drop proof writes chat history through a self-scoped operator credential, not a provisioner credential whose least-privilege grant has no chat publish row.",
   "command": "pnpm --filter @cotal-ai/core... build && pnpm smoke:web-seed:live",
-  "minTicks": 4,
   "proveWith": "node scripts/mutation-proof.mjs --config implementations/cli/smoke/fixtures/web-seed-live.mutations.json",
   "why": [
     "The provisioner still creates streams and registry state, but it deliberately cannot publish chat. Seeding history with it crashes on a broker permission violation before the purge behavior is tested.",

--- a/implementations/cli/smoke/web-seed-live.smoke.ts
+++ b/implementations/cli/smoke/web-seed-live.smoke.ts
@@ -11,10 +11,12 @@
  * Needs `nats-server` on PATH (like the other auth smokes). Kills only the broker it spawns.
  * Run: pnpm smoke:web-seed:live
  */
+import { once } from "node:events";
 import { closeSync, mkdtempSync, writeFileSync, openSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn } from "node:child_process";
+import { createServer } from "node:net";
 import {
   CotalEndpoint,
   clearChannel,
@@ -26,9 +28,19 @@ import {
   serverConfig,
   setupSpaceStreams,
 } from "@cotal-ai/core";
-import { pickFreePort } from "../../auth/smoke/_free-port.js";
+import { killAndAwaitExit } from "@cotal-ai/smoke-kit";
 
-const port = await pickFreePort();
+async function freePort(): Promise<number> {
+  const socket = createServer();
+  socket.listen(0, "127.0.0.1");
+  await once(socket, "listening");
+  const address = socket.address();
+  if (address === null || typeof address === "string") throw new Error("free-port probe did not bind a TCP port");
+  await new Promise<void>((resolve) => socket.close(() => resolve()));
+  return address.port;
+}
+
+const port = await freePort();
 const server = `nats://127.0.0.1:${port}`;
 const space = "webseed";
 const dir = mkdtempSync(join(tmpdir(), "cotal-webseed-"));
@@ -38,9 +50,7 @@ const log = join(dir, "s.log");
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 let pass = 0;
-const closedChildren = new WeakSet<ChildProcess>();
-let broker: ChildProcess | undefined;
-let pub: CotalEndpoint | undefined;
+let broker: ReturnType<typeof spawn> | undefined;
 const ok = (name: string, cond: boolean, extra?: unknown) => {
   if (!cond) throw new Error(`FAIL: ${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
   pass++;
@@ -56,7 +66,6 @@ try {
   } finally {
     closeSync(fd);
   }
-  broker.once("close", () => closedChildren.add(broker!));
 
   const mgrCreds = await mintCreds(auth, newIdentity(), "provisioner");
   let up = false;
@@ -78,7 +87,7 @@ try {
   const publisherCreds = await mintCreds(auth, newIdentity(), "operator");
 
   // Seed #ops through the same self-scoped operator publish surface a CLI message uses.
-  pub = new CotalEndpoint({
+  const pub = new CotalEndpoint({
     space,
     servers: server,
     creds: publisherCreds,
@@ -89,17 +98,18 @@ try {
   });
   const publisherErrors: string[] = [];
   pub.on("error", (error: Error) => publisherErrors.push(error.message));
-  await pub.start();
-  for (let i = 0; i < 3; i++) {
+  try {
+    await pub.start();
     try {
-      await pub.multicast(`m${i}`, { channel: "ops" });
+      await pub.multicast("seeded history", { channel: "ops" });
     } catch (error) {
       publisherErrors.push(error instanceof Error ? error.message : String(error));
     }
+    await sleep(300);
+    ok("operator publisher seeds #ops without broker permission violations", publisherErrors.length === 0, publisherErrors);
+  } finally {
+    await pub.stop().catch(() => {});
   }
-  await sleep(300);
-  ok("operator publisher seeds #ops without broker permission violations", publisherErrors.length === 0, publisherErrors);
-  await pub.stop();
 
   // The ADMIN connection cred (what web connects with) must NOT be able to purge — that's the whole
   // reason web mints a manager cred separately.
@@ -121,18 +131,9 @@ try {
 
   console.log(`\nweb account-seed live e2e: ${pass} checks passed`);
 } finally {
-  await pub?.stop().catch(() => {});
-  let brokerClosed = broker === undefined || closedChildren.has(broker);
-  if (broker && !brokerClosed) {
-    const closed = new Promise<boolean>((resolve) => {
-      const onClose = () => { clearTimeout(timer); resolve(true); };
-      const timer = setTimeout(() => { broker!.off("close", onClose); resolve(false); }, 5_000);
-      broker.once("close", onClose);
-    });
-    try { broker.kill("SIGKILL"); } catch { /* already gone */ }
-    brokerClosed = await closed;
-  }
-  if (!brokerClosed) throw new Error(`web-seed broker did not close; preserving scratch state at ${dir}`);
+  if (broker) await killAndAwaitExit(broker, "SIGKILL", 5_000);
+  const brokerStopped = broker === undefined || broker.exitCode !== null || broker.signalCode !== null;
+  if (!brokerStopped) throw new Error(`web-seed broker did not stop; preserving scratch state at ${dir}`);
   rmSync(dir, { recursive: true, force: true });
 }
 process.exit(0);

--- a/implementations/cli/smoke/web-seed-live.smoke.ts
+++ b/implementations/cli/smoke/web-seed-live.smoke.ts
@@ -11,7 +11,7 @@
  * Needs `nats-server` on PATH (like the other auth smokes). Kills only the broker it spawns.
  * Run: pnpm smoke:web-seed:live
  */
-import { mkdtempSync, writeFileSync, openSync, readFileSync, rmSync } from "node:fs";
+import { closeSync, mkdtempSync, writeFileSync, openSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawn, type ChildProcess } from "node:child_process";
@@ -26,8 +26,9 @@ import {
   serverConfig,
   setupSpaceStreams,
 } from "@cotal-ai/core";
+import { pickFreePort } from "../../auth/smoke/_free-port.js";
 
-const port = 4461;
+const port = await pickFreePort();
 const server = `nats://127.0.0.1:${port}`;
 const space = "webseed";
 const dir = mkdtempSync(join(tmpdir(), "cotal-webseed-"));
@@ -37,7 +38,9 @@ const log = join(dir, "s.log");
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 let pass = 0;
-const kids: ChildProcess[] = [];
+const closedChildren = new WeakSet<ChildProcess>();
+let broker: ChildProcess | undefined;
+let pub: CotalEndpoint | undefined;
 const ok = (name: string, cond: boolean, extra?: unknown) => {
   if (!cond) throw new Error(`FAIL: ${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
   pass++;
@@ -48,7 +51,12 @@ try {
   const auth = await createSpaceAuth(space); // the account signing SEED
   writeFileSync(conf, serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port, storeDir }));
   const fd = openSync(log, "w");
-  kids.push(spawn("nats-server", ["-c", conf], { stdio: ["ignore", fd, fd] }));
+  try {
+    broker = spawn("nats-server", ["-c", conf], { stdio: ["ignore", fd, fd] });
+  } finally {
+    closeSync(fd);
+  }
+  broker.once("close", () => closedChildren.add(broker!));
 
   const mgrCreds = await mintCreds(auth, newIdentity(), "provisioner");
   let up = false;
@@ -67,20 +75,24 @@ try {
   // web's NEW model: connect as ADMIN, pre-mint ONE MANAGER cred for the purge, drop the seed.
   const adminCreds = await mintCreds(auth, newIdentity(), "admin");
   const purgeCreds = await mintCreds(auth, newIdentity(), "channel-purger"); // pre-minted once, like web
+  const publisherCreds = await mintCreds(auth, newIdentity(), "operator");
 
-  // Seed #ops with history (via a manager endpoint — a plain publisher).
-  const pub = new CotalEndpoint({
+  // Seed #ops through the same self-scoped operator publish surface a CLI message uses.
+  pub = new CotalEndpoint({
     space,
     servers: server,
-    creds: mgrCreds,
+    creds: publisherCreds,
     card: { name: "seed", kind: "endpoint" },
     consume: false,
     registerPresence: false,
     watchPresence: false,
   });
+  const publisherErrors: string[] = [];
+  pub.on("error", (error: Error) => publisherErrors.push(error.message));
   await pub.start();
   for (let i = 0; i < 3; i++) await pub.multicast(`m${i}`, { channel: "ops" });
   await sleep(300);
+  ok("operator publisher seeds #ops without broker permission violations", publisherErrors.length === 0, publisherErrors);
   await pub.stop();
 
   // The ADMIN connection cred (what web connects with) must NOT be able to purge — that's the whole
@@ -103,14 +115,18 @@ try {
 
   console.log(`\nweb account-seed live e2e: ${pass} checks passed`);
 } finally {
-  for (const k of kids) {
-    try {
-      k.kill("SIGKILL");
-    } catch {
-      /* already gone */
-    }
+  await pub?.stop().catch(() => {});
+  let brokerClosed = broker === undefined || closedChildren.has(broker);
+  if (broker && !brokerClosed) {
+    const closed = new Promise<boolean>((resolve) => {
+      const onClose = () => { clearTimeout(timer); resolve(true); };
+      const timer = setTimeout(() => { broker!.off("close", onClose); resolve(false); }, 5_000);
+      broker.once("close", onClose);
+    });
+    try { broker.kill("SIGKILL"); } catch { /* already gone */ }
+    brokerClosed = await closed;
   }
-  await sleep(300);
+  if (!brokerClosed) throw new Error(`web-seed broker did not close; preserving scratch state at ${dir}`);
   rmSync(dir, { recursive: true, force: true });
 }
 process.exit(0);

--- a/implementations/cli/smoke/web-seed-live.smoke.ts
+++ b/implementations/cli/smoke/web-seed-live.smoke.ts
@@ -90,7 +90,13 @@ try {
   const publisherErrors: string[] = [];
   pub.on("error", (error: Error) => publisherErrors.push(error.message));
   await pub.start();
-  for (let i = 0; i < 3; i++) await pub.multicast(`m${i}`, { channel: "ops" });
+  for (let i = 0; i < 3; i++) {
+    try {
+      await pub.multicast(`m${i}`, { channel: "ops" });
+    } catch (error) {
+      publisherErrors.push(error instanceof Error ? error.message : String(error));
+    }
+  }
   await sleep(300);
   ok("operator publisher seeds #ops without broker permission violations", publisherErrors.length === 0, publisherErrors);
   await pub.stop();


### PR DESCRIPTION
## Summary

- seed chat history through the self-scoped operator publish surface instead of the least-privilege provisioner credential, which intentionally has no chat publish grant
- keep the CLI smoke self-contained, use an OS-assigned broker port, close the inherited log descriptor, scope the publisher with `try/finally`, and reuse the shared smoke teardown helper before scratch removal
- add a mutation that substitutes the provisioner credential and requires the named broker-permission cell to fail

## Validation

- `pnpm smoke:web-seed:live` — 4/4
- four concurrent live runs — 4/4 each, no new scratch directories
- web-seed mutation proof — 1/1 named kill
- `pnpm smoke:mutation-fixtures` — 204 fixtures, 1,128 anchors, zero failures
- full build and `git diff --check`
