### PR TITLE
fix(smoke): strip COTAL_ from suite child environments

### DIFF
--- a/bin/smoke/fixtures/control-transport-cleanup.mts
+++ b/bin/smoke/fixtures/control-transport-cleanup.mts
@@ -27,13 +27,21 @@ const check = (name: string, condition: boolean, extra?: unknown) => {
   else { fail++; console.log(`  ✗ FAIL: ${name}`, extra ?? ""); }
 };
 
+// The child is the control-dial suite, which authenticates and persists real credential material.
+// Whatever runs this fixture may itself be a managed agent session, so an ambient copy would hand
+// that child a live credential and a live broker URL. Strip the prefix; the only COTAL_ names the
+// child reads are the two fixture knobs set on top of the copy below, and it sets its own
+// COTAL_HOME.
+const childEnv: NodeJS.ProcessEnv = { ...process.env };
+for (const key of Object.keys(childEnv)) if (key.startsWith("COTAL_")) delete childEnv[key];
+
 const child = spawn(process.execPath, [
   join(process.cwd(), "node_modules", "tsx", "dist", "cli.mjs"),
   join(process.cwd(), "bin", "smoke", "control-transport-dial.smoke.ts"),
 ], {
   cwd: process.cwd(),
   env: {
-    ...process.env,
+    ...childEnv,
     COTAL_SMOKE_CONTROL_DIAL_ID: fixtureId,
     COTAL_SMOKE_CONTROL_DIAL_PID_FILE: pidFile,
   },

--- a/bin/smoke/fixtures/control-transport-crash-cleanup.mts
+++ b/bin/smoke/fixtures/control-transport-crash-cleanup.mts
@@ -26,13 +26,21 @@ const check = (name: string, condition: boolean, extra?: unknown) => {
   else { fail++; console.log(`  ✗ FAIL: ${name}`, extra ?? ""); }
 };
 
+// The child is the control-dial suite, which authenticates and persists real credential material.
+// Whatever runs this fixture may itself be a managed agent session, so an ambient copy would hand
+// that child a live credential and a live broker URL. Strip the prefix; the only COTAL_ names the
+// child reads are the two fixture knobs set on top of the copy below, and it sets its own
+// COTAL_HOME.
+const childEnv: NodeJS.ProcessEnv = { ...process.env };
+for (const key of Object.keys(childEnv)) if (key.startsWith("COTAL_")) delete childEnv[key];
+
 const child = spawn(process.execPath, [
   join(process.cwd(), "node_modules", "tsx", "dist", "cli.mjs"),
   join(process.cwd(), "bin", "smoke", "control-transport-dial.smoke.ts"),
 ], {
   cwd: process.cwd(),
   env: {
-    ...process.env,
+    ...childEnv,
     COTAL_SMOKE_FAIL_CONTROL_DIAL_AFTER_AUTH: "1",
     COTAL_SMOKE_CONTROL_DIAL_ID: fixtureId,
   },

--- a/bin/smoke/pr-head-gate.smoke.ts
+++ b/bin/smoke/pr-head-gate.smoke.ts
@@ -197,11 +197,16 @@ for (const conclusion of ["neutral", "skipped"]) {
 }
 
 function shippedCommand(mode: "success" | "missing") {
+  // The shipped gate reads GitHub credentials (GH_TOKEN/GITHUB_TOKEN/GITHUB_REPOSITORY) and no
+  // COTAL_ name at all, so an ambient copy would hand a live credential and broker URL to a child
+  // that has no use for either. Strip the prefix.
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  for (const key of Object.keys(env)) if (key.startsWith("COTAL_")) delete env[key];
   return spawnSync("pnpm", ["--silent", "pr-head-gate", "1098"], {
     cwd: ROOT,
     encoding: "utf8",
     env: {
-      ...process.env,
+      ...env,
       GITHUB_REPOSITORY: "Cotal-AI/Cotal",
       NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --import=${fixtureFetch}`.trim(),
       PR_HEAD_GATE_FIXTURE: mode,

--- a/bin/smoke/shard-never-ran.smoke.ts
+++ b/bin/smoke/shard-never-ran.smoke.ts
@@ -27,9 +27,14 @@ function runShippedShard(scripts: Record<string, string>) {
     writeFileSync(join(dir, "package.json"), JSON.stringify({ private: true, scripts }));
     const listPath = join(dir, "ci-suites.txt");
     writeFileSync(listPath, `${names.join("\n")}\n`);
+    // The shipped shard runner reads exactly one COTAL_ name, COTAL_CI_SUITES, which is set on top
+    // of the copy below. Everything else the ambient environment carries under that prefix is
+    // connection material this fixture has no use for.
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    for (const key of Object.keys(env)) if (key.startsWith("COTAL_")) delete env[key];
     const r = spawnSync(process.execPath, [SHARD, "0", "1"], {
       cwd: dir,
-      env: { ...process.env, COTAL_CI_SUITES: listPath },
+      env: { ...env, COTAL_CI_SUITES: listPath },
       encoding: "utf8",
       timeout: 60_000,
       maxBuffer: 2 * 1024 * 1024,

--- a/implementations/cli/smoke/seed-migration-provenance.smoke.ts
+++ b/implementations/cli/smoke/seed-migration-provenance.smoke.ts
@@ -26,9 +26,15 @@ function check(name: string, condition: boolean, extra?: unknown): void {
 }
 
 function cotal(cfg: string, args: string[]): { status: number; stdout: string; stderr: string } {
+  // The child is the compiled CLI, which DOES read connection material. Clearing one name by hand
+  // left the rest of the prefix reachable - the credential path, the broker URL, the control token -
+  // so scrub the whole prefix from the copy instead. That subsumes the old
+  // `COTAL_SKIP_CONNECTOR_SEED: undefined`, and XDG_CONFIG_HOME below still pins the seed store.
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  for (const key of Object.keys(env)) if (key.startsWith("COTAL_")) delete env[key];
   const run = spawnSync("node", [BIN, ...args], {
     encoding: "utf8",
-    env: { ...process.env, COTAL_SKIP_CONNECTOR_SEED: undefined, XDG_CONFIG_HOME: cfg },
+    env: { ...env, XDG_CONFIG_HOME: cfg },
   });
   return { status: run.status ?? -1, stdout: run.stdout ?? "", stderr: run.stderr ?? "" };
 }

--- a/implementations/cli/smoke/status-skills-remedy.smoke.ts
+++ b/implementations/cli/smoke/status-skills-remedy.smoke.ts
@@ -53,11 +53,16 @@ exit 0
   writeFileSync(join(home, "bin", "cotal"), "#!/bin/sh\nexit 0\n");
   chmodSync(join(home, "bin", "claude"), 0o755);
   chmodSync(join(home, "bin", "cotal"), 0o755);
+  // The child runs the shipped status/remedy path, which reads connection material. Every COTAL_
+  // name it genuinely needs (COTAL_HOME, COTAL_SKIP_CONNECTOR_SEED) is set on top of the copy below,
+  // so strip the prefix rather than trusting the runner's environment to be clean.
+  const ambientEnv: NodeJS.ProcessEnv = { ...process.env };
+  for (const key of Object.keys(ambientEnv)) if (key.startsWith("COTAL_")) delete ambientEnv[key];
   return {
     home,
     cwd,
     env: {
-      ...process.env,
+      ...ambientEnv,
       HOME: home,
       USERPROFILE: home,
       COTAL_HOME: join(home, ".cotal"),

--- a/implementations/manager/smoke/orphan-seat-succession.smoke.ts
+++ b/implementations/manager/smoke/orphan-seat-succession.smoke.ts
@@ -32,10 +32,16 @@ const alive = (pid: number): boolean => {
 };
 const stopGroup = (pid?: number) => { if (!pid) return; try { process.kill(-pid, "SIGKILL"); } catch { try { process.kill(pid, "SIGKILL"); } catch {} } };
 const here = dirname(fileURLToPath(import.meta.url)); const repo = resolve(here, "../../.."); const host = join(here, "_orphan-seat-host.ts"); const tsx = join(repo, "node_modules", ".bin", "tsx");
+// One scrubbed copy for both children below: this suite re-entered, and the manager host. Both
+// reach real connection material, and a run started from a managed session would otherwise pass it
+// down whole. Copy-and-strip rather than scrubbing process.env in place - the re-entered child reads
+// COTAL_ORPHAN_SEAT_THROW_CONTROL, which is set on top of the copy at the spawn site.
+const ambientEnv: NodeJS.ProcessEnv = { ...process.env };
+for (const key of Object.keys(ambientEnv)) if (key.startsWith("COTAL_")) delete ambientEnv[key];
 if (process.env.COTAL_ORPHAN_SEAT_THROW_CONTROL !== "1") {
   const throwControl = spawnSync(tsx, [fileURLToPath(import.meta.url)], {
     cwd: repo,
-    env: { ...process.env, COTAL_ORPHAN_SEAT_THROW_CONTROL: "1" },
+    env: { ...ambientEnv, COTAL_ORPHAN_SEAT_THROW_CONTROL: "1" },
     encoding: "utf8",
   });
   check(
@@ -48,7 +54,7 @@ const port = await freePort(); const servers = `nats://127.0.0.1:${port}`; const
 const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN)); const root = join(dir, "ws"); mkdirSync(join(root, ".cotal", "agents"), { recursive: true }); saveSpaceAuth(authDir(root), auth); writeFileSync(join(root, ".cotal", "agents", "worker.md"), "---\nname: worker\nrole: worker\nsubscribe: []\nallowSubscribe: []\nallowPublish: []\n---\n"); writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port, storeDir: join(dir, "js") }));
 const broker = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" }); const releaseBroker = teardownOnSignal(broker, dir); let daemon: CotalEndpoint | undefined; const managers: ChildProcess[] = []; const seats: number[] = [];
 async function startManager(tag: string, returnAtManager = false): Promise<{ child: ChildProcess; manager?: { managerPid: number; managerInstanceId: string }; ready?: { managerPid: number; managerInstanceId: string; seatPid: number; actor: string; lifecycleUid: string }; spawn?: { managerPid: number; managerInstanceId: string; reply: { ok: boolean; error?: string; data?: unknown }; managedNames: string[] }; stdout: () => string; stderr: () => string }> {
-  const child = spawn(tsx, [host], { cwd: repo, env: { ...process.env, REPRO_ROOT: root, REPRO_SPACE: space, REPRO_SERVERS: servers, REPRO_OBSERVER_CREDS: observerCreds, REPRO_EVICTOR_CREDS: evictorCreds, REPRO_ACCOUNT_ID: auth.account.pub, COTAL_SERVER: "", COTAL_SERVERS: "", COTAL_CREDS: "", NATS_URL: "" }, detached: true, stdio: ["ignore", "pipe", "pipe"] }); managers.push(child); let out = "", err = ""; child.stdout?.on("data", (b) => out += String(b)); child.stderr?.on("data", (b) => err += String(b)); const deadline = Date.now() + 120_000;
+  const child = spawn(tsx, [host], { cwd: repo, env: { ...ambientEnv, REPRO_ROOT: root, REPRO_SPACE: space, REPRO_SERVERS: servers, REPRO_OBSERVER_CREDS: observerCreds, REPRO_EVICTOR_CREDS: evictorCreds, REPRO_ACCOUNT_ID: auth.account.pub, COTAL_SERVER: "", COTAL_SERVERS: "", COTAL_CREDS: "", NATS_URL: "" }, detached: true, stdio: ["ignore", "pipe", "pipe"] }); managers.push(child); let out = "", err = ""; child.stdout?.on("data", (b) => out += String(b)); child.stderr?.on("data", (b) => err += String(b)); const deadline = Date.now() + 120_000;
   while (Date.now() < deadline) { const readyLine = out.split("\n").find((x) => x.startsWith("REPRO_READY ")); if (readyLine) { const ready = JSON.parse(readyLine.slice("REPRO_READY ".length)); seats.push(ready.seatPid); return { child, ready, stdout: () => out, stderr: () => err }; } const spawnLine = out.split("\n").find((x) => x.startsWith("REPRO_SPAWN ")); if (spawnLine) return { child, spawn: JSON.parse(spawnLine.slice("REPRO_SPAWN ".length)), stdout: () => out, stderr: () => err }; const managerLine = out.split("\n").find((x) => x.startsWith("REPRO_MANAGER ")); if (managerLine && returnAtManager) return { child, manager: JSON.parse(managerLine.slice("REPRO_MANAGER ".length)), stdout: () => out, stderr: () => err }; if (child.exitCode !== null) throw new Error(`${tag} manager exited ${child.exitCode}: ${err}`); await wait(100); }
   throw new Error(`${tag} manager readiness timeout: ${err}`);
 }


### PR DESCRIPTION
## Repro

Fresh clone, `main` @ `d1a932d4`, `pnpm install`, `pnpm -r build`, then:

```
$ pnpm smoke:suite-ambient-env
AssertionError [ERR_ASSERTION]: these suite files spread the ambient environment into a child without stripping COTAL_ first:
  bin/smoke/fixtures/control-transport-cleanup.mts
  bin/smoke/fixtures/control-transport-crash-cleanup.mts
  bin/smoke/pr-head-gate.smoke.ts
  bin/smoke/shard-never-ran.smoke.ts
  implementations/cli/smoke/seed-migration-provenance.smoke.ts
  implementations/cli/smoke/status-skills-remedy.smoke.ts
  implementations/manager/smoke/orphan-seat-succession.smoke.ts
```

Main is red on its own census, so every open PR inherits the failure.

## Remedy chosen

All seven take remedy #1 — strip `COTAL_` from the env copy before the spread. **No file needed a
`REVIEWED` entry, and `FROZEN` is untouched.** Every one of these children either reads no `COTAL_`
name at all, or reads only names the suite sets explicitly *on top of* the copy, so the strip is
behaviour-preserving in each case. The idiom mirrors the existing
`implementations/cli/smoke/component-health.smoke.ts:43-44` shape (copy, then
`for (const key of Object.keys(env)) if (key.startsWith("COTAL_")) delete env[key];`) rather than a
new spelling — `implementations/cli/smoke/meshes-registry.smoke.ts:126-131` records that the census
grades that exact spelling, so folding the test into a regex reads as no filter at all.

| File | Child | Measured reason the strip is safe |
|---|---|---|
| `bin/smoke/fixtures/control-transport-cleanup.mts` | `control-transport-dial.smoke.ts` via tsx | Child reads only `COTAL_SMOKE_CONTROL_DIAL_ID` / `..._PID_FILE`, both set after the copy; it sets its own `COTAL_HOME` (`control-transport-dial.smoke.ts:61`). |
| `bin/smoke/fixtures/control-transport-crash-cleanup.mts` | same suite | Same, plus `COTAL_SMOKE_FAIL_CONTROL_DIAL_AFTER_AUTH`, also set after the copy. |
| `bin/smoke/pr-head-gate.smoke.ts` | `pnpm pr-head-gate` → `scripts/pr-head-gate.mjs` | That script reads `GH_TOKEN`/`GITHUB_TOKEN`/`GITHUB_REPOSITORY` and **no** `COTAL_` name (`scripts/pr-head-gate.mjs:137,178`). |
| `bin/smoke/shard-never-ran.smoke.ts` | `bin/smoke/shard.mjs` | Reads exactly one `COTAL_` name, `COTAL_CI_SUITES` (`shard.mjs:28`), set after the copy. |
| `implementations/cli/smoke/seed-migration-provenance.smoke.ts` | compiled `cotal` CLI | The CLI **does** read connection material. The old code cleared one name by hand (`COTAL_SKIP_CONNECTOR_SEED: undefined`) and left the credential path, broker URL and control token reachable. The prefix strip subsumes that clearing; `XDG_CONFIG_HOME` still pins the seed store. |
| `implementations/cli/smoke/status-skills-remedy.smoke.ts` | shipped status/remedy path | Every `COTAL_` name the child needs (`COTAL_HOME`, `COTAL_SKIP_CONNECTOR_SEED`) is set on top of the copy. |
| `implementations/manager/smoke/orphan-seat-succession.smoke.ts` | this suite re-entered, and `_orphan-seat-host.ts` | Two spread sites share one scrubbed copy. Copy-and-strip, **not** an in-place `process.env` scrub: the re-entered child reads `COTAL_ORPHAN_SEAT_THROW_CONTROL` (set at the spawn site), so scrubbing in place would recurse forever. The host reads only `REPRO_*`/`PATH` and builds its descendants' `COTAL_*` from `LaunchOpts` (`_orphan-seat-host.ts:7-16`). Its explicit `COTAL_SERVER`/`COTAL_SERVERS`/`COTAL_CREDS` blanks are left as-is to keep "" vs unset unchanged. |

## Gate outputs

```
$ pnpm smoke:suite-ambient-env
• census: 96 suite file(s) spread the ambient environment (49 strip, 4 reviewed-safe, 43 frozen and UNAUDITED)
suite-ambient-env: PASS
```
(was 42 strip + 7 offenders; now 49 strip + 0 offenders — reviewed-safe 4 and frozen 43 unchanged)

Every suite owning a touched file:

```
$ pnpm smoke:pr-head-gate
  ✓ every cell ran (34 before sentinel)
PR HEAD GATE SMOKE OK (35 passed, 0 failed)
SUITE COMPLETE

$ pnpm smoke:shard-never-ran
  ✓ every cell ran - 17 expected, so a cell that stops existing is not mistaken for one that passed
SUITE COMPLETE: 18 passed, 0 failed

$ pnpm smoke:control-transport-dial      # chains smoke:control-transport-cleanup
control transport dial: 5 passed, 0 failed
  ✓ E: broker store, project root, COTAL_HOME, and XDG artifacts remaining after teardown = 0
CONTROL CLEANUP PROBE OK (13 passed, 0 failed)

$ pnpm smoke:control-transport-crash-cleanup
CONTROL PRE-BROKER CRASH PROBE OK (11 passed, 0 failed)

$ pnpm smoke:seed-migration-provenance
seed-migration-provenance smoke: 9 passed, 0 failed

$ pnpm smoke:status-skills-remedy
status-skills-remedy.smoke: 15 checks passed

$ pnpm smoke:orphan-seat-succession
ORPHAN-SEAT SUCCESSION SMOKE OK ✅ (5 passed, 0 failed)
```

Typecheck:

```
$ pnpm --dir bin typecheck        # tsc -p tsconfig.json --noEmit && tsc -p tsconfig.smoke.json
exit 0
$ pnpm --filter @cotal-ai/cli typecheck        exit 0
$ pnpm --filter @cotal-ai/manager typecheck    exit 0
```

Note on typecheck coverage, since it affected how I verified: `bin/tsconfig.smoke.json` includes
`**/*.ts`, which does **not** match `.mts`, and the `cli`/`manager` tsconfigs are scoped to `src`.
So four of the seven edited files are outside every existing tsc program — a pre-existing gap, not
one this PR introduces. I typechecked them explicitly against `tsconfig.base.json` (exit 0) rather
than claim the standard gates covered them.

## Mutation sanity

Removed the strip loop from `bin/smoke/shard-never-ran.smoke.ts` only, leaving the `{ ...process.env }`
copy in place:

```
$ pnpm smoke:suite-ambient-env
AssertionError [ERR_ASSERTION]: these suite files spread the ambient environment into a child without stripping COTAL_ first:
  bin/smoke/shard-never-ran.smoke.ts
```

Exactly that file, nothing else. Restored via `git checkout --`; census back to PASS with a clean tree.
