### PR TITLE
fix(manager): scope the static terminal's verified eviction to the credential ledger

### DIFF
--- a/.changeset/ledger-scoped-static-eviction.md
+++ b/.changeset/ledger-scoped-static-eviction.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/manager": patch
+---
+
+Scope the static terminal's verified broker eviction to the credential ledger's holder principals. A lifecycle that never minted a credential retires without demanding an oracle for a principal that was never issued, while a non-empty holder set still fail-closes until every named principal is verified gone.

--- a/implementations/manager/smoke/_boot-delivery.ts
+++ b/implementations/manager/smoke/_boot-delivery.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared smoke helper: boot the REAL delivery daemon against an already-running broker, so a suite
+ * that drives a lifecycle terminal can satisfy SPEC 13.1's verified-eviction step instead of dying
+ * on "the delivery daemon is not reachable on the ctl.delivery-admin rail".
+ *
+ * This is the SHIPPED daemon, not a fixture responder that answers the oracle. The `evictPrincipal`
+ * rail under test is served by `CotalEndpoint.handleDeliveryAdmin`, reached through the same
+ * `startPlane3` hook `runDelivery` wires (`implementations/delivery/src/delivery.ts`), and executed
+ * by core's own `evictDeniedPrincipalWithCreds` — the real CONNZ scan → KICK → re-scan verify.
+ * Nothing here re-implements a step of the barrier; a stub that answered `verifiedGone` would be a
+ * stub of the very thing the barrier trusts.
+ *
+ * What is NOT reproduced from `runDelivery`: its CLI arg surface, its `.cotal`-root scan-target
+ * admission check (the smoke mints the $SYS pair directly from the space auth it already holds),
+ * and the singleton delivery lease. Those guard an operator deployment, not the eviction contract.
+ *
+ * The caller must hold the space's `SpaceAuth` WITH its in-memory system-account signing seed —
+ * i.e. the auth object `createSpaceAuth` just returned, since the $SYS seed is never persisted.
+ */
+import {
+  CotalEndpoint,
+  evictDeniedPrincipalWithCreds,
+  mintConnectionEvictorCreds,
+  mintCreds,
+  mintMembershipObserverCreds,
+  newIdentity,
+  type SpaceAuth,
+} from "@cotal-ai/core";
+
+export interface DeliveryDaemon {
+  /** The daemon's endpoint, for suites that need to reach past the helper. */
+  ep: CotalEndpoint;
+  /** Stop the daemon. Idempotent. */
+  stop: () => Promise<void>;
+}
+
+/** Boot the delivery daemon for `space` on `servers` and serve the privileged `ctl.delivery-admin`
+ *  rail (its `evictPrincipal` verb is the liveness oracle every lifecycle barrier fails closed
+ *  without). Returns once the rail is serving. */
+export async function bootDeliveryDaemon(opts: {
+  space: string;
+  servers: string;
+  auth: SpaceAuth;
+}): Promise<DeliveryDaemon> {
+  const { space, servers, auth } = opts;
+  // The $SYS pair the eviction executor connects with: an observer that can CONNZ-scan the account
+  // and an evictor that can KICK it. Mintable only from a space auth still holding the in-memory
+  // system-account seed.
+  const observerCreds = await mintMembershipObserverCreds(auth, newIdentity());
+  const evictorCreds = await mintConnectionEvictorCreds(auth, newIdentity());
+  const id = newIdentity();
+  const ep = new CotalEndpoint({
+    space,
+    servers,
+    creds: await mintCreds(auth, id, "delivery"),
+    card: { id: id.id, name: "delivery", role: "delivery", kind: "endpoint" },
+    channels: [],
+    consume: false, // it pulls the Plane-3 consumers itself; no agent live-tail
+    watchPresence: false,
+    registerPresence: false, // infra, never a roster peer
+    watchChannels: false,
+  });
+  // A broker teardown at suite end is not a daemon fault; suites assert on their own subject.
+  ep.on("error", () => {});
+  await ep.start();
+  await ep.startPlane3((owner, lifecycleUid) => ep.aclForOwner(owner, lifecycleUid), {
+    evictPrincipal: (principal) =>
+      evictDeniedPrincipalWithCreds({
+        servers, observerCreds, evictorCreds, accountId: auth.account.pub, principal,
+        options: { maxVerifyRounds: 12 },
+      }),
+  });
+  let stopped = false;
+  return {
+    ep,
+    stop: async () => {
+      if (stopped) return;
+      stopped = true;
+      await ep.stop().catch(() => {});
+    },
+  };
+}

--- a/implementations/manager/smoke/mutations/renewal-terminal-serialization.json
+++ b/implementations/manager/smoke/mutations/renewal-terminal-serialization.json
@@ -53,8 +53,8 @@
     {
       "name": "the active static terminal no longer revokes its recorded credential rows",
       "file": "implementations/manager/src/static-lifecycle.ts",
-      "find": "  if (headNow.mapping.state !== \"retired\")\n    await headBeginRetirement(t, { owner: args.owner, actor: args.actor, lifecycleUid: args.lifecycleUid, opId: args.opId });\n  await revokeStaticCredentialRows(t, args.lifecycleUid, slot.row.credentialIds, hooks.log);",
-      "replace": "  if (headNow.mapping.state !== \"retired\")\n    await headBeginRetirement(t, { owner: args.owner, actor: args.actor, lifecycleUid: args.lifecycleUid, opId: args.opId });",
+      "find": "  const holders = await revokeStaticCredentialRows(t, args.lifecycleUid, slot.row.credentialIds, hooks.log);",
+      "replace": "  const holders: string[] = [];",
       "expectRed": "no credential row remains active after retirement",
       "cell": "no credential row remains active after retirement"
     },

--- a/implementations/manager/smoke/mutations/static-terminal-eviction-set.json
+++ b/implementations/manager/smoke/mutations/static-terminal-eviction-set.json
@@ -1,0 +1,36 @@
+{
+  "suite": "implementations/manager/smoke/static-lifecycle.smoke.ts",
+  "guard": "The static terminal's verified-eviction barrier (SPEC 13.1) targets the credential ledger's holder principals. A lifecycle whose ledger names a holder stays `terminalizing` with its alias held until that holder is verify-evicted; a lifecycle that never released a credential retires on an empty set without asking the liveness oracle about a principal that was never issued.",
+  "command": "pnpm smoke:static-lifecycle",
+  "completionMarker": "STATIC-LIFECYCLE SMOKE",
+  "proveWith": "pnpm mutation-proof --config implementations/manager/smoke/mutations/static-terminal-eviction-set.json",
+  "why": [
+    "§7 drives both ledger shapes through the real reconcile entrypoint against a real JWT broker,",
+    "with the eviction seam held UNVERIFIED for both. `heldorphan` releases a bounded credential in",
+    "the manager's own order (slot record -> ledger row), so its ledger names a holder; `orphan`",
+    "releases none.",
+    "",
+    "The two cells are each other's control. One mutation collapses the target set to empty and the",
+    "fail-closed cell must notice; the other restores the pre-narrowing demand on a principal",
+    "synthesized from the alias and the ledgerless cell must notice. A repair that satisfied only one",
+    "of them would have moved the barrier rather than scoped it."
+  ],
+  "mutations": [
+    {
+      "name": "the eviction target set is emptied, so a ledger-bearing lifecycle retires unverified",
+      "file": "implementations/manager/src/static-lifecycle.ts",
+      "find": "    const row = parseLedgerRow(entry.value, key);\n    holders.add(row.holderPrincipal);",
+      "replace": "    const row = parseLedgerRow(entry.value, key);",
+      "expectRed": "an unverified orphan eviction keeps the slot terminalizing",
+      "cell": "an unverified orphan eviction keeps the slot terminalizing (never frees the alias into two owners)"
+    },
+    {
+      "name": "an empty set falls back to the synthesized alias principal (the pre-narrowing demand)",
+      "file": "implementations/manager/src/static-lifecycle.ts",
+      "find": "  if (holders.length === 0) {\n    log(`no credential-ledger row was ever released under uid ${args.lifecycleUid}; the barrier's eviction set is empty (SPEC 13.1)`);\n    return;\n  }",
+      "replace": "  if (holders.length === 0) holders = [`${args.owner}.${args.actor}`];",
+      "expectRed": "a ledgerless orphan retires without a broker eviction",
+      "cell": "a ledgerless orphan retires without a broker eviction (vacuous SPEC 13.1 set)"
+    }
+  ]
+}

--- a/implementations/manager/smoke/secret-store-seam.smoke.ts
+++ b/implementations/manager/smoke/secret-store-seam.smoke.ts
@@ -31,6 +31,7 @@ import {
 } from "@cotal-ai/core";
 import { authDir, saveSpaceAuth, workspaceSecretStore, agentSecretKeyForFile } from "@cotal-ai/workspace";
 import { Manager } from "../src/manager.js";
+import { bootDeliveryDaemon, type DeliveryDaemon } from "./_boot-delivery.js";
 
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 const freePort = (): Promise<number> =>
@@ -76,6 +77,7 @@ const kids: ChildProcess[] = [];
 const srv = spawnProc("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
 kids.push(srv);
 let mgr: InstanceType<typeof Manager> | undefined;
+let delivery: DeliveryDaemon | undefined;
 
 const store = recordingStore(workspaceSecretStore(workspaceRoot));
 
@@ -84,6 +86,12 @@ try {
   for (let i = 0; i < 60; i++) { if (await isReachable(SERVERS)) { up = true; break; } await wait(200); }
   if (!up) throw new Error(`auth nats-server did not come up on ${PORT}`);
   await setupSpaceStreams({ servers: SERVERS, space, creds: await mintCreds(auth, newIdentity(), "provisioner") });
+  // Section D drives a REAL static retirement of an agent that really minted credentials, so SPEC
+  // 13.1's terminal barrier really requires "cluster-verified eviction of every revoked credential's
+  // live connections" here — the ledger names a holder. Without the daemon serving the
+  // `ctl.delivery-admin` rail the barrier fails closed (correctly) and the retirement never reaches
+  // the teardown this suite is about. Boot the shipped daemon rather than weaken the barrier.
+  delivery = await bootDeliveryDaemon({ space, servers: SERVERS, auth });
 
   mgr = new Manager({ space, servers: SERVERS, runtime: "pty", workspaceRoot, secretStore: store });
   // A fake runtime + connector: nothing launches, the credential lifecycle is fully real.
@@ -181,6 +189,7 @@ try {
   console.log(`\nsecret-store-seam smoke: ${pass} passed, ${fail} failed`);
 } finally {
   await mgr?.stop().catch(() => {});
+  await delivery?.stop();
   for (const k of kids) { k.kill("SIGKILL"); }
   await wait(200);
 }

--- a/implementations/manager/smoke/static-lifecycle.smoke.ts
+++ b/implementations/manager/smoke/static-lifecycle.smoke.ts
@@ -22,7 +22,9 @@
  *  6. F3 rollback: a spawn that throws AFTER activation (buildLaunch) drives the exact-op static
  *     terminal — no active orphan survives.
  *  7. RECONCILE (boot sweep): an active slot with no live process is terminalized by
- *     reconcileStaticLifecycles (no active orphan across manager restarts).
+ *     reconcileStaticLifecycles (no active orphan across manager restarts). A ledgerless
+ *     orphan (never minted) retires without a broker eviction. A ledgered orphan whose
+ *     eviction is unverified stays terminalizing so the alias cannot land in two owners.
  *  8. F2: a static spawn carrying endpointCapabilities is REFUSED at spawn-accept.
  *
  * Run: pnpm smoke:static-lifecycle   (needs nats-server + node on PATH; boots its own broker)
@@ -71,6 +73,8 @@ import {
   readStaticSlot,
   activateStaticLifecycle,
   casStaticSlot,
+  recordSlotCredential,
+  appendStaticCredentialRow,
 } from "../src/static-lifecycle.js";
 import { bootBroker } from "./_boot-broker.js";
 
@@ -91,7 +95,7 @@ let ran = 0;
  * when a `check` is deliberately added or removed, because completeness is something only this
  * suite knows, so it has to be the thing that says it.
  */
-const EXPECTED_CHECKS = 39;
+const EXPECTED_CHECKS = 40;
 function check(label: string, cond: boolean, extra?: unknown): void {
   console.log(`${cond ? "✓" : "✗"} ${label}${cond ? "" : ` — ${JSON.stringify(extra) ?? ""}`}`);
   ran++;
@@ -228,6 +232,32 @@ async function readLifecycleAudit(actor: string, uid: string): Promise<Record<st
   } finally { await nc.drain().catch(() => nc.close()); }
 }
 
+async function plantActiveOrphan(alias: string, actor: string, uid: string, ledger: boolean): Promise<void> {
+  const creds = await mintCreds(auth, newIdentity(), "lifecycle-executor", {
+    lifecycleExecutor: { owner: DEV_OWNER, actor, lifecycleUid: uid, alias },
+  });
+  const nc = await connect({ servers: SERVERS, ...standaloneConnectOpts({ creds, tls: false }), maxReconnectAttempts: 0 });
+  try {
+    const kvm = new Kvm(nc);
+    const t = staticLifecycleTransport(await kvm.open(recordsBucket(space)), await kvm.open(epAuthBucket(space)));
+    await activateStaticLifecycle(t, { owner: DEV_OWNER, alias, actor, lifecycleUid: uid, managerInstance: "smoke", ownerInstanceId: M.managerInstanceId });
+    if (ledger) {
+      const credentialId = `cred-${alias}`;
+      await recordSlotCredential(t, DEV_OWNER, alias, uid, credentialId);
+      await appendStaticCredentialRow(t, {
+        lifecycleUid: uid,
+        credentialId,
+        holderPrincipal: principalKey(DEV_OWNER, actor).key,
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      });
+    }
+    const slot = await readStaticSlot(t, DEV_OWNER, alias);
+    await casStaticSlot(t, { ...slot!.row, phase: "active" }, slot!.revision);
+  } finally {
+    await nc.drain().catch(() => nc.close());
+  }
+}
+
 try {
   await setupSpaceStreams({ servers: SERVERS, space, creds: await mintCreds(auth, newIdentity(), "provisioner") });
 
@@ -321,35 +351,31 @@ try {
     check("the crashed spawn's head is RETIRED and its gate terminally retired", sc.head?.state === "retired" && sc.gate?.state === "retired", { head: sc.head?.state, gate: sc.gate?.state });
   }
 
-  // ── 7. Reconcile: an active slot with no live process terminalizes ─────────
+  // ── 7. Reconcile: ledgerless-vacuous vs fail-closed holder ─────────────────
   const orphanId = newIdentity();
   const orphanUid = mintLifecycleUid();
-  {
-    const creds = await mintCreds(auth, newIdentity(), "lifecycle-executor", {
-      lifecycleExecutor: { owner: DEV_OWNER, actor: orphanId.id, lifecycleUid: orphanUid, alias: "orphan" },
-    });
-    const nc = await connect({ servers: SERVERS, ...standaloneConnectOpts({ creds, tls: false }), maxReconnectAttempts: 0 });
-    try {
-      const kvm = new Kvm(nc);
-      const t = staticLifecycleTransport(await kvm.open(recordsBucket(space)), await kvm.open(epAuthBucket(space)));
-      await activateStaticLifecycle(t, { owner: DEV_OWNER, alias: "orphan", actor: orphanId.id, lifecycleUid: orphanUid, managerInstance: "smoke", ownerInstanceId: M.managerInstanceId });
-      const slot = await readStaticSlot(t, DEV_OWNER, "orphan");
-      await casStaticSlot(t, { ...slot!.row, phase: "active" }, slot!.revision);
-    } finally {
-      await nc.drain().catch(() => nc.close());
-    }
-  }
+  await plantActiveOrphan("orphan", orphanId.id, orphanUid, false);
+  evictionVerified = false;
+  evictionCalls = [];
+  await M.reconcileStaticLifecycles();
+  check("a ledgerless orphan retires without a broker eviction (vacuous SPEC 13.1 set)",
+    (await readSlotOnly("orphan"))?.phase === "retired" && evictionCalls.length === 0,
+    { slot: await readSlotOnly("orphan"), evictionCalls });
+
+  const heldId = newIdentity();
+  const heldUid = mintLifecycleUid();
+  await plantActiveOrphan("heldorphan", heldId.id, heldUid, true);
   evictionVerified = false;
   evictionCalls = [];
   await M.reconcileStaticLifecycles();
   check("an unverified orphan eviction keeps the slot terminalizing (never frees the alias into two owners)",
-    (await readSlotOnly("orphan"))?.phase === "terminalizing" && evictionCalls.includes(principalKey(DEV_OWNER, orphanId.id).key),
-    { slot: await readSlotOnly("orphan"), evictionCalls });
+    (await readSlotOnly("heldorphan"))?.phase === "terminalizing" && evictionCalls.includes(principalKey(DEV_OWNER, heldId.id).key),
+    { slot: await readSlotOnly("heldorphan"), evictionCalls });
   evictionVerified = true;
   await M.reconcileStaticLifecycles();
-  const oSettled = await until(async () => (await readSlotOnly("orphan"))?.phase === "retired", 30_000, "the orphan's reconcile terminal");
+  const oSettled = await until(async () => (await readSlotOnly("heldorphan"))?.phase === "retired", 30_000, "the ledgered orphan's reconcile terminal");
   check("reconcile terminalized the dead-but-active slot (no active orphan across restarts)", oSettled);
-  check("the orphan's principal is refused at the control surface after reconcile", typeof M.lifecycleMembershipRefusal(principalKey(DEV_OWNER, orphanId.id).key) === "string");
+  check("the orphan's principal is refused at the control surface after reconcile", typeof M.lifecycleMembershipRefusal(principalKey(DEV_OWNER, heldId.id).key) === "string");
   check("the LIVE agent (worker B) survived the reconcile untouched", M.agents.get("worker")?.lifecycleUid === uidB && (await readSlotOnly("worker"))?.phase === "active");
 
   // ── 7b. F3 RESUME-PATH orphan (distsys/security4 CONDITIONAL @ 9e13648) ─────

--- a/implementations/manager/src/static-lifecycle.ts
+++ b/implementations/manager/src/static-lifecycle.ts
@@ -8,9 +8,10 @@
  * Three-way split (the Unit B design note, panel-locked): the key/value GRAMMAR lives in core
  * `lifecycle-state.ts`; the CAS SEQUENCING is the shared core saga this module DELEGATES to
  * (never a hand-ordered local copy); the barrier ORCHESTRATION here is the static executor's
- * own (revoke from the slot's recorded credentialIds, fail-closed broker connection eviction that
- * holds the lifecycle terminalizing until a complete scan verifies the principal gone, then
- * footprint cleanup via the manager's deprovision hooks).
+ * own (revoke from the slot's recorded credentialIds, fail-closed broker connection eviction of the
+ * holder principals THOSE ROWS name — SPEC 13.1's own target set — that holds the lifecycle
+ * terminalizing until a complete scan verifies each gone, then footprint cleanup via the manager's
+ * deprovision hooks).
  *
  * F5-bind (the F4 restatement): the wire AUTHORITY coordinate is the incarnation-unique nkey
  * (`actor`); the ALIAS is routing only, protected by the name-keyed slot row + uid reservation +
@@ -18,7 +19,6 @@
  */
 import {
   EpEnvelopeError,
-  principalKey,
   type LifecycleStateTransport,
   type LifecycleKvEntry,
   type StaticManagedSlotRow,
@@ -61,12 +61,40 @@ function sameAudit(a: StaticLifecycleAuditSpec, b: StaticLifecycleAuditSpec): bo
     a.broker.scanComplete === b.broker.scanComplete && a.broker.verifiedGone === b.broker.verifiedGone;
 }
 
+/** The terminal barrier's verified-eviction step, over the SPEC'S TARGET SET.
+ *
+ *  SPEC 13.1 scopes it exactly: "cluster-verified eviction of every revoked credential's live
+ *  connections", by the `holderPrincipal` "(from its ledger row)". `holders` is that set, returned
+ *  by the B1 revoke above.
+ *
+ *  An EMPTY set is not a skipped eviction — it is the required eviction of nothing. A lifecycle
+ *  whose ledger released no credential (a durable slot row whose spawn never reached its mint: a
+ *  crashed provision, a pre-3b-2 legacy row, an orphan reconciled at boot) has no `holderPrincipal`
+ *  anywhere, and its incarnation-unique actor nkey (F5-bind) never authenticated to the broker at
+ *  all, so no connection can exist under it for an oracle to find. Demanding the liveness oracle
+ *  there asks it to prove the absence of a principal that was never issued.
+ *
+ *  Where the set is NON-empty the barrier is unchanged and fail-closed: every holder is
+ *  verify-evicted or the lifecycle stays `terminalizing` and the alias stays held. No fallback arm,
+ *  no degraded mode, no skip. */
 async function evictAndAudit(
   t: LifecycleStateTransport,
   args: { owner: string; alias: string; actor: string; lifecycleUid: string; opId: string; managerInstance: string; managerProcessUid: string },
+  holders: readonly string[],
   evict: (principal: string) => Promise<EvictionResult>,
-): Promise<string> {
-  const principal = principalKey(args.owner, args.actor).key;
+  log: (line: string) => void,
+): Promise<void> {
+  if (holders.length === 0) {
+    log(`no credential-ledger row was ever released under uid ${args.lifecycleUid}; the barrier's eviction set is empty (SPEC 13.1)`);
+    return;
+  }
+  // Every static ledger row of one lifecycle carries that incarnation's own principal (the mint
+  // sites record exactly `principalKey(DEV_OWNER, actor)`), so the set is a singleton and the audit
+  // record below is one row per lifecycle. A second holder means the ledger disagrees with the
+  // incarnation it is keyed under: refuse rather than evict some of a set we cannot audit.
+  if (holders.length > 1)
+    throw new EpEnvelopeError("internal", `the ledger rows of uid ${args.lifecycleUid} name ${holders.length} holder principals (${holders.join(", ")}); a static lifecycle has exactly one (SPEC 13.1)`);
+  const principal = holders[0]!;
   const result = await evict(principal);
   if (!result.verifiedGone || !result.scanComplete || result.remaining !== 0)
     throw new EpEnvelopeError("unavailable", `static retirement could not verify-evict ${principal}; the lifecycle remains terminalizing and the alias stays held (SPEC 13.1)`);
@@ -88,7 +116,6 @@ async function evictAndAudit(
     if (!sameAudit(value as StaticLifecycleAuditSpec, spec)) throw new EpEnvelopeError("already-exists", `lifecycle audit ${key} records different evidence`);
     // Timestamp may differ only after the stable manager identities and retirement op prove the same retry.
   }
-  return principal;
 }
 
 /** The direct-KV transport over the two authority stores, bound per lifecycle OPERATION on an
@@ -201,13 +228,19 @@ export async function appendStaticCredentialRow(
 /** The static terminal's B1 revoke: CAS every recorded row `active -> revoked`. Enumeration is
  *  the SLOT's recorded credentialIds (recorded before every mint), never a store listing. An
  *  ABSENT row is the legitimate crash window (id recorded, mint never reached) — no credential
- *  exists for it, logged and skipped; a revoked row is idempotence. */
+ *  exists for it, logged and skipped; a revoked row is idempotence.
+ *
+ *  RETURNS the barrier's eviction TARGET SET: the distinct `holderPrincipal` of every ledger row
+ *  this revoke COVERED — the rows it just CASed AND the already-`revoked` rows a resume walked
+ *  over, because a crash between revoke and eviction must never leave a revoked credential's
+ *  connection live. An absent row contributes nothing: no credential exists for it. */
 export async function revokeStaticCredentialRows(
   t: LifecycleStateTransport,
   lifecycleUid: string,
   credentialIds: readonly string[],
   log: (line: string) => void,
-): Promise<void> {
+): Promise<string[]> {
+  const holders = new Set<string>();
   for (const id of credentialIds) {
     const key = credRowKey(lifecycleUid, id);
     const entry = await t.getAuth(key);
@@ -218,9 +251,11 @@ export async function revokeStaticCredentialRows(
     if (entry.operation !== "PUT")
       throw new EpEnvelopeError("failed-precondition", `the ledger row ${key} carries a ${entry.operation} marker; a ledger row is never deleted (SPEC 13.12)`);
     const row = parseLedgerRow(entry.value, key);
+    holders.add(row.holderPrincipal);
     if (row.state === "revoked") continue;
     await t.putAuth(key, enc.encode(JSON.stringify({ ...row, state: "revoked" })), entry.revision);
   }
+  return [...holders].sort();
 }
 
 /** The static ACTIVATION: F3 intent FIRST (durable outer spawn intent, phase `provisioning`),
@@ -277,8 +312,8 @@ export async function runStaticTerminal(
     const head = await headCandidate(t, args.owner, args.actor);
     if (head !== undefined && head.mapping.lifecycleUid === args.lifecycleUid)
       throw new EpEnvelopeError("internal", `the head for "${args.owner}/${args.actor}" names uid ${args.lifecycleUid} but its gate does not exist; an active head without a gate is corruption (SPEC 13.1)`);
-    await revokeStaticCredentialRows(t, args.lifecycleUid, slot.row.credentialIds, hooks.log);
-    await evictAndAudit(t, args, hooks.evict);
+    const preGateHolders = await revokeStaticCredentialRows(t, args.lifecycleUid, slot.row.credentialIds, hooks.log);
+    await evictAndAudit(t, args, preGateHolders, hooks.evict, hooks.log);
     await hooks.cleanup();
     await casStaticSlot(t, { ...slot.row, phase: "retired" }, slotRevision);
     return "retired";
@@ -295,8 +330,8 @@ export async function runStaticTerminal(
       // The head never won: burn the uid THROUGH the activation's own op (op-pinned exact-op
       // static retirement), then settle the slot — there is no head to retire.
       await gateRetire(t, { lifecycleUid: args.lifecycleUid, revision: gate.revision, opId: gate.row.op.opId });
-      await revokeStaticCredentialRows(t, args.lifecycleUid, slot.row.credentialIds, hooks.log);
-      await evictAndAudit(t, args, hooks.evict);
+      const lostHeadHolders = await revokeStaticCredentialRows(t, args.lifecycleUid, slot.row.credentialIds, hooks.log);
+      await evictAndAudit(t, args, lostHeadHolders, hooks.evict, hooks.log);
       await hooks.cleanup();
       const cur = await readStaticSlot(t, args.owner, args.alias);
       if (cur !== undefined && cur.row.lifecycleUid === args.lifecycleUid && cur.row.phase !== "retired")
@@ -325,15 +360,17 @@ export async function runStaticTerminal(
     throw new EpEnvelopeError("failed-precondition", `the head for "${args.owner}/${args.actor}" names uid ${headNow.mapping.lifecycleUid}, not ${args.lifecycleUid}; foreign movement - refuse (SPEC 13.1)`);
   if (headNow.mapping.state !== "retired")
     await headBeginRetirement(t, { owner: args.owner, actor: args.actor, lifecycleUid: args.lifecycleUid, opId: args.opId });
-  await revokeStaticCredentialRows(t, args.lifecycleUid, slot.row.credentialIds, hooks.log);
+  const holders = await revokeStaticCredentialRows(t, args.lifecycleUid, slot.row.credentialIds, hooks.log);
   // A crash may leave the prior seat process alive after its manager disappeared. Deny-new is
   // durable above; verify the predecessor principal has no live broker connections before cleanup,
   // then before retiring the gate/head and freeing the alias. This does not reap the OS process.
   // Failure leaves the lifecycle terminalizing, so a successor never gains simultaneous broker rails.
-  const principal = principalKey(args.owner, args.actor).key;
-  hooks.log(`verify-evicting orphan seat principal ${principal} before lifecycle cleanup`);
-  await evictAndAudit(t, args, hooks.evict);
-  hooks.log(`verified orphan seat principal gone: ${principal}`);
+  // The set is the ledger's, not a synthesized alias principal (`evictAndAudit`): a lifecycle that
+  // released no credential has no seat to contain, and this narration would be a claim about a
+  // principal that never existed.
+  for (const principal of holders) hooks.log(`verify-evicting orphan seat principal ${principal} before lifecycle cleanup`);
+  await evictAndAudit(t, args, holders, hooks.evict, hooks.log);
+  for (const principal of holders) hooks.log(`verified orphan seat principal gone: ${principal}`);
   await hooks.cleanup();
   // The terminal tail, in the (b2) order: gate frozen->retired FIRST (retains the opId, the
   // recovery coordinate), head retiring->retired LAST (drops the op; the alias frees only now).


### PR DESCRIPTION
## Root cause

Main was red on `smoke:manager-reconcile-ownership` (3/3 cells), `smoke:manager-reconcile-startup` (1) and `smoke:secret-store-seam` (2). Every failing cell was preceded by the same refusal:

> the delivery daemon is not reachable on the `ctl.delivery-admin` rail (no responders: …); a restart on an auth mesh cannot verify-evict the superseded serve family principal … without the liveness oracle. Start the delivery daemon (`cotal up` runs it) and retry — eviction is never skipped (SPEC 13.1)

First-parent bisect: `a257db81` (parent of the #1097 merge) green, `5881a6fe` (merge of #1097, `fix/817-manager-orphan-succession`) red.

#1097 inserted an unconditional `evictAndAudit` into all three branches of `runStaticTerminal`, targeting a **synthesized** principal — `principalKey(args.owner, args.actor).key` — regardless of whether the lifecycle ever released a credential. Measured (temporary instrumentation of `slot.row.credentialIds`, since reverted):

| suite | lifecycle | `credentialIds` |
|---|---|---|
| `manager-reconcile-ownership` | `own-agent`, `legacy-agent` | `[]` |
| `manager-reconcile-startup` | all 8 orphans | `[]` |
| `secret-store-seam` | `worker` | `["sha256-c581b5e7…", "sha256-8083f2b3…"]` |

So the answer is genuinely split, and both halves fall out of the same sentence.

## The deciding spec text

SPEC.md §13.1, terminal-retirement barrier (line 1261):

> → **cluster-verified eviction of every revoked credential's live connections** (`evictPrincipal`, as in the takeover barrier above) →

and the takeover barrier it refers back to (line 1030), which names the target:

> → evict the live connections of every revoked credential's **`holderPrincipal` (from its ledger row, above)** cluster-wide and verify the re-scan found none

The ledger row shape pins it further (line 1052): `holderPrincipal` is "the `<owner>.<actor>` whose connections the barrier evicts; the credential id is NOT the principal, and eviction is by principal".

The eviction set is therefore **derived from the ledger**, not synthesized from the alias. And the ledger is complete by construction — "every credential the auth authority has ever released MUST resolve to a `cred.<lifecycleUid>.<credentialId>` row" — so a lifecycle with zero ledger rows released zero credentials, its incarnation-unique actor nkey (F5-bind) never authenticated to the broker at all, and no connection can exist under it for an oracle to find. An empty set is **the required eviction of nothing**, not a skipped eviction. Demanding the oracle there asks it to prove the absence of a principal that was never issued.

## 2b — narrow the requirement in src (the two reconcile suites)

- `revokeStaticCredentialRows` now **returns the target set**: the distinct `holderPrincipal` of every ledger row the revoke covered — the rows it just CASed **and** the already-`revoked` rows a resume walks over, because a crash between revoke and eviction must never leave a revoked credential's connection live. An absent row (id recorded, mint never reached) contributes nothing.
- `evictAndAudit` takes that set. Empty → logged as the empty eviction set and returns. **Non-empty → completely unchanged and fail-closed**: every holder is verify-evicted or the lifecycle stays `terminalizing` and the alias stays held. No fallback arm, no degraded mode, no skip. Two holders under one static lifecycle is ledger corruption and refuses rather than evicting part of a set it cannot audit.
- The `verify-evicting orphan seat principal …` / `verified orphan seat principal gone: …` narration now loops the ledger's holders instead of asserting a claim about a principal that never existed.

## 2a — provision the fixture (`secret-store-seam`)

That suite's `worker` really minted two credentials, so the ledger names a holder and SPEC 13.1's verified eviction genuinely binds. The suite was under-provisioned, and the barrier was right to refuse. It now boots the **shipped** daemon via a new `implementations/manager/smoke/_boot-delivery.ts`: `CotalEndpoint` with the delivery card → `start()` → `startPlane3(ep.aclForOwner, { evictPrincipal: evictDeniedPrincipalWithCreds(…) })` — the same objects `runDelivery` assembles (`implementations/delivery/src/delivery.ts:256`), so the `ctl.delivery-admin` rail under test is core's own `handleDeliveryAdmin` and the eviction is core's own CONNZ scan → KICK → re-scan verify. Nothing in it re-implements a step of the barrier. What it deliberately does not reproduce from `runDelivery` — CLI arg parsing, the `.cotal`-root scan-target admission check, the singleton delivery lease — guards an operator deployment, not the eviction contract.

Reordering `hooks.cleanup()` ahead of the barrier was considered and rejected: the retirement would still be stuck at `terminalizing` with the alias held, so those two cells would have been a fake green.

## The review BLOCK, closed

**1. `smoke:static-lifecycle` was a real regression in `5c5afce8`, not an inherited red.** Reproduced
independently in a detached scratch worktree at that exact SHA: `✗ an unverified orphan eviction keeps
the slot terminalizing (never frees the alias into two owners)`, with `credentialIds: []` and
`evictionCalls: []`. §7's orphan had a durable ACTIVE slot but no ledger row, so the narrowing let it
retire on an empty set and the fail-closed cell lost its subject.

Closed by `9b6073f3`, which does not delete that assertion — it splits §7 into the two ledger shapes so
each is the other's control:

- a **ledgerless** orphan (a spawn that crashed before its mint, or a pre-3b-2 legacy row) retires with
  `evictionCalls.length === 0`: the oracle is never asked about a principal that was never issued;
- a **ledgered** orphan (`heldorphan`, planted through the manager's own `recordSlotCredential` +
  `appendStaticCredentialRow`) keeps the original fail-closed cell as a security claim again — with the
  eviction seam held UNVERIFIED the slot stays `terminalizing` and the alias stays held.

`EXPECTED_CHECKS` 39 → 40, suite green at 40/40.

**2. The dead mutation anchor is re-anchored** (`9b6073f3`). `renewal-terminal-serialization.json`'s
`the active static terminal no longer revokes its recorded credential rows` now targets the
holder-returning revoke call. `pnpm smoke:mutation-fixtures` reports **0 dead, 0 ambiguous** across the
whole fixture set.

**3. The missing changeset is added** (`9b6073f3`) for the `@cotal-ai/manager` behavior change.

**4. The two new §7 cells are now proved to discriminate** (`0c250cc1`) — see M4/M5 below. Splitting the
cell was necessary but not sufficient: nothing yet showed that each half *notices* the mutation aimed at
the other, which is the only thing separating "the barrier was scoped" from "the barrier was moved".

## The second CI layer — discrimination

With the three target suites cured the shards ran further and died at a second layer. Each of those
four suites was run locally on this machine (`nats-server v2.14.0`, node v24.20.0) against four trees,
each built with `pnpm --filter cotal-ai... build` first. The baseline trees are separate detached
worktrees; this branch's tree was never mutated to produce them.

| suite | base `57969be7` | main `fe3b455a` | head `5c5afce8` | tip (this PR) | verdict |
|---|---|---|---|---|---|
| `smoke:static-lifecycle` | ✅ 39/39 | ✅ 39/39 | ❌ 1 failed | ✅ 40/40 | **narrowing-regression** — ours, closed above |
| `smoke:delivery-renewal` | ❌ | ❌ | ❌ | ❌ | **masked pre-existing, main-wide** |
| `smoke:standing-renewal` | ❌ 10/11 | ❌ 10/11 | ❌ 10/11 | ❌ 10/11 | **masked pre-existing, main-wide** |
| `smoke:jcode-host` | ✅ 41 | ✅ 53 | ✅ 41 | ✅ 41 | **not attributable to this branch** |

**`delivery-renewal` and `standing-renewal` are the same defect, and it is not the oracle.** Both fail
on the same commit: `b36bf501` (#891, "emit recoverable endpoint retries on warning"), an ancestor of
this branch's base. It moved every recoverable endpoint notice from the `error` channel to `warning` and
updated `docs/embedding.md`, but left the consumers that were reading `error` behind:

- `packages/core/smoke/standing-renewal-auth.smoke.ts` listens on `on("error")` and asserts
  `/creds have expired.*renewal.*failing/`. That message is emitted through `emitRecoverable` →
  `this.emit("warning", …)` (`packages/core/src/endpoint.ts:695`), so the cell cannot pass. Red 3/3 on
  repeat at base — deterministic, not a flake.
- `implementations/delivery/src/delivery.ts:228` subscribes only to `error`, so the daemon stopped
  printing its own passive-backstop repair line. The suite's `75% backstop re-read is LOUD on an
  unchanged stale file` then burns the remaining TTL in its `until(…, TTL * 1000)`, the daemon rides to
  `exp`, and every later phase dies on `no responders` for `ctl.delivery-admin`.

That `no responders` line is the smoke's **own** admin request failing against a dead daemon. It is not
this PR's SPEC 13.1 eviction refusal — that text (`the delivery daemon is not reachable on the
'ctl.delivery-admin' rail`) appears **0 times** in the whole shard-0 log. Same rail, different origin.

**`jcode-host` is not this branch's.** CI's failing cell is `model_mismatch names the connector-owned
refusal` (one `ERR_ASSERTION` after 41 ✓, not ten). That cell does not exist at this branch's base — it
arrived on main after `57969be7`, via the jcode work merged up to `fe3b455a`. Locally it passes at base
(41), at this tip (41), and on main (53 checks, `model_mismatch` included). Its CI-only failure
(`spawned Jcode bridge <pid> does not carry its launch-bound identity — refusing unsafe teardown`) needs
the CI environment to classify.

**Scope call:** the two `#891` suites are red on plain main with byte-identical cells, so they are not
this PR's to carry. Their repairs are measured and verified green on main (`standing-renewal` 11/11,
`delivery-renewal` 18/18) and are written up on #1137 for their own change. Folding an `@cotal-ai/core`
smoke and an `@cotal-ai/delivery` shipped change into a SPEC 13.1 manager PR would put three unrelated
causes under one title.

## Gates

| suite | result |
|---|---|
| `smoke:manager-reconcile-ownership` | **6 passed, 0 failed** ✅ |
| `smoke:manager-reconcile-startup` | **4 passed, 0 failed** ✅ |
| `smoke:secret-store-seam` | **9 passed, 0 failed** ✅ |
| `smoke:manager-service` (neighbour) | **25 passed, 0 failed** ✅ |
| `smoke:orphan-seat-succession` (#1097's own suite) | **5 passed, 0 failed** ✅ |
| `smoke:static-lifecycle` (the review's BLOCK 1) | **40/40 assertions** ✅ |
| `smoke:mutation-fixtures` (the review's BLOCK 2) | **0 dead, 0 ambiguous** ✅ |

`pnpm -r build` exit 0. `pnpm --filter ./bin typecheck` (incl. `tsconfig.smoke.json`) exit 0.
`pnpm --filter @cotal-ai/manager typecheck` exit 0. `pnpm changeset status` clean.

`smoke:delivery-renewal` and `smoke:standing-renewal` remain red on this tree, exactly as they are on
main and at this branch's base. See the discrimination above.

## Mutation evidence

Each mutation was applied to the **shipped** code, rebuilt, run, and reverted.

**M1 — `revokeStaticCredentialRows` returns `[]`** (as if the ledger named no holder). This is the
mutation that proves the narrowing did not silently disarm the barrier where it must fire:

```
✗ FAIL: successor verifies the orphan principal's broker rails gone before lifecycle retirement
ORPHAN-SEAT SUCCESSION SMOKE FAILED ❌ (4 passed, 1 failed)
```

**M2 — remove the empty-set arm, restore #1097's synthesized-principal demand.** Reproduces pure main
verbatim, refusal message and all:

```
✗ FAIL: this instance's OWN dead-but-active row is reconciled (terminalized) {"phase":"terminalizing"}
✗ FAIL: a LEGACY row (pre-3b-2, no owner) is reconciled as the single-manager past {"phase":"terminalizing"}
✗ FAIL: the OWN row's principal IS in the refusal index after its terminal
RECONCILE-OWNERSHIP SMOKE FAILED  (3 passed, 3 failed)
```

**M3 — do not boot the daemon in `secret-store-seam`.** This is what makes the 2a/2b split honest: the
reconcile suites pass *without* the daemon (empty set), and this one cannot, because its ledger names a
holder:

```
✗ FAIL: the teardown really happened (the credential file is gone)
✗ FAIL: the credential was DELETED through the injected store (else a retired agent's cred is left in the configured backend)
secret-store-seam smoke: 7 passed, 2 failed
```

**M4/M5 — the registered two-way control** (`static-terminal-eviction-set.json`, `0c250cc1`), run under
`pnpm mutation-proof`. Each §7 cell must notice the mutation aimed at the *other* one, so a repair that
moved the barrier rather than scoping it cannot pass both:

```
KILLED  the eviction target set is emptied, so a ledger-bearing lifecycle retires unverified
  red, and named: an unverified orphan eviction keeps the slot terminalizing - 38 marks (baseline 40)
KILLED  an empty set falls back to the synthesized alias principal (the pre-narrowing demand)
  red, and named: a ledgerless orphan retires without a broker eviction - 39 marks (baseline 40)
All 2 mutation(s) killed. The suite discriminates.
```

**M6 — the re-anchored ledger anchor** in `renewal-terminal-serialization.json`, proved with
`pnpm mutation-proof --config implementations/manager/smoke/mutations/renewal-terminal-serialization.json`:

```
KILLED  the active static terminal no longer revokes its recorded credential rows
  red, and named: no credential row remains active after retirement - 46 marks (baseline 48)
All 11 mutation(s) killed. The suite discriminates.
```

Fixes #1137
