### PR TITLE
fix(ci): build before running smoke shards

### DIFF
--- a/bin/smoke/ci-suites.smoke.ts
+++ b/bin/smoke/ci-suites.smoke.ts
@@ -48,6 +48,18 @@ const same = (a: unknown, b: string[]) => JSON.stringify(a) === JSON.stringify(b
 
 console.log("ci-suites: the chain file's parser");
 
+// The root entrypoint must produce the dist/ that package-importing suites grade. The hosted CI
+// workflow also builds before invoking shard.mjs directly, but `pnpm smoke:ci` is the documented
+// local gate and must not depend on ambient artifacts from an earlier checkout or edit.
+const packageScripts = (JSON.parse(readFileSync(join(process.cwd(), "package.json"), "utf8")) as {
+  scripts?: Record<string, string>;
+}).scripts ?? {};
+check(
+  "smoke:ci builds before starting its shard",
+  packageScripts["smoke:ci"] === "pnpm build && node bin/smoke/shard.mjs 0 1",
+  packageScripts["smoke:ci"],
+);
+
 // ---- Comments and blanks are removed, and are NOT entries --------------------------------------
 const withNoise = ["# a heading", "", "smoke:alpha", "   ", "# trailing note", "smoke:beta", ""].join("\n");
 check(
@@ -163,7 +175,7 @@ check(
   simultaneousAppendsConflict,
 );
 
-const EXPECTED = 23;
+const EXPECTED = 24;
 check(
   `every cell ran - ${EXPECTED} expected, so a cell that stops existing is not mistaken for one that passed`,
   pass + fail === EXPECTED,

--- a/bin/smoke/dist-freshness.smoke.ts
+++ b/bin/smoke/dist-freshness.smoke.ts
@@ -21,11 +21,12 @@
  * exactly when it lies. Freshness is not correctness, and only a source/build identity manifest
  * would close that.
  *
- * BE HONEST ABOUT WHERE THIS BITES. In `smoke:ci` it is nearly inert, because the gate builds
- * before it runs — it can only catch a build that silently produced nothing for a package. Its real
- * use is the ad-hoc case: run it after editing core and before trusting a manager-side suite. That
- * makes it a better instruction, not yet a ratchet, and the distinction matters because instructions
- * are the form that leaks — the person who most needs one is the person not thinking about it.
+ * BE HONEST ABOUT WHERE THIS BITES. `pnpm smoke:ci` builds before starting its shard, and the hosted
+ * CI workflow likewise builds before invoking the shard directly, so this check is nearly inert in
+ * those gates: it can only catch a build that silently produced nothing for a package. Its real use
+ * is the ad-hoc case: run it after editing core and before trusting a manager-side suite. That makes
+ * it a better instruction, not yet a ratchet, and the distinction matters because instructions are
+ * the form that leaks — the person who most needs one is the person not thinking about it.
  *
  * THE VERSION THAT WOULD ACTUALLY RATCHET is a startup assertion inside every suite that reads
  * `dist`, so the check runs whether or not anyone remembered. 104 suites import `@cotal-ai/core`,

--- a/bin/smoke/mutations/smoke-ci-build-first.json
+++ b/bin/smoke/mutations/smoke-ci-build-first.json
@@ -1,0 +1,23 @@
+{
+  "suite": "bin/smoke/ci-suites.smoke.ts",
+  "guard": "the smoke:ci entrypoint builds before starting the shard",
+  "command": "pnpm smoke:ci-suites",
+  "completionMarker": "SUITE COMPLETE",
+  "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/smoke-ci-build-first.json",
+  "why": [
+    "Package-importing smoke suites resolve through dist/. Without a build at the root smoke:ci entrypoint, early cells grade whatever artifacts were already present in the checkout.",
+    "",
+    "The mutation restores the ambient-dist entrypoint and must redden the named build-before-shard assertion. The anchor is the unique package script line, with no comment text in the match."
+  ],
+  "mutations": [
+    {
+      "name": "restore the smoke:ci entrypoint that starts its shard against ambient dist",
+      "file": "package.json",
+      "find": "    \"smoke:ci\": \"pnpm build && node bin/smoke/shard.mjs 0 1\",",
+      "replace": "    \"smoke:ci\": \"node bin/smoke/shard.mjs 0 1\",",
+      "expectRed": "✗ FAIL: smoke:ci builds before starting its shard",
+      "cell": "smoke:ci builds before starting its shard"
+    }
+  ],
+  "grades": "tool"
+}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "check:shard-stability": "tsx bin/smoke/shard-stability.ts",
     "test": "pnpm -r --if-present test",
     "check": "pnpm typecheck && pnpm check:docsbundle && pnpm test && pnpm smoke:docs && pnpm smoke:orientation && pnpm smoke:view && pnpm smoke:core-boundary && pnpm smoke:sandbox-guard && pnpm smoke:spawn-from-anywhere && pnpm smoke:spawn-from-anywhere:live && pnpm smoke:connect && pnpm smoke:preflight && pnpm smoke:update-concurrency && pnpm smoke:ci && pnpm smoke:spawn-detach:live && pnpm smoke:readiness:live && pnpm smoke:setup-pure:live && pnpm smoke:up-stack:live && pnpm smoke:up-manifest:live && pnpm smoke:join-external:live && pnpm smoke:ext:live && pnpm smoke:dogfood:live && pnpm smoke:freeslot-barrier:live && pnpm smoke:int2-revoke:live && pnpm smoke:backup-perms:live && pnpm smoke:backup-restore:live && pnpm smoke:backup-conservation:live && pnpm smoke:backup-usermode:live && pnpm smoke:backup-faults:live && pnpm smoke:down-manifest-usermode:live",
-    "smoke:ci": "node bin/smoke/shard.mjs 0 1",
+    "smoke:ci": "pnpm build && node bin/smoke/shard.mjs 0 1",
     "clean:dry": "git clean -ndX -- node_modules .pnpm-store packages extensions implementations examples remotion",
     "clean": "git clean -fdX -- node_modules .pnpm-store packages extensions implementations examples remotion",
     "cotal": "tsx bin/cotal.ts",


### PR DESCRIPTION
## Summary

- build the repository before `smoke:ci` starts its shard, so package-importing cells grade artifacts produced by that invocation
- pin the entrypoint ordering in the existing CI-chain regression suite and mutation fixture
- correct the dist-freshness header to distinguish the local `pnpm smoke:ci` entrypoint from hosted CI's direct shard invocation

Closes #401

## Validation

- lightweight source/entrypoint probe reproduced 116 smoke cells before the first build-bearing suite on `origin/main`
- intercepted the real `pnpm smoke:ci` entrypoint: it invoked `pnpm build`, exited on the injected build failure, and never printed the shard banner
- `pnpm build`
- `pnpm smoke:ci-suites` (25 passed, 0 failed)
- `node scripts/mutation-proof.mjs --config bin/smoke/mutations/smoke-ci-build-first.json` (1/1 killed on the named assertion)
- `pnpm smoke:mutation-fixtures` (224 fixtures, 1,228 anchors, 0 failures)
- `pnpm smoke:dist-freshness`
- `pnpm smoke:gate-inventory`
- `git diff --check`

## What was NOT proven

- full `smoke:ci` was not run because this live-mesh host forbids suites that can drive live broker/lifecycle workflows
- no claim is made that the mtime-based freshness check establishes source/build identity; it remains an ordering-only check
