### PR TITLE
fix(delivery): subscribe the daemon to the channel its recoverable notices moved to

### DIFF
--- a/implementations/delivery/src/delivery.ts
+++ b/implementations/delivery/src/delivery.ts
@@ -225,7 +225,13 @@ export async function runDelivery(args: ParsedArgs, store?: SecretStore): Promis
     registerPresence: false, // … but NEVER publish the daemon onto the roster (it's infra, not a peer)
     card: { id: idFromCreds(creds.initial), name: "delivery", role: "delivery", kind: "endpoint" },
   });
-  ep.on("error", (e: Error) => console.error(`! delivery endpoint: ${e.message}`));
+  // Both channels: raw connection errors ride `error`, while every condition the endpoint is
+  // already surviving — a failed 75% renewal, the passive backstop's "still holds the previous
+  // cred" repair line — rides `warning` (#891). An operator who only sees the first watches the
+  // daemon go silent and then die at `exp` with no word of the remint it was waiting for.
+  const say = (e: Error) => console.error(`! delivery endpoint: ${e.message}`);
+  ep.on("error", say);
+  ep.on("warning", say);
   await ep.start();
 
   // Acquire the single-flight lease BEFORE binding the loops: a loud refusal-to-bind if another daemon

--- a/packages/core/smoke/standing-renewal-auth.smoke.ts
+++ b/packages/core/smoke/standing-renewal-auth.smoke.ts
@@ -120,6 +120,10 @@ try {
   let expiringReads = 0;
   let failedRebuildLogStart = -1;
   const expiringErrors: string[] = [];
+  // Recoverable notices — the failed renewal and the pre-dial refusal below — ride `warning`,
+  // not `error`: Node rethrows an unhandled `error` and would kill a host the endpoint is still
+  // surviving (#891). The subject here is that the refusal is LOUD and names the renewal path.
+  const expiringWarnings: string[] = [];
   const expiringSource = () => {
     expiringReads++;
     if (expiringReads <= 3) {
@@ -142,6 +146,7 @@ try {
     watchPresence: false,
   });
   expiringEp.on("error", (e: Error) => { expiringErrors.push(e.message); });
+  expiringEp.on("warning", (e: Error) => { expiringWarnings.push(e.message); });
   await expiringEp.start();
   let recovered = false;
   const recoveryDeadline = Date.now() + 15_000;
@@ -167,8 +172,8 @@ try {
   );
   check(
     "the pre-dial refusal is loud and names the failing renewal path",
-    expiringErrors.some((m) => /creds have expired.*renewal.*failing/.test(m)),
-    expiringErrors,
+    expiringWarnings.some((m) => /creds have expired.*renewal.*failing/.test(m)),
+    { warnings: expiringWarnings, errors: expiringErrors },
   );
   await expiringEp.stop();
 


### PR DESCRIPTION
`b36bf501` (#891) routed every condition an endpoint survives — the failed 75% renewal, the passive backstop's repair line — through `warning`, because Node rethrows an unhandled `error` and would kill the host. The delivery daemon kept listening only on `error`: an operator watching a real daemon saw silence, then death at JWT `exp`, with no word of the remint it was waiting for. One listener now serves both channels.

The standing-renewal smoke had the same gap as a consumer: it collected `error` and asserted the pre-dial refusal is loud — a cell that could never pass again after #891. It now collects `warning` (keeping the `error` listener) and reports both arrays on failure, so a regression that moves the refusal back to `error` still shows what was seen where.

Evidence:
- Red on plain main, green with the change, measured in one pipeline on current main (`e37c5a9b`): `smoke:standing-renewal` exit 1 → 0, `smoke:delivery-renewal` exit 1 → 0.
- Independently discovered, discriminated across four trees, and repair-verified during the #1137 second-layer work: https://github.com/Cotal-AI/Cotal/issues/1137#issuecomment-5469112333 — both suites are red on plain main with byte-identical cells and are this one defect, not the eviction oracle.
- These two files are the one row of #1156 with a suite that proves the loss today; the other seven consumers stay on #1156 for per-file evidence.

With #1143, this closes the two suite layers that have kept the smoke shards red on main since 5881a6fe.