### PR TITLE
test(smoke): bump the standaloneConnectOpts census to 109/80

### DIFF
--- a/bin/smoke/required-arg-seam.smoke.ts
+++ b/bin/smoke/required-arg-seam.smoke.ts
@@ -275,9 +275,10 @@ const SEAMS: Seam[] = [
   // 101/74 -> 102/75: the remote-agent-bearer live smoke opens the already-enrolled managed
   // actor with bearer+sentinel and an explicit plaintext-broker `tls: false` decision.
   // 102/75 -> 108/79: component status and remote manager registration add two typechecked calls;
+  // 108/79 -> 109/80: the static-lifecycle eviction audit (2579d7f8) adds one smoke-side call.
   // the manager boot self-heal and registered-user-authority smokes add four untypechecked calls.
   // Every added site states the transport decision explicitly.
-  { fn: "standaloneConnectOpts", key: "tls", sites: 108, untypecheckedSites: 79 },
+  { fn: "standaloneConnectOpts", key: "tls", sites: 109, untypecheckedSites: 80 },
 ];
 
 /**


### PR DESCRIPTION
2579d7f8 (test(manager): query lifecycle eviction audit) added a 109th `standaloneConnectOpts` call site — a smoke-side one — without bumping the required-arg-seam census, so `smoke:required-arg-seam` reds on main at found 109/expected 108 and 80/79.

The red was invisible until now because every shard-0 run since #1153's merge died earlier at `smoke:mutation-fixtures` (the dead anchors, cured by #1161, merged as 3893599d); #1161's run was the first to reach the census and exposed it.

This bumps the two expected numbers and extends the census history comment naming the new site. Verified locally on this exact tree: `pnpm smoke:required-arg-seam` exit 0, both EXACTLY cells green at 109/80.