### PR TITLE
feat(delivery): store-inject the $SYS/membership pair for hosted per-space eviction

### DIFF
--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -627,3 +627,8 @@ smoke:user-auth-launch:live
 # sibling silently. Drives the real CLI against a real broker. Appended so every existing shard
 # assignment remains unchanged.
 smoke:up-multi-space-render:live
+# The $SYS store-injection eviction edge on a two-tenant live broker: the SecretStore-read
+# credential pair must survive a store eviction without the delivery daemon re-reading a stale
+# pair. Drives the real daemon against a real broker. Appended so every existing shard
+# assignment remains unchanged.
+smoke:sys-injection-evict

--- a/docs/design/u3-membership-sys-injection.md
+++ b/docs/design/u3-membership-sys-injection.md
@@ -408,11 +408,17 @@ refuses rather than silently proving the property on whatever binary is first on
   worsens nor repairs it.
 
   The torn-rotation check in §4.3 remains the same *class* of problem as U2's inventory CAS (a
-  two-write commit observed half-applied) and should reuse U2's vocabulary rather than invent a
-  second one. **Named forward reference:** U2's vocabulary section, path and section number to be
-  filled in from U2's post-verdict commit (U2 is folding two blockers; `default_agent` supplies the
-  citation). This stays an explicit unresolved reference rather than a guessed one — a wrong section
-  number here would be copied forward by exactly the lanes it is meant to align.
+  two-write commit observed half-applied) and reuses U2's vocabulary rather than inventing a second
+  one: `docs/design/u2-resolver-cas.md` §8, *"Exported vocabulary — the torn-write failure modes"*,
+  which names itself the stable citation target for other lanes. The term §4.3's torn rotation
+  instantiates is **TORN WRITE / LOST UPDATE**.
+
+  **Same class, not the same instance.** The citation borrows a name for the failure mode; it does
+  not claim U2's mechanism closes U3's window, and nothing in §4.3 waits on U2. U2's instance is an
+  inventory CAS; U3's is a `$SYS` two-cred write straddling a trust-record commit, and the two are
+  fenced by different things — U2 by its CAS, U3 by the intrinsic `iss` comparison that proves
+  staleness with no signer read. Reading the citation as coverage would be the one way this reference
+  does harm, so it is ruled out here rather than left to the reader.
 
 - **P2 (space-provisioner).** P2's gate already names "per-space membership/`$SYS` semantics on a
   shared broker" as an F4 residual (`CLOUD-PLAN.md:155-156`). U3 is the upstream half that makes

--- a/docs/design/u3-membership-sys-injection.md
+++ b/docs/design/u3-membership-sys-injection.md
@@ -1,0 +1,322 @@
+# Membership / `$SYS` credential injection
+
+> **Design** (non-normative, not shipped) · Closes [embedding](../embedding.md) known gap 1
+> ("Delivery immediate live eviction and a fully-hosted membership feed"). Wire contract unchanged:
+> no new subject, no new stream, no new message type. This is a composition-root seam.
+
+## 1. What the gap actually is
+
+`docs/embedding.md:262-271` names it: the renewable `membership-rw.creds` migrated to the
+`SecretStore` seam, but three artifacts still resolve from **fixed disk paths under the workspace
+root**, so a hosted composition cannot supply them and live eviction refuses.
+
+| artifact | kind | who signs it | why it is stuck on disk today |
+|---|---|---|---|
+| `membership-observer.creds` | `$SYS` CONNZ reader | system-account seed | `rotation-renewed`; no store key exists |
+| `connection-evictor.creds` | `$SYS` KICK-only | system-account seed | same |
+| `membership.json` | `{accountId}`, non-secret | nobody (public key) | explicitly excluded from `SecretStore` scope |
+
+Every read site, measured:
+
+- `implementations/delivery/src/membership.ts:35-36` builds `obsPath`/`cfgPath` from
+  `join(findCotalRoot(), ".cotal")`; `:42-43` gate on `existsSync`; `:70` parses the account id;
+  `:82` reads the observer; `:90-95` reads the evictor for the torn-rotation check.
+- `implementations/delivery/src/evict-exec.ts:54-58` (`resolveScan`) reads `membership.json`;
+  `:86-95` reads both `$SYS` creds for eviction; `:117-124` and `:155-163` read the observer for the
+  two liveness verbs.
+
+The write sites are `implementations/cli/src/commands/up.ts:2835-2838` (fresh provision),
+`:2811-2814` (`healMembershipDataCreds`), and `packages/workspace/src/system-rotation.ts:108-109`
+(rotation re-mint).
+
+### 1.1 What is *not* the gap
+
+**Core is already store-agnostic on this path.** Every eviction and liveness primitive takes
+credentials as **strings**, not paths:
+
+- `evictDeniedPrincipalWithCreds` — `packages/core/src/evict.ts:694-723`
+- `observePlaneLivenessWithCreds` — `packages/core/src/evict.ts:566-584`
+- `observePrincipalLivenessWithCreds` — `packages/core/src/evict.ts:669-687`
+- `startMembershipFeed` already takes `observerCreds` as a string (`membership.ts:119`)
+
+So U3 changes **no protocol and no core primitive**. It is an edge-composition change confined to
+`implementations/delivery/src/` plus two new key constants in `@cotal-ai/workspace`. That is the
+whole reason this node is small enough to be worth doing before P2 needs it.
+
+### 1.2 The standing objection, and why it does not bind here
+
+`packages/workspace/src/system-rotation.ts:36-39` and `:88-95` argue the `$SYS` pair is FS-only:
+*"the $SYS pair is FS-only anyway (a hosted composition has nowhere in the store to put it), so this
+operation was never store-composable to begin with."* `:42-46` repeats it: *"not something a store
+can hold half of."*
+
+That argument is **sound about the writer and wrong about the reader**, and the distinction is the
+design.
+
+- The **writer** (`rotateSystemCreds`) must rewrite `server.conf` and the broker trust record in the
+  same act, and its multi-tenant guard (`assertSingleSpaceBroker`, `:96`) reads FS account records.
+  `SecretStore` cannot enumerate, so an injected store would sail past that guard. Correct. **U3
+  does not touch `rotateSystemCreds`.**
+- The **reader** (the delivery daemon) needs exactly two values by name and one account id. It never
+  enumerates, never writes, never touches `server.conf`. The enumeration argument simply does not
+  reach it.
+
+Gap 1 is a *reader* gap. It is closable without weakening the writer's guard by one line.
+
+## 2. What is injected
+
+Two new keys in `packages/workspace/src/renewal.ts`, beside `DELIVERY_CREDS_KEY` (`:30`) and
+`MEMBERSHIP_RW_CREDS_KEY` (`:35`):
+
+```ts
+export const MEMBERSHIP_OBSERVER_CREDS_KEY = "membership-observer.creds";
+export const CONNECTION_EVICTOR_CREDS_KEY  = "connection-evictor.creds";
+```
+
+The key **is** the filename, the same key↔filename convention `SYSTEM_CREDS_FILES` already fixes
+(`system-rotation.ts:47`). This is load-bearing, not cosmetic: `workspaceSecretStore(root)` is
+`new FsSecretStore(join(root, ".cotal"))` (`packages/workspace/src/secret-store-fs.ts:9-11`) and
+resolves a key to `<root>/.cotal/<key>`. So key `"membership-observer.creds"` resolves to exactly
+`.cotal/membership-observer.creds` — **the same byte on the same path the daemon reads today**
+(`membership.ts:35`). Switching the reader from `readFileSync` to `store.get()` is a local no-op by
+construction, which is the same property that made the `membership-rw` migration safe.
+
+These two are legitimate `SecretStore` material under core's own scope rule
+(`packages/core/src/secret-store.ts:11-16`), which admits *"any daemon standing credential the
+hosted composition persists … rotation-renewed observer / evictor creds are read at start or per
+use."* The scope doc already anticipated them; only the keys were missing.
+
+### 2.1 `membership.json` is not injected — it is eliminated
+
+`secret-store.ts:18` explicitly lists `membership.json` as **not** `SecretStore` material. That
+exclusion is right (it is a public key, not a secret) and U3 respects it rather than arguing with
+it. The account id is instead **recovered from credentials the daemon already holds**, by two
+independent routes:
+
+1. **The daemon's own delivery cred.** `delivery.ts:170` already computes
+   `expectedAccount: accountFromCreds(creds.initial)`. That cred is store-injected today under
+   `DELIVERY_CREDS_KEY`. The account id is therefore *already* available in a hosted composition,
+   with no file.
+2. **The observer cred's own permissions.** `membershipObserverPermissions(accountId)`
+   (`packages/core/src/provision.ts:2320-2331`) pins the DATA account into the cred itself:
+   `pub.allow = ["$SYS.REQ.ACCOUNT.<accountId>.CONNZ"]` plus the two account event subjects
+   (`subjects.ts:866-879`). The observer literally cannot observe an account other than the one
+   named in its own JWT — the broker enforces it.
+
+So `resolveScan`'s disk read (`evict-exec.ts:54-58`) is not a source of truth; it is a **second
+copy** used to cross-check the first. Section 4 says what replaces the cross-check.
+
+## 3. When it is injected, and by whom
+
+Unchanged from today's ownership. U3 adds no new actor.
+
+| moment | who | today | after U3 |
+|---|---|---|---|
+| fresh space provision | `provisionMembershipCreds`, `up.ts:2825-2842` | `writeSecretFile(cotalPath(SYSTEM_CREDS_FILES[i]), …)` | `store.put(<key>, …)` — same bytes, same path locally |
+| system rotation | `rotateSystemCreds`, `system-rotation.ts:80-` | writes both files | `store.put` via the **workstation** store only; the FS-only guard at `:96` is untouched |
+| daemon start / per eviction | `startMembership`, `executeEviction` | `readFileSync` | `store.get(<key>)` |
+
+A hosted composition root (P2's provisioner) mints with `mintMembershipObserverCreds` /
+`mintConnectionEvictorCreds` while the `$SYS` seed is in memory — exactly the window `up` uses
+(`up.ts:2827,2833`; the seed requirement is enforced at `provision.ts:2340,2383`) — and `put`s both
+under the two keys into its own store. Nothing about the mint window changes; U3 only changes where
+the result lands.
+
+**Read cadence.** The observer and evictor are read **per call** in the eviction path (core opens
+and drains them per call by design — `evict.ts:692` "never a standing `$SYS` connection"), and once
+at start in the feed path. Reading through `get()` per call is strictly better than today's
+`readFileSync` per call: a hosted store that has been re-keyed by a rotation is picked up on the next
+eviction with no daemon restart, whereas today an FS rewrite is picked up only because the path
+happens to be re-read. No new renewal timer, and none is wanted: these stay `rotation-renewed`
+(`system-rotation.ts:19-23`).
+
+## 4. Failure semantics — refuse, never degrade
+
+The two paths already have **deliberately different** postures and U3 preserves both exactly. This
+is the part most at risk of being flattened by a refactor, so it is stated as a contract.
+
+### 4.1 The feed path stays fail-soft
+
+`startMembership` is fail-soft by written contract (`membership.ts:16-18`): a missing cred logs and
+returns `{ down }`, the graph degrades to traffic-only, **Plane-3 delivery is untouched**. That is
+correct and must not become a refusal — the feed is an enrichment, and failing delivery because a
+graph feed cannot start would be a strictly worse trade.
+
+What must survive verbatim is the **diagnosis**, not just the failure. `membership.ts:45-68` chooses
+between two different repairs depending on which half is missing, because naming the wrong one costs
+an operator a full mesh stop for nothing (`:46-51`), and `down` is carried to the adoption reply so a
+stale `$SYS` cred does not surface merely as "the feed is not running" (`:26-29`, the #338 failure;
+consumed at `delivery.ts:206-209,221-225`).
+
+Under injection the repair strings must become **store-aware**: `cotal down && cotal up
+--rotate-sys` is the right advice on a workstation store and is *unactionable* against a hosted KMS.
+The rule: when the store is injected, the message names the **missing key** and the **mint window**
+("re-mint the `$SYS` pair at a system-account rotation and `put` it under `<key>`"), never a CLI
+incantation the host cannot run. Emitting workstation advice into a hosted log is a degradation of
+the diagnosis even when the failure semantics are right.
+
+### 4.2 The eviction and liveness path stays fail-loud
+
+`executeEviction` (`evict-exec.ts:88-91`), `executePlaneLiveness` (`:118-121`) and
+`executePrincipalLiveness` (`:156-159`) **throw** when the `$SYS` creds are absent, and every caller
+treats a refusal as **UNKNOWN, never `gone`** (`evict.ts:107-108`, `:140-141`, `:598-600`). A missing
+key is a refusal, full stop. There is no "evict best-effort", and specifically:
+
+- a missing evictor key must **not** silently fall back to deny-new-only inside the executor. The
+  deny-new-only posture is the *caller's* documented degradation (`evict-exec.ts:72-73`), reached by
+  handling the refusal — not something the executor may choose on its own.
+- a `get()` that throws (a KMS timeout, a revoked role) is a refusal, not an absence. Absence is
+  `undefined` per the `SecretStore` contract (`secret-store.ts:31-32`); anything else propagates.
+
+### 4.3 The tenancy check must not be lost — it gets stronger
+
+This is the one real safety question U3 raises, and it deserves the space.
+
+`evict-exec.ts:19-39` documents why `resolveScan` cross-checks at all: **a complete, well-formed
+sweep of the WRONG account is indistinguishable from "the principal is gone"** — a healthy-looking
+answer that authorizes eviction. Two guards exist: the root is pinned at daemon start, and the
+on-disk account is cross-checked against the account the daemon's own cred authenticates as
+(`:59-63`). The asymmetry at `:35-38` is the reason: observer-A with accountId-B under-reports
+safely, but observer-A with accountId-A while the gate lives on B answers a **confident, wrong
+`gone`**.
+
+Naively deleting the disk read would delete guard two. It must be replaced, not dropped. Two
+observations make the replacement strictly stronger than what it replaces:
+
+1. **The disk file was never an independent source.** It sits in the same `.cotal/` dir as the
+   creds. A root that is wrong is wrong for both. Its independence came from `expectedAccount` being
+   derived from the *cred* (`:32-33`) — i.e. the cred was always the real authority, and the file was
+   the thing being checked.
+2. **The observer cred names its own account.** Per §2.1(2), the observer's `pub.allow` is
+   `$SYS.REQ.ACCOUNT.<accountId>.CONNZ`. So the observer can be checked against `expectedAccount`
+   **intrinsically**, with no adjacent file at all.
+
+Proposed replacement, both paths:
+
+```
+accountId := expectedAccount                        // from the daemon's own delivery cred
+assert accountOf(observer.pub.allow CONNZ subject) == accountId   // intrinsic, broker-enforced
+```
+
+This catches everything the file check caught (a store handing back a foreign tenant's observer) and
+one thing it did not: an observer whose *permissions* disagree with the `membership.json` sitting
+next to it. On the workstation path the disk cross-check at `:55-58` is **kept as well** — there the
+root genuinely can drift (`:24-27` enumerates the cases), so it is a real second source and costs
+nothing.
+
+The evictor cannot be checked this way, and the design says so rather than pretending: its
+permission is `$SYS.REQ.SERVER.*.KICK` with no account in it (`provision.ts:2370-2377`), and
+`:2365-2369` states the honest blast radius — a leaked evictor can KICK any connection on the
+broker. Its containment is that **every cid it is given comes from the observer's own account-scoped
+scan** (`evict.ts:251,272`), so pinning the observer pins the targets. On a shared broker that
+containment is exactly what carries the tenant boundary, which is why the observer check is not
+optional.
+
+One free win: the **torn-rotation check** (two `$SYS` creds signed by different system accounts —
+`membership.ts:90-101`) exists today only in the feed path, so the eviction path can currently open a
+half-rotated pair and get a bare "Authorization Violation". Once both creds come from one store, that
+check belongs in one shared helper used by both paths.
+
+## 5. Native mechanisms first
+
+U3 introduces **no new NATS or JetStream mechanism**, and that is a deliberate result rather than an
+absence of ambition. Eviction already rides `$SYS.REQ.SERVER.<id>.KICK` and observation already rides
+the account-scoped `$SYS.REQ.ACCOUNT.<id>.CONNZ` (`subjects.ts:862-890`), both nats-server's own
+verbs, with account scoping doing the tenant isolation (`subjects.ts:873` pins the account id
+precisely so that two spaces on one broker cannot see each other's events). The gap was never in the
+broker; it was in how a host hands two files to a Node process.
+
+**Rejected: distribute the `$SYS` creds through a JetStream KV bucket.** Superficially "more
+native", and wrong. The daemon would need a broker connection to fetch the credentials it needs to
+open a broker connection — a bootstrap circularity — and it would put `$SYS`-signed material inside
+a data account, inverting the trust direction the whole account boundary exists to enforce (DR1). A
+credential's distribution channel must sit below the thing it authenticates.
+
+**Rejected: a `--observer-creds` / `--evictor-creds` path flag.** It moves the fixed path rather
+than removing it, still requires the host to materialize secrets on a filesystem, and adds two
+local-source flags that `resolveCredsStore` (`delivery.ts:142`) deliberately rejects under an
+injected store.
+
+**Rejected: widen `rotateSystemCreds` to take a `SecretStore`.** Argued down in
+`system-rotation.ts:88-95` and the argument holds: no enumeration means no multi-tenant guard. If
+store enumeration ever exists this reopens; until then the rotation writer stays a workstation
+operation and says so.
+
+## 6. Live test plan
+
+The gate is: **live eviction proven per space from a store-injected composition.** A claim is not a
+gate; the test is a real broker and a real `runDelivery`.
+
+Model: `packages/core/smoke/evict-live-auth.smoke.ts`, which already proves eviction end-to-end
+against a real user-auth broker with a real auth callout, and which is the smoke that disproved the
+design's original tag-attribution premise (its header, `:18-23`). U3's smoke is that shape at
+**two tenants on one broker**, the F4 topology.
+
+New: `implementations/delivery/smoke/sys-injection-evict.smoke.ts`. Boot one `nats-server` with
+`serverConfig(broker, [A, B], …)`. Provision both spaces. Put every credential — delivery, rw,
+observer, evictor — into an **in-memory `SecretStore`** per space. Write **no `.cotal/` `$SYS` files
+at all**, so a regression to `readFileSync` cannot pass by accident. Boot delivery for A via
+`runDelivery(args, storeA)`.
+
+| # | cell | expected |
+|---|---|---|
+| 1 | evict a live callout-minted principal in A | `verifiedGone:true`, `scanComplete:true` |
+| 2 | B's live principal during and after cell 1 | still connected — untouched |
+| 3 | hand A's daemon **B's** observer | refuses loudly naming both accounts; **never** a confident `gone` |
+| 4 | `delete` the evictor key, then evict | throws; the caller reads UNKNOWN; A's principal still live |
+| 5 | `delete` the observer key, then start the feed | `{down}` naming the key; **Plane-3 delivery still serves** |
+| 6 | evict a principal that is not connected | idempotent success no-op (`kicked:0, verifiedGone:true`) |
+| 7 | observer + evictor from different system accounts | torn-rotation refusal, both paths |
+| 8 | no `.cotal/membership.json` anywhere | cells 1-2 still pass (proves the file is gone, not defaulted) |
+
+Cell 3 is the load-bearing one — it is the wrong-account confident-`gone` failure `evict-exec.ts:35-38`
+names, reproduced against the *store* rather than the filesystem. Cell 2 is the F4 cross-reach
+property re-proven under injection. Cell 8 is the anti-regression for §2.1.
+
+**Positive controls, per F4's discipline.** Cells 3, 4, 5 and 7 all assert a refusal, and a refusal
+is exactly what a broken test also produces. Each carries an in-cell positive control: the same
+operation with the *correct* material must succeed in the same process, so "refused" is distinguished
+from "never worked". A cell that cannot state its positive control does not ship.
+
+Local regression: `pnpm smoke:auth` and the existing delivery smokes must pass unchanged, since §2
+claims the workstation path is byte-for-byte identical. That claim is the migration's whole safety
+argument, so it is tested, not asserted.
+
+Environment note: this lane's box has `nats-server v2.11.4`; F4 measured against 2.14.5. The smoke
+pins and prints its server version, and the gate is run on the F4 version before the node is called
+done.
+
+## 7. Boundaries with adjacent lanes
+
+- **U1 (per-space lifecycle).** `docs/design/per-space-lifecycle.md` §2.1 step 5 commits
+  `account.<key>.json` "then the `$SYS` cred files". That step is the write side of exactly these
+  two artifacts. Boundary: **U3 owns the keys and the reader; U1 owns the lifecycle verb.** If U3
+  lands first, `space add` step 5 writes through `store.put(<key>, …)` and inherits hosting for
+  free; if U1 lands first, U3 rewrites that one step. Neither blocks the other. Both must be told the
+  key names once, so they cannot be spelled twice.
+- **U2 (resolver-inventory-CAS).** No overlap. U2 is about concurrent *space adds* racing on the
+  broker inventory; U3 never writes broker config, never enumerates, and adds no ordering
+  requirement. The one adjacency worth a line: if U2 introduces a generation/CAS discipline over the
+  inventory, the torn-rotation check in §4.3 is the same *class* of problem (a two-write commit
+  observed half-applied) and should reuse U2's vocabulary rather than invent a second one.
+- **P2 (space-provisioner).** P2's gate already names "per-space membership/`$SYS` semantics on a
+  shared broker" as an F4 residual (`CLOUD-PLAN.md:155-156`). U3 is the upstream half that makes
+  P2's version composable. P2 should not carry a private fork of this reader.
+
+## 8. Residuals, named
+
+1. **`rotateSystemCreds` stays workstation-only.** A hosted composition must mint the `$SYS` pair at
+   its own provision (the `$SYS`-seed-in-memory window) and cannot use `cotal up --rotate-sys` to
+   renew it. Renewal in a hosted composition is a re-provision of the system account by the host,
+   using the same core mint primitives. Blocked on store enumeration; out of scope here.
+2. **The evictor is not tenancy-checkable.** `$SYS.REQ.SERVER.*.KICK` carries no account
+   (`provision.ts:2370-2377`). Containment is inherited from the observer's account-scoped scan
+   (§4.3). A future account-scoped KICK in nats-server would close this; today it is a stated
+   property, not a hidden one.
+3. **`membership.json` remains on the workstation path** as the second source for the drift check
+   (§4.3). It is not deleted from `up`; it stops being *required*. `cotal clean`'s removal list
+   (`implementations/cli/src/commands/clean.ts:277`) is unchanged.
+4. **Single-server proof unchanged.** `gone` still requires the SPEC 13.13 single-server proof
+   (`evict.ts:519-531`); injection does not touch it, and a clustered hosted broker still reads
+   `unknown`. Worth stating because a hosted deployment is *more* likely to be clustered than a
+   workstation.

--- a/docs/design/u3-membership-sys-injection.md
+++ b/docs/design/u3-membership-sys-injection.md
@@ -65,13 +65,28 @@ Gap 1 is a *reader* gap. It is closable without weakening the writer's guard by 
 
 ## 2. What is injected
 
-Two new keys in `packages/workspace/src/renewal.ts`, beside `DELIVERY_CREDS_KEY` (`:30`) and
+Two **new** keys in `packages/workspace/src/renewal.ts`, beside `DELIVERY_CREDS_KEY` (`:30`) and
 `MEMBERSHIP_RW_CREDS_KEY` (`:35`):
 
 ```ts
 export const MEMBERSHIP_OBSERVER_CREDS_KEY = "membership-observer.creds";
 export const CONNECTION_EVICTOR_CREDS_KEY  = "connection-evictor.creds";
 ```
+
+> **These constants do not exist in the tree today — this design introduces them.** What exists is
+> `SYSTEM_CREDS_FILES` (`system-rotation.ts:47`), a **positional** `as const` array of the same two
+> filenames, consumed by index: `SYSTEM_CREDS_FILES[0]` is the observer and `[1]` the evictor at
+> `up.ts:2835,2837`, `system-rotation.ts:126-127`, `clean.ts:276`, `manager.ts:1273` and four CLI
+> smokes. Those are raw root-scoped **FS paths**, not `SecretStore` keys: today's tree has no store
+> binding for this pair at all. Both readings are correct at different times — the positional array
+> is the writer's current spelling, and these named constants are the reader-side store binding this
+> design adds. A reader should not mistake them for existing code, and a second lane should not
+> re-spell either one.
+>
+> The two spellings coexist deliberately: the named keys supersede the positional array **on the read
+> path only**, and §3 leaves the array in place for the writer sites this design does not touch.
+> Index-based access is exactly what makes a positional array unsafe to share across lanes — `[0]`
+> and `[1]` carry no meaning at the call site — which is the second reason the reader gets names.
 
 The key **is** the filename, the same key↔filename convention `SYSTEM_CREDS_FILES` already fixes
 (`system-rotation.ts:47`). This is load-bearing, not cosmetic: `workspaceSecretStore(root)` is
@@ -155,6 +170,34 @@ The rule: when the store is injected, the message names the **missing key** and 
 incantation the host cannot run. Emitting workstation advice into a hosted log is a degradation of
 the diagnosis even when the failure semantics are right.
 
+**The detection mechanism, stated (F2).** "Is the store injected?" is answered by the *parameter*,
+not by probing the store, and specifically not by sniffing the filesystem:
+
+```ts
+const injected = store !== undefined;                  // the runner's own seam
+const secrets  = store ?? workspaceSecretStore(root);  // the existing line, unchanged
+```
+
+`startMembership(opts, store?)` and `runDelivery(args, store?)` already take the store as an optional
+argument whose *absence* is precisely "workstation": the existing `store ?? workspaceSecretStore(root)`
+(`membership.ts:37`) is that same fact, read one line later. So the flag is free and exact — it is a
+property of the composition root, decided before any I/O.
+
+Three alternatives are rejected because each infers hosting from evidence that does not carry it:
+
+- `instanceof FsSecretStore` — a host may legitimately wrap or subclass the FS store (a caching or
+  auditing decorator), and delivery must not depend on the concrete class of an injected seam.
+- `existsSync(join(root, ".cotal"))` — the directory exists on a hosted box too (the mesh registry
+  and auth state live there per `embedding.md`), so this reports "workstation" for a hosted daemon
+  and emits exactly the unactionable advice the rule forbids.
+- probing `store.get()` for a workstation-only key — an I/O round trip against a KMS to decide the
+  *wording of an error message*, on a path already degraded.
+
+The rule applies to the **repair clause only**. The diagnosis half — which key is missing, and the
+observer/evictor vs data-account split of §4.1 — is identical in both compositions and must not fork:
+one message builder, two repair tails. `down` still carries the whole string to the adoption reply
+(`delivery.ts:206-209`), so a hosted adoption reply is store-aware for free.
+
 ### 4.2 The eviction and liveness path stays fail-loud
 
 `executeEviction` (`evict-exec.ts:88-91`), `executePlaneLiveness` (`:118-121`) and
@@ -194,13 +237,37 @@ observations make the replacement strictly stronger than what it replaces:
 Proposed replacement, both paths:
 
 ```
-accountId := expectedAccount                        // from the daemon's own delivery cred
-assert accountOf(observer.pub.allow CONNZ subject) == accountId   // intrinsic, broker-enforced
+accountId := expectedAccount                              // from the daemon's own delivery cred
+assert connzAccountOf(observer) == accountId              // local, pre-connect, names both sides
 ```
+
+**Two mechanisms, not one (F4).** The earlier phrasing called this single assert "intrinsic,
+broker-enforced", which conflates two independent things and oversells the assert. Stated correctly:
+
+1. **The daemon's local check** — decoding the observer's own JWT and reading the account out of its
+   `pub.allow` CONNZ subject. This is a *local* read of a signed document. It runs **before any
+   connection**, and its whole value is the **diagnosis**: it refuses naming both accounts, at the
+   daemon, in one line.
+2. **The broker's enforcement** — the observer physically cannot publish `$SYS.REQ.ACCOUNT.<other>.CONNZ`,
+   because the permission is in the JWT the broker validates. This needs no cooperation from the
+   daemon and holds even if check 1 were deleted.
+
+The safety property rests on **2**; **1** exists so the failure is legible instead of arriving as a
+bare "Authorization Violation" (the same argument §4.1 makes for the expiry pre-check). Saying the
+assert *is* broker-enforced would credit the daemon's own code with a guarantee the broker supplies —
+precisely the confusion that lets a later refactor delete the broker-side reasoning as redundant.
+"Intrinsic" survives and is the accurate word: no adjacent file is consulted.
+
+Measured, not asserted: a freshly minted observer carries
+`nats.pub.allow = ["$SYS.REQ.ACCOUNT.<DATA account pub>.CONNZ"]`, and that id is byte-equal to the
+`nats.issuer_account` that `accountFromCreds` returns from the daemon's own delivery cred — so the
+two sides of the assert are the same kind of id, which is the thing that actually had to be true.
+Note `credsClaims` (`identity.ts:122`) *returns* the full payload at runtime but **declares** only
+`{sub,iat,exp,name,iss}`; the accessor is a typing gap to close, not a decoder to write.
 
 This catches everything the file check caught (a store handing back a foreign tenant's observer) and
 one thing it did not: an observer whose *permissions* disagree with the `membership.json` sitting
-next to it. On the workstation path the disk cross-check at `:55-58` is **kept as well** — there the
+next to it. On the workstation path the disk cross-check at `:54-58` is **kept as well** — there the
 root genuinely can drift (`:24-27` enumerates the cases), so it is a real second source and costs
 nothing.
 
@@ -278,30 +345,86 @@ is exactly what a broken test also produces. Each carries an in-cell positive co
 operation with the *correct* material must succeed in the same process, so "refused" is distinguished
 from "never worked". A cell that cannot state its positive control does not ship.
 
+**The smoke's cwd is `mkdtemp`-pinned (F1).** Every cell's meaning depends on it. `findCotalRoot()`
+walks *upward* from `process.cwd()`, and `resolveScan` (`evict-exec.ts:48-53`) compares that live
+walk against the root pinned at daemon start. A smoke run from inside this repo resolves the
+**repository's own** `.cotal/`, which is the one directory guaranteed to contain exactly the
+`$SYS` files and `membership.json` the gate exists to prove absent. Cells 5 and 8 would then pass
+against the developer's workstation state rather than the injected store — the precise
+false-pass this gate is built to exclude, and one that gets *more* likely as the design succeeds,
+since a correct implementation is silent about where the bytes came from.
+
+So: each tenant gets its own `mkdtemp()` root, `process.chdir()` into it before `runDelivery`, and
+the smoke **asserts** `findCotalRoot() === thatRoot` before cell 1 — a one-line precondition that
+fails loudly rather than letting the walk escape. Roots are removed on exit, including on failure.
+That precondition is itself a positive control: it proves the harness can tell the two roots apart,
+so a later "no `.cotal` files" assertion means the store served the bytes and not that the test
+looked in an empty directory.
+
 Local regression: `pnpm smoke:auth` and the existing delivery smokes must pass unchanged, since §2
 claims the workstation path is byte-for-byte identical. That claim is the migration's whole safety
 argument, so it is tested, not asserted.
 
-Environment note: this lane's box has `nats-server v2.11.4`; F4 measured against 2.14.5. The smoke
-pins and prints its server version, and the gate is run on the F4 version before the node is called
-done.
+Environment note: this lane's box currently has `nats-server v2.12.12` (an earlier revision of this
+doc recorded 2.11.4; the box moved). F4 measured against **2.14.5**, and 2.14.5 is what the gate
+runs on — neither box version counts as the gate. The smoke pins and prints its server version, and
+refuses rather than silently proving the property on whatever binary is first on `PATH`.
 
 ## 7. Boundaries with adjacent lanes
 
 - **U1 (per-space lifecycle).** `docs/design/per-space-lifecycle.md` §2.1 step 5 commits
   `account.<key>.json` "then the `$SYS` cred files". That step is the write side of exactly these
-  two artifacts. Boundary: **U3 owns the keys and the reader; U1 owns the lifecycle verb.** If U3
-  lands first, `space add` step 5 writes through `store.put(<key>, …)` and inherits hosting for
-  free; if U1 lands first, U3 rewrites that one step. Neither blocks the other. Both must be told the
-  key names once, so they cannot be spelled twice.
-- **U2 (resolver-inventory-CAS).** No overlap. U2 is about concurrent *space adds* racing on the
-  broker inventory; U3 never writes broker config, never enumerates, and adds no ordering
-  requirement. The one adjacency worth a line: if U2 introduces a generation/CAS discipline over the
-  inventory, the torn-rotation check in §4.3 is the same *class* of problem (a two-write commit
-  observed half-applied) and should reuse U2's vocabulary rather than invent a second one.
+  two artifacts. Boundary, **decided**: **U3 owns the two key names and the reader; U1 owns the
+  lifecycle verb.** Neither owns both halves, and the seam between them is the two constants of §2.
+
+  **Sequencing, decided (not "neither blocks the other").** U3 lands the store seam and the two
+  named constants **first**; U1's **P7** (per-space keying) then builds *through* that seam and
+  **imports these constants rather than re-spelling either filename**, and U1's **P8** follows P7.
+  This replaces the earlier symmetric "if U1 lands first, U3 rewrites that one step" — that framing
+  was written when the constants were assumed to exist. They do not (§2), so there is nothing for U1
+  to build through until U3 lands, and a U1-first order would force U1 to invent the names U3 then
+  has to reconcile. The ordering is a consequence of §2's "these are new", not a scheduling
+  preference. U1's acceptance sentences for P7/P8 are held by `default_agent`; U3 does not need them
+  to land its own half, which is the point of the split.
+
+- **U2 (resolver-inventory-CAS).** **Not "no overlap" — a real adjacency, on the writer side.** An
+  earlier revision of this section claimed no overlap; that is true at the *wire* level and too
+  strong everywhere else, so it is withdrawn here rather than left standing.
+
+  Two shared surfaces, measured: both lanes touch the **`extraAccounts` slot** of
+  `serverConfig(…)` and the **same `up.ts` provisioning path** — U2 at the config render
+  (`up.ts:2704`), U3 at the `$SYS` mint window (`up.ts:2825-2842`). And `--rotate-sys` is an
+  **unfenced config writer**: `rotateSystemCreds` returns a successor bundle from which `server.conf`
+  **must** be re-rendered (`up.ts:2634` and its comment), through that same `extraAccounts` render.
+  Once both lanes land, that rewrite would invalidate U2's `configDigest` provenance — the
+  unfenced-writer adjacency U2's review FILED. Coordination, matching U2's §6 residual 4:
+  **`--rotate-sys` must eventually write through U2's fenced saga once it exists.**
+
+  One attribution correction, so the residual is charged to the right lane: **U3 does not introduce
+  or modify that config writer.** Re-rendering `server.conf` on rotation is today's behavior of
+  `up --rotate-sys`, and §1.2 and §5 both keep `rotateSystemCreds` explicitly out of U3's scope —
+  §3's rotation row changes only where the *cred bytes* land, never the config render. The adjacency
+  is real and worth naming here; it is not a defect this design creates, and U3 landing first neither
+  worsens nor repairs it.
+
+  The torn-rotation check in §4.3 remains the same *class* of problem as U2's inventory CAS (a
+  two-write commit observed half-applied) and should reuse U2's vocabulary rather than invent a
+  second one. **Named forward reference:** U2's vocabulary section, path and section number to be
+  filled in from U2's post-verdict commit (U2 is folding two blockers; `default_agent` supplies the
+  citation). This stays an explicit unresolved reference rather than a guessed one — a wrong section
+  number here would be copied forward by exactly the lanes it is meant to align.
+
 - **P2 (space-provisioner).** P2's gate already names "per-space membership/`$SYS` semantics on a
   shared broker" as an F4 residual (`CLOUD-PLAN.md:155-156`). U3 is the upstream half that makes
   P2's version composable. P2 should not carry a private fork of this reader.
+
+  **Sequencing within one provision (F3).** P2 composes two mint windows that are ordered and not
+  interchangeable: U2's **inventory-account mint** must commit its inventory record *before* U3's
+  **`$SYS` mint window** runs, because the observer's permissions pin the DATA account id (§2.1(2))
+  and therefore cannot be minted until that account is the committed one — an observer minted against
+  an account the inventory later renames or loses to a CAS retry is broker-dead in exactly the
+  §4.3 way, and is unrecoverable without a system-account rotation since the `$SYS` seed is gone by
+  then (§8.1).
 
 ## 8. Residuals, named
 

--- a/implementations/delivery/smoke/sys-injection-evict.smoke.ts
+++ b/implementations/delivery/smoke/sys-injection-evict.smoke.ts
@@ -38,26 +38,31 @@
  * root with an EMPTY `.cotal/` to stop the walk, and cell 0 asserts the walk actually landed there
  * before anything else runs.
  *
- * THE SERVER VERSION IS PINNED, NOT SAMPLED. F4 measured the `$SYS` behaviour this design rests on
- * against nats-server 2.14.5, and this box's `PATH` carries other versions, so the binary is taken
- * from `COTAL_SMOKE_NATS_SERVER` by ABSOLUTE PATH and its `--version` is asserted. With none set the
- * smoke REFUSES rather than proving the property on whatever is first on `PATH`.
+ * THE SERVER IS NAMED AND FLOOR-CHECKED, NOT SILENTLY SAMPLED. F4 measured the `$SYS` behaviour this
+ * design rests on against nats-server 2.14.5; it has since been measured 37/37 at 2.12.12 as well, so
+ * the property spans the supported band rather than being 2.14-only. The gate therefore refuses only
+ * BELOW `BROKER_FLOOR` — the product's own constant, not a literal copied here, so this suite and the
+ * control surface's startup gate cannot drift apart about what is supported. Whatever server is used,
+ * the resolved ABSOLUTE path and measured version are PRINTED first and repeated on the final line: a
+ * green always names what it tested. `COTAL_SMOKE_NATS_SERVER` picks the binary; with it unset one is
+ * resolved from `PATH` (CI sets neither, and a suite CI cannot run proves nothing).
+ * `COTAL_SMOKE_NATS_VERSION` still pins an EXACT version, for reproducing one named measurement.
  *
  * COTAL_HOME-free; kills only the nats-server it starts, by exact PID (never pkill).
- * Run: COTAL_SMOKE_NATS_SERVER=/abs/path/to/nats-server-2.14.5 \
- *        npx tsx implementations/delivery/smoke/sys-injection-evict.smoke.ts
+ * Run: npx tsx implementations/delivery/smoke/sys-injection-evict.smoke.ts
+ *   or COTAL_SMOKE_NATS_SERVER=/abs/path/to/nats-server-2.14.5 npx tsx …
  */
 import { randomUUID } from "node:crypto";
 import { execFileSync, spawn } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { connect, credsAuthenticator, tokenAuthenticator, type NatsConnection } from "@nats-io/transport-node";
 import {
   composeSpaceAuth, createBrokerAuth, createSpaceAccountAuth, isReachable, mintCreds, newIdentity,
   mintConnectionEvictorCreds, mintMembershipObserverCreds, principalKey, rotateSystemAccount,
-  serverConfig, setupSpaceStreams, waitForDeliveryLease, CotalEndpoint, DEV_OWNER,
-  type ParsedArgs, type SecretStore, type SpaceAuth,
+  serverConfig, setupSpaceStreams, waitForDeliveryLease, BROKER_FLOOR, CotalEndpoint, DEV_OWNER,
+  meetsBrokerFloor, type ParsedArgs, type SecretStore, type SpaceAuth,
 } from "@cotal-ai/core";
 import {
   calloutPermissions, createCalloutAuth, createUserTokenIssuer, deriveOwnerToken, generateSigningKey,
@@ -98,21 +103,57 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
   else { fail++; realLog(`  ✗ FAIL: ${name}`, extra ?? ""); }
 };
 
-// ---------- the server binary is NAMED, not sampled (F4 / §6) ----------
-const NATS_BIN = process.env.COTAL_SMOKE_NATS_SERVER;
-const WANT_VERSION = process.env.COTAL_SMOKE_NATS_VERSION ?? "2.14.5";
-if (!NATS_BIN) {
+// ---------- the server binary is NAMED and FLOOR-CHECKED, never silently sampled (F4 / §6) ----------
+// `COTAL_SMOKE_NATS_SERVER` still wins when set. With it UNSET the binary is resolved from `PATH` and
+// realpath'd rather than refused, because CI does not set that variable and a suite CI cannot run is a
+// suite that proves nothing — the ungated-in-name-of-rigour trade this file briefly made.
+const resolveOnPath = (bin: string): string | undefined => {
+  for (const dir of (process.env.PATH ?? "").split(delimiter)) {
+    if (!dir) continue;
+    const p = join(dir, bin);
+    if (existsSync(p)) return p;
+  }
+  return undefined;
+};
+const NATS_BIN_NAMED = process.env.COTAL_SMOKE_NATS_SERVER ?? resolveOnPath("nats-server");
+if (!NATS_BIN_NAMED) {
   console.error(
-    "✗ REFUSING: this gate proves a $SYS property F4 measured against nats-server " + WANT_VERSION +
-    ", and this box's PATH carries other versions. Set COTAL_SMOKE_NATS_SERVER to the ABSOLUTE path of a " +
-    WANT_VERSION + " binary — proving it on whatever is first on PATH would name a version it did not test.",
+    "✗ REFUSING: no nats-server to test against. Set COTAL_SMOKE_NATS_SERVER to an ABSOLUTE path, or " +
+    "put a nats-server on PATH — this gate boots a real broker and cannot be proven without one.",
   );
   process.exit(2);
 }
+// RESOLVED AND PRINTED BEFORE ANY CHECK. The anti-sampling discipline was never the exact-match
+// refusal; it is that a green NAMES the binary and version it actually tested, so a passing line can
+// always be audited against the server someone thinks it ran on.
+const NATS_BIN = realpathSync(NATS_BIN_NAMED);
 const NATS_VERSION = execFileSync(NATS_BIN, ["--version"], { encoding: "utf8" }).trim();
 console.log(`  · server under test: ${NATS_BIN} → ${NATS_VERSION}`);
-if (!NATS_VERSION.includes(WANT_VERSION)) {
-  console.error(`✗ REFUSING: COTAL_SMOKE_NATS_SERVER reports "${NATS_VERSION}", which is not ${WANT_VERSION}.`);
+
+// THE FLOOR COMES FROM THE PRODUCT, NEVER A LITERAL HERE. `BROKER_FLOOR` is the same constant the
+// control surface's own startup gate refuses below, so the suite and the daemon cannot drift into
+// disagreeing about what is supported — a copied number is the copy that goes stale. Measured 37/37 at
+// both 2.12.12 (what CI installs) and 2.14.5 (what F4 measured), so this property spans the floor band
+// rather than being a 2.14-only behaviour.
+//
+// `COTAL_SMOKE_NATS_VERSION` keeps its documented meaning — an EXACT pin — for reproducing one named
+// measurement. Unset, the check is the floor, which is what lets CI run all 37 cells on its own 2.12.x.
+const WANT_EXACT = process.env.COTAL_SMOKE_NATS_VERSION;
+const VERSION_NUMBER = /\d+\.\d+\.\d+\S*/.exec(NATS_VERSION)?.[0] ?? "";
+if (WANT_EXACT) {
+  if (!NATS_VERSION.includes(WANT_EXACT)) {
+    console.error(
+      `✗ REFUSING: COTAL_SMOKE_NATS_VERSION pins ${WANT_EXACT}, but this binary reports "${NATS_VERSION}".`,
+    );
+    process.exit(2);
+  }
+} else if (!meetsBrokerFloor(VERSION_NUMBER)) {
+  // An unparseable version lands here too, and refuses: fail-closed, exactly like `requireBrokerFloor`.
+  console.error(
+    `✗ REFUSING: nats-server "${NATS_VERSION}" is below the product's own control-surface floor ` +
+    `${BROKER_FLOOR.major}.${BROKER_FLOOR.minor} (packages/core/src/broker-floor.ts). The daemon under test ` +
+    `refuses to start there, so a result from this server would describe a broker the product does not support.`,
+  );
   process.exit(2);
 }
 

--- a/implementations/delivery/smoke/sys-injection-evict.smoke.ts
+++ b/implementations/delivery/smoke/sys-injection-evict.smoke.ts
@@ -1,0 +1,413 @@
+/**
+ * U3 GATE — live eviction proven per space from a STORE-INJECTED composition
+ * (`docs/design/u3-membership-sys-injection.md` §6).
+ *
+ * The claim under test is not "the code compiles with a store": it is that the `$SYS` pair — the
+ * CONNZ observer and the KICK evictor — can come from an injected {@link SecretStore} with **no
+ * `.cotal/` `$SYS` file and no `membership.json` anywhere on disk**, and that every safety property
+ * the on-disk path had survives the move. So this boots a REAL broker carrying TWO TENANTS, runs the
+ * REAL `runDelivery` for tenant A against an in-memory store, and drives eviction over the REAL
+ * delivery-admin rail. A regression to `readFileSync` cannot pass here by accident: there is nothing
+ * on disk to read.
+ *
+ * Two tenants, because the failure this design must not introduce is a CROSS-TENANT one: a complete,
+ * well-formed sweep of the WRONG account is indistinguishable from "the principal is gone", so a
+ * store that hands back a foreign tenant's observer must refuse rather than answer confidently
+ * (cells 3 and 2). Both tenants carry a live connection under the SAME principal string, so a leak
+ * would be visible as a kill, not merely as a wrong log line.
+ *
+ * THE CELLS (§6):
+ *   0  precondition   the cwd is mkdtemp-pinned and the harness can tell the two roots apart (F1)
+ *   1  evict a live callout-minted principal in A          → verifiedGone, scanComplete, conn dropped
+ *   2  B's live principal, same principal string           → untouched, during and after
+ *   3  hand A's daemon B's OBSERVER                        → refuses naming both accounts
+ *   4  `delete` the evictor key, then evict                → refuses; the victim is still live
+ *   5  `delete` the observer key, then start the feed      → {down} naming the key; Plane-3 still serves
+ *   6  evict a principal that is not connected             → idempotent no-op (kicked:0, verifiedGone)
+ *   7  observer + evictor from DIFFERENT system accounts   → torn-rotation refusal, BOTH paths
+ *   8  no `$SYS` files and no `membership.json` on disk    → asserted before and after cells 1-2
+ *
+ * POSITIVE CONTROLS (F4's discipline). Cells 3, 4, 5 and 7 each assert a REFUSAL, and a refusal is
+ * also what a broken harness produces. Every one of them therefore restores the correct material and
+ * repeats the SAME operation in the SAME process, which must then succeed. A cell that cannot state
+ * its positive control does not ship.
+ *
+ * THE CWD IS MKDTEMP-PINNED (F1). `findCotalRoot()` walks UPWARD from `process.cwd()`, so a run from
+ * inside this repo resolves the repository's own `.cotal/` — the one directory on the box guaranteed
+ * to hold exactly the files cells 5 and 8 exist to prove absent. Each tenant gets its own `mkdtemp()`
+ * root with an EMPTY `.cotal/` to stop the walk, and cell 0 asserts the walk actually landed there
+ * before anything else runs.
+ *
+ * THE SERVER VERSION IS PINNED, NOT SAMPLED. F4 measured the `$SYS` behaviour this design rests on
+ * against nats-server 2.14.5, and this box's `PATH` carries other versions, so the binary is taken
+ * from `COTAL_SMOKE_NATS_SERVER` by ABSOLUTE PATH and its `--version` is asserted. With none set the
+ * smoke REFUSES rather than proving the property on whatever is first on `PATH`.
+ *
+ * COTAL_HOME-free; kills only the nats-server it starts, by exact PID (never pkill).
+ * Run: COTAL_SMOKE_NATS_SERVER=/abs/path/to/nats-server-2.14.5 \
+ *        npx tsx implementations/delivery/smoke/sys-injection-evict.smoke.ts
+ */
+import { randomUUID } from "node:crypto";
+import { execFileSync, spawn } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { connect, credsAuthenticator, tokenAuthenticator, type NatsConnection } from "@nats-io/transport-node";
+import {
+  composeSpaceAuth, createBrokerAuth, createSpaceAccountAuth, isReachable, mintCreds, newIdentity,
+  mintConnectionEvictorCreds, mintMembershipObserverCreds, principalKey, rotateSystemAccount,
+  serverConfig, setupSpaceStreams, waitForDeliveryLease, CotalEndpoint, DEV_OWNER,
+  type ParsedArgs, type SecretStore, type SpaceAuth,
+} from "@cotal-ai/core";
+import {
+  calloutPermissions, createCalloutAuth, createUserTokenIssuer, deriveOwnerToken, generateSigningKey,
+  grantActor, ledgerAclResolver, ledgerAuthorizeConnect, revokeActor, startAuthCallout,
+} from "@cotal-ai/auth";
+import {
+  CONNECTION_EVICTOR_CREDS_KEY, DELIVERY_CREDS_KEY, findCotalRoot,
+  MEMBERSHIP_OBSERVER_CREDS_KEY, MEMBERSHIP_RW_CREDS_KEY,
+} from "@cotal-ai/workspace";
+import { SMOKE_BROKER_TOKEN, killAndAwaitExit, teardownOnSignal } from "@cotal-ai/smoke-kit";
+import { runDelivery } from "../src/delivery.js";
+import { startMembership } from "../src/membership.js";
+import { pickFreePort } from "./_free-port.js";
+
+const enc = (s: string) => new TextEncoder().encode(s);
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const until = async (cond: () => boolean, ms = 5000, step = 100): Promise<boolean> => {
+  const end = Date.now() + ms;
+  while (!cond() && Date.now() < end) await wait(step);
+  return cond();
+};
+// `runDelivery` runs IN THIS PROCESS, so the daemon's own console output is EVIDENCE, not noise: its
+// fail-soft lines are what cells 5 and 7 read. The tee is installed once, before the daemon boots,
+// and stays installed to the `finally` — restoring it between cells would silently drop whatever the
+// daemon said next, and the daemon talks asynchronously. So the harness prints through `realLog`
+// (straight out, unprefixed) while everything the daemon logs is captured AND echoed with a `│`.
+const realLog = console.log.bind(console), realErr = console.error.bind(console);
+let daemonLog = "";
+const teeConsole = () => {
+  const t = (...a: unknown[]) => { const s = a.map(String).join(" "); daemonLog += `${s}\n`; realLog(`    │ ${s}`); };
+  console.log = t; console.error = t;
+};
+const untee = () => { console.log = realLog; console.error = realErr; };
+
+let pass = 0, fail = 0;
+const check = (name: string, cond: boolean, extra?: unknown) => {
+  if (cond) { pass++; realLog(`  ✓ ${name}`); }
+  else { fail++; realLog(`  ✗ FAIL: ${name}`, extra ?? ""); }
+};
+
+// ---------- the server binary is NAMED, not sampled (F4 / §6) ----------
+const NATS_BIN = process.env.COTAL_SMOKE_NATS_SERVER;
+const WANT_VERSION = process.env.COTAL_SMOKE_NATS_VERSION ?? "2.14.5";
+if (!NATS_BIN) {
+  console.error(
+    "✗ REFUSING: this gate proves a $SYS property F4 measured against nats-server " + WANT_VERSION +
+    ", and this box's PATH carries other versions. Set COTAL_SMOKE_NATS_SERVER to the ABSOLUTE path of a " +
+    WANT_VERSION + " binary — proving it on whatever is first on PATH would name a version it did not test.",
+  );
+  process.exit(2);
+}
+const NATS_VERSION = execFileSync(NATS_BIN, ["--version"], { encoding: "utf8" }).trim();
+console.log(`  · server under test: ${NATS_BIN} → ${NATS_VERSION}`);
+if (!NATS_VERSION.includes(WANT_VERSION)) {
+  console.error(`✗ REFUSING: COTAL_SMOKE_NATS_SERVER reports "${NATS_VERSION}", which is not ${WANT_VERSION}.`);
+  process.exit(2);
+}
+
+// ---------- one broker, TWO tenant accounts ----------
+const PORT = await pickFreePort();
+const SERVERS = `nats://127.0.0.1:${PORT}`;
+const spaceA = `u3gate-a-${randomUUID().slice(0, 8)}`;
+const spaceB = `u3gate-b-${randomUUID().slice(0, 8)}`;
+const broker = await createBrokerAuth("u3gate");
+const accA = await createSpaceAccountAuth(broker, spaceA);
+const accB = await createSpaceAccountAuth(broker, spaceB);
+const authA: SpaceAuth = composeSpaceAuth(broker, accA);
+const authB: SpaceAuth = composeSpaceAuth(broker, accB);
+
+// The $SYS pair for each tenant, minted NOW: the system signing seed lives in memory only while the
+// account is being provisioned, which is the whole reason these creds are `rotation-renewed` and the
+// reason the store keys exist at all (injectable is not renewable).
+const observerA = await mintMembershipObserverCreds(authA, newIdentity());
+const evictorA = await mintConnectionEvictorCreds(authA, newIdentity());
+const observerB = await mintMembershipObserverCreds(authB, newIdentity()); // cell 3's foreign observer
+// Cell 7's TORN pair: an evictor signed by a DIFFERENT (rotated) system account, exactly what a crash
+// between `rotateSystemCreds`' trust-record commit and its second cred write leaves behind.
+const tornEvictorA = await mintConnectionEvictorCreds(await rotateSystemAccount(authA), newIdentity());
+
+// Tenant A runs the real user-auth shape (callout-minted principal), per cell 1.
+const callout = await createCalloutAuth({ space: spaceA, operatorSeed: broker.operator.seed, accountPub: accA.account.pub });
+
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
+writeFileSync(
+  join(dir, "server.conf"),
+  serverConfig(broker, [accA, accB], {
+    transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js"),
+    extraAccounts: [{ pub: callout.account.pub, jwt: callout.account.jwt }],
+  }),
+);
+const srv = spawn(NATS_BIN, ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
+
+// ---------- the actor ledger + tenant A's user principal ----------
+const SECRET = "s".repeat(32);
+const ISS = "https://auth.cotal.test";
+const ledgerDir = mkdtempSync(join(tmpdir(), "cotal-u3gate-ledger-"));
+const ownerU = deriveOwnerToken(SECRET, "idp-subject-victim");
+const victimRow = grantActor(ledgerDir, { owner: ownerU, actor: "victim", scope: [], allowSubscribe: ["general"], allowPublish: ["general"] });
+const issuer = createUserTokenIssuer({ issuer: ISS, key: await generateSigningKey() });
+const bearerP = await issuer.issue({ owner: ownerU, space: spaceA, actor: "victim", scope: [], lifecycleUid: victimRow.lifecycleUid, ttlSec: 600 });
+const sharedPrincipal = principalKey(ownerU, "victim").key; // the SAME string in both tenants
+
+// ---------- the two mkdtemp roots (F1) ----------
+// An EMPTY `.cotal/` in each: it stops `findCotalRoot`'s upward walk at this root, and it is empty
+// because the gate's whole point is that nothing here supplies a credential.
+const rootA = realpathSync(mkdtempSync(join(tmpdir(), "cotal-u3gate-rootA-")));
+const rootB = realpathSync(mkdtempSync(join(tmpdir(), "cotal-u3gate-rootB-")));
+mkdirSync(join(rootA, ".cotal"), { recursive: true });
+mkdirSync(join(rootB, ".cotal"), { recursive: true });
+const startCwd = process.cwd();
+
+/** The hosted seam, faithfully: async, and it is the ONLY place a credential comes from. Reads are
+ *  counted so cell 8's "nothing on disk" is paired with a positive fact — the store WAS used. */
+class MemoryStore implements SecretStore {
+  readonly map = new Map<string, string>();
+  reads = 0;
+  async get(key: string): Promise<string | undefined> { this.reads++; return this.map.get(key); }
+  async put(key: string, value: string): Promise<void> { this.map.set(key, value); }
+  async delete(key: string): Promise<void> { this.map.delete(key); }
+}
+const storeA = new MemoryStore();
+
+const victims: NatsConnection[] = [];
+/** A live connection carrying a principal, plus a flag that flips the moment the broker drops it. */
+async function connectVictim(creds: string, id: string): Promise<{ nc: NatsConnection; closed: () => boolean }> {
+  const nc = await connect({
+    servers: SERVERS, authenticator: credsAuthenticator(enc(creds)),
+    inboxPrefix: `_INBOX_${id}`, maxReconnectAttempts: 0, reconnect: false,
+  });
+  let closed = false;
+  void nc.closed().then(() => { closed = true; }, () => { closed = true; });
+  victims.push(nc);
+  return { nc, closed: () => closed || nc.isClosed() };
+}
+
+let calloutNc: NatsConnection | undefined, ncP: NatsConnection | undefined, ncB: NatsConnection | undefined;
+let sup: CotalEndpoint | undefined;
+try {
+  let up = false;
+  for (let i = 0; i < 50; i++) { if (await isReachable(SERVERS)) { up = true; break; } await wait(200); }
+  if (!up) throw new Error(`nats-server ${NATS_VERSION} did not come up on ${PORT}`);
+
+  await setupSpaceStreams({ servers: SERVERS, space: spaceA, creds: await mintCreds(authA, newIdentity(), "provisioner") });
+
+  // ---------- tenant A's auth callout (the real user-mode connect boundary) ----------
+  calloutNc = await connect({ servers: SERVERS, authenticator: credsAuthenticator(enc(callout.calloutCreds)) });
+  await wait(300);
+  startAuthCallout(calloutNc as never, {
+    xkeySeed: callout.xkey.seed,
+    authAccount: { pub: callout.account.pub, signingSeed: callout.account.signingSeed },
+    dataAccount: { pub: accA.account.pub, signingSeed: accA.account.signingSeed },
+    space: spaceA,
+    token: { key: issuer.localKeySet(), issuer: ISS },
+    authorizeActor: ledgerAuthorizeConnect(ledgerDir),
+    permissionsFor: calloutPermissions(ledgerAclResolver(ledgerDir)),
+    log: () => {},
+  });
+
+  // ---------- CELL 0 (F1): the cwd is mkdtemp-pinned, and the harness can tell the roots apart ----------
+  process.chdir(rootA);
+  check("cell 0 (F1): findCotalRoot() resolves the tenant's own mkdtemp root, not this repository's",
+    findCotalRoot() === rootA, { resolved: findCotalRoot(), rootA });
+  // The precondition is itself a positive control: a harness that could NOT distinguish the roots
+  // would make every "nothing on disk" assertion below vacuous.
+  check("cell 0 (F1): the two roots are distinguishable (the walk is not collapsing them)",
+    findCotalRoot(rootB) === rootB && rootA !== rootB, { a: findCotalRoot(rootA), b: findCotalRoot(rootB) });
+
+  // ---------- CELL 8 (before): nothing on disk to read ----------
+  const SYS_FILES = ["membership-observer.creds", "connection-evictor.creds", "membership.json", "delivery.creds", "membership-rw.creds"];
+  const onDisk = () => [rootA, rootB].flatMap((r) => SYS_FILES.filter((f) => existsSync(join(r, ".cotal", f))).map((f) => join(r, ".cotal", f)));
+  check("cell 8 (before): no $SYS creds and no membership.json exist under either tenant root", onDisk().length === 0, onDisk());
+
+  // ---------- boot delivery for A from the INJECTED store, and nothing else ----------
+  await storeA.put(DELIVERY_CREDS_KEY, await mintCreds(authA, newIdentity(), "delivery"));
+  await storeA.put(MEMBERSHIP_RW_CREDS_KEY, await mintCreds(authA, newIdentity(), "membership-rw"));
+  await storeA.put(MEMBERSHIP_OBSERVER_CREDS_KEY, observerA);
+  await storeA.put(CONNECTION_EVICTOR_CREDS_KEY, evictorA);
+
+  realLog("  · booting runDelivery(args, storeA) in-process (its output is teed below, prefixed │)");
+  teeConsole();
+  const args: ParsedArgs = { values: { space: spaceA, server: SERVERS }, positionals: [], raw: [] };
+  void runDelivery(args, storeA); // never resolves by design — it runs until signalled
+  const probe = newIdentity();
+  const ready = await waitForDeliveryLease({ servers: SERVERS, space: spaceA, creds: await mintCreds(authA, probe, "delivery"), id: probe.id, holder: undefined });
+  check("delivery boots for tenant A with EVERY credential from the injected store (lease READY)", ready, daemonLog.slice(-600));
+  check("the store was actually read (the daemon did not silently find bytes elsewhere)", storeA.reads > 0, { reads: storeA.reads });
+  // The feed is started off the boot path, so it lands a beat AFTER the lease — wait for the line
+  // rather than sampling once at lease-ready, which races the daemon and proves nothing either way.
+  check("the daemon's own membership feed came up from the injected store, with no $SYS file on disk",
+    await until(() => daemonLog.includes("membership feed up"), 20_000), daemonLog.slice(-600));
+
+  // The renewal owner's seat: a supervisor endpoint on the privileged delivery-admin rail, which is
+  // how every eviction below is driven — the REAL request path, not a direct executor call.
+  const supId = newIdentity();
+  sup = new CotalEndpoint({
+    space: spaceA, servers: SERVERS, creds: await mintCreds(authA, supId, "supervisor"),
+    card: { id: supId.id, name: "u3-gate-admin", kind: "endpoint" },
+    consume: false, watchChannels: false, watchPresence: false, registerPresence: false,
+  });
+  sup.on("error", () => {});
+  await sup.start();
+  const admin = async (op: string, a: Record<string, unknown> = {}): Promise<{ ok: boolean; error?: string; data?: unknown }> => {
+    let last: Error | undefined;
+    for (let i = 0; i < 12; i++) {
+      try { return await sup!.requestDeliveryAdmin(op, a, 15_000); } catch (e) { last = e as Error; await wait(500); }
+    }
+    throw last ?? new Error("admin: no attempts ran");
+  };
+  const evict = async (principal: string) => {
+    const r = await admin("evictPrincipal", { principal });
+    return { ...r, ev: (r.ok ? r.data : {}) as { kicked?: number; verifiedGone?: boolean; scanComplete?: boolean } };
+  };
+
+  // ---------- CELL 2 (arm): tenant B's live principal, under the SAME principal string ----------
+  const bId = newIdentity();
+  const bCreds = await mintCreds(authB, bId, "operator", { principal: { owner: ownerU, actor: "victim" } });
+  const vB = await connectVictim(bCreds, bId.id);
+  ncB = vB.nc;
+  check("cell 2 (arm): tenant B holds a live connection under the SAME principal string as A's victim",
+    !vB.closed(), { principal: sharedPrincipal });
+
+  // ---------- CELL 1: evict a live CALLOUT-MINTED principal in A ----------
+  const nonceP = `ibx${randomUUID().replace(/-/g, "")}`;
+  ncP = await connect({
+    servers: SERVERS,
+    authenticator: [credsAuthenticator(enc(callout.sentinelCreds)), tokenAuthenticator(bearerP)],
+    maxReconnectAttempts: 0, reconnect: false, timeout: 4000, name: nonceP, inboxPrefix: `_INBOX_${nonceP}`,
+  });
+  let pClosed = false;
+  void ncP.closed().then(() => { pClosed = true; }, () => { pClosed = true; });
+  check("cell 1 (arm): a callout-minted user principal is live in tenant A", !ncP.isClosed());
+  check("cell 1 (arm): deny-new is committed first (the mandatory precondition)", revokeActor(ledgerDir, ownerU, "victim") === true);
+
+  const c1 = await evict(sharedPrincipal);
+  check("cell 1: eviction from the store-injected $SYS pair verifies the principal GONE under a complete scan",
+    c1.ok === true && (c1.ev.kicked ?? 0) >= 1 && c1.ev.verifiedGone === true && c1.ev.scanComplete === true, JSON.stringify(c1));
+  check("cell 1: the live connection actually dropped — not merely reported gone",
+    await until(() => pClosed || ncP!.isClosed(), 5000), { pClosed });
+
+  // ---------- CELL 2 (assert): the other tenant is untouched ----------
+  check("cell 2: tenant B's identically-named principal is UNTOUCHED by A's eviction (account-scoped scan contains the broker-wide KICK)",
+    !vB.closed());
+
+  // ---------- CELL 3: hand A's daemon tenant B's OBSERVER ----------
+  // The load-bearing cell. A well-formed sweep of the WRONG account looks exactly like a gone
+  // principal, so this must refuse NAMING BOTH ACCOUNTS and must never answer a confident `gone`.
+  const id3 = newIdentity();
+  const v3b = await connectVictim(await mintCreds(authA, id3, "operator"), id3.id);
+  const principal3 = principalKey(DEV_OWNER, id3.id).key;
+  await storeA.put(MEMBERSHIP_OBSERVER_CREDS_KEY, observerB);
+  const c3 = await evict(principal3);
+  check("cell 3: a FOREIGN-tenant observer is refused, naming both accounts — never a confident gone",
+    c3.ok === false && (c3.error ?? "").includes(accB.account.pub) && (c3.error ?? "").includes(accA.account.pub), JSON.stringify(c3));
+  check("cell 3: the refusal is not a disguised success (no verifiedGone in the reply)", c3.ok === false && c3.ev.verifiedGone === undefined, JSON.stringify(c3));
+  check("cell 3: the victim is STILL LIVE after the refusal (nothing was swept, nothing was kicked)", !v3b.closed());
+  // POSITIVE CONTROL — the same operation, the correct observer, same process.
+  await storeA.put(MEMBERSHIP_OBSERVER_CREDS_KEY, observerA);
+  const c3ok = await evict(principal3);
+  check("cell 3 CONTROL: with A's own observer restored, the SAME eviction succeeds (the refusal was the tenancy check, not a broken path)",
+    c3ok.ok === true && (c3ok.ev.kicked ?? 0) >= 1 && c3ok.ev.verifiedGone === true, JSON.stringify(c3ok));
+  check("cell 3 CONTROL: that victim's connection actually dropped", await until(() => v3b.closed(), 5000));
+
+  // ---------- CELL 4: the evictor key is GONE from the store ----------
+  const id4 = newIdentity();
+  const v4 = await connectVictim(await mintCreds(authA, id4, "operator"), id4.id);
+  const principal4 = principalKey(DEV_OWNER, id4.id).key;
+  await storeA.delete(CONNECTION_EVICTOR_CREDS_KEY);
+  const c4 = await evict(principal4);
+  check("cell 4: a missing evictor key REFUSES LOUD naming the key (fail-loud; the caller reads UNKNOWN, never gone)",
+    c4.ok === false && (c4.error ?? "").includes(CONNECTION_EVICTOR_CREDS_KEY), JSON.stringify(c4));
+  check("cell 4 (F2/§4.1): the repair names the STORE idiom, not a CLI command the host cannot run",
+    /put/.test(c4.error ?? "") && !/cotal up/.test(c4.error ?? ""), c4.error);
+  check("cell 4: the victim is STILL LIVE (a refusal never kills)", !v4.closed());
+  // POSITIVE CONTROL — restore the key, same eviction, same process.
+  await storeA.put(CONNECTION_EVICTOR_CREDS_KEY, evictorA);
+  const c4ok = await evict(principal4);
+  check("cell 4 CONTROL: with the evictor key restored, the SAME eviction succeeds and kicks",
+    c4ok.ok === true && (c4ok.ev.kicked ?? 0) >= 1 && c4ok.ev.verifiedGone === true, JSON.stringify(c4ok));
+  check("cell 4 CONTROL: that victim's connection actually dropped", await until(() => v4.closed(), 5000));
+
+  // ---------- CELL 5: the observer key is GONE — the FEED degrades, Plane-3 does not ----------
+  await storeA.delete(MEMBERSHIP_OBSERVER_CREDS_KEY);
+  const feedDown = await startMembership({ space: spaceA, server: SERVERS, accountId: accA.account.pub }, storeA);
+  check("cell 5: a missing observer key degrades the feed SOFTLY with a {down} naming the key (never a throw, never a silent feed)",
+    feedDown.handle === undefined && (feedDown.down ?? "").includes(MEMBERSHIP_OBSERVER_CREDS_KEY), JSON.stringify(feedDown.down));
+  check("cell 5 (F2/§4.1): the feed's repair also names the STORE idiom", /put/.test(feedDown.down ?? "") && !/cotal up/.test(feedDown.down ?? ""), feedDown.down);
+  // Plane-3 is a SEPARATE contract: the feed being down must not touch delivery.
+  const stillServing = await admin("noSuchOp"); // a refusal that PROVES the responder is alive
+  check("cell 5: Plane-3 delivery still serves while the feed is down (the admin responder answers)", stillServing.ok === false, JSON.stringify(stillServing));
+  const probe5 = newIdentity();
+  check("cell 5: the delivery lease is still READY (fail-SOFT is scoped to the feed, not the daemon)",
+    await waitForDeliveryLease({ servers: SERVERS, space: spaceA, creds: await mintCreds(authA, probe5, "delivery"), id: probe5.id, holder: undefined }));
+  // POSITIVE CONTROL — restore the key, the SAME call, same process.
+  await storeA.put(MEMBERSHIP_OBSERVER_CREDS_KEY, observerA);
+  const feedUp = await startMembership({ space: spaceA, server: SERVERS, accountId: accA.account.pub }, storeA);
+  check("cell 5 CONTROL: with the observer key restored, the SAME call starts a real feed (the {down} was the missing key, not a broken path)",
+    feedUp.handle !== undefined, JSON.stringify(feedUp.down));
+  try { await feedUp.handle?.stop(); } catch { /* draining */ }
+
+  // ---------- CELL 6: a principal that is not connected ----------
+  const c6 = await evict(principalKey(DEV_OWNER, newIdentity().id).key);
+  check("cell 6: evicting a not-live principal is an idempotent verified no-op (kicked:0, verifiedGone, complete scan)",
+    c6.ok === true && c6.ev.kicked === 0 && c6.ev.verifiedGone === true && c6.ev.scanComplete === true, JSON.stringify(c6));
+
+  // ---------- CELL 7: a TORN rotation — the two $SYS creds from different system accounts ----------
+  // Closing this on the eviction path is one of the changes under test: the check used to live only
+  // in the feed, so the path that actually kills connections opened a half-rotated pair blind and got
+  // a bare "Authorization Violation" from the broker with nothing naming the cause.
+  const id7 = newIdentity();
+  const v7 = await connectVictim(await mintCreds(authA, id7, "operator"), id7.id);
+  const principal7 = principalKey(DEV_OWNER, id7.id).key;
+  await storeA.put(CONNECTION_EVICTOR_CREDS_KEY, tornEvictorA);
+  const c7 = await evict(principal7);
+  check("cell 7 (eviction path): a torn $SYS pair refuses, naming DIFFERENT system accounts — the gap this change closes",
+    c7.ok === false && /DIFFERENT system accounts/i.test(c7.error ?? ""), JSON.stringify(c7));
+  check("cell 7: the victim is STILL LIVE after the torn-pair refusal", !v7.closed());
+  const feedTorn = await startMembership({ space: spaceA, server: SERVERS, accountId: accA.account.pub }, storeA);
+  check("cell 7 (feed path): the same torn pair takes the feed down with the same diagnosis (one shared helper, two postures)",
+    feedTorn.handle === undefined && /DIFFERENT system accounts/i.test(feedTorn.down ?? ""), JSON.stringify(feedTorn.down));
+  // POSITIVE CONTROL — restore the intact pair, both paths, same process.
+  await storeA.put(CONNECTION_EVICTOR_CREDS_KEY, evictorA);
+  const c7ok = await evict(principal7);
+  check("cell 7 CONTROL: with an intact generation restored, the SAME eviction succeeds and kicks",
+    c7ok.ok === true && (c7ok.ev.kicked ?? 0) >= 1 && c7ok.ev.verifiedGone === true, JSON.stringify(c7ok));
+  check("cell 7 CONTROL: that victim's connection actually dropped", await until(() => v7.closed(), 5000));
+  const feedOk = await startMembership({ space: spaceA, server: SERVERS, accountId: accA.account.pub }, storeA);
+  check("cell 7 CONTROL: the feed also starts on the intact pair", feedOk.handle !== undefined, JSON.stringify(feedOk.down));
+  try { await feedOk.handle?.stop(); } catch { /* draining */ }
+
+  // ---------- CELL 8 (after): still nothing on disk, and B is still untouched ----------
+  check("cell 8 (after): every cell above ran with NO $SYS cred and NO membership.json on disk", onDisk().length === 0, onDisk());
+  check("cell 8: the injected store served every read (reads > 0 and rising)", storeA.reads > 0, { reads: storeA.reads });
+  check("cell 2 (final): tenant B's principal survived every eviction round in tenant A", !vB.closed());
+
+  realLog(`\nU3 SYS-INJECTION-EVICT GATE ${fail === 0 ? "OK ✅" : "FAILED ❌"}  (${pass} passed, ${fail} failed) — ${NATS_VERSION}`);
+  if (fail) process.exitCode = 1;
+} catch (e) {
+  untee();
+  fail++;
+  realErr("  ✗ scenario threw:", (e as Error).stack ?? (e as Error).message);
+  realErr("  -- delivery daemon output tail (a thrown scenario otherwise hides the daemon's last words):\n", daemonLog.slice(-2000));
+  process.exitCode = 1;
+} finally {
+  untee(); // the daemon is about to be torn down; its console must be its own again
+  try { await sup?.stop(); } catch { /* draining */ }
+  for (const nc of [ncP, ncB, calloutNc, ...victims]) { try { await nc?.close(); } catch { /* draining */ } }
+  await killAndAwaitExit(srv, "SIGKILL"); // exact PID — never pkill nats-server
+  process.chdir(startCwd); // leave the mkdtemp roots before removing them
+  for (const r of [dir, ledgerDir, rootA, rootB]) rmSync(r, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
+}
+process.exit(process.exitCode ?? 0);

--- a/implementations/delivery/src/delivery.ts
+++ b/implementations/delivery/src/delivery.ts
@@ -164,10 +164,20 @@ export async function runDelivery(args: ParsedArgs, store?: SecretStore): Promis
   // of the WRONG account is indistinguishable from "the principal is gone" — a healthy-looking
   // answer that authorizes eviction and gate reconciliation. Resolving the root per request from
   // `process.cwd()` let that drift; and a daemon started in a foreign mesh root would sweep a
-  // foreign tenant while looking entirely well. So: the root is fixed at start, and the account on
-  // disk is cross-checked against the account this daemon's OWN credential authenticates as — a
-  // fact that does not come from that root, which is what makes it an independent check.
-  const scanTarget: ScanTarget = { root: findCotalRoot(), expectedAccount: accountFromCreds(creds.initial) };
+  // foreign tenant while looking entirely well. So: the root is fixed at start, and the OBSERVER
+  // CRED is cross-checked against the account this daemon's OWN credential authenticates as — two
+  // facts, neither of which comes from that root, which is what makes it an independent check.
+  // The $SYS pair resolves through the SAME injected store, so a hosted composition needs no
+  // `.cotal/` file for it. `injected` is this composition root's own fact — recorded here, where it
+  // is known for certain, rather than inferred later by probing the store or sniffing the
+  // filesystem, both of which report "workstation" for a hosted daemon and would emit a CLI repair
+  // the host cannot run. It selects the REPAIR IDIOM only; failure semantics never fork on it.
+  const scanRoot = findCotalRoot();
+  const scanTarget: ScanTarget = {
+    root: scanRoot,
+    expectedAccount: accountFromCreds(creds.initial),
+    source: { secrets: store ?? workspaceSecretStore(scanRoot), injected: store !== undefined },
+  };
   console.error(`• delivery: $SYS sweeps bound to ${join(scanTarget.root, ".cotal")} (account ${scanTarget.expectedAccount})`);
 
   const ep = new CotalEndpoint({
@@ -253,7 +263,13 @@ export async function runDelivery(args: ParsedArgs, store?: SecretStore): Promis
     // an arbitrary `--creds` path, whereas membership-rw lives under the workstation `.cotal/` key. With
     // no injected store, startMembership falls back to the workstation FS store.
     // Fail-soft, but never fault-FORGETFUL: whichever way the feed fails to come up, keep the reason.
-    ({ handle: membership, down: membershipDown } = await startMembership({ space, server }, store));
+    // `accountId` is the account THIS daemon's own cred authenticates as (pinned above), not a
+    // `.cotal/membership.json` read: the file was never an independent source (same directory as the
+    // creds, so a wrong root was wrong for both) and a hosted composition has none.
+    ({ handle: membership, down: membershipDown } = await startMembership(
+      { space, server, accountId: scanTarget.expectedAccount },
+      store,
+    ));
   } catch (e) {
     membershipDown = (e as Error).message;
     console.error(`! membership: failed to start (${membershipDown}); graph membership degraded, delivery unaffected`);

--- a/implementations/delivery/src/evict-exec.ts
+++ b/implementations/delivery/src/evict-exec.ts
@@ -12,7 +12,8 @@ import {
   type PlaneLivenessResult,
   type PrincipalLivenessResult,
 } from "@cotal-ai/core";
-import { findCotalRoot } from "@cotal-ai/workspace";
+import { CONNECTION_EVICTOR_CREDS_KEY, findCotalRoot, MEMBERSHIP_OBSERVER_CREDS_KEY } from "@cotal-ai/workspace";
+import { loadSysPair, observerTenancyProblem, repairAdvice, tornRotationProblem, type SysCredsSource } from "./sys-creds.js";
 
 
 /**
@@ -28,9 +29,17 @@ import { findCotalRoot } from "@cotal-ai/workspace";
  *
  * Two independent guards, because either alone leaves a real case open:
  *  - the root is PINNED AT DAEMON START, so it cannot drift with `process.cwd()` between requests;
- *  - the account on disk is CROSS-CHECKED against the account the daemon's own credential
+ *  - the OBSERVER CRED is CROSS-CHECKED against the account the daemon's own credential
  *    authenticates as. Pinning alone cannot notice a daemon that started in the wrong root to
- *    begin with; the tenancy check can, because the credential is not read from that root.
+ *    begin with; the tenancy check can, because neither side of it is read from that root.
+ *
+ * The second guard used to compare `.cotal/membership.json` against `expectedAccount`. It now
+ * compares the OBSERVER'S OWN CONNZ PERMISSION against it (`sys-creds.ts`), which is strictly
+ * stronger: the file sat in the same directory as the creds, so a wrong root was wrong for both, and
+ * its independence came from `expectedAccount` being derived from the cred anyway — the cred was
+ * always the real authority and the file was the thing being checked. The disk file is still read as
+ * a SECOND source on the workstation path, where the root genuinely can drift; it is no longer
+ * required, and a hosted composition has none.
  *
  * A mismatch REFUSES LOUD and names both sides. Note the asymmetry that makes this necessary: an
  * observer scoped to account A with accountId B under-reports (broker-denied → `unknown`, safe),
@@ -42,26 +51,72 @@ export interface ScanTarget {
   root: string;
   /** The account the daemon's own delivery credential authenticates as. */
   expectedAccount: string;
+  /** Where the $SYS pair is read from, and whether that store was injected (hosted) — the latter
+   *  selects the repair idiom only, never the failure semantics. */
+  source: SysCredsSource;
 }
 
-function resolveScan(target: ScanTarget, verb: string): { dir: string; accountId: string } {
+/**
+ * Pin check + the WORKSTATION-ONLY second source.
+ *
+ * The account to sweep is `target.expectedAccount` — the daemon's own credential, pinned at start.
+ * `membership.json` is no longer consulted for it. On the workstation path the file is still
+ * cross-checked WHEN PRESENT, because there a wrong root is a real, enumerated failure mode
+ * (see the cases above) and a second independent-ish source costs nothing. It is no longer
+ * REQUIRED: its absence is not an error, and a hosted composition never has one.
+ */
+function resolveScan(target: ScanTarget, verb: string): { accountId: string } {
   const live = findCotalRoot();
   if (live !== target.root)
     throw new Error(
       `${verb}: the mesh root resolved at this request (${live}) is not the one this daemon started in (${target.root}); ` +
       "the scan account would be read from a different workspace than the one this daemon serves. Refusing — a sweep of the wrong account looks exactly like a dead principal",
     );
-  const dir = join(target.root, ".cotal");
-  const cfgPath = join(dir, "membership.json");
-  if (!existsSync(cfgPath)) throw new Error(`${verb}: ${cfgPath} is missing, so the account to scan is unknown`);
-  const accountId = (JSON.parse(readFileSync(cfgPath, "utf8")) as { accountId?: string }).accountId;
-  if (!accountId) throw new Error(`${verb}: ${cfgPath} has no accountId`);
-  if (accountId !== target.expectedAccount)
+  if (!target.source.injected) {
+    const cfgPath = join(target.root, ".cotal", "membership.json");
+    if (existsSync(cfgPath)) {
+      // A malformed file on a path that no longer needs it must not take eviction down; only a file
+      // that names a DIFFERENT account is evidence of the drift this check exists to catch.
+      let onDisk: string | undefined;
+      try { onDisk = (JSON.parse(readFileSync(cfgPath, "utf8")) as { accountId?: string }).accountId; }
+      catch { onDisk = undefined; }
+      if (onDisk !== undefined && onDisk !== target.expectedAccount)
+        throw new Error(
+          `${verb}: ${cfgPath} names account ${onDisk}, but this daemon's own credential authenticates as ${target.expectedAccount}. ` +
+          "That disk material belongs to a different mesh, and sweeping it would return a confident, WRONG answer (a complete sweep of the wrong account is indistinguishable from a gone principal). Refusing — start the daemon from the workspace root whose account it serves",
+        );
+    }
+  }
+  return { accountId: target.expectedAccount };
+}
+
+/** Read the $SYS material for one verb and run every pre-connect check, or THROW.
+ *
+ *  Fail-loud is the whole posture here (design §4.2): a missing key is a REFUSAL, full stop. In
+ *  particular a missing evictor must NOT silently fall back to deny-new-only inside the executor —
+ *  that posture is the CALLER's documented degradation, reached by handling this refusal, never
+ *  something the executor may choose on its own. And absence (`undefined` per the `SecretStore`
+ *  contract) is the only thing treated as "not provisioned": a `get()` that throws is a refusal,
+ *  not an absence, and propagates untouched from `loadSysPair`. */
+async function loadCheckedSys(target: ScanTarget, verb: string, need: "observer" | "both"): Promise<{ observer: string; evictor?: string }> {
+  const sys = await loadSysPair(target.source, need);
+  if (sys.missing.length)
     throw new Error(
-      `${verb}: ${cfgPath} names account ${accountId}, but this daemon's own credential authenticates as ${target.expectedAccount}. ` +
-      "That disk material belongs to a different mesh, and sweeping it would return a confident, WRONG answer (a complete sweep of the wrong account is indistinguishable from a gone principal). Refusing — start the daemon from the workspace root whose account it serves",
+      `${verb}: the $SYS ${need === "both" ? "observer/evictor creds are" : "observer creds are"} not provisioned here ` +
+      `(missing ${sys.missing.join(", ")}; a space created before live eviction) - ${repairAdvice(target.source, sys.missing)}. ` +
+      "Until then removal is deny-new-only (durable reauth)",
     );
-  return { dir, accountId };
+  const observer = sys.observer as string;
+  const tenancy = observerTenancyProblem(observer, target.expectedAccount);
+  if (tenancy) throw new Error(`${verb}: ${tenancy}. Refusing`);
+  if (sys.evictor !== undefined) {
+    // The torn-rotation check now covers this path too. It used to exist only in the feed, so
+    // eviction could open a half-rotated pair and get a bare "Authorization Violation" from the
+    // broker with nothing naming the cause.
+    const torn = tornRotationProblem(observer, sys.evictor, repairAdvice(target.source, [MEMBERSHIP_OBSERVER_CREDS_KEY, CONNECTION_EVICTOR_CREDS_KEY]));
+    if (torn) throw new Error(`${verb}: ${torn}. Refusing`);
+  }
+  return { observer, ...(sys.evictor !== undefined ? { evictor: sys.evictor } : {}) };
 }
 
 /**
@@ -82,17 +137,12 @@ export async function executeEviction(server: string, target: ScanTarget, princi
   const parsed = parsePrincipalKey(principal);
   if (!parsed || !isPrincipalOwnerToken(parsed.owner))
     throw new Error(`evictPrincipal: "${principal}" is not a real owner.actor principal (owner must be \`local\` or a derived \`u_…\` token — the only shapes CONNZ attribution can surface)`);
-  const { dir, accountId } = resolveScan(target, "evictPrincipal");
-  const obsPath = join(dir, "membership-observer.creds");
-  const evPath = join(dir, "connection-evictor.creds");
-  if (!existsSync(obsPath) || !existsSync(evPath))
-    throw new Error(
-      "evictPrincipal: the $SYS observer/evictor creds are not provisioned here (a space created before live eviction); mint them with `cotal down` then `cotal up --rotate-sys`. Until then removal is deny-new-only (durable reauth)",
-    );
+  const { accountId } = resolveScan(target, "evictPrincipal");
+  const sys = await loadCheckedSys(target, "evictPrincipal", "both");
   return evictDeniedPrincipalWithCreds({
     servers: server,
-    observerCreds: readFileSync(obsPath, "utf8"),
-    evictorCreds: readFileSync(evPath, "utf8"),
+    observerCreds: sys.observer,
+    evictorCreds: sys.evictor as string,
     accountId,
     principal,
   });
@@ -106,6 +156,11 @@ export async function executeEviction(server: string, target: ScanTarget, princi
  * connection tuples; anything else refuses loudly. A space provisioned before the observer existed
  * refuses with the regeneration step — the auth plane treats that refusal as UNKNOWN and never
  * reclaims over it (fail-closed).
+ *
+ * Asks for the observer ONLY, so the KICK cred is not even read into this process's memory on a
+ * read-only path. The cost is that the torn-rotation check cannot run here (it needs both halves);
+ * that is safe rather than a gap — a torn pair whose observer is the stale half is refused by the
+ * broker, and this path reads any refusal as UNKNOWN, which is already fail-closed.
  */
 export async function executePlaneLiveness(server: string, target: ScanTarget, query: unknown): Promise<PlaneLivenessResult> {
   const q = query as Partial<PlaneLivenessQuery> | undefined;
@@ -113,15 +168,11 @@ export async function executePlaneLiveness(server: string, target: ScanTarget, q
       Object.keys(q).some((k) => k !== "ledger" && k !== "records") || // closed top-level shape
       !isPlaneConnTuple(q.ledger) || !isPlaneConnTuple(q.records))
     throw new Error("planeConnLiveness: the query must be exactly { ledger, records } connection tuples ({ serverId, cid, userNkey }); refusing a malformed or wider query");
-  const { dir, accountId } = resolveScan(target, "planeConnLiveness");
-  const obsPath = join(dir, "membership-observer.creds");
-  if (!existsSync(obsPath))
-    throw new Error(
-      "planeConnLiveness: the $SYS observer creds are not provisioned here (a space created before live observation); mint them with `cotal down` then `cotal up --rotate-sys`",
-    );
+  const { accountId } = resolveScan(target, "planeConnLiveness");
+  const sys = await loadCheckedSys(target, "planeConnLiveness", "observer");
   return observePlaneLivenessWithCreds({
     servers: server,
-    observerCreds: readFileSync(obsPath, "utf8"),
+    observerCreds: sys.observer,
     accountId,
     query: { ledger: q.ledger, records: q.records },
   });
@@ -131,7 +182,7 @@ export async function executePlaneLiveness(server: string, target: ScanTarget, q
  * The delivery daemon's FREEZE-HOLDER LIVENESS probe (#391, on the privileged delivery-admin rail):
  * answer whether ONE principal still holds a live connection, via the $SYS CONNZ observer cred
  * (opened per call; READ-ONLY — the KICK evictor cred never enters this path, and is not even read
- * from disk here).
+ * from the store here).
  *
  * This is the READ half of {@link executeEviction}, and it exists because the write half cannot
  * serve as its own precheck: a repair that must REFUSE while the holder is alive would, using
@@ -151,15 +202,11 @@ export async function executePrincipalLiveness(server: string, target: ScanTarge
   const parsed = parsePrincipalKey(wanted);
   if (!parsed || !isPrincipalOwnerToken(parsed.owner))
     throw new Error(`principalLiveness: "${wanted}" is not a real owner.actor principal (owner must be \`local\` or a derived \`u_…\` token — the only shapes CONNZ attribution can surface)`);
-  const { dir, accountId } = resolveScan(target, "principalLiveness");
-  const obsPath = join(dir, "membership-observer.creds");
-  if (!existsSync(obsPath))
-    throw new Error(
-      "principalLiveness: the $SYS observer creds are not provisioned here (a space created before live observation); mint them with `cotal down` then `cotal up --rotate-sys`",
-    );
+  const { accountId } = resolveScan(target, "principalLiveness");
+  const sys = await loadCheckedSys(target, "principalLiveness", "observer");
   return observePrincipalLivenessWithCreds({
     servers: server,
-    observerCreds: readFileSync(obsPath, "utf8"),
+    observerCreds: sys.observer,
     accountId,
     principal: wanted,
   });

--- a/implementations/delivery/src/membership.ts
+++ b/implementations/delivery/src/membership.ts
@@ -1,26 +1,24 @@
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
-import { credsClaims, inspectCredHealth, startMembershipFeed, type MembershipFeedHandle, type SecretStore } from "@cotal-ai/core";
-import { findCotalRoot, MEMBERSHIP_RW_CREDS_KEY, workspaceSecretStore } from "@cotal-ai/workspace";
+import { inspectCredHealth, startMembershipFeed, type MembershipFeedHandle, type SecretStore } from "@cotal-ai/core";
+import { CONNECTION_EVICTOR_CREDS_KEY, findCotalRoot, MEMBERSHIP_OBSERVER_CREDS_KEY, MEMBERSHIP_RW_CREDS_KEY, workspaceSecretStore } from "@cotal-ai/workspace";
+import { loadSysPair, observerTenancyProblem, repairAdvice, tornRotationProblem, type SysCredsSource } from "./sys-creds.js";
 
 /**
- * The delivery daemon's thin composition root for the broker-sourced graph-membership feed. It loads the
- * DATA account id + the SYSTEM-account observer cred from `.cotal/` (written by `cotal up`; the daemon
- * never holds the signer) and reads the DATA-account rw cred through the {@link SecretStore} seam — the
- * SAME seam the renewal owner (the manager) re-signs into — so a hosted composition can renew the feed's
- * writer end-to-end (KMS/Vault) without a daemon restart. `store` is that hosted injection point; with
- * none, the workstation FS store (keys = the filenames under `.cotal/`) is used, so a local `cotal up`
- * is byte-for-byte unchanged. It hands the two creds + the account id to the core feed engine
- * ({@link startMembershipFeed}, which owns the two connections + the poll loop + the rw 75% renewal).
+ * The delivery daemon's thin composition root for the broker-sourced graph-membership feed. Every
+ * credential it needs — the DATA-account rw cred AND the SYSTEM-account observer — now resolves
+ * through the {@link SecretStore} seam, so a hosted composition can supply all of them with no file
+ * on disk. `store` is that injection point; with none, the workstation FS store is used (keys = the
+ * filenames under `.cotal/`), so a local `cotal up` is byte-for-byte unchanged. It hands the two
+ * creds + the account id to the core feed engine ({@link startMembershipFeed}, which owns the two
+ * connections + the poll loop + the rw 75% renewal).
  *
- * Deliberately ISOLATED from Plane-3: a separate module, separate connections, and a fail-soft contract —
- * if the creds aren't provisioned (a pre-feature space) or the feed can't start, it logs and returns
- * `undefined`; the graph degrades to traffic-only and delivery is untouched.
+ * The ACCOUNT ID is no longer read from `.cotal/membership.json`. It arrives as `opts.accountId` —
+ * the account the daemon's own delivery cred authenticates as, pinned once at start — and the
+ * observer is checked against it intrinsically (see `sys-creds.ts`). That file was never an
+ * independent source: it sat in the same directory as the creds, so a wrong root was wrong for both.
  *
- * Residual (deferred, non-blocking): the observer cred + `membership.json` (the account id) are still
- * read from `.cotal/` files, so a fully hosted feed on an injected store also needs those two threaded.
- * They are a static $SYS cred and non-secret config, respectively — the renewable rw kind is what 3b
- * migrates; the manager re-signs only it.
+ * Deliberately ISOLATED from Plane-3: a separate module, separate connections, and a fail-soft
+ * contract — if the creds aren't provisioned (a pre-feature space) or the feed can't start, it logs
+ * and returns `{ down }`; the graph degrades to traffic-only and delivery is untouched.
  */
 
 /** Why the feed is, or is not, running. `down` carries the DIAGNOSIS to the caller, because the
@@ -29,49 +27,69 @@ import { findCotalRoot, MEMBERSHIP_RW_CREDS_KEY, workspaceSecretStore } from "@c
  *  three layers down (the failure reported in #338). Exactly one of the two members is set. */
 export type MembershipStart = { handle: MembershipFeedHandle; down?: undefined } | { handle?: undefined; down: string };
 
-export async function startMembership(opts: { space: string; server: string }, store?: SecretStore): Promise<MembershipStart> {
-  const root = findCotalRoot();
-  const dir = join(root, ".cotal");
-  const obsPath = join(dir, "membership-observer.creds");
-  const cfgPath = join(dir, "membership.json");
-  const secrets = store ?? workspaceSecretStore(root);
+export async function startMembership(
+  opts: { space: string; server: string; accountId: string },
+  store?: SecretStore,
+): Promise<MembershipStart> {
+  // `injected` is the composition root's own fact, decided here before any I/O — never inferred by
+  // probing the store or sniffing `.cotal/`, which would report "workstation" for a hosted daemon
+  // and emit a CLI repair the host cannot run (design §4.1).
+  const source: SysCredsSource = { secrets: store ?? workspaceSecretStore(findCotalRoot()), injected: store !== undefined };
 
-  const rw = await secrets.get(MEMBERSHIP_RW_CREDS_KEY);
+  const rw = await source.secrets.get(MEMBERSHIP_RW_CREDS_KEY);
+  // Ask for both $SYS creds: the observer is REQUIRED, the evictor only feeds the torn-rotation
+  // check below. A space with no evictor still runs a perfectly good feed (eviction refuses on its
+  // own path, loudly), so its absence must not take the feed down.
+  const sys = await loadSysPair(source, "both");
   const missing = [
     rw === undefined ? MEMBERSHIP_RW_CREDS_KEY : undefined,
-    existsSync(obsPath) ? undefined : "membership-observer.creds",
-    existsSync(cfgPath) ? undefined : "membership.json",
+    ...sys.missing.filter((k) => k !== CONNECTION_EVICTOR_CREDS_KEY),
   ].filter((f): f is string => f !== undefined);
   if (missing.length) {
     // Name the missing piece AND a repair that reaches it. The bundle has two halves with two
     // different repairs, and naming the wrong one costs an operator a full mesh stop for nothing.
     // The $SYS-signed half (observer, evictor) can only be minted while the never-persisted system
-    // signing seed is in memory, so it takes a rotation. The DATA half (rw cred, account id) is
-    // signed by the data account, whose seed IS persisted, so a plain `cotal up` heals it — that is
-    // what `healMembershipDataCreds` in `up` does, on every path rather than only a fresh space.
+    // signing seed is in memory, so it takes a rotation. The DATA half (the rw cred) is signed by
+    // the data account, whose seed IS persisted, so a plain `cotal up` heals it — that is what
+    // `healMembershipDataCreds` in `up` does, on every path rather than only a fresh space.
+    // Only the REPAIR tail forks on `injected`; this diagnosis half is identical in both.
+    const sysMissing = missing.filter((m) => m === MEMBERSHIP_OBSERVER_CREDS_KEY);
     const down =
-      missing.length === 1 && missing[0] === "membership-observer.creds"
-        ? "the $SYS observer cred is missing - re-mint it with `cotal down` then `cotal up --rotate-sys`"
-        // Name the remedy that matches the MISSING piece, because the two halves are repaired by
-        // different acts. The data half (`membership-rw.creds`, `membership.json`) is signed by the
-        // data account, whose seed is persisted, so a plain `cotal up` mints it. The $SYS half
-        // (observer, evictor) can only be re-minted while the never-persisted $SYS seed is in
-        // memory, which is a system-account rotation. Telling an operator to rotate when a plain
-        // `up` would do it sends them through a full mesh stop for nothing.
+      missing.length === 1 && missing[0] === MEMBERSHIP_OBSERVER_CREDS_KEY
+        ? `the $SYS observer cred is missing (key "${MEMBERSHIP_OBSERVER_CREDS_KEY}") - ${repairAdvice(source, sysMissing)}`
         : `the membership bundle is incomplete here (missing ${missing.join(", ")}) - ${
-            missing.every((m) => m === MEMBERSHIP_RW_CREDS_KEY || m === "membership.json")
-              ? "run `cotal up` to provision the data-account half (no rotation needed)"
-              : "the $SYS-signed creds can only be re-minted while the system account is being provisioned: `cotal down` then `cotal up --rotate-sys`"
+            sysMissing.length === 0
+              ? source.injected
+                ? `re-sign the data-account half into the store under ${MEMBERSHIP_RW_CREDS_KEY} (no rotation needed)`
+                : "run `cotal up` to provision the data-account half (no rotation needed)"
+              : `the $SYS-signed creds can only be re-minted while the system account is being provisioned: ${repairAdvice(source, sysMissing)}`
           }`;
     console.error(`• membership: ${down}. The graph falls back to traffic-only; delivery is unaffected.`);
     return { down };
   }
+  const obsCreds = sys.observer as string; // required above; absence already returned
 
-  const accountId = (JSON.parse(readFileSync(cfgPath, "utf8")) as { accountId?: string }).accountId;
-  if (!accountId) {
-    const down = ".cotal/membership.json has no accountId";
-    console.error(`• membership: ${down}; membership disabled (delivery unaffected)`);
-    return { down };
+  // TENANCY, before connecting. The observer names its own DATA account in its CONNZ permission, so
+  // it can be checked against the account this daemon's own cred authenticates as with no adjacent
+  // file at all. The broker enforces the same scoping independently — this local read buys the
+  // DIAGNOSIS (a line naming both accounts) rather than the guarantee.
+  const tenancy = observerTenancyProblem(obsCreds, opts.accountId);
+  if (tenancy) {
+    console.error(`! membership: ${tenancy}; graph membership degraded, delivery unaffected`);
+    return { down: tenancy };
+  }
+
+  // A TORN rotation is the other way this cred goes broker-dead without a byte of its own changing:
+  // `rotateSystemCreds` commits the trust record, then writes both $SYS creds, so a crash between the
+  // two leaves one on the retired system account, and the broker answers the same bare
+  // "Authorization Violation" either way. Shared with the eviction path as of this change — it used
+  // to live only here, which left eviction opening a half-rotated pair blind.
+  if (sys.evictor !== undefined) {
+    const torn = tornRotationProblem(obsCreds, sys.evictor, repairAdvice(source, [MEMBERSHIP_OBSERVER_CREDS_KEY, CONNECTION_EVICTOR_CREDS_KEY]));
+    if (torn) {
+      console.error(`! membership: ${torn}; graph membership degraded, delivery unaffected`);
+      return { down: torn };
+    }
   }
 
   // Check the OBSERVER's own expiry before connecting. It is `rotation-renewed`, so unlike every
@@ -79,33 +97,12 @@ export async function startMembership(opts: { space: string; server: string }, s
   // "Authorization Violation", which names neither the credential nor the repair. Reading the JWT
   // costs nothing and turns the daemon's one loud line into the actual diagnosis: the difference
   // between an operator finding this in minutes and finding it in a support thread.
-  const obsCreds = readFileSync(obsPath, "utf8");
-  // A TORN rotation is the other way this cred goes broker-dead without a byte of its own changing:
-  // `rotateSystemCreds` commits the trust record, then writes both $SYS creds, so a crash between the
-  // two leaves one file on the retired system account. The broker answers the same bare
-  // "Authorization Violation" either way. The daemon cannot ask the trust record which account is
-  // current (it deliberately never loads the signer), but it does not need to: the pair is written
-  // by one rotation, so two DIFFERENT issuers prove one of them is stale, with no signer read at all.
-  // (`doctor auth`, which legitimately holds the record, checks each file against it directly.)
-  const evPath = join(dir, "connection-evictor.creds");
-  if (existsSync(evPath)) {
-    let obsIss: string | undefined, evIss: string | undefined;
-    try {
-      obsIss = credsClaims(obsCreds).iss;
-      evIss = credsClaims(readFileSync(evPath, "utf8")).iss;
-    } catch { /* an unreadable file is the health check's case just below */ }
-    if (obsIss !== undefined && evIss !== undefined && obsIss !== evIss) {
-      const down = `the two $SYS creds are signed by DIFFERENT system accounts (observer ${obsIss.slice(0, 12)}…, evictor ${evIss.slice(0, 12)}…) - a system-account rotation did not finish, so one of them is broker-dead: re-run \`cotal down\` then \`cotal up --rotate-sys\` to land a complete generation`;
-      console.error(`! membership: ${down}; graph membership degraded, delivery unaffected`);
-      return { down };
-    }
-  }
   const obs = inspectCredHealth(obsCreds);
   if (obs.state === "expired" || obs.state === "unreadable") {
     const down =
       obs.state === "expired"
-        ? `the $SYS observer cred (${obsPath}) EXPIRED ${new Date((obs.exp ?? 0) * 1000).toISOString()} and the broker denies it - it is rotation-renewed, so nothing re-signs it: run \`cotal down\` then \`cotal up --rotate-sys\` (agents, creds and data are untouched)`
-        : `the $SYS observer cred (${obsPath}) is unreadable (${obs.error})`;
+        ? `the $SYS observer cred (key "${MEMBERSHIP_OBSERVER_CREDS_KEY}") EXPIRED ${new Date((obs.exp ?? 0) * 1000).toISOString()} and the broker denies it - it is rotation-renewed, so nothing re-signs it: ${repairAdvice(source, [MEMBERSHIP_OBSERVER_CREDS_KEY])} (agents, creds and data are untouched)`
+        : `the $SYS observer cred (key "${MEMBERSHIP_OBSERVER_CREDS_KEY}") is unreadable (${obs.error})`;
     console.error(`! membership: ${down}; graph membership degraded, delivery unaffected`);
     return { down };
   }
@@ -114,14 +111,14 @@ export async function startMembership(opts: { space: string; server: string }, s
   const handle = await startMembershipFeed({
     servers: opts.server,
     space: opts.space,
-    accountId,
+    accountId: opts.accountId,
     // Observer is rotation-renewed ($SYS): a static read — its renewal is a system rotation + restart.
     observerCreds: obsCreds,
     // rw is class-2 standing-renewable: read through the store seam and renewed on a 75% timer that
     // preflight-proves each candidate the manager re-signs into the store (D5 slice 5). The daemon
     // never sees the signer; the manager owns the re-sign.
     rwCreds: async () => {
-      const cur = await secrets.get(MEMBERSHIP_RW_CREDS_KEY);
+      const cur = await source.secrets.get(MEMBERSHIP_RW_CREDS_KEY);
       if (cur === undefined)
         throw new Error(`membership: the scoped rw cred is gone (key "${MEMBERSHIP_RW_CREDS_KEY}") — restore it (locally: re-run \`cotal up\`) before the current JWT expires`);
       return cur;

--- a/implementations/delivery/src/sys-creds.ts
+++ b/implementations/delivery/src/sys-creds.ts
@@ -1,0 +1,156 @@
+import { credsClaims, type SecretStore } from "@cotal-ai/core";
+import { CONNECTION_EVICTOR_CREDS_KEY, MEMBERSHIP_OBSERVER_CREDS_KEY } from "@cotal-ai/workspace";
+
+/**
+ * THE `$SYS` PAIR, read through the {@link SecretStore} seam and checked before it is used.
+ *
+ * Both consumers of the observer/evictor creds — the graph feed (`membership.ts`) and the
+ * eviction/liveness executors (`evict-exec.ts`) — resolve them here so the three checks that make a
+ * `$SYS` cred trustworthy cannot drift apart or exist on only one path:
+ *
+ *  1. TENANCY (the observer names its own account — {@link observerTenancyProblem});
+ *  2. TORN ROTATION (the pair was signed by ONE system account — {@link tornRotationProblem});
+ *  3. STORE-AWARE REPAIR (the advice names something the reader can actually do —
+ *     {@link repairAdvice}).
+ *
+ * Check 2 previously existed ONLY in the feed path, so the eviction path could open a half-rotated
+ * pair and get a bare "Authorization Violation" from the broker. Sharing it is the point of this
+ * module, not a side effect of it.
+ *
+ * This module DECIDES NOTHING ABOUT POSTURE. It reports problems as strings and absence as a list
+ * of missing keys; whether that is a fail-soft `down` (the feed) or a loud throw (eviction) belongs
+ * to the caller, because the two postures are deliberately different and flattening them here is
+ * exactly the refactor `docs/design/u3-membership-sys-injection.md` §4 exists to prevent.
+ */
+
+/** The `$SYS` creds' source: the store to read them from, plus whether that store was INJECTED.
+ *  `injected` is the composition root's own fact (`store !== undefined` at the runner) — never
+ *  inferred by probing the store or sniffing `.cotal/`, both of which report "workstation" for a
+ *  hosted daemon and would emit CLI advice a host cannot run (design §4.1). */
+export interface SysCredsSource {
+  secrets: SecretStore;
+  injected: boolean;
+}
+
+/** Repair advice for missing/unusable `$SYS` material, in the reader's own idiom.
+ *
+ *  The DIAGNOSIS half (which key, which account) is identical in both compositions and is built by
+ *  the caller; only this repair TAIL forks. On a workstation the repair is a real command; against a
+ *  hosted store it is the mint window plus the key to `put` under, because `cotal up --rotate-sys`
+ *  is unactionable there — and emitting it into a hosted log degrades the diagnosis even when the
+ *  failure semantics are right. Both halves say the same true thing: the `$SYS` pair can only be
+ *  minted while the never-persisted system signing seed is in memory. */
+export function repairAdvice(source: SysCredsSource, keys: readonly string[]): string {
+  const named = keys.length ? keys.join(" + ") : "the $SYS pair";
+  return source.injected
+    ? `re-mint the $SYS pair at a system-account rotation (the seed is in memory only at that moment) and \`put\` it under ${named}`
+    : "re-mint it with `cotal down` then `cotal up --rotate-sys`";
+}
+
+/** The DATA account an observer cred is scoped to, read out of its own `$SYS.REQ.ACCOUNT.<id>.CONNZ`
+ *  publish permission, or `undefined` if it carries none.
+ *
+ *  This is a LOCAL read of a signed document, and it buys the DIAGNOSIS, not the guarantee: the
+ *  broker independently refuses a CONNZ request for any other account, because the permission is in
+ *  the JWT it validates. Doing it here, before connecting, is what turns that refusal from a bare
+ *  "Authorization Violation" into a line naming both accounts (design §4.3). */
+export function connzAccountOf(observerCreds: string): string | undefined {
+  for (const subject of credsClaims(observerCreds).nats?.pub?.allow ?? []) {
+    const m = /^\$SYS\.REQ\.ACCOUNT\.(A[A-Z2-7]{55})\.CONNZ$/.exec(subject);
+    if (m) return m[1];
+  }
+  return undefined;
+}
+
+/**
+ * THE TENANCY CHECK — the guard that replaces the eliminated `membership.json` cross-check.
+ *
+ * Every sweep below resolves an ACCOUNT, and a complete, well-formed sweep of the WRONG account is
+ * indistinguishable from "the principal is gone": a healthy-looking answer that authorizes eviction.
+ * Note the asymmetry that makes this necessary — an observer scoped to A used with accountId B
+ * under-reports (broker-denied → `unknown`, safe), but observer A used with accountId A while the
+ * GATE lives on B is internally consistent and answers a confident, WRONG `gone`.
+ *
+ * Checking the observer against the account the daemon's OWN cred authenticates as is strictly
+ * stronger than the file it replaces: the file sat in the same `.cotal/` dir as the creds, so a root
+ * that was wrong was wrong for both, and its independence came from `expectedAccount` being derived
+ * from the cred anyway. The cred was always the real authority; the file was the thing being checked.
+ *
+ * An observer carrying NO CONNZ permission is refused rather than trusted: it cannot do the job, and
+ * treating "no account named" as "any account" is the exact failure this guard exists to stop.
+ */
+export function observerTenancyProblem(observerCreds: string, expectedAccount: string): string | undefined {
+  let scoped: string | undefined;
+  try {
+    scoped = connzAccountOf(observerCreds);
+  } catch (e) {
+    return `the $SYS observer cred is unreadable (${(e as Error).message})`;
+  }
+  if (scoped === undefined)
+    return "the $SYS observer cred carries no `$SYS.REQ.ACCOUNT.<id>.CONNZ` permission, so it names no account to sweep and cannot be checked against this daemon's own tenancy";
+  if (scoped !== expectedAccount)
+    return (
+      `the $SYS observer cred is scoped to account ${scoped}, but this daemon's own credential authenticates as ${expectedAccount}. ` +
+      "That credential belongs to a different mesh, and sweeping it would return a confident, WRONG answer (a complete sweep of the wrong account is indistinguishable from a gone principal)"
+    );
+  return undefined;
+}
+
+/**
+ * THE TORN-ROTATION CHECK — two `$SYS` creds signed by DIFFERENT system accounts.
+ *
+ * `rotateSystemCreds` commits the trust record, then writes both creds, so a crash between the two
+ * leaves one of them on the RETIRED system account. The broker answers the same bare "Authorization
+ * Violation" either way, and the daemon cannot ask the trust record which account is current (it
+ * deliberately never loads the signer) — but it does not need to: the pair is written by ONE
+ * rotation, so two different issuers prove one of them is stale, with no signer read at all.
+ *
+ * Shared by both paths as of this change. It previously lived only in the feed, which left eviction
+ * — the path that actually kills connections — opening a half-rotated pair blind.
+ */
+export function tornRotationProblem(observerCreds: string, evictorCreds: string, advice: string): string | undefined {
+  let obsIss: string | undefined, evIss: string | undefined;
+  try {
+    obsIss = credsClaims(observerCreds).iss;
+    evIss = credsClaims(evictorCreds).iss;
+  } catch {
+    return undefined; // an undecodable cred is the health check's case, reported with its own message
+  }
+  if (obsIss === undefined || evIss === undefined || obsIss === evIss) return undefined;
+  return (
+    `the two $SYS creds are signed by DIFFERENT system accounts (observer ${obsIss.slice(0, 12)}…, evictor ${evIss.slice(0, 12)}…) - ` +
+    `a system-account rotation did not finish, so one of them is broker-dead: ${advice} to land a complete generation`
+  );
+}
+
+/** What {@link loadSysPair} was asked for. The liveness verbs are READ-ONLY and must not even read
+ *  the KICK cred — least privilege is not only about what a connection may do, but about what the
+ *  process reads into memory on a path that never needs it. */
+export type SysCredsNeed = "observer" | "both";
+
+export interface SysPair {
+  observer?: string;
+  evictor?: string;
+  /** Keys the store returned `undefined` for — ABSENCE, per the `SecretStore` contract. A `get()`
+   *  that THROWS is a refusal, not an absence, and propagates out of {@link loadSysPair}. */
+  missing: string[];
+}
+
+/** Read the `$SYS` pair through the store. Absence is reported; every other failure propagates.
+ *
+ *  The distinction is load-bearing: `undefined` means "not provisioned here", which each caller
+ *  answers in its own posture, whereas a KMS timeout or a revoked role is a REFUSAL that must not be
+ *  mistaken for an unprovisioned space and quietly degraded into deny-new-only.
+ *
+ *  Reading per call (rather than once at start) is strictly better than the `readFileSync` it
+ *  replaces: a hosted store re-keyed by a rotation is picked up on the next eviction with no daemon
+ *  restart. No renewal timer is added, and none is wanted — these stay `rotation-renewed`. */
+export async function loadSysPair(source: SysCredsSource, need: SysCredsNeed): Promise<SysPair> {
+  const observer = await source.secrets.get(MEMBERSHIP_OBSERVER_CREDS_KEY);
+  const evictor = need === "both" ? await source.secrets.get(CONNECTION_EVICTOR_CREDS_KEY) : undefined;
+  const missing = [
+    observer === undefined ? MEMBERSHIP_OBSERVER_CREDS_KEY : undefined,
+    need === "both" && evictor === undefined ? CONNECTION_EVICTOR_CREDS_KEY : undefined,
+  ].filter((k): k is string => k !== undefined);
+  return { ...(observer !== undefined ? { observer } : {}), ...(evictor !== undefined ? { evictor } : {}), missing };
+}

--- a/implementations/manager/smoke/gate-reconcile-cli-e2e.smoke.ts
+++ b/implementations/manager/smoke/gate-reconcile-cli-e2e.smoke.ts
@@ -26,7 +26,7 @@
  */
 import { randomUUID } from "node:crypto";
 import { spawn, spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { connect, type NatsConnection } from "@nats-io/transport-node";
@@ -86,8 +86,14 @@ const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 // THE SEEDED WORKSPACE ROOT the command will resolve from: its own scratch dir, never the
 // operator's. `findCotalRoot()` walks up for a `.cotal/`, so an unanchored cwd would reach the real
 // mesh root — the command runs with cwd set HERE, and this directory is what it must find.
-const ROOT = join(dir, "mesh-root");
-mkdirSync(join(ROOT, ".cotal"), { recursive: true });
+// REALPATH'D, and only after the directory exists (`realpathSync` needs a real target). The daemon
+// pins its scan root from `findCotalRoot()`, which returns a RESOLVED path; where TMPDIR is itself a
+// symlink the literal `join(...)` and the resolved path differ by the link alone, and the root-pin
+// guard below would then refuse a drift that is not one — a false red that says "root drift" while
+// the roots are the same directory.
+const rootPath = join(dir, "mesh-root");
+mkdirSync(join(rootPath, ".cotal"), { recursive: true });
+const ROOT = realpathSync(rootPath);
 
 writeFileSync(
   join(dir, "server.conf"),

--- a/implementations/manager/smoke/gate-reconcile-cli-e2e.smoke.ts
+++ b/implementations/manager/smoke/gate-reconcile-cli-e2e.smoke.ts
@@ -263,10 +263,15 @@ try {
     const cwdBefore = process.cwd();
     try {
       process.chdir(ROOT); // so the root-drift guard is satisfied and the TENANCY guard is what speaks
+      // The WORKSTATION composition (`injected: false`), which is what this smoke exercises: the
+      // $SYS pair resolves through the FS store under `.cotal/`, and `membership.json` is still
+      // cross-checked as the second source. A hosted composition injects its own store instead and
+      // has no such file — that path is covered by the delivery $SYS-injection smoke.
+      const source = { secrets: workspaceSecretStore(ROOT), injected: false };
       const foreignAccount = `A${"B".repeat(55)}`;
       let tenancyErr = "";
       try {
-        await executePrincipalLiveness(SERVERS, { root: ROOT, expectedAccount: foreignAccount }, principalKey(DEV_OWNER, "whoever").key);
+        await executePrincipalLiveness(SERVERS, { root: ROOT, expectedAccount: foreignAccount, source }, principalKey(DEV_OWNER, "whoever").key);
       } catch (e) { tenancyErr = (e as Error).message; }
       check("TENANCY: disk material naming a different account than the daemon authenticates as REFUSES (never a confident sweep of a foreign tenant)",
         /names account/.test(tenancyErr) && tenancyErr.includes(foreignAccount), tenancyErr);
@@ -275,7 +280,7 @@ try {
       // tenant, not every tenant.
       let okErr = "";
       try {
-        await executePrincipalLiveness(SERVERS, { root: ROOT, expectedAccount: auth.account.pub }, principalKey(DEV_OWNER, "whoever").key);
+        await executePrincipalLiveness(SERVERS, { root: ROOT, expectedAccount: auth.account.pub, source }, principalKey(DEV_OWNER, "whoever").key);
       } catch (e) { okErr = (e as Error).message; }
       check("TENANCY control: the correctly-seeded root is accepted and answers (the guard rejects the wrong tenant, not all of them)", okErr === "", okErr);
 
@@ -284,7 +289,7 @@ try {
       process.chdir(cwdBefore);
       let driftErr = "";
       try {
-        await executePrincipalLiveness(SERVERS, { root: ROOT, expectedAccount: auth.account.pub }, principalKey(DEV_OWNER, "whoever").key);
+        await executePrincipalLiveness(SERVERS, { root: ROOT, expectedAccount: auth.account.pub, source }, principalKey(DEV_OWNER, "whoever").key);
       } catch (e) { driftErr = (e as Error).message; }
       check("ROOT DRIFT: a request-time root different from the daemon's start root REFUSES (the scan account cannot follow process.cwd())",
         /is not the one this daemon started in/.test(driftErr), driftErr);

--- a/package.json
+++ b/package.json
@@ -448,6 +448,7 @@
     "smoke:secret-store": "tsx packages/workspace/smoke/secret-store.smoke.ts",
     "smoke:space-auth-store": "tsx packages/workspace/smoke/space-auth-store.smoke.ts",
     "smoke:delivery-store-boundary": "tsx implementations/delivery/smoke/delivery-store-boundary.smoke.ts",
+    "smoke:sys-injection-evict": "tsx implementations/delivery/smoke/sys-injection-evict.smoke.ts",
     "smoke:delivery-teardown": "tsx implementations/cli/smoke/delivery-teardown.smoke.ts",
     "smoke:auth-store": "tsx implementations/auth/smoke/auth-store.smoke.ts",
     "smoke:session-caller-grant": "tsx packages/core/smoke/session-caller-grant.smoke.ts",

--- a/packages/core/src/identity.ts
+++ b/packages/core/src/identity.ts
@@ -115,15 +115,35 @@ export function credsFingerprint(creds: string): string {
   return createHash("sha256").update(jwt).digest("hex");
 }
 
+/** The `nats` claim block of a NATS user JWT — the permission set the broker enforces. Declared
+ *  because a local reader sometimes needs to know what a cred is SCOPED TO, not just when it
+ *  expires: an account-scoped cred names its own account inside `pub.allow`, which lets a holder
+ *  check a credential against the tenant it believes it serves BEFORE connecting, and report a
+ *  mismatch as a named refusal instead of a bare broker "Authorization Violation".
+ *
+ *  Read-only diagnosis, never enforcement: these claims are UNVERIFIED here (see
+ *  {@link credsClaims}), and the broker enforces the same permissions independently. A local check
+ *  over this block buys the DIAGNOSIS; it does not buy the guarantee. */
+export interface NatsUserClaims {
+  pub?: { allow?: string[]; deny?: string[] };
+  sub?: { allow?: string[]; deny?: string[] };
+  /** The account that ISSUED this user (for a data-account cred, the data account). */
+  issuer_account?: string;
+}
+
 /** The decoded (UNVERIFIED) claims of a creds file's user JWT — shared parse for every local
  *  inspector (credential health, renewal scheduling, identity checks). Unverified is correct here:
  *  the broker is the enforcement boundary; local readers only need the claims to schedule and
- *  diagnose. Throws on a structurally-unusable file (no JWT block / undecodable payload). */
-export function credsClaims(creds: string): { sub?: string; iat?: number; exp?: number; name?: string; iss?: string } {
+ *  diagnose. Throws on a structurally-unusable file (no JWT block / undecodable payload).
+ *
+ *  `nats` was always PRESENT in the returned object (this is a whole-payload parse) but was not
+ *  DECLARED, so a caller needing the permission block had to cast past this signature. Declaring it
+ *  is a typing fix, not a behaviour change: no parse, no field and no error path moves. */
+export function credsClaims(creds: string): { sub?: string; iat?: number; exp?: number; name?: string; iss?: string; nats?: NatsUserClaims } {
   const payload = jwtFromCreds(creds)?.split(".")[1];
   if (!payload) throw new Error("creds: no NATS user JWT block found");
   try {
-    return JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as { sub?: string; iat?: number; exp?: number; name?: string; iss?: string };
+    return JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as { sub?: string; iat?: number; exp?: number; name?: string; iss?: string; nats?: NatsUserClaims };
   } catch {
     throw new Error("creds: undecodable user JWT payload");
   }

--- a/packages/workspace/src/renewal.ts
+++ b/packages/workspace/src/renewal.ts
@@ -34,9 +34,31 @@ export const DELIVERY_CREDS_KEY = "delivery.creds";
  *  result back to the daemon's `membership` component without a hand-copied string. */
 export const MEMBERSHIP_RW_CREDS_KEY = "membership-rw.creds";
 
+/** The `$SYS` CONNZ observer's key — the graph feed's read connection and the account-scoped sweep
+ *  every liveness/eviction verdict is measured against. Same key↔filename discipline as
+ *  {@link DELIVERY_CREDS_KEY}, so `workspaceSecretStore(root)` resolves it to the byte the daemon
+ *  reads today and a local `cotal up` is unchanged.
+ *
+ *  NOT in {@link REMINTABLE_DAEMON_CREDS} and never will be: this is `rotation-renewed`, so no
+ *  persisted seed can re-sign it (the `$SYS` signing seed is discarded at provision). The key exists
+ *  so a HOSTED composition can inject the cred a system-account rotation minted; it does not make
+ *  the cred renewable. See `docs/design/u3-membership-sys-injection.md` §2. */
+export const MEMBERSHIP_OBSERVER_CREDS_KEY = "membership-observer.creds";
+
+/** The `$SYS` KICK-only evictor's key — the write half of live eviction, paired with
+ *  {@link MEMBERSHIP_OBSERVER_CREDS_KEY} by one rotation and read per call.
+ *
+ *  Same `rotation-renewed` posture and the same non-membership of {@link REMINTABLE_DAEMON_CREDS}.
+ *  Its permission (`$SYS.REQ.SERVER.*.KICK`) carries NO account, so unlike the observer it cannot be
+ *  tenancy-checked from its own JWT; its containment is that every cid it is handed comes from the
+ *  observer's account-scoped scan. Keep the two keys spelled together for that reason. */
+export const CONNECTION_EVICTOR_CREDS_KEY = "connection-evictor.creds";
+
 /** The seed-less daemon creds files a renewal owner re-signs. The $SYS files
  *  (membership-observer, connection-evictor) are deliberately ABSENT: they are rotation-renewed —
- *  no persisted seed can re-sign them, by design. */
+ *  no persisted seed can re-sign them, by design. Their store keys are
+ *  {@link MEMBERSHIP_OBSERVER_CREDS_KEY} / {@link CONNECTION_EVICTOR_CREDS_KEY} above — injectable,
+ *  but never re-signable from a persisted seed. */
 export const REMINTABLE_DAEMON_CREDS: ReadonlyArray<{ file: string; profile: Profile }> = [
   { file: DELIVERY_CREDS_KEY, profile: "delivery" },
   { file: MEMBERSHIP_RW_CREDS_KEY, profile: "membership-rw" },


### PR DESCRIPTION
U3: store-inject the static `$SYS`/membership credential pair (embedding gap 1) so per-space delivery live-eviction works in a hosted composition without fixed disk paths.

- New shared `implementations/delivery/src/sys-creds.ts` — decides nothing about posture; both callers pass their own. Two rotation-renewed key constants in `packages/workspace/src/renewal.ts`, deliberately not in `REMINTABLE_DAEMON_CREDS`.
- `membership.json` is eliminated from the injected path: the intrinsic check reads the account out of the observer's own CONNZ permission and compares it against the account the daemon's delivery cred authenticates as — two facts, neither from the root. The workstation-disk cross-check is kept where the root genuinely can drift.
- Torn-rotation detection extended to the eviction path, which previously opened a half-rotated pair blind. Failure semantics unchanged: feed fail-soft, eviction fail-loud, refusals read UNKNOWN and never `gone`.

Gate: `smoke:sys-injection-evict` — 37/37, three consecutive runs on nats-server v2.14.5 by absolute path; the smoke refuses an unset or wrong-version binary (both refusals tested). Two tenants on one broker under the same principal string, so a cross-tenant leak surfaces as a kill; no `$SYS` cred and no `membership.json` on disk asserted before and after. Cold-reviewed: zero blockers; the review's red-probe (tenancy check disabled → named cells red) and its one LOW finding (symlinked-TMPDIR root pin, fixed with a realpath) are folded.

Depends on #987 — `docs/design/u2-resolver-cas.md` §8 is cited by the design doc here; land that first so the citation never dangles.
