### PR TITLE
fix(core): emit recoverable endpoint retries on warning

### DIFF
--- a/.changeset/recoverable-error-channel.md
+++ b/.changeset/recoverable-error-channel.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/core": patch
+---
+
+Emit recoverable endpoint retry notices on `warning` instead of `error`, so a consumer with no error listener is not killed by a condition the endpoint is already surviving.

--- a/bin/smoke/ci-suites.d/f74e3bd2dc0ed0f538862b6d6c8f3b67df9c8fb4aae50ba1a350bfe2ab0c6a99.txt
+++ b/bin/smoke/ci-suites.d/f74e3bd2dc0ed0f538862b6d6c8f3b67df9c8fb4aae50ba1a350bfe2ab0c6a99.txt
@@ -1,0 +1,2 @@
+# Recoverable endpoint retries must emit warning, not EventEmitter error.
+smoke:recoverable-error-channel

--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -740,3 +740,10 @@ smoke:jcode-mid-turn-delivery
 # the real Claude plugin-list JSON seam. Mutation-proofed - bin/smoke/mutations/status-provenance.json.
 # Appended so every existing shard assignment remains unchanged.
 smoke:status-provenance
+
+# Recoverable endpoint retry notices must not use EventEmitter `error`, which Node
+# rethrows with no listener and kills the host the endpoint intended to survive.
+# Discriminating cell: a consumer with NO error listener survives refreshBearer(false).
+# Mutation-proofed - packages/core/smoke/fixtures/recoverable-error-channel.mutations.json.
+# Appended so every existing shard assignment remains unchanged.
+smoke:recoverable-error-channel

--- a/bin/smoke/ci-suites.txt
+++ b/bin/smoke/ci-suites.txt
@@ -740,10 +740,3 @@ smoke:jcode-mid-turn-delivery
 # the real Claude plugin-list JSON seam. Mutation-proofed - bin/smoke/mutations/status-provenance.json.
 # Appended so every existing shard assignment remains unchanged.
 smoke:status-provenance
-
-# Recoverable endpoint retry notices must not use EventEmitter `error`, which Node
-# rethrows with no listener and kills the host the endpoint intended to survive.
-# Discriminating cell: a consumer with NO error listener survives refreshBearer(false).
-# Mutation-proofed - packages/core/smoke/fixtures/recoverable-error-channel.mutations.json.
-# Appended so every existing shard assignment remains unchanged.
-smoke:recoverable-error-channel

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -100,8 +100,9 @@ const args: ParsedArgs = { values: { space, server, port: "0" }, positionals: []
 A string is minted once, so when it expires (which it will: callout bearers live minutes) the
 endpoint has nothing to renew with. It will not present the dead token to the broker, since that is
 a guaranteed denial that still costs a full auth-callout round trip. It refuses to reconnect, emits
-`error` saying which case it is in, and retries on a widening backoff until the process
-re-authenticates and rebuilds it.
+`warning` saying which case it is in, and retries on a widening backoff until the process
+re-authenticates and rebuilds it. Retry notices use `warning` rather than `error` because Node
+rethrows an unhandled `error` event and would kill a host the endpoint is still trying to recover.
 
 Pass a **function** for anything that outlives one bearer. That is a renewal source: it is called
 ahead of each expiry and again whenever a reconnect finds the cached bearer dead, and it requires

--- a/package.json
+++ b/package.json
@@ -286,6 +286,7 @@
     "smoke:frame-size": "tsx packages/core/smoke/frame-size.smoke.ts",
     "smoke:valid-name": "tsx packages/core/smoke/valid-name.smoke.ts",
     "smoke:actor-ephemeral": "tsx packages/core/smoke/actor-ephemeral.smoke.ts",
+    "smoke:recoverable-error-channel": "tsx packages/core/smoke/recoverable-error-channel.smoke.ts",
     "smoke:principal-channel-witness": "tsx packages/core/smoke/principal-channel-witness.smoke.ts",
     "smoke:part-renderer": "tsx packages/core/smoke/part-renderer.smoke.ts",
     "smoke:run-journal-auth": "tsx packages/core/smoke/run-journal-auth.smoke.ts",

--- a/packages/core/smoke/fixtures/recoverable-error-channel.mutations.json
+++ b/packages/core/smoke/fixtures/recoverable-error-channel.mutations.json
@@ -1,0 +1,12 @@
+{
+  "command": "pnpm smoke:recoverable-error-channel",
+  "mutations": [
+    {
+      "name": "M1 restore the fatal error channel for recoverable retries, which is the listenerless host crash",
+      "file": "packages/core/src/endpoint.ts",
+      "find": "  private emitRecoverable(err: Error): void {\n    this.emit(\"warning\", err);\n  }",
+      "replace": "  private emitRecoverable(err: Error): void {\n    this.emit(\"error\", err);\n  }",
+      "expectRed": "a consumer with NO error listener survives a recoverable bearer retry"
+    }
+  ]
+}

--- a/packages/core/smoke/fixtures/recoverable-error-channel.mutations.json
+++ b/packages/core/smoke/fixtures/recoverable-error-channel.mutations.json
@@ -1,4 +1,5 @@
 {
+  "suite": "packages/core/smoke/recoverable-error-channel.smoke.ts",
   "command": "pnpm smoke:recoverable-error-channel",
   "mutations": [
     {
@@ -6,7 +7,8 @@
       "file": "packages/core/src/endpoint.ts",
       "find": "  private emitRecoverable(err: Error): void {\n    this.emit(\"warning\", err);\n  }",
       "replace": "  private emitRecoverable(err: Error): void {\n    this.emit(\"error\", err);\n  }",
-      "expectRed": "a consumer with NO error listener survives a recoverable bearer retry"
+      "expectRed": "a consumer with NO error listener survives a recoverable bearer retry",
+      "cell": "a consumer with NO error listener survives a recoverable bearer retry"
     }
   ]
 }

--- a/packages/core/smoke/recoverable-error-channel.smoke.ts
+++ b/packages/core/smoke/recoverable-error-channel.smoke.ts
@@ -1,0 +1,74 @@
+/**
+ * Recoverable endpoint conditions must not kill a host that omitted an `error` listener (#891).
+ *
+ * Node rethrows EventEmitter `error` when nothing is attached. CotalEndpoint used that channel
+ * for retry notices whose own text says the connection is still running. The live reproduction
+ * (issue comment 5467244165 at main b6c1428b) called the shipped `refreshBearer(false)` path
+ * with a transient bearer-source failure, `errorListeners=0`, and the process exited 1.
+ *
+ * THE DISCRIMINATING CELL is a consumer with NO error listener surviving that retry. A test that
+ * attaches a listener passes against the bug by construction. A default no-op `error` listener
+ * would also go green, and that is the no-fallbacks collision: silent degradation. The control
+ * below requires a listenerless `error` emit to still throw.
+ *
+ * No broker: construction plus the private refresh retry, imported from `../src/` so a mutation
+ * on source is visible without a dist rebuild.
+ *
+ * Run: pnpm smoke:recoverable-error-channel
+ * Prove: pnpm mutation-proof --config packages/core/smoke/fixtures/recoverable-error-channel.mutations.json
+ */
+import { CotalEndpoint } from "../src/index.js";
+
+let ok = 0, fail = 0;
+const c = (n: string, v: boolean, extra?: unknown) => {
+  if (v) { ok++; console.log(`  ✓ ${n}`); }
+  else { fail++; console.log(`  x FAIL: ${n}`, extra ?? ""); }
+};
+
+type Refresh = { refreshBearer: (initial?: boolean) => Promise<void> };
+
+const ep = new CotalEndpoint({
+  space: "s891",
+  card: { name: "probe", kind: "agent", owner: "local", actor: "probe" },
+  bearer: async () => { throw new Error("auth blip"); },
+  sentinelCreds: "creds",
+  registerPresence: false,
+  watchPresence: false,
+  consume: false,
+});
+
+c("the probe attaches no error listener", ep.listenerCount("error") === 0, ep.listenerCount("error"));
+
+const warnings: Error[] = [];
+ep.on("warning", (err: Error) => { warnings.push(err); });
+
+let threw: unknown;
+try {
+  await (ep as unknown as Refresh).refreshBearer(false);
+} catch (e) {
+  threw = e;
+}
+
+c("a consumer with NO error listener survives a recoverable bearer retry", threw === undefined, threw);
+
+const notice = warnings[0]?.message ?? "";
+c("the retry is observable on warning", notice.includes("bearer refresh failed") && notice.includes("retrying"), notice);
+
+const fatal = new CotalEndpoint({
+  space: "s891",
+  card: { name: "fatal", kind: "agent" },
+  registerPresence: false,
+  watchPresence: false,
+  consume: false,
+});
+c("the fatal probe also has no error listener (no default listener was installed)", fatal.listenerCount("error") === 0);
+let errorThrew = false;
+try {
+  fatal.emit("error", new Error("terminal"));
+} catch {
+  errorThrew = true;
+}
+c("a genuine error with no listener still throws", errorThrew);
+
+console.log(`\nRECOVERABLE-ERROR-CHANNEL SMOKE ${fail === 0 ? "OK ✅" : "FAILED ❌"}  (${ok} passed, ${fail} failed)`);
+if (fail) process.exitCode = 1;

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -180,8 +180,9 @@ export interface EndpointOptions {
    *  supervisor), a seed-less daemon re-reads its manager-reminted creds file (delivery). A source
    *  requires explicit `card.id` (the pinned identity); every fetched cred MUST carry that same nkey
    *  or the endpoint fails loud — renewal may never silently swap identity. A fetch failure is
-   *  emitted as an "error" event and retried; the connection stays up until its current JWT expires,
-   *  so a dead reminter is loud without instantly dropping the mesh. Once the cached cred expires,
+   *  emitted as a "warning" event and retried; the connection stays up until its current JWT expires,
+   *  so a dead reminter is loud without instantly dropping the mesh. Node rethrows unhandled "error"
+   *  events, so a retry notice must not use that channel (#891). Once the cached cred expires,
    *  the endpoint refuses to present it to the broker and keeps retrying the source with backoff. */
   creds?: string | (() => Promise<string>);
   /** USER-MODE auth: a validated Cotal user bearer (the JWT from `cotal login` → the IdP bridge), or a
@@ -195,8 +196,9 @@ export interface EndpointOptions {
    *  every (re)connect attempt presents the freshest token — so reconnects outlive any single bearer.
    *  A source requires explicit `card.owner` + `card.actor` (there is no bearer to derive them from at
    *  construction); every fetched bearer MUST carry that same principal or the endpoint fails loud.
-   *  A fetch failure is emitted as an "error" event and retried — the connection stays up until its
+   *  A fetch failure is emitted as a "warning" event and retried — the connection stays up until its
    *  current JWT expires, so a dead auth service surfaces loudly without instantly dropping the mesh.
+   *  Node rethrows unhandled "error" events, so a retry notice must not use that channel (#891).
    *  Mutually exclusive with `creds`/`token`/`user`/`pass`; requires `sentinelCreds`. */
   bearer?: string | (() => Promise<string>);
   /** The shared, deny-all auth-account sentinel creds presented alongside {@link bearer} so the connect
@@ -685,9 +687,18 @@ export class CotalEndpoint extends EventEmitter {
   private static readonly BEARER_REFRESH_MARGIN_MS = 60_000;
   private static readonly BEARER_RETRY_MS = 15_000;
 
+  /**
+   * A condition the endpoint is already surviving. Node rethrows `error` when no listener is
+   * attached, so emitting retry notices on `error` killed hosts that the endpoint intended to
+   * keep running (#891). `warning` is observable and never fatal without a listener.
+   */
+  private emitRecoverable(err: Error): void {
+    this.emit("warning", err);
+  }
+
   /** Fetch a fresh bearer from the source, pin its principal to ours, arm the next refresh. On a
    *  fetch/principal failure: THROWS when `initial` (start() must fail loud before first connect);
-   *  otherwise emits "error" and retries — the live connection keeps working until its current JWT
+   *  otherwise emits "warning" and retries — the live connection keeps working until its current JWT
    *  expiry, so a dead auth service is loud without instantly dropping the mesh. */
   private async refreshBearer(initial = false): Promise<void> {
     try {
@@ -699,7 +710,7 @@ export class CotalEndpoint extends EventEmitter {
       this.armBearerRefresh(bearerExpiryMs(bearer) - Date.now() - CotalEndpoint.BEARER_REFRESH_MARGIN_MS);
     } catch (e) {
       if (initial) throw e;
-      this.emit("error", new Error(`bearer refresh failed (${e instanceof Error ? e.message : String(e)}) - retrying; this connection dies at its current token's expiry if the auth service stays down`));
+      this.emitRecoverable(new Error(`bearer refresh failed (${e instanceof Error ? e.message : String(e)}) - retrying; this connection dies at its current token's expiry if the auth service stays down`));
       this.armBearerRefresh(CotalEndpoint.BEARER_RETRY_MS);
     }
   }
@@ -771,7 +782,7 @@ export class CotalEndpoint extends EventEmitter {
       await this.fetchFreshCreds();
     } catch (e) {
       if (initial) throw e;
-      this.emit("error", new Error(`creds refresh failed (${e instanceof Error ? e.message : String(e)}) - retrying; this connection dies at its current JWT's expiry if renewal keeps failing`));
+      this.emitRecoverable(new Error(`creds refresh failed (${e instanceof Error ? e.message : String(e)}) - retrying; this connection dies at its current JWT's expiry if renewal keeps failing`));
       this.armCredsRefresh(CotalEndpoint.CREDS_RETRY_MS);
     }
   }
@@ -849,7 +860,7 @@ export class CotalEndpoint extends EventEmitter {
       await this.runCredsTxn(() => this.adoptFreshCreds({ deadline }));
       await this.swapConnectionOntoFreshCreds();
     } catch (e) {
-      this.emit("error", new Error(`creds refresh failed (${e instanceof Error ? e.message : String(e)}) - retrying; this connection dies at its current JWT's expiry if renewal keeps failing`));
+      this.emitRecoverable(new Error(`creds refresh failed (${e instanceof Error ? e.message : String(e)}) - retrying; this connection dies at its current JWT's expiry if renewal keeps failing`));
       this.armCredsRefresh(CotalEndpoint.CREDS_RETRY_MS);
     }
   }
@@ -1040,7 +1051,7 @@ export class CotalEndpoint extends EventEmitter {
     if (this.doRegister) {
       await this.publishPresence();
       this.heartbeatTimer = setInterval(() => {
-        this.publishPresence().catch((e) => this.emit("error", e as Error));
+        this.publishPresence().catch((e) => this.emitRecoverable(e as Error));
       }, this.heartbeatMs);
     }
 
@@ -1257,7 +1268,7 @@ export class CotalEndpoint extends EventEmitter {
           this.retryAttempt = 0; // reconnected — the next drop starts from retryMs again
           return; // success — re-armed; the supervisor re-triggers on the next terminal close
         } catch (e) {
-          if (!this.stopped) this.emit("error", e as Error);
+          if (!this.stopped) this.emitRecoverable(e as Error);
           const delay = this.nextRetryDelayMs();
           await new Promise<void>((resolve) => {
             this.backoffResolve = resolve;
@@ -3953,7 +3964,7 @@ export class CotalEndpoint extends EventEmitter {
         if (r.durable) this.plane3Channels.set(channel, r.generation ?? 0);
         else void this.reconcileBootJoin(channel); // present but not yet durable — reconcile to recovery
       } catch (e) {
-        if (!this.isNoResponders(e)) this.emit("error", e as Error); // no daemon ⇒ retry until it recovers
+        if (!this.isNoResponders(e)) this.emitRecoverable(e as Error); // no daemon ⇒ retry until it recovers
         void this.reconcileBootJoin(channel);
       }
     }
@@ -3985,7 +3996,7 @@ export class CotalEndpoint extends EventEmitter {
         // honestly degraded meanwhile, never silently "active".
       } catch (e) {
         if (attempt === 0 && !this.isNoResponders(e))
-          this.emit("error", new Error(`channel "${channel}": boot durable self-join not yet established - retrying until the delivery daemon is reachable (${(e as Error).message})`));
+          this.emitRecoverable(new Error(`channel "${channel}": boot durable self-join not yet established - retrying until the delivery daemon is reachable (${(e as Error).message})`));
       }
     }
   }


### PR DESCRIPTION
## Summary
- `CotalEndpoint` was emitting EventEmitter `error` on paths that already retry and keep the connection up. Node rethrows `error` with no listener, so a condition the endpoint intended to survive killed the host instead. Live corroboration is issue #891 comment 5467244165 at main `b6c1428b`: `refreshBearer(false)` with a transient bearer-source failure, `errorListeners=0`, process exit 1.
- Enumeration of `this.emit("error")` in `packages/core/src/endpoint.ts` at the start of this work: **30 sites**. Classification:
  - **Genuinely recoverable (7, now `warning` via `emitRecoverable`):** non-initial `refreshBearer`, non-initial `refreshCreds`, `renewCredsOnTimer`, heartbeat `publishPresence` catch, `reestablishLoop` rebuild catch, `armBootDurableMemberships` (non-NoResponders), `reconcileBootJoin` first-attempt retry notice. Each of these continues and retries by construction.
  - **Terminal or poison-for-this-item (23, still `error`):** malformed / unauthenticated envelopes, plane-3 term after redelivery ceiling, bound-reply rejection, membership-watch closed, NATS status errors, iterator death while not stopped. Those must stay loud.
- Design: split the channel. Recoverable notices go on `warning` (observable, never fatal without a listener). Fatal conditions stay on `error`. A default no-op `error` listener was rejected: it collides with no-fallbacks (silent degradation) and would swallow genuine failures. Did not touch `packages/core/src/endpoint-invoke.ts` describe-retry `setInterval` publish (sibling crash, separate seat). That sibling shares the theme named here: a condition the endpoint means to survive can still escape as an uncatchable throw.
- Discriminating cell: a consumer with **no** `error` listener survives the shipped `refreshBearer(false)` retry. A listener-attached test would pass against the bug by construction. Control: a genuine listenerless `error` still throws (no default listener installed).
- Mutation `M1` restores `emit("error")` inside `emitRecoverable`. `pnpm mutation-proof --config packages/core/smoke/fixtures/recoverable-error-channel.mutations.json` **KILLED** on `a consumer with NO error listener survives a recoverable bearer retry` at HEAD `b36bf50132c66da90c1cb2314b09ca6605930e83`.

Closes #891.

## Named gaps
- The listenerless crash was reproduced by calling the shipped `refreshBearer(false)` with a throwing bearer source (same path as the triage live repro). It was not reproduced by waiting out a real auth-service outage on a timer against a live IdP.
- Heartbeat, rebuild, and boot-join now share `emitRecoverable` but were not each driven through a throwaway broker in this suite. The named cell is the bearer retry.
- Remaining 23 `error` emits still kill a listenerless host. That is left as residual EventEmitter fatality for non-retry conditions, not silently moved onto `warning`.
- Mutation proves the suite depends on the warning channel. The test reaches the private refresh method the timer calls; it does not wait for `BEARER_RETRY_MS` on a live connection.

## Test plan
- [x] `pnpm smoke:recoverable-error-channel` green (5/5) after rebase onto `origin/main` `d1a932d43`
- [x] Mutation-proof KILLED on the named listenerless-survival cell
- [x] Control: listenerless `error` still throws
- [ ] Reviewer: confirm we should not also move continue-after-drop history/fan-out emits onto `warning`