### PR TITLE
fix(smoke): tolerate torn JSONL tails when polling the fake host log

### DIFF
--- a/extensions/connector-codex/smoke/codex-host.smoke.ts
+++ b/extensions/connector-codex/smoke/codex-host.smoke.ts
@@ -83,12 +83,15 @@ interface LogEntry {
   mcpTokenPresent?: boolean;
   cotalLeak?: string[];
 }
+function readJsonLines<T>(path: string): T[] {
+  if (!existsSync(path)) return [];
+  const raw = readFileSync(path, "utf8");
+  const lines = raw.split("\n");
+  if (!raw.endsWith("\n")) lines.pop();
+  return lines.filter(Boolean).map((line) => JSON.parse(line) as T);
+}
 function logEntries(): LogEntry[] {
-  if (!existsSync(LOG)) return [];
-  return readFileSync(LOG, "utf8")
-    .split("\n")
-    .filter(Boolean)
-    .map((l) => JSON.parse(l) as LogEntry);
+  return readJsonLines<LogEntry>(LOG);
 }
 function turnStarts(): string[] {
   return logEntries()
@@ -603,8 +606,7 @@ try {
   // destroying exactly the same-lifecycle redrive the restart rail exists to preserve. The old
   // UI must be retired as EXPECTED synchronously, before the replacement is awaited.
   const tcLog = join(dir, "tuicrash.log.jsonl");
-  const tcEntries = (): LogEntry[] =>
-    existsSync(tcLog) ? readFileSync(tcLog, "utf8").split("\n").filter(Boolean).map((l) => JSON.parse(l) as LogEntry) : [];
+  const tcEntries = (): LogEntry[] => readJsonLines<LogEntry>(tcLog);
   const tuiCrash = spawn(TSX, [HOST_ENTRY], {
     env: {
       ...cleanEnv,
@@ -745,10 +747,7 @@ try {
   let genErr = "";
   genPeer.stderr!.setEncoding("utf8");
   genPeer.stderr!.on("data", (d: string) => (genErr += d));
-  const genEntries = (): LogEntry[] =>
-    existsSync(genLog)
-      ? readFileSync(genLog, "utf8").split("\n").filter(Boolean).map((l) => JSON.parse(l) as LogEntry)
-      : [];
+  const genEntries = (): LogEntry[] => readJsonLines<LogEntry>(genLog);
   let genOnline = false;
   const genWatch = (e: { type: string; presence: { card: { id: string; name: string } } }) => {
     if (e.presence.card.name === "genpeer" && e.type !== "offline") genOnline = true;
@@ -879,9 +878,7 @@ try {
     new Promise<number | null>((r) => meshFail.on("exit", (code) => r(code))),
     sleep(30_000).then(() => "timeout" as const),
   ]);
-  const meshFailEntries = !existsSync(meshFailLog)
-    ? []
-    : readFileSync(meshFailLog, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line) as LogEntry);
+  const meshFailEntries = readJsonLines<LogEntry>(meshFailLog);
   check("the startup failure names mesh readiness and the unreachable broker", /mesh did not become ready/.test(meshFailErr) && meshFailErr.includes(deadServers), meshFailErr.slice(-500));
   check("a Codex host with no mesh fails within the bounded readiness window", typeof meshFailExit === "number" && meshFailExit !== 0, {
     meshFailExit,
@@ -1177,10 +1174,7 @@ try {
     },
     stdio: ["ignore", "ignore", "inherit"],
   });
-  const shutEntries = (): LogEntry[] =>
-    existsSync(shutLog)
-      ? readFileSync(shutLog, "utf8").split("\n").filter(Boolean).map((l) => JSON.parse(l) as LogEntry)
-      : [];
+  const shutEntries = (): LogEntry[] => readJsonLines<LogEntry>(shutLog);
   // JOIN BARRIER, not optional: if the operator never saw this peer online, core treats its
   // departure as a first-seen-offline stale snapshot and records it QUIETLY, emitting no offline
   // presence event — so the assertion below would fail on a healthy leave. Wait for the join.

--- a/extensions/connector-jcode/smoke/jcode-host.smoke.ts
+++ b/extensions/connector-jcode/smoke/jcode-host.smoke.ts
@@ -95,8 +95,15 @@ const check = (name: string, condition: boolean, actual?: unknown): void => {
   pass++;
   console.log(`  ✓ ${name}`);
 };
+function readJsonLines<T>(path: string): T[] {
+  if (!existsSync(path)) return [];
+  const raw = readFileSync(path, "utf8");
+  const lines = raw.split("\n");
+  if (!raw.endsWith("\n")) lines.pop();
+  return lines.filter(Boolean).map((line) => JSON.parse(line) as T);
+}
 const entries = (): Array<{ ev: string; [key: string]: unknown }> =>
-  existsSync(log) ? readFileSync(log, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line)) : [];
+  readJsonLines(log);
 
 type JcodeMcpEntry = { command: string; args: string[]; env: Record<string, string> };
 
@@ -413,7 +420,7 @@ try {
   let raceErr = "";
   race.stderr?.on("data", (chunk: Buffer) => (raceErr += chunk.toString()));
   await Promise.race([once(race, "exit"), sleep(20_000)]);
-  const raceEntries = readFileSync(raceLog, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line)) as Array<{ ev: string; frame?: { req?: string; content?: string; no_reply?: boolean } }>;
+  const raceEntries = readJsonLines<{ ev: string; frame?: { req?: string; content?: string; no_reply?: boolean } }>(raceLog);
   const raceTurns = raceEntries.filter((entry) => entry.ev === "request" && entry.frame?.req === "send_message" && !entry.frame?.no_reply && String(entry.frame?.content).includes("cotal_orientation"));
   check("a first-turn MCP snapshot race recovers on one bounded retry", announced.has("racepeer") && raceTurns.length === 2, { code: race.exitCode, turns: raceTurns, stderr: raceErr });
   await stopHostTree(race, "SIGTERM");
@@ -449,7 +456,7 @@ try {
   await Promise.race([once(absent, "exit"), sleep(20_000)]);
   const absentCode = absent.exitCode;
   await stopHostTree(absent, "SIGKILL");
-  const absentEntries = readFileSync(absentLog, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line)) as Array<{ ev: string; frame?: { req?: string; content?: string; no_reply?: boolean } }>;
+  const absentEntries = readJsonLines<{ ev: string; frame?: { req?: string; content?: string; no_reply?: boolean } }>(absentLog);
   const absentTurns = absentEntries.filter((entry) => entry.ev === "request" && entry.frame?.req === "send_message" && !entry.frame?.no_reply && String(entry.frame?.content).includes("cotal_orientation"));
   check("a permanently absent cotal tool gets exactly two readiness turns", absentTurns.length === 2, absentTurns);
   check("a permanently absent cotal tool ends the launch", absentCode !== null && absentCode !== 0, { code: absentCode, stderr: absentErr });
@@ -506,7 +513,7 @@ try {
     refusedErr,
   );
   check("a seat whose effort was refused never reaches the roster", !announced.has("refusedpeer"), [...announced]);
-  const refusedEntries = existsSync(refusedLog) ? readFileSync(refusedLog, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line)) as Array<{ ev: string; frame?: { req?: string; no_reply?: boolean } }> : [];
+  const refusedEntries = readJsonLines<{ ev: string; frame?: { req?: string; no_reply?: boolean } }>(refusedLog);
   check(
     "a seat whose effort was refused never takes a turn",
     !refusedEntries.some((entry) => entry.ev === "request" && entry.frame?.req === "send_message" && !entry.frame?.no_reply),
@@ -543,7 +550,7 @@ try {
   let outageErr = "";
   outage.stderr?.on("data", (chunk: Buffer) => (outageErr += chunk.toString()));
   const outageEntries = (): Array<{ ev: string; frame?: { req?: string; content?: string; no_reply?: boolean } }> =>
-    existsSync(outageLog) ? readFileSync(outageLog, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line)) : [];
+    readJsonLines(outageLog);
   await waitFor("outage readiness proof", () => outageEntries().find((entry) => entry.ev === "orientation_done") ? true : undefined);
   await waitFor("outage broker refusal", () => /mesh unreachable/.test(outageErr) ? true : undefined);
   const findOutageNotice = () =>
@@ -599,7 +606,7 @@ try {
   let foregroundErr = "";
   foreground.stderr?.on("data", (chunk: Buffer) => (foregroundErr += chunk.toString()));
   await waitFor("foreground readiness proof", () => existsSync(tuiLog) && readFileSync(tuiLog, "utf8").includes('"ev":"orientation_done"') ? true : undefined);
-  const tuiEntries = readFileSync(tuiLog, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line)) as Array<{ ev: string; frame?: { req?: string; content?: string; no_reply?: boolean } }>;
+  const tuiEntries = readJsonLines<{ ev: string; frame?: { req?: string; content?: string; no_reply?: boolean } }>(tuiLog);
   const tuiAt = tuiEntries.findIndex((entry) => entry.ev === "tui");
   const readinessDoneAt = tuiEntries.findIndex((entry) => entry.ev === "orientation_done");
   check("foreground TUI starts before its readiness turn finishes", tuiAt >= 0 && tuiAt < readinessDoneAt, { tuiAt, readinessDoneAt, entries: tuiEntries });
@@ -663,7 +670,7 @@ try {
   refusal.stderr?.on("data", (chunk: Buffer) => (refusalErr += chunk.toString()));
   await waitFor("provider refusal readiness request", () => {
     if (!existsSync(refusalLog)) return undefined;
-    return readFileSync(refusalLog, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line)).find(
+    return readJsonLines<{ ev?: string; frame?: { req?: string; content?: string } }>(refusalLog).find(
       (entry: { ev?: string; frame?: { req?: string; content?: string } }) =>
         entry.ev === "request" && entry.frame?.req === "send_message" && entry.frame.content?.includes("cotal_orientation"),
     );
@@ -676,7 +683,7 @@ try {
       exitCode: refusal.exitCode,
       signalCode: refusal.signalCode,
       stderr: refusalErr,
-      fakeEvents: existsSync(refusalLog) ? readFileSync(refusalLog, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line)) : [],
+      fakeEvents: readJsonLines(refusalLog),
     },
   );
   check(

--- a/extensions/connector-jcode/smoke/jcode-inbound-wedge.smoke.ts
+++ b/extensions/connector-jcode/smoke/jcode-inbound-wedge.smoke.ts
@@ -69,8 +69,14 @@ const check = (name: string, condition: boolean, actual?: unknown): void => {
   pass++;
   console.log(`  ✓ ${name}`);
 };
-const entries = (): Entry[] =>
-  existsSync(log) ? readFileSync(log, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line) as Entry) : [];
+function readJsonLines<T>(path: string): T[] {
+  if (!existsSync(path)) return [];
+  const raw = readFileSync(path, "utf8");
+  const lines = raw.split("\n");
+  if (!raw.endsWith("\n")) lines.pop();
+  return lines.filter(Boolean).map((line) => JSON.parse(line) as T);
+}
+const entries = (): Entry[] => readJsonLines<Entry>(log);
 const turnRequests = (): Entry[] => entries().filter((entry) => entry.ev === "request" && entry.frame?.req === "send_message" && !entry.frame.no_reply);
 const steerText = (): string =>
   entries()

--- a/extensions/connector-jcode/smoke/jcode-lifecycle.smoke.ts
+++ b/extensions/connector-jcode/smoke/jcode-lifecycle.smoke.ts
@@ -73,8 +73,15 @@ const check = (name: string, condition: boolean, actual?: unknown): void => {
   pass++;
   console.log(`  ✓ ${name}`);
 };
+function readJsonLines<T>(path: string): T[] {
+  if (!existsSync(path)) return [];
+  const raw = readFileSync(path, "utf8");
+  const lines = raw.split("\n");
+  if (!raw.endsWith("\n")) lines.pop();
+  return lines.filter(Boolean).map((line) => JSON.parse(line) as T);
+}
 const entriesOf = (log: string): Array<{ ev: string; [key: string]: unknown }> =>
-  existsSync(log) ? readFileSync(log, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line)) : [];
+  readJsonLines(log);
 
 interface HostRun {
   child: ChildProcess;

--- a/extensions/connector-jcode/smoke/jcode-mid-turn-delivery.smoke.ts
+++ b/extensions/connector-jcode/smoke/jcode-mid-turn-delivery.smoke.ts
@@ -70,8 +70,14 @@ const check = (name: string, condition: boolean, actual?: unknown): void => {
   pass++;
   console.log(`  ✓ ${name}`);
 };
-const entries = (): Entry[] =>
-  existsSync(log) ? readFileSync(log, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line) as Entry) : [];
+function readJsonLines<T>(path: string): T[] {
+  if (!existsSync(path)) return [];
+  const raw = readFileSync(path, "utf8");
+  const lines = raw.split("\n");
+  if (!raw.endsWith("\n")) lines.pop();
+  return lines.filter(Boolean).map((line) => JSON.parse(line) as T);
+}
+const entries = (): Entry[] => readJsonLines<Entry>(log);
 const turnRequests = (): Entry[] => entries().filter((entry) => entry.ev === "request" && entry.frame?.req === "send_message" && !entry.frame.no_reply);
 const steerText = (): string =>
   entries()

--- a/extensions/connector-jcode/smoke/jcode-provider-disconnect.smoke.ts
+++ b/extensions/connector-jcode/smoke/jcode-provider-disconnect.smoke.ts
@@ -63,8 +63,15 @@ const check = (name: string, condition: boolean, actual?: unknown): void => {
   pass++;
   console.log(`  ✓ ${name}`);
 };
+function readJsonLines<T>(path: string): T[] {
+  if (!existsSync(path)) return [];
+  const raw = readFileSync(path, "utf8");
+  const lines = raw.split("\n");
+  if (!raw.endsWith("\n")) lines.pop();
+  return lines.filter(Boolean).map((line) => JSON.parse(line) as T);
+}
 const entriesOf = (path: string): Array<{ ev: string; [key: string]: unknown }> =>
-  existsSync(path) ? readFileSync(path, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line)) : [];
+  readJsonLines(path);
 const entries = (): Array<{ ev: string; [key: string]: unknown }> => entriesOf(log);
 const alive = (pid: number): boolean => {
   try {

--- a/extensions/connector-jcode/smoke/jcode-provider-permanent-refusal.smoke.ts
+++ b/extensions/connector-jcode/smoke/jcode-provider-permanent-refusal.smoke.ts
@@ -49,8 +49,15 @@ const check = (name: string, condition: boolean, actual?: unknown): void => {
   passed++;
   console.log(`  ✓ ${name}`);
 };
+function readJsonLines<T>(path: string): T[] {
+  if (!existsSync(path)) return [];
+  const raw = readFileSync(path, "utf8");
+  const lines = raw.split("\n");
+  if (!raw.endsWith("\n")) lines.pop();
+  return lines.filter(Boolean).map((line) => JSON.parse(line) as T);
+}
 const entries = (): Array<{ ev: string; [key: string]: unknown }> =>
-  existsSync(log) ? readFileSync(log, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line)) : [];
+  readJsonLines(log);
 
 try {
   const directCodes = [


### PR DESCRIPTION
## Defect

The Codex and Jcode host smokes poll JSONL files while their fake children append records with `appendFileSync(JSON.stringify(entry) + "\n")`. A poll can read the file during that append, leaving a final segment without its newline. The previous reader parsed every non-empty segment, so it treated that in-progress tail as complete JSON and threw.

This was measured in run 33302484163, job 99233214305 (PR #1056 shard 1/4): `jcode-mid-turn-delivery` observed its deliberate 4 KiB DM frame mid-append and failed with `Unterminated string in JSON` at position 4008.

Each of the seven affected smoke files now uses the same local JSONL reader: when the current bytes do not end in `\n`, it excludes only the final segment. Complete lines still pass directly through `JSON.parse`, so malformed committed records remain loud.

## Proof

### Torn tail before and after

```text
OLD torn tail: THREW Unexpected end of JSON input
NEW torn tail: [{"id":1}]
NEW completed tail: [{"id":1},{"id":2}]
```

The first two reads use identical bytes: one complete entry followed by `{"id":` without a trailing newline. After appending `2}\n`, the new reader returns both entries.

### Complete corruption stays loud

```text
NEW complete corruption: THREW Unexpected token 'g', "garbage" is not valid JSON
```

The malformed segment is newline-terminated, so the new reader still parses it and throws.

### Local verification

```text
pnpm install
Done in 2.8s using pnpm v11.1.2

pnpm -r build
Scope: 26 of 27 workspace projects
...
bin build: Done
examples/01-lateral-coordination build: Done
examples/02-self-improving-console build: Done

pnpm smoke:jcode-mid-turn-delivery
JCODE MID-TURN DELIVERY PASSED (6 checks)

pnpm smoke:jcode-lifecycle
JCODE LIFECYCLE SMOKE PASSED (18 checks)

pnpm --filter @cotal-ai/connector-jcode exec tsc -p tsconfig.json --noEmit 2>/dev/null || true
(no output; exited successfully)
```