### PR TITLE
test(ci): gate the live user-auth composition suite

### DIFF
--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -618,3 +618,7 @@ smoke:manager-runtime-deps
 # Seat provenance rows must stay correct across the three ps presentations; appended so
 # every existing shard assignment remains unchanged.
 smoke:ps-provenance
+# The real user-auth composition root owns a broker, Better Auth IdP, auth daemon, manager, and
+# CLI subprocesses through grant, exchange, connect, revoke, crash-heal, and teardown. Appended so
+# every existing shard assignment remains unchanged.
+smoke:user-auth-launch:live

--- a/bin/smoke/gate-inventory.smoke.ts
+++ b/bin/smoke/gate-inventory.smoke.ts
@@ -82,7 +82,6 @@ const UNGATED: Record<string, string> = {
   // `smoke:user-spawn:live` left this list when it was gated: it had thrown at section B1e on a
   // missing explicit `tls` and stopped after 14 of its 66 cells, and being ungated is why nobody
   // heard about it. "Too slow for the gate" was 105 seconds.
-  "smoke:user-auth-launch:live": "full live stack",
   // Untriaged debt. These are the ones that should shrink.
   "smoke:attention": "UNTRIAGED",
   "smoke:attention:auth": "UNTRIAGED",
@@ -111,7 +110,7 @@ const CITED_IN_PLAN = new Set([
   "smoke:auth", "smoke:channel-attention", "smoke:channel-attention:auth", "smoke:channels",
   "smoke:doctor-auth", "smoke:install", "smoke:ledger",
   "smoke:manifest-launch", "smoke:members", "smoke:membership-feed:auth", "smoke:presence-scrub",
-  "smoke:start-model", "smoke:static-lifecycle", "smoke:user-auth-launch:live",
+  "smoke:start-model", "smoke:static-lifecycle",
   "smoke:user-spawn:live",
 ]);
 

--- a/bin/smoke/suite-ambient-env.smoke.ts
+++ b/bin/smoke/suite-ambient-env.smoke.ts
@@ -112,7 +112,6 @@ const FROZEN: readonly string[] = [
   "implementations/auth/smoke/_ps-arm2.smoke.ts",
   "implementations/auth/smoke/ps-operator-path.smoke.ts",
   "implementations/auth/smoke/ps-user-mode.smoke.ts",
-  "implementations/auth/smoke/user-auth-launch.smoke.ts",
   "implementations/auth/smoke/user-spawn.smoke.ts",
   "implementations/cli/smoke/bind-fence-live.smoke.ts",
   "implementations/cli/smoke/ext-seed-help.smoke.ts",

--- a/implementations/auth/smoke/mutations/user-auth-regrant-lifecycle.json
+++ b/implementations/auth/smoke/mutations/user-auth-regrant-lifecycle.json
@@ -24,7 +24,7 @@
     {
       "name": "R2 the legacy static control mints a pre-lifecycle agent credential",
       "file": "implementations/auth/smoke/user-auth-launch.smoke.ts",
-      "find": "      lifecycleUid: mintLifecycleUid(),\n      allowSubscribe: [\"general\"],",
+      "find": "      lifecycleUid: oldStaticUid,\n      allowSubscribe: [\"general\"],",
       "replace": "      allowSubscribe: [\"general\"],",
       "expectRed": "the legacy static-agent control is a lifecycle-bound credential, not a pre-cut stub"
     },

--- a/implementations/auth/smoke/user-auth-launch.smoke.ts
+++ b/implementations/auth/smoke/user-auth-launch.smoke.ts
@@ -44,7 +44,12 @@ process.env.COTAL_HOME = home;
 process.env.XDG_CONFIG_HOME = configDir;
 const root = mkdtempSync(join(tmpdir(), "cotal-ua-root-"));
 const sandbox = recordSmokeSandbox({ root, cotalHome: home, xdgConfigHome: configDir });
-const childEnv = { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: configDir };
+// Ambient COTAL_* vars are a seat's environment, not this sandbox's: an inherited
+// COTAL_LIFECYCLE_UID silently satisfies `join --creds`'s lifecycle pairing and flips which
+// refusal fires, so a cell can pass on an operator's machine and fail in CI's clean env
+// (measured, PR #962 shard 3). The child sees only the sandbox's own pins.
+const inheritedEnv = Object.fromEntries(Object.entries(process.env).filter(([k]) => !k.startsWith("COTAL_")));
+const childEnv = { ...inheritedEnv, COTAL_HOME: home, XDG_CONFIG_HOME: configDir };
 
 const { connect, credsAuthenticator, tokenAuthenticator } = await import("@nats-io/transport-node");
 const { chatSubject, isReachable, mintCreds, mintLifecycleUid, newIdentity } = await import("@cotal-ai/core");
@@ -396,9 +401,10 @@ try {
   const oldStaticCreds = join(oldCredsDir, "old-static.creds");
   let oldStaticMaterial = "";
   let oldStaticError = "";
+  const oldStaticUid = mintLifecycleUid();
   try {
     oldStaticMaterial = await mintCreds(auth, newIdentity(), "agent", {
-      lifecycleUid: mintLifecycleUid(),
+      lifecycleUid: oldStaticUid,
       allowSubscribe: ["general"],
       allowPublish: ["general"],
     });
@@ -408,7 +414,12 @@ try {
   check("the legacy static-agent control is a lifecycle-bound credential, not a pre-cut stub",
     oldStaticMaterial.includes("BEGIN NATS USER JWT"), oldStaticError);
   writeFileSync(oldStaticCreds, oldStaticMaterial, { mode: 0o600 });
-  const joinOldStatic = await cotal(["join", "--creds", oldStaticCreds, "--server", SERVER, "--space", SPACE], { timeoutMs: 15_000 });
+  // Without its provision-time uid, --creds is refused at the lifecycle-pairing guard BEFORE the
+  // user-mesh flip is even consulted — that ordering is what the ambient-env leak masked.
+  const joinUnpaired = await cotal(["join", "--creds", oldStaticCreds, "--server", SERVER, "--space", SPACE], { timeoutMs: 15_000 });
+  check("`join --creds` without its lifecycle uid is refused as lifecycle-paired (SPEC 13.1)",
+    joinUnpaired.status !== 0 && joinUnpaired.out.includes("lifecycle-paired"), joinUnpaired.out);
+  const joinOldStatic = await cotal(["join", "--creds", oldStaticCreds, "--lifecycle-uid", oldStaticUid, "--server", SERVER, "--space", SPACE], { timeoutMs: 15_000 });
   check("the flip: `join --creds` with an old static cred is refused on a known user mesh", joinOldStatic.status !== 0 && joinOldStatic.out.includes("per-user-auth") && joinOldStatic.out.includes("cotal spawn"), joinOldStatic.out);
   const sendOldStatic = await cotal(["send", "msg", "general", "old static", "--creds", oldStaticCreds, "--server", SERVER, "--space", SPACE], { timeoutMs: 15_000 });
   check("the flip: raw `--creds` send is refused on a known user mesh", sendOldStatic.status !== 0 && sendOldStatic.out.includes("per-user-auth"), sendOldStatic.out);


### PR DESCRIPTION
The `smoke:user-auth-launch:live` suite drives the real user-auth composition root — broker, Better Auth IdP, auth daemon, manager, and CLI subprocesses — through grant, exchange, connect, revoke, crash-heal, and teardown. It was cited in the plan but ungated ("full live stack"); nobody would hear about a regression.

With the interactive lifecycle retirement merged (#954) the suite runs green on main: 67 passed, 0 failed.

- `bin/smoke/ci-suites.txt`: appended `smoke:user-auth-launch:live` (append-only; `check:shard-stability origin/main HEAD` confirms 0 existing suites move shards).
- `bin/smoke/gate-inventory.smoke.ts`: removed it from `UNGATED` and from `CITED_IN_PLAN`'s exemption list; gate inventory reports 0 cited-but-ungated, 0 BROKEN.