### PR TITLE
fix(connector-hermes): inspect the uv harness

### DIFF
--- a/.changeset/honest-hermes-harness.md
+++ b/.changeset/honest-hermes-harness.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/connector-hermes": patch
+---
+
+Inspect and launch the external `uv` harness Hermes actually requires instead of treating the project-provided `hermes` command as a PATH prerequisite.

--- a/bin/smoke/ci-suites.d/182d4bad7f6d5e87f960cd7f2f7773cd25ecfa02bfd5fea4fad2e77a9080090f.txt
+++ b/bin/smoke/ci-suites.d/182d4bad7f6d5e87f960cd7f2f7773cd25ecfa02bfd5fea4fad2e77a9080090f.txt
@@ -1,0 +1,3 @@
+# Hermes runs its gateway through uv, which supplies the project-pinned command. Drive the real
+# installed-extension manager boot and prove uv-only is available while hermes-only is refused.
+smoke:hermes-boot-requirement

--- a/extensions/connector-hermes/smoke/boot-requirement.smoke.ts
+++ b/extensions/connector-hermes/smoke/boot-requirement.smoke.ts
@@ -2,7 +2,8 @@
  * Hermes boot requirement smoke (issue #1144).
  *
  * Drives the real installed-extension manager boot path twice. The cached connector metadata comes
- * from the real source connector, so mutations of `requires` reach the manifest the manager reads.
+ * from the built package artifact customers install. The mutation command rebuilds that artifact
+ * after changing source, so a source mutation reaches the exact metadata the manager reads.
  */
 import { spawn } from "node:child_process";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
@@ -12,7 +13,9 @@ import { join } from "node:path";
 import { isReachable } from "@cotal-ai/core";
 import { cacheConnector, extensionsDir, saveExtensionsManifest } from "../../../packages/workspace/src/index.js";
 import { Manager } from "../../../implementations/manager/src/manager.js";
-import { hermesConnector } from "../src/extension.js";
+
+type HermesConnector = (typeof import("../src/extension.js"))["hermesConnector"];
+const { hermesConnector } = await import("../dist/index.js") as { hermesConnector: HermesConnector };
 
 const freePort = (): Promise<number> => new Promise((resolve, reject) => {
   const server = createServer();

--- a/extensions/connector-hermes/smoke/boot-requirement.smoke.ts
+++ b/extensions/connector-hermes/smoke/boot-requirement.smoke.ts
@@ -24,10 +24,11 @@ const freePort = (): Promise<number> => new Promise((resolve, reject) => {
 });
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 let pass = 0;
+let fail = 0;
 const check = (name: string, condition: boolean, actual?: unknown): void => {
-  if (!condition) throw new Error(`${name}${actual === undefined ? "" : ` - ${JSON.stringify(actual)}`}`);
-  pass++;
-  console.log(`  ✓ ${name}`);
+  if (condition) pass++;
+  else fail++;
+  console.log(`  ${condition ? "✓" : "✗"} ${name}${condition || actual === undefined ? "" : ` - ${JSON.stringify(actual)}`}`);
 };
 
 const root = mkdtempSync(join(tmpdir(), "cotal-hermes-boot-"));
@@ -98,5 +99,6 @@ try {
   rmSync(root, { recursive: true, force: true });
 }
 
-if (pass !== 2) throw new Error(`expected 2 checks, ran ${pass}`);
-console.log(`\n${pass} checks passed`);
+if (pass + fail !== 2) throw new Error(`expected 2 checks, ran ${pass + fail}`);
+console.log(`\n${pass} passed, ${fail} failed`);
+if (fail) process.exitCode = 1;

--- a/extensions/connector-hermes/smoke/boot-requirement.smoke.ts
+++ b/extensions/connector-hermes/smoke/boot-requirement.smoke.ts
@@ -1,0 +1,102 @@
+/**
+ * Hermes boot requirement smoke (issue #1144).
+ *
+ * Drives the real installed-extension manager boot path twice. The cached connector metadata comes
+ * from the real source connector, so mutations of `requires` reach the manifest the manager reads.
+ */
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { isReachable } from "@cotal-ai/core";
+import { cacheConnector, extensionsDir, saveExtensionsManifest } from "../../../packages/workspace/src/index.js";
+import { Manager } from "../../../implementations/manager/src/manager.js";
+import { hermesConnector } from "../src/extension.js";
+
+const freePort = (): Promise<number> => new Promise((resolve, reject) => {
+  const server = createServer();
+  server.on("error", reject);
+  server.listen(0, "127.0.0.1", () => {
+    const port = (server.address() as AddressInfo).port;
+    server.close(() => resolve(port));
+  });
+});
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+let pass = 0;
+const check = (name: string, condition: boolean, actual?: unknown): void => {
+  if (!condition) throw new Error(`${name}${actual === undefined ? "" : ` - ${JSON.stringify(actual)}`}`);
+  pass++;
+  console.log(`  ✓ ${name}`);
+};
+
+const root = mkdtempSync(join(tmpdir(), "cotal-hermes-boot-"));
+const configHome = join(root, "config");
+const oldConfigHome = process.env.XDG_CONFIG_HOME;
+const oldPath = process.env.PATH;
+process.env.XDG_CONFIG_HOME = configHome;
+mkdirSync(extensionsDir(), { recursive: true });
+saveExtensionsManifest({
+  extensions: [{
+    pkg: "@cotal-ai/connector-hermes",
+    version: "0.36.0",
+    spec: ".",
+    provides: [{ kind: "connector", name: "hermes" }],
+    commands: [],
+    connectors: [cacheConnector(hermesConnector)],
+  }],
+});
+
+const port = await freePort();
+const servers = `nats://127.0.0.1:${port}`;
+const broker = spawn("nats-server", ["-js", "-p", String(port), "-sd", join(root, "js")], { stdio: "ignore" });
+const managers: Manager[] = [];
+
+try {
+  for (let i = 0; i < 100 && !(await isReachable(servers)); i++) await wait(50);
+  if (!(await isReachable(servers))) throw new Error("owned broker did not start");
+
+  for (const [label, binaries] of [["uv-only", ["uv"]], ["hermes-only", ["hermes"]]] as const) {
+    const binDir = join(root, label, "bin");
+    const workspaceRoot = join(root, label, "ws");
+    mkdirSync(binDir, { recursive: true });
+    mkdirSync(join(workspaceRoot, ".cotal", "agents"), { recursive: true });
+    for (const binary of binaries) {
+      const path = join(binDir, process.platform === "win32" ? `${binary}.cmd` : binary);
+      writeFileSync(path, process.platform === "win32" ? "@exit /b 0\r\n" : "#!/bin/sh\nexit 0\n", { mode: 0o700 });
+    }
+    process.env.PATH = binDir;
+    const manager = new Manager({ space: `hermes-boot-${label}`, servers, runtime: "pty", workspaceRoot, installedExtensions: true });
+    managers.push(manager);
+    await manager.start();
+    const status = (manager as unknown as {
+      managerStatusData(): { connectors: Array<{ agent: string; state: string; binaries: Record<string, string>; reason?: string }> };
+    }).managerStatusData().connectors.find((row) => row.agent === "hermes");
+    if (label === "uv-only") {
+      const expected = join(binDir, process.platform === "win32" ? "uv.cmd" : "uv");
+      check(
+        "Hermes is available when uv is the only harness executable",
+        status?.state === "available" && status.binaries.uv === expected && !("hermes" in status.binaries),
+        status,
+      );
+    } else {
+      check(
+        "Hermes is unavailable when only the project command is on PATH",
+        status?.state === "unavailable" && status.reason?.includes("needs uv on PATH") === true && Object.keys(status.binaries).length === 0,
+        status,
+      );
+    }
+  }
+} finally {
+  if (oldPath === undefined) delete process.env.PATH;
+  else process.env.PATH = oldPath;
+  if (oldConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = oldConfigHome;
+  for (const manager of managers.reverse()) await manager.stop().catch(() => {});
+  broker.kill("SIGKILL");
+  for (let i = 0; i < 100 && broker.exitCode === null && broker.signalCode === null; i++) await wait(20);
+  rmSync(root, { recursive: true, force: true });
+}
+
+if (pass !== 2) throw new Error(`expected 2 checks, ran ${pass}`);
+console.log(`\n${pass} checks passed`);

--- a/extensions/connector-hermes/smoke/launch-env.smoke.ts
+++ b/extensions/connector-hermes/smoke/launch-env.smoke.ts
@@ -8,6 +8,7 @@
  * Run: pnpm --filter @cotal-ai/connector-hermes test
  */
 import { strict as assert } from "node:assert";
+import { hermesUvCommand } from "../src/binary.js";
 import { hermesConnector } from "../src/extension.js";
 
 if (process.platform === "win32") {
@@ -40,6 +41,7 @@ const HOST_MARKERS = [
 const PER_SESSION = [
   "COTAL_LAUNCH_MATERIAL", "COTAL_CREDS", "COTAL_SERVERS", "COTAL_CONTROL_TOKEN",
   "COTAL_CONTROL_SOCKET", "COTAL_OWNER", "COTAL_ACTOR", "COTAL_SENTINEL_CREDS", "COTAL_BEARER_CMD",
+  "COTAL_HERMES_UV_BIN",
   "COTAL_LIFECYCLE_UID", "COTAL_ID", "COTAL_ROLE", "COTAL_MODEL", "COTAL_VARIANT",
   "COTAL_AGENT_FILE", "COTAL_LINK", "COTAL_SUBSCRIBE", "COTAL_ALLOW_SUBSCRIBE",
   "COTAL_ALLOW_PUBLISH", "COTAL_CAPABILITIES", "COTAL_EVENTS", "COTAL_WORKSPACE_ROOT",
@@ -104,6 +106,15 @@ assert.throws(
   "a prompt the connector cannot submit must refuse the launch",
 );
 
+const bootResolved = hermesConnector.buildLaunch({
+  space: "smoke",
+  name: "hermes-boot-resolved",
+  resolvedBinaries: { uv: "/manager/boot/uv" },
+}).env ?? {};
+assert.equal(bootResolved.COTAL_HERMES_UV_BIN, "/manager/boot/uv", "the exact manager-boot uv path reaches the launcher");
+assert.equal(hermesUvCommand(bootResolved), "/manager/boot/uv", "the launcher executes the exact manager-boot uv path");
+
+console.log("2 checks passed");
 console.log(
   `launch-env smoke: ${PROVIDER_KEYS.length} declared provider keys forwarded, ` +
     `${FORMERLY_EXCLUDED.length + HOST_MARKERS.length + 1} undeclared names withheld, ` +

--- a/extensions/connector-hermes/smoke/launch-env.smoke.ts
+++ b/extensions/connector-hermes/smoke/launch-env.smoke.ts
@@ -11,6 +11,7 @@ import { strict as assert } from "node:assert";
 import type { ChildProcess } from "node:child_process";
 import { hermesUvCommand, spawnHermesGateway } from "../src/binary.js";
 import { hermesConnector } from "../src/extension.js";
+import { assertHermesVersion } from "../src/launch.js";
 
 if (process.platform === "win32") {
   console.log("✓ launch-env smoke skipped on Windows (the Hermes connector is Unix-only; buildLaunch throws)");
@@ -134,7 +135,26 @@ assert.deepEqual(
   "the gateway spawn executes the exact manager-boot uv path",
 );
 
-console.log("3 checks passed");
+let inspected: { command: string; args: readonly string[] } | undefined;
+assertHermesVersion({
+  env: bootResolved,
+  pkgDir: "/connector/hermes",
+  execFileImpl: (command, args) => {
+    inspected = { command, args };
+    return "0.16.7\n";
+  },
+  logImpl: () => {},
+});
+assert.deepEqual(
+  inspected,
+  {
+    command: "/manager/boot/uv",
+    args: ["run", "--project", "/connector/hermes", "--quiet", "python", "-c", "from importlib.metadata import version; print(version('hermes-agent'))"],
+  },
+  "version inspection executes the exact manager-boot uv path",
+);
+
+console.log("4 checks passed");
 console.log(
   `launch-env smoke: ${PROVIDER_KEYS.length} declared provider keys forwarded, ` +
     `${FORMERLY_EXCLUDED.length + HOST_MARKERS.length + 1} undeclared names withheld, ` +

--- a/extensions/connector-hermes/smoke/launch-env.smoke.ts
+++ b/extensions/connector-hermes/smoke/launch-env.smoke.ts
@@ -8,7 +8,8 @@
  * Run: pnpm --filter @cotal-ai/connector-hermes test
  */
 import { strict as assert } from "node:assert";
-import { hermesUvCommand } from "../src/binary.js";
+import type { ChildProcess } from "node:child_process";
+import { hermesUvCommand, spawnHermesGateway } from "../src/binary.js";
 import { hermesConnector } from "../src/extension.js";
 
 if (process.platform === "win32") {
@@ -114,7 +115,26 @@ const bootResolved = hermesConnector.buildLaunch({
 assert.equal(bootResolved.COTAL_HERMES_UV_BIN, "/manager/boot/uv", "the exact manager-boot uv path reaches the launcher");
 assert.equal(hermesUvCommand(bootResolved), "/manager/boot/uv", "the launcher executes the exact manager-boot uv path");
 
-console.log("2 checks passed");
+let spawned: { command: string; args: readonly string[]; env?: NodeJS.ProcessEnv } | undefined;
+spawnHermesGateway({
+  pkgDir: "/connector/hermes",
+  env: bootResolved,
+  spawnImpl: ((command: string, args: readonly string[], options: { env?: NodeJS.ProcessEnv }) => {
+    spawned = { command, args, env: options.env };
+    return {} as ChildProcess;
+  }) as typeof import("node:child_process").spawn,
+});
+assert.deepEqual(
+  spawned,
+  {
+    command: "/manager/boot/uv",
+    args: ["run", "--project", "/connector/hermes", "hermes", "gateway", "run"],
+    env: bootResolved,
+  },
+  "the gateway spawn executes the exact manager-boot uv path",
+);
+
+console.log("3 checks passed");
 console.log(
   `launch-env smoke: ${PROVIDER_KEYS.length} declared provider keys forwarded, ` +
     `${FORMERLY_EXCLUDED.length + HOST_MARKERS.length + 1} undeclared names withheld, ` +

--- a/extensions/connector-hermes/smoke/mutations/boot-binary.json
+++ b/extensions/connector-hermes/smoke/mutations/boot-binary.json
@@ -14,12 +14,12 @@
       "cell": "the exact manager-boot uv path reaches the launcher"
     },
     {
-      "name": "Hermes launcher ignores the manager-boot uv path",
+      "name": "Hermes gateway spawn ignores the manager-boot uv path",
       "file": "extensions/connector-hermes/src/binary.ts",
-      "find": "  return env.COTAL_HERMES_UV_BIN?.trim() || \"uv\";",
-      "replace": "  return \"uv\";",
-      "expectRed": "the launcher executes the exact manager-boot uv path",
-      "cell": "the launcher executes the exact manager-boot uv path"
+      "find": "  return spawnImpl(hermesUvCommand(opts.env), [\"run\", \"--project\", opts.pkgDir, \"hermes\", \"gateway\", \"run\"], spawnOptions);",
+      "replace": "  return spawnImpl(\"uv\", [\"run\", \"--project\", opts.pkgDir, \"hermes\", \"gateway\", \"run\"], spawnOptions);",
+      "expectRed": "the gateway spawn executes the exact manager-boot uv path",
+      "cell": "the gateway spawn executes the exact manager-boot uv path"
     }
   ]
 }

--- a/extensions/connector-hermes/smoke/mutations/boot-binary.json
+++ b/extensions/connector-hermes/smoke/mutations/boot-binary.json
@@ -20,6 +20,14 @@
       "replace": "  return spawnImpl(\"uv\", [\"run\", \"--project\", opts.pkgDir, \"hermes\", \"gateway\", \"run\"], spawnOptions);",
       "expectRed": "the gateway spawn executes the exact manager-boot uv path",
       "cell": "the gateway spawn executes the exact manager-boot uv path"
+    },
+    {
+      "name": "Hermes version inspection ignores the manager-boot uv path",
+      "file": "extensions/connector-hermes/src/launch.ts",
+      "find": "      hermesUvCommand(opts.env),",
+      "replace": "      \"uv\",",
+      "expectRed": "version inspection executes the exact manager-boot uv path",
+      "cell": "version inspection executes the exact manager-boot uv path"
     }
   ]
 }

--- a/extensions/connector-hermes/smoke/mutations/boot-binary.json
+++ b/extensions/connector-hermes/smoke/mutations/boot-binary.json
@@ -1,0 +1,25 @@
+{
+  "suite": "extensions/connector-hermes/smoke/launch-env.smoke.ts",
+  "guard": "the manager's boot-resolved uv executable reaches the Hermes launcher and is the command it executes",
+  "command": "pnpm smoke:hermes-launch-env",
+  "progressPattern": "launch-env smoke:",
+  "minTicks": 1,
+  "mutations": [
+    {
+      "name": "Hermes launch drops the manager-boot uv path",
+      "file": "extensions/connector-hermes/src/extension.ts",
+      "find": "    if (opts.resolvedBinaries?.uv) env.COTAL_HERMES_UV_BIN = opts.resolvedBinaries.uv;",
+      "replace": "    void opts.resolvedBinaries?.uv;",
+      "expectRed": "the exact manager-boot uv path reaches the launcher",
+      "cell": "the exact manager-boot uv path reaches the launcher"
+    },
+    {
+      "name": "Hermes launcher ignores the manager-boot uv path",
+      "file": "extensions/connector-hermes/src/binary.ts",
+      "find": "  return env.COTAL_HERMES_UV_BIN?.trim() || \"uv\";",
+      "replace": "  return \"uv\";",
+      "expectRed": "the launcher executes the exact manager-boot uv path",
+      "cell": "the launcher executes the exact manager-boot uv path"
+    }
+  ]
+}

--- a/extensions/connector-hermes/smoke/mutations/boot-requirement.json
+++ b/extensions/connector-hermes/smoke/mutations/boot-requirement.json
@@ -1,0 +1,25 @@
+{
+  "suite": "extensions/connector-hermes/smoke/boot-requirement.smoke.ts",
+  "guard": "the real installed-extension manager boot classifies Hermes from the external uv harness, not the project-provided command",
+  "command": "pnpm smoke:hermes-boot-requirement",
+  "progressPattern": "✓",
+  "minTicks": 2,
+  "mutations": [
+    {
+      "name": "Hermes boot inspection still requires the project-provided command",
+      "file": "extensions/connector-hermes/src/extension.ts",
+      "find": "  requires: [\"uv\"],",
+      "replace": "  requires: [\"hermes\"],",
+      "expectRed": "Hermes is available when uv is the only harness executable",
+      "cell": "Hermes is available when uv is the only harness executable"
+    },
+    {
+      "name": "Hermes boot inspection admits a connector with no external harness",
+      "file": "extensions/connector-hermes/src/extension.ts",
+      "find": "  requires: [\"uv\"],",
+      "replace": "  requires: [],",
+      "expectRed": "Hermes is unavailable when only the project command is on PATH",
+      "cell": "Hermes is unavailable when only the project command is on PATH"
+    }
+  ]
+}

--- a/extensions/connector-hermes/src/binary.ts
+++ b/extensions/connector-hermes/src/binary.ts
@@ -1,5 +1,19 @@
+import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
+
 /** The exact `uv` executable resolved by manager boot. A bare fallback remains for library
  * compositions that do not run the installed-extension inventory. */
 export function hermesUvCommand(env: NodeJS.ProcessEnv = process.env): string {
   return env.COTAL_HERMES_UV_BIN?.trim() || "uv";
+}
+
+/** Spawn the project-pinned Hermes gateway through the exact manager-resolved uv executable. The
+ * injectable spawn function is a smoke seam over this real call, not a second launch renderer. */
+export function spawnHermesGateway(opts: {
+  pkgDir: string;
+  env: NodeJS.ProcessEnv;
+  spawnImpl?: typeof spawn;
+}): ChildProcess {
+  const spawnImpl = opts.spawnImpl ?? spawn;
+  const spawnOptions: SpawnOptions = { env: opts.env, stdio: "inherit" };
+  return spawnImpl(hermesUvCommand(opts.env), ["run", "--project", opts.pkgDir, "hermes", "gateway", "run"], spawnOptions);
 }

--- a/extensions/connector-hermes/src/binary.ts
+++ b/extensions/connector-hermes/src/binary.ts
@@ -1,0 +1,5 @@
+/** The exact `uv` executable resolved by manager boot. A bare fallback remains for library
+ * compositions that do not run the installed-extension inventory. */
+export function hermesUvCommand(env: NodeJS.ProcessEnv = process.env): string {
+  return env.COTAL_HERMES_UV_BIN?.trim() || "uv";
+}

--- a/extensions/connector-hermes/src/extension.ts
+++ b/extensions/connector-hermes/src/extension.ts
@@ -35,7 +35,9 @@ export const HERMES_PROVIDER_KEYS: readonly string[] = [
 export const hermesConnector: Connector = {
   kind: "connector",
   name: "hermes",
-  requires: ["hermes"],
+  // `uv` is the external harness. It provisions the project-pinned `hermes` command below, so a
+  // separately installed `hermes` on PATH is neither required nor sufficient to launch this seat.
+  requires: ["uv"],
   buildLaunch(opts: LaunchOpts): LaunchSpec {
     if (opts.continueSession) throw new Error("the Hermes connector does not support exact-session continuation");
     // Hermes is Unix-only: its sidecar bridge + hook relay use AF_UNIX `.sock` paths and a Python
@@ -68,7 +70,7 @@ export const hermesConnector: Connector = {
       COTAL_SPACE: opts.space,
       COTAL_NAME: opts.name,
     };
-    if (opts.resolvedBinaries?.hermes) env.COTAL_HERMES_BIN = opts.resolvedBinaries.hermes;
+    if (opts.resolvedBinaries?.uv) env.COTAL_HERMES_UV_BIN = opts.resolvedBinaries.uv;
     if (opts.role) env.COTAL_ROLE = opts.role;
     if (opts.id) env.COTAL_ID = opts.id;
     if (opts.lifecycleUid) env.COTAL_LIFECYCLE_UID = opts.lifecycleUid;

--- a/extensions/connector-hermes/src/launch.ts
+++ b/extensions/connector-hermes/src/launch.ts
@@ -16,7 +16,7 @@
 import { execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync, cpSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { LAUNCH_MATERIAL_ENV, discardLaunchMaterial, loadAgentFile, readLaunchMaterial, writeLaunchMaterial } from "@cotal-ai/core";
 import { hasIdentity, configFromEnv, controlEndpoint, ORIENTATION_BOOTSTRAP, MESH_FIRST_STEER } from "@cotal-ai/connector-core";
@@ -79,12 +79,18 @@ function setupProfile(home: string, opts: { model?: string; persona?: string }):
 
 /** Assert the installed hermes-agent is on the pinned API line, or throw. No silent degrade: a
  *  different major.minor can shift the plugin/platform/hook contract this connector depends on. */
-function assertHermesVersion(): void {
+export function assertHermesVersion(opts: {
+  env?: NodeJS.ProcessEnv;
+  pkgDir?: string;
+  execFileImpl?: (file: string, args: readonly string[], options: { encoding: "utf8" }) => string;
+  logImpl?: (message: string) => void;
+} = {}): void {
   let raw: string;
   try {
-    raw = execFileSync(
-      hermesUvCommand(),
-      ["run", "--project", PKG_DIR, "--quiet", "python", "-c", "from importlib.metadata import version; print(version('hermes-agent'))"],
+    const execFileImpl = opts.execFileImpl ?? ((file, args, options) => execFileSync(file, args, options));
+    raw = execFileImpl(
+      hermesUvCommand(opts.env),
+      ["run", "--project", opts.pkgDir ?? PKG_DIR, "--quiet", "python", "-c", "from importlib.metadata import version; print(version('hermes-agent'))"],
       { encoding: "utf8" },
     ).trim();
   } catch (e) {
@@ -93,7 +99,7 @@ function assertHermesVersion(): void {
   const line = raw.split(".").slice(0, 2).join(".");
   if (line !== HERMES_PIN)
     throw new Error(`hermes-agent ${raw} is not on the pinned ${HERMES_PIN} line this connector targets — pin ${HERMES_PIN}.x or update src/launch.ts + pyproject.toml together`);
-  log(`hermes-agent ${raw} (pinned line ${HERMES_PIN}) ✓`);
+  (opts.logImpl ?? log)(`hermes-agent ${raw} (pinned line ${HERMES_PIN}) ✓`);
 }
 
 async function main(): Promise<void> {
@@ -192,7 +198,9 @@ async function main(): Promise<void> {
   process.on("SIGTERM", () => void shutdown(0));
 }
 
-main().catch((e) => {
-  log(`fatal: ${(e as Error).stack ?? String(e)}`);
-  process.exit(1);
-});
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  main().catch((e) => {
+    log(`fatal: ${(e as Error).stack ?? String(e)}`);
+    process.exit(1);
+  });
+}

--- a/extensions/connector-hermes/src/launch.ts
+++ b/extensions/connector-hermes/src/launch.ts
@@ -20,6 +20,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { LAUNCH_MATERIAL_ENV, discardLaunchMaterial, loadAgentFile, readLaunchMaterial, writeLaunchMaterial } from "@cotal-ai/core";
 import { hasIdentity, configFromEnv, controlEndpoint, ORIENTATION_BOOTSTRAP, MESH_FIRST_STEER } from "@cotal-ai/connector-core";
+import { hermesUvCommand } from "./binary.js";
 import { startSidecar } from "./sidecar.js";
 
 /** Hermes API line this connector is written + pinned against (see pyproject.toml). A different
@@ -164,7 +165,7 @@ async function main(): Promise<void> {
   };
 
   log(`launching hermes gateway as ${config.name}${config.role ? `/${config.role}` : ""} (HERMES_HOME=${home})`);
-  const child = spawn("uv", ["run", "--project", PKG_DIR, process.env.COTAL_HERMES_BIN?.trim() || "hermes", "gateway", "run"], {
+  const child = spawn(hermesUvCommand(), ["run", "--project", PKG_DIR, process.env.COTAL_HERMES_BIN?.trim() || "hermes", "gateway", "run"], {
     env: childEnv,
     stdio: "inherit",
   });

--- a/extensions/connector-hermes/src/launch.ts
+++ b/extensions/connector-hermes/src/launch.ts
@@ -13,14 +13,14 @@
  *
  * The manager runs this in a PTY; stdio is inherited so the gateway's output is what you attach to.
  */
-import { spawn, execFileSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync, cpSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { LAUNCH_MATERIAL_ENV, discardLaunchMaterial, loadAgentFile, readLaunchMaterial, writeLaunchMaterial } from "@cotal-ai/core";
 import { hasIdentity, configFromEnv, controlEndpoint, ORIENTATION_BOOTSTRAP, MESH_FIRST_STEER } from "@cotal-ai/connector-core";
-import { hermesUvCommand } from "./binary.js";
+import { hermesUvCommand, spawnHermesGateway } from "./binary.js";
 import { startSidecar } from "./sidecar.js";
 
 /** Hermes API line this connector is written + pinned against (see pyproject.toml). A different
@@ -83,7 +83,7 @@ function assertHermesVersion(): void {
   let raw: string;
   try {
     raw = execFileSync(
-      "uv",
+      hermesUvCommand(),
       ["run", "--project", PKG_DIR, "--quiet", "python", "-c", "from importlib.metadata import version; print(version('hermes-agent'))"],
       { encoding: "utf8" },
     ).trim();
@@ -165,10 +165,7 @@ async function main(): Promise<void> {
   };
 
   log(`launching hermes gateway as ${config.name}${config.role ? `/${config.role}` : ""} (HERMES_HOME=${home})`);
-  const child = spawn(hermesUvCommand(), ["run", "--project", PKG_DIR, process.env.COTAL_HERMES_BIN?.trim() || "hermes", "gateway", "run"], {
-    env: childEnv,
-    stdio: "inherit",
-  });
+  const child = spawnHermesGateway({ pkgDir: PKG_DIR, env: childEnv });
 
   let shuttingDown = false;
   const shutdown = async (code: number): Promise<void> => {

--- a/implementations/manager/smoke/start-model-preflight.smoke.ts
+++ b/implementations/manager/smoke/start-model-preflight.smoke.ts
@@ -187,7 +187,7 @@ registry.register(recNoResumeCon);
 
   check("claude.requires == [claude]", JSON.stringify(claudeConnector.requires) === '["claude"]');
   check("opencode.requires == [opencode]", JSON.stringify(opencodeConnector.requires) === '["opencode"]');
-  check("hermes.requires == [hermes]", JSON.stringify(hermesConnector.requires) === '["hermes"]');
+  check("hermes.requires == [uv]", JSON.stringify(hermesConnector.requires) === '["uv"]');
 
   // Hermes is Unix-only: on win32 buildLaunch throws BEFORE producing a spec — assert that guard here
   // and skip the Hermes model rows below (they'd all throw). claude + opencode still run on both OSes.

--- a/package.json
+++ b/package.json
@@ -549,7 +549,7 @@
     "smoke:hermes-tool-closed": "tsx extensions/connector-hermes/smoke/tool-input-closed.smoke.ts",
     "smoke:hermes-hooks-control": "tsx extensions/connector-hermes/smoke/hooks-control.smoke.ts",
     "smoke:hermes-launch-env": "tsx extensions/connector-hermes/smoke/launch-env.smoke.ts",
-    "smoke:hermes-boot-requirement": "tsx extensions/connector-hermes/smoke/boot-requirement.smoke.ts",
+    "smoke:hermes-boot-requirement": "pnpm --filter @cotal-ai/connector-hermes... build && tsx extensions/connector-hermes/smoke/boot-requirement.smoke.ts",
     "smoke:hermes-empty-id": "tsx extensions/connector-hermes/smoke/empty-id-bridge.smoke.ts",
     "smoke:codex-tool-closed": "tsx extensions/connector-codex/smoke/tool-input-closed.smoke.ts",
     "smoke:cli-on-instance": "tsx implementations/manager/smoke/cli-on-instance-live.smoke.ts",

--- a/package.json
+++ b/package.json
@@ -549,6 +549,7 @@
     "smoke:hermes-tool-closed": "tsx extensions/connector-hermes/smoke/tool-input-closed.smoke.ts",
     "smoke:hermes-hooks-control": "tsx extensions/connector-hermes/smoke/hooks-control.smoke.ts",
     "smoke:hermes-launch-env": "tsx extensions/connector-hermes/smoke/launch-env.smoke.ts",
+    "smoke:hermes-boot-requirement": "tsx extensions/connector-hermes/smoke/boot-requirement.smoke.ts",
     "smoke:hermes-empty-id": "tsx extensions/connector-hermes/smoke/empty-id-bridge.smoke.ts",
     "smoke:codex-tool-closed": "tsx extensions/connector-codex/smoke/tool-input-closed.smoke.ts",
     "smoke:cli-on-instance": "tsx implementations/manager/smoke/cli-on-instance-live.smoke.ts",


### PR DESCRIPTION
## Summary

- declare `uv` as Hermes' external harness instead of the project-provided `hermes` command
- forward the manager-boot-resolved `uv` path to the launcher and execute that exact path
- add a shipped installed-extension manager boot smoke for both classification directions
- add four named mutations covering the two classifications and the launch-path handoff

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm --filter @cotal-ai/connector-hermes test`
- `pnpm smoke:hermes-boot-requirement`
- `pnpm smoke:hermes-launch-env`
- `pnpm smoke:manager-harness-boot`
- `pnpm smoke:mutation-fixtures`
- mutation coverage validation before proof
- 4/4 named mutations killed
- `pnpm smoke:ci-fragments`
- shard stability: 470 -> 471, zero pre-existing movement
- `pnpm changeset status`
- `pnpm check:docs-voice`

Closes #1144