### PR TITLE
fix(core): stop presence and channel-registry watches on endpoint teardown

### DIFF
--- a/.changeset/lane-897-endpoint-watch-teardown.md
+++ b/.changeset/lane-897-endpoint-watch-teardown.md
@@ -1,0 +1,9 @@
+---
+"@cotal-ai/core": patch
+---
+
+Stop the presence and channel-registry KV watches on endpoint teardown. Each watch binds an
+ordered JetStream push consumer whose idle-heartbeat monitor runs on its own timer, independent
+of the connection; without an explicit `.stop()` before drain, that monitor keeps trying to reset
+the consumer against a draining or closed connection, throwing an uncaught `DrainingConnectionError`
+every 30 seconds until the process exits by some other means.

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -349,6 +349,12 @@ export class CotalEndpoint extends EventEmitter {
   private jsm?: JetStreamManager;
   private kv?: KV;
   private channelKv?: KV;
+  /** The presence/channel-registry watches' own handles. Each is an ORDERED push consumer: its idle
+   *  heartbeat monitor lives on a JS timer independent of the connection, so a drain that doesn't
+   *  `.stop()` it first leaves the monitor to fire into a closing connection every 30s, throwing
+   *  `DrainingConnectionError` out of `reset()` on a timer nothing awaits. */
+  private presenceWatchIter?: Awaited<ReturnType<KV["watch"]>>;
+  private channelWatchIter?: Awaited<ReturnType<KV["watch"]>>;
   /** Plane-3 durable-membership registry KV — lazily opened by the privileged delivery daemon (or a
    *  short-lived provisioner). */
   private membersKv?: KV;
@@ -1039,6 +1045,18 @@ export class CotalEndpoint extends EventEmitter {
       }
     }
     this.streamMsgs.length = 0;
+    try {
+      this.presenceWatchIter?.stop();
+    } catch {
+      /* already closed with the connection */
+    }
+    this.presenceWatchIter = undefined;
+    try {
+      this.channelWatchIter?.stop();
+    } catch {
+      /* already closed with the connection */
+    }
+    this.channelWatchIter = undefined;
     for (const sub of this.chatSubs.values()) {
       try {
         sub.unsubscribe();
@@ -1258,6 +1276,18 @@ export class CotalEndpoint extends EventEmitter {
         /* already closed */
       }
     }
+    try {
+      this.presenceWatchIter?.stop();
+    } catch {
+      /* already closed */
+    }
+    this.presenceWatchIter = undefined;
+    try {
+      this.channelWatchIter?.stop();
+    } catch {
+      /* already closed */
+    }
+    this.channelWatchIter = undefined;
     try {
       if (this.doRegister) {
         this.status = "offline";
@@ -4289,6 +4319,7 @@ export class CotalEndpoint extends EventEmitter {
     let hydrated!: () => void;
     this.presenceSnapshot = new Promise<void>((resolve) => { hydrated = resolve; });
     const iter = await this.kv.watch();
+    this.presenceWatchIter = iter;
     void (async () => {
       let ready = false;
       for await (const e of iter) {
@@ -4309,6 +4340,7 @@ export class CotalEndpoint extends EventEmitter {
   private async startChannelWatch(): Promise<void> {
     if (!this.channelKv) return;
     const iter = await this.channelKv.watch();
+    this.channelWatchIter = iter;
     void (async () => {
       for await (const e of iter) this.handleChannelEntry(e);
     })().catch((e) => this.emit("error", e as Error));


### PR DESCRIPTION
## Context (#897)

#897 was filed as "smoke:opencode-events-release hangs shard 2 into the 30-minute CI timeout".
By the time this branch was cut from main (66d3f882), that headline symptom was already resolved
upstream: 85d4d421 raised the smoke job's `timeout-minutes` from 30 to 40, and the issue's own
last two comments confirm shard 2 now completes routinely (26-34 min against the new 40-min
ceiling). There is no hang left to reproduce for the title as written.

The issue's final comment identified a real, separate defect that survives the timeout fix:
`smoke:opencode-events-release` finishes its actual assertions in about two minutes, then spends
roughly five more minutes emitting `DrainingConnectionError` every 30 seconds during its own
teardown, before the process finally exits. That is what this PR fixes.

## Root cause

`CotalEndpoint.startPresenceWatch()` and `startChannelWatch()` each call `kv.watch()`, which binds
an ORDERED JetStream push consumer. That consumer's idle-heartbeat monitor runs on its own timer,
independent of the connection. Both call sites discarded the returned iterator instead of storing
it, so nothing was ever able to call `.stop()` on it — not in `clearConnectionScoped()` (the
reconnect/rebuild teardown) and not in `stop()` (permanent shutdown).

Once the connection starts draining, the monitor's next scheduled timeout still fires. Because the
consumer is ordered, the monitor's callback calls the consumer's `reset()`, which calls
`nc._resub()`, which throws `DrainingConnectionError` since the connection is mid-drain. That
exception is never caught (it's thrown out of a bare timer callback deep in `@nats-io/jetstream`,
not out of anything this code awaits), so it prints to stderr and the monitor reschedules itself,
repeating every 30s until the process exits some other way.

This is a general `@cotal-ai/core` teardown gap, not specific to the opencode connector or to this
one smoke suite — any endpoint that opens a presence or channel watch and later stops or
reconnects hits it.

## Fix

Store both `kv.watch()` iterators on the endpoint and stop them in the same two places
`streamMsgs` is already stopped (`clearConnectionScoped()` and `stop()`), before the connection
drains.

## Both-polarity proof

Reproduced locally (`export XDG_CONFIG_HOME=$(mktemp -d) && pnpm smoke:opencode-events-release`,
bounded by a `timeout 900` watchdog, never an unbounded wait):

| | revert (pre-fix) | this branch |
|---|---|---|
| exit code | 0 (PASSED, 20 checks) | 0 (PASSED, 20 checks) |
| wall time | 420s | 419s |
| `DrainingConnectionError` count | 19 | **0** |

Same pass count and duration either way — the fix removes the uncaught teardown errors, it does
not change the suite's deliberate bounded waits (that's a separate, smaller question the issue's
last comment already flagged as independent). Confirmed with `git diff` reverted and reapplied
against the identical built `@cotal-ai/core`, never a restated copy.

## Regression coverage

Ran locally, all green, no lingering `nats-server` processes after any run:

- `pnpm smoke:opencode-events-release` (the suite named in #897)
- `pnpm smoke:presence-watch-rebuild:auth` (presence watch across reconnect/rebuild)
- `pnpm smoke:kv-scan`
- `pnpm smoke:channels`
- `pnpm smoke:presence-scrub`
- `pnpm smoke:delivery-reconnect:auth`
- `pnpm smoke` (core smoke)
- `pnpm typecheck` (core package)

## Scope note

This does not touch shard balancing, per-suite timeouts, or "treat cancelled as failure" — the
other three items #897 raised. Those are either already addressed (the timeout raise) or separate
open questions the issue thread itself deferred. Flagging for the maintainer to decide whether #897
should close on this or stay open for the remaining items.