### PR TITLE
fix(ci): fail closed on unparsed workflow events

### DIFF
--- a/.changeset/fail-closed-workflow-comments.md
+++ b/.changeset/fail-closed-workflow-comments.md
@@ -1,0 +1,5 @@
+---
+"cotal-ai": patch
+---
+
+Fail closed when a pull-request workflow uses an unsupported `on` declaration, including flow event lists with trailing YAML comments.

--- a/bin/smoke/ci-suites.d/564b98715990754f523fe79cd96db17e1beb4e09c94f3aae92e57b29ad309a24.txt
+++ b/bin/smoke/ci-suites.d/564b98715990754f523fe79cd96db17e1beb4e09c94f3aae92e57b29ad309a24.txt
@@ -1,0 +1,1 @@
+smoke:mutation-coverage-gradability

--- a/bin/smoke/mutation-coverage-gradability.smoke.ts
+++ b/bin/smoke/mutation-coverage-gradability.smoke.ts
@@ -1,0 +1,14 @@
+/** The coverage auditor must accept a suite that imports its mutation target directly by relative path. */
+import { spawnSync } from "node:child_process";
+
+const run = spawnSync(
+  process.execPath,
+  ["scripts/mutation-coverage.mjs", "bin/smoke/mutations/pr-head-gate.json"],
+  { cwd: process.cwd(), encoding: "utf8" },
+);
+const output = `${run.stdout ?? ""}${run.stderr ?? ""}`;
+const accepted = run.status === 0 && /bin\/smoke\/pr-head-gate\.smoke\.ts\s+6 \/\s+26 cells observed failing/.test(output);
+console.log(`  ${accepted ? "✓" : "✗"} a direct cross-directory source import is accepted as product-smoke gradability`);
+if (!accepted) console.log(output);
+console.log(`MUTATION COVERAGE GRADABILITY: ${accepted ? 1 : 0} checks passed`);
+if (!accepted) process.exitCode = 1;

--- a/bin/smoke/mutations/pr-head-gate.json
+++ b/bin/smoke/mutations/pr-head-gate.json
@@ -52,6 +52,22 @@
       "replace": "if (false) throw new Error(`unsupported workflow path pattern: ${pattern}`);",
       "expectRed": "unsupported GitHub glob syntax fails closed instead of being treated as a literal",
       "cell": "unsupported GitHub glob syntax fails closed"
+    },
+    {
+      "name": "a trailing YAML comment hides a pull_request flow sequence",
+      "file": "scripts/pr-head-gate.mjs",
+      "find": "  const onHead = stripYamlComment(lines[onIndex].replace(/^on:\\s*/, \"\")).trim();",
+      "replace": "  const onHead = lines[onIndex].replace(/^on:\\s*/, \"\").trim();",
+      "expectRed": "commented flow sequence pull_request declaration is detected",
+      "cell": "commented flow sequence pull_request declaration is detected"
+    },
+    {
+      "name": "an unrecognised top-level on declaration silently omits its workflow",
+      "file": "scripts/pr-head-gate.mjs",
+      "find": "      throw new Error(`${file}:${onIndex + 1}: unsupported top-level on declaration`);",
+      "replace": "      return undefined;",
+      "expectRed": "an unrecognised top-level on declaration fails closed instead of omitting a workflow",
+      "cell": "an unrecognised top-level on declaration fails closed instead of omitting a workflow"
     }
   ]
 }

--- a/bin/smoke/pr-head-gate.smoke.ts
+++ b/bin/smoke/pr-head-gate.smoke.ts
@@ -29,10 +29,31 @@ function check(name: string, condition: unknown, detail?: unknown): void {
 
 const expectedNames = ["CI", "Docs", "Windows"];
 check(
-  "path-filtered workflows are included only when a changed path matches their declaration",
+  "the real repository workflows and path filters yield the exact expected names",
   JSON.stringify(expectedPullRequestWorkflows(workflows, ["package.json"])) === JSON.stringify(["CI", "Windows"]) &&
     JSON.stringify(expectedPullRequestWorkflows(workflows, ["install.sh"])) === JSON.stringify(["CI", "Installer", "Windows"]),
 );
+const declarationForms = [
+  ["plain flow sequence", "name: Plain Flow\non: [push, pull_request]\n", "Plain Flow"],
+  ["commented flow sequence", "name: Commented Flow\non: [push, pull_request] # ordinary YAML comment\n", "Commented Flow"],
+  ["block mapping", "name: Block Mapping\non:\n  pull_request:\n", "Block Mapping"],
+] as const;
+for (const [label, source, name] of declarationForms) {
+  check(
+    `${label} pull_request declaration is detected`,
+    JSON.stringify(expectedPullRequestWorkflows({ [`${label}.yml`]: source }, ["package.json"])) === JSON.stringify([name]),
+  );
+}
+check("every supported pull_request declaration form ran (3)", declarationForms.length === 3);
+let malformedOnRefused = false;
+try {
+  expectedPullRequestWorkflows({
+    "malformed.yml": "name: Malformed\non: push pull_request\n",
+  }, ["package.json"]);
+} catch (error) {
+  malformedOnRefused = /unsupported top-level on declaration/.test(String(error));
+}
+check("an unrecognised top-level on declaration fails closed instead of omitting a workflow", malformedOnRefused);
 let unsupportedRefused = false;
 try {
   expectedPullRequestWorkflows({
@@ -110,7 +131,7 @@ for (const conclusion of ["neutral", "skipped"]) {
   check(`a ${conclusion} expected workflow is failing, never green`, JSON.stringify(verdict.failing) === '["CI"]' && !verdict.green, verdict);
 }
 
-const EXPECTED = 20;
+const EXPECTED = 25;
 check(`every cell ran (${EXPECTED} before sentinel)`, passed + failed === EXPECTED);
 console.log(`PR HEAD GATE SMOKE ${failed === 0 ? "OK" : "FAILED"} (${passed} passed, ${failed} failed)`);
 console.log("SUITE COMPLETE");

--- a/bin/smoke/pr-head-gate.smoke.ts
+++ b/bin/smoke/pr-head-gate.smoke.ts
@@ -39,9 +39,17 @@ const declarationForms = [
   ["block mapping", "name: Block Mapping\non:\n  pull_request:\n", "Block Mapping"],
 ] as const;
 for (const [label, source, name] of declarationForms) {
+  let detected = false;
+  let detail: unknown;
+  try {
+    detected = JSON.stringify(expectedPullRequestWorkflows({ [`${label}.yml`]: source }, ["package.json"])) === JSON.stringify([name]);
+  } catch (error) {
+    detail = error;
+  }
   check(
     `${label} pull_request declaration is detected`,
-    JSON.stringify(expectedPullRequestWorkflows({ [`${label}.yml`]: source }, ["package.json"])) === JSON.stringify([name]),
+    detected,
+    detail,
   );
 }
 check("every supported pull_request declaration form ran (3)", declarationForms.length === 3);

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "gen:ci-suites-dts": "tsx bin/smoke/gen-ci-suites-dts.mts",
     "mutation-proof": "node scripts/mutation-proof.mjs",
     "mutation-coverage": "node scripts/mutation-coverage.mjs",
+    "smoke:mutation-coverage-gradability": "tsx bin/smoke/mutation-coverage-gradability.smoke.ts",
     "doc-binding": "node scripts/doc-binding.mjs",
     "smoke:doc-binding": "node scripts/doc-binding.mjs --self-test",
     "smoke:sandbox-guard": "tsx packages/smoke-kit/smoke/sandbox-guard.smoke.ts",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,6 +22,8 @@ non-green categories are distinct:
 
 The path-filter reader understands the declaration and glob forms used in this repository. A new
 form it does not understand is an error, not a silently ignored or literal filter.
+Top-level flow event lists may carry a trailing YAML comment; any other unrecognised `on` form is
+also an error rather than a workflow silently removed from the expected set.
 
 The guard is read-only. It does not drain GitHub's queue, retrigger a run, or diagnose or fix the
 external scheduler that creates workflow runs.

--- a/scripts/mutation-coverage.mjs
+++ b/scripts/mutation-coverage.mjs
@@ -19,6 +19,7 @@
  */
 import { readFileSync } from "node:fs";
 import { execSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
 
 /**
  * The config list is DISCOVERED from the tree, never a remembered list of directories: a config
@@ -74,6 +75,12 @@ const REQUIRED_MAY_BE_EMPTY = ["replace"];
 /** `packages/core/src/x.ts` -> `packages/core`; `implementations/runtime/smoke/y.ts` -> `implementations/runtime`. */
 const packageRoot = (p) => p.split("/").slice(0, 2).join("/");
 
+function directRelativeImports(suite) {
+  const source = readFileSync(suite, "utf8");
+  return [...source.matchAll(/(?:\bfrom\s*|\bimport\s*\()(["'])(\.{1,2}\/[^"']+)\1/g)]
+    .map((match) => resolve(dirname(suite), match[2]));
+}
+
 /**
  * A mutation is only gradable if the suite runs the file it mutates. A suite that imports its
  * target's package BY NAME gets `dist`, so mutating the source cannot reach the running code and
@@ -83,6 +90,7 @@ const packageRoot = (p) => p.split("/").slice(0, 2).join("/");
  * remembering it is the rule that just failed.
  */
 const assertGradable = (configPath, suite, m) => {
+  if (directRelativeImports(suite).includes(resolve(m.file))) return;
   if (packageRoot(m.file) === packageRoot(suite) && readFileSync(suite, "utf8").includes("../src/")) return;
   throw new Error(
     `${configPath}: mutation "${m.name}" targets ${m.file}, which ${suite} does not import by source path — ` +

--- a/scripts/mutations/mutation-coverage-relative-import.json
+++ b/scripts/mutations/mutation-coverage-relative-import.json
@@ -1,0 +1,17 @@
+{
+  "suite": "bin/smoke/mutation-coverage-gradability.smoke.ts",
+  "guard": "the mutation coverage auditor recognizes an exact direct relative source import across repository directories without misclassifying a product smoke as an instrument self-test",
+  "command": "pnpm smoke:mutation-coverage-gradability",
+  "completionMarker": "MUTATION COVERAGE GRADABILITY",
+  "grades": "tool",
+  "proveWith": "node scripts/mutation-proof.mjs --config scripts/mutations/mutation-coverage-relative-import.json",
+  "mutations": [
+    {
+      "name": "the auditor ignores exact direct relative imports outside the suite's package directory",
+      "file": "scripts/mutation-coverage.mjs",
+      "find": "  if (directRelativeImports(suite).includes(resolve(m.file))) return;",
+      "replace": "  if (false) return;",
+      "expectRed": "a direct cross-directory source import is accepted as product-smoke gradability"
+    }
+  ]
+}

--- a/scripts/pr-head-gate.mjs
+++ b/scripts/pr-head-gate.mjs
@@ -14,6 +14,19 @@ function unquote(value) {
   return trimmed;
 }
 
+function stripYamlComment(value) {
+  let quote;
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i];
+    if (quote === '"' && ch === "\\") { i += 1; continue; }
+    if (quote === "'" && ch === "'" && value[i + 1] === "'") { i += 1; continue; }
+    if (quote) { if (ch === quote) quote = undefined; continue; }
+    if (ch === "'" || ch === '"') { quote = ch; continue; }
+    if (ch === "#" && (i === 0 || /\s/.test(value[i - 1]))) return value.slice(0, i);
+  }
+  return value;
+}
+
 function bracketList(value, file, line) {
   const inner = value.trim().slice(1, -1).trim();
   if (!inner) return [];
@@ -28,14 +41,16 @@ function pullRequestDeclaration(file, text) {
   const lines = text.split("\n");
   const onIndex = lines.findIndex((line) => /^on:\s*(?:$|\S)/.test(line));
   if (onIndex < 0) throw new Error(`${file}: missing top-level on declaration`);
-  const onHead = lines[onIndex].replace(/^on:\s*/, "").trim();
+  const onHead = stripYamlComment(lines[onIndex].replace(/^on:\s*/, "")).trim();
   let handlesPullRequest = false;
   if (onHead) {
     if (/^\[.*\]$/.test(onHead)) {
       const events = bracketList(onHead, file, onIndex + 1);
       handlesPullRequest = events.includes("pull_request");
-    } else {
+    } else if (/^[A-Za-z_][A-Za-z0-9_-]*$/.test(onHead)) {
       handlesPullRequest = onHead === "pull_request";
+    } else {
+      throw new Error(`${file}:${onIndex + 1}: unsupported top-level on declaration`);
     }
     if (!handlesPullRequest) return undefined;
     const nameLine = lines.find((line) => /^name:\s*\S/.test(line));


### PR DESCRIPTION
## Summary

- detect top-level pull-request flow event lists that carry trailing YAML comments
- fail closed on any still-unrecognized top-level `on` declaration instead of silently omitting its workflow
- make the mutation coverage auditor recognize exact direct relative source imports across repository directories without misclassifying product smoke coverage as a tool self-test
- add counted declaration-form coverage, nine red-and-named mutations, a gate fragment, docs, and a changeset

Closes #1104

## Red-first reproduction

Before the fix, a valid workflow declaration:

```yaml
name: Hidden
on: [push, pull_request] # comment
```

was silently omitted from `expectedPullRequestWorkflows()`. With a successful CI run, `classifyPullRequestHead()` returned `green: true` while `Hidden` had no run. The new smoke was run before implementation and failed both the commented-flow detection cell and the malformed-`on` refusal cell.

The existing mutation coverage auditor also exited 1 on `bin/smoke/mutations/pr-head-gate.json`, despite direct mutations killing, because it only recognized same-package `../src` imports and missed the suite's exact `../../scripts/pr-head-gate.mjs` import.

## Validation

- `pnpm smoke:pr-head-gate`: 26/0, including a count sentinel over plain flow sequence, commented flow sequence, block mapping, malformed refusal, and the real repository workflows
- `node scripts/mutation-proof.mjs --config bin/smoke/mutations/pr-head-gate.json`: 8/8 KILLED red-and-named
- `node scripts/mutation-proof.mjs --config scripts/mutations/mutation-coverage-relative-import.json`: 1/1 KILLED red-and-named
- `node scripts/mutation-coverage.mjs bin/smoke/mutations/pr-head-gate.json scripts/mutations/mutation-coverage-relative-import.json`: accepted the product smoke as product coverage and the auditor self-test separately as a tool config
- shipped live boundary: PR #1044 reports `missing: CI, Docs, Windows`, NOT GREEN, exit 1; PR #1099 reports `pending: CI, Windows`, NOT GREEN, exit 1
- `pnpm smoke:ci-fragments`, `pnpm smoke:gate-inventory`, `pnpm smoke:mutation-fixtures`
- `pnpm check:shard-stability 43e9dd303f71528ece5e13b169838b29cfff2de5 HEAD`: zero pre-existing suite moves
- `bash bin/smoke/verify-shard-inputs.sh HEAD`
- `pnpm typecheck`
- `pnpm check:docsbundle`
- `pnpm changeset status`
- real detached merge with current main `43e9dd303f71528ece5e13b169838b29cfff2de5`: clean

## Limits

This remains a deliberately small reader for the workflow declaration forms used by this repository, not a general GitHub Actions expression engine. Unsupported forms now fail closed. No live mesh, stack lifecycle command, `pnpm smoke:ci`, `pnpm check`, or suite ending in `-live` / `:live` was run.
