### PR TITLE
test(smoke): re-census the standaloneConnectOpts call sites

### DIFF
--- a/bin/smoke/required-arg-seam.smoke.ts
+++ b/bin/smoke/required-arg-seam.smoke.ts
@@ -277,7 +277,9 @@ const SEAMS: Seam[] = [
   // 102/75 -> 108/79: component status and remote manager registration add two typechecked calls;
   // the manager boot self-heal and registered-user-authority smokes add four untypechecked calls.
   // Every added site states the transport decision explicitly.
-  { fn: "standaloneConnectOpts", key: "tls", sites: 108, untypecheckedSites: 79 },
+  // 108/79 -> 109/80: the manager lifecycle eviction audit smoke reads the records bucket over one
+  // untypechecked probe connection with an explicit plaintext-broker `tls: false` decision.
+  { fn: "standaloneConnectOpts", key: "tls", sites: 109, untypecheckedSites: 80 },
 ];
 
 /**


### PR DESCRIPTION
`smoke:required-arg-seam` has been red since 05:40Z on two population-count cells. This moves
the two numbers and records why, which is what those cells exist to make someone do by hand.

## What was red

```
✗ standaloneConnectOpts: the scan finds EXACTLY 108 call sites   { found: 109, expected: 108 }
✗ standaloneConnectOpts: EXACTLY 79 of them are under smoke/     { found: 80,  expected: 79  }
```

251 passed, 2 failed.

## The seam is intact; only the census moved

The two cells either side of the failures pass: `every call site states tls`, and `the name is
never rebound, so no call can hide behind an alias`. The added site is

```ts
standaloneConnectOpts({ creds, tls: false })
```

in `implementations/manager/smoke/static-lifecycle.smoke.ts`, which states the transport decision
explicitly. So the property the seam guards holds, and what changed is the population.

## Attribution, and why one addition explains both cells

`2579d7f89` ("test(manager): query lifecycle eviction audit", 2026-08-30 05:40Z) added the call.
It is the only commit touching a `standaloneConnectOpts(` call since the last census refresh
(`b53ae9bcb`, 2026-08-28), so the single addition accounts for the +1 on both cells rather than a
net +2/-1 that would look identical. The new site is under `smoke/`, which is why the
under-smoke count moved with the total.

## Verification at this tree

| state | result |
| --- | --- |
| 109 / 80 (this PR) | **green**, 253 passed, 0 failed |
| 110 / 80 | red on the total cell, `{ found: 109, expected: 110 }` |
| 109 / 79 | red on the under-smoke cell, `{ found: 80, expected: 79 }` |
| back to 109 / 80 | green again |

Both cells still discriminate independently, so neither is passing vacuously.

The counts were measured at this branch's own tree rather than copied from the CI log that
surfaced the failure. That log's run was on an older tree, and a census number taken from a stale
run is the same mistake as reading a stale red as current.

## Why it surfaced only now

The suite is line 364 of `bin/smoke/ci-suites.txt`. Shard 0 stops at its first failure, and it
had been stopping earlier all day, so this red never ran. It became visible once the mutation
anchor repair let the shard reach line 364. It is the fifth such layer today and there is no
reason to assume it is the last: 35 of 119 suites in that partition still have not started.

No changeset: test-only, no shipped behaviour changes.
