### PR TITLE
test(ci): repair web smoke coverage

### DIFF
--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -603,3 +603,11 @@ smoke:web-seed:live
 # broker, including a caller-only COTAL_DEFAULT_AGENT crossing into an already-running manager.
 # Appended to preserve every existing shard assignment.
 smoke:persona-agent
+# The web component probe parses the recorded process command and refuses unrelated PIDs,
+# wildcard hosts, and invalid ports instead of guessing at the dashboard default. Appended so
+# every existing shard assignment remains unchanged.
+smoke:web-probe-target
+# The web runtime binds the requested remote host, rejects wildcard public URLs, and keeps the
+# loopback default when no host is supplied. Appended so every existing shard assignment remains
+# unchanged.
+smoke:web-remote-bind

--- a/implementations/cli/smoke/fixtures/component-health.mutations.json
+++ b/implementations/cli/smoke/fixtures/component-health.mutations.json
@@ -33,7 +33,7 @@
     {
       "name": "a live pid whose command is not the web dashboard is guessed onto the default port instead of refused",
       "file": "implementations/cli/src/commands/status.ts",
-      "find": "if (!portMatch && !isWebCommand)\n    return { name: \"web\", verdict: \"refused\", facts: [...facts, \"port probe refused (recorded PID is not a web command)\"] };",
+      "find": "  if (!portMatch && !isWebCommand)\n    return { refused: \"port probe refused (recorded PID is not a web command)\" };",
       "replace": "",
       "expectRed": "a live non-web pidfile is a probe refusal (3), never a healthy default-port guess",
       "cell": "a live non-web pidfile is a probe refusal (3), never a healthy default-port guess",


### PR DESCRIPTION
## Summary

- retarget the component-health web-process mutation after PR #957 extracted `webProbeTarget`
- keep the original claim unchanged: an unrelated live PID must never be guessed onto the default dashboard port
- append the new `smoke:web-probe-target` and `smoke:web-remote-bind` suites to the CI tail without moving any existing suite
- restore both mutation inventory and gate inventory on current main

## Validation

- `pnpm smoke:component-health` — 17/17
- component-health mutation proof — 4/4 named kills
- `pnpm smoke:web-probe-target` — green
- `pnpm smoke:web-remote-bind` — 19/19
- `pnpm smoke:gate-inventory` — 465 scripts, 444 reached, 21 not run, 11 UNTRIAGED, 0 BROKEN; only the intentionally pending user-auth live suite remains cited-but-ungated
- `pnpm smoke:mutation-fixtures` — 207 fixtures, 1,154 anchors, zero dead/ambiguous/prose-spanning/missing anchors
- `pnpm check:shard-stability origin/main HEAD` — 405 → 407 suites; 0 of 405 existing suites moved shards
