### PR TITLE
fix(smoke): adopt tokened broker ownership in the five unmigrated suites

### DIFF
--- a/bin/smoke/attach-auth-root.smoke.ts
+++ b/bin/smoke/attach-auth-root.smoke.ts
@@ -40,6 +40,7 @@
  * COTAL_HOME and XDG_CONFIG_HOME are sandboxed; kills ONLY the PIDs it spawns. Needs nats-server on PATH.
  */
 import { spawn as spawnProc, spawnSync, type ChildProcess } from "node:child_process";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
@@ -75,6 +76,7 @@ import type { Command, Connector, LaunchOpts } from "@cotal-ai/core";
 let pass = 0;
 let fail = 0;
 const kids: ChildProcess[] = [];
+let releaseBroker: (() => void) | undefined;
 /** A graded cell. It RECORDS rather than throws, so every cell runs and the banner below always
  *  prints. That is not a style preference: `mutation-proof` treats a run that never reached its
  *  completion marker as INCONCLUSIVE rather than as a kill, so a fail-fast suite reports every
@@ -249,11 +251,12 @@ try {
   writeFileSync(join(authDir(rootCorrupt), "broker.json"), "{not json");
 
   // ---- 3. a REAL authed broker that trusts ONLY the live chain -----------------------------------
-  const storeDir = mkdtempSync(join(tmpdir(), "cotal-authroot-js-"));
+  const storeDir = mkdtempSync(join(tmpdir(), `${SMOKE_BROKER_TOKEN}authroot-js-`));
   const conf = join(base, "server.conf");
   writeFileSync(conf, serverConfig(live, [live], { transport: { kind: "plaintext" }, port: PORT, storeDir, host: "127.0.0.1" }));
   const broker = spawnProc("nats-server", ["-c", conf], { stdio: "ignore" });
   kids.push(broker);
+  releaseBroker = teardownOnSignal(broker, storeDir);
   // An AUTHED broker answers a CREDLESS probe `auth-required`, and that answer is itself proof it
   // is up. A readiness loop waiting for `ok` here would never see one, and the suite would time out
   // rather than fail - a stall reads as infrastructure, and this cell would stop being a cell.
@@ -431,4 +434,5 @@ try {
   // like that to whichever suite was running.
   await Promise.race([mgr?.stop().catch(() => {}) ?? Promise.resolve(), sleep(10_000)]);
   await Promise.all(kids.map((k) => { k.kill("SIGKILL"); return awaitExit(k); }));
+  releaseBroker?.();
 }

--- a/bin/smoke/discovery-bundle-consumable.smoke.ts
+++ b/bin/smoke/discovery-bundle-consumable.smoke.ts
@@ -68,6 +68,7 @@ if (SUBCOMMAND === "auth-service") {
 type ChildProcess = import("node:child_process").ChildProcess;
 
 const { spawn } = await import("node:child_process");
+const { SMOKE_BROKER_TOKEN, teardownOnSignal } = await import("@cotal-ai/smoke-kit");
 const { mkdtempSync, writeFileSync, rmSync } = await import("node:fs");
 const { createRequire } = await import("node:module");
 const { tmpdir } = await import("node:os");
@@ -156,6 +157,7 @@ const dir = userAuthStateDir(root, SPACE);
 const store = workspaceSecretStore(root);
 
 let broker: ChildProcess | undefined;
+let releaseBroker: (() => void) | undefined;
 let authChild: ChildProcess | undefined;
 let jsDir: string | undefined;
 const idpSrv = createServer((req, res) => handler!(req, res));
@@ -190,12 +192,13 @@ try {
   const expectedCallout = await loadCalloutAuth(store, SPACE);
   if (!expectedCallout) throw new Error("prepared callout material was not persisted");
 
-  jsDir = mkdtempSync(join(tmpdir(), "cotal-dbc-js-"));
+  jsDir = mkdtempSync(join(tmpdir(), `${SMOKE_BROKER_TOKEN}dbc-js-`));
   writeFileSync(
     join(root, "server.conf"),
     serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: jsDir, extraAccounts: prepared.extraAccounts }),
   );
   broker = spawn("nats-server", ["-c", join(root, "server.conf")], { stdio: "ignore" });
+  releaseBroker = teardownOnSignal(broker, jsDir);
   let up = false;
   for (let i = 0; i < 50 && !up; i++) { up = await isReachable(SERVER); if (!up) await wait(200); }
   check("user-auth broker is reachable", up);
@@ -305,6 +308,7 @@ try {
 } finally {
   await stopOwned(authChild, true);
   await stopOwned(broker);
+  releaseBroker?.();
   if (idpSrv.listening) await new Promise<void>((resolveClose) => idpSrv.close(() => resolveClose()));
   if (jsDir) rmSync(jsDir, { recursive: true, force: true });
   rmSync(root, { recursive: true, force: true });

--- a/bin/smoke/persona-agent.smoke.ts
+++ b/bin/smoke/persona-agent.smoke.ts
@@ -28,6 +28,7 @@
  * Run: pnpm smoke:persona-agent
  */
 import { spawn as spawnProc, type ChildProcess } from "node:child_process";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
@@ -50,6 +51,7 @@ const { Manager } = await import("@cotal-ai/manager");
 let pass = 0;
 let fail = 0;
 const kids: ChildProcess[] = [];
+let releaseBroker: (() => void) | undefined;
 const ok = (name: string, cond: boolean, extra?: unknown) => {
   if (cond) { pass++; console.log(`  ✓ ${name}`); return; }
   fail++;
@@ -151,8 +153,10 @@ async function captureProcess(command: string, args: string[], env: NodeJS.Proce
 
 let mgr: InstanceType<typeof Manager> | undefined;
 try {
-  const broker = spawnProc("nats-server", ["-a", "127.0.0.1", "-p", String(PORT), "-js", "-sd", mkdtempSync(join(tmpdir(), "cotal-869-js-"))], { stdio: "ignore" });
+  const brokerStore = mkdtempSync(join(tmpdir(), `${SMOKE_BROKER_TOKEN}869-js-`));
+  const broker = spawnProc("nats-server", ["-a", "127.0.0.1", "-p", String(PORT), "-js", "-sd", brokerStore], { stdio: "ignore" });
   kids.push(broker);
+  releaseBroker = teardownOnSignal(broker, brokerStore);
   for (let i = 0; i < 50; i++) {
     if ((await probeConnect(SERVER, { timeoutMs: 400 })).ok) break;
     await sleep(100);
@@ -330,4 +334,5 @@ try {
 } finally {
   try { await mgr?.stop(); } catch { /* teardown best-effort */ }
   for (const k of kids) k.kill("SIGKILL");
+  releaseBroker?.();
 }

--- a/bin/smoke/readiness-window-live.smoke.ts
+++ b/bin/smoke/readiness-window-live.smoke.ts
@@ -14,6 +14,7 @@
  * Run: pnpm smoke:readiness:live   (build first — imports @cotal-ai/* dist)
  */
 import { spawn as spawnProc, type ChildProcess } from "node:child_process";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
@@ -49,6 +50,7 @@ import type { Connector } from "@cotal-ai/core";
 
 let pass = 0;
 const kids: ChildProcess[] = [];
+let releaseBroker: (() => void) | undefined;
 const ok = (name: string, cond: boolean, extra?: unknown) => {
   if (!cond) throw new Error(`FAIL: ${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
   pass++;
@@ -145,8 +147,10 @@ let mgr: InstanceType<typeof Manager> | undefined;
 let driver: InstanceType<typeof MeshAgent> | undefined;
 let ep: InstanceType<typeof CotalEndpoint> | undefined;
 try {
-  const broker = spawnProc("nats-server", ["-a", "127.0.0.1", "-p", String(PORT), "-js", "-sd", mkdtempSync(join(tmpdir(), "cotal-readiness-js-"))], { stdio: "ignore" });
+  const brokerStore = mkdtempSync(join(tmpdir(), `${SMOKE_BROKER_TOKEN}readiness-js-`));
+  const broker = spawnProc("nats-server", ["-a", "127.0.0.1", "-p", String(PORT), "-js", "-sd", brokerStore], { stdio: "ignore" });
   kids.push(broker);
+  releaseBroker = teardownOnSignal(broker, brokerStore);
   for (let i = 0; i < 50; i++) {
     if ((await probeConnect(SERVER, { timeoutMs: 400 })).ok) break;
     await sleep(100);
@@ -322,4 +326,5 @@ try {
     k.kill("SIGKILL");
     return awaitExit(k);
   }));
+  releaseBroker?.();
 }

--- a/bin/smoke/spawn-detach-live.smoke.ts
+++ b/bin/smoke/spawn-detach-live.smoke.ts
@@ -16,6 +16,7 @@
  * Run: pnpm smoke:spawn-detach:live   (build first — bin/cotal.ts subprocess checks run dist)
  */
 import { spawn as spawnProc, spawnSync, type ChildProcess } from "node:child_process";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
@@ -51,6 +52,7 @@ import type { Command, Connector, ControlReply, LaunchOpts, SessionGrant } from 
 
 let pass = 0;
 const kids: ChildProcess[] = [];
+let releaseBroker: (() => void) | undefined;
 const ok = (name: string, cond: boolean, extra?: unknown) => {
   if (!cond) throw new Error(`FAIL: ${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
   pass++;
@@ -142,8 +144,10 @@ let mgr: InstanceType<typeof Manager> | undefined;
 try {
   // Real broker (open mode — authed control ops are covered by smoke:control-auth; this e2e is
   // about the CLI↔manager grammar) + registry entry so the CLI resolver finds the mesh.
-  const broker = spawnProc("nats-server", ["-a", "127.0.0.1", "-p", String(PORT), "-js", "-sd", mkdtempSync(join(tmpdir(), "cotal-detach-js-"))], { stdio: "ignore" });
+  const brokerStore = mkdtempSync(join(tmpdir(), `${SMOKE_BROKER_TOKEN}detach-js-`));
+  const broker = spawnProc("nats-server", ["-a", "127.0.0.1", "-p", String(PORT), "-js", "-sd", brokerStore], { stdio: "ignore" });
   kids.push(broker);
+  releaseBroker = teardownOnSignal(broker, brokerStore);
   for (let i = 0; i < 50; i++) {
     if ((await probeConnect(SERVER, { timeoutMs: 400 })).ok) break;
     await sleep(100);
@@ -356,4 +360,5 @@ try {
     k.kill("SIGKILL");
     return awaitExit(k);
   }));
+  releaseBroker?.();
 }


### PR DESCRIPTION
Addresses the five-suite migration gap in #1008 (the reaper-reporting design question that issue deliberately leaves open stays open, and the 108 measured orphans are left in place for re-measurement before cleanup).

All five suites were verified to have correct normal-path teardown first (defect 2 in the helper's own taxonomy - "teardown that never unwinds" - not defect 1), so adoption is a fix rather than a rename: each mints its store dir through `SMOKE_BROKER_TOKEN` (old tag preserved after the pid segment, so attribution survives), takes ownership with `teardownOnSignal` right after the spawn, and releases as the last act of its own teardown, per the migrated `persona-announce` pattern. `discovery-bundle-consumable` imports dynamically to respect its self-dispatch discipline.

Verification (measured, both polarities, on macOS with poll-timed kills aimed at the tsx child - the process that actually holds the handlers):

- **Patched arm**: `persona-agent` SIGTERMed mid-run with its broker up -> 0 surviving brokers, tokened store dir removed, no teardown-failure stderr.
- **Control arm**: the origin/main suite under the identical kill -> 1 orphaned `nats-server`, store dirs untouched - the defect is visible to the instrument that graded the fix.
- **Normal path**: all five suites green post-migration (14, 22, 32, 26, 11 cells; RC=0 each) and `pnpm typecheck` green.
- **A measured limit, matching the helper's header**: SIGTERM delivered to the tsx *wrapper* (not the child) takes the child down without its handlers, and the broker is orphaned even when patched - that is the SIGKILL-shaped case parentage cannot cover, and it is exactly what the minted token is for: the store dir now records the dead owner's pid, so the reaper can claim it instead of listing it unclaimable.
