### PR TITLE
fix(core): grant STREAM.INFO alongside the consumer-create deny triple

### DIFF
--- a/.changeset/stream-info-grants.md
+++ b/.changeset/stream-info-grants.md
@@ -1,0 +1,10 @@
+---
+"@cotal-ai/core": patch
+---
+
+`provisionAgent`'s agent-profile grant template emitted the JetStream consumer-create deny
+triple on the DM, TASK, and DLV streams without a matching `$JS.API.STREAM.INFO` grant, and
+never granted it on the EPC contract store either. Every JetStream API call is a NATS publish,
+so a provisioned actor was refused stream-level state reads (message counts, first/last seq) on
+all four streams, not just consumer creation. Added the four missing `STREAM.INFO` grants; the
+consumer-create deny triple is untouched.

--- a/SPEC.md
+++ b/SPEC.md
@@ -608,7 +608,7 @@ credential diverge (§2): the principal keys subjects/durables/presence; the con
 
 | Profile | Application publish | Read surface | Notes |
 | --- | --- | --- | --- |
-| `agent` | own `chat.<owner>.<actor>.<ch>` for each `allowPublish` channel (post ACL, default-deny), `inst.*.*.<owner>.<actor>`, `svc.*.<owner>.<actor>`; endpoint request forms per minted capability (`ep.one`/`ep.all`/`ep.inst` with the capability's authz-mode/target pattern, caller triple `<owner>.<actor>.<uid>` pinned; `describe` by default; `epj` submissions for journaled capabilities; §13.9); own presence key | own `_INBOX_<connId>.>` + own endpoint reply rail (`ep.reply.*.*.*.<owner>.<actor>.<uid>.*`, exact arity); channel live tail via native `sub.allow` subscriptions to `chat.*.*.<channel>` per `allowSubscribe` (wildcards preserved); presence and channel-registry KV watches, including create/info/delete of their client-managed ordered consumers on those two streams only; CHAT history via single-filter `chathist_<owner>-<actor>-<uid>` creates, one per `allowSubscribe` channel (ACL-bounded); own lifecycle-scoped `dm_…`/`svc_…` bind-only; durable backstop via own bind-only lifecycle-scoped `dlv_…` DELIVER consumer, **no** grant on the mixed pre-auth fan-out stream; granted record-key/event-topic read subtrees per capability | read bounded by `allowSubscribe`; ordered-consumer cleanup cannot delete KV records or streams; durable copies re-authorized (current ACL + membership + lifecycle) by the trusted reader before the `dlv` handoff; no Direct Get; DM/TASK/DLV create denied |
+| `agent` | own `chat.<owner>.<actor>.<ch>` for each `allowPublish` channel (post ACL, default-deny), `inst.*.*.<owner>.<actor>`, `svc.*.<owner>.<actor>`; endpoint request forms per minted capability (`ep.one`/`ep.all`/`ep.inst` with the capability's authz-mode/target pattern, caller triple `<owner>.<actor>.<uid>` pinned; `describe` by default; `epj` submissions for journaled capabilities; §13.9); own presence key | own `_INBOX_<connId>.>` + own endpoint reply rail (`ep.reply.*.*.*.<owner>.<actor>.<uid>.*`, exact arity); channel live tail via native `sub.allow` subscriptions to `chat.*.*.<channel>` per `allowSubscribe` (wildcards preserved); `STREAM.INFO` (stream-level state only, no body read) on `CHAT`, `DM`, `TASK`, `DLV`, and `EPC`; presence and channel-registry KV watches, including create/info/delete of their client-managed ordered consumers on those two streams only; CHAT history via single-filter `chathist_<owner>-<actor>-<uid>` creates, one per `allowSubscribe` channel (ACL-bounded); own lifecycle-scoped `dm_…`/`svc_…` bind-only; durable backstop via own bind-only lifecycle-scoped `dlv_…` DELIVER consumer, **no** grant on the mixed pre-auth fan-out stream; granted record-key/event-topic read subtrees per capability | read bounded by `allowSubscribe`; ordered-consumer cleanup cannot delete KV records or streams; durable copies re-authorized (current ACL + membership + lifecycle) by the trusted reader before the `dlv` handoff; no Direct Get; DM/TASK/DLV create denied |
 | `observer` | none | chat, CHAT history, presence, channel registry | DMs invisible |
 | `admin` | none | whole space live tap plus DM history | plaintext god-view, opt-in |
 | scoped host profiles | least-privilege per function | least-privilege per function | The former allow-all `manager` is **deleted**; its host duties split into scoped, single-function creds (`supervisor`, `provisioner`, `delivery`, `membership-rw`, `operator`, `purger`, `teardown`, `channel-writer`, …). No allow-all credential exists. Appendix B summarizes them; the concrete grant lists are **generated from the §13.9 ownership matrix** into `provision.ts` (the matrix is the single oracle; `provision.ts` is its artifact, Appendix B its summary). |
@@ -662,11 +662,14 @@ can emit only as itself and only to its declared `allowPublish` channels, and re
 DMs and chat *content* within `allowSubscribe` (and, for `durable` content, its current
 membership), enforced by the server. It does not provide
 non-repudiation, does not survive an untrusted relay, and DMs are plaintext to the broker and
-to `admin`. The read bound is on **content**, not metadata: agents hold `STREAM.INFO` on CHAT
-(for the join watermark, the recall drop-marker, and channel-list counts), so a `subjects_filter`
-query leaks chat subject *metadata* (channel names, sender ids, and per-subject counts) for
-channels outside `allowSubscribe` (channel names are already public via the registry). Hiding
-that metadata is deferred strict-containment work. See [docs/security.md](docs/security.md).
+to `admin`. The read bound is on **content**, not metadata: agents hold `STREAM.INFO` on CHAT,
+DM, TASK, DLV, and EPC (message counts, first/last seq; e.g. the join watermark, the recall
+drop-marker, and channel-list counts on CHAT, and the state a role like `board` renders from on
+the rest), so a `subjects_filter` query leaks subject *metadata* for each stream: chat subject
+metadata (channel names, sender ids, per-subject counts) for channels outside `allowSubscribe`
+(channel names are already public via the registry), and on DM/TASK, who DMed whom
+(`inst.<owner>.<actor>.<owner>.<actor>`) and who anycast which role (`svc.<role>.<owner>.<actor>`).
+Hiding that metadata is deferred strict-containment work. See [docs/security.md](docs/security.md).
 
 **Consumer-delivery confused deputy on the read grants.** A JetStream consumer delivers stored
 bytes to a **caller-chosen destination the broker does NOT confine to the requester's
@@ -3900,7 +3903,7 @@ Grouped placeholders such as `<CHAT|DM|TASK>` mean one concrete subject per list
   subscription to granted `P.epe.…` subtrees within `allowSubscribe` (bytes land only on its
   own subscription, never a caller-chosen subject)
 - `$JS.API.INFO`
-- `$JS.API.STREAM.INFO.<CHAT|KV|CHKV|DLVKV>`: CHAT plus the world-readable presence/registry/lease KVs only; **not** DM/TASK (agents bind those by name and never inspect them, so INFO there would only leak inbox/task metadata)
+- `$JS.API.STREAM.INFO.<CHAT|DM|TASK|DLV|EPC|KV|CHKV|DLVKV>`: CHAT and the world-readable presence/registry/lease KVs, plus DM/TASK/DLV (the streams `pub.deny` below also refuses consumer-create on) and EPC — stream-level state only (message counts, first/last seq), no body read; a role like `board` needs this to render
 - `$JS.API.CONSUMER.CREATE.<CHAT>.<chatHistD>.<P.chat.*.*.<ch>>` for every `allowSubscribe` channel (history reads; the single filter the server pins to the body, the agent's only CHAT consumer create. The live tail is the core `sub.allow` subscription above, not a JetStream consumer)
 - `$JS.API.CONSUMER.INFO.<CHAT>.<chatHistD>`
 - `$JS.API.CONSUMER.MSG.NEXT.<CHAT>.<chatHistD>`

--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -135,6 +135,7 @@ smoke:signing-key-rotation
 smoke:system-account-rotation
 smoke:cutover-restart-eviction
 smoke:deprovision
+smoke:provision-stream-info
 smoke:channels:auth
 smoke:e2e:acl
 smoke:cross-owner:auth

--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -135,7 +135,6 @@ smoke:signing-key-rotation
 smoke:system-account-rotation
 smoke:cutover-restart-eviction
 smoke:deprovision
-smoke:provision-stream-info
 smoke:channels:auth
 smoke:e2e:acl
 smoke:cross-owner:auth
@@ -691,3 +690,9 @@ smoke:agent-secret-segmentation
 # spellings, one of them the release workflow. The property is only observable on main after a
 # merge, so it needs a static guard. Appended so every existing shard assignment remains unchanged.
 smoke:workflow-concurrency
+# #903: the agent profile's grant template emitted the JetStream consumer-create deny triple on
+# DM/TASK/DLV and bound EPC without ever granting the matching $JS.API.STREAM.INFO, so a
+# provisioned actor (a board endpoint was the live report) was refused every stream-level state
+# read. The suite drives the read path live on all four streams and asserts the deny triple's
+# polarity survives. Appended at the END so every existing shard assignment is unchanged.
+smoke:provision-stream-info

--- a/docs/security.md
+++ b/docs/security.md
@@ -72,6 +72,11 @@ The guarantees, at a glance, each enforced by the broker per
     never message content, and channel *names* are already public via the registry. Hiding
     even the existence/volume of other channels requires the per-channel-stream model and is
     deferred strict-containment work ([roadmap](roadmap.md)).
+  - **Same leak, DM/TASK/DLV stream state:** agents also hold `STREAM.INFO` on the DM, TASK, and
+    delivery streams (message counts, first/last seq, needed for a role like `board` to render),
+    so the same `subjects_filter` query enumerates DM subjects (`inst.<owner>.<actor>.<owner>.<actor>`)
+    and task subjects (`svc.<role>.<owner>.<actor>`): who DMed whom and who anycast which role.
+    Never message content, and bounded by the same deferred per-stream-per-peer containment work.
 - **DM / task peer confidentiality**: per-identity inbox prefixes plus
   provisioner-created bind-only consumers, so an agent cannot read someone else's inbox or
   steal another role's work; durable-channel backstop reads are re-authorized by a trusted

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "smoke:cutover-restart-eviction": "tsx packages/core/smoke/cutover-restart-eviction-auth.smoke.ts",
     "smoke:evict-live:auth": "tsx packages/core/smoke/evict-live-auth.smoke.ts",
     "smoke:deprovision": "tsx packages/core/smoke/deprovision-agent-auth.smoke.ts",
+    "smoke:provision-stream-info": "tsx packages/core/smoke/provision-stream-info.smoke.ts",
     "smoke:attention": "tsx extensions/connector-core/smoke/attention.smoke.ts",
     "smoke:injection-framing": "tsx extensions/connector-core/smoke/injection-framing.smoke.ts",
     "smoke:control-reply": "tsx extensions/connector-core/smoke/control-reply.smoke.ts",

--- a/packages/core/smoke/provision-stream-info.smoke.ts
+++ b/packages/core/smoke/provision-stream-info.smoke.ts
@@ -1,0 +1,141 @@
+/**
+ * `permissionsFor`'s agent-profile grant template must include a `$JS.API.STREAM.INFO` grant for
+ * every stream family it also emits the consumer-create deny triple for (DM/TASK/DLV), plus the
+ * EPC contract store — proven end to end against a real JWT-auth nats-server, both polarities:
+ * the read path works, and the deny triple's "no consumer-create" intent survives.
+ *
+ * Run: pnpm smoke:provision-stream-info
+ */
+import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { connect, credsAuthenticator } from "@nats-io/transport-node";
+import { jetstreamManager } from "@nats-io/jetstream";
+import {
+  isReachable,
+  createSpaceAuth,
+  mintCreds,
+  serverConfig,
+  newIdentity,
+  setupSpaceStreams,
+  seedChannelRegistry,
+  provisionAgent,
+  mintLifecycleUid,
+  jwtFromCreds,
+  CotalEndpoint,
+  dmStream,
+  dlvStream,
+  taskStream,
+} from "../src/index.js";
+import { epcStreamName } from "../src/endpoint-binding.js";
+import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+
+const PORT = await pickFreePort();
+const SERVERS = `nats://127.0.0.1:${PORT}`;
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const awaitExit = (proc: ReturnType<typeof spawn>, timeoutMs = 3000): Promise<void> =>
+  new Promise((resolve) => {
+    if (proc.exitCode !== null || proc.signalCode !== null) return resolve();
+    proc.once("exit", () => resolve());
+    setTimeout(resolve, timeoutMs);
+  });
+let pass = 0;
+let fail = 0;
+const check = (name: string, cond: boolean, extra?: unknown) => {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    fail++;
+    console.log(`  ✗ FAIL: ${name}`, extra ?? "");
+  }
+};
+
+const space = `stinfo-${randomUUID().slice(0, 8)}`;
+const auth = await createSpaceAuth(space);
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
+writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
+const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
+
+try {
+  let up = false;
+  for (let i = 0; i < 50; i++) {
+    if (await isReachable(SERVERS)) { up = true; break; }
+    await wait(200);
+  }
+  if (!up) throw new Error(`auth nats-server did not come up on ${PORT}`);
+
+  const DM = dmStream(space), TASK = taskStream(space), DLV = dlvStream(space), EPC = epcStreamName(space);
+
+  const provId = newIdentity();
+  const provCreds = await mintCreds(auth, provId, "provisioner");
+  await setupSpaceStreams({ servers: SERVERS, space, creds: provCreds });
+  await seedChannelRegistry({ servers: SERVERS, space, creds: provCreds, file: { channels: { general: {} } } });
+  const prov = new CotalEndpoint({
+    space, servers: SERVERS, creds: provCreds,
+    card: { id: provId.id, name: "prov", kind: "endpoint" },
+    channels: [], consume: false, registerPresence: false, watchPresence: false, watchChannels: false,
+  });
+  await prov.start();
+
+  const boardId = newIdentity();
+  const uid = mintLifecycleUid();
+  const boardCreds = await provisionAgent(prov, auth, boardId, {
+    allowSubscribe: ["general"], allowPublish: [], role: "board", lifecycleUid: uid,
+  });
+  await prov.stop();
+
+  // The grant, off the credential itself: EPC has no deny triple of its own, so its polarity is
+  // a single positive check, alongside the minimality check that no STREAM.INFO grant was widened
+  // to a wildcard to get there.
+  const jwt = jwtFromCreds(boardCreds)!;
+  const payload = JSON.parse(Buffer.from(jwt.split(".")[1]!, "base64url").toString("utf8")) as {
+    nats?: { pub?: { allow?: string[] } };
+  };
+  const pubAllow = payload.nats?.pub?.allow ?? [];
+  check("STREAM.INFO EPC granted in the minted JWT", pubAllow.includes(`$JS.API.STREAM.INFO.${EPC}`), pubAllow);
+  check("no STREAM.INFO grant was widened to a wildcard",
+    !pubAllow.some((s) => s.startsWith("$JS.API.STREAM.INFO") && s.includes("*")), pubAllow);
+
+  const nc = await connect({
+    servers: SERVERS,
+    authenticator: credsAuthenticator(new TextEncoder().encode(boardCreds)),
+    inboxPrefix: `_INBOX_${boardId.id}`,
+    maxReconnectAttempts: 0,
+  });
+  const jsm = await jetstreamManager(nc);
+
+  // ---- polarity 1: the read path now works ----
+  for (const [label, stream] of [["DM", DM], ["TASK", TASK], ["DLV", DLV]] as const) {
+    let threw: string | undefined;
+    try { await jsm.streams.info(stream); } catch (e) { threw = (e as Error).message; }
+    check(`STREAM.INFO ${label} succeeds`, threw === undefined, threw);
+  }
+
+  // ---- polarity 2: the consumer-create deny triple survives ----
+  for (const [label, stream] of [["DM", DM], ["TASK", TASK], ["DLV", DLV]] as const) {
+    let denied = false;
+    try { await jsm.consumers.add(stream, { durable_name: "hostile" }); } catch (e) {
+      denied = /Permissions Violation/.test((e as Error).message);
+    }
+    check(`CONSUMER.CREATE ${label} still denied (the deny triple's intent survives the fix)`, denied);
+  }
+
+  await nc.drain().catch(() => {});
+
+  console.log(`\nPROVISION STREAM.INFO SMOKE ${fail === 0 ? "OK ✅" : "FAILED ❌"}  (${pass} passed, ${fail} failed)`);
+  if (fail) process.exitCode = 1;
+} catch (e) {
+  fail++;
+  console.error("  ✗ scenario threw:", (e as Error).message);
+  process.exitCode = 1;
+} finally {
+  srv.kill("SIGKILL");
+  await awaitExit(srv);
+  rmSync(dir, { recursive: true, force: true });
+  releaseBroker();
+}

--- a/packages/core/src/provision.ts
+++ b/packages/core/src/provision.ts
@@ -1167,10 +1167,13 @@ export function permissionsFor(
     // JetStream control plane — scoped to this agent's own streams/durables.
     "$JS.API.INFO",
     // STREAM.INFO: CHAT (join watermark, recall drop-marker, channel-list counts — a documented
-    // metadata surface, see SPEC §9) + the world-readable presence/registry KVs. NOT DM/TASK: agents
-    // bind their dm_<id>/svc_<role> by name and never inspect those streams, so granting INFO there
-    // would only leak DM-inbox / task subject metadata across peers for no functional gain.
+    // metadata surface, see SPEC §9) + the world-readable presence/registry KVs, PLUS DM/TASK/DLV
+    // (the three streams the create-deny below refuses body-read consumers on) and the EPC
+    // contract store. Stream-level metadata (message counts, first/last seq) carries no per-peer
+    // body, so granting it does not undo the deny triple's "no consumer-create" intent.
     `$JS.API.STREAM.INFO.${CHAT}`, `$JS.API.STREAM.INFO.${KV}`, `$JS.API.STREAM.INFO.${CHKV}`,
+    `$JS.API.STREAM.INFO.${DM}`, `$JS.API.STREAM.INFO.${TASK}`, `$JS.API.STREAM.INFO.${DLV}`,
+    `$JS.API.STREAM.INFO.${epcStreamName(space)}`,
     // Live channel delivery is the agent's own native core subscription (sub.allow over chat.*.<ch>,
     // below) — there is NO per-instance chat live-tail durable to bind. The durable backstop is
     // Plane-3 (the bind-only dlv_<id> durable below). So no CHAT consumer bind/ack grants here.


### PR DESCRIPTION
## Problem

`permissionsFor`'s agent-profile grant template emits the JetStream consumer-create deny triple

```
$JS.API.CONSUMER.CREATE.<stream>
$JS.API.CONSUMER.CREATE.<stream>.>
$JS.API.CONSUMER.DURABLE.CREATE.<stream>.>
```

on the DM, TASK, and DLV streams (the "bind your pre-created durable, never mint your own" family), but never granted the matching `$JS.API.STREAM.INFO` on any of them, and never granted it on the EPC contract store either. Every `$JS.API.*` subject is a NATS *publish*, so a provisioned actor was refused stream-level state reads (message counts, first/last seq — no message body) on all four streams, not just consumer creation.

Reported in #903: a `role: "board"` endpoint hit this on `DM_<space>` (72 live broker denials over a 6h window). The issue also flagged `DLV`/`TASK`/`EPC` as latent (same template, no caller had exercised them yet), and a follow-up comment confirmed the same class live on the `hack` space's freshly-spawned user-mode actor seats, whose connectors loop on a JetStream read-path denial and never come online — mesh-mute, indistinguishable from a dead model.

## Fix

Grant the four missing `$JS.API.STREAM.INFO.<stream>` subjects (`DM`, `TASK`, `DLV`, `EPC`) in the agent profile's `pub.allow`. No wildcard widening, no other grant touched. The deny triple's "no consumer-create" intent is unchanged.

## Proof (both polarities, live broker)

`packages/core/smoke/provision-stream-info.smoke.ts` boots a real JWT-auth `nats-server`, provisions a `role: "board"` agent through `provisionAgent`, connects with its minted creds, and drives the actual JetStream API calls:

```
✓ STREAM.INFO EPC granted in the minted JWT
✓ no STREAM.INFO grant was widened to a wildcard
✓ STREAM.INFO DM succeeds
✓ STREAM.INFO TASK succeeds
✓ STREAM.INFO DLV succeeds
✓ CONSUMER.CREATE DM still denied (the deny triple's intent survives the fix)
✓ CONSUMER.CREATE TASK still denied (the deny triple's intent survives the fix)
✓ CONSUMER.CREATE DLV still denied (the deny triple's intent survives the fix)

PROVISION STREAM.INFO SMOKE OK ✅  (8 passed, 0 failed)
```

Mutation-proven: reverting the fix and re-running turns exactly the four STREAM.INFO/EPC-grant checks red (4/8) while the three deny-triple checks stay green, confirming the test fails for the right reason rather than trivially.

Wired into the CI shard chain (`bin/smoke/ci-suites.txt`) right after its sibling `smoke:deprovision`, and added `smoke:provision-stream-info` to `package.json`.

Regression-checked against the closely related suites: `smoke:mint-provision:auth` (41/41), `smoke:deprovision` (24/24), `smoke:core-boundary` (clean), `pnpm typecheck` (all packages), `pnpm check:docs-voice` (39 pages).

## Not in scope: the CONSUMER.INFO evidence from `hack`

The follow-up comment on #903 also showed `Publish Violation` on `$JS.API.CONSUMER.INFO.TASK_hack.svc_manager` from the `hack` space. Checked against this branch: `permissionsFor` already grants `$JS.API.CONSUMER.INFO.${TASK}.${svcD}` on the role's bind-only durable (added in `a29fa111`, which predates this fix's base). That evidence is consistent with the deployed `hack.cotal.ai` broker/manager running an older core build than what's on `main` today, not a gap in the current template — no code change needed for it here.

## Docs

Extended `docs/security.md`'s existing "known metadata leak (not content)" bullet, and `SPEC.md` (§9 table, §9 prose, and Appendix B's normative agent `pub.allow` enumeration), to state that the same `subjects_filter` STREAM.INFO enumeration technique now also surfaces DM subject metadata (who DMed whom) and TASK subject metadata (who anycast which role) on top of the pre-existing CHAT leak — metadata only, never message content, bounded by the same deferred per-stream-per-peer containment work.

## Changeset

`@cotal-ai/core` patch (bug fix, template correction, no breaking change).