### PR TITLE
test: catch two suites up with the status warning channel

### DIFF
--- a/implementations/auth/smoke/expiry-renewal.smoke.ts
+++ b/implementations/auth/smoke/expiry-renewal.smoke.ts
@@ -124,6 +124,7 @@ try {
     registerPresence: false, watchPresence: false, watchChannels: false, consume: false,
   });
   epA.on("error", (e: Error) => errorsA.push({ ms: Date.now() - t0, msg: e.message }));
+  epA.on("warning", (e: Error) => errorsA.push({ ms: Date.now() - t0, msg: e.message }));
   await epA.start();
   const denialsBeforeA = denials.length;
 

--- a/packages/workspace/smoke/fixtures/presence-render-sinks.json
+++ b/packages/workspace/smoke/fixtures/presence-render-sinks.json
@@ -1,10 +1,10 @@
 {
   "expected": {
-    "total": 303,
+    "total": 305,
     "honest-text": 32,
     "presence-only-glyph/count": 41,
     "command-ack": 8,
-    "non-render/control": 222
+    "non-render/control": 224
   },
   "renderers": [
     {
@@ -64,7 +64,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "extensions/connector-core/smoke/orientation.smoke.ts",
-        "anchor": "assert.match(o.peers.summary, /bob\\/worker \\(working \u00b7 progress unknown\\)/,"
+        "anchor": "assert.match(o.peers.summary, /bob\\/worker \\(working · progress unknown\\)/,"
       }
     },
     {
@@ -75,7 +75,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "extensions/connector-core/smoke/orientation.smoke.ts",
-        "anchor": "assert.match(o.peers.summary, /bob\\/worker \\(working \u00b7 progress unknown\\)/,"
+        "anchor": "assert.match(o.peers.summary, /bob\\/worker \\(working · progress unknown\\)/,"
       }
     },
     {
@@ -95,12 +95,12 @@
     {
       "path": "extensions/connector-core/src/orientation.ts",
       "kind": "derived-output",
-      "anchor": "`  \u2022 status: ${honestStatus(o.status)} \u00b7 attention: ${o.attention}`",
+      "anchor": "`  • status: ${honestStatus(o.status)} · attention: ${o.attention}`",
       "class": "honest-text",
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "extensions/connector-core/smoke/orientation.smoke.ts",
-        "anchor": "assert.match(o.peers.summary, /bob\\/worker \\(working \u00b7 progress unknown\\)/,"
+        "anchor": "assert.match(o.peers.summary, /bob\\/worker \\(working · progress unknown\\)/,"
       }
     },
     {
@@ -111,46 +111,46 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "extensions/connector-core/smoke/orientation.smoke.ts",
-        "anchor": "assert.match(o.peers.summary, /bob\\/worker \\(working \u00b7 progress unknown\\)/,"
+        "anchor": "assert.match(o.peers.summary, /bob\\/worker \\(working · progress unknown\\)/,"
       }
     },
     {
       "path": "extensions/connector-core/src/tool-specs.ts",
       "kind": "status-token",
-      "anchor": "string {\n  return s === \"working\" ? \"\u25cf\" : s === \"waiting\"",
+      "anchor": "string {\n  return s === \"working\" ? \"●\" : s === \"waiting\"",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "extensions/connector-core/src/tool-specs.ts",
       "kind": "status-token",
-      "anchor": "\"working\" ? \"\u25cf\" : s === \"waiting\" ? \"\u25d0\" : s === \"idle\" ? ",
+      "anchor": "\"working\" ? \"●\" : s === \"waiting\" ? \"◐\" : s === \"idle\" ? ",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "extensions/connector-core/src/tool-specs.ts",
       "kind": "status-token",
-      "anchor": "\"waiting\" ? \"\u25d0\" : s === \"idle\" ? \"\u25cb\" : \"\u00b7\";\n}\n\n/** One",
+      "anchor": "\"waiting\" ? \"◐\" : s === \"idle\" ? \"○\" : \"·\";\n}\n\n/** One",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "extensions/connector-core/src/tool-specs.ts",
       "kind": "status-token",
-      "anchor": "progress = p.status === \"working\" ? \"working \u00b7 progress u",
+      "anchor": "progress = p.status === \"working\" ? \"working · progress u",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "extensions/connector-core/src/tool-specs.ts",
       "kind": "derived-output",
-      "anchor": "`${statusGlyph(p.status)} ${who} \u2014 ${progress}${p.activity ? `: ${p.activity}` : \"\"}${attn}${me}${mutedHint}${id}`",
+      "anchor": "`${statusGlyph(p.status)} ${who} — ${progress}${p.activity ? `: ${p.activity}` : \"\"}${attn}${me}${mutedHint}${id}`",
       "class": "honest-text",
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "extensions/connector-core/src/tool-specs.ts",
-        "anchor": "const progress = p.status === \"working\" ? \"working \u00b7 progress unknown\" : p.status;"
+        "anchor": "const progress = p.status === \"working\" ? \"working · progress unknown\" : p.status;"
       }
     },
     {
@@ -163,14 +163,14 @@
     {
       "path": "extensions/connector-core/src/tool-specs.ts",
       "kind": "derived-output",
-      "anchor": "`  \u2022 ${c.name}${c.role ? `/${c.role}` : \"\"} (${c.status}) \u2014 id: ${c.id}`",
+      "anchor": "`  • ${c.name}${c.role ? `/${c.role}` : \"\"} (${c.status}) — id: ${c.id}`",
       "class": "command-ack",
       "rationale": "Command result or ambiguity guidance reports the status involved in that operation, not observed work progress."
     },
     {
       "path": "extensions/connector-core/src/tool-specs.ts",
       "kind": "derived-output",
-      "anchor": "`\"${e.target}\" is ambiguous \u2014 ${e.candidates.length} peers share that name. ` +\n                `Re-send cotal_dm with the exact instance id as \"to\":\\n${who}`",
+      "anchor": "`\"${e.target}\" is ambiguous — ${e.candidates.length} peers share that name. ` +\n                `Re-send cotal_dm with the exact instance id as \"to\":\\n${who}`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -238,7 +238,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/manager/smoke/cli-seat-locality.smoke.ts",
-        "anchor": "check(\"ps textual working mesh row names unknown progress\", /working \u00b7 progress unknown/.test(ps.out), ps.out.slice(-1200));"
+        "anchor": "check(\"ps textual working mesh row names unknown progress\", /working · progress unknown/.test(ps.out), ps.out.slice(-1200));"
       }
     },
     {
@@ -256,7 +256,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/manager/smoke/cli-seat-locality.smoke.ts",
-        "anchor": "check(\"ps textual working mesh row names unknown progress\", /working \u00b7 progress unknown/.test(ps.out), ps.out.slice(-1200));"
+        "anchor": "check(\"ps textual working mesh row names unknown progress\", /working · progress unknown/.test(ps.out), ps.out.slice(-1200));"
       }
     },
     {
@@ -318,7 +318,7 @@
     {
       "path": "implementations/cli/src/commands/down.ts",
       "kind": "derived-output",
-      "anchor": "`\u2713 preserved state for \"${mesh.space}\"`",
+      "anchor": "`✓ preserved state for \"${mesh.space}\"`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -337,7 +337,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
+        "anchor": "return c.green(\"● working · progress unknown\");"
       }
     },
     {
@@ -348,7 +348,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
+        "anchor": "return c.green(\"● working · progress unknown\");"
       }
     },
     {
@@ -375,12 +375,12 @@
     {
       "path": "implementations/cli/src/commands/join.ts",
       "kind": "derived-output",
-      "anchor": "c.green(`\u2192 ${who(ev.presence.card)} joined `) + statusBadge(ev.presence.status)",
+      "anchor": "c.green(`→ ${who(ev.presence.card)} joined `) + statusBadge(ev.presence.status)",
       "class": "honest-text",
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
+        "anchor": "return c.green(\"● working · progress unknown\");"
       }
     },
     {
@@ -391,7 +391,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
+        "anchor": "return c.green(\"● working · progress unknown\");"
       }
     },
     {
@@ -404,12 +404,12 @@
     {
       "path": "implementations/cli/src/commands/join.ts",
       "kind": "derived-output",
-      "anchor": "`${c.dim(\"\u2022\")} ${who(ev.presence.card)} ${statusBadge(ev.presence.status)}${ev.presence.activity ? c.dim(\" - \" + ev.presence.activity) : \"\"}`",
+      "anchor": "`${c.dim(\"•\")} ${who(ev.presence.card)} ${statusBadge(ev.presence.status)}${ev.presence.activity ? c.dim(\" - \" + ev.presence.activity) : \"\"}`",
       "class": "honest-text",
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
+        "anchor": "return c.green(\"● working · progress unknown\");"
       }
     },
     {
@@ -420,7 +420,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
+        "anchor": "return c.green(\"● working · progress unknown\");"
       }
     },
     {
@@ -431,7 +431,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
+        "anchor": "return c.green(\"● working · progress unknown\");"
       }
     },
     {
@@ -442,7 +442,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
+        "anchor": "return c.green(\"● working · progress unknown\");"
       }
     },
     {
@@ -453,7 +453,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
+        "anchor": "return c.green(\"● working · progress unknown\");"
       }
     },
     {
@@ -471,7 +471,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
+        "anchor": "return c.green(\"● working · progress unknown\");"
       }
     },
     {
@@ -482,7 +482,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
+        "anchor": "return c.green(\"● working · progress unknown\");"
       }
     },
     {
@@ -523,21 +523,21 @@
     {
       "path": "implementations/cli/src/commands/meshes-add.ts",
       "kind": "derived-output",
-      "anchor": "`\u2717 ${what} answered ${res.status} (a redirect to ${JSON.stringify(res.headers.get(\"location\") ?? \"\")}) - a redirect can move a pinned fetch onto plaintext or onto another host, so it is refused rather than followed; publish the document at the pinned URL itself`",
+      "anchor": "`✗ ${what} answered ${res.status} (a redirect to ${JSON.stringify(res.headers.get(\"location\") ?? \"\")}) - a redirect can move a pinned fetch onto plaintext or onto another host, so it is refused rather than followed; publish the document at the pinned URL itself`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "implementations/cli/src/commands/meshes-add.ts",
       "kind": "derived-output",
-      "anchor": "`\u2717 the pinned exchange at ${base} answered /health with ${res.status} - it is not serving as the bundle promises`",
+      "anchor": "`✗ the pinned exchange at ${base} answered /health with ${res.status} - it is not serving as the bundle promises`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "implementations/cli/src/commands/meshes-add.ts",
       "kind": "derived-output",
-      "anchor": "`\u2717 the pinned exchange at ${base} answered /jwks with ${res.status}`",
+      "anchor": "`✗ the pinned exchange at ${base} answered /jwks with ${res.status}`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -551,14 +551,14 @@
     {
       "path": "implementations/cli/src/commands/meshes.ts",
       "kind": "derived-output",
-      "anchor": "`\u2717 ${disco} answered ${res.status} (a redirect to ${JSON.stringify(res.headers.get(\"location\") ?? \"\")}) - a redirect can move the fetch onto plaintext or onto another host, so it is refused rather than followed; publish the discovery document at the URL you pass`",
+      "anchor": "`✗ ${disco} answered ${res.status} (a redirect to ${JSON.stringify(res.headers.get(\"location\") ?? \"\")}) - a redirect can move the fetch onto plaintext or onto another host, so it is refused rather than followed; publish the discovery document at the URL you pass`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "implementations/cli/src/commands/meshes.ts",
       "kind": "derived-output",
-      "anchor": "`\u2717 ${disco} answered ${res.status} - no discovery document there`",
+      "anchor": "`✗ ${disco} answered ${res.status} - no discovery document there`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -593,14 +593,14 @@
     {
       "path": "implementations/cli/src/commands/setup.ts",
       "kind": "derived-output",
-      "anchor": "`mesh     ${dim(mesh.reachable ? `${mesh.server} \u00b7 space ${mesh.space}` : `down \u00b7 start: ${cmd} up --detach`)}`",
+      "anchor": "`mesh     ${dim(mesh.reachable ? `${mesh.server} · space ${mesh.space}` : `down · start: ${cmd} up --detach`)}`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "implementations/cli/src/commands/setup.ts",
       "kind": "derived-output",
-      "anchor": "`${mesh.server} \u00b7 space ${mesh.space}`",
+      "anchor": "`${mesh.server} · space ${mesh.space}`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -619,7 +619,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
+        "anchor": "return c.green(\"● working · progress unknown\");"
       }
     },
     {
@@ -630,7 +630,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
+        "anchor": "return c.green(\"● working · progress unknown\");"
       }
     },
     {
@@ -958,23 +958,23 @@
     {
       "path": "implementations/cli/src/console/ui/Detail.tsx",
       "kind": "derived-output",
-      "anchor": "{s.dot + \" \" + s.word + (status === \"working\" ? \" \u00b7 progress unknown\" : \"\")}",
+      "anchor": "{s.dot + \" \" + s.word + (status === \"working\" ? \" · progress unknown\" : \"\")}",
       "class": "honest-text",
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/console/ui/Detail.tsx",
-        "anchor": "<Text color={s.color}>{s.dot + \" \" + s.word + (status === \"working\" ? \" \u00b7 progress unknown\" : \"\")}</Text>"
+        "anchor": "<Text color={s.color}>{s.dot + \" \" + s.word + (status === \"working\" ? \" · progress unknown\" : \"\")}</Text>"
       }
     },
     {
       "path": "implementations/cli/src/console/ui/Detail.tsx",
       "kind": "derived-output",
-      "anchor": "s.dot + \" \" + s.word + (status === \"working\" ? \" \u00b7 progress unknown\" : \"\")",
+      "anchor": "s.dot + \" \" + s.word + (status === \"working\" ? \" · progress unknown\" : \"\")",
       "class": "honest-text",
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/console/ui/Detail.tsx",
-        "anchor": "<Text color={s.color}>{s.dot + \" \" + s.word + (status === \"working\" ? \" \u00b7 progress unknown\" : \"\")}</Text>"
+        "anchor": "<Text color={s.color}>{s.dot + \" \" + s.word + (status === \"working\" ? \" · progress unknown\" : \"\")}</Text>"
       }
     },
     {
@@ -1008,7 +1008,7 @@
     {
       "path": "implementations/cli/src/console/ui/Dm.tsx",
       "kind": "indexed-map",
-      "anchor": "              {\"  \u21b3 \" + STATUS[c.status].dot + \" \" + c.with + ro",
+      "anchor": "              {\"  ↳ \" + STATUS[c.status].dot + \" \" + c.with + ro",
       "class": "presence-only-glyph/count",
       "rationale": "Narrow presence glyph, color, or aggregate count; it makes no textual progress claim."
     },
@@ -1054,14 +1054,14 @@
     {
       "path": "implementations/cli/src/console/ui/Roster.tsx",
       "kind": "derived-output",
-      "anchor": "{(isAgent ? s.dot : \"\u2699\") + \" \" + p.card.name + kind + act + \"  \" + age}",
+      "anchor": "{(isAgent ? s.dot : \"⚙\") + \" \" + p.card.name + kind + act + \"  \" + age}",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "implementations/cli/src/console/ui/Roster.tsx",
       "kind": "derived-output",
-      "anchor": "(isAgent ? s.dot : \"\u2699\") + \" \" + p.card.name + kind + act + \"  \" + age",
+      "anchor": "(isAgent ? s.dot : \"⚙\") + \" \" + p.card.name + kind + act + \"  \" + age",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -1082,7 +1082,7 @@
     {
       "path": "implementations/cli/src/console/ui/Roster.tsx",
       "kind": "derived-output",
-      "anchor": "{isAgent ? s.dot : \"\u2699\"}",
+      "anchor": "{isAgent ? s.dot : \"⚙\"}",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -1170,21 +1170,21 @@
     {
       "path": "implementations/cli/src/console/ui/StatusBar.tsx",
       "kind": "derived-output",
-      "anchor": "{status.connected ? \"\u25cf \" : \"\u2a2f \"}",
+      "anchor": "{status.connected ? \"● \" : \"⨯ \"}",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "implementations/cli/src/console/ui/StatusBar.tsx",
       "kind": "derived-output",
-      "anchor": "{status.space + \" \u00b7 #\" + activeChannel + \" \u00b7 \" + agentCount + \" agents \u00b7 \" +\n            rates.msgsPerSec.toFixed(1) + \" msg/s\"}",
+      "anchor": "{status.space + \" · #\" + activeChannel + \" · \" + agentCount + \" agents · \" +\n            rates.msgsPerSec.toFixed(1) + \" msg/s\"}",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "implementations/cli/src/console/ui/StatusBar.tsx",
       "kind": "derived-output",
-      "anchor": "status.space + \" \u00b7 #\" + activeChannel + \" \u00b7 \" + agentCount + \" agents \u00b7 \" +\n            rates.msgsPerSec.toFixed(1) + \" msg/s\"",
+      "anchor": "status.space + \" · #\" + activeChannel + \" · \" + agentCount + \" agents · \" +\n            rates.msgsPerSec.toFixed(1) + \" msg/s\"",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -1198,7 +1198,7 @@
     {
       "path": "implementations/cli/src/console/ui/StatusBar.tsx",
       "kind": "derived-output",
-      "anchor": "{status.error ? (\n          <Text color=\"red\">{\"  ! \" + status.error}</Text>\n        ) : (\n          <Text dimColor>{\"   \" + keys}</Text>\n        )}",
+      "anchor": "{status.error ? (\n          <Text color=\"red\">{\"  ! \" + status.error}</Text>\n        ) : status.warning ? (\n          <Text color=\"yellow\">{\"  ! \" + status.warning}</Text>\n        ) : (\n          <Text dimColor>{\"   \" + keys}</Text>\n        )}",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -1213,6 +1213,20 @@
       "path": "implementations/cli/src/console/ui/StatusBar.tsx",
       "kind": "derived-output",
       "anchor": "\"  ! \" + status.error",
+      "class": "non-render/control",
+      "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
+    },
+    {
+      "path": "implementations/cli/src/console/ui/StatusBar.tsx",
+      "kind": "derived-output",
+      "anchor": "{\"  ! \" + status.warning}",
+      "class": "non-render/control",
+      "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
+    },
+    {
+      "path": "implementations/cli/src/console/ui/StatusBar.tsx",
+      "kind": "derived-output",
+      "anchor": "\"  ! \" + status.warning",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -1401,7 +1415,7 @@
     {
       "path": "implementations/cli/src/console/ui/topo/model.ts",
       "kind": "derived-output",
-      "anchor": "src.key + \"\u2192\" + dst.key",
+      "anchor": "src.key + \"→\" + dst.key",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -1429,7 +1443,7 @@
     {
       "path": "implementations/cli/src/lib/up-report.ts",
       "kind": "derived-output",
-      "anchor": "`\u2713 running in the background: ${components.join(\", \")} - stop with: cotal down`",
+      "anchor": "`✓ running in the background: ${components.join(\", \")} - stop with: cotal down`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -1455,7 +1469,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
+        "anchor": "return c.green(\"● working · progress unknown\");"
       }
     },
     {
@@ -1466,7 +1480,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
+        "anchor": "return c.green(\"● working · progress unknown\");"
       }
     },
     {
@@ -1477,7 +1491,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
+        "anchor": "return c.green(\"● working · progress unknown\");"
       }
     },
     {
@@ -1488,7 +1502,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
+        "anchor": "return c.green(\"● working · progress unknown\");"
       }
     },
     {
@@ -1499,7 +1513,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
+        "anchor": "return c.green(\"● working · progress unknown\");"
       }
     },
     {
@@ -1510,7 +1524,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
+        "anchor": "return c.green(\"● working · progress unknown\");"
       }
     },
     {
@@ -1621,14 +1635,14 @@
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "derived-output",
-      "anchor": "`<div class=\"peer ${p.status}${nav}\"${attrs}>\n    <span class=\"dot ${p.status}\">${GLYPH[p.status] ?? \"\u25cb\"}</span>\n    <div class=\"c\">\n      <div class=\"l1\">\n        <span class=\"name\">${esc(p.name)}</span>\n        ${p.harness ? harnessBadge(p.harness, { compact: true }) : \"\"}\n        ${p.role ? `<span class=\"role\">${esc(p.role)}</span>` : \"\"}\n        ${attentionChip(p.attention, { compact: true })}\n        ${p.tag ? `<span class=\"tag\">${esc(p.tag)}</span>` : \"\"}\n      </div>\n      ${p.act ? `<div class=\"act\" title=\"${esc(p.act)}\">${esc(p.act)}</div>` : \"\"}\n    </div>\n  </div>`",
+      "anchor": "`<div class=\"peer ${p.status}${nav}\"${attrs}>\n    <span class=\"dot ${p.status}\">${GLYPH[p.status] ?? \"○\"}</span>\n    <div class=\"c\">\n      <div class=\"l1\">\n        <span class=\"name\">${esc(p.name)}</span>\n        ${p.harness ? harnessBadge(p.harness, { compact: true }) : \"\"}\n        ${p.role ? `<span class=\"role\">${esc(p.role)}</span>` : \"\"}\n        ${attentionChip(p.attention, { compact: true })}\n        ${p.tag ? `<span class=\"tag\">${esc(p.tag)}</span>` : \"\"}\n      </div>\n      ${p.act ? `<div class=\"act\" title=\"${esc(p.act)}\">${esc(p.act)}</div>` : \"\"}\n    </div>\n  </div>`",
       "class": "presence-only-glyph/count",
       "rationale": "Narrow presence glyph, color, or aggregate count; it makes no textual progress claim."
     },
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "indexed-map",
-      "anchor": "ass=\"dot ${p.status}\">${GLYPH[p.status] ?? \"\u25cb\"}</span>\n    <div",
+      "anchor": "ass=\"dot ${p.status}\">${GLYPH[p.status] ?? \"○\"}</span>\n    <div",
       "class": "presence-only-glyph/count",
       "rationale": "Narrow presence glyph, color, or aggregate count; it makes no textual progress claim."
     },
@@ -1649,28 +1663,28 @@
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "status-token",
-      "anchor": "  return r ? r.status : \"offline\";\n}\n// id\u2192name resolutio",
+      "anchor": "  return r ? r.status : \"offline\";\n}\n// id→name resolutio",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "derived-output",
-      "anchor": "`<div class=\"dm${expanded ? \" sel\" : \"\"}\" data-dm=\"${esc(p.id)}\">\n    <span class=\"caret\">${expanded ? \"\u25be\" : \"\u25b8\"}</span>\n    <span class=\"l\">\n      <span class=\"dot ${p.status}\">${GLYPH[p.status] ?? \"\u25cb\"}</span>\n      <span class=\"nm\">${esc(p.name)}</span>\n      ${p.role ? `<span class=\"role\">${esc(p.role)}</span>` : \"\"}\n    </span>\n    ${p.unread ? `<span class=\"mention\">${p.unread}</span>` : \"\"}\n    ${expanded ? \"\" : `<span class=\"threads\">${plural(p.threads, \"thread\")}</span>`}\n  </div>`",
+      "anchor": "`<div class=\"dm${expanded ? \" sel\" : \"\"}\" data-dm=\"${esc(p.id)}\">\n    <span class=\"caret\">${expanded ? \"▾\" : \"▸\"}</span>\n    <span class=\"l\">\n      <span class=\"dot ${p.status}\">${GLYPH[p.status] ?? \"○\"}</span>\n      <span class=\"nm\">${esc(p.name)}</span>\n      ${p.role ? `<span class=\"role\">${esc(p.role)}</span>` : \"\"}\n    </span>\n    ${p.unread ? `<span class=\"mention\">${p.unread}</span>` : \"\"}\n    ${expanded ? \"\" : `<span class=\"threads\">${plural(p.threads, \"thread\")}</span>`}\n  </div>`",
       "class": "presence-only-glyph/count",
       "rationale": "Narrow presence glyph, color, or aggregate count; it makes no textual progress claim."
     },
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "indexed-map",
-      "anchor": "ass=\"dot ${p.status}\">${GLYPH[p.status] ?? \"\u25cb\"}</span>\n      <s",
+      "anchor": "ass=\"dot ${p.status}\">${GLYPH[p.status] ?? \"○\"}</span>\n      <s",
       "class": "presence-only-glyph/count",
       "rationale": "Narrow presence glyph, color, or aggregate count; it makes no textual progress claim."
     },
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "derived-output",
-      "anchor": "`<div class=\"dm sub${sel ? \" sel\" : \"\"}\" data-dm=\"${esc(peer)}${SEP}${esc(c.with)}\">\n    <span class=\"ln\">\u21b3</span>\n    <span class=\"l\">\n      <span class=\"dot ${c.status}\">${GLYPH[c.status] ?? \"\u25cb\"}</span>\n      <span class=\"nm\">${esc(c.withName ?? c.with)}</span>\n      ${c.role ? `<span class=\"role\">${esc(c.role)}</span>` : \"\"}\n    </span>\n    ${c.unread ? `<span class=\"mention\">${c.unread}</span>` : \"\"}\n  </div>`",
+      "anchor": "`<div class=\"dm sub${sel ? \" sel\" : \"\"}\" data-dm=\"${esc(peer)}${SEP}${esc(c.with)}\">\n    <span class=\"ln\">↳</span>\n    <span class=\"l\">\n      <span class=\"dot ${c.status}\">${GLYPH[c.status] ?? \"○\"}</span>\n      <span class=\"nm\">${esc(c.withName ?? c.with)}</span>\n      ${c.role ? `<span class=\"role\">${esc(c.role)}</span>` : \"\"}\n    </span>\n    ${c.unread ? `<span class=\"mention\">${c.unread}</span>` : \"\"}\n  </div>`",
       "class": "presence-only-glyph/count",
       "rationale": "Narrow presence glyph, color, or aggregate count; it makes no textual progress claim."
     },
@@ -1684,14 +1698,14 @@
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "derived-output",
-      "anchor": "`<div class=\"cmsg\">\n    <span class=\"ts\">${esc(m.ts)}</span>\n    <span class=\"dot ${m.status}\">${GLYPH[m.status] ?? \"\u25cf\"}</span>\n    <div class=\"c\">\n      <div class=\"l1\"><span class=\"who\">${esc(m.who)}</span>${m.role ? `<span class=\"role\">${esc(m.role)}</span>` : \"\"}</div>\n      ${bodyBlock(m.body)}\n      ${m.thread ? `<span class=\"thread\">${esc(m.thread)}</span>` : \"\"}\n    </div>\n  </div>`",
+      "anchor": "`<div class=\"cmsg\">\n    <span class=\"ts\">${esc(m.ts)}</span>\n    <span class=\"dot ${m.status}\">${GLYPH[m.status] ?? \"●\"}</span>\n    <div class=\"c\">\n      <div class=\"l1\"><span class=\"who\">${esc(m.who)}</span>${m.role ? `<span class=\"role\">${esc(m.role)}</span>` : \"\"}</div>\n      ${bodyBlock(m.body)}\n      ${m.thread ? `<span class=\"thread\">${esc(m.thread)}</span>` : \"\"}\n    </div>\n  </div>`",
       "class": "presence-only-glyph/count",
       "rationale": "Narrow presence glyph, color, or aggregate count; it makes no textual progress claim."
     },
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "indexed-map",
-      "anchor": "<div class=\"cmsg\">\n    <span class=\"ts\">${esc(m.ts)}</span>\n    <span class=\"dot ${m.status}\">${GLYPH[m.status] ?? \"\u25cf\"}</span>\n    <div class=\"c\">\n      <div class=\"l1\"><span class=\"who\">${esc(m.who)}</span>",
+      "anchor": "<div class=\"cmsg\">\n    <span class=\"ts\">${esc(m.ts)}</span>\n    <span class=\"dot ${m.status}\">${GLYPH[m.status] ?? \"●\"}</span>\n    <div class=\"c\">\n      <div class=\"l1\"><span class=\"who\">${esc(m.who)}</span>",
       "class": "presence-only-glyph/count",
       "rationale": "Narrow presence glyph, color, or aggregate count; it makes no textual progress claim."
     },
@@ -1705,14 +1719,14 @@
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "derived-output",
-      "anchor": "$(\"center\").innerHTML = `\n    <div class=\"ch-head\">\n      <div class=\"row\">\n        <div class=\"title\"><span class=\"h\"># ${esc(name)}</span>${sub ? `<span class=\"sub\">${esc(sub)}</span>` : \"\"}</div>\n        <div class=\"ctrls\">\n          ${toggleAllChip(items)}\n          <span class=\"chip mode on\">\ud83d\udc65 ${plural(memberCount, \"member\")}</span>\n          ${policy.join(\"\")}\n          ${isDemo ? `<span class=\"chip static\" title=\"demo only\">\u2726 summarize</span><span class=\"chip static\" title=\"demo only\">\ud83d\udd15 mute</span>` : \"\"}\n          ${isDemo ? \"\" : `<span class=\"chip danger\" id=\"ch-del\" title=\"Delete this channel and all its messages\">\ud83d\uddd1 delete</span>`}\n        </div>\n      </div>\n      <div class=\"purpose\">${purpose}</div>\n    </div>\n    ${orderNoticeHtml()}\n    <div class=\"clist\">${items.length ? items.map(cmsgHTML).join(\"\") : `<div class=\"empty\">no messages</div>`}</div>`",
+      "anchor": "$(\"center\").innerHTML = `\n    <div class=\"ch-head\">\n      <div class=\"row\">\n        <div class=\"title\"><span class=\"h\"># ${esc(name)}</span>${sub ? `<span class=\"sub\">${esc(sub)}</span>` : \"\"}</div>\n        <div class=\"ctrls\">\n          ${toggleAllChip(items)}\n          <span class=\"chip mode on\">👥 ${plural(memberCount, \"member\")}</span>\n          ${policy.join(\"\")}\n          ${isDemo ? `<span class=\"chip static\" title=\"demo only\">✦ summarize</span><span class=\"chip static\" title=\"demo only\">🔕 mute</span>` : \"\"}\n          ${isDemo ? \"\" : `<span class=\"chip danger\" id=\"ch-del\" title=\"Delete this channel and all its messages\">🗑 delete</span>`}\n        </div>\n      </div>\n      <div class=\"purpose\">${purpose}</div>\n    </div>\n    ${orderNoticeHtml()}\n    <div class=\"clist\">${items.length ? items.map(cmsgHTML).join(\"\") : `<div class=\"empty\">no messages</div>`}</div>`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "derived-output",
-      "anchor": "`\n    <div class=\"ch-head\">\n      <div class=\"row\">\n        <div class=\"title\"><span class=\"h\"># ${esc(name)}</span>${sub ? `<span class=\"sub\">${esc(sub)}</span>` : \"\"}</div>\n        <div class=\"ctrls\">\n          ${toggleAllChip(items)}\n          <span class=\"chip mode on\">\ud83d\udc65 ${plural(memberCount, \"member\")}</span>\n          ${policy.join(\"\")}\n          ${isDemo ? `<span class=\"chip static\" title=\"demo only\">\u2726 summarize</span><span class=\"chip static\" title=\"demo only\">\ud83d\udd15 mute</span>` : \"\"}\n          ${isDemo ? \"\" : `<span class=\"chip danger\" id=\"ch-del\" title=\"Delete this channel and all its messages\">\ud83d\uddd1 delete</span>`}\n        </div>\n      </div>\n      <div class=\"purpose\">${purpose}</div>\n    </div>\n    ${orderNoticeHtml()}\n    <div class=\"clist\">${items.length ? items.map(cmsgHTML).join(\"\") : `<div class=\"empty\">no messages</div>`}</div>`",
+      "anchor": "`\n    <div class=\"ch-head\">\n      <div class=\"row\">\n        <div class=\"title\"><span class=\"h\"># ${esc(name)}</span>${sub ? `<span class=\"sub\">${esc(sub)}</span>` : \"\"}</div>\n        <div class=\"ctrls\">\n          ${toggleAllChip(items)}\n          <span class=\"chip mode on\">👥 ${plural(memberCount, \"member\")}</span>\n          ${policy.join(\"\")}\n          ${isDemo ? `<span class=\"chip static\" title=\"demo only\">✦ summarize</span><span class=\"chip static\" title=\"demo only\">🔕 mute</span>` : \"\"}\n          ${isDemo ? \"\" : `<span class=\"chip danger\" id=\"ch-del\" title=\"Delete this channel and all its messages\">🗑 delete</span>`}\n        </div>\n      </div>\n      <div class=\"purpose\">${purpose}</div>\n    </div>\n    ${orderNoticeHtml()}\n    <div class=\"clist\">${items.length ? items.map(cmsgHTML).join(\"\") : `<div class=\"empty\">no messages</div>`}</div>`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -1726,14 +1740,14 @@
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "derived-output",
-      "anchor": "`<div class=\"cmsg\">\n    <span class=\"ts\">${esc(m.ts)}</span>\n    <span class=\"dot ${m.status}\">${GLYPH[m.status] ?? \"\u25cf\"}</span>\n    <div class=\"c\">\n      <div class=\"l1\"><span class=\"who\">${esc(m.whoName ?? m.who)}</span><span class=\"dir\">\u2192 ${esc(to)}</span></div>\n      <div class=\"body md\">${MD.render(m.body)}</div>\n    </div>\n  </div>`",
+      "anchor": "`<div class=\"cmsg\">\n    <span class=\"ts\">${esc(m.ts)}</span>\n    <span class=\"dot ${m.status}\">${GLYPH[m.status] ?? \"●\"}</span>\n    <div class=\"c\">\n      <div class=\"l1\"><span class=\"who\">${esc(m.whoName ?? m.who)}</span><span class=\"dir\">→ ${esc(to)}</span></div>\n      <div class=\"body md\">${MD.render(m.body)}</div>\n    </div>\n  </div>`",
       "class": "presence-only-glyph/count",
       "rationale": "Narrow presence glyph, color, or aggregate count; it makes no textual progress claim."
     },
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "indexed-map",
-      "anchor": "<div class=\"cmsg\">\n    <span class=\"ts\">${esc(m.ts)}</span>\n    <span class=\"dot ${m.status}\">${GLYPH[m.status] ?? \"\u25cf\"}</span>\n    <div class=\"c\">\n      <div class=\"l1\"><span class=\"who\">${esc(m.whoName ?? m",
+      "anchor": "<div class=\"cmsg\">\n    <span class=\"ts\">${esc(m.ts)}</span>\n    <span class=\"dot ${m.status}\">${GLYPH[m.status] ?? \"●\"}</span>\n    <div class=\"c\">\n      <div class=\"l1\"><span class=\"who\">${esc(m.whoName ?? m",
       "class": "presence-only-glyph/count",
       "rationale": "Narrow presence glyph, color, or aggregate count; it makes no textual progress claim."
     },
@@ -1761,7 +1775,7 @@
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "derived-output",
-      "anchor": "`${esc(progress)} \u00b7 heartbeat ${esc(ago(p.ts))} ago`",
+      "anchor": "`${esc(progress)} · heartbeat ${esc(ago(p.ts))} ago`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -1775,14 +1789,14 @@
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "derived-output",
-      "anchor": "`\n    <div class=\"detail${waiting ? \" amber\" : \"\"}\">\n      <div class=\"d-head\">\n        <span class=\"dot ${p.status}\">${GLYPH[p.status] ?? \"\u25cf\"}</span>\n        <span class=\"d-status\">${esc(waiting ? \"WAITING\" : p.status)}</span>\n        <span class=\"d-age\">${since}</span>\n      </div>\n      <div class=\"d-who\">${who}</div>\n      ${badges ? `<div class=\"d-badges\">${badges}</div>` : \"\"}\n      ${desc}\n      ${blocked}\n      ${sec(\"Channel attention\", channelModes)}\n      ${sec(\"Tags\", tags)}\n      ${sec(\"Skills\", skills)}\n      ${sec(\"Metadata\", metaKv)}\n      <div class=\"d-foot\"><span class=\"d-foot-item id\">${esc(card.id)}</span>${proto}</div>\n    </div>`",
+      "anchor": "`\n    <div class=\"detail${waiting ? \" amber\" : \"\"}\">\n      <div class=\"d-head\">\n        <span class=\"dot ${p.status}\">${GLYPH[p.status] ?? \"●\"}</span>\n        <span class=\"d-status\">${esc(waiting ? \"WAITING\" : p.status)}</span>\n        <span class=\"d-age\">${since}</span>\n      </div>\n      <div class=\"d-who\">${who}</div>\n      ${badges ? `<div class=\"d-badges\">${badges}</div>` : \"\"}\n      ${desc}\n      ${blocked}\n      ${sec(\"Channel attention\", channelModes)}\n      ${sec(\"Tags\", tags)}\n      ${sec(\"Skills\", skills)}\n      ${sec(\"Metadata\", metaKv)}\n      <div class=\"d-foot\"><span class=\"d-foot-item id\">${esc(card.id)}</span>${proto}</div>\n    </div>`",
       "class": "presence-only-glyph/count",
       "rationale": "Narrow presence glyph, color, or aggregate count; it makes no textual progress claim."
     },
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "indexed-map",
-      "anchor": "ass=\"dot ${p.status}\">${GLYPH[p.status] ?? \"\u25cf\"}</span>\n        ",
+      "anchor": "ass=\"dot ${p.status}\">${GLYPH[p.status] ?? \"●\"}</span>\n        ",
       "class": "presence-only-glyph/count",
       "rationale": "Narrow presence glyph, color, or aggregate count; it makes no textual progress claim."
     },
@@ -1831,14 +1845,14 @@
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "status-token",
-      "anchor": "8\", who: \"bob\", status: \"working\", body: \"on it \u2014 grabbin",
+      "anchor": "8\", who: \"bob\", status: \"working\", body: \"on it — grabbin",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "status-token",
-      "anchor": ", who: \"alice\", status: \"waiting\", body: \"\ud83d\ude4f thanks \u2014 I'l",
+      "anchor": ", who: \"alice\", status: \"waiting\", body: \"🙏 thanks — I'l",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -1852,7 +1866,7 @@
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "status-token",
-      "anchor": ", who: \"alice\", status: \"waiting\", body: \"yes please \u2014 a ",
+      "anchor": ", who: \"alice\", status: \"waiting\", body: \"yes please — a ",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -1873,7 +1887,7 @@
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "status-token",
-      "anchor": "\", who: \"dave\", status: \"working\", body: \"ty \u2014 running th",
+      "anchor": "\", who: \"dave\", status: \"working\", body: \"ty — running th",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -1901,7 +1915,7 @@
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "status-token",
-      "anchor": "ole: \"builder\", status: \"working\", act: \"writing tests \u00b7 ",
+      "anchor": "ole: \"builder\", status: \"working\", act: \"writing tests · ",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -1915,7 +1929,7 @@
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "status-token",
-      "anchor": ": \"researcher\", status: \"idle\", act: \"\u2014\", harness: \"op",
+      "anchor": ": \"researcher\", status: \"idle\", act: \"—\", harness: \"op",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -2202,37 +2216,37 @@
     {
       "path": "implementations/web/src/web/graph.js",
       "kind": "derived-output",
-      "anchor": "el.innerHTML = `<span class=\"x\" id=\"dx\">\u2715</span>\n        <div class=\"d-kind\">channel</div>\n        <div class=\"d-who\">#${esc(sel.name)}</div>\n        ${sel.desc ? `<div class=\"d-block\">${esc(sel.desc)}</div>` : \"\"}\n        <div class=\"d-rows\">\n          <div class=\"d-row\"><span class=\"k\">subscribers</span><span class=\"v\">${hiddenOff ? `${mem.length} shown <span style=\"color:var(--faint)\">+${hiddenOff} offline hidden</span>` : `${mem.length} agent${mem.length === 1 ? \"\" : \"s\"}`}</span></div>\n          <div class=\"d-row\"><span class=\"k\">messages</span><span class=\"v\">${sel.msgs || 0}</span></div>\n          ${deliveryRow}\n          ${replayRow}\n        </div>\n        <div class=\"d-section\"><div class=\"d-label\">members</div>${memberList}</div>\n        <div class=\"d-section\"><div class=\"d-label\">recent</div><div class=\"d-msgs\">${recentRows((m) => m.chan === sel.name)}</div></div>`",
+      "anchor": "el.innerHTML = `<span class=\"x\" id=\"dx\">✕</span>\n        <div class=\"d-kind\">channel</div>\n        <div class=\"d-who\">#${esc(sel.name)}</div>\n        ${sel.desc ? `<div class=\"d-block\">${esc(sel.desc)}</div>` : \"\"}\n        <div class=\"d-rows\">\n          <div class=\"d-row\"><span class=\"k\">subscribers</span><span class=\"v\">${hiddenOff ? `${mem.length} shown <span style=\"color:var(--faint)\">+${hiddenOff} offline hidden</span>` : `${mem.length} agent${mem.length === 1 ? \"\" : \"s\"}`}</span></div>\n          <div class=\"d-row\"><span class=\"k\">messages</span><span class=\"v\">${sel.msgs || 0}</span></div>\n          ${deliveryRow}\n          ${replayRow}\n        </div>\n        <div class=\"d-section\"><div class=\"d-label\">members</div>${memberList}</div>\n        <div class=\"d-section\"><div class=\"d-label\">recent</div><div class=\"d-msgs\">${recentRows((m) => m.chan === sel.name)}</div></div>`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "implementations/web/src/web/graph.js",
       "kind": "derived-output",
-      "anchor": "`<span class=\"x\" id=\"dx\">\u2715</span>\n        <div class=\"d-kind\">channel</div>\n        <div class=\"d-who\">#${esc(sel.name)}</div>\n        ${sel.desc ? `<div class=\"d-block\">${esc(sel.desc)}</div>` : \"\"}\n        <div class=\"d-rows\">\n          <div class=\"d-row\"><span class=\"k\">subscribers</span><span class=\"v\">${hiddenOff ? `${mem.length} shown <span style=\"color:var(--faint)\">+${hiddenOff} offline hidden</span>` : `${mem.length} agent${mem.length === 1 ? \"\" : \"s\"}`}</span></div>\n          <div class=\"d-row\"><span class=\"k\">messages</span><span class=\"v\">${sel.msgs || 0}</span></div>\n          ${deliveryRow}\n          ${replayRow}\n        </div>\n        <div class=\"d-section\"><div class=\"d-label\">members</div>${memberList}</div>\n        <div class=\"d-section\"><div class=\"d-label\">recent</div><div class=\"d-msgs\">${recentRows((m) => m.chan === sel.name)}</div></div>`",
+      "anchor": "`<span class=\"x\" id=\"dx\">✕</span>\n        <div class=\"d-kind\">channel</div>\n        <div class=\"d-who\">#${esc(sel.name)}</div>\n        ${sel.desc ? `<div class=\"d-block\">${esc(sel.desc)}</div>` : \"\"}\n        <div class=\"d-rows\">\n          <div class=\"d-row\"><span class=\"k\">subscribers</span><span class=\"v\">${hiddenOff ? `${mem.length} shown <span style=\"color:var(--faint)\">+${hiddenOff} offline hidden</span>` : `${mem.length} agent${mem.length === 1 ? \"\" : \"s\"}`}</span></div>\n          <div class=\"d-row\"><span class=\"k\">messages</span><span class=\"v\">${sel.msgs || 0}</span></div>\n          ${deliveryRow}\n          ${replayRow}\n        </div>\n        <div class=\"d-section\"><div class=\"d-label\">members</div>${memberList}</div>\n        <div class=\"d-section\"><div class=\"d-label\">recent</div><div class=\"d-msgs\">${recentRows((m) => m.chan === sel.name)}</div></div>`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "implementations/web/src/web/graph.js",
       "kind": "derived-output",
-      "anchor": "el.innerHTML = `<span class=\"x\" id=\"dx\">\u2715</span>\n        <div class=\"d-kind\">agent</div>\n        <div class=\"d-who\">${esc(sel.name)}${sel.role ? `<span class=\"role\">${esc(sel.role)}</span>` : \"\"}</div>\n        <div class=\"d-status ${sel.status}\"><span class=\"dot\"></span>${esc(sel.status === \"working\" && sel.progress?.kind === \"unknown\" ? \"working \u00b7 progress unknown\" : sel.status)}</div>\n        ${descBlock}\n        <div class=\"d-section\"><div class=\"d-label\">activity</div><div class=\"d-block ${sel.activity ? \"\" : \"muted\"}\">${esc(sel.activity || \"no current activity\")}</div></div>\n        ${(harnessRow || modelRow || attRow) ? `<div class=\"d-rows\">${harnessRow}${modelRow}${attRow}</div>` : \"\"}\n        <div class=\"d-section\"><div class=\"d-label\">subscribes</div>${subs}</div>\n        ${modesSection}\n        ${tagsSection}\n        <div class=\"d-section\"><div class=\"d-label\">recent</div><div class=\"d-msgs\">${recentRows((m) => m.from === sel.name || m.to === sel.name)}</div></div>`",
+      "anchor": "el.innerHTML = `<span class=\"x\" id=\"dx\">✕</span>\n        <div class=\"d-kind\">agent</div>\n        <div class=\"d-who\">${esc(sel.name)}${sel.role ? `<span class=\"role\">${esc(sel.role)}</span>` : \"\"}</div>\n        <div class=\"d-status ${sel.status}\"><span class=\"dot\"></span>${esc(sel.status === \"working\" && sel.progress?.kind === \"unknown\" ? \"working · progress unknown\" : sel.status)}</div>\n        ${descBlock}\n        <div class=\"d-section\"><div class=\"d-label\">activity</div><div class=\"d-block ${sel.activity ? \"\" : \"muted\"}\">${esc(sel.activity || \"no current activity\")}</div></div>\n        ${(harnessRow || modelRow || attRow) ? `<div class=\"d-rows\">${harnessRow}${modelRow}${attRow}</div>` : \"\"}\n        <div class=\"d-section\"><div class=\"d-label\">subscribes</div>${subs}</div>\n        ${modesSection}\n        ${tagsSection}\n        <div class=\"d-section\"><div class=\"d-label\">recent</div><div class=\"d-msgs\">${recentRows((m) => m.from === sel.name || m.to === sel.name)}</div></div>`",
       "class": "honest-text",
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/web/src/web/graph.js",
-        "anchor": "<div class=\"d-status ${sel.status}\"><span class=\"dot\"></span>${esc(sel.status === \"working\" && sel.progress?.kind === \"unknown\" ? \"working \u00b7 progress unknown\" : sel.status)}</div>"
+        "anchor": "<div class=\"d-status ${sel.status}\"><span class=\"dot\"></span>${esc(sel.status === \"working\" && sel.progress?.kind === \"unknown\" ? \"working · progress unknown\" : sel.status)}</div>"
       }
     },
     {
       "path": "implementations/web/src/web/graph.js",
       "kind": "derived-output",
-      "anchor": "`<span class=\"x\" id=\"dx\">\u2715</span>\n        <div class=\"d-kind\">agent</div>\n        <div class=\"d-who\">${esc(sel.name)}${sel.role ? `<span class=\"role\">${esc(sel.role)}</span>` : \"\"}</div>\n        <div class=\"d-status ${sel.status}\"><span class=\"dot\"></span>${esc(sel.status === \"working\" && sel.progress?.kind === \"unknown\" ? \"working \u00b7 progress unknown\" : sel.status)}</div>\n        ${descBlock}\n        <div class=\"d-section\"><div class=\"d-label\">activity</div><div class=\"d-block ${sel.activity ? \"\" : \"muted\"}\">${esc(sel.activity || \"no current activity\")}</div></div>\n        ${(harnessRow || modelRow || attRow) ? `<div class=\"d-rows\">${harnessRow}${modelRow}${attRow}</div>` : \"\"}\n        <div class=\"d-section\"><div class=\"d-label\">subscribes</div>${subs}</div>\n        ${modesSection}\n        ${tagsSection}\n        <div class=\"d-section\"><div class=\"d-label\">recent</div><div class=\"d-msgs\">${recentRows((m) => m.from === sel.name || m.to === sel.name)}</div></div>`",
+      "anchor": "`<span class=\"x\" id=\"dx\">✕</span>\n        <div class=\"d-kind\">agent</div>\n        <div class=\"d-who\">${esc(sel.name)}${sel.role ? `<span class=\"role\">${esc(sel.role)}</span>` : \"\"}</div>\n        <div class=\"d-status ${sel.status}\"><span class=\"dot\"></span>${esc(sel.status === \"working\" && sel.progress?.kind === \"unknown\" ? \"working · progress unknown\" : sel.status)}</div>\n        ${descBlock}\n        <div class=\"d-section\"><div class=\"d-label\">activity</div><div class=\"d-block ${sel.activity ? \"\" : \"muted\"}\">${esc(sel.activity || \"no current activity\")}</div></div>\n        ${(harnessRow || modelRow || attRow) ? `<div class=\"d-rows\">${harnessRow}${modelRow}${attRow}</div>` : \"\"}\n        <div class=\"d-section\"><div class=\"d-label\">subscribes</div>${subs}</div>\n        ${modesSection}\n        ${tagsSection}\n        <div class=\"d-section\"><div class=\"d-label\">recent</div><div class=\"d-msgs\">${recentRows((m) => m.from === sel.name || m.to === sel.name)}</div></div>`",
       "class": "honest-text",
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/web/src/web/graph.js",
-        "anchor": "<div class=\"d-status ${sel.status}\"><span class=\"dot\"></span>${esc(sel.status === \"working\" && sel.progress?.kind === \"unknown\" ? \"working \u00b7 progress unknown\" : sel.status)}</div>"
+        "anchor": "<div class=\"d-status ${sel.status}\"><span class=\"dot\"></span>${esc(sel.status === \"working\" && sel.progress?.kind === \"unknown\" ? \"working · progress unknown\" : sel.status)}</div>"
       }
     },
     {


### PR DESCRIPTION
Two main-side suite reds unmasked by today's shard-0 cures, both the #891/#1157 consumer-sweep class tracked in #1156:

1. `smoke:expiry-renewal:auth` — the errorsA collector listened only on `error`; the no-renewal-path refusal now arrives as `warning`, so the loud-refusal and growing-backoff cells saw zero refusals. The collector now listens on both channels.
2. `smoke:presence-render-census` — the StatusBar manifest anchor pinned the old two-arm render block, and the warning arm's two new AST candidates were unclassified. Anchor updated to the three-arm block; candidates classified `non-render/control` like their error-arm siblings; reviewed totals bumped 303→305 / 222→224.

Repro/proof: both suites fail on pure origin/main with exactly the CI cells (also seen on #1049's run 33322641649, shards 0 and 2); with this change locally: expiry-renewal 7 passed/0 failed, census totals match. Refs #1156 #1155.