### PR TITLE
fix(core): slack the scatter-liveness probe-budget floor by 20ms

### DIFF
--- a/packages/core/smoke/scatter-liveness.smoke.ts
+++ b/packages/core/smoke/scatter-liveness.smoke.ts
@@ -268,7 +268,7 @@ try {
     const elapsed = Date.now() - t0;
     await held.drain();
     c("an instance that HOLDS a subscription but never answers is UNKNOWN, never gone", v === "unknown", { v });
-    c("the probe gives up at its budget rather than waiting on an answer it does not read", elapsed >= 400 && elapsed < 1200, { elapsed });
+    c("the probe gives up at its budget rather than waiting on an answer it does not read", elapsed >= 380 && elapsed < 1200, { elapsed });
   }
   {
     // The safety direction, stated as a cell: an instance that is present but silent must never be


### PR DESCRIPTION
Closes #625.

`packages/core/smoke/scatter-liveness.smoke.ts:271` asserted a lower bound equal to the deadline the
same cell passes in:

```ts
const v = await epProbeInstanceInterest(nc, SPACE, ENDPOINT, A, caller, { deadlineMs: 400 });
const elapsed = Date.now() - t0;
c("the probe gives up at its budget ...", elapsed >= 400 && elapsed < 1200, { elapsed });
```

`elapsed` is wall clock with millisecond truncation, and a timer may fire a hair before its own
deadline by that clock, so `399` is an ordinary reading of a 400 ms budget rather than a probe
defect. The floor is now 380 ms. The 1200 ms upper bound is unchanged, so a probe that waits past
its budget still fails.

The cell aborts its whole shard when it fires, so the cost is not one red cell: the run that
prompted this lost 48 of 121 planned suites in that partition, none of which reported on the branch
they were pushed for.

## Why not the other candidate fix

The issue offers a second option, measuring the probe's own notion of its deadline. That would
either change product code to expose an internal clock, or stop asserting the wall-clock wait the
cell exists to check. The floor change keeps the cell's subject intact.

## Guards

`packages/core/smoke/fixtures/scatter-liveness.mutations.json` holds six mutants against this suite,
one of which mutates the very timer this cell measures. Mutation-proof was run before and after the
change: all six killed both times, with identical marks (35/34/31/23/33/35 against a baseline of 36)
and no movement in the predicted counts the mutant names carry.

Disclosed, pre-existing and unchanged by this PR: M5's name predicts `(2 red)` while its marks drop
by 3. That mismatch is present on `main` and is not touched here.

## Reproduction

A 1 ms timing flake cannot be summoned on demand. This rests on the deterministic structural claim —
the floor equals the `deadlineMs` the cell itself sets, visible in source — together with the two
recorded CI reds at the identical `elapsed: 399` and 35-passed/1-failed split, the first with a green
re-run at the same sha and no tree change.

## Verified

`pnpm typecheck`, `pnpm build`, `pnpm smoke:scatter-liveness` (36/36), and the mutation config before
and after all exit 0. `pnpm changeset status` exits 0 with no new entry: the change is smoke-only and
ships nothing.
