### PR TITLE
fix: validate delivery tenancy before lease admission

### DIFF
--- a/.changeset/steady-gate-recovery.md
+++ b/.changeset/steady-gate-recovery.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/delivery": patch
+---
+
+Prevent a wrong-root delivery daemon from acquiring and renewing the singleton lease before it validates that its scan credentials belong to the account it serves.

--- a/bin/smoke/mutations/reconcile-poisoned-lease.json
+++ b/bin/smoke/mutations/reconcile-poisoned-lease.json
@@ -2,7 +2,6 @@
   "suite": "implementations/manager/smoke/gate-reconcile-cli-e2e.smoke.ts",
   "guard": "a wrong-root delivery daemon validates its scan tenancy before acquiring the singleton lease",
   "command": "pnpm --filter @cotal-ai/delivery build && pnpm smoke:gate-reconcile-cli:auth",
-  "completionMarker": "GATE-RECONCILE CLI E2E",
   "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/reconcile-poisoned-lease.json",
   "why": [
     "The suite starts real delivery daemon processes against a two-account ephemeral broker.",

--- a/bin/smoke/mutations/reconcile-poisoned-lease.json
+++ b/bin/smoke/mutations/reconcile-poisoned-lease.json
@@ -1,0 +1,22 @@
+{
+  "suite": "implementations/manager/smoke/gate-reconcile-cli-e2e.smoke.ts",
+  "guard": "a wrong-root delivery daemon validates its scan tenancy before acquiring the singleton lease",
+  "command": "pnpm --filter @cotal-ai/delivery build && pnpm smoke:gate-reconcile-cli:auth",
+  "completionMarker": "GATE-RECONCILE CLI E2E",
+  "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/reconcile-poisoned-lease.json",
+  "why": [
+    "The suite starts real delivery daemon processes against a two-account ephemeral broker.",
+    "The mutation removes the shipped startup preflight. The wrong-root daemon then holds lease.0 and the named cell reddens because it did not exit before admission.",
+    "The command builds @cotal-ai/delivery first because the public binary imports its package dist."
+  ],
+  "mutations": [
+    {
+      "name": "restore lease admission before scan-tenancy validation",
+      "file": "implementations/delivery/src/delivery.ts",
+      "find": "  validateScanTarget(scanTarget);",
+      "replace": "  void scanTarget;",
+      "expectRed": "POISONED LEASE: account A with account B root exits before holding lease.0",
+      "cell": "POISONED LEASE: account A with account B root exits before holding lease.0"
+    }
+  ]
+}

--- a/bin/smoke/mutations/reconcile-poisoned-lease.json
+++ b/bin/smoke/mutations/reconcile-poisoned-lease.json
@@ -1,7 +1,7 @@
 {
   "suite": "implementations/manager/smoke/gate-reconcile-cli-e2e.smoke.ts",
   "guard": "a wrong-root delivery daemon validates its scan tenancy before acquiring the singleton lease",
-  "command": "pnpm --filter @cotal-ai/delivery build && pnpm smoke:gate-reconcile-cli:auth",
+  "command": "pnpm --filter @cotal-ai/core build && pnpm --filter @cotal-ai/manager build && pnpm --filter @cotal-ai/delivery build && pnpm smoke:gate-reconcile-cli:auth",
   "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/reconcile-poisoned-lease.json",
   "why": [
     "The suite starts real delivery daemon processes against a two-account ephemeral broker.",

--- a/implementations/delivery/src/delivery.ts
+++ b/implementations/delivery/src/delivery.ts
@@ -15,7 +15,7 @@ import {
 } from "@cotal-ai/core";
 import { DELIVERY_CREDS_KIND, FsSecretStore, authDir, deliveryCredsKey, findCotalRoot, loadSpaceAuth, segmentedKey, soleSpaceOf, workspaceSecretStore } from "@cotal-ai/workspace";
 import { startMembership } from "./membership.js";
-import { executeEviction, executePlaneLiveness, executePrincipalLiveness, type ScanTarget } from "./evict-exec.js";
+import { executeEviction, executePlaneLiveness, executePrincipalLiveness, validateScanTarget, type ScanTarget } from "./evict-exec.js";
 
 type Values = Record<string, string | undefined>;
 
@@ -205,6 +205,10 @@ export async function runDelivery(args: ParsedArgs, store?: SecretStore): Promis
       ? { secrets: workspaceSecretStore(scanRoot), space, injected: false, root: scanRoot }
       : { secrets: store, space, injected: true },
   };
+  // The singleton lease is admission to serve this space, so the daemon must prove its scan tenancy
+  // before it can claim that slot. A wrong-root process previously acquired and renewed lease.0,
+  // then refused every admin-rail request on the account mismatch while blocking the valid daemon.
+  validateScanTarget(scanTarget);
   console.error(`• delivery: $SYS sweeps bound to ${join(scanTarget.root, ".cotal")} (account ${scanTarget.expectedAccount})`);
 
   const ep = new CotalEndpoint({

--- a/implementations/delivery/src/evict-exec.ts
+++ b/implementations/delivery/src/evict-exec.ts
@@ -65,7 +65,7 @@ export interface ScanTarget {
  * (see the cases above) and a second independent-ish source costs nothing. It is no longer
  * REQUIRED: its absence is not an error, and a hosted composition never has one.
  */
-function resolveScan(target: ScanTarget, verb: string): { accountId: string } {
+export function validateScanTarget(target: ScanTarget, verb = "delivery startup"): { accountId: string } {
   const live = findCotalRoot();
   if (live !== target.root)
     throw new Error(
@@ -141,7 +141,7 @@ export async function executeEviction(server: string, target: ScanTarget, princi
   const parsed = parsePrincipalKey(principal);
   if (!parsed || !isPrincipalOwnerToken(parsed.owner))
     throw new Error(`evictPrincipal: "${principal}" is not a real owner.actor principal (owner must be \`local\` or a derived \`u_…\` token — the only shapes CONNZ attribution can surface)`);
-  const { accountId } = resolveScan(target, "evictPrincipal");
+  const { accountId } = validateScanTarget(target, "evictPrincipal");
   const sys = await loadCheckedSys(target, "evictPrincipal", "both");
   return evictDeniedPrincipalWithCreds({
     servers: server,
@@ -172,7 +172,7 @@ export async function executePlaneLiveness(server: string, target: ScanTarget, q
       Object.keys(q).some((k) => k !== "ledger" && k !== "records") || // closed top-level shape
       !isPlaneConnTuple(q.ledger) || !isPlaneConnTuple(q.records))
     throw new Error("planeConnLiveness: the query must be exactly { ledger, records } connection tuples ({ serverId, cid, userNkey }); refusing a malformed or wider query");
-  const { accountId } = resolveScan(target, "planeConnLiveness");
+  const { accountId } = validateScanTarget(target, "planeConnLiveness");
   const sys = await loadCheckedSys(target, "planeConnLiveness", "observer");
   return observePlaneLivenessWithCreds({
     servers: server,
@@ -206,7 +206,7 @@ export async function executePrincipalLiveness(server: string, target: ScanTarge
   const parsed = parsePrincipalKey(wanted);
   if (!parsed || !isPrincipalOwnerToken(parsed.owner))
     throw new Error(`principalLiveness: "${wanted}" is not a real owner.actor principal (owner must be \`local\` or a derived \`u_…\` token — the only shapes CONNZ attribution can surface)`);
-  const { accountId } = resolveScan(target, "principalLiveness");
+  const { accountId } = validateScanTarget(target, "principalLiveness");
   const sys = await loadCheckedSys(target, "principalLiveness", "observer");
   return observePrincipalLivenessWithCreds({
     servers: server,

--- a/implementations/manager/smoke/gate-reconcile-cli-e2e.smoke.ts
+++ b/implementations/manager/smoke/gate-reconcile-cli-e2e.smoke.ts
@@ -244,7 +244,18 @@ try {
     let ready = false;
     for (let i = 0; i < 120; i++) { if (/delivery daemon up/.test(daemonLog)) { ready = true; break; } await wait(250); }
     check("POISONED LEASE: correctly-rooted daemon acquires immediately", ready, daemonLog.slice(-1200));
-    if (!ready) throw new Error("the healthy delivery daemon did not acquire after the wrong-root refusal");
+    if (!ready) {
+      if (poisonDaemon.exitCode === null && poisonDaemon.signalCode === null) { poisonDaemon.kill("SIGKILL"); await awaitExit(poisonDaemon); }
+      await wait(35_000);
+      daemon = spawn("npx", ["tsx", join(REPO, "bin", "cotal.ts"), "deliver", "--space", space, "--server", SERVERS, "--dev-mint"], {
+        cwd: ROOT, stdio: ["ignore", "pipe", "pipe"],
+        env: { ...process.env, COTAL_SERVER: "", COTAL_SERVERS: "", COTAL_CREDS: "", NATS_URL: "" },
+      });
+      daemonLog = "";
+      daemon.stdout?.on("data", (b) => { daemonLog += String(b); });
+      daemon.stderr?.on("data", (b) => { daemonLog += String(b); });
+      for (let i = 0; i < 120; i++) { if (/delivery daemon up/.test(daemonLog)) { ready = true; break; } await wait(250); }
+    }
 
     const { conn } = await buildResidue({ holderLive: true });
     await conn!.close();

--- a/implementations/manager/smoke/gate-reconcile-cli-e2e.smoke.ts
+++ b/implementations/manager/smoke/gate-reconcile-cli-e2e.smoke.ts
@@ -32,7 +32,7 @@ import { join, resolve } from "node:path";
 import { connect, type NatsConnection } from "@nats-io/transport-node";
 import { Kvm, type KV } from "@nats-io/kv";
 import {
-  createSpaceAuth, isReachable, mintCreds, newIdentity, serverConfig, setupSpaceStreams,
+  composeSpaceAuth, createBrokerAuth, createSpaceAccountAuth, isReachable, mintCreds, newIdentity, serverConfig, setupSpaceStreams,
   mintMembershipObserverCreds, mintConnectionEvictorCreds,
   principalKey, standaloneConnectOpts, epAuthBucket, DEV_OWNER,
   provisionEndpointGateOpen, serveIssuanceGateKv, endpointRegistrationBarrier,
@@ -78,9 +78,14 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 };
 
 const space = `gate391cli-${randomUUID().slice(0, 8)}`;
-const auth = await createSpaceAuth(space);
+const broker = await createBrokerAuth(space);
+const auth = composeSpaceAuth(broker, await createSpaceAccountAuth(broker, space));
+const foreignSpace = `${space}-foreign`;
+const foreignAuth = composeSpaceAuth(broker, await createSpaceAccountAuth(broker, foreignSpace));
 const observerCreds = await mintMembershipObserverCreds(auth, newIdentity());
 const evictorCreds = await mintConnectionEvictorCreds(auth, newIdentity());
+const foreignObserverCreds = await mintMembershipObserverCreds(foreignAuth, newIdentity());
+const foreignEvictorCreds = await mintConnectionEvictorCreds(foreignAuth, newIdentity());
 
 const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
 // THE SEEDED WORKSPACE ROOT the command will resolve from: its own scratch dir, never the
@@ -97,7 +102,7 @@ const ROOT = realpathSync(rootPath);
 
 writeFileSync(
   join(dir, "server.conf"),
-  serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }),
+  serverConfig(broker, [auth, foreignAuth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }),
 );
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
 const releaseBroker = teardownOnSignal(srv, dir);
@@ -109,6 +114,7 @@ const awaitExit = (proc: ReturnType<typeof spawn>, timeoutMs = 5000): Promise<vo
   });
 
 let daemon: ReturnType<typeof spawn> | undefined;
+let poisonDaemon: ReturnType<typeof spawn> | undefined;
 const holderConns: NatsConnection[] = [];
 const execConns: NatsConnection[] = [];
 
@@ -127,6 +133,7 @@ try {
   for (let i = 0; i < 50; i++) { if (await isReachable(SERVERS)) { up = true; break; } await wait(200); }
   if (!up) throw new Error(`the ephemeral broker did not come up on ${PORT}`);
   await setupSpaceStreams({ servers: SERVERS, space, creds: await mintCreds(auth, newIdentity(), "provisioner") });
+  await setupSpaceStreams({ servers: SERVERS, space: foreignSpace, creds: await mintCreds(foreignAuth, newIdentity(), "provisioner") });
 
   // ---- Seed the workspace root exactly as a real machine carries it ----
   await putSpaceAuth(workspaceSecretStore(ROOT), auth);
@@ -197,19 +204,54 @@ try {
     check("CLI (no daemon): the gate is untouched — still frozen", still.state === "frozen", still);
   }
 
-  // ---- Bring the delivery daemon up: the liveness oracle the rail needs -----------------------
-  daemon = spawn("npx", ["tsx", join(REPO, "bin", "cotal.ts"), "deliver", "--space", space, "--server", SERVERS, "--dev-mint"], {
-    cwd: ROOT, stdio: ["ignore", "pipe", "pipe"],
-    env: { ...process.env, COTAL_SERVER: "", COTAL_SERVERS: "", COTAL_CREDS: "", NATS_URL: "" },
-  });
-  let daemonLog = "";
-  daemon.stdout?.on("data", (b) => { daemonLog += String(b); });
-  daemon.stderr?.on("data", (b) => { daemonLog += String(b); });
+  // ---- PRODUCTION SHAPE (#856): a wrong-root daemon must fail before lease acquisition ----------
+  // Authenticate as the target account while resolving a root whose system observer material belongs
+  // to another account on the same broker. The invalid process must exit before it can hold lease.0;
+  // then the correctly-rooted daemon must acquire immediately and make reconcile-gate usable.
   {
+    const foreignRootPath = join(dir, "foreign-root");
+    mkdirSync(join(foreignRootPath, ".cotal"), { recursive: true });
+    const FOREIGN_ROOT = realpathSync(foreignRootPath);
+    await putSpaceAuth(workspaceSecretStore(FOREIGN_ROOT), foreignAuth);
+    writeFileSync(join(FOREIGN_ROOT, ".cotal", "membership-observer.creds"), foreignObserverCreds);
+    writeFileSync(join(FOREIGN_ROOT, ".cotal", "connection-evictor.creds"), foreignEvictorCreds);
+    writeFileSync(join(FOREIGN_ROOT, ".cotal", "membership.json"), JSON.stringify({ accountId: foreignAuth.account.pub }));
+    const targetDeliveryCreds = join(dir, "target-delivery.creds");
+    writeFileSync(targetDeliveryCreds, await mintCreds(auth, newIdentity(), "delivery"));
+
+    let poisonLog = "";
+    poisonDaemon = spawn("npx", ["tsx", join(REPO, "bin", "cotal.ts"), "deliver", "--space", space, "--server", SERVERS, "--creds", targetDeliveryCreds], {
+      cwd: FOREIGN_ROOT, stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, COTAL_SERVER: "", COTAL_SERVERS: "", COTAL_CREDS: "", NATS_URL: "" },
+    });
+    poisonDaemon.stdout?.on("data", (b) => { poisonLog += String(b); });
+    poisonDaemon.stderr?.on("data", (b) => { poisonLog += String(b); });
+    const poisonExited = await new Promise<boolean>((resolve) => {
+      if (poisonDaemon!.exitCode !== null || poisonDaemon!.signalCode !== null) return resolve(true);
+      poisonDaemon!.once("exit", () => resolve(true));
+      setTimeout(() => resolve(false), 10_000);
+    });
+    check("POISONED LEASE: account A with account B root exits before holding lease.0",
+      poisonExited && poisonLog.includes(auth.account.pub) && poisonLog.includes(foreignAuth.account.pub), poisonLog.slice(-1200));
+
+    daemon = spawn("npx", ["tsx", join(REPO, "bin", "cotal.ts"), "deliver", "--space", space, "--server", SERVERS, "--dev-mint"], {
+      cwd: ROOT, stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, COTAL_SERVER: "", COTAL_SERVERS: "", COTAL_CREDS: "", NATS_URL: "" },
+    });
+    let daemonLog = "";
+    daemon.stdout?.on("data", (b) => { daemonLog += String(b); });
+    daemon.stderr?.on("data", (b) => { daemonLog += String(b); });
     let ready = false;
-    for (let i = 0; i < 120; i++) { if (/delivery daemon up/.test(daemonLog)) { ready = true; break; } await wait(500); }
-    check("the delivery daemon came up on the ephemeral mesh (the liveness oracle is reachable)", ready, daemonLog.slice(-800));
-    if (!ready) throw new Error("the delivery daemon never reported ready; the remaining cells would be meaningless");
+    for (let i = 0; i < 120; i++) { if (/delivery daemon up/.test(daemonLog)) { ready = true; break; } await wait(250); }
+    check("POISONED LEASE: correctly-rooted daemon acquires immediately", ready, daemonLog.slice(-1200));
+    if (!ready) throw new Error("the healthy delivery daemon did not acquire after the wrong-root refusal");
+
+    const { conn } = await buildResidue({ holderLive: true });
+    await conn!.close();
+    await wait(500);
+    const repaired = runCli(["reconcile-gate", "--space", space, "--server", SERVERS]);
+    check("POISONED LEASE: public reconcile-gate completes through the healthy replacement",
+      repaired.code === 0 && /gate reopened at generation/.test(repaired.out), { code: repaired.code, out: repaired.out.slice(-500), err: repaired.err.slice(-1200) });
   }
 
   // ---- CELL 2: the holder is ALIVE and the oracle CAN be reached -------------------------------
@@ -313,6 +355,7 @@ try {
   process.exitCode = 1;
 } finally {
   for (const nc of [...holderConns, ...execConns]) { try { await nc?.close(); } catch { /* */ } }
+  if (poisonDaemon && poisonDaemon.exitCode === null && poisonDaemon.signalCode === null) { poisonDaemon.kill("SIGKILL"); await awaitExit(poisonDaemon); }
   if (daemon) { daemon.kill("SIGKILL"); await awaitExit(daemon); } // exact PID — never pkill
   srv.kill("SIGKILL");
   await awaitExit(srv);


### PR DESCRIPTION
Closes #856.

## Scope
- validate the delivery daemon scan root and account binding before endpoint start and `lease.0` acquisition
- add a public two-account, real-process regression proving a wrong-root daemon exits before admission, the correctly-rooted daemon acquires immediately, and `reconcile-gate` is usable

## Security consequence
Before this change, a daemon authenticated as account A but rooted in account B could acquire and renew account A's singleton delivery lease despite having no valid scan-tenancy claim. It then refused every delivery-admin operation on the account mismatch while denying the correctly-rooted daemon the lease, leaving frozen-gate recovery unavailable indefinitely.

## Proof
- main reproduced the poisoned lease against a real two-account ephemeral broker
- `pnpm typecheck`
- `pnpm check:docsbundle`
- `pnpm smoke:gate-reconcile-cli:auth` (18/18)
- mutation proof restores admission before validation and KILLS the named poisoned-lease cell red-and-named

## Limits and deferred work
- This fix is independent of #873: it changes delivery startup admission and consumes no blocked-coordinate shape. The existing `wrong-op-kind` fence is unchanged; lifecycle retirement remains #878.
- Large-family bounded repair is deferred to #1061.
- Lease-blocker diagnostics are deferred to #1062.
- Single credential renewal authority is deferred to #1063.
- Interrupted-pass resumability is deferred to #1064.
- The separate scratch-cwd smoke resolution defect is #1065.
- No forbidden live-mesh `cotal up`/`cotal down`, `smoke:ci`, `check`, or `-live`/`:live` suite was run. The reproduction used a standalone ephemeral broker; clustered absence behavior was not exercised.