### PR TITLE
test(installer): repin the pinned-version case to 0.19.0 and keep the probe's stderr

### DIFF
--- a/install/test-matrix.sh
+++ b/install/test-matrix.sh
@@ -40,6 +40,11 @@ fi
 # `arg` is one of: empty, AS_ROOT, TWICE, an installer flag (--dry-run), or an env
 # assignment (CI=1). `expectation` is a shell snippet run after the installer with $out
 # (combined output) and $rc (exit code) in scope; it must return 0 to pass.
+#
+# `pinned-version` pins 0.19.0, and the number is load-bearing: it is the oldest release that
+# still installs from a blank machine. Every earlier core floats json-canonicalize ^2.0.0, and
+# json-canonicalize 2.0.1 (published 2026-08-14) stopped shipping the bundle its `main` points
+# at, so every earlier cotal-ai now crashes on launch when installed fresh (#994).
 scenarios() {
   cat <<'MATRIX'
 bare~ubuntu:24.04~apt-get update -qq && apt-get install -y -qq curl ca-certificates >/dev/null && useradd -m -s /bin/bash tester~~installs_ok && vendored && contained
@@ -58,7 +63,7 @@ ascii-locale~node:22-bookworm-slim~useradd -m -s /bin/bash tester~LC_ALL=C~insta
 no-color~node:22-bookworm-slim~useradd -m -s /bin/bash tester~NO_COLOR=1~installs_ok && no_ansi
 ci-mode~node:22-bookworm-slim~useradd -m -s /bin/bash tester~CI=1~installs_ok && no_setup_handoff
 upgrade~node:22-bookworm-slim~useradd -m -s /bin/bash tester~TWICE~installs_ok && single_path_block && contained
-pinned-version~node:22-bookworm-slim~useradd -m -s /bin/bash tester~--version 0.14.1~installs_ok && version_is 0.14.1
+pinned-version~node:22-bookworm-slim~useradd -m -s /bin/bash tester~--version 0.19.0~installs_ok && version_is 0.19.0
 dry-run~node:22-bookworm-slim~useradd -m -s /bin/bash tester~--dry-run~changed_nothing
 MATRIX
 }
@@ -415,7 +420,9 @@ export ${env_pairs:-IGNORE=1}
 mkdir -p /marker && touch /marker/start
 ${user_prefix} 'cd \$HOME && ${install_cmd}'
 echo "___RC=\$?"
-echo "___VERSION=\$(${user_prefix} '\$HOME/.local/bin/cotal --version 2>/dev/null | head -1' || echo none)"
+# stderr is deliberately kept: a binary that installs but crashes on launch must name its
+# crash in the failure report, not read as "did not report a version:" with nothing after it.
+echo "___VERSION=\$(${user_prefix} '\$HOME/.local/bin/cotal --version 2>&1 | head -5' | tr '\n' ' ' || echo none)"
 echo "___NODE=\$(${user_prefix} '\$HOME/.local/share/cotal/nodebin/node -v 2>/dev/null' || echo none)"
 echo "___PATHBLOCKS=\$(cat /home/tester/.zshrc /home/tester/.bashrc /home/tester/.bash_profile /home/tester/.config/fish/config.fish 2>/dev/null | grep -c '^# cotal\$' || echo 0)"
 echo "___RCTOUCHED=\$(cd /home/tester 2>/dev/null && grep -rl '# cotal' .zshrc .bashrc .bash_profile .config/fish/config.fish 2>/dev/null | tr '\n' ' ')"


### PR DESCRIPTION
## What broke

The installer matrix's pinned-version case installs cotal-ai@0.14.1 fresh and asserts the binary reports that version. It cannot pass at any head anymore, for a reason outside this repo: json-canonicalize 2.0.1, published 2026-08-14, ships no bundles/ directory while its main still points at bundles/index.umd.js. Every cotal-ai release before 0.19.0 floats json-canonicalize ^2.0.0 in @cotal-ai/core, so a fresh install today resolves 2.0.1 and the installed binary crashes on launch with ERR_MODULE_NOT_FOUND from @cotal-ai/core/dist/canonical.js. Releases from 0.19.0 on pin json-canonicalize exactly to 2.0.0, whose tarball ships the bundle, and are unaffected. Current main also pins 2.0.0 exactly.

This is the failure currently red on #980 (installer-ok / matrix), and it is documented in #994: the gate is path-filtered and last ran on main on 2026-08-01, before the 2.0.1 publish, so it rotted silently until #980 touched installer.yml.

## The fix

Two changes to install/test-matrix.sh, nothing else:

1. Repin the scenario from 0.14.1 to 0.19.0, the oldest release that still installs cleanly from a blank machine, with a comment recording why that number is load-bearing. The case's property (the --version flag installs exactly what it names and the binary reports it) is unchanged.
2. Keep stderr in the version probe, flattened to one line. The probe discarded stderr, so this whole class of failure read as 'installed cotal did not report a version:' with nothing after the colon. A binary that installs but cannot launch now names its crash in the failure report.

## Verification

No container runtime exists on the box this was authored on, so the matrix itself could not be run locally; the installer workflow on this PR is the authoritative run. What was verified locally, in a sandboxed HOME via env -i with the repo's install.sh:

- Fresh install of 0.14.1 reproduces the exact CI failure: install exits 0, the harness-style probe (stderr discarded) prints nothing, and the stderr-visible probe shows ERR_MODULE_NOT_FOUND on json-canonicalize/bundles/index.umd.js.
- Fresh install of 0.19.0 succeeds and reports cotal-ai 0.19.0 through the exact probe pipeline this PR ships.
- json-canonicalize 2.0.0 vs 2.0.1 tarballs compared directly: 2.0.0 ships bundles/, 2.0.1 does not, both declare main ./bundles/index.umd.js.
- The new probe line was simulated with the exact runner text against three states: the broken 0.14.1 install (crash text lands in the report), the working 0.19.0 install (version_is matches), and a missing launcher (not-found lands in the report).
- bash -n passes; the tr flatten idiom already appears in the same runner heredoc.

## Out of scope

#994's second point, the gate's dormancy (path-filtered, so it cannot notice its subject rotting), is a workflow policy decision and is deliberately not bundled here. #994 stays open for it.