### PR TITLE
test(herdr): kill the real manager, not its wrapper, and exit deterministically

### DIFF
--- a/bin/smoke/herdr-e2e-live.smoke.ts
+++ b/bin/smoke/herdr-e2e-live.smoke.ts
@@ -63,12 +63,14 @@ catch {
 // ── recorded identities, for teardown by exact name ────────────────────────────
 let srvPid: number | undefined;
 let mgrPid: number | undefined;
+let realMgrPid: number | undefined;
 let scratch: string | undefined;
 let cleaned = false;
 function cleanup() {
   if (cleaned) return;
   cleaned = true;
   if (mgrPid !== undefined) { try { process.kill(mgrPid, "SIGKILL"); } catch { /* gone */ } }
+  if (realMgrPid !== undefined) { try { process.kill(realMgrPid, "SIGKILL"); } catch { /* gone */ } }
   try { herdr.stopSession(HERDR_SESSION); } catch { /* not running */ }
   try { execFileSync("herdr", ["session", "delete", HERDR_SESSION], { stdio: "ignore" }); } catch { /* gone */ }
   if (srvPid !== undefined) { try { process.kill(srvPid); } catch { /* gone */ } }
@@ -170,10 +172,19 @@ check("pane scrollback does NOT contain the agent's nkey seed", seed.length > 20
 
 // ── THE headline claim: kill the manager, the agent lives ─────────────────────
 console.log("\n  … SIGKILL the manager and watch the agent:\n");
+// `child.pid` is the tsx WRAPPER; the Manager lives in the process the child reports as
+// managerPid. Killing only the wrapper leaves a live orphaned manager — which, since the
+// manager stopped ending its process over a lost liveness lease, serves forever and holds
+// this suite's stdio pipes open, so the suite goes green and then never exits (the CI hang).
+// The survival claim is only about the REAL manager dying, so kill and assert on that pid.
+realMgrPid = Number(ready!.managerPid);
+check("the child reported the real manager pid", realMgrPid > 0, String(ready!.managerPid));
 check("the agent is running before the kill", alive(agentPid));
-process.kill(mgrPid!, "SIGKILL");
-const managerDead = await until(() => !alive(mgrPid!), 15_000);
+process.kill(realMgrPid, "SIGKILL");
+try { process.kill(mgrPid!, "SIGKILL"); } catch { /* wrapper already followed its child down */ }
+const managerDead = await until(() => !alive(realMgrPid!), 15_000);
 mgrPid = undefined; // no longer ours to kill in teardown
+realMgrPid = undefined;
 check("the manager process is really dead", managerDead);
 // Give any process-group signal that WOULD have killed the agent time to land.
 await wait(3_000);
@@ -189,4 +200,6 @@ check("the agent process exits with its pane", await until(() => !alive(agentPid
 console.log(`\n────────────────────────────────────────────────`);
 console.log(`\n${pass} passed, ${fail} failed  (${pass + fail} cells ran)\n`);
 cleanup();
-if (fail > 0) process.exit(1);
+// Exit explicitly: a verdict has been printed and teardown has run, so nothing a leaked
+// handle might still reference is allowed to keep this process (and a CI job) alive.
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
Every CI live job on every branch has hung at `herdr e2e` and died at the 25-minute cap since 2026-08-28 (last green live job: 2026-08-27T23:41Z). This unblocks the whole queue, including #958 and #962.

**Mechanism.** The suite spawns the manager child through the tsx CLI and records `child.pid` — the wrapper. The Manager runs in the process the child itself reports as `managerPid` in its READY line, which the suite never read. `SIGKILL(child.pid)` killed the wrapper; the real manager survived as an orphan holding the suite's stdout/stderr pipe write-ends. Pre-#925 that orphan ended its own process over the lost liveness lease, so the pipes EOF'd and the suite's unstated reliance on natural event-loop exit held. #925 makes an orphaned manager keep serving by design — correct for production, but now the green suite never exits: verdict printed, pipes held, job killed at the cap.

**Evidence.**
- Post-#925 main: 25/25 then `timeout 300` exit 124; `getActiveResourcesInfo()` after cleanup names `ProcessWrap, PipeWrap, PipeWrap`.
- Pre-#925 main (2dc2c9063), same machine: 25/25 and natural exit 0.
- CI bracket: live=success through 2026-08-27T23:41Z, live hung/cancelled on every run after #925 merged.

**Fix.** Kill `managerPid` (the wrapper follows), assert death on that pid — the survival claim is now about the actual manager for the first time — add a cell pinning that the child reported a real pid, and end the smoke with an explicit `process.exit(fail > 0 ? 1 : 0)`: a smoke that has printed its verdict and torn down has no business waiting on the event loop.

Local: 26/26, exit 0, ~3 minutes. This PR's own live job is the CI proof.