### PR TITLE
test(cli): derive the packed-fixture manifest version from the tarball

### DIFF
--- a/implementations/cli/smoke/setup-provider-pack.smoke.ts
+++ b/implementations/cli/smoke/setup-provider-pack.smoke.ts
@@ -46,7 +46,7 @@ try {
     join(extensionsDir, "extensions.json"),
     JSON.stringify({ extensions: [{
       pkg: "@cotal-ai/connector-claude-code",
-      version: "0.36.0",
+      version: JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8")).version as string,
       spec: "packed-fixture",
       provides: [{ kind: "connector", name: "claude" }, { kind: "connector-setup", name: "claude" }],
       commands: [],


### PR DESCRIPTION
First post-release main run (33332432256) red on shard 0: `smoke:setup-provider-pack` pins its fixture manifest at a literal `0.36.0`, so the 0.37.0 version bump broke it — and every future release would again. The manifest version is now read from the packed connector tarball's own `package.json` (already extracted by the suite), making the fixture release-proof. Locally: red on pure 80c42e43 with the exact CI error, 8/8 green with this change; `mutation-fixtures` green (no fixture anchors touch the edited line).