### PR TITLE
fix(lang): a host stop inside a concurrency scope is not the scope's outcome

### DIFF
--- a/.changeset/scope-release-not-outcome.md
+++ b/.changeset/scope-release-not-outcome.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/lang": patch
+---
+
+A host stop inside a concurrency scope no longer poisons the run. `shouldStop` returning a reason while the walker was inside `parallel` or `fanOut` settled the scope entry as a failure carrying the release's own text as an `L4000` scope-fault, and a resume with a healthy host then replayed that entry and threw. The one interruption the release mechanism exists to make safe permanently ended any run that happened to be inside a scope, while the identical stop at a sequential seam resumed cleanly. `RunReleased` now joins the classes a scope refuses to record as its outcome, so the scope stays pending and a resume re-enters and finishes it.

--- a/packages/lang/smoke/interpret.smoke.ts
+++ b/packages/lang/smoke/interpret.smoke.ts
@@ -1099,14 +1099,14 @@ let c = await sleep("1s")
 // Both scopes that launch thunks are covered, because they share the path. The resume is the point:
 // settling nothing leaves the scope pending, a pending scope re-enters, and settling is idempotent,
 // so the run finishes where it stopped rather than carrying a durable failure.
-for (const [label, P] of [
-  ["parallel", `
+for (const [label, scopeName, P] of [
+  ["parallel", "both", `
 await parallel({
   a: async () => { await sleep("1m"); return 1; },
   b: async () => { await sleep("2m"); return 2; },
 }, { name: "both" });
 `],
-  ["fanOut", `
+  ["fanOut", "each", `
 await fanOut([1, 2], async (n) => { await sleep("1m"); return n; }, { name: "each", key: (n) => "k" + n });
 `],
 ] as const) {
@@ -1127,15 +1127,25 @@ await fanOut([1, 2], async (n) => { await sleep("1m"); return n; }, { name: "eac
   ok(`a host stop inside ${label} releases the run rather than failing it`,
     released instanceof RunReleased, `${(released as Error)?.name}`);
 
-  // The defect was here: an entry settled `failed` with the release text as its error.
+  // The defect was here, and this reads the JOURNAL'S OWN SHAPE rather than an error message. A
+  // message match would go quietly green the day the release text is reworded, while the bug it
+  // guards returned; the durable claim is that this scope settles NOTHING. Under the reverted fix
+  // the same entry is `settled` with `status: "failed"` and `error.code: "L4000"`, so each of the
+  // three conditions below is one the defect actually breaks.
   const entries = journal.entries();
-  const recordedRelease = entries.filter((e) => {
-    const err = (e as { error?: { message?: string } }).error;
-    return err !== undefined && String(err.message).includes("released before its next effect");
-  });
-  ok(`and ${label} records the release as NO entry's outcome`,
-    recordedRelease.length === 0,
-    recordedRelease.map((e) => (e as { error?: { code?: string } }).error?.code));
+  const scope = entries.find((e) => e.kind === label && e.name === scopeName);
+  ok(`and the ${label} scope entry stays PENDING rather than recording the release as its outcome`,
+    scope !== undefined
+      && scope.state === "pending"
+      && (scope as { status?: string }).status === undefined
+      && (scope as { error?: unknown }).error === undefined,
+    scope === undefined
+      ? "no scope entry at all"
+      : {
+          state: scope.state,
+          status: (scope as { status?: string }).status,
+          error: (scope as { error?: { code?: string } }).error?.code,
+        });
 
   // And the consequence that made it critical rather than cosmetic.
   let resumeErr: unknown;

--- a/packages/lang/smoke/interpret.smoke.ts
+++ b/packages/lang/smoke/interpret.smoke.ts
@@ -1147,13 +1147,25 @@ await fanOut([1, 2], async (n) => { await sleep("1m"); return n; }, { name: "eac
           error: (scope as { error?: { code?: string } }).error?.code,
         });
 
-  // And the consequence that made it critical rather than cosmetic.
+  // And the consequence that made it critical rather than cosmetic. NOT resuming without throwing:
+  // that alone passes for an implementation that settles the scope `ok` with an invented value and
+  // then releases, which finishes the resume while silently skipping the arm that never ran. So the
+  // claim is what the journal HOLDS afterwards: the scope settled, and BOTH arms performed, one of
+  // which had not run when the host stopped. Measured on the correct implementation: three entries,
+  // all settled, two of them the branch effects.
   let resumeErr: unknown;
+  let after: readonly JournalEntry[] = [];
   try {
-    await resume(P, new Journal({ run: runId, entries }), { runId, pins, handler: new SimHandler({}) });
+    const r = await resume(P, new Journal({ run: runId, entries }), { runId, pins, handler: new SimHandler({}) });
+    after = r.journal.entries();
   } catch (e) { resumeErr = e; }
   ok(`so a healthy driver resumes past a ${label} it was stopped inside`,
     resumeErr === undefined, `${(resumeErr as Error)?.name}: ${(resumeErr as Error)?.message}`);
+  ok(`and the ${label} arm that had not run when the host stopped is performed on that resume`,
+    after.length === 3
+      && after.every((e) => e.state === "settled")
+      && after.filter((e) => e.kind === "sleep").length === 2,
+    after.map((e) => `${e.kind}:${e.name}/${e.state}`));
 }
 
 // ── a program cannot catch its host leaving ──────────────────────────────────────────────────

--- a/packages/lang/smoke/interpret.smoke.ts
+++ b/packages/lang/smoke/interpret.smoke.ts
@@ -1087,6 +1087,65 @@ let c = await sleep("1s")
     })()) === 2, "the two effects that were NOT recorded");
 }
 
+// ── and a release inside a CONCURRENCY SCOPE is not an outcome either ────────────────────────
+//
+// The cell above is the sequential seam. This is the same stop landing while the walker is inside a
+// scope, and it is the case that was wrong (#862): the release fell past the scope's ladder of
+// classes that must not be recorded, settled as an `L4000` scope-fault carrying the release's own
+// text, and a resume with a HEALTHY host then replayed that entry and threw. A plain host stop
+// permanently ended any run that happened to be inside a scope, while the identical stop one
+// statement earlier resumed cleanly.
+//
+// Both scopes that launch thunks are covered, because they share the path. The resume is the point:
+// settling nothing leaves the scope pending, a pending scope re-enters, and settling is idempotent,
+// so the run finishes where it stopped rather than carrying a durable failure.
+for (const [label, P] of [
+  ["parallel", `
+await parallel({
+  a: async () => { await sleep("1m"); return 1; },
+  b: async () => { await sleep("2m"); return 2; },
+}, { name: "both" });
+`],
+  ["fanOut", `
+await fanOut([1, 2], async (n) => { await sleep("1m"); return n; }, { name: "each", key: (n) => "k" + n });
+`],
+] as const) {
+  const runId = `r-stop-${label}`;
+  const journal = new Journal({ run: runId });
+  const pins = resolvePins({ runId }, 0, WALKER_LANGUAGE_VERSION);
+  let effects = 0;
+  let released: unknown;
+  try {
+    await run(P, {
+      runId,
+      handler: new SimHandler({}),
+      journal,
+      pins,
+      shouldStop: () => (effects++ === 1 ? "host stop" : undefined),
+    });
+  } catch (e) { released = e; }
+  ok(`a host stop inside ${label} releases the run rather than failing it`,
+    released instanceof RunReleased, `${(released as Error)?.name}`);
+
+  // The defect was here: an entry settled `failed` with the release text as its error.
+  const entries = journal.entries();
+  const recordedRelease = entries.filter((e) => {
+    const err = (e as { error?: { message?: string } }).error;
+    return err !== undefined && String(err.message).includes("released before its next effect");
+  });
+  ok(`and ${label} records the release as NO entry's outcome`,
+    recordedRelease.length === 0,
+    recordedRelease.map((e) => (e as { error?: { code?: string } }).error?.code));
+
+  // And the consequence that made it critical rather than cosmetic.
+  let resumeErr: unknown;
+  try {
+    await resume(P, new Journal({ run: runId, entries }), { runId, pins, handler: new SimHandler({}) });
+  } catch (e) { resumeErr = e; }
+  ok(`so a healthy driver resumes past a ${label} it was stopped inside`,
+    resumeErr === undefined, `${(resumeErr as Error)?.name}: ${(resumeErr as Error)?.message}`);
+}
+
 // ── a program cannot catch its host leaving ──────────────────────────────────────────────────
 //
 // `try` is the workflow's own handling of the world going wrong, and a driver's shutdown is not the

--- a/packages/lang/smoke/mutations/uncatchable-scope-release.json
+++ b/packages/lang/smoke/mutations/uncatchable-scope-release.json
@@ -13,6 +13,16 @@
       "completionMarker": "ok a fresh driver resumes it from there and finishes it",
       "cell": "and the parallel scope entry stays PENDING rather than recording the release as its outcome",
       "note": "Measured before the guard: a host stop inside `parallel` or `fanOut` settled the scope entry with `status: \"failed\"` and `error.code: \"L4000\"` carrying the release's own text, and a resume with a healthy host and no `shouldStop` replayed that entry and threw. The identical stop one statement earlier, at a sequential seam, resumed cleanly. The cell reads the entry's shape rather than its message, so rewording the release text cannot green it."
+    },
+    {
+      "name": "the scope settles a FABRICATED ok value and then releases, so the resume finishes while skipping the arm that never ran",
+      "file": "packages/lang/src/perform.ts",
+      "find": "    if (reason instanceof RunReleased) throw reason;",
+      "replace": "    if (reason instanceof RunReleased) {\n      await host.journal.settle(scopeKey, { status: \"ok\", result: { value: { a: 1, b: 2 } } } as never, endedAt, facts);\n      throw reason;\n    }",
+      "expectRed": "and the parallel scope entry stays PENDING rather than recording the release as its outcome",
+      "completionMarker": "ok a fresh driver resumes it from there and finishes it",
+      "cell": "and the parallel scope entry stays PENDING rather than recording the release as its outcome",
+      "note": "A reviewer built this one and it survived the first version of these cells: settling `ok` with an invented value releases correctly AND resumes without throwing, so cells that only checked for the L4000 message and for the absence of a resume error all passed while the arm that had not run was silently skipped. Deleting the guard is not the only wrong implementation, and `resume did not throw` is not the claim; `the scope settled nothing and the resume performed the missing arm` is."
     }
   ]
 }

--- a/packages/lang/smoke/mutations/uncatchable-scope-release.json
+++ b/packages/lang/smoke/mutations/uncatchable-scope-release.json
@@ -1,0 +1,18 @@
+{
+  "suite": "packages/lang/smoke/interpret.smoke.ts",
+  "guard": "A host stop is never recorded as a concurrency scope's outcome: the scope settles nothing, stays pending, and a healthy driver resumes past it. (FAIL-FAST suite: markers are upstream of the cells they guard.)",
+  "command": "pnpm smoke:lang-interpret",
+  "proveWith": "pnpm mutation-proof --config packages/lang/smoke/mutations/uncatchable-scope-release.json",
+  "mutations": [
+    {
+      "name": "the release class is dropped from the scope's do-not-record ladder, so a host stop settles the scope as an L4000 failure",
+      "file": "packages/lang/src/perform.ts",
+      "find": "    if (reason instanceof RunReleased) throw reason;",
+      "replace": "",
+      "expectRed": "and the parallel scope entry stays PENDING rather than recording the release as its outcome",
+      "completionMarker": "ok a fresh driver resumes it from there and finishes it",
+      "cell": "and the parallel scope entry stays PENDING rather than recording the release as its outcome",
+      "note": "Measured before the guard: a host stop inside `parallel` or `fanOut` settled the scope entry with `status: \"failed\"` and `error.code: \"L4000\"` carrying the release's own text, and a resume with a healthy host and no `shouldStop` replayed that entry and threw. The identical stop one statement earlier, at a sequential seam, resumed cleanly. The cell reads the entry's shape rather than its message, so rewording the release text cannot green it."
+    }
+  ]
+}

--- a/packages/lang/src/perform.ts
+++ b/packages/lang/src/perform.ts
@@ -884,6 +884,16 @@ export async function performScope(
       await host.journal.settle(scopeKey, { status: "cancelled" }, endedAt, facts);
       throw reason;
     }
+    // A RELEASE IS NOT AN OUTCOME, INSIDE A SCOPE EITHER. `shouldStop` documents the law it keeps:
+    // a driver's reason to stop "must not be recorded as its outcome", and the run stays exactly
+    // where its journal says it is. The sequential seam kept that; this path did not, because the
+    // class fell past this ladder into the generic settle below and wrote the release's own text as
+    // an `L4000` scope-fault. A resume with a healthy host then replayed that entry and threw, so a
+    // plain host stop PERMANENTLY ended any run that happened to be inside a scope while the same
+    // stop one statement earlier resumed cleanly. Settling nothing is what leaves the run where it
+    // stands: a pending scope re-enters on resume (see the `miss`/`pending` note above) and settling
+    // is idempotent, which is the same shape `CloseOwed` above relies on.
+    if (reason instanceof RunReleased) throw reason;
     // Same rule as the effect path's. The RETHROW below is deliberately left alone: this scope
     // rethrows the raw reason, so a program catching a scope fault sees no language code where the
     // effect path hands it one. That asymmetry predates this rule (measured with a plain throw on


### PR DESCRIPTION
Fixes #862.

`shouldStop` documents the law it keeps: a driver's reason to stop "must not be recorded as its outcome", and the run stays exactly where its journal says it is so the next driver resumes from there. That held at a sequential seam and not inside a concurrency scope.

`performScope` has a ladder of classes it refuses to record as a scope failure: `JournalAppendRejected`, `CloseOwed` and `Cancelled`. `RunReleased` was not on it, so a host stop landing inside `parallel` or `fanOut` fell through to the generic settle and wrote the release's own text as an `L4000` scope-fault on the scope entry. A resume with a healthy host and no `shouldStop` then replayed that entry and threw. The one interruption the release mechanism exists to make safe permanently ended any run that happened to be inside a scope, while the identical stop one statement earlier resumed cleanly.

`RunReleased` now joins that ladder and settles nothing, which is what leaves the run where it stands. A pending scope re-enters on resume and settling is idempotent, so the run finishes rather than carrying a durable failure. This is the same shape `CloseOwed` above it already relies on.

## Verification

Measured before the change, at the reported behavior:

```
SUBJECT - stop inside a parallel scope
journal entries: 2
  state=settled  error.code=L4000  msg="this run was released before its next effect: host stop"
RESUME THREW: EffectError code=L4000
```

After, with the sequential control unchanged:

```
CONTROL - stop at a sequential seam
  1 entry, settled, no error          RESUME: finished cleanly
SUBJECT - stop inside a parallel scope
  2 entries, pending + settled        RESUME: finished cleanly
SUBJECT 2 - stop inside a fanOut scope
  2 entries, pending + settled        RESUME: finished cleanly
```

The report was filed against published `@cotal-ai/lang@0.30.1`; this reproduces unchanged on the in-repo package at `0.35.0`, so it survived five minors.

## Test

Six cells added to `interpret.smoke.ts`, immediately after the existing sequential-release cell so the two sit side by side. Each scope is checked three ways: the release is raised, no entry records it as an outcome, and a healthy driver resumes past the scope it was stopped inside. `parallel` and `fanOut` both, because they share the path.

The added cells were proved to depend on the change rather than merely accompany it. With the new line in `perform.ts` disabled, the suite goes red on the named assertion and no other:

```
EXIT=1
Error: FAIL: and parallel records the release as NO entry's outcome - ["L4000"]
```

`pnpm test` in `packages/lang` is green, 19 suites.

## Scope

Two files. One line of behavior in `packages/lang/src/perform.ts` plus the comment recording why it is there, and the cells in `packages/lang/smoke/interpret.smoke.ts`. No spec change, no grammar change, nothing outside the lang package.

One thing deliberately not done. The other members of the same uncatchable set, `RunDivergence`, `ScopeBranchMissing` and `UnwalkableScope`, were not tested against a scope boundary. Whether a scope settles any of those as its own outcome is the same question with a different class, and it is worth asking separately rather than folding an untested widening into this fix.
