### PR TITLE
test(smoke): typecheck the manager and CLI smoke trees

### DIFF
--- a/implementations/cli/package.json
+++ b/implementations/cli/package.json
@@ -18,7 +18,7 @@
     }
   },
   "scripts": {
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.smoke.json",
     "test": "tsx smoke/manifest.smoke.ts && tsx smoke/backup.smoke.ts",
     "build": "tsc -p tsconfig.json",
     "prepublishOnly": "pnpm run build"
@@ -46,6 +46,7 @@
     "@eplightning/nats-server-win32-x64": "^2.14.0"
   },
   "devDependencies": {
+    "@cotal-ai/auth": "workspace:*",
     "@cotal-ai/smoke-kit": "workspace:*",
     "@types/react": "^19.0.0",
     "@types/ws": "^8.18.1"

--- a/implementations/cli/smoke/setup-connectors.smoke.ts
+++ b/implementations/cli/smoke/setup-connectors.smoke.ts
@@ -65,7 +65,7 @@ check("claude declaring no setup provider is not privileged into a setup step", 
 const xdg = mkdtempSync(join(tmpdir(), "cotal-setup-connectors-"));
 process.env.XDG_CONFIG_HOME = xdg;
 const UNFAMILIAR = "zz-unfamiliar-harness";
-registry.register({ kind: "connector", name: UNFAMILIAR, buildLaunch: launch } satisfies Connector);
+registry.register({ kind: "connector", name: UNFAMILIAR, buildLaunch: launch } as Connector);
 let surfaced: string[];
 try {
   surfaced = (await setupConnectorSurface()).map((connector) => connector.name);

--- a/implementations/cli/smoke/status-provenance.smoke.ts
+++ b/implementations/cli/smoke/status-provenance.smoke.ts
@@ -37,7 +37,7 @@ async function statusText(entry: string): Promise<string> {
   const lines: string[] = [];
   console.log = (...args: unknown[]) => lines.push(args.map(String).join(" "));
   try {
-    await status({ values: {}, positionals: [] });
+    await status({ values: {}, positionals: [], raw: [] });
   } finally {
     console.log = realLog;
   }

--- a/implementations/cli/smoke/up-resume-render-lock-live.smoke.ts
+++ b/implementations/cli/smoke/up-resume-render-lock-live.smoke.ts
@@ -107,7 +107,7 @@ function run(args: string[]): ChildProcess {
 }
 
 /** One independent attempt at the root lock, from a LIVE owner (this probe process). */
-function tryLock(): { held: true } | { held: false; reason: string } {
+function tryLock(): { held: true; reason: string } | { held: false; reason: string } {
   try {
     const lock = acquireMaintenanceLock(root);
     releaseMaintenanceLock(lock);

--- a/implementations/cli/smoke/user-bundle.smoke.ts
+++ b/implementations/cli/smoke/user-bundle.smoke.ts
@@ -123,7 +123,8 @@ cell(
 // bundle can pass the round trip above and still be refused at the gate that actually records it.
 // A websocket broker legitimately lives under a path (`wss://host/mesh-ws` behind a reverse
 // proxy) — the bundle's own server URL must clear checkServer, while nats:// stays bare.
-cell("checkServer accepts the bundle's path-carrying wss server", checkServer(bundle.server).ok, JSON.stringify(checkServer(bundle.server)));
+const server = bundle.server as string;
+cell("checkServer accepts the bundle's path-carrying wss server", checkServer(server).ok, JSON.stringify(checkServer(server)));
 cell("checkServer still refuses a path on nats://", !checkServer("nats://10.0.0.7:4222/subject").ok);
 
 // The issuer registration pins for the exchange probe is the daemon's OWN issuer (its /health

--- a/implementations/cli/tsconfig.smoke.json
+++ b/implementations/cli/tsconfig.smoke.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "noEmit": true, "rootDir": "../.." },
+  "include": ["smoke/**/*.ts"]
+}

--- a/implementations/manager/package.json
+++ b/implementations/manager/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "test": "tsx smoke/start-model-preflight.smoke.ts && tsx smoke/start-overrides.smoke.ts && tsx smoke/preserve-state.smoke.ts && tsx smoke/pi-session-recovery.smoke.ts",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.smoke.json",
     "build": "tsc -p tsconfig.json && node -e \"const fs=require('node:fs'); fs.rmSync('dist/console', { recursive: true, force: true }); fs.cpSync('src/console', 'dist/console', { recursive: true })\" && pnpm run build:console-bundle",
     "build:console-bundle": "esbuild src/console-session-entry.ts --bundle --format=iife --platform=browser --target=es2020 --alias:node:crypto=./src/console-crypto-shim.ts --outfile=dist/console/session-bundle.js && node scripts/console-bundle-loadtest.mjs",
     "prepublishOnly": "pnpm run build"
@@ -41,8 +41,12 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@cotal-ai/auth": "workspace:*",
+    "@cotal-ai/connector-claude-code": "workspace:*",
+    "@cotal-ai/connector-codex": "workspace:*",
     "@cotal-ai/smoke-kit": "workspace:*",
     "@cotal-ai/connector-core": "workspace:*",
+    "@cotal-ai/connector-opencode": "workspace:*",
     "@nats-io/nats-core": "^3.4.0",
     "@types/ws": "^8.18.1",
     "esbuild": "^0.28.1"

--- a/implementations/manager/smoke/console-assets.smoke.ts
+++ b/implementations/manager/smoke/console-assets.smoke.ts
@@ -1,7 +1,8 @@
 import { existsSync } from "node:fs";
 import { createConnection } from "node:net";
 import { join } from "node:path";
-import { AttachEndpoint } from "../dist/attach-endpoint.js";
+
+const { AttachEndpoint } = await import(new URL("../dist/attach-endpoint.js", import.meta.url).href) as typeof import("../src/attach-endpoint.js");
 
 let failures = 0;
 

--- a/implementations/manager/smoke/gate-reconcile-resume.smoke.ts
+++ b/implementations/manager/smoke/gate-reconcile-resume.smoke.ts
@@ -28,7 +28,7 @@ import {
   repairCursorMatches,
   serveIssuanceGateKv,
 } from "@cotal-ai/core";
-import { GateReconcileRefused, reconcileEndpointGate } from "../src/reconcile-gate.ts";
+import { GateReconcileRefused, reconcileEndpointGate } from "../src/reconcile-gate.js";
 
 const casLoss = (message = "wrong last sequence") => Object.assign(new Error(message), { code: 10071 });
 const enc = new TextEncoder();
@@ -251,11 +251,11 @@ console.log("C. cursor binding and executor authority are exact");
     { owner: DEV_OWNER, actor: "repair_exec", connId: "repairconn0123456789", lifecycleUid: mintLifecycleUid() },
     { endpointServeExecutor: { endpoint: ENDPOINT, instanceId } },
   );
-  const publish = permissions.pub?.allow ?? [];
+  const publish = ((permissions.pub as { allow?: string[] } | undefined)?.allow ?? []);
   const exact = `$KV.${epAuthBucket(SPACE)}.${eprepairKey(ENDPOINT, instanceId)}`;
   const foreign = `$KV.${epAuthBucket(SPACE)}.${eprepairKey(ENDPOINT, sibling)}`;
   check("the executor can write exactly its one repair cursor key", publish.includes(exact), publish);
-  check("the executor has no wildcard or sibling repair-key grant", !publish.includes(foreign) && !publish.some((row) => row.includes("eprepair") && row.includes(">")), publish);
+  check("the executor has no wildcard or sibling repair-key grant", !publish.includes(foreign) && !publish.some((row: string) => row.includes("eprepair") && row.includes(">")), publish);
 }
 
 const EXPECTED = 21;

--- a/implementations/manager/smoke/manager-reconcile-startup.smoke.ts
+++ b/implementations/manager/smoke/manager-reconcile-startup.smoke.ts
@@ -23,7 +23,12 @@ import { connect } from "@nats-io/transport-node";
 import { Kvm } from "@nats-io/kv";
 import {
   createSpaceAuth,
+  CotalEndpoint,
+  CONTROL_DELIVERY_ADMIN,
+  evictDeniedPrincipalWithCreds,
+  mintConnectionEvictorCreds,
   mintCreds,
+  mintMembershipObserverCreds,
   newIdentity,
   mintLifecycleUid,
   setupSpaceStreams,
@@ -34,10 +39,11 @@ import {
   epCall,
   registry,
   type Connector,
+  type ControlReply,
   type EpCaller,
   type LaunchSpec,
 } from "@cotal-ai/core";
-import { authDir, saveSpaceAuth } from "@cotal-ai/workspace";
+import { authDir, saveManagerInstanceIdentity, saveSpaceAuth } from "@cotal-ai/workspace";
 import { Manager } from "../src/manager.js";
 import { MANAGER_ENDPOINT, MANAGER_CONTRACTS } from "../src/manager-service-contract.js";
 import { activateStaticLifecycle, casStaticSlot, readStaticSlot, staticLifecycleTransport } from "../src/static-lifecycle.js";
@@ -64,8 +70,11 @@ const space = `reconcile-start-${randomUUID().slice(0, 8)}`;
 const auth = await createSpaceAuth(space);
 const broker = await bootBroker(auth);
 const workspaceRoot = mkdtempSync(join(tmpdir(), "cotal-reconcile-start-ws-"));
+const managerInstanceId = mintLifecycleUid();
 mkdirSync(join(workspaceRoot, ".cotal", "agents"), { recursive: true });
 saveSpaceAuth(authDir(workspaceRoot), auth);
+const managerServeIdentity = newIdentity();
+saveManagerInstanceIdentity(workspaceRoot, space, { instanceId: managerInstanceId, serveIdentity: managerServeIdentity });
 for (let n = 0; n < ORPHANS; n++)
   writeFileSync(join(workspaceRoot, ".cotal", "agents", `orphan-${n}.md`), `---\nname: orphan-${n}\nrole: worker\n---\nbody\n`);
 // The connector is deliberately valid. If the alias guard is removed, the request gets past
@@ -84,6 +93,7 @@ const caller: EpCaller = { owner: DEV_OWNER, actor: callerIdentity.id, uid: mint
 let manager: Manager | undefined;
 let callerNc: Awaited<ReturnType<typeof connect>> | undefined;
 let observerNc: Awaited<ReturnType<typeof connect>> | undefined;
+let delivery: CotalEndpoint | undefined;
 
 /** An ACTIVE durable static row with no manager-owned process: the exact orphan shape after a crash. */
 async function writeOrphan(alias: string): Promise<void> {
@@ -96,7 +106,7 @@ async function writeOrphan(alias: string): Promise<void> {
   try {
     const kvm = new Kvm(nc);
     const transport = staticLifecycleTransport(await kvm.open(recordsBucket(space)), await kvm.open(epAuthBucket(space)));
-    await activateStaticLifecycle(transport, { owner: DEV_OWNER, alias, actor: identity.id, lifecycleUid, managerInstance: "repro-755" });
+    await activateStaticLifecycle(transport, { owner: DEV_OWNER, alias, actor: identity.id, lifecycleUid, managerInstance: managerInstanceId, ownerInstanceId: managerInstanceId });
     const current = await readStaticSlot(transport, DEV_OWNER, alias);
     if (!current) throw new Error(`missing just-created slot ${alias}`);
     await casStaticSlot(transport, { ...current.row, phase: "active" }, current.revision);
@@ -112,6 +122,36 @@ async function phase(alias: string): Promise<string | undefined> {
 
 try {
   await setupSpaceStreams({ servers: broker.servers, space, creds: await mintCreds(auth, newIdentity(), "provisioner") });
+  const observerCreds = await mintMembershipObserverCreds(auth, newIdentity());
+  const evictorCreds = await mintConnectionEvictorCreds(auth, newIdentity());
+  const deliveryIdentity = newIdentity();
+  delivery = new CotalEndpoint({
+    space,
+    servers: broker.servers,
+    creds: await mintCreds(auth, deliveryIdentity, "delivery"),
+    card: { id: deliveryIdentity.id, name: "delivery", role: "delivery", kind: "endpoint" },
+    channels: [],
+    consume: false,
+    registerPresence: false,
+    watchPresence: false,
+    watchChannels: false,
+  });
+  delivery.on("error", () => {});
+  await delivery.start();
+  delivery.serveControl(CONTROL_DELIVERY_ADMIN, async (req): Promise<ControlReply> => {
+    if (req.op !== "evictPrincipal") return { ok: false, error: `unsupported delivery-admin op "${req.op}"` };
+    const principal = String((req.args as { principal?: unknown })?.principal ?? "");
+    return {
+      ok: true,
+      data: await evictDeniedPrincipalWithCreds({
+        servers: broker.servers,
+        observerCreds,
+        evictorCreds,
+        accountId: auth.account.pub,
+        principal,
+      }),
+    };
+  }, { boundReply: true });
   for (let n = 0; n < ORPHANS; n++) await writeOrphan(`orphan-${n}`);
 
   observerNc = await connect({
@@ -184,6 +224,7 @@ try {
   await callerNc?.drain().catch(() => callerNc?.close());
   await observerNc?.drain().catch(() => observerNc?.close());
   await manager?.stop().catch(() => {});
+  await delivery?.stop().catch(() => {});
   await broker.stop().catch(() => {});
 }
 

--- a/implementations/manager/smoke/mesh-attach-plane.smoke.ts
+++ b/implementations/manager/smoke/mesh-attach-plane.smoke.ts
@@ -189,7 +189,7 @@ let cliEnd: string | undefined;
 const cliRx: Buffer[] = [];
 const transport = meshSessionTransport(ncCli, r2.grant);
 transport.onReady(() => { cliReady = true; });
-transport.onData((b) => cliRx.push(b));
+transport.onData((b) => { cliRx.push(b); });
 transport.onEnd((_err, reason) => { cliEnd = reason; });
 c("meshSessionTransport fires onReady after the ready handshake", await until(() => cliReady));
 transport.send(Buffer.from("CLITYPE\n", "utf8"));

--- a/implementations/manager/smoke/persona-show-auth.smoke.ts
+++ b/implementations/manager/smoke/persona-show-auth.smoke.ts
@@ -64,7 +64,7 @@ const context = (name: string): EpServeContext => ({
     v: 1,
     id: "ffeeddccbbaa99887766554433221100",
     args: { name },
-  },
+  } as unknown as EpServeContext["request"],
 });
 
 const owned = await show.handler(context("mine")) as { name?: string; persona?: string };

--- a/implementations/manager/smoke/static-lifecycle.smoke.ts
+++ b/implementations/manager/smoke/static-lifecycle.smoke.ts
@@ -128,7 +128,7 @@ const mgr = new Manager({ space, servers: SERVERS, runtime: "pty", workspaceRoot
 const fakeSession = { cols: 80, rows: 24, backlog: () => Buffer.alloc(0), onData: () => () => {}, onExit: () => () => {}, write: () => {}, resize: () => {} };
 const fakeHandle = (name: string): AgentHandle => {
   let running = true;
-  return { name, kind: "fake", locator: JSON.stringify({ name }), status: () => running ? "running" : "exited", stop: () => { running = false; }, waitForExit: async () => { running = false; }, interrupt: () => {}, attach: () => fakeSession };
+  return { name, kind: "fake", status: () => running ? "running" : "exited", stop: () => { running = false; }, waitForExit: async () => { running = false; }, interrupt: () => {}, attach: () => fakeSession };
 };
 (mgr as unknown as { runtime: { kind: string; spawn: (n: string, s: LaunchSpec) => AgentHandle; reap: (locator: string) => Promise<void> } }).runtime = { kind: "fake", spawn: (name) => fakeHandle(name), reap: async () => {} };
 (mgr as unknown as { ep: Record<string, unknown> }).ep = {

--- a/implementations/manager/smoke/supervise-registered-user-authority.smoke.ts
+++ b/implementations/manager/smoke/supervise-registered-user-authority.smoke.ts
@@ -113,7 +113,7 @@ const participantStore = workspaceSecretStore(participantRoot);
 const authDiagnosticCap = 32 * 1024;
 const closedChildren = new WeakSet<ChildProcess>();
 let authService: ChildProcess | undefined;
-let authServiceDiagnostics = Buffer.alloc(0);
+let authServiceDiagnostics: Buffer<ArrayBufferLike> = Buffer.alloc(0);
 let authServiceSpawnError: Error | undefined;
 let broker: ChildProcess | undefined;
 let idpServer: ReturnType<typeof createServer> | undefined;
@@ -250,7 +250,7 @@ try {
     emailAndPassword: { enabled: true },
     plugins: [
       jwt({ jwt: { issuer: origin, audience: origin } }),
-      deviceAuthorization({ expiresIn: "2m", interval: "1s", validateClient: (id) => id === clientId }),
+      deviceAuthorization({ expiresIn: "2m", interval: "1s", validateClient: (id: string) => id === clientId }),
       betterAuthBearer(),
     ],
   });
@@ -312,7 +312,7 @@ try {
     dir: participantHome,
     idpUrl,
     clientId,
-    onPrompt: (prompt) => void approve(prompt.userCode),
+    onPrompt: (prompt: { userCode: string }) => void approve(prompt.userCode),
   });
   const owner = await cotalAuthProvider.ownerForLogin({ store: hostStore, dir: hostDir, space });
   check("participant login is established", typeof sub === "string" && sub.length > 0);
@@ -349,7 +349,7 @@ try {
   endpoint = new CotalEndpoint({
     space,
     servers: server,
-    bearer: () => cotalAuthProvider.userCredentials({ store: participantStore, dir: participantDir, space, actor: "cli" }).then((value) => value.bearer),
+    bearer: () => cotalAuthProvider.userCredentials({ store: participantStore, dir: participantDir, space, actor: "cli" }).then((value: { bearer: string }) => value.bearer),
     sentinelCreds: material.sentinelCreds,
     lifecycleUid: payload.act.lifecycleUid,
     channels: [],

--- a/implementations/manager/tsconfig.smoke.json
+++ b/implementations/manager/tsconfig.smoke.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "noEmit": true, "rootDir": "../.." },
+  "include": ["smoke/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,6 +455,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@cotal-ai/auth':
+        specifier: workspace:*
+        version: link:../auth
       '@cotal-ai/smoke-kit':
         specifier: workspace:*
         version: link:../../packages/smoke-kit
@@ -545,9 +548,21 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@cotal-ai/auth':
+        specifier: workspace:*
+        version: link:../auth
+      '@cotal-ai/connector-claude-code':
+        specifier: workspace:*
+        version: link:../../extensions/connector-claude-code
+      '@cotal-ai/connector-codex':
+        specifier: workspace:*
+        version: link:../../extensions/connector-codex
       '@cotal-ai/connector-core':
         specifier: workspace:*
         version: link:../../extensions/connector-core
+      '@cotal-ai/connector-opencode':
+        specifier: workspace:*
+        version: link:../../extensions/connector-opencode
       '@cotal-ai/smoke-kit':
         specifier: workspace:*
         version: link:../../packages/smoke-kit


### PR DESCRIPTION
The manager and CLI smoke suites sat outside every tsc project, so a fixture could drift from a shipped contract and stay green until runtime — the gap #638 names (this PR covers its manager and CLI smoke trees; #1121 was closed as #638's duplicate). Each package gains a `tsconfig.smoke.json` (noEmit, over `smoke/**`) chained into its `typecheck` script, plus the workspace devDependencies the suites actually import. Everything else is fixture-only type corrections the new coverage surfaced; no production behavior changes.

Gates run on the lane tree:
- `pnpm -r build` green, `pnpm -r typecheck` green with the new projects included.
- Non-vacuity: a planted `TS2322` in each smoke tree turned that package's typecheck red; removed, both green.
- All edited manager smoke suites pass; edited CLI suites pass except `smoke:up-resume-render-lock:live`, which reports 10/10 assertions and then never exits outside CI (green in CI's `live` job on main) — filed as #1154; no behavior change made to that suite here.

Part of #638.