### PR TITLE
fix(smoke): validate workspace import exports

### DIFF
--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -690,3 +690,9 @@ smoke:agent-secret-segmentation
 # spellings, one of them the release workflow. The property is only observable on main after a
 # merge, so it needs a static guard. Appended so every existing shard assignment remains unchanged.
 smoke:workflow-concurrency
+
+# Most smoke trees are still outside their package TypeScript projects. A type-only import from a
+# workspace package can therefore name something the package never exported and vanish when tsx runs
+# the suite. This compiler-API intersection checks every named workspace import against the package's
+# public exports. Appended so every existing shard assignment remains unchanged.
+smoke:workspace-import-exports

--- a/bin/smoke/mutations/workspace-import-exports.json
+++ b/bin/smoke/mutations/workspace-import-exports.json
@@ -1,0 +1,16 @@
+{
+  "suite": "bin/smoke/workspace-import-exports.smoke.ts",
+  "guard": "every named import from a workspace package resolves to a public export, including type-only imports in smoke trees outside package TypeScript projects",
+  "command": "pnpm smoke:workspace-import-exports",
+  "completionMarker": "WORKSPACE IMPORT EXPORTS",
+  "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/workspace-import-exports.json",
+  "mutations": [
+    {
+      "name": "W1 MeshAgent moves back to core",
+      "file": "implementations/manager/smoke/pi-session-recovery.smoke.ts",
+      "find": "import { controlEndpoint, startControlServer, type MeshAgent } from \"@cotal-ai/connector-core\";",
+      "replace": "import { controlEndpoint, startControlServer } from \"@cotal-ai/connector-core\";\nimport type { MeshAgent } from \"@cotal-ai/core\";",
+      "expectRed": "@cotal-ai/core does not export MeshAgent"
+    }
+  ]
+}

--- a/bin/smoke/mutations/workspace-import-exports.json
+++ b/bin/smoke/mutations/workspace-import-exports.json
@@ -2,7 +2,6 @@
   "suite": "bin/smoke/workspace-import-exports.smoke.ts",
   "guard": "every named import from a workspace package resolves to a public export, including type-only imports in smoke trees outside package TypeScript projects",
   "command": "pnpm smoke:workspace-import-exports",
-  "completionMarker": "WORKSPACE IMPORT EXPORTS",
   "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/workspace-import-exports.json",
   "mutations": [
     {

--- a/bin/smoke/workspace-import-exports.smoke.ts
+++ b/bin/smoke/workspace-import-exports.smoke.ts
@@ -1,0 +1,88 @@
+/**
+ * Static workspace import/export check.
+ *
+ * Type-only imports disappear when a smoke runs under tsx, and most smoke trees are not included in
+ * their package's TypeScript project. That allowed one manager smoke to import `MeshAgent` from core
+ * even though connector-core defines and exports it. Scan every TypeScript tree with the compiler's
+ * module resolver and require every named import from a workspace package to be publicly exported.
+ *
+ * Run: pnpm smoke:workspace-import-exports
+ */
+import assert from "node:assert/strict";
+import { readdirSync } from "node:fs";
+import { dirname, extname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const SOURCE_ROOTS = ["packages", "extensions", "implementations", "examples", "bin"];
+const SOURCE_EXTENSIONS = new Set([".ts", ".mts", ".cts", ".tsx"]);
+const SKIP_DIRS = new Set(["dist", "node_modules"]);
+
+const sourceFiles: string[] = [];
+const walk = (path: string): void => {
+  for (const entry of readdirSync(path, { withFileTypes: true })) {
+    if (entry.isDirectory() && SKIP_DIRS.has(entry.name)) continue;
+    const fullPath = join(path, entry.name);
+    if (entry.isDirectory()) walk(fullPath);
+    else if (SOURCE_EXTENSIONS.has(extname(entry.name))) sourceFiles.push(fullPath);
+  }
+};
+for (const root of SOURCE_ROOTS) walk(join(ROOT, root));
+
+const configPath = join(ROOT, "tsconfig.base.json");
+const rawConfig = ts.readConfigFile(configPath, ts.sys.readFile);
+assert.equal(rawConfig.error, undefined, "tsconfig.base.json parses");
+const parsedConfig = ts.parseJsonConfigFileContent(rawConfig.config, ts.sys, ROOT, {
+  noEmit: true,
+  skipLibCheck: true,
+});
+assert.equal(parsedConfig.errors.length, 0, "tsconfig.base.json options resolve");
+
+const program = ts.createProgram(sourceFiles, parsedConfig.options);
+const checker = program.getTypeChecker();
+const failures: string[] = [];
+let importCount = 0;
+let nameCount = 0;
+
+for (const filePath of sourceFiles) {
+  const source = program.getSourceFile(filePath);
+  assert.ok(source, `compiler loaded ${relative(ROOT, filePath)}`);
+
+  for (const statement of source.statements) {
+    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
+    const packageName = statement.moduleSpecifier.text;
+    const clause = statement.importClause;
+    if (!packageName.startsWith("@cotal-ai/") || clause === undefined) continue;
+
+    importCount++;
+    const moduleSymbol = checker.getSymbolAtLocation(statement.moduleSpecifier);
+    const line = source.getLineAndCharacterOfPosition(statement.moduleSpecifier.getStart()).line + 1;
+    if (moduleSymbol === undefined) {
+      failures.push(`${relative(ROOT, filePath)}:${line}: package does not resolve: ${packageName}`);
+      continue;
+    }
+
+    const exportedNames = new Set(checker.getExportsOfModule(moduleSymbol).map((symbol) => symbol.name));
+    const checkName = (importedName: string, position: number): void => {
+      nameCount++;
+      if (exportedNames.has(importedName)) return;
+      const importLine = source.getLineAndCharacterOfPosition(position).line + 1;
+      failures.push(
+        `${relative(ROOT, filePath)}:${importLine}: ${packageName} does not export ${importedName}`,
+      );
+    };
+
+    if (clause.name !== undefined) checkName("default", clause.name.getStart());
+    if (clause.namedBindings !== undefined && ts.isNamedImports(clause.namedBindings)) {
+      for (const element of clause.namedBindings.elements) {
+        checkName((element.propertyName ?? element.name).text, element.name.getStart());
+      }
+    }
+  }
+}
+
+assert.ok(importCount > 0, "workspace imports were found");
+assert.ok(nameCount > 0, "workspace import names were checked");
+assert.deepEqual(failures, [], failures.join("\n"));
+console.log(`WORKSPACE IMPORT EXPORTS: ${nameCount} names across ${importCount} imports`);

--- a/implementations/manager/smoke/pi-session-recovery.smoke.ts
+++ b/implementations/manager/smoke/pi-session-recovery.smoke.ts
@@ -9,9 +9,8 @@ import {
   type Connector,
   type LaunchOpts,
   type LaunchSpec,
-  type MeshAgent,
 } from "@cotal-ai/core";
-import { controlEndpoint, startControlServer } from "@cotal-ai/connector-core";
+import { controlEndpoint, startControlServer, type MeshAgent } from "@cotal-ai/connector-core";
 import { Manager } from "../src/manager.js";
 
 let checks = 0;

--- a/package.json
+++ b/package.json
@@ -465,6 +465,7 @@
     "smoke:attach-host-persistence": "tsx implementations/cli/smoke/attach-host-persistence.smoke.ts",
     "smoke:dist-freshness": "tsx bin/smoke/dist-freshness.smoke.ts",
     "smoke:gate-inventory": "tsx bin/smoke/gate-inventory.smoke.ts",
+    "smoke:workspace-import-exports": "tsx bin/smoke/workspace-import-exports.smoke.ts",
     "smoke:required-arg-seam": "tsx bin/smoke/required-arg-seam.smoke.ts",
     "smoke:ci-suites": "tsx bin/smoke/ci-suites.smoke.ts",
     "smoke:workflow-concurrency": "tsx bin/smoke/workflow-concurrency.smoke.ts",


### PR DESCRIPTION
Closes #973.

## Scope

- import `MeshAgent` from `@cotal-ai/connector-core`, which defines and exports it
- add a compiler-API smoke that scans TypeScript sources across packages, extensions, implementations, examples, and bin
- reject named imports from `@cotal-ai/*` packages when the package does not publicly export the requested name, including type-only imports erased by tsx
- gate the check in the append-only smoke chain and add a mutation fixture for the original regression

## Verification

- reproduced before the fix: manager's source-only typecheck passed, while a one-file smoke TypeScript config failed with `TS2305: Module '"@cotal-ai/core"' has no exported member 'MeshAgent'`
- `pnpm smoke:workspace-import-exports` (4,586 names across 853 imports)
- `tsc -p bin/tsconfig.smoke.json --pretty false`
- `pnpm --filter @cotal-ai/manager exec tsx smoke/pi-session-recovery.smoke.ts` (20 checks)
- `pnpm smoke:gate-inventory`
- `pnpm smoke:mutation-fixtures`
- `node scripts/mutation-proof.mjs --config bin/smoke/mutations/workspace-import-exports.json` (1/1 killed on the named export diagnostic)

## Evidence limits

This does not make every smoke tree fully typechecked. Existing coverage remains uneven: bin, runtime, and lang have explicit smoke TypeScript projects, while most other smoke trees do not. The new guard closes the workspace named-import/export class specifically. It does not check arbitrary local type errors, dynamic imports, namespace member access, or third-party package exports.
