### PR TITLE
test(claude): cover both PATH spellings, not one instead of the other

### DIFF
--- a/extensions/connector-claude-code/smoke/launch-env.smoke.ts
+++ b/extensions/connector-claude-code/smoke/launch-env.smoke.ts
@@ -73,7 +73,29 @@ for (const k of UNRELATED) {
   check(`${k} was withheld (not a declared auth var)`, !(k in env));
 }
 
-check("PATH present so the seat still launches", typeof env.PATH === "string" && env.PATH.length > 0);
+// PATH reaches the child under either spelling. Windows env names are case-insensitive but keep
+// their source casing, so a host spelling `Path` must forward as `Path` and one spelling `PATH` must
+// forward as `PATH` — exactly once each, never both, since a case-duplicate chokes Windows process
+// creation. Both rows run on every platform on purpose: fixturing one spelling leaves the other free
+// to regress unseen, and asserting only `env.PATH` is how the `Path` failure (#1141) reached CI.
+const ambientPath = process.env.PATH ?? process.env.Path ?? "";
+check("the ambient PATH fixture is non-empty, so the rows below can discriminate", ambientPath.length > 0);
+for (const spelling of ["PATH", "Path"] as const) {
+  delete process.env.PATH;
+  delete process.env.Path;
+  process.env[spelling] = ambientPath;
+  const row =
+    claudeConnector.buildLaunch({ space: "smoke", name: `claude-path-${spelling}` } as never).env ?? {};
+  const forwarded = Object.keys(row).filter((k) => k.toLowerCase() === "path");
+  check(
+    `a host spelling of ${spelling} is forwarded exactly once, keeping its source casing`,
+    forwarded.length === 1 && forwarded[0] === spelling,
+    forwarded,
+  );
+  check(`${spelling} reaches the child with its value unchanged`, row[spelling] === ambientPath, row[spelling]);
+}
+delete process.env.Path;
+process.env.PATH = ambientPath;
 
 const opted = claudeConnector.buildLaunch({
   space: "smoke",


### PR DESCRIPTION
Fixes #1141. Supersedes the approach in #1142, which is blocked on a proven blind spot.

## Mechanism

`launchEnv` matches its allowlist case-insensitively and preserves the source key casing, so a Windows host spelling `Path` is forwarded as `Path` and a `PATH` host is forwarded as `PATH`. Forwarding both at once is what it is avoiding: a case-duplicate environment chokes Windows process creation. The suite asserted `env.PATH` only, so the correct Windows behaviour failed it.

The obvious repair is to install `Path` in the fixture instead of `PATH`. That fixes Windows and stops testing the uppercase spelling anywhere, which trades one blind spot for another. This runs both spellings as rows on every platform. Each row asserts that exactly one path key is forwarded, that it keeps its source casing, and that its value is unchanged.

## Evidence

Mutations were applied to `extensions/connector-core/dist/launch.js`, the artifact the suite actually loads. A positive control ran first, confirming that a mutation there reaches the suite at all: blanking the copy guard took the suite to 6 passed / 42 failed. Without that control a survived mutation is indistinguishable from a mutation that never executed, and the first attempt at this proof did survive for exactly that reason.

| fixture | drop `PATH` | drop `Path` |
| --- | --- | --- |
| main today | killed, rc=1 | **survived, rc=0** |
| this change | killed, rc=1 | killed, rc=1 |

The surviving cell in the top-right is #1141: main cannot see a regression in the Windows spelling. Each mutation fails exactly its own two cells and leaves the other spelling green, so the kill sets stay legible rather than collapsing the suite.

Unmutated: 48 passed, 0 failed, rc=0. Previously 44 cells; the four new ones are the two rows.

## Why not #1142

#1142 is correct about the mechanism and its body describes it accurately. Its fixture substitutes `Path` for `PATH` globally, and a review demonstrated that a mutation breaking only the uppercase spelling then survives 44/44 while an all-path control kills. That finding is what this PR is built on; the repair shape here follows the one named on that PR. If this lands, #1142 should close as superseded.

## Not verified here

Windows is not runnable in this environment, so the Windows lane on this PR is the proving gate for actual `Path`-cased hosts. What is verified locally is that both spellings are now exercised and that a regression in either is caught.