### PR TITLE
ci: give the smoke shards a real timeout budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,10 @@ jobs:
 
   smoke:
     name: smoke (shard ${{ matrix.shard }}/4)
-    timeout-minutes: 40
+    # Shard 2/4 runs ~39-40 min, so the previous 40 left a median margin of 15 seconds and
+    # cancelled healthy runs (#1220 died at 40m18s). Sized at ~1.5x the slowest observed
+    # success, which absorbs runner variance and lets the corpus grow before this binds again.
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## The smoke shards run at the wall

`timeout-minutes: 40` on the smoke job is below what shard 2/4 actually needs, so healthy runs are
being reported as failures. #1220's shard 2/4 was cancelled at 40m18s.

Measured across recent CI runs, counting only jobs that ran to completion, since a cancelled job is a
truncated run rather than a duration:

| shard | completed | min | median | max |
|---|---|---|---|---|
| 0/4 | 4 | 25m57s | 26m12s | 26m49s |
| 1/4 | 6 | 33m34s | 36m19s | 37m12s |
| **2/4** | 5 | **39m06s** | **39m45s** | **39m56s** |
| 3/4 | 7 | 15m44s | 18m51s | 19m33s |

Shard 2/4's **median** margin against the old budget was 15 seconds, and its best was 4. That is not
a tail risk to be absorbed by retrying; the typical run finishes seconds before the wall, and a
slightly slower runner loses.

## The number

60, about 1.5x the slowest observed success. It absorbs runner variance, which nobody has measured
and which moves these by minutes rather than seconds, and it leaves room for the corpus to grow
before this binds again.

Growth matters here because it is invisible at review time. Fragment suites hash to a shard by name
(`bin/smoke/ci-suites.mjs`: `createHash("sha256").update(suite).digest().readUInt32BE(0) % count`),
so whoever adds a suite cannot tell which shard they are lengthening and nothing reports that one
just grew. Sizing to "observed max plus a little" means the next fragment puts us back here.

## Why raise rather than tune

The asymmetry decides it, not the numbers. A budget below the real duration converts green runs into
false failures on gated lanes, repeatedly, and every reader then has to re-derive whether a red is
real before trusting it. A budget above it costs runner minutes only when something is genuinely
hung, and only once.

## Verification

- `smoke:shard-stability`, `smoke:workflow-concurrency`, `smoke:ci-suites`, `smoke:ci-declarations`,
  `smoke:ci-fragments`, `smoke:gate-inventory`, `smoke:shard-never-ran` all exit 0.
- `check:shard-stability 3677f9176 dcb0a5558` reports **STABLE**: 488 suites, 0 frozen legacy suites
  changing index, 0 pre-existing suites changing shard. This change moves no suite between runners.
- The workflow YAML parses.

## Caveat on the measurements

These come from 14 runs across four branches, so they are not fully independent samples, and runner
variance is unmeasured. They are enough to show that shard 2/4 sits at the wall on every completed
observation; they are not a cost model.

## Not in this PR

The four shards are unbalanced by about 2x (2/4 peaks at 39m56s against 3/4's 19m33s, and 3/4 never
exceeds 2/4's minimum), so sharding four ways buys roughly the parallelism of two. Rebalancing moves
suites between shards, which is a different change with different risk, and is filed as #1223 rather
than folded in here.
