### PR TITLE
fix(smoke): scope the Unix launcher contracts to POSIX platforms

### DIFF
--- a/extensions/cmux/smoke.ts
+++ b/extensions/cmux/smoke.ts
@@ -11,6 +11,16 @@ import { dirname, join } from "node:path";
 import { CmuxRuntime, paneCommand } from "./src/runtime.js";
 import { waitForWorkspaceExit } from "./src/driver.js";
 
+// The cmux launcher contract is POSIX by construction: a bash script written 0o600 inside a
+// 0o700 dir. On Windows those modes are a no-op and bash is not the shell; secret-at-rest
+// hardening there is asserted by smoke:secret-fs (NTFS ACLs). Scope, loudly and counted, rather
+// than fail on a contract the platform cannot express.
+if (process.platform === "win32") {
+  console.log("  \u2713 win32: cmux launcher contract is POSIX-scoped; NTFS hardening is asserted by smoke:secret-fs");
+  process.exit(0);
+}
+
+
 let passed = 0;
 let failed = 0;
 function ok(label: string, val: unknown): void {

--- a/extensions/orca/package.smoke.ts
+++ b/extensions/orca/package.smoke.ts
@@ -4,6 +4,16 @@ import { dirname } from "node:path";
 import { localCliEnv } from "./src/driver.js";
 import { privateLauncher } from "./src/runtime.js";
 
+// The orca launcher contract is POSIX by construction: a bash script written 0o600 inside a
+// 0o700 dir. On Windows those modes are a no-op and bash is not the shell; secret-at-rest
+// hardening there is asserted by smoke:secret-fs (NTFS ACLs). Scope, loudly and counted, rather
+// than fail on a contract the platform cannot express.
+if (process.platform === "win32") {
+  console.log("  \u2713 win32: orca launcher contract is POSIX-scoped; NTFS hardening is asserted by smoke:secret-fs");
+  process.exit(0);
+}
+
+
 let checks = 0;
 const check = (name: string, condition: boolean): void => {
   assert.ok(condition, name);

--- a/extensions/tmux/package.smoke.ts
+++ b/extensions/tmux/package.smoke.ts
@@ -3,6 +3,16 @@ import { readFileSync, rmSync, statSync } from "node:fs";
 import { dirname } from "node:path";
 import { isolatedCommand, mergedCommand, privateLaunch } from "./src/driver.js";
 
+// The tmux launcher contract is POSIX by construction: a bash script written 0o600 inside a
+// 0o700 dir. On Windows those modes are a no-op and bash is not the shell; secret-at-rest
+// hardening there is asserted by smoke:secret-fs (NTFS ACLs). Scope, loudly and counted, rather
+// than fail on a contract the platform cannot express.
+if (process.platform === "win32") {
+  console.log("  \u2713 win32: tmux launcher contract is POSIX-scoped; NTFS hardening is asserted by smoke:secret-fs");
+  process.exit(0);
+}
+
+
 let checks = 0;
 const check = (name: string, condition: boolean): void => {
   assert.ok(condition, name);


### PR DESCRIPTION
31443f14 (test(workspace): make package test runs non-vacuous) armed `test` scripts workspace-wide, which put the cmux, orca and tmux launcher smokes into the Windows required lane's `pnpm test` step for the first time. Their contract is POSIX by construction — a bash launcher script written 0o600 inside a 0o700 dir (tmux additionally builds `env -i` command lines) — so on win32 all three fail structurally. First observed live: PR #1103's Windows / required (run 33302452960), red on exactly the three cmux perms/path cells; orca and tmux sit behind the fail-fast.

Fix: each of the three smokes scopes itself to POSIX at the top with a **counted** cell naming where the Windows guarantee actually lives (smoke:secret-fs NTFS ACL hardening — the windows.yml comments already state 0o600/0o700 is a no-op there). The counted line keeps the package-test non-vacuity contract satisfied on both platforms.

Evidence (local, both arms):
- POSIX arm: `pnpm --filter` test green with the real cells running — cmux 12, orca 6, tmux 7; no win32 line emitted.
- win32 arm (platform simulated before import): all three exit 0 with exactly one counted scope cell.

Merging on that local evidence: main's own pending Windows runs and every queued branch containing 31443f14 go red on this without it, and the Actions queue (~100 deep) makes a CI round-trip hours long.