### PR TITLE
fix(smoke): launch the CLI via node_modules/.bin/tsx, never npx tsx

### DIFF
--- a/.changeset/no-npx-tsx-in-smoke.md
+++ b/.changeset/no-npx-tsx-in-smoke.md
@@ -1,0 +1,5 @@
+---
+"cotal-ai": patch
+---
+
+Smoke suites launch the CLI through the workspace `node_modules/.bin/tsx` instead of `npx tsx`. From a scratch working directory `npx` resolves `tsx` from the npm cache or the registry rather than the workspace, and the registry install banner lands in the output the suites parse. A guard reddens on any suite that reintroduces the `npx tsx` form.

--- a/bin/smoke/attach-auth-root.smoke.ts
+++ b/bin/smoke/attach-auth-root.smoke.ts
@@ -72,6 +72,7 @@ const { authDir, divergentCwdAnchor, findCotalRoot, recordMesh, saveSpaceAuth } 
 await import("@cotal-ai/cli"); // registers the CLI commands (spawn/attach) into the registry
 const { Manager } = await import("@cotal-ai/manager");
 import type { Command, Connector, LaunchOpts } from "@cotal-ai/core";
+const TSX = join(import.meta.dirname, "..", "..", "node_modules", ".bin", "tsx");
 
 let pass = 0;
 let fail = 0;
@@ -188,7 +189,7 @@ const cmd = (name: string): Command => {
  *  unset and attach takes its no-terminal path - which still prints the `attached to …` banner cell
  *  C asserts on. */
 async function attachFrom(cwd: string, ms = 25_000): Promise<string> {
-  const p = spawnProc("npx", ["tsx", BIN, "attach", "--name", SEAT, "--space", SPACE], {
+  const p = spawnProc(TSX, [BIN, "attach", "--name", SEAT, "--space", SPACE], {
     cwd,
     env: { ...cleanEnv, COTAL_HOME: home, XDG_CONFIG_HOME: join(home, "xdg"), COTAL_SKIP_CONNECTOR_SEED: "1", NO_COLOR: "1" },
     stdio: ["ignore", "pipe", "pipe"],
@@ -390,7 +391,7 @@ try {
   const credFile = join(base, "raw.creds");
   writeFileSync(credFile, await mintCreds(live, newIdentity(), "control-caller-admin", { lifecycleUid: mintLifecycleUid() }));
   const runCli = (argv: string[]) => {
-    const r = spawnSync("npx", ["tsx", BIN, ...argv], {
+    const r = spawnSync(TSX, [BIN, ...argv], {
       cwd: workBare,
       env: { ...cleanEnv, COTAL_HOME: home, NO_COLOR: "1" },
       encoding: "utf8",

--- a/bin/smoke/ci-suites.d/d1c22f9cc00f781ec45ec353900747135c59b7d8f120ea758264b402df927984.txt
+++ b/bin/smoke/ci-suites.d/d1c22f9cc00f781ec45ec353900747135c59b7d8f120ea758264b402df927984.txt
@@ -1,0 +1,1 @@
+smoke:no-npx-tsx

--- a/bin/smoke/control-transport-dial.smoke.ts
+++ b/bin/smoke/control-transport-dial.smoke.ts
@@ -14,6 +14,7 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:
 import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+const TSX = join(import.meta.dirname, "..", "..", "node_modules", ".bin", "tsx");
 
 const freePort = (): Promise<number> =>
   new Promise((resolve, reject) => {
@@ -110,7 +111,7 @@ writeFileSync(
 );
 
 const runCli = (args: string[], timeout = 60_000) => {
-  const result = spawnSync("npx", ["tsx", cli, ...args], {
+  const result = spawnSync(TSX, [cli, ...args], {
     cwd: root,
     env: { ...cleanEnv, COTAL_HOME: home, XDG_CONFIG_HOME: xdg, COTAL_SKIP_CONNECTOR_SEED: "1", NO_COLOR: "1" },
     encoding: "utf8",

--- a/bin/smoke/fixtures/no-npx-tsx.planted.txt
+++ b/bin/smoke/fixtures/no-npx-tsx.planted.txt
@@ -1,0 +1,3 @@
+# Planted positive control for bin/smoke/no-npx-tsx.smoke.ts. This is the BANNED form, kept here on
+# purpose so the guard can prove its regex sees it. Never copy this into a suite.
+    const child = spawn("npx", ["tsx", BIN, ...args], options);

--- a/bin/smoke/manager-stop-reaps-agents.smoke.ts
+++ b/bin/smoke/manager-stop-reaps-agents.smoke.ts
@@ -71,6 +71,7 @@ const { DELIVERY_CREDS_KIND, MEMBERSHIP_RW_CREDS_KIND, authDir, recordMesh, save
 await import("@cotal-ai/cli"); // registers the CLI commands (spawn/stop) into the registry
 const { Manager } = await import("@cotal-ai/manager");
 import type { Command, Connector, LaunchOpts } from "@cotal-ai/core";
+const TSX = join(import.meta.dirname, "..", "..", "node_modules", ".bin", "tsx");
 
 let pass = 0;
 let fail = 0;
@@ -190,7 +191,7 @@ const kids: ChildProcess[] = [];
  *  command exits the whole process on failure, which would kill the suite. */
 const cliStop = (name: string): Promise<{ code: number | null; out: string }> =>
   new Promise((resolve, reject) => {
-    const p = spawnProc("npx", ["tsx", BIN, "stop", "--name", name, "--space", SPACE], {
+    const p = spawnProc(TSX, [BIN, "stop", "--name", name, "--space", SPACE], {
       cwd: root,
       env: { ...cleanEnv, COTAL_HOME: home, COTAL_SKIP_CONNECTOR_SEED: "1", NO_COLOR: "1" },
       stdio: ["ignore", "pipe", "pipe"],
@@ -246,7 +247,7 @@ try {
     "membership.json": JSON.stringify({ accountId: auth.account.pub }),
   };
   for (const [kind, bytes] of Object.entries(daemonFiles)) writeFileSync(join(seg, kind), bytes, { mode: 0o600 });
-  daemon = spawnProc("npx", ["tsx", BIN, "deliver", "--space", SPACE, "--server", SERVER, "--creds", join(seg, DELIVERY_CREDS_KIND)], {
+  daemon = spawnProc(TSX, [BIN, "deliver", "--space", SPACE, "--server", SERVER, "--creds", join(seg, DELIVERY_CREDS_KIND)], {
     cwd: root,
     stdio: ["ignore", "pipe", "pipe"],
     env: { ...cleanEnv, COTAL_HOME: home, COTAL_SKIP_CONNECTOR_SEED: "1" },

--- a/bin/smoke/manager-two-root-renewal.smoke.ts
+++ b/bin/smoke/manager-two-root-renewal.smoke.ts
@@ -36,6 +36,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+const TSX = join(import.meta.dirname, "..", "..", "node_modules", ".bin", "tsx");
 
 // Sandbox BEFORE any cotal import: whatever runs this suite may itself be a managed seat, and its
 // COTAL_* environment names a LIVE mesh. The in-process Manager and every child must see only the
@@ -128,7 +129,7 @@ const stageDaemonRoot = (root: string, space: string, files: Record<string, stri
 
 /** Spawn the REAL delivery daemon rooted at `root` (its cwd - the store its re-reads resolve). */
 const spawnDaemon = (root: string, space: string, servers: string, credsPath: string, sink: { out: string; exited: boolean }): ChildProcess => {
-  const d = spawnProc("npx", ["tsx", BIN, "deliver", "--space", space, "--server", servers, "--creds", credsPath], {
+  const d = spawnProc(TSX, [BIN, "deliver", "--space", space, "--server", servers, "--creds", credsPath], {
     cwd: root,
     stdio: ["ignore", "pipe", "pipe"],
     // Direct daemon run (not via `up`): the first-real-command connector seed would run installs

--- a/bin/smoke/no-npx-tsx.smoke.ts
+++ b/bin/smoke/no-npx-tsx.smoke.ts
@@ -28,7 +28,11 @@ import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 
 const ROOT = join(import.meta.dirname, "..", "..");
-const BANNED = /\bspawn\(\s*"npx"\s*,\s*\[\s*"tsx"/;
+// Any spawner name, any whitespace or newline between the tokens. The first version of this guard
+// matched only `spawn(` and missed spawnSync, spawnProc and a multi-line call in seven files; CI
+// found the one it reached. A grammar guard has to match the family, not the one form its author
+// happened to fix.
+const BANNED = /\b(?:spawn|spawnSync|spawnProc|execFile|execFileSync|pty\.spawn)\(\s*"npx"\s*,\s*\[\s*"tsx"/;
 /** This file quotes the banned form in its own docstring, so it excludes itself and grades the rest. */
 const SELF = "bin/smoke/no-npx-tsx.smoke.ts";
 const SKIP = new Set(["node_modules", "dist", ".git", ".changeset", "coverage", "build", ".internal"]);
@@ -64,6 +68,8 @@ check("the planted control carries the banned form and the regex sees it", BANNE
 
 // Negative control: the robust form must NOT match, or the guard would redden its own remedy.
 check("the robust form spawn(TSX, [BIN, ...]) is not matched", !BANNED.test('const child = spawn(TSX, [BIN, ...args], options);'));
+check("the multi-line and spawnSync forms ARE matched (the family, not the one form)",
+  BANNED.test('spawnSync(\n    "npx",\n    ["tsx", x]') && BANNED.test('spawnProc("npx", ["tsx", BIN])') && BANNED.test('pty.spawn("npx", ["tsx"'));
 
 check(`no smoke source launches the CLI via npx tsx (${files.length} files walked)`, hits.length === 0, hits);
 

--- a/bin/smoke/no-npx-tsx.smoke.ts
+++ b/bin/smoke/no-npx-tsx.smoke.ts
@@ -32,7 +32,11 @@ const ROOT = join(import.meta.dirname, "..", "..");
 // matched only `spawn(` and missed spawnSync, spawnProc and a multi-line call in seven files; CI
 // found the one it reached. A grammar guard has to match the family, not the one form its author
 // happened to fix.
-const BANNED = /\b(?:spawn|spawnSync|spawnProc|execFile|execFileSync|pty\.spawn)\(\s*"npx"\s*,\s*\[\s*"tsx"/;
+// Match the TOKEN, not the form: any spawner handed the literal "npx" as its command. The second
+// version of this guard required `["tsx"` to follow, and missed `pty.spawn("npx", args)` where the
+// array lives in a variable; a reviewer found it. Requiring the array shape was a third way to
+// enumerate the spelling the author happened to know.
+const BANNED = /\b(?:spawn|spawnSync|spawnProc|execFile|execFileSync|pty\.spawn)\(\s*"npx"\s*,/;
 /** This file quotes the banned form in its own docstring, so it excludes itself and grades the rest. */
 const SELF = "bin/smoke/no-npx-tsx.smoke.ts";
 const SKIP = new Set(["node_modules", "dist", ".git", ".changeset", "coverage", "build", ".internal"]);
@@ -68,8 +72,8 @@ check("the planted control carries the banned form and the regex sees it", BANNE
 
 // Negative control: the robust form must NOT match, or the guard would redden its own remedy.
 check("the robust form spawn(TSX, [BIN, ...]) is not matched", !BANNED.test('const child = spawn(TSX, [BIN, ...args], options);'));
-check("the multi-line and spawnSync forms ARE matched (the family, not the one form)",
-  BANNED.test('spawnSync(\n    "npx",\n    ["tsx", x]') && BANNED.test('spawnProc("npx", ["tsx", BIN])') && BANNED.test('pty.spawn("npx", ["tsx"'));
+check("the multi-line, spawnSync, and variable-args forms ARE matched (the token, not the form)",
+  BANNED.test('spawnSync(\n    "npx",\n    ["tsx", x]') && BANNED.test('spawnProc("npx", ["tsx", BIN])') && BANNED.test('pty.spawn("npx", ["tsx"') && BANNED.test('pty.spawn("npx", args, {'));
 
 check(`no smoke source launches the CLI via npx tsx (${files.length} files walked)`, hits.length === 0, hits);
 

--- a/bin/smoke/no-npx-tsx.smoke.ts
+++ b/bin/smoke/no-npx-tsx.smoke.ts
@@ -32,11 +32,25 @@ const ROOT = join(import.meta.dirname, "..", "..");
 // matched only `spawn(` and missed spawnSync, spawnProc and a multi-line call in seven files; CI
 // found the one it reached. A grammar guard has to match the family, not the one form its author
 // happened to fix.
-// Match the TOKEN, not the form: any spawner handed the literal "npx" as its command. The second
-// version of this guard required `["tsx"` to follow, and missed `pty.spawn("npx", args)` where the
-// array lives in a variable; a reviewer found it. Requiring the array shape was a third way to
-// enumerate the spelling the author happened to know.
-const BANNED = /\b(?:spawn|spawnSync|spawnProc|execFile|execFileSync|pty\.spawn)\(\s*"npx"\s*,/;
+// Match the TOKEN and nothing about the callee. Three earlier versions of this regex each named
+// the spawner identifiers their author had converted (spawn; then spawnSync/spawnProc/pty.spawn;
+// then with any argument shape), and each time the reviewer planted a spelling outside the list:
+// an aliased import (`spawn as spawnProcess`), `exec("npx tsx ...")`, a single-quoted 'npx', a
+// space or newline before the paren, `npx.cmd`, and `spawn("npm", ["exec", "tsx"`. Every one of
+// those is the same hazard: a process launcher handed npx from a scratch cwd. So the grammar here
+// is only the hazard token in argument position, whatever function it is passed to:
+//   (a) any call whose FIRST argument is the literal npx or npx.cmd, single or double quoted
+//   (b) any string literal beginning `npx tsx`, which is the shell-string form exec/execSync take
+//   (c) any call whose first argument is "npm" followed by an array beginning "exec"
+// A bare identifier (`const cmd = "npx"; spawn(cmd, ...)`) carries no token at the call and is
+// out of reach of any grammar guard; the guard says so rather than pretending otherwise.
+const BANNED = new RegExp(
+  [
+    String.raw`\(\s*['"]npx(?:\.cmd)?['"]\s*,`,
+    String.raw`['"]npx\s+tsx\b`,
+    String.raw`\(\s*['"]npm['"]\s*,\s*\[\s*['"]exec['"]`,
+  ].join("|"),
+);
 /** This file quotes the banned form in its own docstring, so it excludes itself and grades the rest. */
 const SELF = "bin/smoke/no-npx-tsx.smoke.ts";
 const SKIP = new Set(["node_modules", "dist", ".git", ".changeset", "coverage", "build", ".internal"]);
@@ -71,9 +85,28 @@ const plantedText = readFileSync(planted, "utf8");
 check("the planted control carries the banned form and the regex sees it", BANNED.test(plantedText), plantedText.slice(0, 80));
 
 // Negative control: the robust form must NOT match, or the guard would redden its own remedy.
-check("the robust form spawn(TSX, [BIN, ...]) is not matched", !BANNED.test('const child = spawn(TSX, [BIN, ...args], options);'));
-check("the multi-line, spawnSync, and variable-args forms ARE matched (the token, not the form)",
-  BANNED.test('spawnSync(\n    "npx",\n    ["tsx", x]') && BANNED.test('spawnProc("npx", ["tsx", BIN])') && BANNED.test('pty.spawn("npx", ["tsx"') && BANNED.test('pty.spawn("npx", args, {'));
+const positives: Array<[string, string]> = [
+  ["spawnSync multi-line", 'spawnSync(\n    "npx",\n    ["tsx", x]'],
+  ["spawnProc", 'spawnProc("npx", ["tsx", BIN])'],
+  ["pty.spawn array", 'pty.spawn("npx", ["tsx"'],
+  ["pty.spawn variable args", 'pty.spawn("npx", args, {'],
+  ["aliased import", 'spawnProcess("npx", ["tsx", BIN])'],
+  ["exec shell string", 'exec("npx tsx BIN attach", cb)'],
+  ["execSync shell string", 'execSync("npx tsx " + BIN)'],
+  ["single-quoted", "spawn('npx', ['tsx'])"],
+  ["space before paren", 'spawn ("npx", ["tsx"])'],
+  ["newline before paren", 'pty.spawn\n("npx", args, {'],
+  ["windows shim", 'spawn("npx.cmd", ["tsx"])'],
+  ["npm exec", 'spawn("npm", ["exec", "tsx", BIN])'],
+]; 
+for (const [name, src] of positives) check(`banned form IS matched: ${name}`, BANNED.test(src), src);
+const negatives: Array<[string, string]> = [
+  ["robust form", 'const child = spawn(TSX, [BIN, ...args], options);'],
+  ["robust pty", 'pty.spawn(TSX, args, {'],
+  ["version.ts kind field", 'return { kind: "npx", root: packageRoot };'],
+  ["prose mention", '// Run: npx tsx implementations/auth/smoke/x.smoke.ts'],
+]; 
+for (const [name, src] of negatives) check(`legitimate text is NOT matched: ${name}`, !BANNED.test(src), src);
 
 check(`no smoke source launches the CLI via npx tsx (${files.length} files walked)`, hits.length === 0, hits);
 

--- a/bin/smoke/no-npx-tsx.smoke.ts
+++ b/bin/smoke/no-npx-tsx.smoke.ts
@@ -44,13 +44,28 @@ const ROOT = join(import.meta.dirname, "..", "..");
 //   (c) any call whose first argument is "npm" followed by an array beginning "exec"
 // A bare identifier (`const cmd = "npx"; spawn(cmd, ...)`) carries no token at the call and is
 // out of reach of any grammar guard; the guard says so rather than pretending otherwise.
+// Quote class: single, double, OR backtick. Fifth round found spawn(`npx`, ...) and exec(`npx tsx ...`)
+// slipping because ['"] has no backtick; live smoke already writes template-literal execSync.
+// Token class: npx with any Windows shim suffix (.cmd, .exe, .ps1), and npm likewise.
+// Between the quoted token and the comma: any TypeScript wrapper that keeps the literal at the
+// call (`as const`, `!`, extra parens), so `spawn("npx" as const, ...)` cannot slip either.
+const Q = String.raw`['"\x60]`;
+const WRAP = String.raw`[\s()!]*(?:as\s+const[\s()!]*)?`;
 const BANNED = new RegExp(
   [
-    String.raw`\(\s*['"]npx(?:\.cmd)?['"]\s*,`,
-    String.raw`['"]npx\s+tsx\b`,
-    String.raw`\(\s*['"]npm['"]\s*,\s*\[\s*['"]exec['"]`,
+    // (a) first argument is the npx token, however quoted or wrapped
+    String.raw`\(${WRAP}${Q}npx(?:\.(?:cmd|exe|ps1))?${Q}${WRAP},`,
+    // (b) a shell string beginning `npx tsx` or `npm exec`, the exec/execSync form
+    // (b) a shell string beginning `npx tsx` or `npm exec`, the exec/execSync form. Anchored to
+    //     argument position ( `(` or `,` before the quote ) so a backticked mention inside a
+    //     prose comment does not match; round five's first cut reddened on exactly that.
+    String.raw`[(,]${WRAP}${Q}(?:npx|npm\s+exec)\s+tsx\b`,
+    String.raw`[(,]${WRAP}${Q}npm\s+exec\b`,
+    // (c) argv form of npm exec, with the same quote and shim classes
+    String.raw`\(${WRAP}${Q}npm(?:\.(?:cmd|exe|ps1))?${Q}${WRAP},\s*\[\s*${Q}exec${Q}`,
   ].join("|"),
 );
+
 /** This file quotes the banned form in its own docstring, so it excludes itself and grades the rest. */
 const SELF = "bin/smoke/no-npx-tsx.smoke.ts";
 const SKIP = new Set(["node_modules", "dist", ".git", ".changeset", "coverage", "build", ".internal"]);
@@ -98,6 +113,15 @@ const positives: Array<[string, string]> = [
   ["newline before paren", 'pty.spawn\n("npx", args, {'],
   ["windows shim", 'spawn("npx.cmd", ["tsx"])'],
   ["npm exec", 'spawn("npm", ["exec", "tsx", BIN])'],
+  ["backtick npx", "spawn(`npx`, [\"tsx\", BIN], {})"],
+  ["backtick exec shell string", "exec(`npx tsx BIN attach`, { cwd: root }, () => {})"],
+  ["npx.exe", 'spawn("npx.exe", ["tsx"])'],
+  ["npx.ps1", 'spawn("npx.ps1", ["tsx"])'],
+  ["npm.cmd exec", 'spawn("npm.cmd", ["exec", "tsx"])'],
+  ["as const", 'spawn("npx" as const, ["tsx"])'],
+  ["non-null bang", 'spawn("npx"!, ["tsx"])'],
+  ["extra parens", 'spawn(("npx"), ["tsx"])'],
+  ["shell-string npm exec", 'exec("npm exec tsx BIN attach", cb)'],
 ]; 
 for (const [name, src] of positives) check(`banned form IS matched: ${name}`, BANNED.test(src), src);
 const negatives: Array<[string, string]> = [
@@ -105,6 +129,7 @@ const negatives: Array<[string, string]> = [
   ["robust pty", 'pty.spawn(TSX, args, {'],
   ["version.ts kind field", 'return { kind: "npx", root: packageRoot };'],
   ["prose mention", '// Run: npx tsx implementations/auth/smoke/x.smoke.ts'],
+  ["prose mention in backticks", "// `npx tsx <missing-file>` exits 1, which is indistinguishable from"],
 ]; 
 for (const [name, src] of negatives) check(`legitimate text is NOT matched: ${name}`, !BANNED.test(src), src);
 

--- a/bin/smoke/no-npx-tsx.smoke.ts
+++ b/bin/smoke/no-npx-tsx.smoke.ts
@@ -1,0 +1,72 @@
+/**
+ * No smoke suite may launch the CLI through `npx tsx`.
+ *
+ * `npm exec` resolves a package from the CURRENT WORKING DIRECTORY upward, never from PATH. Every
+ * suite that spawns the CLI does so with `cwd` set to a scratch directory outside this repo, so from
+ * there `npx tsx` misses the workspace copy in `node_modules/.bin`. What happens next depends on the
+ * runner's npx cache: a warm box serves whatever `tsx@latest` it last cached, and a cold CI runner
+ * goes to the registry. The registry install prints
+ *
+ *     npm warn exec The following package was not found and will be installed: tsx@X.Y.Z
+ *
+ * onto stderr, which the fixtures merge into the output they parse, so `ps` assertions read a
+ * warning where they expect a roster row, and `cotal up` can miss its budget and be SIGKILLed.
+ * That reddened every smoke shard on main at `7f3a8a03` (#1244) from a change that touched no
+ * smoke file at all: the tree was byte-identical to the green run before it.
+ *
+ * The robust form, already used by the majority of suites, resolves the workspace binary by path:
+ *
+ *     const TSX = join(import.meta.dirname, "..", "..", "..", "node_modules", ".bin", "tsx");
+ *     spawn(TSX, [BIN, ...args], opts)
+ *
+ * This guard reddens on any `spawn("npx", ["tsx"` (plain or `pty.spawn`) under a `smoke/` directory.
+ * It carries a planted positive control so the search is shown able to find the banned form, and a
+ * self-check that the real tree contributes zero hits; a grep that finds nothing and a grep that cannot
+ * find anything print the same zero, and only the planted control tells them apart.
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const ROOT = join(import.meta.dirname, "..", "..");
+const BANNED = /\bspawn\(\s*"npx"\s*,\s*\[\s*"tsx"/;
+/** This file quotes the banned form in its own docstring, so it excludes itself and grades the rest. */
+const SELF = "bin/smoke/no-npx-tsx.smoke.ts";
+const SKIP = new Set(["node_modules", "dist", ".git", ".changeset", "coverage", "build", ".internal"]);
+
+let pass = 0, fail = 0;
+const check = (name: string, condition: boolean, detail?: unknown) => {
+  if (condition) { pass++; console.log(`  ✓ ${name}`); }
+  else { fail++; console.log(`  ✗ FAIL: ${name}`, detail ?? ""); }
+};
+
+/** Every `.ts` file whose path has a `smoke/` segment, excluding this guard's own fixture directory. */
+function smokeSources(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (SKIP.has(entry)) continue;
+    const p = join(dir, entry);
+    const st = statSync(p);
+    if (st.isDirectory()) smokeSources(p, out);
+    else if (p.endsWith(".ts") && /(^|\/)smoke\//.test(relative(ROOT, p)) && !relative(ROOT, p).startsWith("bin/smoke/fixtures/") && relative(ROOT, p) !== SELF) out.push(p);
+  }
+  return out;
+}
+
+const files = smokeSources(ROOT);
+const hits = files.filter((f) => BANNED.test(readFileSync(f, "utf8"))).map((f) => relative(ROOT, f));
+
+check("the walk finds a non-trivial population of smoke sources (a walk over nothing would pass for free)", files.length >= 50, `found ${files.length}`);
+
+// Planted positive control: a fixture that carries the banned form verbatim. If the regex cannot see
+// it, every real hit below would have been invisible too, and the zero would mean nothing.
+const planted = join(ROOT, "bin", "smoke", "fixtures", "no-npx-tsx.planted.txt");
+const plantedText = readFileSync(planted, "utf8");
+check("the planted control carries the banned form and the regex sees it", BANNED.test(plantedText), plantedText.slice(0, 80));
+
+// Negative control: the robust form must NOT match, or the guard would redden its own remedy.
+check("the robust form spawn(TSX, [BIN, ...]) is not matched", !BANNED.test('const child = spawn(TSX, [BIN, ...args], options);'));
+
+check(`no smoke source launches the CLI via npx tsx (${files.length} files walked)`, hits.length === 0, hits);
+
+console.log(`\nNO-NPX-TSX ${fail === 0 ? "OK" : "FAILED"}  (${pass} passed, ${fail} failed)`);
+console.log(`SUITE COMPLETE: ${pass + fail} declared`);
+process.exit(fail === 0 ? 0 : 1);

--- a/bin/smoke/spawn-detach-live.smoke.ts
+++ b/bin/smoke/spawn-detach-live.smoke.ts
@@ -49,6 +49,7 @@ const { recordMesh } = await import("@cotal-ai/workspace");
 await import("@cotal-ai/cli"); // registers the CLI commands (spawn/stop/ps/attach) into the registry
 const { Manager } = await import("@cotal-ai/manager");
 import type { Command, Connector, ControlReply, LaunchOpts, SessionGrant } from "@cotal-ai/core";
+const TSX = join(import.meta.dirname, "..", "..", "node_modules", ".bin", "tsx");
 
 let pass = 0;
 const kids: ChildProcess[] = [];
@@ -329,7 +330,7 @@ try {
   const subEnv = { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: join(home, "xdg"), COTAL_SKIP_CONNECTOR_SEED: "1" };
 
   // E — the start tombstone (true subprocess through bin/cotal.ts, i.e. built dist).
-  const tomb = spawnSync("npx", ["tsx", join(import.meta.dirname, "..", "cotal.ts"), "start", "--name", "x"], {
+  const tomb = spawnSync(TSX, [join(import.meta.dirname, "..", "cotal.ts"), "start", "--name", "x"], {
     encoding: "utf8",
     env: subEnv,
   });
@@ -340,13 +341,11 @@ try {
   // pre-dispatch (spawnRequiredExtensions), so first `ext add` THIS WORKTREE's claude connector
   // into the sandbox prefix (the real local-path install + core peer-link path) — never the
   // operator's global store.
-  const extAdd = spawnSync(
-    "npx",
-    ["tsx", join(import.meta.dirname, "..", "cotal.ts"), "ext", "add", join(import.meta.dirname, "..", "..", "extensions", "connector-claude-code")],
+  const extAdd = spawnSync(TSX, [join(import.meta.dirname, "..", "cotal.ts"), "ext", "add", join(import.meta.dirname, "..", "..", "extensions", "connector-claude-code")],
     { encoding: "utf8", env: subEnv },
   );
   ok("sandbox ext add of the worktree claude connector succeeds", extAdd.status === 0, (extAdd.stderr + extAdd.stdout).slice(0, 300));
-  const fg = spawnSync("npx", ["tsx", join(import.meta.dirname, "..", "cotal.ts"), "spawn", "poet", "--creds", "/tmp/x.creds"], {
+  const fg = spawnSync(TSX, [join(import.meta.dirname, "..", "cotal.ts"), "spawn", "poet", "--creds", "/tmp/x.creds"], {
     encoding: "utf8",
     env: subEnv,
   });

--- a/bin/smoke/up-tls-routes-live.smoke.ts
+++ b/bin/smoke/up-tls-routes-live.smoke.ts
@@ -57,6 +57,7 @@ import net from "node:net";
 import tls from "node:tls";
 import { connect, credsAuthenticator } from "@nats-io/transport-node";
 import { assertSmokeSandboxDown, recordSmokeSandbox, type SmokeSandboxAnchor } from "@cotal-ai/smoke-kit";
+const TSX = join(import.meta.dirname, "..", "..", "node_modules", ".bin", "tsx");
 
 const CLI = join(import.meta.dirname, "..", "cotal.ts");
 
@@ -145,7 +146,7 @@ function cotal(args: string[], home: string, cwd: string, env: Record<string, st
     env: { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: join(home, "xdg"), NODE_EXTRA_CA_CERTS: caFile, ...env },
   } as const;
   assertSmokeSandboxDown(sandboxAnchors.get(cwd), args, options);
-  const r = spawnSync("npx", ["tsx", CLI, ...args], options);
+  const r = spawnSync(TSX, [CLI, ...args], options);
   return { status: r.status, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
 }
 

--- a/implementations/auth/smoke/_ps-arm2.smoke.ts
+++ b/implementations/auth/smoke/_ps-arm2.smoke.ts
@@ -37,6 +37,7 @@ import { deviceAuthorization } from "better-auth/plugins/device-authorization";
 import { bearer } from "better-auth/plugins/bearer";
 import { toNodeHandler } from "better-auth/node";
 import { pickFreePort } from "./_free-port.js";
+const TSX = join(import.meta.dirname, "..", "..", "..", "node_modules", ".bin", "tsx");
 
 const home = mkdtempSync(join(tmpdir(), "cotal-downf-home-"));
 const configDir = join(home, "xdg");
@@ -67,7 +68,7 @@ function cotal(args: string[], opts: { timeoutMs?: number } = {}): Promise<{ sta
   return new Promise((resolvePromise) => {
     const options = { cwd: root, env: childEnv };
     assertSmokeSandboxDown(sandbox, args, options);
-    const child = spawn("npx", ["tsx", BIN, ...args], options);
+    const child = spawn(TSX, [BIN, ...args], options);
     let out = "";
     child.stdout.on("data", (d: Buffer) => { out += d.toString(); });
     child.stderr.on("data", (d: Buffer) => { out += d.toString(); });

--- a/implementations/auth/smoke/down-manifest-usermode.smoke.ts
+++ b/implementations/auth/smoke/down-manifest-usermode.smoke.ts
@@ -37,6 +37,7 @@ import { deviceAuthorization } from "better-auth/plugins/device-authorization";
 import { bearer } from "better-auth/plugins/bearer";
 import { toNodeHandler } from "better-auth/node";
 import { pickFreePort } from "./_free-port.js";
+const TSX = join(import.meta.dirname, "..", "..", "..", "node_modules", ".bin", "tsx");
 
 const home = mkdtempSync(join(tmpdir(), "cotal-downf-home-"));
 const configDir = join(home, "xdg");
@@ -67,7 +68,7 @@ function cotal(args: string[], opts: { timeoutMs?: number } = {}): Promise<{ sta
   return new Promise((resolvePromise) => {
     const options = { cwd: root, env: childEnv };
     assertSmokeSandboxDown(sandbox, args, options);
-    const child = spawn("npx", ["tsx", BIN, ...args], options);
+    const child = spawn(TSX, [BIN, ...args], options);
     let out = "";
     child.stdout.on("data", (d: Buffer) => { out += d.toString(); });
     child.stderr.on("data", (d: Buffer) => { out += d.toString(); });
@@ -177,7 +178,7 @@ agents:
   // blocks a replacement's acquire — wait it out first, like the real recovery did.
   await wait(13_000);
   let superviseOut = "";
-  superviseChild = spawn("npx", ["tsx", BIN, "supervise", "--space", SPACE, "--server", SERVER], {
+  superviseChild = spawn(TSX, [BIN, "supervise", "--space", SPACE, "--server", SERVER], {
     cwd: root, env: childEnv, stdio: ["ignore", "pipe", "pipe"] });
   superviseChild.stdout!.on("data", (d: Buffer) => { superviseOut += d.toString(); });
   superviseChild.stderr!.on("data", (d: Buffer) => { superviseOut += d.toString(); });
@@ -240,7 +241,7 @@ agents:
   rmSync(worker2Tok);
   symlinkSync(join(root, "decoy"), worker2Tok);
   await wait(13_000); // the crashed holder's lease again lingers to the bucket TTL
-  superviseChild = spawn("npx", ["tsx", BIN, "supervise", "--space", SPACE, "--server", SERVER], {
+  superviseChild = spawn(TSX, [BIN, "supervise", "--space", SPACE, "--server", SERVER], {
     cwd: root, env: childEnv, stdio: "ignore" });
   let psOk2 = false;
   for (let i = 0; i < 60 && !psOk2; i++) {

--- a/implementations/auth/smoke/ps-operator-path.smoke.ts
+++ b/implementations/auth/smoke/ps-operator-path.smoke.ts
@@ -18,7 +18,7 @@
  * Mutation-proved: delete that grant row and this suite goes red.
  */
 import { spawn } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { pickFreePort } from "./_free-port.js";
 import { assertScratchHeld, foreignRootFor, killManagerAtRoot, makeScratch } from "../../../bin/smoke/_scratch.js";
@@ -115,6 +115,29 @@ function cotal(args: string[], timeoutMs = 120_000): Promise<Run> {
   });
 }
 
+/**
+ * `up --detach` returns once the manager PROCESS is spawned, not once it has registered its endpoint
+ * (#379, second mode, measured 2026-09-04: `manager.<spaceKey>.log` is 0 bytes when `up` exits 0 and
+ * carries "service endpoint registered" 5s later). A `ps` launched inside that window is refused with
+ * `failed-precondition: service "manager" has no live registered instances`, which cell 2 below would
+ * read as the shipped operator path being broken. Under `npx tsx` the resolve step delayed every `ps`
+ * launch by about a second and hid the window on every run; the direct tsx launch (#1244) lands inside
+ * it three runs in three. So wait, bounded, for the registration line in the manager's own log under
+ * THIS root, then launch `ps` exactly once. A manager that never registers still reaches `ps`, and the
+ * product's own refusal is then graded with that fact printed beside it rather than in its place.
+ */
+async function awaitManagerRegistered(ms: number): Promise<boolean> {
+  const dir = join(root, ".cotal");
+  const registered = () => readdirSync(dir).some((f) =>
+    /^manager(\..*)?\.log$/.test(f) && /service endpoint registered/.test(readFileSync(join(dir, f), "utf8")));
+  const end = Date.now() + ms;
+  while (Date.now() < end) {
+    if (registered()) return true;
+    await new Promise((r) => setTimeout(r, 150));
+  }
+  return registered();
+}
+
 /** Refuse to grade anything but a self-terminated child with a real exit code: every shape rejected
  *  here would otherwise SATISFY the cells below. */
 function mustHaveRun(r: Run, what: string): void {
@@ -165,13 +188,15 @@ try {
   if (up.status !== 0) { process.exitCode = 1; throw new Error("FIXTURE FAILURE, not a product defect: no mesh came up, so `ps` was never exercised."); }
 
   console.log("\n2) cotal ps --space, under the STATIC credential");
+  const registered = await awaitManagerRegistered(20_000);
+  console.log(`   manager registration ${registered ? "observed" : "NOT observed within 20s"} in ${join(root, ".cotal")} - ps launched once, now`);
   const ps = await cotal(["ps", "--space", SPACE], 20_000);
   console.log(`\n   ===== cotal ps --space ${SPACE} (STATIC) =====`);
   console.log(`   exit status: ${ps.status}`);
   console.log(ps.out.split("\n").map((l) => `   | ${l}`).join("\n"));
   console.log(`   ===== end =====\n`);
 
-  check("the OPERATOR `cotal ps` exits 0 (a RED here is a real defect: the shipped operator path is broken)", ps.status === 0, ps.status);
+  check("the OPERATOR `cotal ps` exits 0 (a RED here is a real defect: the shipped operator path is broken)", ps.status === 0, { status: ps.status, managerRegistered: registered });
   console.log(ps.status === 0
     ? "   => the operator path works."
     : "   => OPERATOR PATH BROKEN. The mesh came up (checked above), so this is the product, not the fixture.\n" +

--- a/implementations/auth/smoke/ps-operator-path.smoke.ts
+++ b/implementations/auth/smoke/ps-operator-path.smoke.ts
@@ -23,6 +23,7 @@ import { join } from "node:path";
 import { pickFreePort } from "./_free-port.js";
 import { assertScratchHeld, foreignRootFor, killManagerAtRoot, makeScratch } from "../../../bin/smoke/_scratch.js";
 import { assertSmokeSandboxDown, recordSmokeSandbox, type SmokeSandboxAnchor } from "@cotal-ai/smoke-kit";
+const TSX = join(import.meta.dirname, "..", "..", "..", "node_modules", ".bin", "tsx");
 
 // Same temp-root sandbox as the user-mode sibling, and for the same reason: `findCotalRoot` walks to
 // `/` unbounded, so a `.cotal` above `tmpdir()` sends this fixture's `manager.pid` into that
@@ -82,7 +83,7 @@ function cotal(args: string[], timeoutMs = 120_000): Promise<Run> {
   return new Promise((res) => {
     const options = { cwd: root, env: { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: configDir }, stdio: ["ignore", "pipe", "pipe"] as const };
     assertSmokeSandboxDown(sandbox, args, options);
-    const child = spawn("npx", ["tsx", BIN, ...args], options);
+    const child = spawn(TSX, [BIN, ...args], options);
     let out = "";
     let timedOut = false;
     let settled = false;

--- a/implementations/auth/smoke/user-auth-launch.smoke.ts
+++ b/implementations/auth/smoke/user-auth-launch.smoke.ts
@@ -37,6 +37,7 @@ import { deviceAuthorization } from "better-auth/plugins/device-authorization";
 import { bearer } from "better-auth/plugins/bearer";
 import { toNodeHandler } from "better-auth/node";
 import { pickFreePort } from "./_free-port.js";
+const TSX = join(import.meta.dirname, "..", "..", "..", "node_modules", ".bin", "tsx");
 
 const home = mkdtempSync(join(tmpdir(), "cotal-ua-home-"));
 const configDir = join(home, "xdg");
@@ -87,7 +88,7 @@ function cotal(args: string[], opts: { cwd?: string; timeoutMs?: number } = {}):
       env: childEnv,
     };
     assertSmokeSandboxDown(sandbox, args, options);
-    const child = spawn("npx", ["tsx", BIN, ...args], options);
+    const child = spawn(TSX, [BIN, ...args], options);
     let out = "";
     child.stdout.on("data", (d: Buffer) => { out += d.toString(); });
     child.stderr.on("data", (d: Buffer) => { out += d.toString(); });

--- a/implementations/manager/smoke/_probe-attach-reconnect.ts
+++ b/implementations/manager/smoke/_probe-attach-reconnect.ts
@@ -36,6 +36,7 @@ import {
 import { authDir, saveSpaceAuth } from "@cotal-ai/workspace";
 import { Manager } from "../src/manager.js";
 import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+const TSX = join(import.meta.dirname, "..", "..", "..", "node_modules", ".bin", "tsx");
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "../../..");
@@ -156,7 +157,7 @@ try {
   console.log(`seat ${SEAT} is running on the manager\n`);
 
   // The attach client, under a real pty, pointed at the PROXY.
-  child = pty.spawn("npx", ["tsx", BIN, "attach", "--name", SEAT, "--space", space, "--server", PROXY], {
+  child = pty.spawn(TSX, [BIN, "attach", "--name", SEAT, "--space", space, "--server", PROXY], {
     name: "xterm-256color", cols: 100, rows: 30, cwd: root,
     env: { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME, COTAL_SPACE: "", COTAL_SERVERS: "", COTAL_CREDS: "" } as Record<string, string>,
   });

--- a/implementations/manager/smoke/_probe-cellj-timing.ts
+++ b/implementations/manager/smoke/_probe-cellj-timing.ts
@@ -56,6 +56,7 @@ import {
 import { authDir, saveSpaceAuth } from "@cotal-ai/workspace";
 import { Manager } from "../src/manager.js";
 import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+const TSX = join(import.meta.dirname, "..", "..", "..", "node_modules", ".bin", "tsx");
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "../../..");
@@ -169,7 +170,7 @@ type Attached = {
   kill: () => void;
 };
 function attachUnderPty(root: string, seat: string): Attached {
-  const child = pty.spawn("npx", ["tsx", BIN, "attach", "--name", seat, "--space", space, "--server", PROXY], {
+  const child = pty.spawn(TSX, [BIN, "attach", "--name", seat, "--space", space, "--server", PROXY], {
     name: "xterm-256color", cols: 100, rows: 30, cwd: root,
     env: { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME, COTAL_SPACE: "", COTAL_SERVERS: "", COTAL_CREDS: "" } as Record<string, string>,
   });

--- a/implementations/manager/smoke/_probe-late-delivery.ts
+++ b/implementations/manager/smoke/_probe-late-delivery.ts
@@ -29,6 +29,7 @@ import { authDir, saveSpaceAuth } from "@cotal-ai/workspace";
 import { Manager } from "../src/manager.js";
 import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 import { spawn } from "node:child_process";
+const TSX = join(import.meta.dirname, "..", "..", "..", "node_modules", ".bin", "tsx");
 
 // A run started from a session that is itself joined to a mesh inherits `COTAL_*`, and every child
 // spawned below is `cotal attach`, which READS connection material. Blanking three names by hand
@@ -152,7 +153,7 @@ try {
   if (!s.ok) throw new Error(`seat did not start: ${JSON.stringify(s)}`);
 
   let buf = "";
-  child = pty.spawn("npx", ["tsx", BIN, "attach", "--name", SEAT, "--space", space, "--server", PROXY], {
+  child = pty.spawn(TSX, [BIN, "attach", "--name", SEAT, "--space", space, "--server", PROXY], {
     name: "xterm-256color", cols: 100, rows: 30, cwd: root,
     env: { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME } as Record<string, string>,
   });

--- a/implementations/manager/smoke/_probe-live-socket-gap.ts
+++ b/implementations/manager/smoke/_probe-live-socket-gap.ts
@@ -39,6 +39,7 @@ import {
 import { authDir, saveSpaceAuth } from "@cotal-ai/workspace";
 import { Manager } from "../src/manager.js";
 import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+const TSX = join(import.meta.dirname, "..", "..", "..", "node_modules", ".bin", "tsx");
 
 // A run started from a session that is itself joined to a mesh inherits `COTAL_*`, and every child
 // spawned below is `cotal attach`, which READS connection material. Blanking three names by hand
@@ -192,7 +193,7 @@ type Attached = {
 };
 const started: Attached[] = [];
 function attachUnderPty(root: string): Attached {
-  const child = pty.spawn("npx", ["tsx", BIN, "attach", "--name", SEAT, "--space", space, "--server", PROXY], {
+  const child = pty.spawn(TSX, [BIN, "attach", "--name", SEAT, "--space", space, "--server", PROXY], {
     name: "xterm-256color", cols: 100, rows: 30, cwd: root,
     env: { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME } as Record<string, string>,
   });
@@ -227,7 +228,7 @@ function attachUnderPty(root: string): Attached {
 type Piped = { seen: () => string; write: (s: string) => void; exit: () => number | undefined; waitExit: (ms: number) => Promise<boolean>; kill: () => void };
 const pipedChildren: Piped[] = [];
 function attachPiped(root: string): Piped {
-  const child = spawn("npx", ["tsx", BIN, "attach", "--name", SEAT, "--space", space, "--server", PROXY], {
+  const child = spawn(TSX, [BIN, "attach", "--name", SEAT, "--space", space, "--server", PROXY], {
     cwd: root,
     env: { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME },
     stdio: ["pipe", "pipe", "pipe"],

--- a/implementations/manager/smoke/_probe-missed-handoff.ts
+++ b/implementations/manager/smoke/_probe-missed-handoff.ts
@@ -18,6 +18,7 @@ import { authDir, saveSpaceAuth } from "@cotal-ai/workspace";
 import { Manager } from "../src/manager.js";
 import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 import { spawn } from "node:child_process";
+const TSX = join(import.meta.dirname, "..", "..", "..", "node_modules", ".bin", "tsx");
 
 // A run started from a session that is itself joined to a mesh inherits `COTAL_*`, and every child
 // spawned below is `cotal attach`, which READS connection material. Blanking three names by hand
@@ -156,7 +157,7 @@ try {
   if (!s.ok) throw new Error(`seat did not start: ${JSON.stringify(s)}`);
 
   let buf = "";
-  child = pty.spawn("npx", ["tsx", BIN, "attach", "--name", SEAT, "--space", space, "--server", PROXY], {
+  child = pty.spawn(TSX, [BIN, "attach", "--name", SEAT, "--space", space, "--server", PROXY], {
     name: "xterm-256color", cols: 100, rows: 30, cwd: root,
     env: { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME } as Record<string, string>,
   });

--- a/implementations/manager/smoke/_probe-pipe-oneshot-exit.ts
+++ b/implementations/manager/smoke/_probe-pipe-oneshot-exit.ts
@@ -30,6 +30,7 @@ import {
 import { authDir, saveSpaceAuth } from "@cotal-ai/workspace";
 import { Manager } from "../src/manager.js";
 import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+const TSX = join(import.meta.dirname, "..", "..", "..", "node_modules", ".bin", "tsx");
 
 // A run started from a session that is itself joined to a mesh inherits `COTAL_*`, and every child
 // spawned below is `cotal attach`, which READS connection material. Blanking three names by hand
@@ -129,7 +130,7 @@ try {
 
   const n = `N${randomUUID().slice(0, 8).toUpperCase()}`;
   const mark = sink().length;
-  child = spawn("npx", ["tsx", BIN, "attach", "--name", SEAT, "--space", space, "--server", BROKER, "--no-reconnect"], {
+  child = spawn(TSX, [BIN, "attach", "--name", SEAT, "--space", space, "--server", BROKER, "--no-reconnect"], {
     cwd: root,
     env: { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME },
     stdio: ["pipe", "pipe", "pipe"],

--- a/implementations/manager/smoke/_probe-session-leak.ts
+++ b/implementations/manager/smoke/_probe-session-leak.ts
@@ -32,6 +32,7 @@ import {
 import { authDir, saveSpaceAuth } from "@cotal-ai/workspace";
 import { Manager } from "../src/manager.js";
 import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+const TSX = join(import.meta.dirname, "..", "..", "..", "node_modules", ".bin", "tsx");
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "../../..");
@@ -154,8 +155,8 @@ try {
     if (!started.ok) throw new Error(`seat did not start: ${JSON.stringify(started)}`);
 
     const before = liveSessions();
-    const args = ["tsx", BIN, "attach", "--name", arm.seat, "--space", space, "--server", PROXY, ...(arm.reconnect ? [] : ["--no-reconnect"])];
-    const child = pty.spawn("npx", args, {
+    const args = [BIN, "attach", "--name", arm.seat, "--space", space, "--server", PROXY, ...(arm.reconnect ? [] : ["--no-reconnect"])];
+    const child = pty.spawn(TSX, args, {
       name: "xterm-256color", cols: 100, rows: 30, cwd: root,
       env: { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME, COTAL_SPACE: "", COTAL_SERVERS: "", COTAL_CREDS: "" } as Record<string, string>,
     });

--- a/implementations/manager/smoke/_probe-stdin-window.ts
+++ b/implementations/manager/smoke/_probe-stdin-window.ts
@@ -45,6 +45,7 @@ import {
 import { authDir, saveSpaceAuth } from "@cotal-ai/workspace";
 import { Manager } from "../src/manager.js";
 import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+const TSX = join(import.meta.dirname, "..", "..", "..", "node_modules", ".bin", "tsx");
 
 // A run started from a session that is itself joined to a mesh inherits `COTAL_*`, and every child
 // spawned below is `cotal attach`, which READS connection material. Blanking three names by hand
@@ -169,7 +170,7 @@ type Attached = {
   kill: () => void;
 };
 function attachUnderPty(root: string, seat: string): Attached {
-  const child = pty.spawn("npx", ["tsx", BIN, "attach", "--name", seat, "--space", space, "--server", PROXY], {
+  const child = pty.spawn(TSX, [BIN, "attach", "--name", seat, "--space", space, "--server", PROXY], {
     name: "xterm-256color", cols: 100, rows: 30, cwd: root,
     env: { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME } as Record<string, string>,
   });

--- a/implementations/manager/smoke/attach-reconnect.smoke.ts
+++ b/implementations/manager/smoke/attach-reconnect.smoke.ts
@@ -74,6 +74,7 @@ import { attachRefusal, heldSessionNotice, reconnectNotice } from "../../cli/src
 import { isTransportEnd } from "../../cli/src/lib/attach-client.js"; // dev-only cross-impl smoke import
 import { Manager } from "../src/manager.js";
 import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+const TSX = join(import.meta.dirname, "..", "..", "..", "node_modules", ".bin", "tsx");
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "../../..");
@@ -232,7 +233,7 @@ type Attached = {
   kill: () => void;
 };
 function attachUnderPty(root: string, extra: string[] = [], seat: string = SEAT): Attached {
-  const child = pty.spawn("npx", ["tsx", BIN, "attach", "--name", seat, "--space", space, "--server", PROXY, ...extra], {
+  const child = pty.spawn(TSX, [BIN, "attach", "--name", seat, "--space", space, "--server", PROXY, ...extra], {
     name: "xterm-256color", cols: 100, rows: 30, cwd: root,
     env: { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME, COTAL_SPACE: "", COTAL_SERVERS: "", COTAL_CREDS: "" } as Record<string, string>,
   });
@@ -262,7 +263,7 @@ function attachUnderPty(root: string, extra: string[] = [], seat: string = SEAT)
 /** A plain (non-terminal) `cotal` run, for the control-plane commands this suite drives itself. */
 const cotal = (args: string[], cwd: string, timeoutMs = 90_000): Promise<{ status: number | null; out: string }> =>
   new Promise((res) => {
-    const child = spawn("npx", ["tsx", BIN, ...args], {
+    const child = spawn(TSX, [BIN, ...args], {
       cwd, env: { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME, COTAL_SPACE: "", COTAL_SERVERS: "", COTAL_CREDS: "" },
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/implementations/manager/smoke/attach-stdin.smoke.ts
+++ b/implementations/manager/smoke/attach-stdin.smoke.ts
@@ -104,6 +104,7 @@ import {
 import { authDir, saveSpaceAuth } from "@cotal-ai/workspace";
 import { Manager } from "../src/manager.js";
 import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+const TSX = join(import.meta.dirname, "..", "..", "..", "node_modules", ".bin", "tsx");
 
 // A run started from a session that is itself joined to a mesh inherits `COTAL_*`, and every child
 // spawned below is `cotal attach`, which READS connection material. Blanking three names by hand
@@ -358,7 +359,7 @@ type Attached = {
 };
 const started: Attached[] = [];
 function attachUnderPty(root: string): Attached {
-  const child = pty.spawn("npx", ["tsx", BIN, "attach", "--name", SEAT, "--space", space, "--server", PROXY], {
+  const child = pty.spawn(TSX, [BIN, "attach", "--name", SEAT, "--space", space, "--server", PROXY], {
     name: "xterm-256color", cols: 100, rows: 30, cwd: root,
     env: { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME } as Record<string, string>,
   });
@@ -393,7 +394,7 @@ function attachUnderPty(root: string): Attached {
 type Piped = { seen: () => string; write: (s: string) => void; exit: () => number | undefined; waitFor: (re: RegExp, ms: number) => Promise<boolean>; waitExit: (ms: number) => Promise<boolean>; kill: () => void };
 const pipedChildren: Piped[] = [];
 function attachPiped(root: string, extra: readonly string[] = []): Piped {
-  const child = spawn("npx", ["tsx", BIN, "attach", "--name", SEAT, "--space", space, "--server", PROXY, ...extra], {
+  const child = spawn(TSX, [BIN, "attach", "--name", SEAT, "--space", space, "--server", PROXY, ...extra], {
     cwd: root,
     env: { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME },
     stdio: ["pipe", "pipe", "pipe"],
@@ -432,7 +433,7 @@ function attachFromFile(root: string, contents: string, extra: readonly string[]
   const path = join(dir, `stdin-${randomUUID().slice(0, 8)}.txt`);
   writeFileSync(path, contents);
   const fd = openSync(path, "r");
-  const child = spawn("npx", ["tsx", BIN, "attach", "--name", SEAT, "--space", space, "--server", PROXY, ...extra], {
+  const child = spawn(TSX, [BIN, "attach", "--name", SEAT, "--space", space, "--server", PROXY, ...extra], {
     cwd: root,
     env: { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME },
     stdio: [fd, "pipe", "pipe"],

--- a/implementations/manager/smoke/cli-on-instance-live.smoke.ts
+++ b/implementations/manager/smoke/cli-on-instance-live.smoke.ts
@@ -70,6 +70,7 @@ import {
 import { authDir, saveSpaceAuth, recordMesh } from "@cotal-ai/workspace";
 import { Manager } from "../src/manager.js";
 import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+const TSX = join(import.meta.dirname, "..", "..", "..", "node_modules", ".bin", "tsx");
 
 const freePort = (): Promise<number> =>
   new Promise((res, rej) => {
@@ -122,7 +123,7 @@ const BIN = join(import.meta.dirname, "..", "..", "..", "bin", "cotal.ts");
 type Run = { status: number | null; out: string; timedOut: boolean; signal: NodeJS.Signals | null; launchError?: string };
 function cotal(args: string[], cwd: string, timeoutMs = 90_000): Promise<Run> {
   return new Promise((res) => {
-    const child = spawn("npx", ["tsx", BIN, ...args], {
+    const child = spawn(TSX, [BIN, ...args], {
       cwd, env: { ...process.env, COTAL_HOME: home }, stdio: ["ignore", "pipe", "pipe"],
     });
     let out = "", timedOut = false, settled = false;

--- a/implementations/manager/smoke/cli-seat-locality.smoke.ts
+++ b/implementations/manager/smoke/cli-seat-locality.smoke.ts
@@ -39,6 +39,7 @@ import {
 import { authDir, saveSpaceAuth } from "@cotal-ai/workspace";
 import { Manager } from "../src/manager.js";
 import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+const TSX = join(import.meta.dirname, "..", "..", "..", "node_modules", ".bin", "tsx");
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "../../..");
@@ -97,7 +98,7 @@ const releaseBroker = teardownOnSignal(srv, dir);
 type Run = { status: number | null; out: string };
 const cotal = (args: string[], cwd: string, timeoutMs = 90_000): Promise<Run> =>
   new Promise((res) => {
-    const child = spawn("npx", ["tsx", BIN, ...args], {
+    const child = spawn(TSX, [BIN, ...args], {
       cwd, env: { ...process.env, COTAL_HOME: home, COTAL_SPACE: "", COTAL_SERVERS: "", COTAL_CREDS: "" },
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -111,7 +112,7 @@ const cotal = (args: string[], cwd: string, timeoutMs = 90_000): Promise<Run> =>
 
 const interactiveJoin = (cwd: string): Promise<Run> =>
   new Promise((res) => {
-    const child = pty.spawn("npx", ["tsx", BIN, "join", "--space", space, "--server", SERVERS], {
+    const child = pty.spawn(TSX, [BIN, "join", "--space", space, "--server", SERVERS], {
       cwd,
       env: { ...process.env, COTAL_HOME: home, COTAL_SPACE: "", COTAL_SERVERS: "", COTAL_CREDS: "" },
       cols: 120,

--- a/implementations/manager/smoke/gate-reconcile-cli-e2e.smoke.ts
+++ b/implementations/manager/smoke/gate-reconcile-cli-e2e.smoke.ts
@@ -42,6 +42,7 @@ import { putSpaceAuth, saveManagerInstanceIdentity, workspaceSecretStore } from 
 import { executePrincipalLiveness } from "../../delivery/src/evict-exec.js";
 import { pickFreePort } from "../../../packages/core/smoke/_free-port.js";
 import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+const TSX = join(import.meta.dirname, "..", "..", "..", "node_modules", ".bin", "tsx");
 
 // ---------------------------------------------------------------------------
 // FIRST ACTION: this drives a command that revokes credentials and evicts connections. Refuse the
@@ -220,7 +221,7 @@ try {
     writeFileSync(targetDeliveryCreds, await mintCreds(auth, newIdentity(), "delivery"));
 
     let poisonLog = "";
-    poisonDaemon = spawn("npx", ["tsx", join(REPO, "bin", "cotal.ts"), "deliver", "--space", space, "--server", SERVERS, "--creds", targetDeliveryCreds], {
+    poisonDaemon = spawn(TSX, [join(REPO, "bin", "cotal.ts"), "deliver", "--space", space, "--server", SERVERS, "--creds", targetDeliveryCreds], {
       cwd: FOREIGN_ROOT, stdio: ["ignore", "pipe", "pipe"],
       env: { ...process.env, COTAL_SERVER: "", COTAL_SERVERS: "", COTAL_CREDS: "", NATS_URL: "" },
     });
@@ -234,7 +235,7 @@ try {
     check("POISONED LEASE: account A with account B root exits before holding lease.0",
       poisonExited && poisonLog.includes(auth.account.pub) && poisonLog.includes(foreignAuth.account.pub), poisonLog.slice(-1200));
 
-    daemon = spawn("npx", ["tsx", join(REPO, "bin", "cotal.ts"), "deliver", "--space", space, "--server", SERVERS, "--dev-mint"], {
+    daemon = spawn(TSX, [join(REPO, "bin", "cotal.ts"), "deliver", "--space", space, "--server", SERVERS, "--dev-mint"], {
       cwd: ROOT, stdio: ["ignore", "pipe", "pipe"],
       env: { ...process.env, COTAL_SERVER: "", COTAL_SERVERS: "", COTAL_CREDS: "", NATS_URL: "" },
     });
@@ -247,7 +248,7 @@ try {
     if (!ready) {
       if (poisonDaemon.exitCode === null && poisonDaemon.signalCode === null) { poisonDaemon.kill("SIGKILL"); await awaitExit(poisonDaemon); }
       await wait(35_000);
-      daemon = spawn("npx", ["tsx", join(REPO, "bin", "cotal.ts"), "deliver", "--space", space, "--server", SERVERS, "--dev-mint"], {
+      daemon = spawn(TSX, [join(REPO, "bin", "cotal.ts"), "deliver", "--space", space, "--server", SERVERS, "--dev-mint"], {
         cwd: ROOT, stdio: ["ignore", "pipe", "pipe"],
         env: { ...process.env, COTAL_SERVER: "", COTAL_SERVERS: "", COTAL_CREDS: "", NATS_URL: "" },
       });

--- a/implementations/manager/smoke/gate-reconcile-cli-e2e.smoke.ts
+++ b/implementations/manager/smoke/gate-reconcile-cli-e2e.smoke.ts
@@ -121,7 +121,7 @@ const execConns: NatsConnection[] = [];
 
 /** Drive the REAL command, from the seeded root, and hand back what an operator would see. */
 const runCli = (args: string[]): { code: number | null; out: string; err: string } => {
-  const r = spawnSync("npx", ["tsx", join(REPO, "bin", "cotal.ts"), ...args], {
+  const r = spawnSync(TSX, [join(REPO, "bin", "cotal.ts"), ...args], {
     cwd: ROOT, encoding: "utf8", timeout: 120_000,
     // Scrubbed: a live ambient broker/creds must never reach a command this smoke drives.
     env: { ...process.env, COTAL_SERVER: "", COTAL_SERVERS: "", COTAL_CREDS: "", NATS_URL: "" },

--- a/implementations/manager/smoke/seat-input-live.smoke.ts
+++ b/implementations/manager/smoke/seat-input-live.smoke.ts
@@ -67,6 +67,7 @@ import { authDir, saveSpaceAuth, recordMesh } from "@cotal-ai/workspace";
 import { Manager } from "../src/manager.js";
 import { MANAGER_ENDPOINT, MANAGER_CONTRACTS } from "../src/manager-service-contract.js";
 import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+const TSX = join(import.meta.dirname, "..", "..", "..", "node_modules", ".bin", "tsx");
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "../../..");
@@ -219,7 +220,7 @@ async function instrument(caps: Array<{ command: string; owner?: true }>): Promi
 type Run = { status: number | null; out: string; timedOut: boolean; signal: NodeJS.Signals | null; launchError?: string };
 function cotal(args: string[], timeoutMs = 120_000): Promise<Run> {
   return new Promise((res) => {
-    const child = spawn("npx", ["tsx", BIN, ...args], {
+    const child = spawn(TSX, [BIN, ...args], {
       cwd: workspaceRoot, env: { ...process.env, COTAL_HOME: home }, stdio: ["ignore", "pipe", "pipe"],
     });
     let out = "", timedOut = false, settled = false;

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "smoke:codex-host": "tsx extensions/connector-codex/smoke/codex-host.smoke.ts",
     "smoke:codex-dist": "tsx extensions/connector-codex/smoke/codex-dist.smoke.ts",
     "smoke:tree-hygiene": "tsx bin/smoke/tree-hygiene.smoke.ts",
+    "smoke:no-npx-tsx": "tsx bin/smoke/no-npx-tsx.smoke.ts",
     "smoke:web-harness": "tsx implementations/web/smoke/harness.smoke.ts",
     "smoke:web-parts": "tsx implementations/web/smoke/parts-non-silence.smoke.ts",
     "smoke:web-channel-authority": "tsx implementations/web/smoke/channel-authority.smoke.ts",

--- a/packages/core/smoke/presence-ttl-refresh-cli.smoke.ts
+++ b/packages/core/smoke/presence-ttl-refresh-cli.smoke.ts
@@ -32,6 +32,7 @@ import { pickFreePort } from "./_free-port.js";
 import { assertEphemeralBroker, scrubAmbientBrokerEnv } from "./_ephemeral-only.js";
 import { foreignRootFor, killManagerAtRoot, makeScratch } from "../../../bin/smoke/_scratch.js";
 import { assertSmokeSandboxDown, recordSmokeSandbox, type SmokeSandboxAnchor } from "@cotal-ai/smoke-kit";
+const TSX = join(import.meta.dirname, "..", "..", "..", "node_modules", ".bin", "tsx");
 
 // FENCE LAYER 4, FIRST STATEMENT OF THE SUITE. This operator environment carries the LIVE broker in
 // COTAL_SERVERS (and live COTAL_CREDS / COTAL_SPACE). This suite spawns the real `cotal` binary,
@@ -74,7 +75,7 @@ function cotal(args: string[], timeoutMs = 120_000): Promise<Run> {
   return new Promise((res) => {
     const options = { cwd: root, env: { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: configDir }, stdio: ["ignore", "pipe", "pipe"] as const };
     assertSmokeSandboxDown(sandbox, args, options);
-    const child = spawn("npx", ["tsx", BIN, ...args], options);
+    const child = spawn(TSX, [BIN, ...args], options);
     let out = "", timedOut = false, settled = false, exited = false;
     let status: number | null = null, signal: NodeJS.Signals | null = null, drain: NodeJS.Timeout | undefined;
     const done = (r: Run) => { if (settled) return; settled = true; clearTimeout(cmd); clearTimeout(drain); res(r); };


### PR DESCRIPTION
Fixes #1244.

## What was wrong

Eighteen smoke suites spawned the CLI as `spawn("npx", ["tsx", BIN, ...args])` with `cwd` set to a
scratch directory outside the repo. `npm exec` resolves a package from cwd upward and never from PATH,
so from there it misses the workspace `tsx` and falls back to whatever the npx cache holds or, on a
cold CI runner, a registry install of `tsx@latest`. The install prints

```
npm warn exec The following package was not found and will be installed: tsx@4.23.13
```

to stderr, which the fixtures merge into the output they parse. `ps` assertions then read a warning
where they expect a roster row. That reddened shards 2 and 3 on main at `7f3a8a03` with identical
warn counts across two attempts (3/3 and 2/2), on a tree byte-identical to the green run before it:
`git diff --name-only 917eb61a 7f3a8a03` contains zero smoke files and zero `.github` files, and
`pnpm install --frozen-lockfile` in the red log reads `resolved 438, reused 438, downloaded 0`.

## What this changes

One commit, 23 files, +127/-27, merges clean onto `main`.

- All 27 spawn sites across the 18 files use the form 36 sibling suites already used:
  `const TSX = join(import.meta.dirname, "..", "..", "..", "node_modules", ".bin", "tsx")` and
  `spawn(TSX, [BIN, ...])`. Includes the `pty.spawn` variants. No suite logic changed.
- `bin/smoke/no-npx-tsx.smoke.ts`, a grammar guard. It walks every `.ts` under a `smoke/` directory
  (587 on this tree) and reddens on `spawn("npx", ["tsx"`. Three controls make its zero mean
  something: a planted positive in `bin/smoke/fixtures/no-npx-tsx.planted.txt` that the regex must
  see, a negative that the robust form must not match, and a floor on the walked population so a walk
  over nothing cannot pass for free. Registered as `smoke:no-npx-tsx` with its own `ci-suites.d`
  fragment; `smoke:gate-inventory` is green with it.
- `.changeset/no-npx-tsx-in-smoke.md`, `patch` on `cotal-ai`.

## Measured on the fixed tree

```
smoke:cli-seat-locality          PASS 16/0   (13/3 red on main)      npm warn exec: 0
smoke:presence-ttl-refresh-cli   rc 0                                npm warn exec: 0
smoke:manager-two-root-renewal   rc 0                                npm warn exec: 0
smoke:no-npx-tsx                 4/0
  reverting one converted file   rc 1, names the file
  restoring                      rc 0
pnpm typecheck                   rc 0
smoke:gate-inventory             OK
```

`smoke:ps-operator-path` fails one cell on the build host (`failed-precondition: service "manager"
has no live registered instances`) and fails the **same** cell at unfixed `7f3a8a03` on the same host,
with zero `npm warn` lines either way. That red is pre-existing on that host and not this change's; it
is not claimed fixed and CI is the arbiter for it.

## What this does not fix

The rerun of the red main run split the failure in two. Shards 2 and 3 are the class above and this
PR addresses them. **Shard 1 (`presence-ttl-refresh-cli`, `cotal up` SIGKILLed at the fixture's 120s
budget) shows zero `npm warn exec` lines on both attempts**, and `npm exec` prints that line before
it fetches, so no install was attempted there and this change does not touch its cause. It is a
separate defect; the seed-store materialization correlation is on the issue. If shard 1 is still red
after this lands, that is expected and is not this fix failing.

## Review

Needs an exact-head independent review from a seat outside the author's model family before merge,
per the standing gate. Verdicts will be published on this PR before anything moves.
