### PR TITLE
docs(changeset): describe the multi-filter batching that shipped with the single read

### DIFF
--- a/.changeset/activity-single-read.md
+++ b/.changeset/activity-single-read.md
@@ -21,7 +21,9 @@ timeout rather than the broker. `MULTI_FILTER_BATCH` is 1,000 and `MULTI_FILTER_
 sequence before the newest N are taken. The size comes from the sweep rather than from the failure
 point: a fifth of the largest count that still answered, answering in about a quarter of a second, so
 a batch stays far from both the create timeout and the 8000ms response deadline. On the same corpus
-the sweep goes from 43ms, 246ms, 5345ms and a timeout, to 54ms, 343ms, 1163ms and 942ms. A space
+the sweep goes from 43ms, 246ms, 5345ms and a timeout, to 54ms, 343ms, 1163ms and 942ms. Those walls
+are single runs on one host and are shaped by it rather than being bounds; a re-run on another box
+landed outside the last of them, as the paragraph below says of every span here. A space
 with the 69 chat channels this work was aimed at is one batch, so every figure above is unchanged at
 that size. Merging on stream sequence rather than the payload's `ts` is asserted in
 `packages/core/smoke/history-recent.smoke.ts` against a corpus whose arrival order and `ts` order are
@@ -30,8 +32,13 @@ opposite.
 Two limits remain and are stated rather than buried. On a 20,000 channel and 20,000 message corpus
 the batched read still fails at 5,000 filters and above, because batching removes the create size
 ceiling and not the cost of a batch matching a small fraction of a long stream; no unbatched numbers
-were taken on that corpus, so no comparative claim is made about it. Separately, a filter list around
-40,000 exceeds `max_payload` and is refused by the broker rather than timing out.
+were taken on that corpus, so no comparative claim is made about it. Separately, a filter list
+big enough to exceed the connection's `max_payload` is refused by the client before anything is
+sent, rather than by the broker and rather than timing out: the client compares the request against
+the limit the broker advertised at connect and throws, so no bytes leave and the broker's own logs
+show nothing. On this corpus's subject shape 40,000 filters serialize to 1,480,032 bytes against an
+advertised 1,048,576. That threshold moves with both the advertised limit and the length of the
+subjects, so the count is an observation on one shape rather than a bound.
 
 Measured on the wire by a proxy between the endpoint and the broker that counts `$JS.API` request
 lines and bytes per direction, over a seeded corpus of 69 chat channels plus 24 event channels at

--- a/.changeset/activity-single-read.md
+++ b/.changeset/activity-single-read.md
@@ -13,6 +13,26 @@ decides the read's filter set instead of deciding which of seventy reads to issu
 authority: a multi-filter create rides the bare `$JS.API.CONSUMER.CREATE.<CHAT>` row the observer
 and admin profiles already hold.
 
+The multi-filter read batches its filter list. One consumer create naming every subject is a single
+request, but a large enough request stops being answerable: on a seeded sweep the create succeeded
+at 70, 1,000 and 5,000 channels and failed at 10,000, and what gives way is the client's request
+timeout rather than the broker. `MULTI_FILTER_BATCH` is 1,000 and `MULTI_FILTER_READ_CONCURRENCY` is
+4, so the list is split and at most four batches are in flight, and the pages are merged by stream
+sequence before the newest N are taken. The size comes from the sweep rather than from the failure
+point: a fifth of the largest count that still answered, answering in about a quarter of a second, so
+a batch stays far from both the create timeout and the 8000ms response deadline. On the same corpus
+the sweep goes from 43ms, 246ms, 5345ms and a timeout, to 54ms, 343ms, 1163ms and 942ms. A space
+with the 69 chat channels this work was aimed at is one batch, so every figure above is unchanged at
+that size. Merging on stream sequence rather than the payload's `ts` is asserted in
+`packages/core/smoke/history-recent.smoke.ts` against a corpus whose arrival order and `ts` order are
+opposite.
+
+Two limits remain and are stated rather than buried. On a 20,000 channel and 20,000 message corpus
+the batched read still fails at 5,000 filters and above, because batching removes the create size
+ceiling and not the cost of a batch matching a small fraction of a long stream; no unbatched numbers
+were taken on that corpus, so no comparative claim is made about it. Separately, a filter list around
+40,000 exceeds `max_payload` and is refused by the broker rather than timing out.
+
 Measured on the wire by a proxy between the endpoint and the broker that counts `$JS.API` request
 lines and bytes per direction, over a seeded corpus of 69 chat channels plus 24 event channels at
 limit 200. The before column is that same committed suite file, with its `package.json` script,

--- a/.changeset/activity-single-read.md
+++ b/.changeset/activity-single-read.md
@@ -32,14 +32,16 @@ opposite.
 
 Two limits remain and are stated rather than buried. On a 20,000 channel and 20,000 message corpus
 the batched read still fails at 5,000 filters and above, because batching removes the create size
-ceiling and not the cost of a batch matching a small fraction of a long stream; no unbatched numbers
-were taken on that corpus, so no comparative claim is made about it. Separately, a filter list
-big enough to exceed the connection's `max_payload` is refused by the client before anything is
-sent, rather than by the broker and rather than timing out: the client compares the request against
-the limit the broker advertised at connect and throws, so no bytes leave and the broker's own logs
-show nothing. On this corpus's subject shape 40,000 filters serialize to 1,480,032 bytes against an
-advertised 1,048,576. That threshold moves with both the advertised limit and the length of the
-subjects, so the count is an observation on one shape rather than a bound.
+ceiling and not the cost of a batch matching a small fraction of a long stream; no unbatched
+numbers were taken on that corpus, so no comparative claim is made about it. Separately, a filter
+list big enough to exceed the connection's `max_payload` is refused by the client before anything
+is sent, rather than by the broker and rather than timing out: the client compares the request
+against the limit the broker advertised at connect and throws, so no bytes leave and the broker's
+own logs show nothing. On this corpus's subject shape the filter list alone serializes to 1,480,032
+bytes, already past an advertised 1,048,576 before the rest of the request is counted, so a list
+that long cannot be sent whatever the envelope adds. That threshold moves with both the advertised
+limit and the length of the subjects, so the count is an observation on one shape rather than a
+bound.
 
 Measured on the wire by a proxy between the endpoint and the broker that counts `$JS.API` request
 lines and bytes per direction, over a seeded corpus of 69 chat channels plus 24 event channels at

--- a/.changeset/activity-single-read.md
+++ b/.changeset/activity-single-read.md
@@ -25,7 +25,7 @@ the sweep goes from 43ms, 246ms, 5345ms and a timeout, to 54ms, 343ms, 1163ms an
 are single runs on one host and are shaped by it rather than being bounds; a re-run on another box
 landed outside the last of them, as the paragraph below says of every span here. A space
 with the 69 chat channels this work was aimed at is one batch, so the request counts and byte totals
-above are unchanged at that size. The walls are not claimed to be, for the reason just given.
+are unchanged at that size. The walls are not claimed to be, for the reason just given.
 Merging on stream sequence rather than the payload's `ts` is asserted in
 `packages/core/smoke/history-recent.smoke.ts` against a corpus whose arrival order and `ts` order are
 opposite.
@@ -37,11 +37,9 @@ numbers were taken on that corpus, so no comparative claim is made about it. Sep
 list big enough to exceed the connection's `max_payload` is refused by the client before anything
 is sent, rather than by the broker and rather than timing out: the client compares the request
 against the limit the broker advertised at connect and throws, so no bytes leave and the broker's
-own logs show nothing. On this corpus's subject shape the filter list alone serializes to 1,480,032
-bytes, already past an advertised 1,048,576 before the rest of the request is counted, so a list
-that long cannot be sent whatever the envelope adds. That threshold moves with both the advertised
-limit and the length of the subjects, so the count is an observation on one shape rather than a
-bound.
+own logs show nothing. A list of 40,000 filters on this corpus's subject shape is refused that way.
+Where the limit falls moves with both the advertised `max_payload` and the length of the subjects,
+so 40,000 is a length that was tried and not a threshold.
 
 Measured on the wire by a proxy between the endpoint and the broker that counts `$JS.API` request
 lines and bytes per direction, over a seeded corpus of 69 chat channels plus 24 event channels at

--- a/.changeset/activity-single-read.md
+++ b/.changeset/activity-single-read.md
@@ -24,8 +24,8 @@ a batch stays far from both the create timeout and the 8000ms response deadline.
 the sweep goes from 43ms, 246ms, 5345ms and a timeout, to 54ms, 343ms, 1163ms and 942ms. Those walls
 are single runs on one host and are shaped by it rather than being bounds; a re-run on another box
 landed outside the last of them, as the paragraph below says of every span here. A space
-with the 69 chat channels this work was aimed at is one batch, so every figure above is unchanged at
-that size. Merging on stream sequence rather than the payload's `ts` is asserted in
+with the 69 chat channels this work was aimed at is one batch, so the request counts and byte totals
+above are unchanged at that size. The walls are not claimed to be, for the reason just given. Merging on stream sequence rather than the payload's `ts` is asserted in
 `packages/core/smoke/history-recent.smoke.ts` against a corpus whose arrival order and `ts` order are
 opposite.
 

--- a/.changeset/activity-single-read.md
+++ b/.changeset/activity-single-read.md
@@ -25,7 +25,8 @@ the sweep goes from 43ms, 246ms, 5345ms and a timeout, to 54ms, 343ms, 1163ms an
 are single runs on one host and are shaped by it rather than being bounds; a re-run on another box
 landed outside the last of them, as the paragraph below says of every span here. A space
 with the 69 chat channels this work was aimed at is one batch, so the request counts and byte totals
-above are unchanged at that size. The walls are not claimed to be, for the reason just given. Merging on stream sequence rather than the payload's `ts` is asserted in
+above are unchanged at that size. The walls are not claimed to be, for the reason just given.
+Merging on stream sequence rather than the payload's `ts` is asserted in
 `packages/core/smoke/history-recent.smoke.ts` against a corpus whose arrival order and `ts` order are
 opposite.
 


### PR DESCRIPTION
## What this is

Markdown only. One file, 20 insertions, 0 deletions, no frontmatter change, so the version bumps
this changeset declares are untouched.

`.changeset/activity-single-read.md` on main describes the one-stream read and its measurement, and
says nothing about the batching that shipped beside it. Both constants are live on main:

```
packages/core/src/endpoint.ts:169  export const MULTI_FILTER_BATCH = 1_000;
packages/core/src/endpoint.ts:174  export const MULTI_FILTER_READ_CONCURRENCY = 4;
packages/core/src/endpoint.ts:2569 const size = Math.max(1, Math.trunc(opts?.batch ?? MULTI_FILTER_BATCH));
packages/core/src/endpoint.ts:2590 Array.from({ length: Math.min(MULTI_FILTER_READ_CONCURRENCY, batches.length) }, readBatch),
```

They are **exported**, and the changeset declares `@cotal-ai/core: minor`. So the release ships new
API surface with no CHANGELOG line describing it. That is the reason this is worth a PR rather than
being left thin.

## Why now

Release PR #1221 is open and was last updated at 17:58:22Z, so the changeset is still consumable.
Once #1221 merges, the changeset file is deleted and the CHANGELOG is written from what it said at
that moment. Editing the generated CHANGELOG inside #1221 would not survive the next regeneration;
the changeset file on main is the durable place for this.

## What the paragraph says

The create ceiling from a seeded sweep (succeeded at 70, 1,000 and 5,000 channels, failed at
10,000, and what gives way is the client request timeout rather than the broker); the batch size and
that it is derived from the sweep rather than from the failure point; the before and after sweep
numbers; that a 69 channel space is a single batch so every figure at that size is unchanged; the
sequence-merge assertion that covers it; and the two limits that survive, stated rather than buried.

## Verification

Claims checked against main rather than taken from the draft:

- Both constants exist at the stated values and call sites, quoted above.
- The cited assertion exists: `packages/core/smoke/history-recent.smoke.ts:277`,
  `check("multiChannelHistory merges BATCHES by arrival, not by the highest \`ts\`", …)`, with the
  corpus deliberately built so arrival order and `ts` order disagree (see the comment at line 287,
  which says that without it a corpus whose `ts` matched arrival would pass for free).
- Diff is one file, 20 insertions, 0 deletions. No line removed, so nothing existing is reworded.

The measurement figures in the paragraph come from the same instrumented runs as the rest of the
changeset and are not re-derived here.

## Not claimed

This does not change behaviour, tests or versions. It does not restate the two remaining limits as
fixed; they are recorded as open, and #1231 tracks them.
