### PR TITLE
docs: record P0 and P2 as landed in per-space-lifecycle, correct P1's status

### DIFF
--- a/docs/design/per-space-lifecycle.md
+++ b/docs/design/per-space-lifecycle.md
@@ -168,10 +168,24 @@ writer, and it must keep booting the one space it was asked for.
 **Serialization is the root maintenance lock.** `acquireMaintenanceLock` already gives an exclusive,
 owner-recorded, stale-reaping lock per root, and `backup` and `clean` take it. The lock is per root
 rather than per space on purpose: the config, the store and the broker process are shared, so two
-tenants' lifecycle verbs are not independent. `up` already holds it across its own render, and so
-does `up -f`. What escapes it is narrow: a resume re-entry skips acquiring the lock and still reaches
-the render. Closing that is prerequisite P2 (§7); until it lands, the lock is mutual exclusion over
-every writer of `server.conf` except a resumed `up`.
+tenants' lifecycle verbs are not independent. Every `up` now holds it across its render — the
+ordinary path, `up -f`, and a resume re-entry alike, which is prerequisite P2 (§7). A re-entry used
+to hold no lock at all and still reach the renderer, so a concurrent `up` could rewrite the
+whole-broker config — every tenant's trust, unserialized — while a resume was mid-flight. The lock is
+now mutual exclusion over every writer of `server.conf`, with no exception.
+
+**A resumed `up` inherits that lock, and must hand it down.** The recovery journals `resume-intent`
+under the lock it already holds, so releasing it for the re-entry to re-acquire would leave exactly
+the window the lock is there to close: the journal in a resume state with the lock free. Inheriting
+in turn makes handing the lock down mandatory rather than tidy. The lock is not reentrant, and it
+cannot stale-reap its way out either, because the recorded owner is alive — it is the caller. A
+helper that self-acquired would take the "held by a live owner" refusal and fail the resume outright.
+So every helper that journals under it takes the lock as a `heldLock` parameter and the re-entry
+passes it, on the restore and the ordinary side alike; the one caller that does not is the
+prepare-failure path, where the lock has genuinely not been taken in that frame and the helper is
+meant to take its own. Audit that by the callee, not by the call site: a site that passes no lock
+says nothing about whether the callee acquires one, and threading only the sites that visibly named
+a lock left `up --restore` dead in its listener bind, on the self-acquiring restore-side writers.
 
 **Promotion is compare-and-set, because the lock is advisory.** A small non-secret
 `broker-config.json` beside `server.conf` records `{ gen, inventoryDigest }`. A verb reads
@@ -260,7 +274,9 @@ P8. Until it lands, retaining the seed is a decision taken at broker creation wi
 - **P1.** Re-key `auth/creds` by `spaceSegment` so per-agent secrets name their tenant and
   `space rm` can reap them (§2.2).
 - **P2.** Make a resumed `up` take the root maintenance lock before it renders, which the ordinary
-  and manifest paths already do, so the lock covers every writer of `server.conf` (§4).
+  and manifest paths already do, so the lock covers every writer of `server.conf` (§4). Landed: the
+  re-entry inherits the recovery's lock rather than taking its own, and hands it to every helper that
+  journals under it.
 - **P3.** A multi-tenant backup inventory validator (§2.3).
 - **P4.** `deleteSpaceAccountAuth(store, space)`, deleting one tenant's account key and nothing else.
 - **P5.** Retained broker system signing seed behind the multi-space opt-in (§5).

--- a/docs/design/per-space-lifecycle.md
+++ b/docs/design/per-space-lifecycle.md
@@ -233,9 +233,16 @@ The two creds are not equivalent. The membership observer pins the data account 
 connect and disconnect subjects, so it is genuinely per-space and a new space needs its own. The
 connection evictor is `$SYS.REQ.SERVER.*.KICK` with no account scoping, so it is broker-wide and one
 per broker would do, though today one is minted per space at `up`. Both land on root-scoped paths,
-alongside a root-scoped `membership.json` naming one account, so a second space's `up` overwrites the
-first space's observer with one pinned to the wrong data account. Keying those three paths per space
-is prerequisite P7, and `space rm` step 7 can only reap them once it lands.
+alongside a root-scoped `membership.json` naming one account and a root-scoped `membership-rw.creds`
+store key. One tenant's set is all a root can hold, and the way that bites is INHERITANCE, not an
+overwrite. A second space's `up` cannot overwrite the first space's, because `up` refuses a `--space`
+the root does not already hold — at the workspace-root identity check, before any trust write — so on
+an established root the fresh-space branch that mints the bundle never runs at all. On a root that
+already holds two tenants neither space is fresh either, so the only writer that runs is the
+absent-only heal path, which writes what is missing and nothing else. The first tenant to boot
+therefore wins the root-scoped bundle and the second silently runs on it: after the second tenant
+boots, `membership.json` still names the FIRST tenant's data account. Keying those paths per space is
+prerequisite P7, and `space rm` step 7 can only reap them once it lands.
 
 Without the seed a later-added space has no observer, which degrades membership to traffic-only and
 makes live eviction refuse. `space add` refuses rather than provisioning a second-class tenant.
@@ -291,8 +298,8 @@ P8. Until it lands, retaining the seed is a decision taken at broker creation wi
 - **P5.** Retained broker system signing seed behind the multi-space opt-in (§5).
 - **P6.** Port the §4 reload spike into this tree as a smoke. No longer gating, since the behavior
   is already proven live.
-- **P7.** Key the `$SYS` cred pair and `membership.json` per space, so two tenants' `up` runs stop
-  overwriting each other and `space rm` can reap them (§5).
+- **P7.** Key the `$SYS` cred pair, `membership.json` and `membership-rw.creds` per space, so a
+  tenant stops silently running on whichever sibling booted first and `space rm` can reap them (§5).
 - **P8.** A broker-wide system-account rotation that re-mints every tenant's `$SYS` pair, so §5's
   named recovery works on the multi-tenant root it is prescribed for (§5).
 

--- a/docs/design/per-space-lifecycle.md
+++ b/docs/design/per-space-lifecycle.md
@@ -53,10 +53,10 @@ Steps 1 to 4 change nothing on disk, so a crash there leaves the root untouched.
 account exists and, after step 6, the broker trusts it, while its streams may not exist yet. That
 state is real and is made resumable rather than hidden: re-running `space add <name>` on an account
 record that already composes under this broker skips steps 4 and 5 and completes 6 and 7. Booting
-the space with `up` completes step 7 too, once `up` renders from the full inventory (prerequisite
-P0, §4). The verb is forward-idempotent and never destructive; it refuses only on a corrupt
-inventory, a missing broker record, a missing system seed, or an account record for that name signed
-by a different operator.
+the space with `up` completes step 7 too, now that `up` renders from the full inventory (§4). The
+verb is forward-idempotent and never destructive; it refuses only on a corrupt inventory, a missing
+broker record, a missing system seed, or an account record for that name signed by a different
+operator.
 
 `space add` does not start a manager or a delivery daemon for the new space (§6).
 
@@ -158,12 +158,18 @@ atomic promotion, above the renderer. That is this section.
 the lock and renders from that plus `broker.json`. No verb passes a remembered list, so a render can
 never drop a tenant that another verb added.
 
-`up` violates that rule today, and it is prerequisite P0. It calls
-`serverConfig(auth, [auth], …)` with the one space it resolved from the cwd, so on a root with
-several tenants the next `up` would render a config holding one account and orphan the rest, undoing
-any `space add` that came before it. Nothing guards this: `assertSingleSpaceBroker` covers
-`up --restore` and not a plain boot. `up` must render from the validated inventory like every other
-writer, and it must keep booting the one space it was asked for.
+`up` used to violate that rule, which was prerequisite P0. It called `serverConfig(auth, [auth], …)`
+with the one space it resolved from the cwd, so on a root with several tenants the next `up` would
+render a config holding one account and orphan the rest, undoing any `space add` that came before it
+— and nothing guarded it, because `assertSingleSpaceBroker` covers `up --restore` and not a plain
+boot. It now renders `serverConfig(auth, preloadSpaceAccounts(dir, auth), …)`: that reader re-reads
+the validated inventory and returns the booting space first with every sibling behind it, so `up`
+renders from disk like every other writer while still booting the one space it was asked for.
+
+It also refuses rather than narrowing the config, in both directions a tenant can go missing between
+the two reads: an unreadable account record fails the render naming the tenant list uncertain, and a
+record that disappears after the inventory validated it fails too. Both say the same thing — a tenant
+left out of the config is evicted from the broker, so an uncertain list is not a list to render from.
 
 **Serialization is the root maintenance lock.** `acquireMaintenanceLock` already gives an exclusive,
 owner-recorded, stale-reaping lock per root, and `backup` and `clean` take it. The lock is per root
@@ -270,9 +276,12 @@ P8. Until it lands, retaining the seed is a decision taken at broker creation wi
 ## 7. Prerequisites
 
 - **P0.** Make `up` render `server.conf` from the validated inventory instead of the single space it
-  booted (§4). Until this lands, every other piece of this design is undone by the next `up`.
+  booted (§4). Landed: `up` renders through `preloadSpaceAccounts`, which re-reads the inventory and
+  refuses the render whenever the tenant list is uncertain.
 - **P1.** Re-key `auth/creds` by `spaceSegment` so per-agent secrets name their tenant and
-  `space rm` can reap them (§2.2).
+  `space rm` can reap them (§2.2). Still open: the split auth records (callout, issuer, owner-secret,
+  service-keys) are keyed `auth/<spaceSegment>/…`, but `agentCredsDir(root)` still takes no space, so
+  §2.2's residue and the unreapable per-agent secrets stand.
 - **P2.** Make a resumed `up` take the root maintenance lock before it renders, which the ordinary
   and manifest paths already do, so the lock covers every writer of `server.conf` (§4). Landed: the
   re-entry inherits the recovery's lock rather than taking its own, and hands it to every helper that


### PR DESCRIPTION
Doc-only. `docs/design/per-space-lifecycle.md` still described the pre-#997 world: §4 called the single-space render current and prerequisite P0, §2.1 conditioned step 7 on it, and §7 listed P0/P2 as open. All three are rewritten from the merged code — `up` renders through `preloadSpaceAccounts` (including what it refuses on: an unreadable account record and one that vanishes between the two reads both fail the render), and a resumed `up` inherits the recovery's maintenance lock, with the callee-side audit rule written down.

P1 is deliberately corrected rather than closed: the split auth records are keyed `auth/<spaceSegment>/…`, but `agentCredsDir(root)` still takes no space, so §2.2's unreapable per-agent residue stands and §7 now says so explicitly.