### PR TITLE
fix(ci): type shard timeout errors

### DIFF
--- a/bin/smoke/shard-never-ran.smoke.ts
+++ b/bin/smoke/shard-never-ran.smoke.ts
@@ -37,7 +37,7 @@ function runShippedShard(scripts: Record<string, string>) {
     const out = `${r.stdout ?? ""}${r.stderr ?? ""}`;
     return {
       status: r.status,
-      timedOut: r.error?.code === "ETIMEDOUT" || r.signal === "SIGTERM",
+      timedOut: (r.error as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT" || r.signal === "SIGTERM",
       out,
     };
   } finally {


### PR DESCRIPTION
## Summary

- type the `spawnSync` timeout error as `NodeJS.ErrnoException`
- preserve optional chaining, so a missing error remains falsy
- make no runtime behavior change

## Before

On clean `origin/main` at `b191d114e988c73a77a53a5f956f286575395a04`:

```text
$ pnpm typecheck
bin typecheck: smoke/shard-never-ran.smoke.ts(40,26): error TS2339: Property 'code' does not exist on type 'Error'.
[ELIFECYCLE] Command failed with exit code 2
```

## After

```text
$ pnpm typecheck
bin typecheck: Done
# exit 0

$ pnpm smoke:shard-never-ran
SUITE COMPLETE: 18 passed, 0 failed
```

## Testing note

No mutation fixture is added because this is a type-only cast with no runtime delta. The required whole-workspace `pnpm typecheck` CI job is the regression test, and the shipped smoke confirms the timeout path still behaves identically.

## Limit

The whole-tree `pnpm typecheck` failure exists on main. Pull requests branched before this fix lands will inherit that red even though it is not their defect.