### PR TITLE
fix(ci): expire ungated suite exemptions

### DIFF
--- a/.changeset/brave-exemptions-expire.md
+++ b/.changeset/brave-exemptions-expire.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI-only: every ungated smoke-suite exemption now carries a machine-checked review date and expires loudly when its premise needs re-evaluation. No shipped package behavior changes.

--- a/bin/smoke/gate-inventory.smoke.ts
+++ b/bin/smoke/gate-inventory.smoke.ts
@@ -62,12 +62,16 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
  *  decision, which needs no fuse and is written as a plain reason. */
 const BROKEN = "BROKEN:";
 
-const UNGATED: Record<string, string> = {
+type UngatedExemption = { reason: string; recheckBy: string };
+const RECHECK = "2026-11-30";
+const exemption = (reason: string): UngatedExemption => ({ reason, recheckBy: RECHECK });
+
+const UNGATED: Record<string, UngatedExemption> = {
   // Need external tooling no CI runner has.
-  "smoke:orca:live": "drives the public orca CLI",
-  "smoke:orca-e2e:live": "drives the public orca CLI", "smoke:pi": "needs a pi install", "smoke:codex-live": "needs a logged-in codex CLI",
-  "smoke:codex-tui-live": "needs a codex TUI session",
-  "smoke:jcode-live": "needs an installed, authenticated jcode CLI (COTAL_E2E_JCODE=1)",
+  "smoke:orca:live": exemption("drives the public orca CLI"),
+  "smoke:orca-e2e:live": exemption("drives the public orca CLI"), "smoke:pi": exemption("needs a pi install"), "smoke:codex-live": exemption("needs a logged-in codex CLI"),
+  "smoke:codex-tui-live": exemption("needs a codex TUI session"),
+  "smoke:jcode-live": exemption("needs an installed, authenticated jcode CLI (COTAL_E2E_JCODE=1)"),
   // A STANDING DECISION, and only for the REAL-SESSION arm. The same suite is GATED as
   // `smoke:agui-map`, pointed at a fixture DERIVED from a real session by
   // `scripts/redact-claude-session.mjs` (whitelist by construction, identifiers pseudonymised
@@ -76,22 +80,22 @@ const UNGATED: Record<string, string> = {
   // TODAY's harness rather than a snapshot, so a new `origin.kind` shows up here as a throw before
   // it shows up in production; and it shares no assumption with the redactor, which itself encodes
   // a belief about which fields matter and could be wrong in the same direction as the mapper.
-  "smoke:agui-map:real": "names an operator's own uncommittable session JSONL (COTAL_AGUI_SESSION); the fixture arm is gated as smoke:agui-map",
+  "smoke:agui-map:real": exemption("names an operator's own uncommittable session JSONL (COTAL_AGUI_SESSION); the fixture arm is gated as smoke:agui-map"),
   // Full-stack live suites: boot a real broker + install tree, too slow/stateful for the PR gate.
-  "smoke:manager-singleton:live": "full live stack", "smoke:seed-tarball:live": "packs a tarball",
+  "smoke:manager-singleton:live": exemption("full live stack"), "smoke:seed-tarball:live": exemption("packs a tarball"),
   // `smoke:user-spawn:live` left this list when it was gated: it had thrown at section B1e on a
   // missing explicit `tls` and stopped after 14 of its 66 cells, and being ungated is why nobody
   // heard about it. "Too slow for the gate" was 105 seconds.
   // Untriaged debt. These are the ones that should shrink.
-  "smoke:attention": "UNTRIAGED",
-  "smoke:attention:auth": "UNTRIAGED",
- "smoke:delivery-boot-retry:auth": "UNTRIAGED",
-  "smoke:delivery-broker-coupling": "UNTRIAGED", "smoke:delivery-old-manager": "UNTRIAGED",
-  "smoke:feedback": "UNTRIAGED",
-  "smoke:lifecycle-files": "UNTRIAGED", "smoke:manager-console": "UNTRIAGED",
-  "smoke:plane3-activation:auth": "UNTRIAGED",
-  "smoke:plane3-gate:auth": "UNTRIAGED",
-  "smoke:self-serve-join-coverage:auth": "UNTRIAGED",
+  "smoke:attention": exemption("UNTRIAGED"),
+  "smoke:attention:auth": exemption("UNTRIAGED"),
+ "smoke:delivery-boot-retry:auth": exemption("UNTRIAGED"),
+  "smoke:delivery-broker-coupling": exemption("UNTRIAGED"), "smoke:delivery-old-manager": exemption("UNTRIAGED"),
+  "smoke:feedback": exemption("UNTRIAGED"),
+  "smoke:lifecycle-files": exemption("UNTRIAGED"), "smoke:manager-console": exemption("UNTRIAGED"),
+  "smoke:plane3-activation:auth": exemption("UNTRIAGED"),
+  "smoke:plane3-gate:auth": exemption("UNTRIAGED"),
+  "smoke:self-serve-join-coverage:auth": exemption("UNTRIAGED"),
 };
 
 /**
@@ -196,8 +200,30 @@ const ungated = [...all].filter((s) => !reached.has(s)).sort();
 // them apart. `UNTRIAGED` is a legitimate value — it is honest debt — but it is counted separately
 // below rather than being allowed to read as a justification.
 const MIN_REASON = 8;
-const unexplained = ungated.filter((s) => !(s in UNGATED) || (UNGATED[s] ?? "").trim().length < MIN_REASON);
+const unexplained = ungated.filter((s) => !(s in UNGATED) || (UNGATED[s]?.reason ?? "").trim().length < MIN_REASON);
 const staleAllowlist = Object.keys(UNGATED).filter((s) => !all.has(s) || reached.has(s)).sort();
+
+const reviewDate = (value: string): string | null => {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return Number.isNaN(parsed.valueOf()) || parsed.toISOString().slice(0, 10) !== value ? null : value;
+};
+const reviewExemptions = (
+  entries: Record<string, UngatedExemption>,
+  today: string,
+): { examined: number; invalid: string[]; expired: string[] } => {
+  const invalid: string[] = [];
+  const expired: string[] = [];
+  for (const [name, entry] of Object.entries(entries)) {
+    const date = reviewDate(entry.recheckBy);
+    if (date === null) invalid.push(name);
+    else if (date < today) expired.push(name);
+  }
+  return { examined: Object.keys(entries).length, invalid, expired };
+};
+const today = new Date().toISOString().slice(0, 10);
+const exemptionReviews = reviewExemptions(UNGATED, today);
+const expiryControl = reviewExemptions({ control: { reason: "control", recheckBy: "2000-01-01" } }, "2026-08-30");
 
 let fail = 0;
 console.log(`gate inventory: ${all.size} smoke scripts, ${all.size - ungated.length} reached, ${ungated.length} not run by anything\n`);
@@ -218,6 +244,28 @@ if (unexplained.length) {
   console.log(`    Gate it in smoke:ci, or add it to UNGATED with the reason it is excluded.`);
 } else {
   console.log(`  ✓ every ungated suite is listed with a reason`);
+}
+
+console.log(`  exemption freshness examined: ${exemptionReviews.examined} of ${Object.keys(UNGATED).length}`);
+if (exemptionReviews.examined !== Object.keys(UNGATED).length) {
+  fail++;
+  console.log(`  ✗ FAIL: exemption freshness did not examine every UNGATED entry`);
+} else if (expiryControl.examined !== 1 || expiryControl.expired.length !== 1) {
+  fail++;
+  console.log(`  ✗ FAIL: exemption expiry control did not expire its one past-due entry`);
+} else if (exemptionReviews.invalid.length || exemptionReviews.expired.length) {
+  fail++;
+  if (exemptionReviews.invalid.length) {
+    console.log(`  ✗ FAIL: ${exemptionReviews.invalid.length} UNGATED exemption(s) have an invalid recheckBy date:`);
+    for (const s of exemptionReviews.invalid) console.log(`      ${s}`);
+  }
+  if (exemptionReviews.expired.length) {
+    console.log(`  ✗ FAIL: ${exemptionReviews.expired.length} UNGATED exemption(s) are past their recheckBy date ${today}:`);
+    for (const s of exemptionReviews.expired) console.log(`      ${s}`);
+    console.log(`    Re-verify the premise, gate the suite, or set a new review date with the decision.`);
+  }
+} else {
+  console.log(`  ✓ all ${exemptionReviews.examined} UNGATED exemptions have a current recheckBy date`);
 }
 
 // THE REVERSE DIRECTION, and the gate needs both. Everything above asks "is this script reached?".
@@ -307,7 +355,7 @@ if (staleAllowlist.length) {
   console.log(`  ✓ no stale UNGATED entries`);
 }
 
-const untriaged = ungated.filter((s) => UNGATED[s] === "UNTRIAGED");
+const untriaged = ungated.filter((s) => UNGATED[s]?.reason === "UNTRIAGED");
 console.log(`\n  ${untriaged.length} of the ungated set are UNTRIAGED debt (not a failure; the number should go down).`);
 
 // The debt-with-a-fuse class, named so the list can say how much of itself is broken rather than
@@ -316,9 +364,9 @@ console.log(`\n  ${untriaged.length} of the ungated set are UNTRIAGED debt (not 
 // was consciously taken. What was missing was never enforcement — it was the COUNT. `smoke:auth`
 // sat in this list for six weeks with its cause correctly written in its own reason string, and
 // nothing anywhere said "one suite here is broken and is supposed to stop being broken".
-const broken = ungated.filter((s) => (UNGATED[s] ?? "").startsWith(BROKEN)).sort();
+const broken = ungated.filter((s) => (UNGATED[s]?.reason ?? "").startsWith(BROKEN)).sort();
 console.log(`  ${broken.length} are BROKEN — red or flaky, and expected to be fixed and removed, not kept:`);
-for (const s of broken) console.log(`      ${s} — ${(UNGATED[s] ?? "").slice(BROKEN.length).trim()}`);
+for (const s of broken) console.log(`      ${s} — ${(UNGATED[s]?.reason ?? "").slice(BROKEN.length).trim()}`);
 
 // Reported, not enforced: every entry here is already an accepted exclusion, so failing on them
 // would just block the gate on debt that was consciously taken. The number is the point.

--- a/bin/smoke/gate-inventory.smoke.ts
+++ b/bin/smoke/gate-inventory.smoke.ts
@@ -63,15 +63,16 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const BROKEN = "BROKEN:";
 
 type UngatedExemption = { reason: string; recheckBy: string };
-const RECHECK = "2026-11-30";
-const exemption = (reason: string): UngatedExemption => ({ reason, recheckBy: RECHECK });
+const EXPECTED_EXEMPTIONS = 20;
+const standing = (reason: string): UngatedExemption => ({ reason, recheckBy: "2026-11-30" });
+const untriaged = (reason: string): UngatedExemption => ({ reason, recheckBy: "2026-09-30" });
 
 const UNGATED: Record<string, UngatedExemption> = {
   // Need external tooling no CI runner has.
-  "smoke:orca:live": exemption("drives the public orca CLI"),
-  "smoke:orca-e2e:live": exemption("drives the public orca CLI"), "smoke:pi": exemption("needs a pi install"), "smoke:codex-live": exemption("needs a logged-in codex CLI"),
-  "smoke:codex-tui-live": exemption("needs a codex TUI session"),
-  "smoke:jcode-live": exemption("needs an installed, authenticated jcode CLI (COTAL_E2E_JCODE=1)"),
+  "smoke:orca:live": standing("drives the public orca CLI"),
+  "smoke:orca-e2e:live": standing("drives the public orca CLI"), "smoke:pi": standing("needs a pi install"), "smoke:codex-live": standing("needs a logged-in codex CLI"),
+  "smoke:codex-tui-live": standing("needs a codex TUI session"),
+  "smoke:jcode-live": standing("needs an installed, authenticated jcode CLI (COTAL_E2E_JCODE=1)"),
   // A STANDING DECISION, and only for the REAL-SESSION arm. The same suite is GATED as
   // `smoke:agui-map`, pointed at a fixture DERIVED from a real session by
   // `scripts/redact-claude-session.mjs` (whitelist by construction, identifiers pseudonymised
@@ -80,22 +81,22 @@ const UNGATED: Record<string, UngatedExemption> = {
   // TODAY's harness rather than a snapshot, so a new `origin.kind` shows up here as a throw before
   // it shows up in production; and it shares no assumption with the redactor, which itself encodes
   // a belief about which fields matter and could be wrong in the same direction as the mapper.
-  "smoke:agui-map:real": exemption("names an operator's own uncommittable session JSONL (COTAL_AGUI_SESSION); the fixture arm is gated as smoke:agui-map"),
+  "smoke:agui-map:real": standing("names an operator's own uncommittable session JSONL (COTAL_AGUI_SESSION); the fixture arm is gated as smoke:agui-map"),
   // Full-stack live suites: boot a real broker + install tree, too slow/stateful for the PR gate.
-  "smoke:manager-singleton:live": exemption("full live stack"), "smoke:seed-tarball:live": exemption("packs a tarball"),
+  "smoke:manager-singleton:live": standing("full live stack"), "smoke:seed-tarball:live": standing("packs a tarball"),
   // `smoke:user-spawn:live` left this list when it was gated: it had thrown at section B1e on a
   // missing explicit `tls` and stopped after 14 of its 66 cells, and being ungated is why nobody
   // heard about it. "Too slow for the gate" was 105 seconds.
   // Untriaged debt. These are the ones that should shrink.
-  "smoke:attention": exemption("UNTRIAGED"),
-  "smoke:attention:auth": exemption("UNTRIAGED"),
- "smoke:delivery-boot-retry:auth": exemption("UNTRIAGED"),
-  "smoke:delivery-broker-coupling": exemption("UNTRIAGED"), "smoke:delivery-old-manager": exemption("UNTRIAGED"),
-  "smoke:feedback": exemption("UNTRIAGED"),
-  "smoke:lifecycle-files": exemption("UNTRIAGED"), "smoke:manager-console": exemption("UNTRIAGED"),
-  "smoke:plane3-activation:auth": exemption("UNTRIAGED"),
-  "smoke:plane3-gate:auth": exemption("UNTRIAGED"),
-  "smoke:self-serve-join-coverage:auth": exemption("UNTRIAGED"),
+  "smoke:attention": untriaged("UNTRIAGED"),
+  "smoke:attention:auth": untriaged("UNTRIAGED"),
+ "smoke:delivery-boot-retry:auth": untriaged("UNTRIAGED"),
+  "smoke:delivery-broker-coupling": untriaged("UNTRIAGED"), "smoke:delivery-old-manager": untriaged("UNTRIAGED"),
+  "smoke:feedback": untriaged("UNTRIAGED"),
+  "smoke:lifecycle-files": untriaged("UNTRIAGED"), "smoke:manager-console": untriaged("UNTRIAGED"),
+  "smoke:plane3-activation:auth": untriaged("UNTRIAGED"),
+  "smoke:plane3-gate:auth": untriaged("UNTRIAGED"),
+  "smoke:self-serve-join-coverage:auth": untriaged("UNTRIAGED"),
 };
 
 /**
@@ -246,8 +247,8 @@ if (unexplained.length) {
   console.log(`  ✓ every ungated suite is listed with a reason`);
 }
 
-console.log(`  exemption freshness examined: ${exemptionReviews.examined} of ${Object.keys(UNGATED).length}`);
-if (exemptionReviews.examined !== Object.keys(UNGATED).length) {
+console.log(`  exemption freshness examined: ${exemptionReviews.examined} of ${EXPECTED_EXEMPTIONS}`);
+if (exemptionReviews.examined !== EXPECTED_EXEMPTIONS) {
   fail++;
   console.log(`  ✗ FAIL: exemption freshness did not examine every UNGATED entry`);
 } else if (expiryControl.examined !== 1 || expiryControl.expired.length !== 1) {

--- a/bin/smoke/gate-inventory.smoke.ts
+++ b/bin/smoke/gate-inventory.smoke.ts
@@ -65,7 +65,7 @@ const BROKEN = "BROKEN:";
 type UngatedExemption = { reason: string; recheckBy: string };
 const EXPECTED_EXEMPTIONS = 20;
 const standing = (reason: string): UngatedExemption => ({ reason, recheckBy: "2026-11-30" });
-const untriaged = (reason: string): UngatedExemption => ({ reason, recheckBy: "2026-09-30" });
+const untriagedExemption = (reason: string): UngatedExemption => ({ reason, recheckBy: "2026-09-30" });
 
 const UNGATED: Record<string, UngatedExemption> = {
   // Need external tooling no CI runner has.
@@ -88,15 +88,15 @@ const UNGATED: Record<string, UngatedExemption> = {
   // missing explicit `tls` and stopped after 14 of its 66 cells, and being ungated is why nobody
   // heard about it. "Too slow for the gate" was 105 seconds.
   // Untriaged debt. These are the ones that should shrink.
-  "smoke:attention": untriaged("UNTRIAGED"),
-  "smoke:attention:auth": untriaged("UNTRIAGED"),
- "smoke:delivery-boot-retry:auth": untriaged("UNTRIAGED"),
-  "smoke:delivery-broker-coupling": untriaged("UNTRIAGED"), "smoke:delivery-old-manager": untriaged("UNTRIAGED"),
-  "smoke:feedback": untriaged("UNTRIAGED"),
-  "smoke:lifecycle-files": untriaged("UNTRIAGED"), "smoke:manager-console": untriaged("UNTRIAGED"),
-  "smoke:plane3-activation:auth": untriaged("UNTRIAGED"),
-  "smoke:plane3-gate:auth": untriaged("UNTRIAGED"),
-  "smoke:self-serve-join-coverage:auth": untriaged("UNTRIAGED"),
+  "smoke:attention": untriagedExemption("UNTRIAGED"),
+  "smoke:attention:auth": untriagedExemption("UNTRIAGED"),
+ "smoke:delivery-boot-retry:auth": untriagedExemption("UNTRIAGED"),
+  "smoke:delivery-broker-coupling": untriagedExemption("UNTRIAGED"), "smoke:delivery-old-manager": untriagedExemption("UNTRIAGED"),
+  "smoke:feedback": untriagedExemption("UNTRIAGED"),
+  "smoke:lifecycle-files": untriagedExemption("UNTRIAGED"), "smoke:manager-console": untriagedExemption("UNTRIAGED"),
+  "smoke:plane3-activation:auth": untriagedExemption("UNTRIAGED"),
+  "smoke:plane3-gate:auth": untriagedExemption("UNTRIAGED"),
+  "smoke:self-serve-join-coverage:auth": untriagedExemption("UNTRIAGED"),
 };
 
 /**

--- a/bin/smoke/mutations/gate-inventory-exemption-review.json
+++ b/bin/smoke/mutations/gate-inventory-exemption-review.json
@@ -1,0 +1,31 @@
+{
+  "suite": "bin/smoke/gate-inventory.smoke.ts",
+  "guard": "every UNGATED exemption has a current machine-checked recheck date and the inventory reports the exact number examined",
+  "command": "pnpm smoke:gate-inventory",
+  "completionMarker": "GATE INVENTORY",
+  "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/gate-inventory-exemption-review.json",
+  "why": [
+    "Most current exemption premises are external environment or policy prose that this repository cannot truthfully evaluate. A required recheckBy date does not claim to prove those premises; it guarantees they expire loudly and receive another decision.",
+    "",
+    "The first mutation disables expiry, and the built-in past-due control must redden on its named cell. The second mutation falsifies the examined count, and the suite must report that the inventory did not inspect all 20 current exemptions."
+  ],
+  "mutations": [
+    {
+      "name": "disable exemption expiry so a stale premise remains certified indefinitely",
+      "file": "bin/smoke/gate-inventory.smoke.ts",
+      "find": "    else if (date < today) expired.push(name);",
+      "replace": "    else if (false) expired.push(name);",
+      "expectRed": "FAIL: exemption expiry control did not expire its one past-due entry",
+      "cell": "exemption expiry control did not expire its one past-due entry"
+    },
+    {
+      "name": "report zero exemptions examined so an empty freshness walk looks complete",
+      "file": "bin/smoke/gate-inventory.smoke.ts",
+      "find": "  return { examined: Object.keys(entries).length, invalid, expired };",
+      "replace": "  return { examined: 0, invalid, expired };",
+      "expectRed": "FAIL: exemption freshness did not examine every UNGATED entry",
+      "cell": "exemption freshness did not examine every UNGATED entry"
+    }
+  ],
+  "grades": "tool"
+}


### PR DESCRIPTION
Closes #924.

## Classification first

Current main has 20 `UNGATED` exemptions. I classified all 20 before choosing the mechanism:

- 7 name external tools, authentication, session files, or environment input.
- 2 are full-stack or packaging policy decisions.
- 11 are `UNTRIAGED` and carry no decision beyond acknowledging debt.

None has a premise this repository can safely validate as a repository fact. Local command presence cannot prove CI has the tool, and a developer login or session cannot prove a runner's state. A predicate validator here would report confident green about the wrong environment.

## What changed

- Every exemption now carries a structured `reason` and `recheckBy` date.
- The expected exemption count is pinned to the literal `20`, not derived from the enumeration under test.
- Invalid or expired dates fail the existing required gate and name the affected exemptions.
- A permanent past-due control proves expiry is active on every run.
- The 11 `UNTRIAGED` entries are reviewed first on 2026-09-30. The 9 standing environment/policy decisions follow on 2026-11-30, avoiding one batch rubber stamp.
- An empty changeset records that this is CI-only.

The mechanism forces re-review. It does not silently convert `UNTRIAGED` into triage, and this PR deliberately does not investigate those 11 suites.

## Reproduction

Before the change, `pnpm smoke:gate-inventory` reported `GATE INVENTORY OK` for all 20 exemptions while checking only that each reason was at least eight characters. No date, predicate, or freshness metadata was read.

## Verification

- `pnpm smoke:gate-inventory`: green; `exemption freshness examined: 20 of 20` and all dates current.
- `node scripts/mutation-proof.mjs --config bin/smoke/mutations/gate-inventory-exemption-review.json`: 2 of 2 killed red-and-named. One disables expiry; one reports zero examined.
- `pnpm smoke:mutation-fixtures`: green, both anchors unique and code-only.
- `pnpm typecheck`: green, including build and bin smoke typecheck.
- `pnpm changeset status`: no packages to bump.
- `git diff --check`: green.

The full typecheck was initially deferred while the host was saturated. It was run after the fleet load gate was rescinded, starting at load average `21.95, 21.39, 15.81` on 12 cores, and completed green in 76.8 seconds.

## Limits

This verifies review currency, not the truth of the reason. External tool availability, authentication, operator session state, and policy judgements remain unverifiable by construction from this repository. The expiry makes those statements stop being certified indefinitely and forces another explicit decision.
