### PR TITLE
fix(ci): parse exact-head workflows as YAML

### DIFF
--- a/.changeset/strict-yaml-head-gate.md
+++ b/.changeset/strict-yaml-head-gate.md
@@ -1,0 +1,5 @@
+---
+"cotal-ai": patch
+---
+
+Parse pull request workflow declarations with the repository YAML parser so valid comments and flow forms cannot silently remove required exact-head checks.

--- a/bin/smoke/fixtures/pr-head-gate-fetch.mjs
+++ b/bin/smoke/fixtures/pr-head-gate-fetch.mjs
@@ -1,0 +1,34 @@
+const sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const workflow = "name: Hidden\non: [push, pull_request] # ordinary YAML comment\n";
+const run = {
+  id: 1,
+  name: "Hidden",
+  event: "pull_request",
+  head_sha: sha,
+  status: "completed",
+  conclusion: "success",
+  created_at: "2026-08-30T00:00:00Z",
+  pull_requests: [{ number: 1098 }],
+};
+
+const json = (value) => new Response(JSON.stringify(value), {
+  status: 200,
+  headers: { "content-type": "application/json" },
+});
+
+globalThis.fetch = async (input, init = {}) => {
+  const url = new URL(String(input));
+  const accept = new Headers(init.headers).get("accept") ?? "";
+  if (url.pathname === "/repos/Cotal-AI/Cotal/pulls/1098") return json({ head: { sha } });
+  if (url.pathname === "/repos/Cotal-AI/Cotal/pulls/1098/files") return json([]);
+  if (url.pathname === "/repos/Cotal-AI/Cotal/contents/.github/workflows") {
+    return json([{ type: "file", name: "hidden.yml", path: ".github/workflows/hidden.yml" }]);
+  }
+  if (url.pathname === "/repos/Cotal-AI/Cotal/contents/.github/workflows/hidden.yml" && accept.includes("raw")) {
+    return new Response(workflow, { status: 200 });
+  }
+  if (url.pathname === "/repos/Cotal-AI/Cotal/actions/runs") {
+    return json({ workflow_runs: process.env.PR_HEAD_GATE_FIXTURE === "missing" ? [] : [run] });
+  }
+  return new Response(`unexpected fixture request: ${url}`, { status: 500 });
+};

--- a/bin/smoke/mutations/pr-head-gate.json
+++ b/bin/smoke/mutations/pr-head-gate.json
@@ -28,6 +28,22 @@
       "cell": "invalid workflow YAML fails closed instead of shrinking the expected set"
     },
     {
+      "name": "empty on sequence silently contributes no expected workflow",
+      "file": "scripts/pr-head-gate.mjs",
+      "find": "    if (on.length === 0) throw new Error(`${file}: top-level on sequence must not be empty`);",
+      "replace": "    if (false) throw new Error(`${file}: top-level on sequence must not be empty`);",
+      "expectRed": "an empty on sequence fails closed",
+      "cell": "an empty on sequence fails closed"
+    },
+    {
+      "name": "empty on mapping silently contributes no expected workflow",
+      "file": "scripts/pr-head-gate.mjs",
+      "find": "  if (events.length === 0) throw new Error(`${file}: top-level on mapping must not be empty`);",
+      "replace": "  if (false) throw new Error(`${file}: top-level on mapping must not be empty`);",
+      "expectRed": "an empty on mapping fails closed",
+      "cell": "an empty on mapping fails closed"
+    },
+    {
       "name": "unsupported pull_request filter is silently ignored",
       "file": "scripts/pr-head-gate.mjs",
       "find": "  if (unsupported.length) throw new Error(`${file}: unsupported pull_request filter: ${unsupported.join(\", \")}`);",

--- a/bin/smoke/mutations/pr-head-gate.json
+++ b/bin/smoke/mutations/pr-head-gate.json
@@ -14,8 +14,8 @@
     {
       "name": "flow event list comments hide pull_request again",
       "file": "scripts/pr-head-gate.mjs",
-      "find": "  if (Array.isArray(on)) {",
-      "replace": "  if (Array.isArray(on) && !on.includes(\"pull_request\")) {",
+      "find": "    return on.includes(\"pull_request\") ? null : undefined;",
+      "replace": "    return undefined;",
       "expectRed": "ordinary YAML comments after a flow event list preserve pull_request",
       "cell": "ordinary YAML comments after a flow event list preserve pull_request"
     },

--- a/bin/smoke/mutations/pr-head-gate.json
+++ b/bin/smoke/mutations/pr-head-gate.json
@@ -3,31 +3,61 @@
   "guard": "an exact pull request head is green only when every workflow derived from the repository declarations exists for that PR and SHA and completed successfully",
   "command": "pnpm smoke:pr-head-gate",
   "completionMarker": "SUITE COMPLETE",
+  "grades": "tool",
   "proveWith": "pnpm mutation-proof --config bin/smoke/mutations/pr-head-gate.json",
+  "why": [
+    "The guard and its smoke are repository tools rather than a published package boundary, so this",
+    "config grades them as a tool. The smoke imports scripts/pr-head-gate.mjs directly, and two cells",
+    "also execute the shipped pnpm pr-head-gate command against deterministic GitHub API responses."
+  ],
   "mutations": [
+    {
+      "name": "flow event list comments hide pull_request again",
+      "file": "scripts/pr-head-gate.mjs",
+      "find": "  if (Array.isArray(on)) {",
+      "replace": "  if (Array.isArray(on) && !on.includes(\"pull_request\")) {",
+      "expectRed": "ordinary YAML comments after a flow event list preserve pull_request",
+      "cell": "ordinary YAML comments after a flow event list preserve pull_request"
+    },
+    {
+      "name": "invalid workflow YAML silently contributes no expected workflow",
+      "file": "scripts/pr-head-gate.mjs",
+      "find": "  if (problem) throw new Error(`${file}: invalid YAML: ${problem.message}`);",
+      "replace": "  if (problem) return undefined;",
+      "expectRed": "invalid workflow YAML fails closed instead of shrinking the expected set",
+      "cell": "invalid workflow YAML fails closed instead of shrinking the expected set"
+    },
+    {
+      "name": "unsupported pull_request filter is silently ignored",
+      "file": "scripts/pr-head-gate.mjs",
+      "find": "  if (unsupported.length) throw new Error(`${file}: unsupported pull_request filter: ${unsupported.join(\", \")}`);",
+      "replace": "  if (false) throw new Error(`${file}: unsupported pull_request filter: ${unsupported.join(\", \")}`);",
+      "expectRed": "a pull_request filter the guard cannot evaluate fails closed",
+      "cell": "a pull_request filter the guard cannot evaluate fails closed"
+    },
     {
       "name": "missing expected workflow stops failing closed",
       "file": "scripts/pr-head-gate.mjs",
       "find": "if (candidates.length === 0) { missing.push(name); continue; }",
       "replace": "if (candidates.length === 0) { continue; }",
-      "expectRed": "PR #921 head 711d69e0: Code Quality or another PR's run does not satisfy this PR",
-      "cell": "Code Quality or another PR's run does not satisfy this PR"
+      "expectRed": "a missing expected workflow keeps the exact head red",
+      "cell": "a missing expected workflow keeps the exact head red"
     },
     {
       "name": "runs from another pull request satisfy the named workflow",
       "file": "scripts/pr-head-gate.mjs",
       "find": "run.pull_requests.some((pull) => pull.number === pr),",
       "replace": "run.pull_requests.some((pull) => pull.number !== pr),",
-      "expectRed": "PR #921 head 71331c9a: Code Quality or another PR's run does not satisfy this PR",
-      "cell": "Code Quality or another PR's run does not satisfy this PR"
+      "expectRed": "a successful run attached to another pull request does not satisfy this pull request",
+      "cell": "a successful run attached to another pull request does not satisfy this pull request"
     },
     {
       "name": "a run for another commit satisfies the exact head",
       "file": "scripts/pr-head-gate.mjs",
       "find": "run.head_sha === headSha &&",
       "replace": "run.head_sha !== headSha &&",
-      "expectRed": "PR #921 head 71331c9a: Code Quality or another PR's run does not satisfy this PR",
-      "cell": "Code Quality or another PR's run does not satisfy this PR"
+      "expectRed": "a successful run for another commit does not satisfy the exact head",
+      "cell": "a successful run for another commit does not satisfy the exact head"
     },
     {
       "name": "queued and running expected workflows count as green",
@@ -52,6 +82,14 @@
       "replace": "if (false) throw new Error(`unsupported workflow path pattern: ${pattern}`);",
       "expectRed": "unsupported GitHub glob syntax fails closed instead of being treated as a literal",
       "cell": "unsupported GitHub glob syntax fails closed"
+    },
+    {
+      "name": "shipped command omits a missing YAML-derived workflow",
+      "file": "scripts/pr-head-gate.mjs",
+      "find": "  const expected = expectedPullRequestWorkflows(workflows, changedPaths);",
+      "replace": "  const expected = [];",
+      "expectRed": "the shipped pr-head-gate command reports the YAML-derived Hidden workflow green",
+      "cell": "the shipped pr-head-gate command reports the YAML-derived Hidden workflow green"
     }
   ]
 }

--- a/bin/smoke/pr-head-gate.smoke.ts
+++ b/bin/smoke/pr-head-gate.smoke.ts
@@ -5,6 +5,7 @@
  * Run: pnpm smoke:pr-head-gate
  * Prove: pnpm mutation-proof --config bin/smoke/mutations/pr-head-gate.json
  */
+import { spawnSync } from "node:child_process";
 import { readFileSync, readdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -20,6 +21,7 @@ const workflows = Object.fromEntries(
     .filter((name) => /\.ya?ml$/.test(name))
     .map((name) => [name, readFileSync(join(ROOT, ".github/workflows", name), "utf8")]),
 );
+const fixtureFetch = join(ROOT, "bin/smoke/fixtures/pr-head-gate-fetch.mjs");
 
 let passed = 0, failed = 0;
 function check(name: string, condition: unknown, detail?: unknown): void {
@@ -33,15 +35,48 @@ check(
   JSON.stringify(expectedPullRequestWorkflows(workflows, ["package.json"])) === JSON.stringify(["CI", "Windows"]) &&
     JSON.stringify(expectedPullRequestWorkflows(workflows, ["install.sh"])) === JSON.stringify(["CI", "Installer", "Windows"]),
 );
+check(
+  "paths-ignore skips a workflow only when every changed path is ignored",
+  JSON.stringify(expectedPullRequestWorkflows({
+    "ignore.yml": "name: Ignore\non:\n  pull_request:\n    paths-ignore: ['docs/**']\n",
+  }, ["docs/cli.md"])) === "[]" &&
+    JSON.stringify(expectedPullRequestWorkflows({
+      "ignore.yml": "name: Ignore\non:\n  pull_request:\n    paths-ignore: ['docs/**']\n",
+    }, ["docs/cli.md", "package.json"])) === '["Ignore"]',
+);
+check(
+  "ordinary YAML comments after a flow event list preserve pull_request",
+  JSON.stringify(expectedPullRequestWorkflows({
+    "hidden.yml": "name: Hidden\non: [push, pull_request] # ordinary YAML comment\n",
+  }, ["package.json"])) === '["Hidden"]',
+);
+let invalidYamlRefused = false;
+try {
+  expectedPullRequestWorkflows({
+    "invalid.yml": "name: Invalid\non: [pull_request\n",
+  }, ["package.json"]);
+} catch (error) {
+  invalidYamlRefused = /invalid YAML/.test(String(error));
+}
+check("invalid workflow YAML fails closed instead of shrinking the expected set", invalidYamlRefused);
 let unsupportedRefused = false;
 try {
   expectedPullRequestWorkflows({
     "unknown.yml": "name: Unknown\non:\n  pull_request:\n    paths: ${{ future.paths }}\n",
   }, ["package.json"]);
 } catch (error) {
-  unsupportedRefused = /unsupported inline paths declaration/.test(String(error));
+  unsupportedRefused = /pull_request paths must be a non-empty string array/.test(String(error));
 }
 check("an unrecognised workflow declaration fails closed instead of shrinking the expected set", unsupportedRefused);
+let unsupportedFilterRefused = false;
+try {
+  expectedPullRequestWorkflows({
+    "unknown.yml": "name: Unknown\non:\n  pull_request:\n    branches: [main]\n",
+  }, ["package.json"]);
+} catch (error) {
+  unsupportedFilterRefused = /unsupported pull_request filter: branches/.test(String(error));
+}
+check("a pull_request filter the guard cannot evaluate fails closed", unsupportedFilterRefused);
 let unsupportedPatternRefused = false;
 try {
   expectedPullRequestWorkflows({
@@ -86,6 +121,34 @@ const green = classifyPullRequestHead({
 });
 check("the exact head is green only after every expected workflow succeeds", green.green, green);
 
+const missingOne = classifyPullRequestHead({
+  pr: positive.pr,
+  headSha: positive.headSha,
+  expected: expectedNames,
+  runs: succeeded.filter((run: Record<string, unknown>) => run.name !== "Docs"),
+});
+check("a missing expected workflow keeps the exact head red", JSON.stringify(missingOne.missing) === '["Docs"]' && !missingOne.green, missingOne);
+
+const wrongPullRequest = classifyPullRequestHead({
+  pr: positive.pr,
+  headSha: positive.headSha,
+  expected: ["CI"],
+  runs: succeeded.map((run: Record<string, unknown>) =>
+    run.name === "CI" ? { ...run, pull_requests: [{ number: positive.pr + 1 }] } : run,
+  ),
+});
+check("a successful run attached to another pull request does not satisfy this pull request", JSON.stringify(wrongPullRequest.missing) === '["CI"]' && !wrongPullRequest.green, wrongPullRequest);
+
+const wrongHead = classifyPullRequestHead({
+  pr: positive.pr,
+  headSha: positive.headSha,
+  expected: ["Windows"],
+  runs: succeeded.map((run: Record<string, unknown>) =>
+    run.name === "Windows" ? { ...run, head_sha: "0".repeat(40) } : run,
+  ),
+});
+check("a successful run for another commit does not satisfy the exact head", JSON.stringify(wrongHead.missing) === '["Windows"]' && !wrongHead.green, wrongHead);
+
 const failedRuns = succeeded.map((run: Record<string, unknown>) =>
   run.name === "CI" ? { ...run, conclusion: "failure" } : run,
 );
@@ -110,7 +173,33 @@ for (const conclusion of ["neutral", "skipped"]) {
   check(`a ${conclusion} expected workflow is failing, never green`, JSON.stringify(verdict.failing) === '["CI"]' && !verdict.green, verdict);
 }
 
-const EXPECTED = 20;
+function shippedCommand(mode: "success" | "missing") {
+  return spawnSync("pnpm", ["--silent", "pr-head-gate", "1098"], {
+    cwd: ROOT,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GITHUB_REPOSITORY: "Cotal-AI/Cotal",
+      NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --import=${fixtureFetch}`.trim(),
+      PR_HEAD_GATE_FIXTURE: mode,
+    },
+  });
+}
+
+const shippedGreen = shippedCommand("success");
+check(
+  "the shipped pr-head-gate command reports the YAML-derived Hidden workflow green",
+  shippedGreen.status === 0 && shippedGreen.stdout.includes("expected: Hidden") && shippedGreen.stdout.includes("verdict: GREEN"),
+  `${shippedGreen.stdout}${shippedGreen.stderr}`,
+);
+const shippedMissing = shippedCommand("missing");
+check(
+  "the shipped pr-head-gate command reports a missing YAML-derived workflow as not green",
+  shippedMissing.status === 1 && shippedMissing.stdout.includes("missing: Hidden") && shippedMissing.stdout.includes("verdict: NOT GREEN"),
+  `${shippedMissing.stdout}${shippedMissing.stderr}`,
+);
+
+const EXPECTED = 29;
 check(`every cell ran (${EXPECTED} before sentinel)`, passed + failed === EXPECTED);
 console.log(`PR HEAD GATE SMOKE ${failed === 0 ? "OK" : "FAILED"} (${passed} passed, ${failed} failed)`);
 console.log("SUITE COMPLETE");

--- a/bin/smoke/pr-head-gate.smoke.ts
+++ b/bin/smoke/pr-head-gate.smoke.ts
@@ -35,6 +35,12 @@ check(
   JSON.stringify(expectedPullRequestWorkflows(workflows, ["package.json"])) === JSON.stringify(["CI", "Windows"]) &&
     JSON.stringify(expectedPullRequestWorkflows(workflows, ["install.sh"])) === JSON.stringify(["CI", "Installer", "Windows"]),
 );
+let repositoryWorkflowsParsed = false;
+try {
+  expectedPullRequestWorkflows(workflows, ["package.json"]);
+  repositoryWorkflowsParsed = true;
+} catch {}
+check("every repository workflow declaration parses without throwing", repositoryWorkflowsParsed);
 check(
   "paths-ignore skips a workflow only when every changed path is ignored",
   JSON.stringify(expectedPullRequestWorkflows({
@@ -59,6 +65,23 @@ try {
   invalidYamlRefused = /invalid YAML/.test(String(error));
 }
 check("invalid workflow YAML fails closed instead of shrinking the expected set", invalidYamlRefused);
+for (const [label, source, pattern] of [
+  ["an empty on sequence fails closed", "name: Empty\non: []\n", /top-level on sequence must not be empty/],
+  ["an empty on mapping fails closed", "name: Empty\non: {}\n", /top-level on mapping must not be empty/],
+] as const) {
+  let refused = false;
+  try { expectedPullRequestWorkflows({ "unknown.yml": source }, ["package.json"]); }
+  catch (error) { refused = pattern.test(String(error)); }
+  check(label, refused);
+}
+check(
+  "a scalar event without pull_request is explicitly omitted",
+  JSON.stringify(expectedPullRequestWorkflows({ "future.yml": "name: Future\non: future_event\n" }, ["package.json"])) === "[]",
+);
+check(
+  "an event mapping without pull_request is explicitly omitted",
+  JSON.stringify(expectedPullRequestWorkflows({ "future.yml": "name: Future\non:\n  future_event:\n" }, ["package.json"])) === "[]",
+);
 let unsupportedRefused = false;
 try {
   expectedPullRequestWorkflows({
@@ -199,7 +222,7 @@ check(
   `${shippedMissing.stdout}${shippedMissing.stderr}`,
 );
 
-const EXPECTED = 29;
+const EXPECTED = 34;
 check(`every cell ran (${EXPECTED} before sentinel)`, passed + failed === EXPECTED);
 console.log(`PR HEAD GATE SMOKE ${failed === 0 ? "OK" : "FAILED"} (${passed} passed, ${failed} failed)`);
 console.log("SUITE COMPLETE");

--- a/package.json
+++ b/package.json
@@ -562,6 +562,7 @@
     "@types/node": "^22.20.0",
     "ts-json-schema-generator": "^2.9.0",
     "tsx": "^4.23.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "yaml": "^2.9.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
   bin:
     dependencies:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,8 +15,10 @@ pnpm pr-head-gate <pull-request-number>
 It parses `.github/workflows/*.yml` at the exact head with the repository's YAML parser and derives
 the expected named set, including `pull_request` path filters. Valid YAML forms such as flow event
 lists with trailing comments are handled by the parser rather than a line reader. Invalid YAML and
-invalid path-filter values stop the guard. It then grades only runs attached to that pull request
-and head. Its non-green categories are distinct:
+invalid path-filter values stop the guard. Empty trigger collections also stop it. A non-empty
+scalar or mapping that names no `pull_request` event is explicitly treated as a non-PR workflow.
+It then grades only runs attached to that pull request and head. Its non-green categories are
+distinct:
 
 - **missing**: an expected workflow run was never created for this PR and head
 - **pending**: the run exists but is queued or running

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,16 +12,18 @@ Use the repository guard instead:
 pnpm pr-head-gate <pull-request-number>
 ```
 
-It derives the expected named set from `.github/workflows/*.yml` at the exact head, including
-`pull_request` path filters, then grades only runs attached to that pull request and head. Its
-non-green categories are distinct:
+It parses `.github/workflows/*.yml` at the exact head with the repository's YAML parser and derives
+the expected named set, including `pull_request` path filters. Valid YAML forms such as flow event
+lists with trailing comments are handled by the parser rather than a line reader. Invalid YAML and
+invalid path-filter values stop the guard. It then grades only runs attached to that pull request
+and head. Its non-green categories are distinct:
 
 - **missing**: an expected workflow run was never created for this PR and head
 - **pending**: the run exists but is queued or running
 - **failing**: the run completed without a `success` conclusion, including `neutral` or `skipped`
 
-The path-filter reader understands the declaration and glob forms used in this repository. A new
-form it does not understand is an error, not a silently ignored or literal filter.
+The path-filter matcher understands the glob forms used in this repository. A new glob form it does
+not understand is an error, not a silently ignored or literal filter.
 
 The guard is read-only. It does not drain GitHub's queue, retrigger a run, or diagnose or fix the
 external scheduler that creates workflow runs.

--- a/scripts/pr-head-gate.mjs
+++ b/scripts/pr-head-gate.mjs
@@ -19,14 +19,18 @@ function stringList(value, file, key) {
 }
 
 function pullRequestConfig(file, on) {
-  if (typeof on === "string") return on === "pull_request" ? null : undefined;
+  if (typeof on === "string") {
+    if (on.length === 0) throw new Error(`${file}: top-level on event must not be empty`);
+    return on === "pull_request" ? null : undefined;
+  }
   if (Array.isArray(on)) {
-    if (on.some((event) => typeof event !== "string" || event.length === 0)) {
-      throw new Error(`${file}: top-level on sequence must contain only non-empty event names`);
-    }
+    if (on.length === 0) throw new Error(`${file}: top-level on sequence must not be empty`);
+    if (on.some((event) => typeof event !== "string" || event.length === 0)) throw new Error(`${file}: top-level on sequence must contain only non-empty event names`);
     return on.includes("pull_request") ? null : undefined;
   }
   if (!plainObject(on)) throw new Error(`${file}: top-level on declaration must name one or more events`);
+  const events = Object.keys(on);
+  if (events.length === 0) throw new Error(`${file}: top-level on mapping must not be empty`);
   return Object.hasOwn(on, "pull_request") ? on.pull_request : undefined;
 }
 

--- a/scripts/pr-head-gate.mjs
+++ b/scripts/pr-head-gate.mjs
@@ -2,85 +2,61 @@
 import { execFileSync } from "node:child_process";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { parseDocument } from "yaml";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const API = "https://api.github.com";
 
-function unquote(value) {
-  const trimmed = value.trim();
-  if (trimmed.length >= 2 && ((trimmed[0] === "'" && trimmed.at(-1) === "'") || (trimmed[0] === '"' && trimmed.at(-1) === '"'))) {
-    return trimmed.slice(1, -1).replace(trimmed[0] === "'" ? /''/g : /\\"/g, trimmed[0]);
-  }
-  return trimmed;
+function plainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function bracketList(value, file, line) {
-  const inner = value.trim().slice(1, -1).trim();
-  if (!inner) return [];
-  return inner.split(",").map((entry) => {
-    const item = unquote(entry);
-    if (!item) throw new Error(`${file}:${line}: empty path filter entry`);
-    return item;
-  });
+function stringList(value, file, key) {
+  if (!Array.isArray(value) || value.length === 0 || value.some((entry) => typeof entry !== "string" || entry.length === 0)) {
+    throw new Error(`${file}: pull_request ${key} must be a non-empty string array`);
+  }
+  return value;
+}
+
+function pullRequestConfig(file, on) {
+  if (typeof on === "string") return on === "pull_request" ? null : undefined;
+  if (Array.isArray(on)) {
+    if (on.some((event) => typeof event !== "string" || event.length === 0)) {
+      throw new Error(`${file}: top-level on sequence must contain only non-empty event names`);
+    }
+    return on.includes("pull_request") ? null : undefined;
+  }
+  if (!plainObject(on)) throw new Error(`${file}: top-level on declaration must name one or more events`);
+  return Object.hasOwn(on, "pull_request") ? on.pull_request : undefined;
 }
 
 function pullRequestDeclaration(file, text) {
-  const lines = text.split("\n");
-  const onIndex = lines.findIndex((line) => /^on:\s*(?:$|\S)/.test(line));
-  if (onIndex < 0) throw new Error(`${file}: missing top-level on declaration`);
-  const onHead = lines[onIndex].replace(/^on:\s*/, "").trim();
-  let handlesPullRequest = false;
-  if (onHead) {
-    if (/^\[.*\]$/.test(onHead)) {
-      const events = bracketList(onHead, file, onIndex + 1);
-      handlesPullRequest = events.includes("pull_request");
-    } else {
-      handlesPullRequest = onHead === "pull_request";
-    }
-    if (!handlesPullRequest) return undefined;
-    const nameLine = lines.find((line) => /^name:\s*\S/.test(line));
-    if (!nameLine) throw new Error(`${file}: a pull-request workflow must declare a top-level name`);
-    return { file, name: unquote(nameLine.replace(/^name:\s*/, "")), paths: undefined };
+  const document = parseDocument(text, {
+    logLevel: "error",
+    strict: true,
+    stringKeys: true,
+    uniqueKeys: true,
+  });
+  const problem = document.errors[0] ?? document.warnings[0];
+  if (problem) throw new Error(`${file}: invalid YAML: ${problem.message}`);
+  const workflow = document.toJS({ maxAliasCount: 100 });
+  if (!plainObject(workflow)) throw new Error(`${file}: workflow document must be a mapping`);
+  if (!Object.hasOwn(workflow, "on")) throw new Error(`${file}: missing top-level on declaration`);
+  const pullRequest = pullRequestConfig(file, workflow.on);
+  if (pullRequest === undefined) return undefined;
+  if (typeof workflow.name !== "string" || workflow.name.trim() === "") {
+    throw new Error(`${file}: a pull-request workflow must declare a non-empty top-level name`);
   }
-
-  let prIndex = -1;
-  for (let i = onIndex + 1; i < lines.length; i++) {
-    if (/^\S/.test(lines[i]) && lines[i].trim()) break;
-    if (/^\s{2}pull_request:\s*/.test(lines[i])) { prIndex = i; break; }
-  }
-  if (prIndex < 0) return undefined;
-  const nameLine = lines.find((line) => /^name:\s*\S/.test(line));
-  if (!nameLine) throw new Error(`${file}: a pull-request workflow must declare a top-level name`);
-  const name = unquote(nameLine.replace(/^name:\s*/, ""));
-  const prHead = lines[prIndex].replace(/^\s{2}pull_request:\s*/, "").trim();
-  if (prHead) {
-    if (prHead === "{}") return { file, name, paths: undefined };
-    throw new Error(`${file}:${prIndex + 1}: unsupported inline pull_request declaration`);
-  }
-
-  let paths;
-  let pathsIgnore;
-  for (let i = prIndex + 1; i < lines.length; i++) {
-    const line = lines[i];
-    if (/^\s{2}\S/.test(line) || /^\S/.test(line)) break;
-    const key = line.match(/^\s{4}(paths|paths-ignore):\s*(.*)$/);
-    if (!key) continue;
-    const values = [];
-    if (key[2].trim()) {
-      if (!/^\[.*\]$/.test(key[2].trim())) throw new Error(`${file}:${i + 1}: unsupported inline ${key[1]} declaration`);
-      values.push(...bracketList(key[2].trim(), file, i + 1));
-    } else {
-      for (i += 1; i < lines.length; i++) {
-        const item = lines[i].match(/^\s{6}-\s*(\S.*)$/);
-        if (!item) { i -= 1; break; }
-        values.push(unquote(item[1]));
-      }
-    }
-    if (key[1] === "paths") paths = values;
-    else pathsIgnore = values;
-  }
+  if (pullRequest === null) return { file, name: workflow.name, paths: undefined, pathsIgnore: undefined };
+  if (!plainObject(pullRequest)) throw new Error(`${file}: pull_request declaration must be a mapping or null`);
+  const unsupported = Object.keys(pullRequest).filter((key) => key !== "paths" && key !== "paths-ignore");
+  if (unsupported.length) throw new Error(`${file}: unsupported pull_request filter: ${unsupported.join(", ")}`);
+  const paths = pullRequest.paths === undefined ? undefined : stringList(pullRequest.paths, file, "paths");
+  const pathsIgnore = pullRequest["paths-ignore"] === undefined
+    ? undefined
+    : stringList(pullRequest["paths-ignore"], file, "paths-ignore");
   if (paths && pathsIgnore) throw new Error(`${file}: pull_request cannot declare both paths and paths-ignore`);
-  return { file, name, paths, pathsIgnore };
+  return { file, name: workflow.name, paths, pathsIgnore };
 }
 
 function globRegex(pattern) {


### PR DESCRIPTION
## Summary

- replace the line-oriented workflow declaration reader with the locked `yaml` parser
- fail closed on invalid YAML, invalid path-filter values, and pull request filters the guard cannot evaluate
- keep existing path-filter and exact PR/head run classification semantics
- make the mutation config tool-gradable and add deterministic controls through the shipped `pnpm pr-head-gate` command

## Reproduction before the fix

The installed parser read `name: Hidden\non: [push, pull_request] # ordinary YAML comment` as a workflow handling `pull_request`. The shipped reader returned an empty expected set, and a successful classifier result was `GREEN` while `Hidden` was absent.

`node scripts/mutation-coverage.mjs bin/smoke/mutations/pr-head-gate.json` also refused the config because the repository tool suite was not marked as tool-graded.

## Validation

- `pnpm smoke:pr-head-gate`
- `node scripts/mutation-coverage.mjs bin/smoke/mutations/pr-head-gate.json`
- `pnpm mutation-proof --config bin/smoke/mutations/pr-head-gate.json` with all 10 named mutations killed
- shipped command controls for both a successful and missing YAML-derived workflow
- `pnpm smoke:ci-fragments`
- `pnpm smoke:gate-inventory`
- `pnpm smoke:ci-declarations`
- `pnpm smoke:ci-suites`
- `pnpm smoke:shard-stability`
- `pnpm check:shard-stability b191d114e988c73a77a53a5f956f286575395a04 HEAD`
- `pnpm check:docs-voice`
- `pnpm build`
- real detached no-fast-forward merge at `b6c9d11bf6ba8e0ddb2e4ef7c2c4ef3202f57ed9`

`pnpm typecheck` reaches the existing `bin/smoke/shard-never-ran.smoke.ts(40,26)` error from main. The same error reproduces on exact base `43e9dd303f71528ece5e13b169838b29cfff2de5` after a full build. This PR does not touch that file.
