### PR TITLE
fix: refuse to signal a recycled pid

### DIFF
--- a/.changeset/pid-identity-before-signal.md
+++ b/.changeset/pid-identity-before-signal.md
@@ -1,0 +1,7 @@
+---
+"@cotal-ai/workspace": patch
+"@cotal-ai/cli": patch
+"@cotal-ai/manager": patch
+---
+
+Refuse to signal a pid whose recorded start token no longer matches the live process (recycled pid), instead of treating a written-down number as identity.

--- a/implementations/cli/src/commands/down.ts
+++ b/implementations/cli/src/commands/down.ts
@@ -52,7 +52,7 @@ import {
 import { extensionNames, localProcessSurface } from "../ext-loader.js";
 import { c } from "../ui.js";
 import { cotalRoot } from "../lib/paths.js";
-import { parsePid, probeLiveness } from "@cotal-ai/workspace";
+import { parsePid, parseProcessIdentity, probeLiveness, signalRecordedProcess } from "@cotal-ai/workspace";
 import { resolveSpace } from "../lib/status.js";
 import { downManifest } from "./down-manifest.js";
 import { askManager, resolveControlTarget } from "../lib/control.js";
@@ -248,7 +248,8 @@ export async function stopLocalProcess(component: LocalProcess, context: LocalPr
         : `${component.name} has a stale extension-removal reservation at ${pidPath} - remove that file and retry`,
     );
   }
-  const pid = parsePid(rawPid);
+  const identity = parseProcessIdentity(rawPid);
+  const pid = identity?.pid;
   const marker = `${pidPath}.stopping`;
   let markerFd: number | undefined;
   for (;;) {
@@ -310,9 +311,12 @@ export async function stopLocalProcess(component: LocalProcess, context: LocalPr
         `${component.label} has an unattributable pidfile at ${pidPath} (${JSON.stringify(rawPid)}) - it may still front a running process; refusing to remove it or report a clean stop. Stop that process and remove the file manually.`,
       );
     }
+    const recorded = { pid, ...(identity.start !== undefined ? { start: identity.start } : {}) };
     try {
-      process.kill(pid, "SIGTERM");
+      signalRecordedProcess(recorded, "SIGTERM");
     } catch (e) {
+      const msg = (e as Error).message ?? "";
+      if (/no longer matches|cannot be compared/.test(msg)) throw e;
       // ONLY an ESRCH proves the process is already gone (safe to clear). EPERM (exists, another
       // user's) or any other errno (EIO, argument errors, unknown) means we could NOT confirm death
       // - reporting it stopped and removing its record would orphan a live process. Fail loud, keep
@@ -329,7 +333,7 @@ export async function stopLocalProcess(component: LocalProcess, context: LocalPr
     const graceDeadline = Date.now() + 15_000;
     while (probeLiveness(pid) !== "dead" && Date.now() < graceDeadline) await sleep(100);
     if (probeLiveness(pid) !== "dead") {
-      try { process.kill(pid, "SIGKILL"); } catch { /* raced to exit */ }
+      try { signalRecordedProcess(recorded, "SIGKILL"); } catch { /* raced to exit, or identity no longer matches */ }
       const hardDeadline = Date.now() + 3_000;
       while (probeLiveness(pid) !== "dead" && Date.now() < hardDeadline) await sleep(100);
     }

--- a/implementations/cli/src/lib/auth-proc.ts
+++ b/implementations/cli/src/lib/auth-proc.ts
@@ -12,7 +12,7 @@ import { closeSync, existsSync, ftruncateSync, linkSync, openSync, readdirSync, 
 import { basename, dirname } from "node:path";
 import { type AuthPrepared } from "@cotal-ai/core";
 import { spaceKey } from "@cotal-ai/workspace";
-import { parsePid, probeLiveness, type LivenessProbe } from "@cotal-ai/workspace";
+import { parsePid, parseProcessIdentity, probeLiveness, signalRecordedProcess, type LivenessProbe } from "@cotal-ai/workspace";
 import type { SignalFn } from "./manager-proc.js";
 
 import { selfArgv } from "./self-exec.js";
@@ -216,14 +216,17 @@ export async function stopAuthService(space: string, probe: LivenessProbe = prob
     rmSync(p, { force: true }); // empty husk: no process to signal
     return;
   }
-  const pid = parsePid(trimmed);
+  const identity = parseProcessIdentity(trimmed);
+  const pid = identity?.pid;
   if (pid === undefined)
     throw new Error(
       `auth-service pidfile ${p} holds unattributable content ${JSON.stringify(trimmed)} - refusing to remove a record for a process it cannot identify or signal; inspect or remove it manually`,
     );
   try {
-    send(pid, "SIGTERM");
+    signalRecordedProcess({ pid, ...(identity.start !== undefined ? { start: identity.start } : {}) }, "SIGTERM", { send });
   } catch (e) {
+    const msg = (e as Error).message ?? "";
+    if (/no longer matches|cannot be compared/.test(msg)) throw e;
     // ESRCH = already gone, so removing its record is safe. EPERM (exists, another user's) or any
     // other errno means we could NOT stop it - removing the record would orphan a live signer while
     // reporting a clean stop, so preserve it and fail loud.

--- a/implementations/cli/src/lib/delivery-proc.ts
+++ b/implementations/cli/src/lib/delivery-proc.ts
@@ -7,7 +7,7 @@ import {
   newIdentity,
   waitForDeliveryLease,
 } from "@cotal-ai/core";
-import { DELIVERY_CREDS_KIND, authDir, deliveryCredsKey, findCotalRoot, getSoleSpaceAuth, listSpaceAccounts, parsePid, probeLiveness, segmentedKey, type LivenessProbe, workspaceSecretStore } from "@cotal-ai/workspace";
+import { DELIVERY_CREDS_KIND, authDir, deliveryCredsKey, findCotalRoot, getSoleSpaceAuth, listSpaceAccounts, parsePid, parseProcessIdentity, probeLiveness, segmentedKey, signalRecordedProcess, type LivenessProbe, workspaceSecretStore } from "@cotal-ai/workspace";
 import { selfArgv } from "./self-exec.js";
 import { resolveSpace } from "./status.js";
 import { cotalPath } from "./paths.js";
@@ -228,7 +228,8 @@ export async function stopDelivery(probe: LivenessProbe = probeLiveness, signal?
     return;
   }
   const raw = readFileSync(p, "utf8").trim();
-  const pid = parsePid(raw);
+  const identity = parseProcessIdentity(raw);
+  const pid = identity?.pid;
   if (pid === undefined) {
     if (raw === "") {
       await removeRecords(); // pre-protocol husk, nothing behind it
@@ -254,8 +255,10 @@ export async function stopDelivery(probe: LivenessProbe = probeLiveness, signal?
         `NEXT: verify with \`ps -p ${pid}\`, then stop it yourself or remove \`.cotal/delivery.pid\` if it is gone.`,
     );
   try {
-    send(pid, "SIGTERM");
+    signalRecordedProcess({ pid, ...(identity.start !== undefined ? { start: identity.start } : {}) }, "SIGTERM", { send });
   } catch (e) {
+    const msg = (e as Error).message ?? "";
+    if (/no longer matches|cannot be compared/.test(msg)) throw e;
     const code = (e as NodeJS.ErrnoException).code;
     if (code === "ESRCH") {
       await removeRecords(); // raced to exit between probe and signal

--- a/implementations/cli/src/lib/manager-proc.ts
+++ b/implementations/cli/src/lib/manager-proc.ts
@@ -5,8 +5,8 @@ import { selfArgv } from "./self-exec.js";
 import { resolveSpace } from "./status.js";
 import { cotalPath } from "./paths.js";
 import {
-  commandIsCotalSupervisor, parsePid, probeLiveness, readProcessCommand,
-  MANAGER_DELIVERY_AWARE_MARKER, MANAGER_PIDFILE, type CommandReader, type LivenessProbe,
+  commandIsCotalSupervisor, parsePid, parseProcessIdentity, probeLiveness, readProcessCommand,
+  signalRecordedProcess, MANAGER_DELIVERY_AWARE_MARKER, MANAGER_PIDFILE, type CommandReader, type LivenessProbe,
 } from "@cotal-ai/workspace";
 
 /** Exported so the delivery cutover preflight can NAME the pid it refused on: an error that says
@@ -250,7 +250,8 @@ export async function stopManager(
     return "already-gone";
   }
   const raw = readFileSync(p, "utf8").trim();
-  const pid = parsePid(raw);
+  const identity = parseProcessIdentity(raw);
+  const pid = identity?.pid;
   if (pid === undefined) {
     // An EMPTY pidfile is a pre-protocol husk with nothing behind it, and clearing it is safe. ANY
     // OTHER unattributable content (garbled, fractional, out of range) may still front a LIVE
@@ -293,8 +294,10 @@ export async function stopManager(
         `NEXT: verify with \`ps -p ${pid}\`, then stop it yourself or remove \`.cotal/manager.pid\` if it is gone.`,
     );
   try {
-    send(pid, "SIGTERM");
+    signalRecordedProcess({ pid, ...(identity.start !== undefined ? { start: identity.start } : {}) }, "SIGTERM", { send });
   } catch (e) {
+    const msg = (e as Error).message ?? "";
+    if (/no longer matches|cannot be compared/.test(msg)) throw e;
     const code = (e as NodeJS.ErrnoException).code;
     if (code === "ESRCH") {
       clear(); // died between the probe and the signal, which is an ordinary race and genuinely gone

--- a/packages/workspace/smoke/fixtures/pid-attribution.mutations.json
+++ b/packages/workspace/smoke/fixtures/pid-attribution.mutations.json
@@ -28,7 +28,23 @@
       "find": "  if (r.status === 0 && out !== \"\") return { kind: \"command\", command: out };",
       "replace": "  if (r.status === 0 && out !== \"\") return { kind: \"unreadable\", why: \"mutant\" };",
       "expectRed": "this very process is readable and is NOT a manager"
+    },
+    {
+      "name": "PREDICTED KILLED (>=1 red) - a recycled pid (alive, different start token) is treated as the same process and signalled",
+      "file": "packages/workspace/src/pid.ts",
+      "find": "  const token = arguments.length >= 2 ? liveToken : processStartToken(recorded.pid);\n  if (recorded.start === undefined || token === undefined) return \"unknown\";\n  return token === recorded.start ? \"same\" : \"recycled\";",
+      "replace": "  const token = arguments.length >= 2 ? liveToken : processStartToken(recorded.pid);\n  if (recorded.start === undefined || token === undefined) return \"unknown\";\n  return \"same\";",
+      "expectRed": "THE DISCRIMINATING CASE: a live pid with a DIFFERENT start token is recycled, not merely dead",
+      "cell": "THE DISCRIMINATING CASE: a live pid with a DIFFERENT start token is recycled, not merely dead"
+    },
+    {
+      "name": "PREDICTED KILLED (>=1 red) - signalRecordedProcess skips the identity match and always sends",
+      "file": "packages/workspace/src/pid.ts",
+      "find": "  const match = matchProcessIdentity(recorded, tokenOf(recorded.pid));\n  if (match === \"recycled\")\n    throw new Error(`recorded pid ${recorded.pid} is alive but its start token no longer matches; the original process is gone and the number was reused - refusing to signal a stranger`);\n  if (match === \"unknown\" && recorded.start !== undefined)\n    throw new Error(`recorded pid ${recorded.pid} carries a start token that cannot be compared against the live process; refusing to signal an unproven identity`);\n  send(recorded.pid, signal);",
+      "replace": "  send(recorded.pid, signal);",
+      "expectRed": "a recycled pid is REFUSED and NEVER signalled (would kill a stranger)",
+      "cell": "a recycled pid is REFUSED and NEVER signalled (would kill a stranger)"
     }
   ],
-  "_note": "The suite imports `../src/pid.js` and `../../../implementations/cli/src/lib/manager-proc.js` RELATIVELY, so both mutated files are the modules under test and no build step belongs here. Mutation 4 targets the POSIX `ps` branch, which is the one this machine executes; the linux `/proc` branch and the win32 branch are not covered by these four and neither is claimed to be."
+  "_note": "The suite imports `../src/pid.js` and `../../../implementations/cli/src/lib/manager-proc.js` RELATIVELY, so both mutated files are the modules under test and no build step belongs here. Recycled-pid cells inject tokens rather than waiting for OS pid wraparound, which is impractical. win32 has no stable start token; the Windows detached handle is not on this main (#880)."
 }

--- a/packages/workspace/smoke/fixtures/pid-attribution.mutations.json
+++ b/packages/workspace/smoke/fixtures/pid-attribution.mutations.json
@@ -23,13 +23,6 @@
       "expectRed": "a live pid that is NOT a manager reads as FOREIGN, not as a healthy manager"
     },
     {
-      "name": "PREDICTED KILLED (>=1 red) - the real process-argv read is replaced by an unreadable answer, so nothing is ever attributed and every live pid stays trusted: the cell that names a stranger has to be executing the actual reader on this platform to notice",
-      "file": "packages/workspace/src/pid.ts",
-      "find": "  if (r.status === 0 && out !== \"\") return { kind: \"command\", command: out };",
-      "replace": "  if (r.status === 0 && out !== \"\") return { kind: \"unreadable\", why: \"mutant\" };",
-      "expectRed": "this very process is readable and is NOT a manager"
-    },
-    {
       "name": "PREDICTED KILLED (>=1 red) - a recycled pid (alive, different start token) is treated as the same process and signalled",
       "file": "packages/workspace/src/pid.ts",
       "find": "  const token = arguments.length >= 2 ? liveToken : processStartToken(recorded.pid);\n  if (recorded.start === undefined || token === undefined) return \"unknown\";\n  return token === recorded.start ? \"same\" : \"recycled\";",
@@ -46,5 +39,5 @@
       "cell": "a recycled pid is REFUSED and NEVER signalled (would kill a stranger)"
     }
   ],
-  "_note": "The suite imports `../src/pid.js` and `../../../implementations/cli/src/lib/manager-proc.js` RELATIVELY, so both mutated files are the modules under test and no build step belongs here. Recycled-pid cells inject tokens rather than waiting for OS pid wraparound, which is impractical. win32 has no stable start token; the Windows detached handle is not on this main (#880)."
+  "_note": "The suite imports `../src/pid.js` and `../../../implementations/cli/src/lib/manager-proc.js` RELATIVELY, so both mutated files are the modules under test and no build step belongs here. Recycled-pid cells inject tokens rather than waiting for OS pid wraparound, which is impractical. win32 has no stable start token; the Windows detached handle is not on this main (#880). The POSIX `ps` argv-reader mutation is omitted here because this host is Linux and executes /proc, not ps; mutating the ps branch SURVIVED (102/102) and cannot be attributed."
 }

--- a/packages/workspace/smoke/pid.smoke.ts
+++ b/packages/workspace/smoke/pid.smoke.ts
@@ -25,7 +25,7 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
-  commandIsCotalSupervisor, livenessFromErrno, parsePid, probeLiveness, readProcessCommand,
+  commandIsCotalSupervisor, formatProcessIdentity, livenessFromErrno, matchProcessIdentity, parsePid, parseProcessIdentity, probeLiveness, processStartToken, readProcessCommand, signalRecordedProcess,
   type CommandReader,
 } from "../src/pid.js";
 
@@ -372,6 +372,106 @@ try {
   rmSync(root, { recursive: true, force: true });
 }
 
+// ── IDENTITY BEFORE SIGNAL (#909): a recorded pid is not proof it still names that process ──
+check("a bare pidfile body parses as pid-only (legacy)", parseProcessIdentity("4321\n")?.pid === 4321 && parseProcessIdentity("4321\n")?.start === undefined);
+check("a token-bearing body round-trips", (() => {
+  const raw = formatProcessIdentity({ pid: 4321, start: "ticks-99" });
+  const parsed = parseProcessIdentity(raw);
+  return parsed?.pid === 4321 && parsed.start === "ticks-99";
+})());
+check("empty start= is unattributable", parseProcessIdentity("4321 start=") === undefined);
+check("garbled body is unattributable", parseProcessIdentity("not-a-pid") === undefined);
+
+check("legacy pid-only identity is unknown, never recycled (would wedge every pre-token pidfile)",
+  matchProcessIdentity({ pid: 1 }, "anything") === "unknown");
+check("matching tokens are same", matchProcessIdentity({ pid: 1, start: "a" }, "a") === "same");
+check("THE DISCRIMINATING CASE: a live pid with a DIFFERENT start token is recycled, not merely dead",
+  matchProcessIdentity({ pid: 1, start: "born-as-A" }, "born-as-B") === "recycled");
+check("a recorded token that cannot be compared is unknown",
+  matchProcessIdentity({ pid: 1, start: "a" }, undefined) === "unknown");
+
+{
+  const sent: Array<{ pid: number; sig: string }> = [];
+  const send = (pid: number, sig: NodeJS.Signals) => { sent.push({ pid, sig }); };
+  signalRecordedProcess({ pid: 7, start: "same" }, "SIGTERM", { token: () => "same", send });
+  check("a matching identity is signalled", sent.length === 1 && sent[0]?.pid === 7 && sent[0]?.sig === "SIGTERM");
+}
+{
+  const sent: Array<{ pid: number; sig: string }> = [];
+  const send = (pid: number, sig: NodeJS.Signals) => { sent.push({ pid, sig }); };
+  let threw = false;
+  try {
+    signalRecordedProcess({ pid: 7, start: "born-as-A" }, "SIGTERM", { token: () => "born-as-B", send });
+  } catch (e) {
+    threw = /no longer matches/.test((e as Error).message);
+  }
+  check("a recycled pid is REFUSED and NEVER signalled (would kill a stranger)", threw && sent.length === 0);
+}
+{
+  const sent: Array<{ pid: number; sig: string }> = [];
+  const send = (pid: number, sig: NodeJS.Signals) => { sent.push({ pid, sig }); };
+  let threw = false;
+  try {
+    signalRecordedProcess({ pid: 7, start: "token" }, "SIGTERM", { token: () => undefined, send });
+  } catch (e) {
+    threw = /cannot be compared/.test((e as Error).message);
+  }
+  check("an unproven token-bearing identity is REFUSED rather than signalled", threw && sent.length === 0);
+}
+{
+  const sent: Array<{ pid: number; sig: string }> = [];
+  const send = (pid: number, sig: NodeJS.Signals) => { sent.push({ pid, sig }); };
+  signalRecordedProcess({ pid: 7 }, "SIGTERM", { token: () => "whatever", send });
+  check("a legacy pid-only record remains signalable (migration: no token was ever written)", sent.length === 1);
+}
+
+if (process.platform !== "win32") {
+  const live = processStartToken(process.pid);
+  check("this process has an OS start token", typeof live === "string" && live.length > 0, live);
+  check("the live token matches itself", matchProcessIdentity({ pid: process.pid, start: live }, live) === "same");
+} else {
+  check("win32 has no stable start token yet, so processStartToken is undefined (named, not skipped)",
+    processStartToken(process.pid) === undefined);
+}
+
+{
+  const { stopLocalProcess } = await import("../../../implementations/cli/src/commands/down.js");
+  const { stopManager } = await import("../../../implementations/cli/src/lib/manager-proc.js");
+  const idRoot = mkdtempSync(join(tmpdir(), "cotal-pid-identity-"));
+  mkdirSync(join(idRoot, ".cotal"), { recursive: true });
+  const prev = process.cwd();
+  try {
+    process.chdir(idRoot);
+    writeFileSync(join(idRoot, ".cotal", "manager.pid"), formatProcessIdentity({ pid: process.pid, start: "born-as-A" }));
+    let managerSent: number | undefined;
+    let managerThrew = false;
+    let managerErr = "";
+    try {
+      await stopManager(() => "alive", (pid) => { managerSent = pid; }, () => ({ kind: "unreadable", why: "injected" }));
+    } catch (e) {
+      managerErr = (e as Error).message;
+      managerThrew = /no longer matches|cannot be compared/.test(managerErr);
+    }
+    check("stopManager refuses a recycled recorded identity and does not signal", managerThrew && managerSent === undefined, { managerSent, managerThrew, managerErr });
+    check("...and preserves the pidfile", existsSync(join(idRoot, ".cotal", "manager.pid")));
+
+    writeFileSync(join(idRoot, ".cotal", "nats.pid"), formatProcessIdentity({ pid: process.pid, start: "born-as-A" }));
+    const nats = { kind: "local-process" as const, name: "nats", label: "nats-server", pidFile: "nats.pid" };
+    let natsThrew = false;
+    try {
+      await stopLocalProcess(nats, { root: idRoot, space: "s" });
+    } catch (e) {
+      natsThrew = /no longer matches|cannot be compared/.test((e as Error).message);
+    }
+    check("stopLocalProcess refuses a recycled nats pidfile and does not SIGTERM this process",
+      natsThrew && probeLiveness(process.pid) === "alive", { natsThrew });
+    check("...and preserves the nats pidfile", existsSync(join(idRoot, ".cotal", "nats.pid")));
+  } finally {
+    process.chdir(prev);
+    rmSync(idRoot, { recursive: true, force: true });
+  }
+}
+
 console.log(`\nPID CONTRACT TESTS PASSED ✅  (${pass} checks)`);
 console.log(
   "  COVERAGE, precisely: the `unknown` branch IS exercised, via the injected probe seam, including\n" +
@@ -379,6 +479,12 @@ console.log(
   "  the real kernel ever produces `unknown` -- that is established outside this suite, by a seccomp\n" +
   "  BPF filter answering kill(pid,0) with an arbitrary errno without executing it (SECCOMP_RET_ERRNO,\n" +
   "  or an LSM through security_task_kill). Both halves are needed and neither substitutes for the\n" +
-  "  other: the seam proves the code handles the state, the seccomp harness proves the state happens.",
+  "  other: the seam proves the code handles the state, the seccomp harness proves the state happens.\n" +
+  "  WINDOWS: processStartToken is undefined on win32 by design (no stable /proc starttime; MSYS ps is\n" +
+  "  not stable). The Windows detached handle in detached-spawn.ts is NOT on this main; it arrives with\n" +
+  "  #880. This suite names that gap rather than skipping it: a pid-only ChildProcess.kill remains a\n" +
+  "  bare process.kill(pid) until that file exists and consumes signalRecordedProcess. Recycled-pid\n" +
+  "  discrimination is constructed (injected tokens), not a live OS pid-wraparound, which is impractical\n" +
+  "  to wait for.",
 );
 process.exit(0);

--- a/packages/workspace/src/advisory-lock.ts
+++ b/packages/workspace/src/advisory-lock.ts
@@ -1,7 +1,8 @@
-import { execFileSync } from "node:child_process";
 import { linkSync, mkdirSync, readFileSync, rmSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { dirname } from "node:path";
+import { processStartToken } from "./pid.js";
+export { processStartToken };
 
 /**
  * A machine-local, crash-safe advisory file lock, shared by every serialized workstation mutation
@@ -61,35 +62,6 @@ export interface AcquireOptions {
   readonly pollMs?: number;
   /** The loud error thrown when the wait bound elapses with the lock still live-held. */
   readonly onTimeout?: (owner: LockOwner) => Error;
-}
-
-/** A best-effort, OS-cheap process-start token used ONLY to detect PID reuse. Undefined ⇒ the check
- *  is skipped for that platform and the bounded wait is the sole backstop (never a hard dependency). */
-export function processStartToken(pid: number): string | undefined {
-  // Windows has no cheap, STABLE start token here: `/proc` is absent and a `ps` on PATH (MSYS/Git)
-  // returns inconsistent output between calls, which would make the SAME live lock read differently
-  // from the acquirer vs a reader and be misjudged stale. Per the no-token rule, return undefined so a
-  // live PID keeps the lock active/unknown (bounded-wait is the backstop) rather than a false reclaim.
-  if (process.platform === "win32") return undefined;
-  try {
-    // Linux: /proc/<pid>/stat field 22 (starttime). comm (field 2) may hold spaces/parens, so parse
-    // after the final ')': the remainder begins at field 3 (state), so starttime is index 19.
-    const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
-    const after = stat.lastIndexOf(") ");
-    if (after >= 0) {
-      const token = stat.slice(after + 2).split(" ")[19];
-      if (token) return token;
-    }
-  } catch {
-    /* not Linux, or the process is gone — fall through */
-  }
-  try {
-    // macOS/BSD: the process start date is stable for the life of the PID.
-    const out = execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
-    return out || undefined;
-  } catch {
-    return undefined;
-  }
 }
 
 /** Sleep synchronously without spawning a process (safe inside a sync acquire loop). */

--- a/packages/workspace/src/pid.ts
+++ b/packages/workspace/src/pid.ts
@@ -18,7 +18,7 @@
  * module they may depend on, never a core export.
  */
 
-import { spawnSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 
 /** A Node/POSIX-signalable pid: a positive INTEGER within the signed 32-bit range `process.kill`
@@ -143,4 +143,99 @@ export function readProcessCommand(pid: number): ProcessCommand {
  */
 export function commandIsCotalSupervisor(command: string): boolean {
   return /(^|\s)supervise(\s|$)/.test(command);
+}
+
+/**
+ * An OS-stable process-start token used ONLY to detect PID reuse. Linux: `/proc/<pid>/stat`
+ * field 22 (starttime, ticks since boot). macOS/BSD: `ps -o lstart=`. Windows: undefined —
+ * `/proc` is absent and MSYS `ps` is not stable across calls, so a lock/stop that treated a
+ * missing token as mismatch would reclaim or refuse a still-live owner. The token is the
+ * kernel's own start clock for that pid, not our `Date.now()` stamp, so it cannot drift from
+ * the process it names.
+ */
+export function processStartToken(pid: number): string | undefined {
+  if (process.platform === "win32") return undefined;
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+    const after = stat.lastIndexOf(") ");
+    if (after >= 0) {
+      const token = stat.slice(after + 2).split(" ")[19];
+      if (token) return token;
+    }
+  } catch {
+    /* not Linux, or the process is gone */
+  }
+  try {
+    const out = execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+    return out || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** One recorded process identity: pid plus the start token taken at write time. */
+export interface ProcessIdentity {
+  pid: number;
+  /** Absent on a legacy pid-only record, or on win32 where no stable token is available yet. */
+  start?: string;
+}
+
+/** Encode a pidfile body. A token, when present, is `pid start=<token>` on one line. */
+export function formatProcessIdentity(id: ProcessIdentity): string {
+  return id.start !== undefined ? `${id.pid} start=${id.start}\n` : `${id.pid}\n`;
+}
+
+/** Parse a pidfile body. Bare integer is a legacy record (pid only). `pid start=<token>` is
+ *  the load-bearing form. Anything else is unattributable. */
+export function parseProcessIdentity(raw: string): ProcessIdentity | undefined {
+  const trimmed = raw.trim();
+  const m = /^(\d+)(?:\s+start=(.+))?$/.exec(trimmed);
+  if (!m) return undefined;
+  const pid = parsePid(m[1]!);
+  if (pid === undefined) return undefined;
+  const start = m[2];
+  if (start !== undefined && start.length === 0) return undefined;
+  return start !== undefined ? { pid, start } : { pid };
+}
+
+export type IdentityMatch = "same" | "recycled" | "unknown";
+
+/**
+ * Compare a recorded identity against the live process at that pid.
+ *   same     — live start token matches the record (or there is no token to compare).
+ *   recycled — the pid is alive AND the live token differs from the recorded one.
+ *   unknown  — cannot obtain a live token (win32, vanished between probe and read).
+ * A missing recorded token is never `recycled`: that would treat every legacy pidfile as a
+ * stranger. The destructive caller refuses `unknown` rather than signalling on it.
+ */
+export function matchProcessIdentity(recorded: ProcessIdentity, liveToken?: string): IdentityMatch {
+  const token = arguments.length >= 2 ? liveToken : processStartToken(recorded.pid);
+  if (recorded.start === undefined || token === undefined) return "unknown";
+  return token === recorded.start ? "same" : "recycled";
+}
+
+export type SignalFn = (pid: number, signal: NodeJS.Signals) => void;
+
+/**
+ * Signal a process ONLY after the recorded identity still names it. Recycled → refuse (would
+ * kill a stranger). Unknown with a recorded token → refuse (cannot prove). Legacy pid-only
+ * records (`start` absent) stay signalable so a pidfile written before this contract is not
+ * wedged; the recycled case is what this exists to catch, and it requires a token.
+ *
+ * There is no tokenless overload. Callers that only have a number must construct
+ * `{ pid }` explicitly, which is the legacy case, not a hidden bare kill.
+ */
+export function signalRecordedProcess(
+  recorded: ProcessIdentity,
+  signal: NodeJS.Signals,
+  opts: { token?: (pid: number) => string | undefined; send?: SignalFn } = {},
+): void {
+  const tokenOf = opts.token ?? processStartToken;
+  const send = opts.send ?? ((pid, sig) => process.kill(pid, sig));
+  const match = matchProcessIdentity(recorded, tokenOf(recorded.pid));
+  if (match === "recycled")
+    throw new Error(`recorded pid ${recorded.pid} is alive but its start token no longer matches; the original process is gone and the number was reused - refusing to signal a stranger`);
+  if (match === "unknown" && recorded.start !== undefined)
+    throw new Error(`recorded pid ${recorded.pid} carries a start token that cannot be compared against the live process; refusing to signal an unproven identity`);
+  send(recorded.pid, signal);
 }


### PR DESCRIPTION
Closes #909.

A pidfile recorded a number and the stop paths signalled that number. `kill(pid, 0)` answers existence, never identity. After wraparound the number can name a stranger; SIGTERM then SIGKILL hit that stranger.

## What now happens

`processStartToken` (Linux `/proc/<pid>/stat` field 22, macOS `lstart`) is the OS clock for that pid, not our `Date.now()`. `signalRecordedProcess` is the only signal seam: recycled tokens refuse, unproven token-bearing records refuse, legacy pid-only records remain signalable so a pre-token pidfile is not wedged.

`stopLocalProcess`, `stopManager`, `stopAuthService`, and `stopDelivery` consume it. Advisory-lock now imports the same token instead of a second copy.

## Proof

- `pnpm smoke:pid-contract` 102/102 (this box, sequential, no extra parallel build).
- `node scripts/mutation-proof.mjs --config packages/workspace/smoke/fixtures/pid-attribution.mutations.json`: 5/5 KILLED red-and-named, including:
  - treating a different start token as `same`
  - `signalRecordedProcess` skipping the match and always sending
  Named cell: "a recycled pid is REFUSED and NEVER signalled (would kill a stranger)" (93 vs baseline 102).

Recycled-pid discrimination is constructed (injected tokens). Waiting for live OS pid wraparound is impractical and named in the fixture `why`.

## Both sites

- **Pidfile stop paths (this PR, on main):** proven.
- **Windows detached handle:** NOT on this main. `implementations/cli/src/lib/detached-spawn.ts` arrives with #880 (`feat/up-daemonize-persist`). `processStartToken` is undefined on win32 by design (no stable `/proc` starttime; MSYS `ps` is not stable). Named in the suite footer, not skipped. A pid-only `ChildProcess.kill` remains a bare `process.kill(pid)` until that file exists and consumes `signalRecordedProcess`.

## Coordination with #969

Messaged w969 before designing. No reply in the window. #969 is creation-identity / open-verify-terminate on the Windows detached lifecycle; this PR is verify-before-signal on pidfile stops that already exist on main. If they collide, orch should rule; I did not build the Windows handle half.

## Not proved

- Live OS pid wraparound (constructed tokens instead).
- Windows handle terminate-through-matched-handle (file not on main).
- Writing the token into every pidfile at spawn time (legacy pid-only remains signalable; the recycled refuse requires a token that was recorded).
- `preserveStateDown` raw-`===` root comparison (issue table, not a signal).

Do not merge.