### PR TITLE
fix(docs): recurse the docs-voice check with an explicit design exemption

### DIFF
--- a/scripts/check-docs-voice.mjs
+++ b/scripts/check-docs-voice.mjs
@@ -1,17 +1,35 @@
-import { readdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const docsDir = new URL("../docs/", import.meta.url);
-const files = readdirSync(docsDir)
-  .filter((name) => name.endsWith(".md"))
-  .sort();
+const docsDir = fileURLToPath(new URL("../docs/", import.meta.url));
+
+// docs/design holds working lane documents: frozen review artifacts with their
+// own vocabulary. The published-docs voice gate deliberately does not apply
+// there. Every other subdirectory of docs/ is scanned.
+const exemptDirs = new Set(["design"]);
+
+const files = [];
+const walk = (dir) => {
+  for (const name of readdirSync(dir).sort()) {
+    const path = join(dir, name);
+    const rel = relative(docsDir, path);
+    if (statSync(path).isDirectory()) {
+      if (exemptDirs.has(rel)) continue;
+      walk(path);
+    } else if (name.endsWith(".md")) {
+      files.push(rel);
+    }
+  }
+};
+walk(docsDir);
 
 const bannedWord = /\b(?:exactly|fold|folds|folded)\b/i;
 const listHeading = /(?:&|,| \/ | \+ |\band\b|\bor\b|:)/i;
 const failures = [];
 
 for (const name of files) {
-  const lines = readFileSync(new URL(name, docsDir), "utf8").split("\n");
+  const lines = readFileSync(join(docsDir, name), "utf8").split("\n");
   let fenced = false;
   for (let index = 0; index < lines.length; index++) {
     const line = lines[index];
@@ -36,4 +54,4 @@ if (failures.length) {
   process.exit(1);
 }
 
-console.log(`check:docs-voice: ${files.length} pages passed`);
+console.log(`check:docs-voice: ${files.length} pages passed (docs/design exempt)`);


### PR DESCRIPTION
Closes #1013.

`scripts/check-docs-voice.mjs` read only the top level of `docs/` (a plain `readdirSync` filter), so every subdirectory was unscanned — `docs/design/` escaped by accident, not by decision. The check now walks `docs/` recursively and exempts `docs/design/` by name, with the reason recorded in a comment: design docs are working lane documents (several are frozen review artifacts) with their own vocabulary, and the published-docs voice gate deliberately does not apply to them. Any future subdirectory of `docs/` is scanned automatically instead of silently skipped, and the pass line names the exemption so the check states what it covered.

Verification (scratch worktree, honest RCs):
- **Vacuous-pass control**: with `docs/newdir/bad.md` containing an em dash, the old checker (run from inside the tree so its relative URL resolves) exits **0** — "39 pages passed"; the new checker exits 1 and names `newdir/bad.md:1`.
- **Top level still enforced**: an em dash appended to `docs/embedding.md` prose exits 1 and names the line.
- **Exemption proven on the live corpus**: `docs/design/` currently holds 164 em dashes, 32 banned-word and 18 heading hits across 4 files; the check passes with them present.
- `pnpm check:docsbundle` green after a full build (the composite chains this check plus both generators and the diff gate); `check:shard-stability origin/main HEAD` STABLE (no suite changes).
