### PR TITLE
fix(ci): stop silent ci-suite merge reordering

### DIFF
--- a/.changeset/tidy-shards-conflict.md
+++ b/.changeset/tidy-shards-conflict.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI-only: simultaneous `ci-suites.txt` tail appends now conflict instead of being silently union-ordered across positional shards. No shipped package behavior changes.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,5 @@
-# The CI gate registry is append-only: every PR that adds a smoke suite writes a comment block
-# and its suite name at the tail, so any two such PRs collide there. Both sides are always
-# additive and the resolution is always "keep both", which makes the conflict pure overhead -
-# and worse, a conflict resolved identically every time stops being read. A resolver in a hurry
-# drops the other side's entry and the result is a silently ungated suite: the file still parses,
-# CI still passes, and only a hand grep notices. Union merge keeps both sides automatically.
-#
-# Verified: union preserves block adjacency, so a multi-line comment stays attached to the suite
-# line beneath it rather than being interleaved away from it.
-bin/smoke/ci-suites.txt merge=union
+# The CI gate registry is positional: shard assignment is `index % count`. Simultaneous tail
+# appends therefore need a visible conflict. Git's union driver keeps both blocks but silently
+# places one before the other's newer suites, moving those pre-existing suites onto other shards.
+# Reset any lower-precedence merge attribute so the normal text driver stops for human ordering.
+bin/smoke/ci-suites.txt !merge

--- a/bin/smoke/ci-suites.smoke.ts
+++ b/bin/smoke/ci-suites.smoke.ts
@@ -19,6 +19,9 @@
  *
  * Run: pnpm smoke:ci-suites
  */
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 // @ts-expect-error - plain .mjs helper, the one parser shared by shard.mjs and gate-inventory.
 import { parseCiSuites, readCiSuites, CI_SUITES_PATH } from "./ci-suites.mjs";
@@ -116,7 +119,51 @@ check(
   realError || real?.length,
 );
 
-const EXPECTED = 22;
+// ---- Simultaneous tail appends must stop for ordering ------------------------------------------------
+// `merge=union` kept both additions but placed the incoming branch block before main's newer block.
+// Because the chain is assigned by index, that clean merge silently moved main's suites to different
+// runners. Exercise Git itself here: both additions survive only after an explicit resolution.
+const mergeRoot = mkdtempSync(join(tmpdir(), "ci-suites-merge-"));
+let simultaneousAppendsConflict = false;
+try {
+  mkdirSync(join(mergeRoot, "bin/smoke"), { recursive: true });
+  writeFileSync(join(mergeRoot, ".gitattributes"), readFileSync(join(process.cwd(), ".gitattributes")));
+  writeFileSync(join(mergeRoot, "bin/smoke/ci-suites.txt"), "smoke:base\n");
+  const git = (args: string[]) => execFileSync("git", args, {
+    cwd: mergeRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  git(["init", "-q"]);
+  git(["config", "user.name", "CI suites smoke"]);
+  git(["config", "user.email", "ci-suites-smoke@example.invalid"]);
+  git(["add", "."]);
+  git(["commit", "-qm", "base"]);
+  git(["branch", "incoming"]);
+  writeFileSync(join(mergeRoot, "bin/smoke/ci-suites.txt"), "smoke:base\nsmoke:main\n");
+  git(["add", "bin/smoke/ci-suites.txt"]);
+  git(["commit", "-qm", "main append"]);
+  git(["branch", "main-side"]);
+  git(["checkout", "-q", "incoming"]);
+  writeFileSync(join(mergeRoot, "bin/smoke/ci-suites.txt"), "smoke:base\nsmoke:branch\n");
+  git(["add", "bin/smoke/ci-suites.txt"]);
+  git(["commit", "-qm", "branch append"]);
+  const merged = spawnSync("git", ["merge", "main-side", "--no-edit"], {
+    cwd: mergeRoot,
+    encoding: "utf8",
+  });
+  simultaneousAppendsConflict = merged.status === 1 &&
+    git(["status", "--short", "bin/smoke/ci-suites.txt"]).trim() === "UU bin/smoke/ci-suites.txt" &&
+    git(["ls-files", "-u", "bin/smoke/ci-suites.txt"]).trim().split("\n").length === 3;
+} finally {
+  rmSync(mergeRoot, { recursive: true, force: true });
+}
+check(
+  "simultaneous tail appends conflict instead of silently choosing shard-changing order",
+  simultaneousAppendsConflict,
+);
+
+const EXPECTED = 23;
 check(
   `every cell ran - ${EXPECTED} expected, so a cell that stops existing is not mistaken for one that passed`,
   pass + fail === EXPECTED,

--- a/bin/smoke/mutations/ci-suites-merge-order.json
+++ b/bin/smoke/mutations/ci-suites-merge-order.json
@@ -1,0 +1,23 @@
+{
+  "suite": "bin/smoke/ci-suites.smoke.ts",
+  "guard": "simultaneous ci-suites tail appends conflict instead of silently taking union order and moving pre-existing suites between shards",
+  "command": "pnpm smoke:ci-suites",
+  "completionMarker": "SUITE COMPLETE",
+  "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/ci-suites-merge-order.json",
+  "why": [
+    "The union merge driver preserves both simultaneous tail appends but cannot preserve both sides' claim to be last. On PR #981 it repeatedly placed the branch block before main's newer suites, moving those pre-existing suites onto different positional shards without a conflict.",
+    "",
+    "The regression drives Git in a scratch repository. Restoring merge=union must make the merge clean and redden the named conflict assertion. The mutation anchor is the attribute line itself, with no comment text in the match."
+  ],
+  "mutations": [
+    {
+      "name": "restore the union merge driver that silently orders simultaneous tail appends",
+      "file": ".gitattributes",
+      "find": "bin/smoke/ci-suites.txt !merge",
+      "replace": "bin/smoke/ci-suites.txt merge=union",
+      "expectRed": "✗ FAIL: simultaneous tail appends conflict instead of silently choosing shard-changing order",
+      "cell": "simultaneous tail appends conflict instead of silently choosing shard-changing order"
+    }
+  ],
+  "grades": "tool"
+}


### PR DESCRIPTION
Closes #983.

## What changed

- Replaces the `merge=union` attribute on `bin/smoke/ci-suites.txt` with an explicit unspecified merge attribute, restoring Git's normal text conflict for simultaneous tail appends.
- Adds a broker-free regression that creates a real scratch repository, appends a suite on both branches, and requires Git to leave the positional registry conflicted instead of silently selecting an order.
- Adds a mutation fixture that restores `merge=union` and must fail on the named conflict assertion.
- Adds an empty changeset because this is CI-only and changes no shipped package behavior.

## Evidence

Reproduced before the fix with a real Git merge: both tail appends survived and the merge exited 0, with the branch block placed before the incoming main block. The same fixture without the union driver exits 1 and leaves all three index stages for `bin/smoke/ci-suites.txt`.

Validation:

- `pnpm smoke:ci-suites`: 24 passed, 0 failed, including the real Git merge regression.
- `node scripts/mutation-proof.mjs --config bin/smoke/mutations/ci-suites-merge-order.json`: 1 of 1 killed on `simultaneous tail appends conflict instead of silently choosing shard-changing order`.
- `pnpm smoke:mutation-fixtures`: green, including the new unique code-only anchor.
- `pnpm check:shard-stability origin/main HEAD`: `STABLE=0`, 0 of 420 pre-existing suites moved.
- `pnpm changeset status`: no packages to bump.
- `git diff --check`: green.

## Evidence limit

This does not choose the correct order automatically. It deliberately converts an unsafe clean merge into a visible conflict, after which the existing committed-ref shard-stability CI gate verifies the resolution.
