### PR TITLE
test(smoke): gate the slow-link serialization probe

### DIFF
--- a/bin/smoke/ci-suites.d/e97baf032c15f3680487b6495b25933b06b75217d8e8bc80ec6808c42b289467.txt
+++ b/bin/smoke/ci-suites.d/e97baf032c15f3680487b6495b25933b06b75217d8e8bc80ec6808c42b289467.txt
@@ -1,0 +1,4 @@
+# The slow-link serialization probe was isolated out of the web smoke into its own script but never
+# gated, so gate-inventory flags it as a suite nothing runs. Appended so every existing shard
+# assignment remains unchanged.
+smoke:web-proxy-order


### PR DESCRIPTION
smoke:web-proxy-order (implementations/web/smoke/slow-link-serialization.probe.ts, isolated in 91e7fb98) was never registered in the suite chain or UNGATED, so `smoke:gate-inventory` fails on every tree that reaches it — currently red on main and surfacing as shard-1 reds across open PRs.

Fix: register it as a `bin/smoke/ci-suites.d/` fragment (tail-append; existing shard assignments unchanged).

Gates: `pnpm smoke:web-proxy-order` green on main (2 passed, 0 failed); `pnpm smoke:gate-inventory` green with the fragment, red without it (the pre-state is the control).