### PR TITLE
test: repair four mutation anchors broken by fixture and pin edits

### DIFF
--- a/extensions/connector-jcode/smoke/mutations/private-state.json
+++ b/extensions/connector-jcode/smoke/mutations/private-state.json
@@ -2,7 +2,7 @@
   "suite": "extensions/connector-jcode/smoke/private-state.smoke.ts",
   "guard": "Jcode credential mirrors exactly reconcile all four source families, remove absent credentials, preserve unrelated state, and keep path safety intact",
   "command": "pnpm smoke:jcode-private-state",
-  "progressPattern": "✓",
+  "progressPattern": "\u2713",
   "minTicks": 19,
   "mutations": [
     {
@@ -48,16 +48,16 @@
     {
       "name": "Jcode privateDirectory replace-symlink mkdir follows the destination path",
       "file": "extensions/connector-jcode/src/private-state.ts",
-      "find": "        unlinkSync(leaf);\n        mkdirSync(leaf, { mode: 0o700 }); // pin-mkdir-replace-symlink",
-      "replace": "        rmSync(path, { force: true });\n        mkdirSync(path, { mode: 0o700 }); // pin-mkdir-replace-symlink",
+      "find": "        unlinkSync(leaf);\n        mkdirSync(leaf, { mode: 0o700 });",
+      "replace": "        rmSync(path, { force: true });\n        mkdirSync(path, { mode: 0o700 });",
       "expectRed": "parent-swap after privateDirectory parent is pinned does not replace the outside file",
       "cell": "parent-swap after privateDirectory parent is pinned does not replace the outside file"
     },
     {
       "name": "Jcode privateDirectory absent mkdir follows the destination path",
       "file": "extensions/connector-jcode/src/private-state.ts",
-      "find": "      mkdirSync(leaf, { mode: 0o700 }); // pin-mkdir-absent",
-      "replace": "      mkdirSync(path, { mode: 0o700 }); // pin-mkdir-absent",
+      "find": "      beforeEnsure?.();\n      mkdirSync(leaf, { mode: 0o700 });",
+      "replace": "      beforeEnsure?.();\n      mkdirSync(path, { mode: 0o700 });",
       "expectRed": "parent-swap after privateDirectory parent is pinned does not mkdir outside",
       "cell": "parent-swap after privateDirectory parent is pinned does not mkdir outside"
     }

--- a/packages/workspace/smoke/fixtures/presence-render-sinks.json
+++ b/packages/workspace/smoke/fixtures/presence-render-sinks.json
@@ -64,7 +64,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "extensions/connector-core/smoke/orientation.smoke.ts",
-        "anchor": "assert.match(o.peers.summary, /bob\\/worker \\(working · progress unknown\\)/,"
+        "anchor": "assert.match(o.peers.summary, /bob\\/worker \\(working \u00b7 progress unknown\\)/,"
       }
     },
     {
@@ -75,7 +75,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "extensions/connector-core/smoke/orientation.smoke.ts",
-        "anchor": "assert.match(o.peers.summary, /bob\\/worker \\(working · progress unknown\\)/,"
+        "anchor": "assert.match(o.peers.summary, /bob\\/worker \\(working \u00b7 progress unknown\\)/,"
       }
     },
     {
@@ -95,12 +95,12 @@
     {
       "path": "extensions/connector-core/src/orientation.ts",
       "kind": "derived-output",
-      "anchor": "`  • status: ${honestStatus(o.status)} · attention: ${o.attention}`",
+      "anchor": "`  \u2022 status: ${honestStatus(o.status)} \u00b7 attention: ${o.attention}`",
       "class": "honest-text",
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "extensions/connector-core/smoke/orientation.smoke.ts",
-        "anchor": "assert.match(o.peers.summary, /bob\\/worker \\(working · progress unknown\\)/,"
+        "anchor": "assert.match(o.peers.summary, /bob\\/worker \\(working \u00b7 progress unknown\\)/,"
       }
     },
     {
@@ -111,46 +111,46 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "extensions/connector-core/smoke/orientation.smoke.ts",
-        "anchor": "assert.match(o.peers.summary, /bob\\/worker \\(working · progress unknown\\)/,"
+        "anchor": "assert.match(o.peers.summary, /bob\\/worker \\(working \u00b7 progress unknown\\)/,"
       }
     },
     {
       "path": "extensions/connector-core/src/tool-specs.ts",
       "kind": "status-token",
-      "anchor": "string {\n  return s === \"working\" ? \"●\" : s === \"waiting\"",
+      "anchor": "string {\n  return s === \"working\" ? \"\u25cf\" : s === \"waiting\"",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "extensions/connector-core/src/tool-specs.ts",
       "kind": "status-token",
-      "anchor": "\"working\" ? \"●\" : s === \"waiting\" ? \"◐\" : s === \"idle\" ? ",
+      "anchor": "\"working\" ? \"\u25cf\" : s === \"waiting\" ? \"\u25d0\" : s === \"idle\" ? ",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "extensions/connector-core/src/tool-specs.ts",
       "kind": "status-token",
-      "anchor": "\"waiting\" ? \"◐\" : s === \"idle\" ? \"○\" : \"·\";\n}\n\n/** One",
+      "anchor": "\"waiting\" ? \"\u25d0\" : s === \"idle\" ? \"\u25cb\" : \"\u00b7\";\n}\n\n/** One",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "extensions/connector-core/src/tool-specs.ts",
       "kind": "status-token",
-      "anchor": "progress = p.status === \"working\" ? \"working · progress u",
+      "anchor": "progress = p.status === \"working\" ? \"working \u00b7 progress u",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "extensions/connector-core/src/tool-specs.ts",
       "kind": "derived-output",
-      "anchor": "`${statusGlyph(p.status)} ${who} — ${progress}${p.activity ? `: ${p.activity}` : \"\"}${attn}${me}${mutedHint}${id}`",
+      "anchor": "`${statusGlyph(p.status)} ${who} \u2014 ${progress}${p.activity ? `: ${p.activity}` : \"\"}${attn}${me}${mutedHint}${id}`",
       "class": "honest-text",
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "extensions/connector-core/src/tool-specs.ts",
-        "anchor": "const progress = p.status === \"working\" ? \"working · progress unknown\" : p.status;"
+        "anchor": "const progress = p.status === \"working\" ? \"working \u00b7 progress unknown\" : p.status;"
       }
     },
     {
@@ -163,14 +163,14 @@
     {
       "path": "extensions/connector-core/src/tool-specs.ts",
       "kind": "derived-output",
-      "anchor": "`  • ${c.name}${c.role ? `/${c.role}` : \"\"} (${c.status}) — id: ${c.id}`",
+      "anchor": "`  \u2022 ${c.name}${c.role ? `/${c.role}` : \"\"} (${c.status}) \u2014 id: ${c.id}`",
       "class": "command-ack",
       "rationale": "Command result or ambiguity guidance reports the status involved in that operation, not observed work progress."
     },
     {
       "path": "extensions/connector-core/src/tool-specs.ts",
       "kind": "derived-output",
-      "anchor": "`\"${e.target}\" is ambiguous — ${e.candidates.length} peers share that name. ` +\n                `Re-send cotal_dm with the exact instance id as \"to\":\\n${who}`",
+      "anchor": "`\"${e.target}\" is ambiguous \u2014 ${e.candidates.length} peers share that name. ` +\n                `Re-send cotal_dm with the exact instance id as \"to\":\\n${who}`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -238,7 +238,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/manager/smoke/cli-seat-locality.smoke.ts",
-        "anchor": "check(\"ps textual working mesh row names unknown progress\", /working · progress unknown/.test(ps.out), ps.out.slice(-1200));"
+        "anchor": "check(\"ps textual working mesh row names unknown progress\", /working \u00b7 progress unknown/.test(ps.out), ps.out.slice(-1200));"
       }
     },
     {
@@ -256,7 +256,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/manager/smoke/cli-seat-locality.smoke.ts",
-        "anchor": "check(\"ps textual working mesh row names unknown progress\", /working · progress unknown/.test(ps.out), ps.out.slice(-1200));"
+        "anchor": "check(\"ps textual working mesh row names unknown progress\", /working \u00b7 progress unknown/.test(ps.out), ps.out.slice(-1200));"
       }
     },
     {
@@ -318,7 +318,7 @@
     {
       "path": "implementations/cli/src/commands/down.ts",
       "kind": "derived-output",
-      "anchor": "`✓ preserved state for \"${mesh.space}\"`",
+      "anchor": "`\u2713 preserved state for \"${mesh.space}\"`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -337,7 +337,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"● working · progress unknown\");"
+        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
       }
     },
     {
@@ -348,7 +348,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"● working · progress unknown\");"
+        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
       }
     },
     {
@@ -375,12 +375,12 @@
     {
       "path": "implementations/cli/src/commands/join.ts",
       "kind": "derived-output",
-      "anchor": "c.green(`→ ${who(ev.presence.card)} joined `) + statusBadge(ev.presence.status)",
+      "anchor": "c.green(`\u2192 ${who(ev.presence.card)} joined `) + statusBadge(ev.presence.status)",
       "class": "honest-text",
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"● working · progress unknown\");"
+        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
       }
     },
     {
@@ -391,7 +391,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"● working · progress unknown\");"
+        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
       }
     },
     {
@@ -404,12 +404,12 @@
     {
       "path": "implementations/cli/src/commands/join.ts",
       "kind": "derived-output",
-      "anchor": "`${c.dim(\"•\")} ${who(ev.presence.card)} ${statusBadge(ev.presence.status)}${ev.presence.activity ? c.dim(\" - \" + ev.presence.activity) : \"\"}`",
+      "anchor": "`${c.dim(\"\u2022\")} ${who(ev.presence.card)} ${statusBadge(ev.presence.status)}${ev.presence.activity ? c.dim(\" - \" + ev.presence.activity) : \"\"}`",
       "class": "honest-text",
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"● working · progress unknown\");"
+        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
       }
     },
     {
@@ -420,7 +420,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"● working · progress unknown\");"
+        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
       }
     },
     {
@@ -431,7 +431,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"● working · progress unknown\");"
+        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
       }
     },
     {
@@ -442,7 +442,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"● working · progress unknown\");"
+        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
       }
     },
     {
@@ -453,7 +453,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"● working · progress unknown\");"
+        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
       }
     },
     {
@@ -471,7 +471,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"● working · progress unknown\");"
+        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
       }
     },
     {
@@ -482,7 +482,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"● working · progress unknown\");"
+        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
       }
     },
     {
@@ -495,7 +495,7 @@
     {
       "path": "implementations/cli/src/commands/join.ts",
       "kind": "status-token",
-      "anchor": "dgedStatus = status === \"working\" ? \"working · progress u",
+      "anchor": "dgedStatus = status === \"working\" ? \"working \u00b7 progress u",
       "class": "command-ack",
       "rationale": "The working-only acknowledgement label explicitly distinguishes presence from unavailable progress observation."
     },
@@ -523,21 +523,21 @@
     {
       "path": "implementations/cli/src/commands/meshes-add.ts",
       "kind": "derived-output",
-      "anchor": "`✗ ${what} answered ${res.status} (a redirect to ${JSON.stringify(res.headers.get(\"location\") ?? \"\")}) - a redirect can move a pinned fetch onto plaintext or onto another host, so it is refused rather than followed; publish the document at the pinned URL itself`",
+      "anchor": "`\u2717 ${what} answered ${res.status} (a redirect to ${JSON.stringify(res.headers.get(\"location\") ?? \"\")}) - a redirect can move a pinned fetch onto plaintext or onto another host, so it is refused rather than followed; publish the document at the pinned URL itself`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "implementations/cli/src/commands/meshes-add.ts",
       "kind": "derived-output",
-      "anchor": "`✗ the pinned exchange at ${base} answered /health with ${res.status} - it is not serving as the bundle promises`",
+      "anchor": "`\u2717 the pinned exchange at ${base} answered /health with ${res.status} - it is not serving as the bundle promises`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "implementations/cli/src/commands/meshes-add.ts",
       "kind": "derived-output",
-      "anchor": "`✗ the pinned exchange at ${base} answered /jwks with ${res.status}`",
+      "anchor": "`\u2717 the pinned exchange at ${base} answered /jwks with ${res.status}`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -551,14 +551,14 @@
     {
       "path": "implementations/cli/src/commands/meshes.ts",
       "kind": "derived-output",
-      "anchor": "`✗ ${disco} answered ${res.status} (a redirect to ${JSON.stringify(res.headers.get(\"location\") ?? \"\")}) - a redirect can move the fetch onto plaintext or onto another host, so it is refused rather than followed; publish the discovery document at the URL you pass`",
+      "anchor": "`\u2717 ${disco} answered ${res.status} (a redirect to ${JSON.stringify(res.headers.get(\"location\") ?? \"\")}) - a redirect can move the fetch onto plaintext or onto another host, so it is refused rather than followed; publish the discovery document at the URL you pass`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "implementations/cli/src/commands/meshes.ts",
       "kind": "derived-output",
-      "anchor": "`✗ ${disco} answered ${res.status} - no discovery document there`",
+      "anchor": "`\u2717 ${disco} answered ${res.status} - no discovery document there`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -593,14 +593,14 @@
     {
       "path": "implementations/cli/src/commands/setup.ts",
       "kind": "derived-output",
-      "anchor": "`mesh     ${dim(mesh.reachable ? `${mesh.server} · space ${mesh.space}` : `down · start: ${cmd} up --detach`)}`",
+      "anchor": "`mesh     ${dim(mesh.reachable ? `${mesh.server} \u00b7 space ${mesh.space}` : `down \u00b7 start: ${cmd} up --detach`)}`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "implementations/cli/src/commands/setup.ts",
       "kind": "derived-output",
-      "anchor": "`${mesh.server} · space ${mesh.space}`",
+      "anchor": "`${mesh.server} \u00b7 space ${mesh.space}`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -619,7 +619,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"● working · progress unknown\");"
+        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
       }
     },
     {
@@ -630,7 +630,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"● working · progress unknown\");"
+        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
       }
     },
     {
@@ -958,23 +958,23 @@
     {
       "path": "implementations/cli/src/console/ui/Detail.tsx",
       "kind": "derived-output",
-      "anchor": "{s.dot + \" \" + s.word + (status === \"working\" ? \" · progress unknown\" : \"\")}",
+      "anchor": "{s.dot + \" \" + s.word + (status === \"working\" ? \" \u00b7 progress unknown\" : \"\")}",
       "class": "honest-text",
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/console/ui/Detail.tsx",
-        "anchor": "<Text color={s.color}>{s.dot + \" \" + s.word + (status === \"working\" ? \" · progress unknown\" : \"\")}</Text>"
+        "anchor": "<Text color={s.color}>{s.dot + \" \" + s.word + (status === \"working\" ? \" \u00b7 progress unknown\" : \"\")}</Text>"
       }
     },
     {
       "path": "implementations/cli/src/console/ui/Detail.tsx",
       "kind": "derived-output",
-      "anchor": "s.dot + \" \" + s.word + (status === \"working\" ? \" · progress unknown\" : \"\")",
+      "anchor": "s.dot + \" \" + s.word + (status === \"working\" ? \" \u00b7 progress unknown\" : \"\")",
       "class": "honest-text",
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/console/ui/Detail.tsx",
-        "anchor": "<Text color={s.color}>{s.dot + \" \" + s.word + (status === \"working\" ? \" · progress unknown\" : \"\")}</Text>"
+        "anchor": "<Text color={s.color}>{s.dot + \" \" + s.word + (status === \"working\" ? \" \u00b7 progress unknown\" : \"\")}</Text>"
       }
     },
     {
@@ -1008,7 +1008,7 @@
     {
       "path": "implementations/cli/src/console/ui/Dm.tsx",
       "kind": "indexed-map",
-      "anchor": "              {\"  ↳ \" + STATUS[c.status].dot + \" \" + c.with + ro",
+      "anchor": "              {\"  \u21b3 \" + STATUS[c.status].dot + \" \" + c.with + ro",
       "class": "presence-only-glyph/count",
       "rationale": "Narrow presence glyph, color, or aggregate count; it makes no textual progress claim."
     },
@@ -1054,14 +1054,14 @@
     {
       "path": "implementations/cli/src/console/ui/Roster.tsx",
       "kind": "derived-output",
-      "anchor": "{(isAgent ? s.dot : \"⚙\") + \" \" + p.card.name + kind + act + \"  \" + age}",
+      "anchor": "{(isAgent ? s.dot : \"\u2699\") + \" \" + p.card.name + kind + act + \"  \" + age}",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "implementations/cli/src/console/ui/Roster.tsx",
       "kind": "derived-output",
-      "anchor": "(isAgent ? s.dot : \"⚙\") + \" \" + p.card.name + kind + act + \"  \" + age",
+      "anchor": "(isAgent ? s.dot : \"\u2699\") + \" \" + p.card.name + kind + act + \"  \" + age",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -1082,7 +1082,7 @@
     {
       "path": "implementations/cli/src/console/ui/Roster.tsx",
       "kind": "derived-output",
-      "anchor": "{isAgent ? s.dot : \"⚙\"}",
+      "anchor": "{isAgent ? s.dot : \"\u2699\"}",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -1170,21 +1170,21 @@
     {
       "path": "implementations/cli/src/console/ui/StatusBar.tsx",
       "kind": "derived-output",
-      "anchor": "{status.connected ? \"● \" : \"⨯ \"}",
+      "anchor": "{status.connected ? \"\u25cf \" : \"\u2a2f \"}",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "implementations/cli/src/console/ui/StatusBar.tsx",
       "kind": "derived-output",
-      "anchor": "{status.space + \" · #\" + activeChannel + \" · \" + agentCount + \" agents · \" +\n            rates.msgsPerSec.toFixed(1) + \" msg/s\"}",
+      "anchor": "{status.space + \" \u00b7 #\" + activeChannel + \" \u00b7 \" + agentCount + \" agents \u00b7 \" +\n            rates.msgsPerSec.toFixed(1) + \" msg/s\"}",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "implementations/cli/src/console/ui/StatusBar.tsx",
       "kind": "derived-output",
-      "anchor": "status.space + \" · #\" + activeChannel + \" · \" + agentCount + \" agents · \" +\n            rates.msgsPerSec.toFixed(1) + \" msg/s\"",
+      "anchor": "status.space + \" \u00b7 #\" + activeChannel + \" \u00b7 \" + agentCount + \" agents \u00b7 \" +\n            rates.msgsPerSec.toFixed(1) + \" msg/s\"",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -1415,7 +1415,7 @@
     {
       "path": "implementations/cli/src/console/ui/topo/model.ts",
       "kind": "derived-output",
-      "anchor": "src.key + \"→\" + dst.key",
+      "anchor": "src.key + \"\u2192\" + dst.key",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -1443,7 +1443,7 @@
     {
       "path": "implementations/cli/src/lib/up-report.ts",
       "kind": "derived-output",
-      "anchor": "`✓ running in the background: ${components.join(\", \")} - stop with: cotal down`",
+      "anchor": "`\u2713 running in the background: ${components.join(\", \")} - stop with: cotal down`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -1469,7 +1469,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"● working · progress unknown\");"
+        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
       }
     },
     {
@@ -1480,7 +1480,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"● working · progress unknown\");"
+        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
       }
     },
     {
@@ -1491,7 +1491,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"● working · progress unknown\");"
+        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
       }
     },
     {
@@ -1502,7 +1502,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"● working · progress unknown\");"
+        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
       }
     },
     {
@@ -1513,7 +1513,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"● working · progress unknown\");"
+        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
       }
     },
     {
@@ -1524,7 +1524,7 @@
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/cli/src/ui.ts",
-        "anchor": "return c.green(\"● working · progress unknown\");"
+        "anchor": "return c.green(\"\u25cf working \u00b7 progress unknown\");"
       }
     },
     {
@@ -1635,14 +1635,14 @@
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "derived-output",
-      "anchor": "`<div class=\"peer ${p.status}${nav}\"${attrs}>\n    <span class=\"dot ${p.status}\">${GLYPH[p.status] ?? \"○\"}</span>\n    <div class=\"c\">\n      <div class=\"l1\">\n        <span class=\"name\">${esc(p.name)}</span>\n        ${p.harness ? harnessBadge(p.harness, { compact: true }) : \"\"}\n        ${p.role ? `<span class=\"role\">${esc(p.role)}</span>` : \"\"}\n        ${attentionChip(p.attention, { compact: true })}\n        ${p.tag ? `<span class=\"tag\">${esc(p.tag)}</span>` : \"\"}\n      </div>\n      ${p.act ? `<div class=\"act\" title=\"${esc(p.act)}\">${esc(p.act)}</div>` : \"\"}\n    </div>\n  </div>`",
+      "anchor": "`<div class=\"peer ${p.status}${nav}\"${attrs}>\n    <span class=\"dot ${p.status}\">${GLYPH[p.status] ?? \"\u25cb\"}</span>\n    <div class=\"c\">\n      <div class=\"l1\">\n        <span class=\"name\">${esc(p.name)}</span>\n        ${p.harness ? harnessBadge(p.harness, { compact: true }) : \"\"}\n        ${p.role ? `<span class=\"role\">${esc(p.role)}</span>` : \"\"}\n        ${attentionChip(p.attention, { compact: true })}\n        ${p.tag ? `<span class=\"tag\">${esc(p.tag)}</span>` : \"\"}\n      </div>\n      ${p.act ? `<div class=\"act\" title=\"${esc(p.act)}\">${esc(p.act)}</div>` : \"\"}\n    </div>\n  </div>`",
       "class": "presence-only-glyph/count",
       "rationale": "Narrow presence glyph, color, or aggregate count; it makes no textual progress claim."
     },
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "indexed-map",
-      "anchor": "ass=\"dot ${p.status}\">${GLYPH[p.status] ?? \"○\"}</span>\n    <div",
+      "anchor": "ass=\"dot ${p.status}\">${GLYPH[p.status] ?? \"\u25cb\"}</span>\n    <div",
       "class": "presence-only-glyph/count",
       "rationale": "Narrow presence glyph, color, or aggregate count; it makes no textual progress claim."
     },
@@ -1663,28 +1663,28 @@
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "status-token",
-      "anchor": "  return r ? r.status : \"offline\";\n}\n// id→name resolutio",
+      "anchor": "  return r ? r.status : \"offline\";\n}\n// id\u2192name resolutio",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "derived-output",
-      "anchor": "`<div class=\"dm${expanded ? \" sel\" : \"\"}\" data-dm=\"${esc(p.id)}\">\n    <span class=\"caret\">${expanded ? \"▾\" : \"▸\"}</span>\n    <span class=\"l\">\n      <span class=\"dot ${p.status}\">${GLYPH[p.status] ?? \"○\"}</span>\n      <span class=\"nm\">${esc(p.name)}</span>\n      ${p.role ? `<span class=\"role\">${esc(p.role)}</span>` : \"\"}\n    </span>\n    ${p.unread ? `<span class=\"mention\">${p.unread}</span>` : \"\"}\n    ${expanded ? \"\" : `<span class=\"threads\">${plural(p.threads, \"thread\")}</span>`}\n  </div>`",
+      "anchor": "`<div class=\"dm${expanded ? \" sel\" : \"\"}\" data-dm=\"${esc(p.id)}\">\n    <span class=\"caret\">${expanded ? \"\u25be\" : \"\u25b8\"}</span>\n    <span class=\"l\">\n      <span class=\"dot ${p.status}\">${GLYPH[p.status] ?? \"\u25cb\"}</span>\n      <span class=\"nm\">${esc(p.name)}</span>\n      ${p.role ? `<span class=\"role\">${esc(p.role)}</span>` : \"\"}\n    </span>\n    ${p.unread ? `<span class=\"mention\">${p.unread}</span>` : \"\"}\n    ${expanded ? \"\" : `<span class=\"threads\">${plural(p.threads, \"thread\")}</span>`}\n  </div>`",
       "class": "presence-only-glyph/count",
       "rationale": "Narrow presence glyph, color, or aggregate count; it makes no textual progress claim."
     },
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "indexed-map",
-      "anchor": "ass=\"dot ${p.status}\">${GLYPH[p.status] ?? \"○\"}</span>\n      <s",
+      "anchor": "ass=\"dot ${p.status}\">${GLYPH[p.status] ?? \"\u25cb\"}</span>\n      <s",
       "class": "presence-only-glyph/count",
       "rationale": "Narrow presence glyph, color, or aggregate count; it makes no textual progress claim."
     },
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "derived-output",
-      "anchor": "`<div class=\"dm sub${sel ? \" sel\" : \"\"}\" data-dm=\"${esc(peer)}${SEP}${esc(c.with)}\">\n    <span class=\"ln\">↳</span>\n    <span class=\"l\">\n      <span class=\"dot ${c.status}\">${GLYPH[c.status] ?? \"○\"}</span>\n      <span class=\"nm\">${esc(c.withName ?? c.with)}</span>\n      ${c.role ? `<span class=\"role\">${esc(c.role)}</span>` : \"\"}\n    </span>\n    ${c.unread ? `<span class=\"mention\">${c.unread}</span>` : \"\"}\n  </div>`",
+      "anchor": "`<div class=\"dm sub${sel ? \" sel\" : \"\"}\" data-dm=\"${esc(peer)}${SEP}${esc(c.with)}\">\n    <span class=\"ln\">\u21b3</span>\n    <span class=\"l\">\n      <span class=\"dot ${c.status}\">${GLYPH[c.status] ?? \"\u25cb\"}</span>\n      <span class=\"nm\">${esc(c.withName ?? c.with)}</span>\n      ${c.role ? `<span class=\"role\">${esc(c.role)}</span>` : \"\"}\n    </span>\n    ${c.unread ? `<span class=\"mention\">${c.unread}</span>` : \"\"}\n  </div>`",
       "class": "presence-only-glyph/count",
       "rationale": "Narrow presence glyph, color, or aggregate count; it makes no textual progress claim."
     },
@@ -1698,14 +1698,14 @@
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "derived-output",
-      "anchor": "`<div class=\"cmsg\">\n    <span class=\"ts\">${esc(m.ts)}</span>\n    <span class=\"dot ${m.status}\">${GLYPH[m.status] ?? \"●\"}</span>\n    <div class=\"c\">\n      <div class=\"l1\"><span class=\"who\">${esc(m.who)}</span>${m.role ? `<span class=\"role\">${esc(m.role)}</span>` : \"\"}</div>\n      ${bodyBlock(m.body)}\n      ${m.thread ? `<span class=\"thread\">${esc(m.thread)}</span>` : \"\"}\n    </div>\n  </div>`",
+      "anchor": "`<div class=\"cmsg\">\n    <span class=\"ts\">${esc(m.ts)}</span>\n    <span class=\"dot ${m.status}\">${GLYPH[m.status] ?? \"\u25cf\"}</span>\n    <div class=\"c\">\n      <div class=\"l1\"><span class=\"who\">${esc(m.who)}</span>${m.role ? `<span class=\"role\">${esc(m.role)}</span>` : \"\"}</div>\n      ${bodyBlock(m.body)}\n      ${m.thread ? `<span class=\"thread\">${esc(m.thread)}</span>` : \"\"}\n    </div>\n  </div>`",
       "class": "presence-only-glyph/count",
       "rationale": "Narrow presence glyph, color, or aggregate count; it makes no textual progress claim."
     },
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "indexed-map",
-      "anchor": "<div class=\"cmsg\">\n    <span class=\"ts\">${esc(m.ts)}</span>\n    <span class=\"dot ${m.status}\">${GLYPH[m.status] ?? \"●\"}</span>\n    <div class=\"c\">\n      <div class=\"l1\"><span class=\"who\">${esc(m.who)}</span>",
+      "anchor": "<div class=\"cmsg\">\n    <span class=\"ts\">${esc(m.ts)}</span>\n    <span class=\"dot ${m.status}\">${GLYPH[m.status] ?? \"\u25cf\"}</span>\n    <div class=\"c\">\n      <div class=\"l1\"><span class=\"who\">${esc(m.who)}</span>",
       "class": "presence-only-glyph/count",
       "rationale": "Narrow presence glyph, color, or aggregate count; it makes no textual progress claim."
     },
@@ -1719,14 +1719,14 @@
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "derived-output",
-      "anchor": "$(\"center\").innerHTML = `\n    <div class=\"ch-head\">\n      <div class=\"row\">\n        <div class=\"title\"><span class=\"h\"># ${esc(name)}</span>${sub ? `<span class=\"sub\">${esc(sub)}</span>` : \"\"}</div>\n        <div class=\"ctrls\">\n          ${toggleAllChip(items)}\n          <span class=\"chip mode on\">👥 ${plural(memberCount, \"member\")}</span>\n          ${policy.join(\"\")}\n          ${isDemo ? `<span class=\"chip static\" title=\"demo only\">✦ summarize</span><span class=\"chip static\" title=\"demo only\">🔕 mute</span>` : \"\"}\n          ${isDemo ? \"\" : `<span class=\"chip danger\" id=\"ch-del\" title=\"Delete this channel and all its messages\">🗑 delete</span>`}\n        </div>\n      </div>\n      <div class=\"purpose\">${purpose}</div>\n    </div>\n    ${orderNoticeHtml()}\n    <div class=\"clist\">${items.length ? items.map(cmsgHTML).join(\"\") : `<div class=\"empty\">no messages</div>`}</div>`",
+      "anchor": "$(\"center\").innerHTML = `\n    <div class=\"ch-head\">\n      <div class=\"row\">\n        <div class=\"title\"><span class=\"h\"># ${esc(name)}</span>${sub ? `<span class=\"sub\">${esc(sub)}</span>` : \"\"}</div>\n        <div class=\"ctrls\">\n          ${toggleAllChip(items)}\n          <span class=\"chip mode on\">\ud83d\udc65 ${plural(memberCount, \"member\")}</span>\n          ${policy.join(\"\")}\n          ${isDemo ? `<span class=\"chip static\" title=\"demo only\">\u2726 summarize</span><span class=\"chip static\" title=\"demo only\">\ud83d\udd15 mute</span>` : \"\"}\n          ${isDemo ? \"\" : `<span class=\"chip danger\" id=\"ch-del\" title=\"Delete this channel and all its messages\">\ud83d\uddd1 delete</span>`}\n        </div>\n      </div>\n      <div class=\"purpose\">${purpose}</div>\n    </div>\n    ${orderNoticeHtml()}\n    <div class=\"clist\">${items.length ? items.map(cmsgHTML).join(\"\") : `<div class=\"empty\">no messages</div>`}</div>`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "derived-output",
-      "anchor": "`\n    <div class=\"ch-head\">\n      <div class=\"row\">\n        <div class=\"title\"><span class=\"h\"># ${esc(name)}</span>${sub ? `<span class=\"sub\">${esc(sub)}</span>` : \"\"}</div>\n        <div class=\"ctrls\">\n          ${toggleAllChip(items)}\n          <span class=\"chip mode on\">👥 ${plural(memberCount, \"member\")}</span>\n          ${policy.join(\"\")}\n          ${isDemo ? `<span class=\"chip static\" title=\"demo only\">✦ summarize</span><span class=\"chip static\" title=\"demo only\">🔕 mute</span>` : \"\"}\n          ${isDemo ? \"\" : `<span class=\"chip danger\" id=\"ch-del\" title=\"Delete this channel and all its messages\">🗑 delete</span>`}\n        </div>\n      </div>\n      <div class=\"purpose\">${purpose}</div>\n    </div>\n    ${orderNoticeHtml()}\n    <div class=\"clist\">${items.length ? items.map(cmsgHTML).join(\"\") : `<div class=\"empty\">no messages</div>`}</div>`",
+      "anchor": "`\n    <div class=\"ch-head\">\n      <div class=\"row\">\n        <div class=\"title\"><span class=\"h\"># ${esc(name)}</span>${sub ? `<span class=\"sub\">${esc(sub)}</span>` : \"\"}</div>\n        <div class=\"ctrls\">\n          ${toggleAllChip(items)}\n          <span class=\"chip mode on\">\ud83d\udc65 ${plural(memberCount, \"member\")}</span>\n          ${policy.join(\"\")}\n          ${isDemo ? `<span class=\"chip static\" title=\"demo only\">\u2726 summarize</span><span class=\"chip static\" title=\"demo only\">\ud83d\udd15 mute</span>` : \"\"}\n          ${isDemo ? \"\" : `<span class=\"chip danger\" id=\"ch-del\" title=\"Delete this channel and all its messages\">\ud83d\uddd1 delete</span>`}\n        </div>\n      </div>\n      <div class=\"purpose\">${purpose}</div>\n    </div>\n    ${orderNoticeHtml()}\n    <div class=\"clist\">${items.length ? items.map(cmsgHTML).join(\"\") : `<div class=\"empty\">no messages</div>`}</div>`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -1740,14 +1740,14 @@
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "derived-output",
-      "anchor": "`<div class=\"cmsg\">\n    <span class=\"ts\">${esc(m.ts)}</span>\n    <span class=\"dot ${m.status}\">${GLYPH[m.status] ?? \"●\"}</span>\n    <div class=\"c\">\n      <div class=\"l1\"><span class=\"who\">${esc(m.whoName ?? m.who)}</span><span class=\"dir\">→ ${esc(to)}</span></div>\n      <div class=\"body md\">${MD.render(m.body)}</div>\n    </div>\n  </div>`",
+      "anchor": "`<div class=\"cmsg\">\n    <span class=\"ts\">${esc(m.ts)}</span>\n    <span class=\"dot ${m.status}\">${GLYPH[m.status] ?? \"\u25cf\"}</span>\n    <div class=\"c\">\n      <div class=\"l1\"><span class=\"who\">${esc(m.whoName ?? m.who)}</span><span class=\"dir\">\u2192 ${esc(to)}</span></div>\n      <div class=\"body md\">${MD.render(m.body)}</div>\n    </div>\n  </div>`",
       "class": "presence-only-glyph/count",
       "rationale": "Narrow presence glyph, color, or aggregate count; it makes no textual progress claim."
     },
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "indexed-map",
-      "anchor": "<div class=\"cmsg\">\n    <span class=\"ts\">${esc(m.ts)}</span>\n    <span class=\"dot ${m.status}\">${GLYPH[m.status] ?? \"●\"}</span>\n    <div class=\"c\">\n      <div class=\"l1\"><span class=\"who\">${esc(m.whoName ?? m",
+      "anchor": "<div class=\"cmsg\">\n    <span class=\"ts\">${esc(m.ts)}</span>\n    <span class=\"dot ${m.status}\">${GLYPH[m.status] ?? \"\u25cf\"}</span>\n    <div class=\"c\">\n      <div class=\"l1\"><span class=\"who\">${esc(m.whoName ?? m",
       "class": "presence-only-glyph/count",
       "rationale": "Narrow presence glyph, color, or aggregate count; it makes no textual progress claim."
     },
@@ -1775,7 +1775,7 @@
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "derived-output",
-      "anchor": "`${esc(progress)} · heartbeat ${esc(ago(p.ts))} ago`",
+      "anchor": "`${esc(progress)} \u00b7 heartbeat ${esc(ago(p.ts))} ago`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -1789,14 +1789,14 @@
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "derived-output",
-      "anchor": "`\n    <div class=\"detail${waiting ? \" amber\" : \"\"}\">\n      <div class=\"d-head\">\n        <span class=\"dot ${p.status}\">${GLYPH[p.status] ?? \"●\"}</span>\n        <span class=\"d-status\">${esc(waiting ? \"WAITING\" : p.status)}</span>\n        <span class=\"d-age\">${since}</span>\n      </div>\n      <div class=\"d-who\">${who}</div>\n      ${badges ? `<div class=\"d-badges\">${badges}</div>` : \"\"}\n      ${desc}\n      ${blocked}\n      ${sec(\"Channel attention\", channelModes)}\n      ${sec(\"Tags\", tags)}\n      ${sec(\"Skills\", skills)}\n      ${sec(\"Metadata\", metaKv)}\n      <div class=\"d-foot\"><span class=\"d-foot-item id\">${esc(card.id)}</span>${proto}</div>\n    </div>`",
+      "anchor": "`\n    <div class=\"detail${waiting ? \" amber\" : \"\"}\">\n      <div class=\"d-head\">\n        <span class=\"dot ${p.status}\">${GLYPH[p.status] ?? \"\u25cf\"}</span>\n        <span class=\"d-status\">${esc(waiting ? \"WAITING\" : p.status)}</span>\n        <span class=\"d-age\">${since}</span>\n      </div>\n      <div class=\"d-who\">${who}</div>\n      ${badges ? `<div class=\"d-badges\">${badges}</div>` : \"\"}\n      ${desc}\n      ${blocked}\n      ${sec(\"Channel attention\", channelModes)}\n      ${sec(\"Tags\", tags)}\n      ${sec(\"Skills\", skills)}\n      ${sec(\"Metadata\", metaKv)}\n      <div class=\"d-foot\"><span class=\"d-foot-item id\">${esc(card.id)}</span>${proto}</div>\n    </div>`",
       "class": "presence-only-glyph/count",
       "rationale": "Narrow presence glyph, color, or aggregate count; it makes no textual progress claim."
     },
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "indexed-map",
-      "anchor": "ass=\"dot ${p.status}\">${GLYPH[p.status] ?? \"●\"}</span>\n        ",
+      "anchor": "ass=\"dot ${p.status}\">${GLYPH[p.status] ?? \"\u25cf\"}</span>\n        ",
       "class": "presence-only-glyph/count",
       "rationale": "Narrow presence glyph, color, or aggregate count; it makes no textual progress claim."
     },
@@ -1845,14 +1845,14 @@
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "status-token",
-      "anchor": "8\", who: \"bob\", status: \"working\", body: \"on it — grabbin",
+      "anchor": "8\", who: \"bob\", status: \"working\", body: \"on it \u2014 grabbin",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "status-token",
-      "anchor": ", who: \"alice\", status: \"waiting\", body: \"🙏 thanks — I'l",
+      "anchor": ", who: \"alice\", status: \"waiting\", body: \"\ud83d\ude4f thanks \u2014 I'l",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -1866,7 +1866,7 @@
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "status-token",
-      "anchor": ", who: \"alice\", status: \"waiting\", body: \"yes please — a ",
+      "anchor": ", who: \"alice\", status: \"waiting\", body: \"yes please \u2014 a ",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -1887,7 +1887,7 @@
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "status-token",
-      "anchor": "\", who: \"dave\", status: \"working\", body: \"ty — running th",
+      "anchor": "\", who: \"dave\", status: \"working\", body: \"ty \u2014 running th",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -1915,7 +1915,7 @@
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "status-token",
-      "anchor": "ole: \"builder\", status: \"working\", act: \"writing tests · ",
+      "anchor": "ole: \"builder\", status: \"working\", act: \"writing tests \u00b7 ",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -1929,7 +1929,7 @@
     {
       "path": "implementations/web/src/web/app.js",
       "kind": "status-token",
-      "anchor": ": \"researcher\", status: \"idle\", act: \"—\", harness: \"op",
+      "anchor": ": \"researcher\", status: \"idle\", act: \"\u2014\", harness: \"op",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
@@ -2216,37 +2216,37 @@
     {
       "path": "implementations/web/src/web/graph.js",
       "kind": "derived-output",
-      "anchor": "el.innerHTML = `<span class=\"x\" id=\"dx\">✕</span>\n        <div class=\"d-kind\">channel</div>\n        <div class=\"d-who\">#${esc(sel.name)}</div>\n        ${sel.desc ? `<div class=\"d-block\">${esc(sel.desc)}</div>` : \"\"}\n        <div class=\"d-rows\">\n          <div class=\"d-row\"><span class=\"k\">subscribers</span><span class=\"v\">${hiddenOff ? `${mem.length} shown <span style=\"color:var(--faint)\">+${hiddenOff} offline hidden</span>` : `${mem.length} agent${mem.length === 1 ? \"\" : \"s\"}`}</span></div>\n          <div class=\"d-row\"><span class=\"k\">messages</span><span class=\"v\">${sel.msgs || 0}</span></div>\n          ${deliveryRow}\n          ${replayRow}\n        </div>\n        <div class=\"d-section\"><div class=\"d-label\">members</div>${memberList}</div>\n        <div class=\"d-section\"><div class=\"d-label\">recent</div><div class=\"d-msgs\">${recentRows((m) => m.chan === sel.name)}</div></div>`",
+      "anchor": "el.innerHTML = `<span class=\"x\" id=\"dx\">\u2715</span>\n        <div class=\"d-kind\">channel</div>\n        <div class=\"d-who\">#${esc(sel.name)}</div>\n        ${sel.desc ? `<div class=\"d-block\">${esc(sel.desc)}</div>` : \"\"}\n        <div class=\"d-rows\">\n          <div class=\"d-row\"><span class=\"k\">subscribers</span><span class=\"v\">${hiddenOff ? `${mem.length} shown <span style=\"color:var(--faint)\">+${hiddenOff} offline hidden</span>` : `${mem.length} agent${mem.length === 1 ? \"\" : \"s\"}`}</span></div>\n          <div class=\"d-row\"><span class=\"k\">messages</span><span class=\"v\">${sel.msgs || 0}</span></div>\n          ${deliveryRow}\n          ${replayRow}\n        </div>\n        <div class=\"d-section\"><div class=\"d-label\">members</div>${memberList}</div>\n        <div class=\"d-section\"><div class=\"d-label\">recent</div><div class=\"d-msgs\">${recentRows((m) => m.chan === sel.name)}</div></div>`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "implementations/web/src/web/graph.js",
       "kind": "derived-output",
-      "anchor": "`<span class=\"x\" id=\"dx\">✕</span>\n        <div class=\"d-kind\">channel</div>\n        <div class=\"d-who\">#${esc(sel.name)}</div>\n        ${sel.desc ? `<div class=\"d-block\">${esc(sel.desc)}</div>` : \"\"}\n        <div class=\"d-rows\">\n          <div class=\"d-row\"><span class=\"k\">subscribers</span><span class=\"v\">${hiddenOff ? `${mem.length} shown <span style=\"color:var(--faint)\">+${hiddenOff} offline hidden</span>` : `${mem.length} agent${mem.length === 1 ? \"\" : \"s\"}`}</span></div>\n          <div class=\"d-row\"><span class=\"k\">messages</span><span class=\"v\">${sel.msgs || 0}</span></div>\n          ${deliveryRow}\n          ${replayRow}\n        </div>\n        <div class=\"d-section\"><div class=\"d-label\">members</div>${memberList}</div>\n        <div class=\"d-section\"><div class=\"d-label\">recent</div><div class=\"d-msgs\">${recentRows((m) => m.chan === sel.name)}</div></div>`",
+      "anchor": "`<span class=\"x\" id=\"dx\">\u2715</span>\n        <div class=\"d-kind\">channel</div>\n        <div class=\"d-who\">#${esc(sel.name)}</div>\n        ${sel.desc ? `<div class=\"d-block\">${esc(sel.desc)}</div>` : \"\"}\n        <div class=\"d-rows\">\n          <div class=\"d-row\"><span class=\"k\">subscribers</span><span class=\"v\">${hiddenOff ? `${mem.length} shown <span style=\"color:var(--faint)\">+${hiddenOff} offline hidden</span>` : `${mem.length} agent${mem.length === 1 ? \"\" : \"s\"}`}</span></div>\n          <div class=\"d-row\"><span class=\"k\">messages</span><span class=\"v\">${sel.msgs || 0}</span></div>\n          ${deliveryRow}\n          ${replayRow}\n        </div>\n        <div class=\"d-section\"><div class=\"d-label\">members</div>${memberList}</div>\n        <div class=\"d-section\"><div class=\"d-label\">recent</div><div class=\"d-msgs\">${recentRows((m) => m.chan === sel.name)}</div></div>`",
       "class": "non-render/control",
       "rationale": "AST candidate is status routing, process/HTTP state, lookup definition, styling, or data shaping rather than a human progress claim."
     },
     {
       "path": "implementations/web/src/web/graph.js",
       "kind": "derived-output",
-      "anchor": "el.innerHTML = `<span class=\"x\" id=\"dx\">✕</span>\n        <div class=\"d-kind\">agent</div>\n        <div class=\"d-who\">${esc(sel.name)}${sel.role ? `<span class=\"role\">${esc(sel.role)}</span>` : \"\"}</div>\n        <div class=\"d-status ${sel.status}\"><span class=\"dot\"></span>${esc(sel.status === \"working\" && sel.progress?.kind === \"unknown\" ? \"working · progress unknown\" : sel.status)}</div>\n        ${descBlock}\n        <div class=\"d-section\"><div class=\"d-label\">activity</div><div class=\"d-block ${sel.activity ? \"\" : \"muted\"}\">${esc(sel.activity || \"no current activity\")}</div></div>\n        ${(harnessRow || modelRow || attRow) ? `<div class=\"d-rows\">${harnessRow}${modelRow}${attRow}</div>` : \"\"}\n        <div class=\"d-section\"><div class=\"d-label\">subscribes</div>${subs}</div>\n        ${modesSection}\n        ${tagsSection}\n        <div class=\"d-section\"><div class=\"d-label\">recent</div><div class=\"d-msgs\">${recentRows((m) => m.from === sel.name || m.to === sel.name)}</div></div>`",
+      "anchor": "el.innerHTML = `<span class=\"x\" id=\"dx\">\u2715</span>\n        <div class=\"d-kind\">agent</div>\n        <div class=\"d-who\">${esc(sel.name)}${sel.role ? `<span class=\"role\">${esc(sel.role)}</span>` : \"\"}</div>\n        <div class=\"d-status ${sel.status}\"><span class=\"dot\"></span>${esc(sel.status === \"working\" && sel.progress?.kind === \"unknown\" ? \"working \u00b7 progress unknown\" : sel.status)}</div>\n        ${descBlock}\n        <div class=\"d-section\"><div class=\"d-label\">activity</div><div class=\"d-block ${sel.activity ? \"\" : \"muted\"}\">${esc(sel.activity || \"no current activity\")}</div></div>\n        ${(harnessRow || modelRow || attRow) ? `<div class=\"d-rows\">${harnessRow}${modelRow}${attRow}</div>` : \"\"}\n        <div class=\"d-section\"><div class=\"d-label\">subscribes</div>${subs}</div>\n        ${modesSection}\n        ${tagsSection}\n        <div class=\"d-section\"><div class=\"d-label\">recent</div><div class=\"d-msgs\">${recentRows((m) => m.from === sel.name || m.to === sel.name)}</div></div>`",
       "class": "honest-text",
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/web/src/web/graph.js",
-        "anchor": "<div class=\"d-status ${sel.status}\"><span class=\"dot\"></span>${esc(sel.status === \"working\" && sel.progress?.kind === \"unknown\" ? \"working · progress unknown\" : sel.status)}</div>"
+        "anchor": "<div class=\"d-status ${sel.status}\"><span class=\"dot\"></span>${esc(sel.status === \"working\" && sel.progress?.kind === \"unknown\" ? \"working \u00b7 progress unknown\" : sel.status)}</div>"
       }
     },
     {
       "path": "implementations/web/src/web/graph.js",
       "kind": "derived-output",
-      "anchor": "`<span class=\"x\" id=\"dx\">✕</span>\n        <div class=\"d-kind\">agent</div>\n        <div class=\"d-who\">${esc(sel.name)}${sel.role ? `<span class=\"role\">${esc(sel.role)}</span>` : \"\"}</div>\n        <div class=\"d-status ${sel.status}\"><span class=\"dot\"></span>${esc(sel.status === \"working\" && sel.progress?.kind === \"unknown\" ? \"working · progress unknown\" : sel.status)}</div>\n        ${descBlock}\n        <div class=\"d-section\"><div class=\"d-label\">activity</div><div class=\"d-block ${sel.activity ? \"\" : \"muted\"}\">${esc(sel.activity || \"no current activity\")}</div></div>\n        ${(harnessRow || modelRow || attRow) ? `<div class=\"d-rows\">${harnessRow}${modelRow}${attRow}</div>` : \"\"}\n        <div class=\"d-section\"><div class=\"d-label\">subscribes</div>${subs}</div>\n        ${modesSection}\n        ${tagsSection}\n        <div class=\"d-section\"><div class=\"d-label\">recent</div><div class=\"d-msgs\">${recentRows((m) => m.from === sel.name || m.to === sel.name)}</div></div>`",
+      "anchor": "`<span class=\"x\" id=\"dx\">\u2715</span>\n        <div class=\"d-kind\">agent</div>\n        <div class=\"d-who\">${esc(sel.name)}${sel.role ? `<span class=\"role\">${esc(sel.role)}</span>` : \"\"}</div>\n        <div class=\"d-status ${sel.status}\"><span class=\"dot\"></span>${esc(sel.status === \"working\" && sel.progress?.kind === \"unknown\" ? \"working \u00b7 progress unknown\" : sel.status)}</div>\n        ${descBlock}\n        <div class=\"d-section\"><div class=\"d-label\">activity</div><div class=\"d-block ${sel.activity ? \"\" : \"muted\"}\">${esc(sel.activity || \"no current activity\")}</div></div>\n        ${(harnessRow || modelRow || attRow) ? `<div class=\"d-rows\">${harnessRow}${modelRow}${attRow}</div>` : \"\"}\n        <div class=\"d-section\"><div class=\"d-label\">subscribes</div>${subs}</div>\n        ${modesSection}\n        ${tagsSection}\n        <div class=\"d-section\"><div class=\"d-label\">recent</div><div class=\"d-msgs\">${recentRows((m) => m.from === sel.name || m.to === sel.name)}</div></div>`",
       "class": "honest-text",
       "rationale": "Textual presence status; the cited output assertion or checked renderer makes working progress uncertainty explicit.",
       "proof": {
         "path": "implementations/web/src/web/graph.js",
-        "anchor": "<div class=\"d-status ${sel.status}\"><span class=\"dot\"></span>${esc(sel.status === \"working\" && sel.progress?.kind === \"unknown\" ? \"working · progress unknown\" : sel.status)}</div>"
+        "anchor": "<div class=\"d-status ${sel.status}\"><span class=\"dot\"></span>${esc(sel.status === \"working\" && sel.progress?.kind === \"unknown\" ? \"working \u00b7 progress unknown\" : sel.status)}</div>"
       }
     },
     {

--- a/packages/workspace/smoke/mutations/presence-render-census.json
+++ b/packages/workspace/smoke/mutations/presence-render-census.json
@@ -69,7 +69,7 @@
     {
       "name": "M9 join working acknowledgement drops unknown progress",
       "file": "implementations/cli/src/commands/join.ts",
-      "find": "    const acknowledgedStatus = status === \"working\" ? \"working · progress unknown\" : status;",
+      "find": "    const acknowledgedStatus = status === \"working\" ? \"working \u00b7 progress unknown\" : status;",
       "replace": "    const acknowledgedStatus = status;",
       "command": "pnpm build && pnpm smoke:cli-seat-locality",
       "expectRed": "join /working acknowledgement names unknown progress"
@@ -77,7 +77,7 @@
     {
       "name": "M8 expected AST candidate total drifts by one",
       "file": "packages/workspace/smoke/fixtures/presence-render-sinks.json",
-      "find": "    \"total\": 303,",
+      "find": "    \"total\": 305,",
       "replace": "    \"total\": 302,",
       "expectRed": "presence render census count drifted"
     }


### PR DESCRIPTION
Main's shard 0 reds at 79ed9ab5+ decompose into two anchor families, both repaired here:

1. `presence-render-census.json` M7/M8 — #1173's fixture edit re-serialized `presence-render-sinks.json` without ASCII escaping (flattening `\u00b7`) and bumped totals 303→305. Restored the ascii-escaped serialization (semantically identical) and re-anchored M8.
2. `private-state.json` [5]/[6] — the pin retarget (249180b8) left trailing `// pin-mkdir-*` comments inside `find`s, tripping the scan's anchor-on-code rule. Finds now end before the comments, kept unique by their surrounding code lines, per the rule's own guidance (widen to code-only windows).

Locally at current main: `smoke:mutation-fixtures` red with exactly these four; green with this change (291 files / 1457 anchors); `presence-render-census` green. Refs #1155.