### PR TITLE
test(ci): typecheck bin/smoke and repair the broken live backup suites

### DIFF
--- a/bin/package.json
+++ b/bin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cotal-ai",
   "version": "0.35.0",
-  "description": "Cotal — lateral agent coordination over NATS. Run `npx cotal-ai` for the CLI.",
+  "description": "Cotal \u2014 lateral agent coordination over NATS. Run `npx cotal-ai` for the CLI.",
   "license": "Apache-2.0",
   "keywords": [
     "cotal",
@@ -33,7 +33,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.smoke.json",
     "build": "tsc -p tsconfig.json",
     "seeded-connectors": "node scripts/copy-seeded-connectors.mjs",
     "prepack": "node scripts/copy-seeded-connectors.mjs",

--- a/bin/smoke/backup-faults-live.smoke.ts
+++ b/bin/smoke/backup-faults-live.smoke.ts
@@ -14,6 +14,7 @@ import {
   newIdentity,
   spaceBackupInventory,
   type SpaceBackupSelection,
+  mintLifecycleUid,
 } from "@cotal-ai/core";
 import { authDir, loadSoleSpaceAuth } from "@cotal-ai/workspace";
 import { assertSmokeSandboxDown, recordSmokeSandbox } from "@cotal-ai/smoke-kit";
@@ -179,7 +180,7 @@ async function restoreExactIdTimeoutReplayScenario(): Promise<void> {
     // would be a vacuous 0 === 0 and could not witness a duplicated restore.
     const senderPath = join(root, "sender.creds");
     writeFileSync(senderPath, await mintCreds(auth, newIdentity(), "agent", {
-      allowPublish: ["seeded"], allowSubscribe: ["seeded"],
+      allowPublish: ["seeded"], allowSubscribe: ["seeded"], lifecycleUid: mintLifecycleUid(),
     }), { mode: 0o600 });
     for (const text of seeded)
       must(`seed chat ${JSON.stringify(text)}`, run("send", "msg", "seeded", text, "--space", space, "--server", server, "--creds", senderPath));

--- a/bin/smoke/backup-restore-live.smoke.ts
+++ b/bin/smoke/backup-restore-live.smoke.ts
@@ -93,7 +93,7 @@ async function scenario(mode: "open" | "auth"): Promise<void> {
   const port = await freePort();
   const server = `nats://127.0.0.1:${port}`;
   const space = `backup_live_${mode}`;
-  const { run } = sandboxRun(root, home);
+  const { run, env } = sandboxRun(root, home);
   const must = (label: string, result: ReturnType<typeof run>) => {
     assert.equal(result.status, 0, `${mode} ${label}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
   };
@@ -340,7 +340,7 @@ async function restoreReentryScenario(
   const port = await freePort();
   const server = `nats://127.0.0.1:${port}`;
   const space = `backup_reentry_${label}`;
-  const { run } = sandboxRun(root, home);
+  const { run, env } = sandboxRun(root, home);
   const journalPath = join(root, ".cotal", "maintenance", "v1", "journal.json");
   try {
     assert.equal(run("up", "--detach", ...(authenticated ? [] : ["--open"]), "--server", server, "--space", space).status, 0);
@@ -414,7 +414,7 @@ async function ordinaryResumeReentryScenario(injection: "resume-commit" | "resum
   const port = await freePort();
   const server = `nats://127.0.0.1:${port}`;
   const space = `backup_ordinary_${injection}`;
-  const { run } = sandboxRun(root, home);
+  const { run, env } = sandboxRun(root, home);
   const journalPath = join(root, ".cotal", "maintenance", "v1", "journal.json");
   try {
     assert.equal(run("up", "--detach", "--open", "--server", server, "--space", space).status, 0);
@@ -463,7 +463,7 @@ async function deadBoundListenerReplacementScenario(): Promise<void> {
   const port = await freePort();
   const server = `nats://127.0.0.1:${port}`;
   const space = "backup_dead_listener_replacement";
-  const { run } = sandboxRun(root, home);
+  const { run, env } = sandboxRun(root, home);
   const journalPath = join(root, ".cotal", "maintenance", "v1", "journal.json");
   try {
     assert.equal(run("up", "--detach", "--open", "--server", server, "--space", space).status, 0);
@@ -509,7 +509,7 @@ async function unboundRestoreReentryScenario(detached: boolean): Promise<void> {
   const port = await freePort();
   const server = `nats://127.0.0.1:${port}`;
   const space = `backup_unbound_${label}`;
-  const { run } = sandboxRun(root, home);
+  const { run, env } = sandboxRun(root, home);
   const journalPath = join(root, ".cotal", "maintenance", "v1", "journal.json");
   const pidPath = join(root, ".cotal", "nats.pid");
   let listenerPid: number | undefined;
@@ -551,7 +551,7 @@ async function boundForeignListenerScenario(): Promise<void> {
   const port = await freePort();
   const server = `nats://127.0.0.1:${port}`;
   const space = "backup_bound_foreign";
-  const { run } = sandboxRun(root, home);
+  const { run, env } = sandboxRun(root, home);
   const journalPath = join(root, ".cotal", "maintenance", "v1", "journal.json");
   let foreign: ChildProcess | undefined;
   try {
@@ -792,7 +792,7 @@ async function backupRestoreCycleScenario(): Promise<void> {
   const port = await freePort();
   const server = `nats://127.0.0.1:${port}`;
   const space = "backup_cycle";
-  const { run } = sandboxRun(root, home);
+  const { run, env } = sandboxRun(root, home);
   const must = (label: string, result: ReturnType<typeof run>) => {
     assert.equal(result.status, 0, `cycle ${label}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
   };

--- a/bin/tsconfig.smoke.json
+++ b/bin/tsconfig.smoke.json
@@ -1,0 +1,11 @@
+{
+  // Typecheck-only companion to tsconfig.json, which stays scoped to the two published
+  // entrypoints so `build`'s emit layout is untouched. This config exists because bin/smoke
+  // held 469 runnable scripts that no tsc ever read — a suite here could reference a variable
+  // that did not exist and nobody heard about it until the suite ran (backup-restore-live did
+  // exactly that, in 7 places). rootDir points at the repo root only because the smokes import
+  // workspace sources directly and noEmit makes layout irrelevant.
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "noEmit": true, "rootDir": ".." },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
bin/smoke held 469 runnable scripts that no tsc ever read: bin/tsconfig.json includes only the two published entrypoints, and nothing else compiles the directory. Two of the five live backup suites had rotted unnoticed behind that gap — they are reached only via the `check` composite, so CI never runs them either.

- **fix(smoke): restore the env destructure in seven backup-restore live scenarios** — `sandboxRun` returns `env`, but seven scenarios destructured only `{ run }` and then referenced `env` in their spawn calls. Seven TS2304/TS18004 errors; at runtime the suite dies at the first such scenario. With the fix, `smoke:backup-restore:live` passes end to end.
- **fix(smoke): mint the replay sender with the lifecycleUid its grant is keyed by** — `mintCreds(..., "agent", ...)` without `lifecycleUid` throws at provision.ts (SPEC 13.1); the replay scenario never started. With the fix the suite proceeds to a deeper, product-level refusal now filed as #991.
- **test(ci): typecheck everything under bin, not just the two entrypoints** — adds `bin/tsconfig.smoke.json` (noEmit companion; the build config keeps its emit layout untouched) and extends the package's `typecheck` script to run both, so `pnpm -r typecheck` covers bin/smoke from now on. Verified green end to end.

Suite status after this branch: `backup-restore:live` passes; `backup-conservation:live` and `backup-perms:live` pass; `backup-faults:live` and `backup-usermode:live` reach real product-level failures filed as #991 and #992. A follow-up commit on this PR will gate the three green suites in `bin/smoke/ci-suites.txt` once #988's append lands (avoiding a queued end-of-file conflict).