### PR TITLE
test(web): let 6.7 accept either named refusal of the raced dms read

### DIFF
--- a/implementations/web/smoke/bounded-aggregation.smoke.ts
+++ b/implementations/web/smoke/bounded-aggregation.smoke.ts
@@ -516,7 +516,14 @@ try {
     const dBody = dRes instanceof Error ? undefined : await dRes.json().catch(() => undefined);
     const dStatus = dRes instanceof Error ? 0 : dRes.status;
     ok("6.6 `/api/dms` REFUSES at its deadline rather than answering long after the reader left", dStatus === 503, { dStatus, dMs });
-    ok("6.7 and the refusal names the deadline it exceeded", /did not finish within 8000ms/.test(String(dBody?.error)), dBody);
+    // WHICH ending wins here is the runner's call, not this suite's: the inner read's own timeout
+    // races the route's 8000ms clock across a loaded link, and both are legitimate bounded endings —
+    // #902 measured both on the same tree in CI. Section 5 pins each ending deterministically and
+    // asserts its exact wording (5.1 the rejected read, 5.5 the deadline); this cell asserts the part
+    // that must hold on EITHER path: the refusal is the route's NAMED refusal, never the bare broker
+    // word the shipped build once sent.
+    ok("6.7 and the refusal is named — the deadline or the failed read, never a bare broker word",
+      /direct messages: the read (did not finish within 8000ms|failed: )/.test(String(dBody?.error)), dBody);
     ok("6.8 bounded in wall time, not just in words", dMs < AGGREGATION_DEADLINE_MS + 5000, dMs);
 
     // A NAMED LIMIT, DRIVEN RATHER THAN DESCRIBED. The deadline bounds the RESPONSE, not the broker


### PR DESCRIPTION
Closes #902.

Section 6 drives /api/dms across a loaded slow link, where the inner read's own timeout races the route's 8000ms clock. Both endings are legitimate bounded refusals, but 6.7 asserted only the deadline wording, so the cell passed or failed by runner load — the flake recorded on main run 33276197324 (46/47, body "direct messages: the read failed: timeout").

Since the issue was filed, section 5 grew both forced arms: 5.1/5.2 pin the rejection ending and assert the named-failure wording, 5.3–5.6 pin the LATE ending (forced hang) and assert the deadline wording. That is option 2 of the issue's suggested scope, already on main. What remained was the leftover raced assertion: 6.7 still demanded one specific ending on an arm the runner decides.

This change makes 6.7 assert the invariant that holds on either path — the refusal is the route's named refusal (the deadline or the failed read), never the bare broker word the shipped build once sent.

Proof, both polarities, driven through the shipped suite (section 6's child inherits the suite env, so the section-5 fault flags reach it):

- Control (unedited tree, `COTAL_WEB_SMOKE_REJECT_HISTORY=1`): exactly cell 6.7 red, 46/47, body byte-identical to the CI flake.
- Fixed tree, same flag (rejection ending forced): 47/47.
- Fixed tree, `COTAL_WEB_SMOKE_HANG_DMS=1` (LATE ending forced): 47/47.
- Fixed tree, no flag: 47/47.
