### PR TITLE
test(jcode): await the redriven turn before post-recovery work

### DIFF
--- a/extensions/connector-jcode/smoke/jcode-provider-disconnect.smoke.ts
+++ b/extensions/connector-jcode/smoke/jcode-provider-disconnect.smoke.ts
@@ -173,7 +173,6 @@ try {
   });
   check("recovered Harness client reattaches the existing private session after the transient loss (#971)", reattachments.length >= 2, reattachments);
 
-  await operator.unicast(peerId!, "RECOVERED_MESH_WORK");
   const retriedTurn = await waitFor("unacknowledged stalled turn redelivery", () => {
     const attempts = entries().filter(
       (entry) =>
@@ -186,6 +185,15 @@ try {
   });
   check("recovered seat redrives the unacknowledged stalled turn (#781)", retriedTurn.length >= 2, retriedTurn);
 
+  // The redriven turn owns the session until its boundary, so the post-recovery work is only sent
+  // once that turn is done. A directed DM arriving while it is still live is delivered through
+  // Jcode's soft-interrupt queue instead, which is the documented mid-turn path and commits at the
+  // containing turn's boundary — a correct delivery that never opens the new turn this cell reads.
+  await waitFor("redriven stalled turn boundary", () =>
+    entries().find(
+      (entry) => entry.ev === "turn_done_emitted" && String(entry.content).includes("SIMULATE_PROVIDER_STALL"),
+    ),
+  );
   await operator.unicast(peerId!, "RECOVERED_MESH_WORK");
   const recoveredTurn = await waitFor("post-recovery turn", () =>
     entries().find(


### PR DESCRIPTION
`pnpm smoke:jcode-provider-disconnect` fails the `post-recovery turn` cell as a race, not deterministically: CI red it on two unrelated branches, and the same merge ref greened on rerun.

## Root cause

A suite defect. The cell polls the fake Harness log for a `send_message` frame carrying `RECOVERED_MESH_WORK`, but the suite sends that work without waiting for the redriven stalled turn to end.

When the redriven turn is still live, the connector takes its documented mid-turn path: a directed DM goes into Jcode's soft-interrupt queue via `steerPending`, and its id commits at the containing turn's clean boundary. The seat accepts the work, but it arrives over a `soft_interrupt` frame, so no `send_message` ever carries that content and the poll times out after 20s. A captured failing run shows the redrive `send_message`, then both `RECOVERED_MESH_WORK` unicasts as `soft_interrupt`, then the redriven turn's boundary.

Both delivery paths are correct connector behavior. Only the observation was timing-dependent, so the fix belongs in the suite.

## Fix

Gate the post-recovery unicast on the redriven turn's boundary, which is the same guard the next cell already applies before the second stall (added in 8e2dee9f6 for this same class of race, one step later in the sequence).

The earlier `RECOVERED_MESH_WORK` unicast is dropped rather than moved. It was never the redrive trigger: the recovery window's own `finally` redrives the un-acked batch because `pendingWake()` stays positive, which the traces confirm (the redrive injection carries exactly one message). Keeping it would leave a second way into the same race, where it lands after the boundary and opens a turn that then swallows the post-recovery work.

## Repro counts

Both loops ran 40 iterations of `pnpm smoke:jcode-provider-disconnect` on the same linux box under the same conditions.

| | iterations | failures | cell |
| --- | --- | --- | --- |
| pre-fix | 40 | 4 | `post-recovery turn` |
| post-fix | 40 | 0 | n/a |

An earlier pre-fix loop on the same box added 6/40 failures, all in the same cell, for 10/80 pre-fix overall.

## Not vacuous

An instrumented post-fix run confirms the cell still exercises the real path: the redrive `send_message` and its boundary, then a genuine new `send_message` carrying `RECOVERED_MESH_WORK` with its own boundary, and no `soft_interrupt` frames. `retriedTurn` still reaches its required 2 attempts.

`pnpm typecheck` and `pnpm check:docs-voice` pass. Smoke-only change, so no changeset, matching 1ae13ce52 and 8e2dee9f6.

Refs #1169