### PR TITLE
fix(smoke): validate workspace re-exports

### DIFF
--- a/bin/smoke/mutations/workspace-import-exports.json
+++ b/bin/smoke/mutations/workspace-import-exports.json
@@ -1,6 +1,6 @@
 {
   "suite": "bin/smoke/workspace-import-exports.smoke.ts",
-  "guard": "every named import from a workspace package resolves to a public export, including type-only imports in smoke trees outside package TypeScript projects",
+  "guard": "every named import or re-export from a workspace package resolves to a public export, including type-only declarations outside package TypeScript projects",
   "command": "pnpm smoke:workspace-import-exports",
   "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/workspace-import-exports.json",
   "mutations": [
@@ -10,6 +10,13 @@
       "find": "import { controlEndpoint, startControlServer, type MeshAgent } from \"@cotal-ai/connector-core\";",
       "replace": "import { controlEndpoint, startControlServer } from \"@cotal-ai/connector-core\";\nimport type { MeshAgent } from \"@cotal-ai/core\";",
       "expectRed": "@cotal-ai/core does not export MeshAgent"
+    },
+    {
+      "name": "W2 bogus named re-export enters a real manager barrel",
+      "file": "implementations/manager/src/runtime/index.ts",
+      "find": "import { existsSync } from \"node:fs\";",
+      "replace": "export type { JcodeBogusReExport1024 } from \"@cotal-ai/core\";\nimport { existsSync } from \"node:fs\";",
+      "expectRed": "@cotal-ai/core does not export JcodeBogusReExport1024"
     }
   ]
 }

--- a/bin/smoke/workspace-import-exports.smoke.ts
+++ b/bin/smoke/workspace-import-exports.smoke.ts
@@ -3,8 +3,9 @@
  *
  * Type-only imports disappear when a smoke runs under tsx, and most smoke trees are not included in
  * their package's TypeScript project. That allowed one manager smoke to import `MeshAgent` from core
- * even though connector-core defines and exports it. Scan every TypeScript tree with the compiler's
- * module resolver and require every named import from a workspace package to be publicly exported.
+ * even though connector-core defines and exports it. Named re-exports carry the same risk in public
+ * barrels. Scan every TypeScript tree with the compiler's module resolver and require every named
+ * import or re-export from a workspace package to be publicly exported.
  *
  * Run: pnpm smoke:workspace-import-exports
  */
@@ -43,6 +44,7 @@ const program = ts.createProgram(sourceFiles, parsedConfig.options);
 const checker = program.getTypeChecker();
 const failures: string[] = [];
 let importCount = 0;
+let reExportCount = 0;
 let nameCount = 0;
 
 for (const filePath of sourceFiles) {
@@ -50,12 +52,20 @@ for (const filePath of sourceFiles) {
   assert.ok(source, `compiler loaded ${relative(ROOT, filePath)}`);
 
   for (const statement of source.statements) {
-    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
+    const isImport = ts.isImportDeclaration(statement);
+    const isNamedReExport =
+      ts.isExportDeclaration(statement) &&
+      statement.exportClause !== undefined &&
+      ts.isNamedExports(statement.exportClause);
+    if ((!isImport && !isNamedReExport) || statement.moduleSpecifier === undefined || !ts.isStringLiteral(statement.moduleSpecifier))
+      continue;
     const packageName = statement.moduleSpecifier.text;
-    const clause = statement.importClause;
-    if (!packageName.startsWith("@cotal-ai/") || clause === undefined) continue;
+    if (!packageName.startsWith("@cotal-ai/")) continue;
+    const clause = isImport ? statement.importClause : undefined;
+    if (isImport && clause === undefined) continue;
 
-    importCount++;
+    if (isImport) importCount++;
+    else reExportCount++;
     const moduleSymbol = checker.getSymbolAtLocation(statement.moduleSpecifier);
     const line = source.getLineAndCharacterOfPosition(statement.moduleSpecifier.getStart()).line + 1;
     if (moduleSymbol === undefined) {
@@ -73,9 +83,14 @@ for (const filePath of sourceFiles) {
       );
     };
 
-    if (clause.name !== undefined) checkName("default", clause.name.getStart());
-    if (clause.namedBindings !== undefined && ts.isNamedImports(clause.namedBindings)) {
+    if (clause?.name !== undefined) checkName("default", clause.name.getStart());
+    if (clause?.namedBindings !== undefined && ts.isNamedImports(clause.namedBindings)) {
       for (const element of clause.namedBindings.elements) {
+        checkName((element.propertyName ?? element.name).text, element.name.getStart());
+      }
+    }
+    if (isNamedReExport) {
+      for (const element of statement.exportClause.elements) {
         checkName((element.propertyName ?? element.name).text, element.name.getStart());
       }
     }
@@ -83,6 +98,9 @@ for (const filePath of sourceFiles) {
 }
 
 assert.ok(importCount > 0, "workspace imports were found");
+assert.ok(reExportCount > 0, "workspace named re-exports were found");
 assert.ok(nameCount > 0, "workspace import names were checked");
 assert.deepEqual(failures, [], failures.join("\n"));
-console.log(`WORKSPACE IMPORT EXPORTS: ${nameCount} names across ${importCount} imports`);
+console.log(
+  `WORKSPACE IMPORT EXPORTS: ${nameCount} names across ${importCount} imports and ${reExportCount} re-exports`,
+);


### PR DESCRIPTION
Follow-up to merged PR #1024 and issue #973.

## Scope

- extend the workspace export guard from named imports to named re-exports in public barrels
- count and validate the existing named workspace re-export declarations alongside imports
- add the exact merge-gate reviewer experiment as a mutation: a bogus type re-export from `@cotal-ai/core` in the real manager runtime barrel must make the guard fail

## Reproduction

At #1024 head `ce44c90c705d7c79d96087f89399179903e72132`, prepending

```ts
export type { JcodeBogusReExport1024 } from "@cotal-ai/core";
```

to `implementations/manager/src/runtime/index.ts` left the guard green at the unchanged `4,586 names across 853 imports`, while manager typecheck failed `TS2305` naming the missing re-export.

## Verification

- `pnpm smoke:workspace-import-exports` (`4,636 names across 853 imports and 14 re-exports`)
- `tsc -p bin/tsconfig.smoke.json --pretty false`
- `pnpm --filter @cotal-ai/manager typecheck`
- `pnpm --filter @cotal-ai/manager exec tsx smoke/pi-session-recovery.smoke.ts` (20 checks)
- `pnpm smoke:gate-inventory`
- `pnpm smoke:mutation-fixtures`
- `node scripts/mutation-proof.mjs --config bin/smoke/mutations/workspace-import-exports.json` (2/2 killed, including the exact bogus barrel re-export)

## Evidence limits

The guard validates named static imports and named static re-exports from first-party packages across the five workspace roots. It still does not inspect dynamic imports, namespace member access, `export *` expansion, or third-party package exports.
