### PR TITLE
fix(smoke): extract the stale-source state the backfill harness runs

### DIFF
--- a/implementations/web/smoke/channel-authority.smoke.ts
+++ b/implementations/web/smoke/channel-authority.smoke.ts
@@ -436,8 +436,8 @@ async function runBackfillFunction(code: string, call: string, file: string, ent
     // bootstrap must pair with one settle, so coalescing overlapping callers is part of the backfill
     // path, and a hand-written stand-in would let this harness keep running after the real declaration
     // changed underneath it.
-    const decls = read("../src/web/app.js").match(/^let (?:refreshing|selecting) = .*$/gm) ?? [];
-    assert.equal(decls.length, 2, "app.js must declare the single-flight state this harness runs");
+    const decls = read("../src/web/app.js").match(/^let (?:refreshing|selecting|staleNow) = .*$/gm) ?? [];
+    assert.equal(decls.length, 3, "app.js must declare the single-flight and stale-source state this harness runs");
     runInContext(decls.join("\n"), c, { filename: "app.js (state)" });
   }
   runInContext(`${code}\n__p = ${call};`, c, { filename: file });


### PR DESCRIPTION
smoke:web-channel-authority is deterministically red on current main: `ReferenceError: staleNow is not defined` at app.js refresh() via the harness's runBackfillFunction. #670 added the `staleNow` page-global (kept-last-good source tracking) and app.js:1054 reads it inside refresh(), but the harness's TAKEN-FROM-THE-FILE state extraction still matched only `refreshing|selecting`. Sibling suites (event-order, snapshot-retention) already track `staleNow` in their wanted-state sets; this harness was the one left behind.

Fix: widen the extraction regex to `^let (?:refreshing|selecting|staleNow) = .*$` and move the declaration-count assert to 3 — still read off disk, so the next declaration drift fails the assert instead of a ReferenceError.

Evidence (local, both arms):
- red: reproduced at main-identical bytes — `pnpm smoke:web-channel-authority` fails with the exact CI ReferenceError (same failure as PR #1056's shard 2/4, run 33297575311).
- green: with this change, full suite passes after `pnpm install && pnpm -r build`.

Merging on that local evidence without waiting for Actions: the queue is ~100 deep and refusing new run minting (#1092's disease), and every branch that folds current main inherits this red, so it blocks the whole landing queue.