### PR TITLE
test(delivery): reproduce the cross-host two-root renewal refusal (#773)

### DIFF
--- a/implementations/delivery/smoke/delivery-cred-renewal.smoke.ts
+++ b/implementations/delivery/smoke/delivery-cred-renewal.smoke.ts
@@ -13,6 +13,10 @@
  *      "file written" can never masquerade as "daemon adopted".
  *   4. CLEAN SWAP: a final explicit reload before the old JWT's exp — the run never logs
  *      "User Authentication Expired" and ends with a READY delivery lease.
+ *   4b. CROSS-HOST TWO-ROOT REFUSAL (#773): the renewal owner re-signs into a SEPARATE workspace
+ *      root, as a manager on another host does, and sends only the fingerprint. The daemon re-reads
+ *      its OWN root and refuses. The refusal is proven PERMANENT, which is what separates this from
+ *      the torn/stale read the same message also covers.
  *
  * NOTE: runs the BUILT dist — `pnpm build` first (the smoke:ci wiring builds).
  * Run: pnpm smoke:delivery-renewal   (needs `nats-server` on PATH; auth/JetStream, local-only; ~30s)
@@ -29,6 +33,7 @@ import {
   identityFromCreds,
   isReachable,
   createSpaceAuth,
+  credsFingerprint,
   mintConnectionEvictorCreds,
   mintCreds,
   mintMembershipObserverCreds,
@@ -164,6 +169,41 @@ try {
   writeFileSync(credsPath, await mintCreds(auth, identityFromCreds(credA), "delivery"), { mode: 0o600 });
   const recovered = await adminReq(sup, "reloadCreds");
   check("explicit reload after re-sign recovers from the stale state", recovered.ok === true, JSON.stringify(recovered));
+
+  // Phase 4b - #773, and it is numbered 4b so the eviction phase below keeps the number it has.
+  //
+  // First a CONTROL, which isolates transport from store semantics. `expected` is proven in-process
+  // by packages/core/smoke/membership-rw-renewal.smoke.ts case 3, but that calls reloadRwCreds()
+  // directly and nothing proves the fingerprint SURVIVES the delivery-admin rail. A value that
+  // cannot match anything must be refused. Were this to adopt, every manager adoption would be
+  // unverified and the two-root question below would not even be reachable.
+  const bogus = await adminReq2(sup, "reloadCreds", { expected: { delivery: "0".repeat(64) } });
+  check("an impossible expected fingerprint is refused over the ADMIN RAIL (expected survives transport)", bogus.ok === false && (bogus.error ?? "").includes("did not match the expected re-signed generation"), JSON.stringify(bogus));
+
+  // Now the two-root shape itself. Every phase above re-signs into the daemon's OWN root, so the
+  // renewal owner's store and the daemon's store are the same file and this suite cannot observe the
+  // stock cross-host composition at all. Here the owner writes its re-signed generation into a
+  // SEPARATE workspace root, which is what a manager on another host does, and sends the
+  // fingerprint, which is all `reloadCreds` transports. The daemon re-reads ITS root, finds the
+  // generation it already held, and refuses. The candidate is rejected before the preflight, so the
+  // resident connection is untouched and the phases after this one still run against a live daemon.
+  const managerRoot = mkdtempSync(join(tmpdir(), "cotal-dlv-renew-mgrroot-"));
+  mkdirSync(join(managerRoot, ".cotal"), { recursive: true });
+  // A DISTINCT TTL, so this generation cannot come out byte-identical to the one phase 4 wrote into
+  // the daemon's root. Two mints of the same identity with the same default TTL inside one second
+  // produce the same JWT and so the same fingerprint, which makes the daemon adopt correctly and
+  // hides the mismatch this phase exists to show.
+  const crossHostGen = await mintCreds(auth, identityFromCreds(credA), "delivery", { expiresInSeconds: 4200 });
+  writeFileSync(join(managerRoot, ".cotal", "delivery.creds"), crossHostGen, { mode: 0o600 });
+  const crossHost = await adminReq2(sup, "reloadCreds", { expected: { delivery: credsFingerprint(crossHostGen) } });
+  check("#773: a generation re-signed into the MANAGER's root is refused by a daemon reading its own root", crossHost.ok === false && (crossHost.error ?? "").includes("did not match the expected re-signed generation"), JSON.stringify(crossHost));
+  // The message returned covers "a different store, or a torn/stale read" without separating them,
+  // and that is the defect rather than an incidental wording choice: a torn read converges on the
+  // next attempt, two different stores never do. Retrying is therefore not a repair here, and an
+  // identical second pass failing identically is what proves which of the two conditions this is.
+  const crossHostAgain = await adminReq2(sup, "reloadCreds", { expected: { delivery: credsFingerprint(crossHostGen) } });
+  check("#773: that refusal is PERMANENT, not transient - an identical retry fails identically", crossHostAgain.ok === false && (crossHostAgain.error ?? "").includes("did not match the expected re-signed generation"), JSON.stringify(crossHostAgain));
+  rmSync(managerRoot, { recursive: true, force: true });
 
   // Phase 5 — the LIVE-EVICTION EXECUTOR on the same rail (D5 slice 6): a victim connection is
   // force-dropped by principal via the daemon's per-call $SYS observer+evictor, structured result.


### PR DESCRIPTION
**This reproduces #773. It does not fix it, and it should not be merged as one.** The architectural choice #773 asks for is still open, and this deliberately does not preempt it.

## Scope

#773 states that a two-root cell is required and that, before any fix, it must reproduce the exact generation-mismatch refusal. That cell did not exist. This adds it.

The existing renewal suite could not observe the defect, for two independent reasons:

- every phase re-signed the new generation into `credsPath`, which lives in the daemon's own workspace root, so the renewal owner's store and the daemon's store were the same file;
- it never constructs a `Manager` at all, so the renewal owner's path was never exercised end to end. The suite plays the owner with a supervisor-cred endpoint on the admin rail, which is the right shape, but the store question never arises.

The suite was green throughout. It was testing something true of the tree in front of it and false of the composition the issue is about.

## What the cell does

The renewal owner writes its re-signed generation into a separate workspace root, which is what a manager on another host does, and sends the fingerprint, which is all `reloadCreds` transports. The daemon re-reads its own root, finds the generation it already held, and refuses.

A second identical pass then asserts the refusal is permanent. That assertion is the point rather than a formality. The message covers "a different store, or a torn/stale read" without separating them, and those two conditions have opposite remedies: a torn read converges on the next attempt, two unshared stores never do. Retrying is not a repair here, and the repeated failure is what distinguishes them.

The candidate is rejected before the preflight, so the resident connection is untouched and the phases after this one still run against a live daemon.

## The control, and why it is in this PR

`expected` was covered in-process by `packages/core/smoke/membership-rw-renewal.smoke.ts` case 3, which calls `reloadRwCreds()` directly. Nothing proved the fingerprint survives the delivery-admin rail. This adds a cell asserting that a value which cannot match anything is refused over the rail. It passes.

It is here because without it the two-root result is unreadable. A refusal proves nothing if `expected` is honoured, and an adoption proves nothing if it is not.

## Evidence that the cells are load-bearing

Not a mutation run, and I am not claiming one. While writing this I twice sent an `expected` the handler could not read: first as a bare string rather than the per-component `{ delivery?, membership? }` map, then as a generation that came out byte-identical to the daemon's because two mints of one identity with the same default TTL inside a single second produce the same JWT. In both cases the daemon replied `ok: true` with a full `brokerAccepted` block and the cells went red. So the cells demonstrably depend on the fingerprint being honoured end to end, not on wording. The second case is also why the cross-host generation is minted with a distinct TTL, and the comment says so.

Worth noting for whoever takes the fix: a malformed `expected` reaches `(req.args?.expected ?? {}) as { delivery?, membership? }` and every key reads `undefined`, which the handler documents as "no expectation" and adopts. That is intended for a genuinely absent expectation. It also means a renewal owner with a shape bug records a green adoption that verified nothing. The stock manager builds the shape correctly, so this is not reachable through it today, and I am not filing it separately on that basis.

## Verification

`pnpm smoke:delivery-renewal` at `8042f96bb`: **21 passed, 0 failed.**

One earlier run also failed `evictPrincipal force-drops the victim` with `kicked: 0, "principal not currently live"`. It passed on every subsequent run with no change to that phase, so it looks like an existing race between the victim connecting and CONNZ attributing it. Unrelated to this change, and flagged rather than touched.

No changeset. The change is smoke-only and no published package's behaviour moves.

## Review

Needs two reviewers from different vendors before it goes anywhere, per standing policy. Two things are worth a reviewer's attention specifically: whether the two-root cell faithfully models the stock cross-host composition rather than a shape that only looks like it, and whether a suite asserting the current broken behaviour is the right artifact to carry until the fix lands, given those assertions must be inverted by whoever fixes it.
