### PR TITLE
fix(ci): guard exact smoke suite indices

### DIFF
--- a/.changeset/honest-shards-hold.md
+++ b/.changeset/honest-shards-hold.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI-only: the shard-stability gate now enforces exact parsed suite indices and grades the invariant with a mutation-proven property smoke. No shipped package behavior changes.

--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -690,14 +690,14 @@ smoke:agent-secret-segmentation
 # spellings, one of them the release workflow. The property is only observable on main after a
 # merge, so it needs a static guard. Appended so every existing shard assignment remains unchanged.
 smoke:workflow-concurrency
-# The shard-stability gate must compare exact parsed indices, not only `index % shardCount`: moving
-# a suite by one complete shard count preserves its runner while violating the append-only registry
-# invariant. The property smoke inserts four names mid-file, grades every common suite, and asserts
-# the exact examined count. Appended so every existing shard assignment remains unchanged.
-smoke:shard-stability
-
 # Most smoke trees are still outside their package TypeScript projects. A type-only import from a
 # workspace package can therefore name something the package never exported and vanish when tsx runs
 # the suite. This compiler-API intersection checks every named workspace import against the package's
 # public exports. Appended so every existing shard assignment remains unchanged.
 smoke:workspace-import-exports
+
+# The shard-stability gate must compare exact parsed indices, not only `index % shardCount`: moving
+# a suite by one complete shard count preserves its runner while violating the append-only registry
+# invariant. The property smoke inserts four names mid-file, grades every common suite, and asserts
+# the exact examined count. Appended so every existing shard assignment remains unchanged.
+smoke:shard-stability

--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -690,3 +690,8 @@ smoke:agent-secret-segmentation
 # spellings, one of them the release workflow. The property is only observable on main after a
 # merge, so it needs a static guard. Appended so every existing shard assignment remains unchanged.
 smoke:workflow-concurrency
+# The shard-stability gate must compare exact parsed indices, not only `index % shardCount`: moving
+# a suite by one complete shard count preserves its runner while violating the append-only registry
+# invariant. The property smoke inserts four names mid-file, grades every common suite, and asserts
+# the exact examined count. Appended so every existing shard assignment remains unchanged.
+smoke:shard-stability

--- a/bin/smoke/mutations/shard-stability-index.json
+++ b/bin/smoke/mutations/shard-stability-index.json
@@ -1,0 +1,31 @@
+{
+  "suite": "bin/smoke/shard-stability.smoke.ts",
+  "guard": "the shard-stability gate compares exact parsed suite indices and examines every pre-existing suite, including moves by a whole shard count",
+  "command": "pnpm smoke:shard-stability",
+  "completionMarker": "SUITE COMPLETE",
+  "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/shard-stability-index.json",
+  "why": [
+    "The existing gate compared only index modulo shard count. Moving a suite by four positions in the four-shard topology therefore kept the same runner and passed, even though issue #920's append-only invariant says every pre-existing suite must keep its exact parsed index.",
+    "",
+    "The property suite inserts four entries at a deterministic mid-file position so the modulo-only mutant sees zero runner changes. The named property cell must redden, and a separate named cell asserts that every pre-existing suite was examined rather than accepting an empty loop."
+  ],
+  "mutations": [
+    {
+      "name": "compare only derived shard numbers, so whole-shard index moves disappear",
+      "file": "bin/smoke/shard-stability.mjs",
+      "find": "    if (headIndex !== baseIndex) changed.push(suite);",
+      "replace": "    if (headIndex % 4 !== baseIndex % 4) changed.push(suite);",
+      "expectRed": "FAIL: a mid-file whole-shard insert reports every pre-existing suite whose index changed",
+      "cell": "a mid-file whole-shard insert reports every pre-existing suite whose index changed"
+    },
+    {
+      "name": "stop counting examined suites, so an empty property loop can look green",
+      "file": "bin/smoke/shard-stability.mjs",
+      "find": "    examined++;",
+      "replace": "    examined += 0;",
+      "expectRed": "FAIL: the mid-file property examined every pre-existing suite",
+      "cell": "the mid-file property examined every pre-existing suite"
+    }
+  ],
+  "grades": "tool"
+}

--- a/bin/smoke/shard-stability.mjs
+++ b/bin/smoke/shard-stability.mjs
@@ -1,0 +1,13 @@
+/** Compare the parsed suite order, not only the derived shard number. */
+export function changedSuiteIndices(base, head) {
+  const headIndices = new Map(head.map((suite, index) => [suite, index]));
+  const changed = [];
+  let examined = 0;
+  base.forEach((suite, baseIndex) => {
+    const headIndex = headIndices.get(suite);
+    if (headIndex === undefined) return;
+    examined++;
+    if (headIndex !== baseIndex) changed.push(suite);
+  });
+  return { changed, examined };
+}

--- a/bin/smoke/shard-stability.smoke.ts
+++ b/bin/smoke/shard-stability.smoke.ts
@@ -1,0 +1,75 @@
+/**
+ * The shard-stability gate must defend the registry's actual invariant: every pre-existing suite
+ * keeps its parsed index. Comparing only `index % shardCount` misses moves by a whole shard count.
+ *
+ * Run: pnpm smoke:shard-stability
+ */
+import { createHash } from "node:crypto";
+// @ts-expect-error - plain .mjs helpers shared with the production checker.
+import { parseCiSuites } from "./ci-suites.mjs";
+// @ts-expect-error - plain .mjs helper shared with the production checker.
+import { changedSuiteIndices } from "./shard-stability.mjs";
+
+let pass = 0;
+let fail = 0;
+const check = (name: string, condition: boolean, extra?: unknown) => {
+  if (condition) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    fail++;
+    console.log(`  ✗ FAIL: ${name}`, extra ?? "");
+  }
+};
+
+console.log("shard-stability: exact parsed-index invariant");
+
+const baseRaw = Array.from({ length: 41 }, (_, index) =>
+  `${index % 5 === 0 ? `# suite ${index}\n` : ""}smoke:position-${index}`
+).join("\n");
+const base = parseCiSuites(baseRaw, "<base>") as string[];
+const seed = createHash("sha256").update(base.join("\n")).digest().readUInt32BE(0);
+const insertAt = 1 + seed % (base.length - 1);
+const additions = Array.from({ length: 4 }, (_, index) => `smoke:insert-${index}`);
+const inserted = [...base.slice(0, insertAt), ...additions, ...base.slice(insertAt)];
+const insertionResult = changedSuiteIndices(base, inserted) as { changed: string[]; examined: number };
+
+check(
+  "a mid-file whole-shard insert reports every pre-existing suite whose index changed",
+  insertionResult.changed.length === base.length - insertAt,
+  `inserted at ${insertAt}; ${insertionResult.changed.length} changed of ${base.length - insertAt} expected`,
+);
+check(
+  "the mid-file property examined every pre-existing suite",
+  insertionResult.examined === base.length,
+  `${insertionResult.examined} examined of ${base.length}`,
+);
+
+const tailResult = changedSuiteIndices(base, [...base, "smoke:tail"]) as {
+  changed: string[];
+  examined: number;
+};
+check("a true tail append changes no pre-existing index", tailResult.changed.length === 0);
+check(
+  "the tail control also examined every pre-existing suite",
+  tailResult.examined === base.length,
+  `${tailResult.examined} examined of ${base.length}`,
+);
+
+const removedResult = changedSuiteIndices(base, base.slice(1)) as { changed: string[]; examined: number };
+check("a deletion reports the surviving suites whose indices changed", removedResult.changed.length === base.length - 1);
+check(
+  "a removed suite is not counted as examined",
+  removedResult.examined === base.length - 1,
+  `${removedResult.examined} examined of ${base.length - 1}`,
+);
+
+const EXPECTED = 6;
+check(
+  `every cell ran - ${EXPECTED} expected, so a missing property is not mistaken for a pass`,
+  pass + fail === EXPECTED,
+  `${pass + fail} cells reported`,
+);
+
+console.log(`SUITE COMPLETE: ${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/bin/smoke/shard-stability.ts
+++ b/bin/smoke/shard-stability.ts
@@ -28,13 +28,15 @@
  *   disagreement with the head topology can be caught and refused; DO NOT PASS IT from a
  *   gate. Hardcoding it at the call site restores the coincidence-coupling this tool exists
  *   to remove and permanently silences the mismatch abort below.
- * Run from inside a worktree of the repo. Exits 1 if any pre-existing suite changes shard,
+ * Run from inside a worktree of the repo. Exits 1 if any pre-existing suite changes index or shard,
  * and likewise when a NEW entry's comment claims "Appended" while the entry sits before a
  * pre-existing suite: the claim sentence is validated against position instead of trusted (#1011).
  *
- * CONTROLS BUILT IN, because a bare zero is not evidence. All nineteen run on every invocation:
+ * CONTROLS BUILT IN, because a bare zero is not evidence. All twenty-one run on every invocation:
  *   - a forced mid-file insert must report non-zero (the instrument responds at all)
  *   - identity (base vs base) must report 0
+ *   - rotating every suite by one complete shard count must report every index changed
+ *   - the same index control must report the exact number of suites it examined
  *   - an unchanged 20-item registry under 4 -> 5 shards must move 16 items
  *   - the reverse 5 -> 4 topology change must also move 16 items
  *   - a comment containing a fake shard row must not shadow the active matrix
@@ -68,6 +70,8 @@ import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+// @ts-expect-error - plain .mjs helper, shared with the property smoke.
+import { changedSuiteIndices } from "./shard-stability.mjs";
 
 // FIRST LINE OF OUTPUT, BEFORE ANY WORK: a gate can grep for this to prove the detector
 // actually ran. `npx tsx <missing-file>` exits 1, which is indistinguishable from
@@ -457,11 +461,20 @@ const replaceRefRuntimeControl = (): boolean => {
 
 const A = read(base), B = read(head);
 const changed = moved(A, B, baseCount, headCount);
+const indices = changedSuiteIndices(A, B) as { changed: string[]; examined: number };
 
 // --- controls, printed before the verdict ---
 const forced = moved(A, [...A.slice(0, 10), "smoke:FORCED-CONTROL", ...A.slice(10)], baseCount, baseCount);
 const identity = moved(A, A, baseCount, baseCount);
 const topologyProbe = Array.from({ length: 20 }, (_, index) => `smoke:TOPOLOGY-CONTROL-${index}`);
+const indexRotation = changedSuiteIndices(
+  topologyProbe,
+  [...topologyProbe.slice(4), ...topologyProbe.slice(0, 4)],
+) as { changed: string[]; examined: number };
+const indexIdentity = changedSuiteIndices(topologyProbe, topologyProbe) as {
+  changed: string[];
+  examined: number;
+};
 const countIncrease = moved(topologyProbe, topologyProbe, 4, 5);
 const countDecrease = moved(topologyProbe, topologyProbe, 5, 4);
 const commentShadowCount = shardCountFromWorkflow(`jobs:
@@ -656,6 +669,8 @@ const claimHistorical = appendedClaimViolations(claimControlBase,
   `${claimSentence}\nsmoke:a\n${claimSentence}\nsmoke:b\n${claimSentence}\nsmoke:c\n`);
 console.log(`CONTROL forced mid-file insert -> ${forced.length} moved  (must be > 0)`);
 console.log(`CONTROL identity               -> ${identity.length} moved  (must be 0)`);
+console.log(`CONTROL same-shard reindex     -> ${indexRotation.changed.length} of ${indexRotation.examined} examined  (must be 20 of 20)`);
+console.log(`CONTROL index identity         -> ${indexIdentity.changed.length} of ${indexIdentity.examined} examined  (must be 0 of 20)`);
 console.log(`CONTROL shard count 4 -> 5     -> ${countIncrease.length} moved  (must be 16)`);
 console.log(`CONTROL shard count 5 -> 4     -> ${countDecrease.length} moved  (must be 16)`);
 console.log(`CONTROL matrix comment shadow  -> ${commentShadowCount ?? "unreadable"} shards (must be 4)`);
@@ -674,7 +689,9 @@ console.log(`CONTROL mid-file "Appended" claim -> ${claimMidFile.length} named  
 console.log(`CONTROL tail "Appended" claim     -> ${claimTail.length} named  (must be 0)`);
 console.log(`CONTROL historical claims         -> ${claimHistorical.length} named  (must be 0)`);
 if (
-  forced.length === 0 || identity.length !== 0 || countIncrease.length !== 16 ||
+  forced.length === 0 || identity.length !== 0 ||
+  indexRotation.changed.length !== 20 || indexRotation.examined !== 20 ||
+  indexIdentity.changed.length !== 0 || indexIdentity.examined !== 20 || countIncrease.length !== 16 ||
   countDecrease.length !== 16 || commentShadowCount !== 4 ||
   commandMismatchCount !== null || duplicateMatrixCount !== null || emptyMatrixCount !== null || excludedMatrixCount !== null ||
   conditionalJobCount !== null || conditionalStepCount !== null || unguardedRunnerCount !== null || !replaceRefRefused ||
@@ -691,6 +708,10 @@ const removed = A.filter((suite) => !B.includes(suite));
 const claimViolations = appendedClaimViolations(A, readRaw(head));
 console.log(`\n${base.slice(0, 8)} -> ${head.slice(0, 8)}  @${baseCount}->${headCount} shards`);
 console.log(`  suites: ${A.length} -> ${B.length} · added ${added.length} · removed ${removed.length}`);
+console.log(`  pre-existing suites CHANGING INDEX: ${indices.changed.length} of ${indices.examined} examined`);
+if (indices.changed.length > 0) {
+  console.log(`  first few reindexed: ${indices.changed.slice(0, 5).join(", ")}`);
+}
 console.log(`  pre-existing suites CHANGING SHARD: ${changed.length} of ${A.length}`);
 if (changed.length > 0) {
   console.log(`  first few: ${changed.slice(0, 5).join(", ")}`);
@@ -698,14 +719,16 @@ if (changed.length > 0) {
 if (claimViolations.length > 0) {
   console.log(`  NEW entries claiming "Appended" while mid-file: ${claimViolations.join(", ")}`);
 }
-if (changed.length > 0 || claimViolations.length > 0) {
+if (indices.changed.length > 0 || removed.length > 0 || changed.length > 0 || claimViolations.length > 0) {
   const remedy = baseCount === headCount
     ? "Append new suites at the END of ci-suites.txt."
     : `The shard matrix changed ${baseCount} -> ${headCount}; review every reassignment as deliberate.`;
   const claimNote = claimViolations.length > 0
     ? ` FALSE "Appended" CLAIM on ${claimViolations.join(", ")}: the sentence is validated against position (#1011); a new entry carrying it must sit after every pre-existing suite.`
     : "";
-  const headline = changed.length > 0 ? `RE-SHARD DETECTED. ${remedy}` : "NO pre-existing suite moved, but the registry lies about how it grew.";
+  const headline = indices.changed.length > 0 || removed.length > 0 || changed.length > 0
+    ? `RE-SHARD DETECTED. ${remedy}`
+    : "NO pre-existing suite moved, but the registry lies about how it grew.";
   verdict("RESHARD", `${headline}${claimNote}`, 1);
 }
-verdict("STABLE", "STABLE - no pre-existing suite changes runner, no false append claims.", 0);
+verdict("STABLE", "STABLE - every pre-existing suite keeps its index and runner, no false append claims.", 0);

--- a/package.json
+++ b/package.json
@@ -467,6 +467,7 @@
     "smoke:gate-inventory": "tsx bin/smoke/gate-inventory.smoke.ts",
     "smoke:required-arg-seam": "tsx bin/smoke/required-arg-seam.smoke.ts",
     "smoke:ci-suites": "tsx bin/smoke/ci-suites.smoke.ts",
+    "smoke:shard-stability": "tsx bin/smoke/shard-stability.smoke.ts",
     "smoke:workflow-concurrency": "tsx bin/smoke/workflow-concurrency.smoke.ts",
     "smoke:mutation-fixtures": "tsx bin/smoke/mutation-fixtures.smoke.ts",
     "smoke:dep-pins": "tsx bin/smoke/dep-pins.smoke.ts",


### PR DESCRIPTION
Closes #920.

## Existing coverage

Current main already has an unsharded required CI step, `pnpm check:shard-stability <base> <head>`, that detects ordinary inserts and reorders when a pre-existing suite changes its derived shard. It also validates shard topology and committed runtime inputs. This PR does not rebuild that gate.

The remaining gap was narrower: the checker compared only `index % shardCount`, not the exact parsed index required by #920. A suite moved by four positions in the four-shard topology kept the same runner and passed.

## What changed

- Compare every suite common to base and head by exact parsed index, while retaining the existing shard-topology comparison.
- Report both the number reindexed and the exact number of common suites examined.
- Refuse removals even when no surviving suite changes shard.
- Add a broker-free property smoke covering a deterministic mid-file four-entry insert, a true tail append, and a deletion.
- Add mutation proof for the exact-index comparison and the examined-count guard.
- Append the new smoke at the true registry tail and add an empty changeset because this is CI-only.

## Reproduction

Before editing, a live 20-suite fixture rotated the list by four positions. All 20 exact indices changed, every suite kept its four-shard runner, and current main returned `STABLE=0` with `pre-existing suites CHANGING SHARD: 0 of 20`.

With this change, the same committed fixture returns `RESHARD=1`, reporting `pre-existing suites CHANGING INDEX: 20 of 20 examined` and still showing zero shard changes.

## Verification

- `pnpm smoke:shard-stability`: 7 passed, 0 failed.
- `node scripts/mutation-proof.mjs --config bin/smoke/mutations/shard-stability-index.json`: 2 of 2 killed red-and-named on the exact property cells.
- `pnpm smoke:mutation-fixtures`: green, including both unique code-only anchors.
- `pnpm check:shard-stability origin/main HEAD`: `STABLE=0`; 420 of 420 pre-existing suites examined, zero changed index or shard, one suite appended.
- `pnpm typecheck`: green, including the build and bin smoke typecheck.
- `pnpm changeset status`: no packages to bump.
- `git diff --check`: green.

## Limits

This preserves positional round-robin sharding and enforces its exact-index invariant. It does not adopt stable hash sharding or otherwise remove order as a source of assignment. That CI-wide mechanism change remains outside this issue's guard-only scope.
