### PR TITLE
fix(core): refuse expired creds before dialing

### DIFF
--- a/.changeset/quiet-creds-expiry.md
+++ b/.changeset/quiet-creds-expiry.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/core": patch
+---
+
+Refuse to dial NATS with cached credentials after their JWT expiry when standing renewal is failing.

--- a/packages/core/smoke/mutations/standing-renewal-expiry.json
+++ b/packages/core/smoke/mutations/standing-renewal-expiry.json
@@ -1,0 +1,25 @@
+{
+  "suite": "packages/core/smoke/standing-renewal-auth.smoke.ts",
+  "guard": "a creds-source endpoint never presents its cached credential after that credential has expired",
+  "command": "pnpm smoke:standing-renewal",
+  "completionMarker": "STANDING RENEWAL SMOKE",
+  "proveWith": "node scripts/mutation-proof.mjs --config packages/core/smoke/mutations/standing-renewal-expiry.json",
+  "why": [
+    "The endpoint's pre-connect refresh is deliberately best-effort after the first connection. If",
+    "the source is down when the cached cred expires, removing this guard restores the reported",
+    "behavior exactly: connectAndBind presents credential material it has already decoded as expired.",
+    "The live smoke captures the disposable broker's authentication-expired denial, so the named",
+    "cell proves the real dial path reached the broker rather than only exercising a local parser."
+  ],
+  "mutations": [
+    {
+      "name": "the creds pre-dial expiry guard is removed",
+      "file": "packages/core/src/endpoint.ts",
+      "find": "    const credsExp = this.currentCreds && credsClaims(this.currentCreds).exp;\n    if (typeof credsExp === \"number\" && credsExp * 1000 <= Date.now())\n      throw new Error(\n        this.credsSource\n          ? \"this endpoint's creds have expired and renewal is failing - not presenting the expired credential to the broker; retrying with backoff\"\n          : \"this endpoint's creds have expired and it holds no creds source to renew them - replace the credential and rebuild the endpoint (pass a creds FUNCTION for standing renewal)\",\n      );\n",
+      "replace": "",
+      "expectRed": "expired creds are presented to the broker ZERO times after renewal fails",
+      "cell": "expired creds are presented to the broker ZERO times after renewal fails",
+      "note": "Deleting the block is the issue's pre-fix behavior and leaves the tree compiling. The source fails twice, so the first reconnect dials the cached expired cred and the broker logs the denial before the source recovers."
+    }
+  ]
+}

--- a/packages/core/smoke/mutations/standing-renewal-expiry.json
+++ b/packages/core/smoke/mutations/standing-renewal-expiry.json
@@ -17,8 +17,8 @@
       "file": "packages/core/src/endpoint.ts",
       "find": "    const credsExp = this.currentCreds && credsClaims(this.currentCreds).exp;\n    if (typeof credsExp === \"number\" && credsExp * 1000 <= Date.now())\n      throw new Error(\n        this.credsSource\n          ? \"this endpoint's creds have expired and renewal is failing - not presenting the expired credential to the broker; retrying with backoff\"\n          : \"this endpoint's creds have expired and it holds no creds source to renew them - replace the credential and rebuild the endpoint (pass a creds FUNCTION for standing renewal)\",\n      );\n",
       "replace": "",
-      "expectRed": "expired creds are presented to the broker ZERO times after renewal fails",
-      "cell": "expired creds are presented to the broker ZERO times after renewal fails",
+      "expectRed": "a rebuild presents cached expired creds to the broker ZERO times after renewal fails",
+      "cell": "a rebuild presents cached expired creds to the broker ZERO times after renewal fails",
       "note": "Deleting the block is the issue's pre-fix behavior and leaves the tree compiling. The source fails twice, so the first reconnect dials the cached expired cred and the broker logs the denial before the source recovers."
     }
   ]

--- a/packages/core/smoke/standing-renewal-auth.smoke.ts
+++ b/packages/core/smoke/standing-renewal-auth.smoke.ts
@@ -56,7 +56,10 @@ const space = `renewal-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
 const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
-const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+let brokerLog = "";
+const srv = spawn("nats-server", ["-D", "-c", join(dir, "server.conf")], { stdio: ["ignore", "pipe", "pipe"] });
+srv.stdout?.on("data", (d: Buffer) => { brokerLog += d.toString(); });
+srv.stderr?.on("data", (d: Buffer) => { brokerLog += d.toString(); });
 const releaseBroker = teardownOnSignal(srv, dir);
 
 try {
@@ -109,6 +112,64 @@ try {
   check("endpoint survives its first cred's expiry (round-trip after exp on the renewed cred)", aliveAfterExp);
   check("no renewal errors on the happy path", errors.length === 0, errors);
   await ep.stop();
+
+  // A failed renewal must never leave the reconnect path presenting the cached, now-expired cred.
+  // The source recovers after the first rebuild so this also proves the guard does not strand a
+  // renewable endpoint: it refuses dead material locally, then reconnects on the fresh cred.
+  const expiring = newIdentity();
+  let expiringReads = 0;
+  const expiringErrors: string[] = [];
+  const expiringSource = () => {
+    expiringReads++;
+    if (expiringReads <= 3) {
+      if (expiringReads === 1)
+        return mintCreds(auth, expiring, "supervisor", { expiresInSeconds: 3 });
+      throw new Error("fixture renewal source offline");
+    }
+    return mintCreds(auth, expiring, "supervisor", { expiresInSeconds: 60 });
+  };
+  const expiringEp = new CotalEndpoint({
+    space,
+    servers: SERVERS,
+    creds: expiringSource,
+    card: { id: expiring.id, name: "expired-creds", kind: "endpoint" },
+    consume: false,
+    lifecycleUid: mintLifecycleUid(),
+    registerPresence: false,
+    watchChannels: false,
+    watchPresence: false,
+  });
+  expiringEp.on("error", (e: Error) => { expiringErrors.push(e.message); });
+  await expiringEp.start();
+  const expiredLogStart = brokerLog.length;
+  let recovered = false;
+  const recoveryDeadline = Date.now() + 15_000;
+  while (!recovered && Date.now() < recoveryDeadline) {
+    if (expiringReads >= 4) {
+      try { await expiringEp.setActivity("recovered"); recovered = true; }
+      catch { /* still rebuilding */ }
+    }
+    if (!recovered) await wait(50);
+  }
+  check(
+    "an endpoint whose creds renewal fails recovers when its source returns",
+    recovered,
+    { reads: expiringReads, errors: expiringErrors },
+  );
+  const expiredCredDenials = brokerLog.slice(expiredLogStart).split("\n").filter((l) =>
+    /User JWT no longer valid.*claim is expired|User Authentication Expired$/.test(l),
+  );
+  check(
+    "expired creds are presented to the broker ZERO times after renewal fails",
+    expiredCredDenials.length === 0,
+    expiredCredDenials,
+  );
+  check(
+    "the pre-dial refusal is loud and names the failing renewal path",
+    expiringErrors.some((m) => /creds have expired.*renewal.*failing/.test(m)),
+    expiringErrors,
+  );
+  await expiringEp.stop();
 
   // ── Fail-loud edges.
   const other = newIdentity();

--- a/packages/core/smoke/standing-renewal-auth.smoke.ts
+++ b/packages/core/smoke/standing-renewal-auth.smoke.ts
@@ -118,12 +118,14 @@ try {
   // renewable endpoint: it refuses dead material locally, then reconnects on the fresh cred.
   const expiring = newIdentity();
   let expiringReads = 0;
+  let failedRebuildLogStart = -1;
   const expiringErrors: string[] = [];
   const expiringSource = () => {
     expiringReads++;
     if (expiringReads <= 3) {
       if (expiringReads === 1)
         return mintCreds(auth, expiring, "supervisor", { expiresInSeconds: 3 });
+      if (expiringReads === 3) failedRebuildLogStart = brokerLog.length;
       throw new Error("fixture renewal source offline");
     }
     return mintCreds(auth, expiring, "supervisor", { expiresInSeconds: 60 });
@@ -141,7 +143,6 @@ try {
   });
   expiringEp.on("error", (e: Error) => { expiringErrors.push(e.message); });
   await expiringEp.start();
-  const expiredLogStart = brokerLog.length;
   let recovered = false;
   const recoveryDeadline = Date.now() + 15_000;
   while (!recovered && Date.now() < recoveryDeadline) {
@@ -156,13 +157,13 @@ try {
     recovered,
     { reads: expiringReads, errors: expiringErrors },
   );
-  const expiredCredDenials = brokerLog.slice(expiredLogStart).split("\n").filter((l) =>
-    /User JWT no longer valid.*claim is expired|User Authentication Expired$/.test(l),
+  const expiredCredDenials = brokerLog.slice(failedRebuildLogStart).split("\n").filter((l) =>
+    /User JWT no longer valid.*claim is expired|cotal:expired-creds.*User Authentication Expired/.test(l),
   );
   check(
-    "expired creds are presented to the broker ZERO times after renewal fails",
-    expiredCredDenials.length === 0,
-    expiredCredDenials,
+    "a rebuild presents cached expired creds to the broker ZERO times after renewal fails",
+    failedRebuildLogStart >= 0 && expiredCredDenials.length === 0,
+    { failedRebuildLogStart, denials: expiredCredDenials },
   );
   check(
     "the pre-dial refusal is loud and names the failing renewal path",

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -179,7 +179,8 @@ export interface EndpointOptions {
    *  requires explicit `card.id` (the pinned identity); every fetched cred MUST carry that same nkey
    *  or the endpoint fails loud — renewal may never silently swap identity. A fetch failure is
    *  emitted as an "error" event and retried; the connection stays up until its current JWT expires,
-   *  so a dead reminter is loud without instantly dropping the mesh. */
+   *  so a dead reminter is loud without instantly dropping the mesh. Once the cached cred expires,
+   *  the endpoint refuses to present it to the broker and keeps retrying the source with backoff. */
   creds?: string | (() => Promise<string>);
   /** USER-MODE auth: a validated Cotal user bearer (the JWT from `cotal login` → the IdP bridge), or a
    *  SOURCE that mints a fresh one. When set, the endpoint connects through the auth callout — presenting
@@ -905,6 +906,13 @@ export class CotalEndpoint extends EventEmitter {
         this.bearerSource
           ? "this endpoint's user bearer has expired and renewal through the auth exchange is failing - not presenting the expired token to the broker; retrying with backoff"
           : "this endpoint's user bearer has expired and it holds no bearer source to renew it - re-authenticate and rebuild the endpoint (construct it with a bearer FUNCTION for standing renewal)",
+      );
+    const credsExp = this.currentCreds && credsClaims(this.currentCreds).exp;
+    if (typeof credsExp === "number" && credsExp * 1000 <= Date.now())
+      throw new Error(
+        this.credsSource
+          ? "this endpoint's creds have expired and renewal is failing - not presenting the expired credential to the broker; retrying with backoff"
+          : "this endpoint's creds have expired and it holds no creds source to renew them - replace the credential and rebuild the endpoint (pass a creds FUNCTION for standing renewal)",
       );
     this.nc = await dialerFor(this.servers)({
       servers: this.servers,


### PR DESCRIPTION
Fixes #1000.

## Scope

- Refuse `connectAndBind()` before NATS dial when cached creds have a numeric JWT `exp` that is already past.
- Keep the existing best-effort renewal posture while the old connection is live, then emit a specific local refusal and retry the creds source through the existing capped backoff once the cred is dead.
- Extend the real-broker standing-renewal smoke with a source that fails across expiry, proves no expired cached cred reaches the broker on rebuild, and proves the endpoint recovers when the source returns.
- Add a mutation fixture and a patch changeset for `@cotal-ai/core`.

## Evidence

Before the fix, the disposable fixture logged `User Authentication Expired` on the endpoint's reconnect and the manual isolated repro also logged `User JWT no longer valid: &{Issues:[claim is expired]}` after the source failed.

After the fix:

- `pnpm smoke:standing-renewal` passes 11/11, including live broker denial absence and recovery.
- `node scripts/mutation-proof.mjs --config packages/core/smoke/mutations/standing-renewal-expiry.json` kills deletion of the guard on the named broker-denial cell.
- `pnpm --filter @cotal-ai/core typecheck` passes.
- `pnpm --filter @cotal-ai/workspace build && pnpm smoke:expiry-renewal:auth` passes 7/7, covering the sibling bearer guard and shared reconnect backoff.
- `pnpm changeset status` reports the fixed-group patch plan successfully.

## Limits

This uses only a spawned local `nats-server` and disposable minted fixture credentials. It does not exercise or alter any live mesh credentials, and no live-mesh lifecycle command was run.
