### PR TITLE
ci(installer): run the matrix on a weekly schedule and on dispatch

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -5,6 +5,13 @@ name: Installer
 # configurations (no Node, old Node, musl, wget-only, each shell); macOS gets a real run on
 # the only honest macOS oracle there is.
 on:
+  # The matrix installs PUBLISHED artifacts, which rot while the tree holds still: the
+  # pinned-version case sat broken for 28 dormant days because nothing touched these paths
+  # (#994). The schedule exists so the gate can notice its subject changing underneath it;
+  # workflow_dispatch is the manual oracle for a re-check without a path-touching commit.
+  schedule:
+    - cron: '23 6 * * 1'
+  workflow_dispatch:
   pull_request:
     paths:
       - 'install.sh'


### PR DESCRIPTION
The dormancy half of #994 (the pin half landed as 697edbe6). The installer matrix installs PUBLISHED registry artifacts, so its subject rots independently of the tree - the gate went 28 days without firing while the `pinned-version` case sat broken, and it surfaced only because #980 happened to touch the workflow file.

This adds two triggers and changes nothing else:

- `schedule: '23 6 * * 1'` - weekly (Mondays 06:23Z, off the crowded minutes). Weekly is proportionate to a 30-case Docker matrix; the drift #994 measured took four weeks to surface, so a seven-day bound on dormancy shrinks the exposure without burning a daily matrix.
- `workflow_dispatch` - the manual oracle: a re-check no longer needs a path-touching commit.

The reason lives in a comment above the triggers, where the next reader of the path filter will meet it. Path triggers and the concurrency group are unchanged.

Verification: the YAML parses and the trigger set is asserted structurally (schedule cron, dispatch present, existing pull_request/push preserved). A schedule cannot be exercised pre-merge; after merge I will fire a `workflow_dispatch` run as the live oracle and record the result on #994.
