### PR TITLE
fix(connector-jcode): pool the MCP bridge across seat sessions

### DIFF
--- a/.changeset/jcode-bridge-pool.md
+++ b/.changeset/jcode-bridge-pool.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/connector-jcode": patch
+---
+
+The Jcode MCP bridge entry is written `shared: true`, so the per-seat daemon pools one bridge process and reuses it across sessions. Under `shared: false` every subagent session spawned its own bridge and none stopped before seat teardown, so seats running repeated subagents accumulated bridge processes without bound. Pooling stays inside the seat: the daemon, its home, its socket, and its relay token are all private to the seat.

--- a/extensions/connector-jcode/smoke/jcode-host.smoke.ts
+++ b/extensions/connector-jcode/smoke/jcode-host.smoke.ts
@@ -361,8 +361,12 @@ try {
   // into the host's MeshAgent. A schema-valid explicit `peek:false` must not be rejected by either
   // hop: the bug was an adapter-only no-argument branch that advertised this input then refused it.
   const privateMcp = JSON.parse(readFileSync(join(peerHome, "mcp.json"), "utf8")) as {
-    servers: { cotal: { env: Record<string, string> } };
+    servers: { cotal: { env: Record<string, string>; shared?: boolean } };
   };
+  // Jcode spawns a `shared: false` server once per session, so under a seat that runs subagents
+  // every member session leaves its own bridge process alive until seat teardown. The bridge must
+  // ride the daemon's pool; the daemon is seat-private, so pooling cannot cross seats.
+  check("bridge entry rides the per-seat daemon pool instead of spawning per session", privateMcp.servers.cotal.shared === true, privateMcp.servers.cotal);
   const relaySocket = privateMcp.servers.cotal.env.COTAL_JCODE_MCP_SOCKET!;
   const relayToken = privateMcp.servers.cotal.env.COTAL_JCODE_MCP_TOKEN!;
   await operator.multicast("quiet buffered", { channel: "team" });

--- a/extensions/connector-jcode/smoke/mutations/jcode-launch.json
+++ b/extensions/connector-jcode/smoke/mutations/jcode-launch.json
@@ -39,6 +39,14 @@
       "replace": "if (false) {",
       "command": "pnpm smoke:jcode-host",
       "expectRed": "Jcode cotal_inbox refuses JSON-own __proto__ without consuming the buffered message"
+    },
+    {
+      "name": "Jcode bridge rides the daemon pool instead of spawning per session",
+      "file": "extensions/connector-jcode/src/host.ts",
+      "find": "        shared: true,",
+      "replace": "        shared: false,",
+      "command": "pnpm smoke:jcode-host",
+      "expectRed": "bridge entry rides the per-seat daemon pool instead of spawning per session"
     }
   ]
 }

--- a/extensions/connector-jcode/src/host.ts
+++ b/extensions/connector-jcode/src/host.ts
@@ -134,7 +134,11 @@ function writeMcpConfig(home: string, relay: RelayEndpoint, config: AgentConfig)
           COTAL_JCODE_MCP_TOKEN: relay.token,
           COTAL_JCODE_MCP_CONFIG: JSON.stringify(publicConfig(config)),
         },
-        shared: false,
+        // Pooled (Jcode's default): one bridge per daemon, reused across every session in the
+        // seat, so repeated subagent sessions cannot each leave a bridge process behind until
+        // teardown. Pooling never crosses seats — the pool lives in the daemon and this daemon is
+        // private to the seat (its own JCODE_HOME, socket, and relay token above).
+        shared: true,
       },
     },
   };


### PR DESCRIPTION
Fixes #844.

## What changed

The Jcode MCP bridge entry in the per-peer `mcp.json` is now written `shared: true`. Jcode pools `shared: true` MCP servers in its daemon and reuses one bridge process across every session the daemon runs; under `shared: false` (the previous state) it spawned a fresh bridge per session and stopped none of them before seat teardown. A seat running repeated subagent sessions therefore accumulated bridge processes without bound — the incident on #844 measured 66 children with 270 starts and 0 stops on one seat, and 143 live bridges totalling 4.8 GB at the moment the box OOM-killed both orchestrators.

Pooling stays inside the seat. The daemon the pool lives in is private to the seat: its own `JCODE_HOME` (0700), its own socket, and its own 256-bit relay token, all written by the same `writeMcpConfig`. One seat's bridge is never visible to another seat's daemon.

## Proof

- `pnpm smoke:jcode-host` green, 56 checks, including the new cell `bridge entry rides the per-seat daemon pool instead of spawning per session`. The cell reads the `mcp.json` that the shipped writer produced during a real host launch, not a hand-built restatement.
- Mutation ledger (`extensions/connector-jcode/smoke/mutations/jcode-launch.json`): all 6 mutations killed. The new mutation (`shared: true` → `shared: false`) goes red on exactly its named cell (11 marks against a 56-mark baseline).
- `pnpm typecheck` green.
- The pooling semantics were verified against jcode's published source (`crates/jcode-base/src/mcp/manager.rs`, quoted on #844): the pool is keyed inside the daemon, and the daemon here is per-seat, so reuse cannot cross seats.

## Named gap

There is no live green-arm experiment (a bounded swarm run under `shared: true` showing a flat bridge count). Running one requires either the live installed connector or bringing up an isolated stack on the fleet host, and neither is safe to do from this lane. The red arm is the incident itself: the #844 measurements above reproduce the defect this change removes. The config-level contract — the entry is written `shared: true` and a regression back to `shared: false` fails a named cell — is what the suite proves.

## Release

One changeset, patch for `@cotal-ai/connector-jcode` (the lockstep group versions the rest).
