### PR TITLE
fix(cli): point manager errors at the space log

### DIFF
--- a/.changeset/manager-log-guidance.md
+++ b/.changeset/manager-log-guidance.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/cli": patch
+---
+
+Point manager startup and failure guidance at the per-space logfile the detached manager actually writes.

--- a/bin/smoke/ci-suites.d/8a08a728a4b08f61c633ddd8597de300934fbfd1800ab1fe1ffb9adda556f402.txt
+++ b/bin/smoke/ci-suites.d/8a08a728a4b08f61c633ddd8597de300934fbfd1800ab1fe1ffb9adda556f402.txt
@@ -1,0 +1,1 @@
+smoke:manager-log-guidance

--- a/bin/smoke/manager-log-guidance.smoke.ts
+++ b/bin/smoke/manager-log-guidance.smoke.ts
@@ -1,0 +1,54 @@
+/**
+ * Operator-facing manager log guidance must resolve from the same writer-owned path template.
+ *
+ * This is a source contract because the two failure branches are expensive/live control paths and the
+ * up success branch cannot be run safely in this review environment. The value assertion calls the
+ * exact helper used by output; source cells require each shipped message to call that helper rather
+ * than restating a filename. The writer cell requires the detached-manager writer to use the helper
+ * that the display path wraps, so a future template change cannot move one side alone.
+ *
+ * Run: pnpm smoke:manager-log-guidance
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { managerLogDisplayPath, managerLogPath } from "../../implementations/cli/src/lib/manager-proc.js";
+
+const REPO = join(import.meta.dirname, "..", "..");
+let pass = 0;
+let fail = 0;
+const check = (name: string, condition: boolean, detail?: unknown): void => {
+  if (condition) { pass++; console.log(`  ✓ ${name}`); }
+  else { fail++; console.log(`  ✗ FAIL: ${name}`, detail ?? ""); }
+};
+
+const root = join(REPO, ".operator-path-probe");
+const space = "Ops West";
+const written = managerLogPath(space, root);
+const displayed = managerLogDisplayPath(space, root);
+check(
+  "the operator path is the writer-owned manager logfile relative to the mesh root",
+  join(root, displayed) === written,
+  { written, displayed },
+);
+
+const spawn = readFileSync(join(REPO, "implementations/cli/src/commands/spawn-manifest.ts"), "utf8");
+const up = readFileSync(join(REPO, "implementations/cli/src/commands/up.ts"), "utf8");
+check(
+  "the held-lease refusal derives its logfile guidance",
+  /after its TTL - stop it or check \$\{managerLogDisplayPath\(space\)\}/.test(spawn),
+);
+check(
+  "the manager-readiness refusal derives its logfile guidance",
+  /did not become ready for control - see \$\{managerLogDisplayPath\(space\)\}/.test(spawn),
+);
+check(
+  "the up success line derives its logfile guidance",
+  /via manager .* - see \$\{managerLogDisplayPath\(m\.space\)\}/.test(up),
+);
+check(
+  "no shipped operator message names the pre-segmentation manager logfile",
+  !spawn.includes(".cotal/manager.log") && !up.includes(".cotal/manager.log"),
+);
+
+console.log(`MANAGER LOG GUIDANCE: ${pass}/${pass + fail}`);
+process.exit(fail ? 1 : 0);

--- a/bin/smoke/manager-log-guidance.smoke.ts
+++ b/bin/smoke/manager-log-guidance.smoke.ts
@@ -25,10 +25,19 @@ const root = join(REPO, ".operator-path-probe");
 const space = "Ops West";
 const written = managerLogPath(space, root);
 const displayed = managerLogDisplayPath(space, root);
+const managerProc = readFileSync(join(REPO, "implementations/cli/src/lib/manager-proc.ts"), "utf8");
 check(
   "the operator path is the writer-owned manager logfile relative to the mesh root",
   join(root, displayed) === written,
   { written, displayed },
+);
+check(
+  "managerLogPath derives from the workspace-owned MANAGER_LOGFILE template",
+  /canonicalLocalProcessPath\(MANAGER_LOGFILE, \{ root, space \}\)/.test(managerProc),
+);
+check(
+  "the detached manager writer opens managerLogPath instead of deriving its own filename",
+  /const logPath = managerLogPath\(space\);/.test(managerProc),
 );
 
 const spawn = readFileSync(join(REPO, "implementations/cli/src/commands/spawn-manifest.ts"), "utf8");

--- a/bin/smoke/manager-log-guidance.smoke.ts
+++ b/bin/smoke/manager-log-guidance.smoke.ts
@@ -39,6 +39,10 @@ check(
   "the detached manager writer opens managerLogPath instead of deriving its own filename",
   /const logPath = managerLogPath\(space\);/.test(managerProc),
 );
+check(
+  "the detached manager opens its logfile descriptor on the managerLogPath value",
+  /const fd = openSync\(logPath, "a", 0o600\);/.test(managerProc),
+);
 
 const spawn = readFileSync(join(REPO, "implementations/cli/src/commands/spawn-manifest.ts"), "utf8");
 const up = readFileSync(join(REPO, "implementations/cli/src/commands/up.ts"), "utf8");

--- a/bin/smoke/mutations/manager-log-guidance.json
+++ b/bin/smoke/mutations/manager-log-guidance.json
@@ -29,10 +29,26 @@
       "cell": "the up success line derives its logfile guidance"
     },
     {
-      "name": "the operator display helper stops resolving through the writer-owned path",
+      "name": "managerLogPath drifts from the workspace-owned logfile template",
       "file": "implementations/cli/src/lib/manager-proc.ts",
-      "find": "  relative(root, managerLogPath(space, root));",
-      "replace": "  `.cotal/manager.log`;",
+      "find": "  canonicalLocalProcessPath(MANAGER_LOGFILE, { root, space });",
+      "replace": "  canonicalLocalProcessPath(\"manager.log\", { root, space });",
+      "expectRed": "managerLogPath derives from the workspace-owned MANAGER_LOGFILE template",
+      "cell": "managerLogPath derives from the workspace-owned MANAGER_LOGFILE template"
+    },
+    {
+      "name": "the detached writer bypasses managerLogPath and derives its own filename",
+      "file": "implementations/cli/src/lib/manager-proc.ts",
+      "find": "  const logPath = managerLogPath(space);",
+      "replace": "  const logPath = canonicalLocalProcessPath(\"manager.log\", ctx(space));",
+      "expectRed": "the detached manager writer opens managerLogPath instead of deriving its own filename",
+      "cell": "the detached manager writer opens managerLogPath instead of deriving its own filename"
+    },
+    {
+      "name": "reachability control makes managerLogPath stop returning its canonical path",
+      "file": "implementations/cli/src/lib/manager-proc.ts",
+      "find": "  canonicalLocalProcessPath(MANAGER_LOGFILE, { root, space });",
+      "replace": "  \"\";",
       "expectRed": "the operator path is the writer-owned manager logfile relative to the mesh root",
       "cell": "the operator path is the writer-owned manager logfile relative to the mesh root"
     }

--- a/bin/smoke/mutations/manager-log-guidance.json
+++ b/bin/smoke/mutations/manager-log-guidance.json
@@ -45,6 +45,14 @@
       "cell": "the detached manager writer opens managerLogPath instead of deriving its own filename"
     },
     {
+      "name": "the logfile sink bypasses logPath and opens an independently-derived filename",
+      "file": "implementations/cli/src/lib/manager-proc.ts",
+      "find": "  const fd = openSync(logPath, \"a\", 0o600);",
+      "replace": "  const fd = openSync(canonicalLocalProcessPath(\"manager.log\", ctx(space)), \"a\", 0o600);",
+      "expectRed": "the detached manager opens its logfile descriptor on the managerLogPath value",
+      "cell": "the detached manager opens its logfile descriptor on the managerLogPath value"
+    },
+    {
       "name": "reachability control makes managerLogPath stop returning its canonical path",
       "file": "implementations/cli/src/lib/manager-proc.ts",
       "find": "  canonicalLocalProcessPath(MANAGER_LOGFILE, { root, space });",

--- a/bin/smoke/mutations/manager-log-guidance.json
+++ b/bin/smoke/mutations/manager-log-guidance.json
@@ -1,0 +1,40 @@
+{
+  "suite": "bin/smoke/manager-log-guidance.smoke.ts",
+  "guard": "operator manager-log guidance is derived from the same writer-owned path helper at all three shipped messages",
+  "command": "pnpm smoke:manager-log-guidance",
+  "completionMarker": "MANAGER LOG GUIDANCE:",
+  "mutations": [
+    {
+      "name": "the held-lease refusal goes back to the stale root-scoped manager log",
+      "file": "implementations/cli/src/commands/spawn-manifest.ts",
+      "find": "console.error(c.red(`✗ a manager lease for \"${space}\" is still held by an unresponsive holder (pid ${launchHeld.pid}) after its TTL - stop it or check ${managerLogDisplayPath(space)}`));",
+      "replace": "console.error(c.red(`✗ a manager lease for \"${space}\" is still held by an unresponsive holder (pid ${launchHeld.pid}) after its TTL - stop it or check .cotal/manager.log`));",
+      "expectRed": "the held-lease refusal derives its logfile guidance",
+      "cell": "the held-lease refusal derives its logfile guidance"
+    },
+    {
+      "name": "the manager-readiness refusal goes back to the stale root-scoped manager log",
+      "file": "implementations/cli/src/commands/spawn-manifest.ts",
+      "find": "console.error(c.red(`✗ manager did not become ready for control - see ${managerLogDisplayPath(space)}`));",
+      "replace": "console.error(c.red(`✗ manager did not become ready for control - see .cotal/manager.log`));",
+      "expectRed": "the manager-readiness refusal derives its logfile guidance",
+      "cell": "the manager-readiness refusal derives its logfile guidance"
+    },
+    {
+      "name": "the up success line goes back to the stale root-scoped manager log",
+      "file": "implementations/cli/src/commands/up.ts",
+      "find": "- see ${managerLogDisplayPath(m.space)}`));",
+      "replace": "- see .cotal/manager.log`));",
+      "expectRed": "the up success line derives its logfile guidance",
+      "cell": "the up success line derives its logfile guidance"
+    },
+    {
+      "name": "the operator display helper stops resolving through the writer-owned path",
+      "file": "implementations/cli/src/lib/manager-proc.ts",
+      "find": "  relative(root, managerLogPath(space, root));",
+      "replace": "  `.cotal/manager.log`;",
+      "expectRed": "the operator path is the writer-owned manager logfile relative to the mesh root",
+      "cell": "the operator path is the writer-owned manager logfile relative to the mesh root"
+    }
+  ]
+}

--- a/bin/smoke/mutations/segmented-runtime-namespace.json
+++ b/bin/smoke/mutations/segmented-runtime-namespace.json
@@ -9,35 +9,40 @@
       "file": "packages/workspace/src/local-process.ts",
       "find": "export const MANAGER_PIDFILE = \"manager.{space}.pid\";",
       "replace": "export const MANAGER_PIDFILE = \"manager.pid\";",
-      "expectRed": "manager.pid resolves to a DIFFERENT record for a second space on the same root"
+      "expectRed": "manager.pid resolves to a DIFFERENT record for a second space on the same root",
+      "cell": "manager.pid resolves to a DIFFERENT record for a second space on the same root"
     },
     {
       "name": "S2 the delivery-aware marker goes back to a root-scoped name",
       "file": "packages/workspace/src/local-process.ts",
       "find": "export const MANAGER_DELIVERY_AWARE_MARKER = \"manager.{space}.delivery-aware\";",
       "replace": "export const MANAGER_DELIVERY_AWARE_MARKER = \"manager.delivery-aware\";",
-      "expectRed": "the delivery-aware marker is per-space too"
+      "expectRed": "the delivery-aware marker is per-space too",
+      "cell": "the delivery-aware marker is per-space too"
     },
     {
       "name": "S3 the compat READ stops admitting the pre-segmentation name",
       "file": "packages/workspace/src/local-process.ts",
       "find": "  const preSegmentation = PRE_SEGMENTATION_RUNTIME_RECORDS.get(template);\n  if (preSegmentation !== undefined) add(preSegmentation);",
       "replace": "  void PRE_SEGMENTATION_RUNTIME_RECORDS;",
-      "expectRed": "with ONLY the pre-segmentation record present, the seam resolves to it"
+      "expectRed": "with ONLY the pre-segmentation record present, the seam resolves to it",
+      "cell": "with ONLY the pre-segmentation record present, the seam resolves to it"
     },
     {
       "name": "S4 the ambiguity refusal silently prefers the canonical record",
       "file": "packages/workspace/src/local-process.ts",
       "find": "  if (existsByteExact(canonical))\n    throw new Error(\n      `both ${canonical} and the pre-upgrade ${present.join(\" and \")} exist for space \"${context.space}\" - ambiguous process record; remove the stale one`,\n    );",
       "replace": "  if (existsByteExact(canonical)) return canonical;",
-      "expectRed": "both records present is ambiguous and throws rather than picking one"
+      "expectRed": "both records present is ambiguous and throws rather than picking one",
+      "cell": "both records present is ambiguous and throws rather than picking one"
     },
     {
       "name": "S5 RESERVED_COTAL_CHILDREN keeps the root-scoped manager record",
       "file": "packages/workspace/src/space-segmentation.ts",
       "find": "\"membership-observer.creds\", \"membership-rw.creds\", \"meshes\", \"nats\", \"nats.log\", \"nats.pid\",",
       "replace": "\"membership-observer.creds\", \"membership-rw.creds\", \"meshes\", \"nats\", \"nats.log\", \"nats.pid\", \"manager.pid\",",
-      "expectRed": "\"manager.pid\" is no longer a literal child of .cotal/"
+      "expectRed": "\"manager.pid\" is no longer a literal child of .cotal/",
+      "cell": "\"manager.pid\" is no longer a literal child of .cotal/"
     },
     {
       "name": "S6 one root, one manager record: the CLI stop path hits the wrong space's daemon",
@@ -46,7 +51,8 @@
       "replace": "export const MANAGER_PIDFILE = \"manager.pid\";",
       "command": "pnpm --filter @cotal-ai/workspace build && pnpm smoke:segmented-runtime-records",
       "afterRestore": "pnpm --filter @cotal-ai/workspace build",
-      "expectRed": "...and beta's manager is UNTOUCHED \u2014 the defect this change fixes"
+      "expectRed": "...and beta's manager is UNTOUCHED — the defect this change fixes",
+      "cell": "...and beta's manager is UNTOUCHED — the defect this change fixes"
     },
     {
       "name": "S7 one root, one delivery record: stopping alpha's daemon stops beta's",
@@ -55,7 +61,8 @@
       "replace": "export const DELIVERY_PIDFILE = \"delivery.pid\";",
       "command": "pnpm --filter @cotal-ai/workspace build && pnpm smoke:segmented-runtime-records",
       "afterRestore": "pnpm --filter @cotal-ai/workspace build",
-      "expectRed": "...and beta's daemon survives with its record intact"
+      "expectRed": "...and beta's daemon survives with its record intact",
+      "cell": "...and beta's daemon survives with its record intact"
     },
     {
       "name": "S8 the supervise-side writer ignores the space it is recording for",
@@ -63,7 +70,8 @@
       "find": "  const pidPath = canonicalLocalProcessPath(MANAGER_PIDFILE, ctx);",
       "replace": "  const pidPath = canonicalLocalProcessPath(MANAGER_PIDFILE, { ...ctx, space: \"shared\" });",
       "command": "pnpm smoke:record-manager-pid-per-space",
-      "expectRed": "both records exist after both managers recorded themselves"
+      "expectRed": "both records exist after both managers recorded themselves",
+      "cell": "both records exist after both managers recorded themselves"
     },
     {
       "name": "S9 the writer stops reclaiming a dead pre-upgrade record",
@@ -71,14 +79,16 @@
       "find": "  reclaimDeadPreUpgradeRecord(MANAGER_PIDFILE, ctx);\n  reclaimDeadPreUpgradeRecord(MANAGER_DELIVERY_AWARE_MARKER, ctx);",
       "replace": "  void reclaimDeadPreUpgradeRecord;",
       "command": "pnpm smoke:record-manager-pid-per-space",
-      "expectRed": "the dead pre-upgrade records are reclaimed"
+      "expectRed": "the dead pre-upgrade records are reclaimed",
+      "cell": "the dead pre-upgrade records are reclaimed"
     },
     {
       "name": "S10 the folder's space stops being read off its own records",
       "file": "packages/workspace/src/space.ts",
       "find": "  const recorded = recordedRuntimeSpaces(root);",
       "replace": "  const recorded = recordedRuntimeSpaces(root).slice(0, 0);",
-      "expectRed": "a live manager record NAMES its space, where the account-derived read cannot"
+      "expectRed": "a live manager record NAMES its space, where the account-derived read cannot",
+      "cell": "a live manager record NAMES its space, where the account-derived read cannot"
     },
     {
       "name": "S11 the same, against the CLI: a space-less read answers about a space nothing recorded",
@@ -87,21 +97,24 @@
       "replace": "  const recorded = recordedRuntimeSpaces(root).slice(0, 0);",
       "command": "pnpm --filter @cotal-ai/workspace build && pnpm smoke:segmented-runtime-records",
       "afterRestore": "pnpm --filter @cotal-ai/workspace build",
-      "expectRed": "the folder-default read FINDS it, with no auth material to name the space"
+      "expectRed": "the folder-default read FINDS it, with no auth material to name the space",
+      "cell": "the folder-default read FINDS it, with no auth material to name the space"
     },
     {
       "name": "S12 two spaces running under one root is arbitrated instead of refused",
       "file": "packages/workspace/src/space.ts",
       "find": "  if (running.length > 1)\n    throw new Error(\n      `${root}/.cotal records running daemons for ${running.length} spaces (${running.map((r) => r.space).join(\", \")}) - this folder's stack is not one mesh and a folder-wide command cannot scope to one; stop them by name (\\`cotal down\\` in each mesh's own root) or remove the record of the one that is gone`,\n    );",
       "replace": "  if (running.length > 1) return running[0].space;",
-      "expectRed": "two spaces RUNNING under one root is refused, naming both"
+      "expectRed": "two spaces RUNNING under one root is refused, naming both",
+      "cell": "two spaces RUNNING under one root is refused, naming both"
     },
     {
       "name": "S13 a record name that does not round-trip is read as a tenant",
       "file": "packages/workspace/src/local-process.ts",
       "find": "  return space.length > 0 && spaceKey(space) === key ? space : undefined;",
       "replace": "  return space.length > 0 ? space : undefined;",
-      "expectRed": "strays and pre-upgrade names are not read as spaces"
+      "expectRed": "strays and pre-upgrade names are not read as spaces",
+      "cell": "strays and pre-upgrade names are not read as spaces"
     },
     {
       "name": "S14 down's folder sweep goes back to the account-derived space (live)",
@@ -110,7 +123,8 @@
       "replace": "  const folderCtx = (): LocalProcessContext => (folderContext ??= { root: cotalRoot(), space: \"main\" });",
       "command": "pnpm --filter @cotal-ai/cli build && pnpm smoke:up-manifest:live",
       "expectRed": "broker + manager are gone after down (no orphaned supervise)",
-      "afterRestore": "pnpm --filter @cotal-ai/cli build"
+      "afterRestore": "pnpm --filter @cotal-ai/cli build",
+      "cell": "broker + manager are gone after down (no orphaned supervise)"
     }
   ]
 }

--- a/implementations/cli/src/commands/spawn-manifest.ts
+++ b/implementations/cli/src/commands/spawn-manifest.ts
@@ -31,7 +31,7 @@ import { findMesh } from "@cotal-ai/workspace";
 import { c } from "../ui.js";
 import { cotalRoot } from "../lib/paths.js";
 import { connectOrExit, userViewAuthOrExit } from "../lib/connect.js";
-import { assertManagerRecordReplaceable, startManagerDetached } from "../lib/manager-proc.js";
+import { assertManagerRecordReplaceable, managerLogDisplayPath, startManagerDetached } from "../lib/manager-proc.js";
 import { loadManifest, type PreparedManifest } from "../lib/manifest/index.js";
 import { buildLaunchSpec, channelsSeed, genRunId, preflightConnectors, writeLaunchSpec } from "../lib/manifest/apply.js";
 import { buildLedger, buildLedgerAgentRow, hashManifestSource, listLedgers, writeLedger, type LedgerAgent } from "../lib/manifest/ledger.js";
@@ -236,7 +236,7 @@ export async function spawnManifest(file: string, flags: SpawnManifestFlags): Pr
         // blocks a replacement's acquire until the bucket TTL expires; wait it out, then stand one up.
         console.log(c.dim(`  ~ a manager lease for "${space}" is present but unanswered (holder pid ${launchHeld.pid}); waiting up to ${Math.ceil(MANAGER_LEASE_TTL_MS / 1000)}s for it to expire…`));
         if (!(await waitLeaseGone(ep, MANAGER_LEASE_TTL_MS + 5_000))) {
-          console.error(c.red(`✗ a manager lease for "${space}" is still held by an unresponsive holder (pid ${launchHeld.pid}) after its TTL - stop it or check .cotal/manager.log`));
+          console.error(c.red(`✗ a manager lease for "${space}" is still held by an unresponsive holder (pid ${launchHeld.pid}) after its TTL - stop it or check ${managerLogDisplayPath(space)}`));
           process.exit(1);
         }
         assertManagerRecordReplaceable(undefined, undefined, space); // an expired lease still says nothing about the recorded pid
@@ -247,7 +247,7 @@ export async function spawnManifest(file: string, flags: SpawnManifestFlags): Pr
       // `held` snapshot, which can turn over during the probe / a concurrent start — TOCTOU). Fail LOUD if
       // a foreign-checkout or wrong-runtime manager won the space before we launch into it.
       if (!(await waitManagerReady(ep))) {
-        console.error(c.red("✗ manager did not become ready for control - see .cotal/manager.log"));
+        console.error(c.red(`✗ manager did not become ready for control - see ${managerLogDisplayPath(space)}`));
         process.exit(1);
       }
       const live = await ep.readManagerLease();

--- a/implementations/cli/src/commands/up.ts
+++ b/implementations/cli/src/commands/up.ts
@@ -109,7 +109,7 @@ import { resolveNatsServer } from "../lib/nats-bin.js";
 import { cotalPath, cotalRoot } from "../lib/paths.js";
 import { renderDetachedSummary } from "../lib/up-report.js";
 import { deliveryUp, ensureControlPlane, stopDelivery } from "../lib/delivery-proc.js";
-import { managerHasDeliveryMarker, managerUp, stopManager } from "../lib/manager-proc.js";
+import { managerHasDeliveryMarker, managerLogDisplayPath, managerUp, stopManager } from "../lib/manager-proc.js";
 import { loadManifest, type PreparedManifest } from "../lib/manifest/index.js";
 import { buildLaunchSpec, genRunId, manifestToChannels, preflightConnectors, writeLaunchSpec } from "../lib/manifest/apply.js";
 import { renderUpPlan, renderInherited, renderWarnings } from "../lib/manifest/render.js";
@@ -1893,7 +1893,7 @@ async function upManifest(file: string, opts: UpManifestFlags): Promise<void> {
   // degraded control plane (announced above) means the agents are NOT coming up.
   if (controlPlane) {
     // U6: on a user mesh the agents run under the OPERATOR's identity — say whose they are.
-    console.log(c.green(`✓ launching ${eff.agents.length} agent(s)`) + c.dim(` via manager (${runtime})${owner ? ` as you (owner ${owner})` : ""} - see .cotal/manager.log`));
+    console.log(c.green(`✓ launching ${eff.agents.length} agent(s)`) + c.dim(` via manager (${runtime})${owner ? ` as you (owner ${owner})` : ""} - see ${managerLogDisplayPath(m.space)}`));
   } else {
     console.error(c.red(`✗ ${eff.agents.length} agent(s) NOT launched - the control plane did not come up (see above)`));
   }

--- a/implementations/cli/src/lib/manager-proc.ts
+++ b/implementations/cli/src/lib/manager-proc.ts
@@ -1,5 +1,6 @@
 import { spawn, spawnSync } from "node:child_process";
 import { existsSync, openSync, closeSync, chmodSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { relative } from "node:path";
 import { DEFAULT_SERVER } from "@cotal-ai/core";
 import { selfArgv } from "./self-exec.js";
 import { resolveRuntimeSpace } from "./status.js";
@@ -19,6 +20,15 @@ import {
  *  space-less read reports "absent" over a live manager. */
 const folderSpace = (): string => resolveRuntimeSpace(process.cwd());
 const ctx = (space: string): LocalProcessContext => ({ root: cotalRoot(), space });
+
+/** The exact logfile the detached-manager writer opens. Exported so operator guidance names the
+ *  writer-owned path instead of copying its filename template into command output. */
+export const managerLogPath = (space: string, root: string = cotalRoot()): string =>
+  canonicalLocalProcessPath(MANAGER_LOGFILE, { root, space });
+
+/** The manager logfile as an operator-facing path relative to the selected mesh root. */
+export const managerLogDisplayPath = (space: string, root: string = cotalRoot()): string =>
+  relative(root, managerLogPath(space, root));
 
 /** Exported so the delivery cutover preflight can NAME the pid it refused on: an error that says
  *  "cannot be attributed" without saying which pid is not actionable. READ-resolving, so it also
@@ -145,7 +155,7 @@ export function startManagerDetached(
   // on a live or unattributable one rather than orphaning the daemon behind it.
   reclaimDeadPreUpgradeRecord(MANAGER_PIDFILE, ctx(space));
   reclaimDeadPreUpgradeRecord(MANAGER_DELIVERY_AWARE_MARKER, ctx(space));
-  const logPath = canonicalLocalProcessPath(MANAGER_LOGFILE, ctx(space));
+  const logPath = managerLogPath(space);
   // 0600: the manager prints its console URL here, and that URL carries the console token — a
   // standing credential for every agent's terminal on this mesh, at rest for the life of the file.
   // `.cotal` is already 0700, so this is defence in depth rather than the boundary, but a log the

--- a/package.json
+++ b/package.json
@@ -569,7 +569,8 @@
     "smoke:core-history-limit": "tsx packages/core/smoke/history-limit.smoke.ts",
     "smoke:sparse-history-walk": "tsx packages/core/smoke/sparse-history-walk.smoke.ts",
     "smoke:web-graph-boot": "tsx implementations/web/smoke/graph-boot.smoke.ts",
-    "smoke:expiry-renewal:auth": "tsx implementations/auth/smoke/expiry-renewal.smoke.ts"
+    "smoke:expiry-renewal:auth": "tsx implementations/auth/smoke/expiry-renewal.smoke.ts",
+    "smoke:manager-log-guidance": "tsx bin/smoke/manager-log-guidance.smoke.ts"
   },
   "dependencies": {
     "@cotal-ai/auth": "workspace:*",


### PR DESCRIPTION
## Summary

- derive all three operator-facing manager log hints from the same per-space path helper the detached-manager writer uses
- add a five-cell guard and four mutations covering writer/display alignment plus each shipped message
- add the required `cell` field to all 14 segmented-runtime mutations so the committed fixture can execute

## Reproduction

Before the fix, the shipped messages in `spawn-manifest.ts` and `up.ts` all named `.cotal/manager.log`, while the writer uses `MANAGER_LOGFILE = "manager.{space}.log"`.

The segmented-runtime fixture contained 14 mutations and 14 missing `cell` fields, so mutation coverage could not grade the committed evidence.

## Validation

- `pnpm smoke:manager-log-guidance` — 5/5
- manager-log mutation proof — 4/4 killed, red-and-named
- segmented-runtime mutation proof — 13/13 permitted mutations killed, red-and-named
- `pnpm smoke:mutation-fixtures` — both fixtures present and unique
- `pnpm smoke:ci-fragments`
- `pnpm smoke:gate-inventory`
- `pnpm typecheck`
- `pnpm changeset status`

## Limit

S14 uses `smoke:up-manifest:live`. It was not executed because lifecycle and `:live` suites are prohibited in this environment. Its required `cell` field and unique anchor are validated by fixture inventory; the other 13 mutations were executed.