### PR TITLE
fix(connector-jcode): keep the host smoke's control sockets under a short root

### DIFF
--- a/extensions/connector-jcode/smoke/jcode-host.smoke.ts
+++ b/extensions/connector-jcode/smoke/jcode-host.smoke.ts
@@ -31,6 +31,12 @@ async function waitFor<T>(name: string, read: () => T | undefined, timeoutMs = 2
 }
 
 const root = mkdtempSync(join(tmpdir(), "cotal-jcode-host-"));
+// Control sockets are AF_UNIX. os.tmpdir() on macOS and a long TMPDIR on Linux
+// put `mismatchedmodel-control.sock` over sun_path (104/107) while the shorter
+// prefix/refuse sockets still bind — the cell then exits 1 with a connector
+// control-listen error instead of the model_mismatch diagnostic.
+const sockRoot = mkdtempSync(join("/tmp", "cjh-"));
+const controlSock = (name: string): string => join(sockRoot, name);
 const port = await freePort();
 const servers = `nats://127.0.0.1:${port}`;
 const fake = fileURLToPath(new URL("./fake-jcode.mjs", import.meta.url));
@@ -312,7 +318,7 @@ try {
       COTAL_JCODE_TUI: "0",
       COTAL_MODEL: "fake-model",
       COTAL_VARIANT: "high",
-      COTAL_CONTROL_SOCKET: join(root, "control.sock"),
+      COTAL_CONTROL_SOCKET: controlSock("control.sock"),
       COTAL_CONTROL_TOKEN: "jcode-host-smoke-control-token",
     },
     stdio: ["ignore", "ignore", "pipe"],
@@ -426,7 +432,7 @@ try {
       COTAL_ALLOW_PUBLISH: "team",
       COTAL_JCODE_HOME: root,
       COTAL_JCODE_TUI: "0",
-      COTAL_CONTROL_SOCKET: join(root, "race-control.sock"),
+      COTAL_CONTROL_SOCKET: controlSock("race-control.sock"),
       COTAL_CONTROL_TOKEN: "race-control-token",
     },
     stdio: ["ignore", "ignore", "pipe"],
@@ -460,7 +466,7 @@ try {
       COTAL_ALLOW_PUBLISH: "team",
       COTAL_JCODE_HOME: root,
       COTAL_JCODE_TUI: "0",
-      COTAL_CONTROL_SOCKET: join(root, "absent-control.sock"),
+      COTAL_CONTROL_SOCKET: controlSock("absent-control.sock"),
       COTAL_CONTROL_TOKEN: "absent-control-token",
     },
     stdio: ["ignore", "ignore", "pipe"],
@@ -500,7 +506,7 @@ try {
       COTAL_JCODE_TUI: "0",
       COTAL_MODEL: "fake-model",
       COTAL_VARIANT: "xhigh",
-      COTAL_CONTROL_SOCKET: join(root, "refused-control.sock"),
+      COTAL_CONTROL_SOCKET: controlSock("refused-control.sock"),
       COTAL_CONTROL_TOKEN: "refused-control-token",
     },
     stdio: ["ignore", "ignore", "pipe"],
@@ -578,7 +584,7 @@ try {
         COTAL_JCODE_HOME: root,
         COTAL_JCODE_TUI: "0",
         COTAL_MODEL: modelCase.model,
-        COTAL_CONTROL_SOCKET: join(root, `${modelCase.name}-control.sock`),
+        COTAL_CONTROL_SOCKET: controlSock(`${modelCase.name}-control.sock`),
         COTAL_CONTROL_TOKEN: `${modelCase.name}-control-token`,
       },
       stdio: ["ignore", "ignore", "pipe"],
@@ -619,7 +625,7 @@ try {
       COTAL_ALLOW_PUBLISH: "team",
       COTAL_JCODE_HOME: root,
       COTAL_JCODE_TUI: "0",
-      COTAL_CONTROL_SOCKET: join(root, "outage-control.sock"),
+      COTAL_CONTROL_SOCKET: controlSock("outage-control.sock"),
       COTAL_CONTROL_TOKEN: "outage-control-token",
     },
     stdio: ["ignore", "ignore", "pipe"],
@@ -675,7 +681,7 @@ try {
       COTAL_ALLOW_PUBLISH: "team",
       COTAL_JCODE_HOME: root,
       COTAL_JCODE_TUI: "1",
-      COTAL_CONTROL_SOCKET: join(root, "tui-control.sock"),
+      COTAL_CONTROL_SOCKET: controlSock("tui-control.sock"),
       COTAL_CONTROL_TOKEN: "tui-control-token",
     },
     stdio: ["ignore", "ignore", "pipe"],
@@ -707,7 +713,7 @@ try {
       COTAL_ALLOW_PUBLISH: "team",
       COTAL_JCODE_HOME: root,
       COTAL_JCODE_TUI: "0",
-      COTAL_CONTROL_SOCKET: join(root, "blocked-control.sock"),
+      COTAL_CONTROL_SOCKET: controlSock("blocked-control.sock"),
       COTAL_CONTROL_TOKEN: "blocked-control-token",
     },
     stdio: ["ignore", "ignore", "pipe"],
@@ -738,7 +744,7 @@ try {
       COTAL_ALLOW_PUBLISH: "team",
       COTAL_JCODE_HOME: root,
       COTAL_JCODE_TUI: "0",
-      COTAL_CONTROL_SOCKET: join(root, "refused-control.sock"),
+      COTAL_CONTROL_SOCKET: controlSock("refused-control.sock"),
       COTAL_CONTROL_TOKEN: "refused-control-token",
     },
     stdio: ["ignore", "ignore", "pipe"],


### PR DESCRIPTION
The env-sensitive `smoke:jcode-host` cell from #1155 — `model_mismatch names the connector-owned refusal` red on CI runners and macOS, green on a linux lane host — is an AF_UNIX path-length overflow. The suite's control sockets lived under its mkdtemp root, which follows `os.tmpdir()`: the longest name (`mismatchedmodel-control.sock`) pushes the socket path over `sun_path` (104/107) on hosts with a long tmpdir, so the connector dies on a control-listen error before the diagnostic, while every shorter socket still binds — exactly the observed asymmetry, and the observed `failedErr` carried the control-socket path.

Sockets now live under a dedicated short mkdtemp in `/tmp`.

Mechanism proof, on the previously-green linux host, with TMPDIR tuned to 58 chars so only the longest control name overflows (tsx's own `$TMPDIR/tsx-<uid>/<pid>.pipe` and all shorter sockets still bind):
- pre-fix: exit 1, red at the `model_mismatch` cell — the CI/macOS shape reproduced;
- post-fix: exit 0 under the identical TMPDIR.

Diagnosed on a lane seat (which also authored most of the conversion before its provider stream stalled); completed and proven from its worktree.