### PR TITLE
fix(workspace): strip the ambient COTAL_ env from the presence-census probe children

### DIFF
--- a/packages/workspace/smoke/presence-render-census.smoke.ts
+++ b/packages/workspace/smoke/presence-render-census.smoke.ts
@@ -234,6 +234,13 @@ function collectCandidates(file: string): Candidate[] {
   return out;
 }
 
+// Child spawns get a COTAL_-stripped copy of the ambient env: whatever runs this suite may be a
+// managed agent session, and spreading its environment would hand the probe child a live credential
+// and a live broker URL (bin/smoke/suite-ambient-env.smoke.ts). The children read only their own
+// COTAL_PRESENCE_RENDER_* controls, set explicitly per spawn.
+const cleanEnv: NodeJS.ProcessEnv = { ...process.env };
+for (const key of Object.keys(cleanEnv)) if (key.startsWith("COTAL_")) delete cleanEnv[key];
+
 const selectedProbe = process.env.COTAL_PRESENCE_RENDER_PROBE_CASE;
 if (selectedProbe) {
   const probe = PROBES.find(([id]) => id === selectedProbe);
@@ -245,7 +252,7 @@ if (selectedProbe) {
     writeFileSync(path, source);
     const scan = spawnSync("pnpm", ["exec", "tsx", self], {
       cwd: root,
-      env: { ...process.env, COTAL_PRESENCE_RENDER_PROBE_CASE: "", COTAL_PRESENCE_RENDER_SINGLE_PROBE: rel, COTAL_PRESENCE_RENDER_EXPECT_KIND: expectedKind },
+      env: { ...cleanEnv, COTAL_PRESENCE_RENDER_PROBE_CASE: "", COTAL_PRESENCE_RENDER_SINGLE_PROBE: rel, COTAL_PRESENCE_RENDER_EXPECT_KIND: expectedKind },
       encoding: "utf8",
       timeout: 120_000,
     });
@@ -334,12 +341,12 @@ if (process.env.COTAL_PRESENCE_RENDER_PROBE_CHILD !== "1") {
       const rel = relative(root, path).split("\\").join("/");
       const scan = spawnSync("pnpm", ["exec", "tsx", self], {
         cwd: root,
-        env: { ...process.env, COTAL_PRESENCE_RENDER_SINGLE_PROBE: rel, COTAL_PRESENCE_RENDER_EXPECT_KIND: expectedKind },
+        env: { ...cleanEnv, COTAL_PRESENCE_RENDER_SINGLE_PROBE: rel, COTAL_PRESENCE_RENDER_EXPECT_KIND: expectedKind },
         encoding: "utf8",
         timeout: 120_000,
       });
       assert.equal(scan.status, 0, `${scan.stdout ?? ""}${scan.stderr ?? ""}`);
-      const run = spawnSync("pnpm", ["exec", "tsx", self], { cwd: root, env: { ...process.env, COTAL_PRESENCE_RENDER_PROBE_CHILD: "1" }, encoding: "utf8", timeout: 120_000 });
+      const run = spawnSync("pnpm", ["exec", "tsx", self], { cwd: root, env: { ...cleanEnv, COTAL_PRESENCE_RENDER_PROBE_CHILD: "1" }, encoding: "utf8", timeout: 120_000 });
       const output = `${run.stdout ?? ""}${run.stderr ?? ""}`;
       assert.notEqual(run.status, 0, `adversarial presence-render probe unexpectedly escaped the AST census: ${rel}`);
       assert.match(output, new RegExp(rel.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `probe failure did not name its new shipped path: ${rel}`);


### PR DESCRIPTION
`bin/smoke/suite-ambient-env.smoke.ts` is red on plain main — it names `packages/workspace/smoke/presence-render-census.smoke.ts` as spreading the ambient environment into a child without stripping `COTAL_` first. The presence-render census self-reenters through three `spawnSync` sites with `...process.env`; whatever runs a suite may be a managed agent session, so that spread hands the probe child a live credential and a live broker URL. The children read only their own `COTAL_PRESENCE_RENDER_*` controls, which every spawn already sets explicitly — they now get a `COTAL_`-stripped copy.

This is the cell currently killing `smoke (shard 2/4)` on every open PR (#1143 and #1153 both die at `smoke:suite-ambient-env` on this exact objection), and it reproduces locally on plain main.

Evidence, measured on current main (`e37c5a9b`):
- `smoke:suite-ambient-env`: exit 1 before (actual `["packages/workspace/smoke/presence-render-census.smoke.ts"]`, expected `[]`) → exit 0 with the change.
- `smoke:presence-render-census`: exit 0 with the change — the probe children run correctly on the stripped copy.

Together with #1143 (manager smokes) and #1157 (renewal warning channel), this closes the third of the three layers keeping the smoke shards red on main.