### PR TITLE
test: prove stop during a rebuild bind, not only start()

### DIFF
--- a/extensions/connector-core/smoke/fixtures/transport-liveness-broker.mutations.json
+++ b/extensions/connector-core/smoke/fixtures/transport-liveness-broker.mutations.json
@@ -47,8 +47,8 @@
     {
       "name": "doRebuild skips tearDownIfStopped, so a stop mid-rebuild-bind leaves the fresh nc live",
       "file": "packages/core/src/endpoint.ts",
-      "find": "      await this.connectAndBind();\n      if (await this.tearDownIfStopped()) return;\n      this.superviseConnection();",
-      "replace": "      await this.connectAndBind();\n      this.superviseConnection();",
+      "find": "      if (await this.tearDownIfStopped()) return;\n      this.superviseConnection();\n    } finally {\n      this.reconnecting = false;",
+      "replace": "      this.superviseConnection();\n    } finally {\n      this.reconnecting = false;",
       "expectRed": "stop during a REAL rebuild bind tears the just-bound connection rather than leaving nc live",
       "cell": "stop during a REAL rebuild bind tears the just-bound connection rather than leaving nc live",
       "note": "PATH-SPECIFIC. start()'s tearDownIfStopped call is left intact. A shared-tail mutation of connectAndBind's stopped emit would redden the start() cell and cannot attribute a kill to doRebuild.",

--- a/extensions/connector-core/smoke/fixtures/transport-liveness-broker.mutations.json
+++ b/extensions/connector-core/smoke/fixtures/transport-liveness-broker.mutations.json
@@ -3,7 +3,7 @@
   "guard": "real NATS transport edges reach CotalEndpoint and MeshAgent without flapping readiness",
   "command": "pnpm --filter @cotal-ai/core build && pnpm smoke:transport-liveness:broker",
   "progressPattern": "  \u2713 ",
-  "completionMarker": "SUITE COMPLETE: 9 cells",
+  "completionMarker": "SUITE COMPLETE: 13 cells",
   "proveWith": "node scripts/mutation-proof.mjs --config extensions/connector-core/smoke/fixtures/transport-liveness-broker.mutations.json",
   "why": [
     "The unit transport-liveness suite proves the stop-versus-bind race by replacing connectAndBind",
@@ -16,7 +16,14 @@
     "The second mutation covers the sibling edge on the same race. watchStatus seeds transport as soon",
     "as the dial returns, which connectAndBind reaches long before the bind completes, so that seed is",
     "the FIRST thing a stop-versus-bind race can expose. Its cell holds a real dial pending behind a TCP",
-    "proxy rather than stubbing anything, so the endpoint runs unmodified."
+    "proxy rather than stubbing anything, so the endpoint runs unmodified.",
+    "THE REBUILD MUTATION IS PATH-SPECIFIC ON PURPOSE (#1028). start() and doRebuild both await the",
+    "same unbranched connectAndBind tail, so mutating that shared `if (this.stopped) return` reddens",
+    "the START cell and cannot prove a cell reached doRebuild. The third mutation therefore skips only",
+    "doRebuild's tearDownIfStopped. That helper is what prevents a rebuild that already emitted",
+    "connection:true (the shared tail ran before stop completed) from leaving nc+heartbeat+supervisor",
+    "live and from supervising a stopped endpoint. A shared-tail mutation is deliberately NOT used to",
+    "grade the rebuild cell."
   ],
   "mutations": [
     {
@@ -35,6 +42,16 @@
       "replace": "    this.emit(\"transport\", { connected: true, server: nc.getServer() } satisfies TransportState);\n",
       "expectRed": "stop during a pending dial never seeds transport live afterwards",
       "cell": "stop during a pending dial never seeds transport live afterwards",
+      "afterRestore": "pnpm --filter @cotal-ai/core build"
+    },
+    {
+      "name": "doRebuild skips tearDownIfStopped, so a stop mid-rebuild-bind leaves the fresh nc live",
+      "file": "packages/core/src/endpoint.ts",
+      "find": "      if (await this.tearDownIfStopped()) return;\n      this.superviseConnection(); // re-arm on the fresh nc",
+      "replace": "      this.superviseConnection(); // re-arm on the fresh nc",
+      "expectRed": "stop during a REAL rebuild bind tears the just-bound connection rather than leaving nc live",
+      "cell": "stop during a REAL rebuild bind tears the just-bound connection rather than leaving nc live",
+      "note": "PATH-SPECIFIC. start()'s tearDownIfStopped call is left intact. A shared-tail mutation of connectAndBind's stopped emit would redden the start() cell and cannot attribute a kill to doRebuild.",
       "afterRestore": "pnpm --filter @cotal-ai/core build"
     }
   ]

--- a/extensions/connector-core/smoke/fixtures/transport-liveness-broker.mutations.json
+++ b/extensions/connector-core/smoke/fixtures/transport-liveness-broker.mutations.json
@@ -47,8 +47,8 @@
     {
       "name": "doRebuild skips tearDownIfStopped, so a stop mid-rebuild-bind leaves the fresh nc live",
       "file": "packages/core/src/endpoint.ts",
-      "find": "      if (await this.tearDownIfStopped()) return;\n      this.superviseConnection(); // re-arm on the fresh nc",
-      "replace": "      this.superviseConnection(); // re-arm on the fresh nc",
+      "find": "      await this.connectAndBind();\n      if (await this.tearDownIfStopped()) return;\n      this.superviseConnection();",
+      "replace": "      await this.connectAndBind();\n      this.superviseConnection();",
       "expectRed": "stop during a REAL rebuild bind tears the just-bound connection rather than leaving nc live",
       "cell": "stop during a REAL rebuild bind tears the just-bound connection rather than leaving nc live",
       "note": "PATH-SPECIFIC. start()'s tearDownIfStopped call is left intact. A shared-tail mutation of connectAndBind's stopped emit would redden the start() cell and cannot attribute a kill to doRebuild.",

--- a/extensions/connector-core/smoke/transport-liveness-broker.smoke.ts
+++ b/extensions/connector-core/smoke/transport-liveness-broker.smoke.ts
@@ -73,6 +73,7 @@ agent.on("connection", (event) => readiness.push(event));
 agent.ep.on("error", (error: Error) => {
   if (/^mesh connection closed/.test(error.message)) terminalIssueAtError = agent.connectionIssue;
 });
+let rebuildAgent: MeshAgent | undefined;
 
 try {
   check("the owned throwaway broker starts", await until(() => false, 0) || await (async () => {
@@ -212,7 +213,51 @@ try {
   );
   for (const socket of dialSockets) socket.destroy();
   await new Promise<void>((resolve) => proxy.close(() => resolve()));
+
+  // #1028: the start() mid-bind cell above does not reach doRebuild. reconnect() is the public
+  // door onto that path. Gate armPlane3 AFTER a successful first bind so the second connectAndBind
+  // (the rebuild) is the one held open; wait on the gate itself, then land stop() inside that
+  // window. Listening on the endpoint, not MeshAgent, for the same reason as the start() cell.
+  rebuildAgent = new MeshAgent({ ...cfg, name: `transport-live-rebuild-${port}` });
+  const rebuildEdges: Array<{ connected: boolean }> = [];
+  rebuildAgent.ep.on("connection", (event: { connected: boolean }) => rebuildEdges.push(event));
+  await rebuildAgent.start(100);
+  check(
+    "rebuild-race setup: first bind completed before the rebuild is forced",
+    await until(() => rebuildAgent.connected, 30_000) && rebuildEdges.some((event) => event.connected === true),
+    { ready: rebuildAgent.connected, rebuildEdges },
+  );
+  const rebuildEp = rebuildAgent.ep as unknown as { armPlane3(): Promise<void>; reconnect(): Promise<void> };
+  let rebuildBindAtFinalStep = false;
+  let releaseRebuildBind: () => void = () => {};
+  const rebuildBindGate = new Promise<void>((resolve) => { releaseRebuildBind = resolve; });
+  rebuildEp.armPlane3 = async () => { rebuildBindAtFinalStep = true; await rebuildBindGate; };
+  const rebuildEdgesBeforeReconnect = rebuildEdges.length;
+  const rebuildWork = rebuildEp.reconnect().catch(() => {});
+  const reachedRebuildFinalStep = await until(() => rebuildBindAtFinalStep, 30_000);
+  check(
+    "rebuild-race wait: stop is landed only after the rebuild bind reached armPlane3",
+    reachedRebuildFinalStep,
+    { reachedRebuildFinalStep, rebuildBindAtFinalStep },
+  );
+  await rebuildAgent.stop();
+  releaseRebuildBind();
+  await rebuildWork;
+  const rebuildNcAfterStop = (rebuildAgent.ep as unknown as { nc?: unknown }).nc;
+  check(
+    "stop during a REAL rebuild bind never announces the connection it then tears down",
+    reachedRebuildFinalStep
+      && !rebuildEdges.slice(rebuildEdgesBeforeReconnect).some((event) => event.connected === true)
+      && rebuildAgent.connected === false,
+    { reachedRebuildFinalStep, afterReconnect: rebuildEdges.slice(rebuildEdgesBeforeReconnect), ready: rebuildAgent.connected },
+  );
+  check(
+    "stop during a REAL rebuild bind tears the just-bound connection rather than leaving nc live",
+    reachedRebuildFinalStep && rebuildNcAfterStop === undefined,
+    { reachedRebuildFinalStep, rebuildNcAfterStop: rebuildNcAfterStop === undefined ? "absent" : "present" },
+  );
 } finally {
+  await rebuildAgent?.stop().catch(() => {});
   await agent.stop().catch(() => {});
   broker.kill("SIGKILL");
   await awaitExit(broker);
@@ -220,7 +265,7 @@ try {
   for (const release of releases) release();
 }
 
-const EXPECTED_CELLS = 9;
+const EXPECTED_CELLS = 13;
 const ran = pass + fail;
 console.log(`\n${fail === 0 ? "PASS" : "FAIL"}: ${pass} passed, ${fail} failed`);
 console.log(`SUITE COMPLETE: ${ran} cells`);

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -1038,10 +1038,10 @@ export class CotalEndpoint extends EventEmitter {
     // every listener reads the same edge; MeshAgent carries its own `stopping` guard and so was
     // never the one exposed, which is the point.
     //
-    // Measured for the start() caller only, by the broker suite's mid-bind cell. doRebuild is
-    // covered by this being one shared unbranched statement both callers await. If this tail ever
-    // becomes caller-aware, or the emit splits per path, that reasoning expires and the rebuild
-    // race needs a cell of its own.
+    // Measured for the start() caller by the broker suite's mid-bind cell. doRebuild is
+    // also measured, by a separate cell that holds the rebuild's connectAndBind at
+    // armPlane3 after a successful first bind and lands stop() in that window (#1028).
+    // Shared-line reasoning is no longer the rebuild proof.
     if (this.stopped) return;
     this.emit("connection", { connected: true });
   }

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -1182,7 +1182,8 @@ export class CotalEndpoint extends EventEmitter {
       // supervisor on a stopped endpoint. (Reads this.nc in its own scope — a bare `this.nc`
       // here in doRebuild narrows to `never` via TS inlining connectAndBind's assignment.)
       if (await this.tearDownIfStopped()) return;
-      this.superviseConnection(); // re-arm on the fresh nc
+      // Re-arm on the fresh nc only after the stopped fence above accepts it.
+      this.superviseConnection();
     } finally {
       this.reconnecting = false;
     }

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -1181,8 +1181,8 @@ export class CotalEndpoint extends EventEmitter {
       // stop() may have run during the await — don't leave a live connection + heartbeat +
       // supervisor on a stopped endpoint. (Reads this.nc in its own scope — a bare `this.nc`
       // here in doRebuild narrows to `never` via TS inlining connectAndBind's assignment.)
+      // Re-arm on the fresh nc only after this stopped fence accepts it.
       if (await this.tearDownIfStopped()) return;
-      // Re-arm on the fresh nc only after the stopped fence above accepts it.
       this.superviseConnection();
     } finally {
       this.reconnecting = false;


### PR DESCRIPTION
Closes #1028.

Follow-up to #981. The stopped guard before the readiness emit, and `tearDownIfStopped` after `connectAndBind`, are shared by `start()` and `doRebuild`. The broker suite proved the race for `start()` only. Shared-line reasoning is not a rebuild cell.

## Measurement

On `b5805ca2` (PR #981 head), `start()` and `doRebuild` both await the same unbranched `connectAndBind` tail. `tearDownIfStopped` is called from both. The gap was coverage, not a missing rebuild teardown. Outcome: test-only. No shipped-code change besides the guard-site comment that recorded the old "start() only" claim.

## What the cell does

After a successful first bind, `armPlane3` is gated so the *second* `connectAndBind` (the rebuild, via public `reconnect()`) is the one held open. The cell waits on that gate (named wait cell, 30s budget, no sleep-as-bet), then lands `stop()` inside the window. It asserts:

- no late `connection: true` after the rebuild starts
- the fresh `nc` is torn down (`undefined`), not left live

## Proof

- `pnpm smoke:transport-liveness:broker` 13/13 on an ephemeral throwaway nats-server (load: this box, sequential, no extra parallel build).
- `node scripts/mutation-proof.mjs --config extensions/connector-core/smoke/fixtures/transport-liveness-broker.mutations.json`: 3/3 KILLED red-and-named.
  - existing start() mid-bind emit guard
  - existing pending-dial transport seed
  - **rebuild-path only:** skip `doRebuild`'s `tearDownIfStopped`, leave `start()`'s call intact. Named cell: "stop during a REAL rebuild bind tears the just-bound connection rather than leaving nc live" (12 marks vs baseline 13).

A mutation of the shared `if (this.stopped) return` before `connection: true` would redden the start() cell and cannot be attributed to doRebuild. That mutation is deliberately not used to grade the rebuild cell.

## Not proved

- Background `reestablishLoop` after a real `nc.closed()` (supervisor self-heal). The public door used is `reconnect()` -> `rebuild()` -> `doRebuild()`. Same `doRebuild` body, different trigger.
- A stop that lands after `connectAndBind` returns but before `tearDownIfStopped` on a machine where the shared emit already fired. The nc-live assertion is the rebuild-specific half; the emit assertion can pass via the shared tail.
- Main without #981. This PR is based on `conn/phase1a-transport-liveness` because the gap is in that branch's broker suite.

No changeset: test + comment only. Do not merge; #981 is still open.