### PR TITLE
fix(smoke): release the manager's pipes so herdr e2e can exit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,10 @@ jobs:
       # The integration the unit suite cannot reach: real broker + real Manager + a real agent in
       # presence, then SIGKILL the manager to prove the agent outlives it.
       - name: herdr e2e (real broker + manager + agent, manager-kill survival)
-        run: pnpm smoke:herdr-e2e:live
+        # A hang here reads as `cancelled` on the job, which looks like a supersession rather
+        # than a failure — that is how a PASSING suite held this gate red for twelve runs. Bound
+        # the step so the next one fails red and names itself.
+        run: timeout 600 pnpm smoke:herdr-e2e:live
       - name: cmux launcher secret-hygiene smoke
         run: pnpm smoke:cmux
       - name: OpenCode cooperative-stop smoke test

--- a/bin/smoke/herdr-e2e-live.smoke.ts
+++ b/bin/smoke/herdr-e2e-live.smoke.ts
@@ -24,6 +24,7 @@ import { randomUUID } from "node:crypto";
 import { execFileSync, spawn } from "node:child_process";
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
 import { createServer, type AddressInfo } from "node:net";
+import type { Readable } from "node:stream";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createSpaceAuth, serverConfig, setupSpaceStreams, mintCreds, newIdentity, isReachable } from "@cotal-ai/core";
@@ -63,12 +64,20 @@ catch {
 // ── recorded identities, for teardown by exact name ────────────────────────────
 let srvPid: number | undefined;
 let mgrPid: number | undefined;
+/** The manager's stdio pipes, recorded so teardown can release them by that exact identity. */
+let mgrPipes: { stdout: Readable; stderr: Readable } | undefined;
 let scratch: string | undefined;
 let cleaned = false;
 function cleanup() {
   if (cleaned) return;
   cleaned = true;
   if (mgrPid !== undefined) { try { process.kill(mgrPid, "SIGKILL"); } catch { /* gone */ } }
+  // herdr's server is spawned DETACHED by the manager, which is the entire claim this suite exists
+  // to prove: it outlives the manager. It also inherits the manager's stdout/stderr, so killing the
+  // manager does NOT close the write ends and these read ends keep the event loop alive long after
+  // the last assertion. Every failure path here calls process.exit, so only a PASSING run hung —
+  // for 18 minutes, until the job limit killed it, with "25 passed, 0 failed" already printed.
+  if (mgrPipes) { mgrPipes.stdout.destroy(); mgrPipes.stderr.destroy(); }
   try { herdr.stopSession(HERDR_SESSION); } catch { /* not running */ }
   try { execFileSync("herdr", ["session", "delete", HERDR_SESSION], { stdio: "ignore" }); } catch { /* gone */ }
   if (srvPid !== undefined) { try { process.kill(srvPid); } catch { /* gone */ } }
@@ -124,6 +133,7 @@ const child = spawn(process.execPath, [
   stdio: ["ignore", "pipe", "pipe"],
 });
 mgrPid = child.pid;
+mgrPipes = { stdout: child.stdout, stderr: child.stderr };
 let ready: Record<string, unknown> | undefined;
 let childErr = "";
 child.stdout.on("data", (b: Buffer) => {


### PR DESCRIPTION
The `live` job has not finished in twelve consecutive CI runs, including on the current `main` tip. It
is not being superseded and it is not short of time. `smoke:herdr-e2e:live` passes and then refuses to
exit.

## The measurement

Step timings for `live` on `main` at `ae9f6164` (run 33220279945, job 99014587114). Everything before
step 17 costs seven minutes in total; step 17 consumes the remaining eighteen and is killed.

| step | | elapsed |
|---|---|---|
| 1-11 | set up, install, build | 48s |
| 12 | core boundary, mesh preflight & resolution | 5m29s |
| 13 | manager lifecycle e2e | 14s |
| 14 | runtime smokes (tmux, orca, herdr) | 23s |
| 15-16 | herdr soak instrument, endurance soak | 5s |
| 17 | **herdr e2e** | **18m13s, killed** |
| 18-19 | cmux secret-hygiene, OpenCode cooperative-stop | never ran |

From that job's log:

```
23:43:12.977  $ tsx bin/smoke/herdr-e2e-live.smoke.ts
23:43:19.336    ✓ the agent process exits with its pane
23:43:19.336  25 passed, 0 failed  (25 cells ran)
00:01:25.647  ##[error]The operation was canceled.
```

All 25 cells in 6.7 seconds, zero failures, then 18 minutes of nothing. The same job's teardown reports
`Terminate orphan process: pid (11877) (node)`.

## Cause

herdr's server is spawned `detached` by the manager. That is the claim this suite exists to prove: the
agent outlives the manager. The detached server also inherits the manager's stdout/stderr, which are
this suite's pipes, so SIGKILLing the manager at L174 does not close the write ends. The read ends stay
open, the event loop never drains, and the process hangs.

Only a **passing** run hangs. Every failure path exits explicitly (L54, L60, L79, L139, L192) and the
success path falls off the end. That asymmetry is why the step read as slow rather than as leaked:
there was no failing observation to compare it against.

## Fix

Record the pipes at creation time and release them in teardown, by that exact identity, which is the
convention the suite's own header states and which it already follows for the broker pid, the manager
pid and the scratch dir.

## Proof

The real suite, same machine and same broker, one difference between the two runs:

```
=== CONTROL: pristine suite ===
25 passed, 0 failed  (25 cells ran)
exit=124        # killed by `timeout 150`
=== FIXED ===
25 passed, 0 failed  (25 cells ran)
exit=0          # 6 seconds
```

The control reproduces the CI failure locally, so this is not a fix for a symptom read off a log.

## The `timeout` on the step

A hang inside a step is badged `cancelled` on the job, which reads as "a newer run replaced this one"
rather than "this did not finish". That is how a passing suite held the gate red for twelve runs
without anyone reading the log. Bounding the step makes the next occurrence fail red and name itself.

The general form of that problem is not fixed here and stays open on #967: any live step can still hang
invisibly, and this only bounds the one that demonstrably does.

## Scope

Two files. `bin/smoke` is not in the published `files` of `bin/package.json`, so no shipped code
changes and no changeset is needed.

Refs #967.
