### PR TITLE
fix(manager): schedule credential renewal so a tick lands in [renewAt, exp) for any TTL (#457)

### DIFF
--- a/.changeset/fix-457-cred-renewal-schedule.md
+++ b/.changeset/fix-457-cred-renewal-schedule.md
@@ -1,0 +1,22 @@
+---
+"@cotal-ai/manager": patch
+---
+
+fix(manager): schedule credential renewal so a tick lands inside `[renewAt, exp)` for any TTL
+
+The manager scheduled `renewDaemonCreds` every `STANDING_RENEWABLE_TTL_SEC / 2`, so on a 24h
+credential the ticks landed at 12h (`healthy`, no-op) and 24h (`expired`, session already
+refused). `inspectCredHealth` enters `near-expiry` at 75% of iat-to-exp lifetime, so the renewal
+window is only TTL/4 wide, and an interval of TTL/2 can miss it entirely for any TTL. The
+manager's own daemon credential died on that ~24h cadence, as reported at 0.37.0.
+
+The interval is now `credRenewIntervalMs(ttlSeconds) = max(1ms, TTL/4·1000)`, derived from the
+caller's TTL. Ticks TTL/4 apart guarantee at least one lands in every `[renewAt, exp)` window
+regardless of TTL, so both the 24h `STANDING_RENEWABLE_TTL_SEC` and the 30-day
+`ROTATION_RENEWED_TTL_SEC` are covered without a hardcoded number. The renewal pass is unchanged
+and idempotent, so a tick that fires before the window costs one health check per owner. Both
+scheduling sites (initial start and preservation abort) are updated together.
+
+Covered by `smoke:manager-renewal-boundary`, a real-broker cell that drives the compressed-ratio
+(TTL=20s) boundary and asserts the schedule reissues inside the window, with an in-probe mutant
+that reverts to TTL/2 to prove the cell reddens when the fix is reverted.

--- a/bin/smoke/ci-suites.d/7c42cc1df879888895f423d25d74384150b1051b2cf2e851b49b1c8d66296b24.txt
+++ b/bin/smoke/ci-suites.d/7c42cc1df879888895f423d25d74384150b1051b2cf2e851b49b1c8d66296b24.txt
@@ -1,0 +1,4 @@
+# Cotal #457: manager credential-renewal schedule must land inside `[renewAt, exp)`. Compressed
+# ratio TTL=20s so the whole boundary fits in ~30s of wall time. See the suite header for the
+# mutant-in-probe scheme.
+smoke:manager-renewal-boundary

--- a/implementations/manager/smoke/_probe-457-renewal-boundary.ts
+++ b/implementations/manager/smoke/_probe-457-renewal-boundary.ts
@@ -1,0 +1,151 @@
+/**
+ * Boundary probe for Cotal #457.
+ *
+ * Reproduces the triage seat's compressed-ratio probe on a real broker: TTL 20s (production
+ * 86400s / 4320x compression), interval driven by the manager's own scheduler.
+ *
+ * At the parent commit the manager schedules every TTL/2. On a TTL=20s cred, ticks land at
+ * t=10s (`healthy`, no-op) and t=20s (`expired`, session already refused), so no tick ever sees
+ * `near-expiry` and renewal never fires while the credential could still be renewed. The
+ * connection is refused at expiry: `BOUNDARY_RESULT=FAILED`.
+ *
+ * At head the manager schedules every TTL/4 via {@link credRenewIntervalMs}. On the same TTL=20s
+ * cred, ticks land at t=5s, 10s, 15s, 20s; the t=15s tick sees `near-expiry` and reissues, so the
+ * refreshed cred is on disk before the broker kicks the session at t=20s. The connection recovers
+ * on its reconnect: `BOUNDARY_RESULT=SURVIVED`.
+ *
+ * The verdict combines TWO signals to be deterministic under real broker + real reconnect timing:
+ *   - `nearExpiryObserved`: some tick's `stateBefore` was `near-expiry`, so a renewal was actually
+ *     issued inside `[renewAt, exp)`. This is the direct schedule signal and cannot be flakey.
+ *   - `connectionAlive`: the session is not closed and can publish after expiry. This is the
+ *     downstream effect the field report described.
+ * Both must hold to SURVIVE. The first alone already discriminates the fix from the parent, but
+ * gating on the second too keeps this cell honest about the outcome the user sees.
+ *
+ * Positive control: `--control` invokes the same renewal pass ONCE inside the near-expiry window
+ * (at ~t=16s), proving the renewal operation itself works so any failure elsewhere is scheduling.
+ * Mutant control: `--mutant` reverts the schedule to the buggy TTL/2 in-probe; the cell asserts
+ * this reddens the boundary. The mutant is in-probe so a green cell requires the SHIPPED helper
+ * to still be correct AND the mutant path to still fail.
+ *
+ * Emits `PROBE_CONFIG`, `TIMER_TICK`, `POST_EXPIRY`, and one line `BOUNDARY_RESULT=<verdict>`,
+ * exits with a matching rc. Uses only real primitives: a real nats-server, a real signed JWT,
+ * a real client connection whose authenticator presents the CURRENT credential on reconnect.
+ *
+ * Run: pnpm tsx implementations/manager/smoke/_probe-457-renewal-boundary.ts [--control|--mutant]
+ */
+import { connect, credsAuthenticator, type NatsConnection } from "@nats-io/transport-node";
+import {
+  createSpaceAuth, mintCreds, newIdentity, inspectCredHealth, mintLifecycleUid,
+} from "@cotal-ai/core";
+import { credRenewIntervalMs } from "../src/manager.js";
+import { bootBroker } from "./_boot-broker.js";
+
+const TTL_SEC = 20;
+
+async function main(): Promise<void> {
+  const control = process.argv.includes("--control");
+  const mutant = process.argv.includes("--mutant");
+  // The manager's own scheduler drives this probe. `--mutant` bypasses it and hardcodes TTL/2 so
+  // the cell can prove a red-when-broken chain without touching the file the fix lives in.
+  const intervalMs = mutant ? (TTL_SEC / 2) * 1000 : credRenewIntervalMs(TTL_SEC);
+
+  const auth = await createSpaceAuth("prb457");
+  const broker = await bootBroker(auth);
+  const identity = newIdentity();
+  const lifecycleUid = mintLifecycleUid();
+
+  const mint = () => mintCreds(auth, identity, "agent", {
+    allowSubscribe: ["prb457"],
+    allowPublish: ["prb457"],
+    lifecycleUid,
+    expiresInSeconds: TTL_SEC,
+  });
+
+  // Cred state: one shared object so the connection authenticator always presents the CURRENT
+  // credential on (re)connect, mirroring the manager's serve authenticator shape.
+  const state: { creds: string } = { creds: await mint() };
+
+  const enc = new TextEncoder();
+  const nc: NatsConnection = await connect({
+    servers: broker.servers,
+    authenticator: (nonce?: string) => credsAuthenticator(enc.encode(state.creds))(nonce),
+    maxReconnectAttempts: -1, reconnectTimeWait: 200, waitOnFirstConnect: true,
+  });
+
+  const status = { closed: false, error: undefined as string | undefined };
+  void (async () => {
+    for await (const s of nc.status()) {
+      if (s.type === "disconnect" || s.type === "error") status.error = String((s as { data?: unknown }).data ?? s.type);
+    }
+  })();
+  nc.closed().then((err) => { status.closed = true; if (err) status.error = err.message; }).catch(() => {});
+
+  let nearExpiryObserved = false;
+  const renew = async () => {
+    const health = inspectCredHealth(state.creds);
+    if (health.state === "healthy") return { changed: false, health };
+    if (health.state === "near-expiry") nearExpiryObserved = true;
+    state.creds = await mint();
+    return { changed: true, health };
+  };
+
+  console.log(`PROBE_CONFIG {"ttlSeconds":${TTL_SEC},"intervalMs":${intervalMs},"mode":"${control ? "control" : mutant ? "mutant" : "scheduled"}"}`);
+
+  const start = Date.now();
+  let timer: ReturnType<typeof setInterval> | undefined;
+  if (!control) {
+    timer = setInterval(async () => {
+      try {
+        const r = await renew();
+        const t = Math.floor((Date.now() - start) / 1000);
+        console.log(`TIMER_TICK {"t":${t},"changed":${r.changed},"stateBefore":"${r.health.state}"}`);
+      } catch (e) {
+        console.log(`TIMER_TICK_ERR {"error":${JSON.stringify((e as Error).message)}}`);
+      }
+    }, intervalMs);
+    timer.unref?.();
+  } else {
+    // Positive control: at t ~= 16s (inside near-expiry, before expired), invoke the SAME
+    // renewal pass exactly once. Success proves the operation, so any failure elsewhere is scheduling.
+    setTimeout(async () => {
+      const r = await renew();
+      const t = Math.floor((Date.now() - start) / 1000);
+      console.log(`CONTROL_RENEW {"t":${t},"changed":${r.changed},"stateBefore":"${r.health.state}"}`);
+    }, 16_000).unref?.();
+  }
+
+  // Sample connection status just after nominal expiry.
+  await new Promise((r) => setTimeout(r, 24_000));
+
+  // A publish reveals whether the connection actually still carries a valid session.
+  let publishOk = true;
+  let publishErr: string | undefined;
+  try {
+    nc.publish("prb457.ping", new Uint8Array());
+    await nc.flush();
+  } catch (e) {
+    publishOk = false;
+    publishErr = (e as Error).message;
+  }
+
+  const post = { closed: status.closed, error: status.error, publishOk, publishErr, nearExpiryObserved };
+  console.log(`POST_EXPIRY ${JSON.stringify(post)}`);
+
+  // The verdict: a renewal must have fired inside `[renewAt, exp)` AND the connection must have
+  // survived past expiry. Both signals are needed to distinguish scheduling from reconnect luck.
+  const connectionAlive = !status.closed && publishOk;
+  const survived = nearExpiryObserved && connectionAlive;
+  console.log(`BOUNDARY_RESULT=${survived ? "SURVIVED" : "FAILED"}`);
+
+  if (timer) clearInterval(timer);
+  try { await nc.drain(); } catch { /* connection may be dead */ }
+  try { nc.close(); } catch { /* already closed */ }
+  await broker.stop();
+  process.exit(survived ? 0 : 3);
+}
+
+main().catch((e) => {
+  console.error(`PROBE_FATAL ${(e as Error).message}`);
+  process.exit(2);
+});

--- a/implementations/manager/smoke/manager-renewal-boundary.smoke.ts
+++ b/implementations/manager/smoke/manager-renewal-boundary.smoke.ts
@@ -1,0 +1,79 @@
+/**
+ * Cotal #457: the manager credential-renewal schedule lands inside `[renewAt, exp)`.
+ *
+ * At the parent commit the manager schedules `renewDaemonCreds` every TTL/2, so on a 24h
+ * credential the ticks land at 12h (`healthy`, no-op) and 24h (`expired`, already refused),
+ * missing the 75% -> 100% renewal window entirely and letting the connection be refused at
+ * expiry. `inspectCredHealth` (packages/core/src/provision.ts) enters `near-expiry` at 75% of
+ * iat-to-exp lifetime, so the window width is TTL/4 and any interval greater than TTL/4 can miss
+ * it for the right phase.
+ *
+ * WHAT THIS CELL GRADES, against a REAL JWT broker + a REAL signed credential (never the live
+ * mesh on :4222):
+ *   1. FIX APPLIED: with `credRenewIntervalMs(TTL)` driving the schedule, one tick lands inside
+ *      `[renewAt, exp)`, the credential is reminted, and the connection survives past nominal
+ *      expiry. `BOUNDARY_RESULT=SURVIVED`.
+ *   2. MUTANT: reverting the interval to TTL/2 in the probe (bypassing the fixed helper) reddens
+ *      this cell with `BOUNDARY_RESULT=FAILED`. Proves the cell tests the schedule, not something
+ *      adjacent. The mutant lives in the probe, not on disk, so a green cell requires the SHIPPED
+ *      helper to still be correct AND the mutant path to still fail.
+ *
+ * COTAL_HOME is scrubbed; the probe boots its own broker on an OS-assigned free loopback port
+ * and kills only that process, per {@link bootBroker}. Compressed-ratio: TTL=20s preserves the
+ * production 86400 / TTL/2 = 43200 = 2:1 ratio (24h class) so the whole boundary fits in ~30s.
+ *
+ * Run: pnpm smoke:manager-renewal-boundary
+ */
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PROBE = join(HERE, "_probe-457-renewal-boundary.ts");
+
+interface ProbeResult { rc: number; stdout: string; verdict: "SURVIVED" | "FAILED" | "UNKNOWN"; }
+
+async function runProbe(flag?: "--mutant" | "--control"): Promise<ProbeResult> {
+  return await new Promise((resolve, reject) => {
+    const args = ["tsx", PROBE];
+    if (flag) args.push(flag);
+    const child = spawn("pnpm", args, { stdio: ["ignore", "pipe", "pipe"], env: { ...process.env, TMPDIR: process.env.TMPDIR ?? "/var/tmp" } });
+    let stdout = ""; let stderr = "";
+    child.stdout.on("data", (b) => { stdout += b.toString(); });
+    child.stderr.on("data", (b) => { stderr += b.toString(); });
+    child.on("error", reject);
+    child.on("exit", (rc) => {
+      const line = stdout.split("\n").find((l) => l.startsWith("BOUNDARY_RESULT="));
+      const verdict = line?.endsWith("SURVIVED") ? "SURVIVED" : line?.endsWith("FAILED") ? "FAILED" : "UNKNOWN";
+      if (verdict === "UNKNOWN") console.error(`  probe stderr: ${stderr}`);
+      resolve({ rc: rc ?? -1, stdout, verdict });
+    });
+  });
+}
+
+let pass = 0, fail = 0;
+const check = (name: string, cond: boolean, extra?: unknown) => {
+  if (cond) { pass++; console.log(`  ✓ ${name}`); }
+  else { fail++; console.log(`  ✗ FAIL: ${name}`, extra === undefined ? "" : extra); }
+};
+
+console.log("== #457 renewal-boundary cell ==");
+
+// Cell 1: the shipped schedule survives the boundary.
+console.log("[cell 1/2] schedule under credRenewIntervalMs(TTL): must SURVIVE the boundary");
+const fixed = await runProbe();
+check("BOUNDARY_RESULT=SURVIVED with the shipped schedule", fixed.verdict === "SURVIVED",
+  { rc: fixed.rc, tail: fixed.stdout.split("\n").slice(-6).join(" | ") });
+check("probe exited 0 when the schedule holds", fixed.rc === 0, { rc: fixed.rc });
+
+// Cell 2: the mutant (interval = TTL/2) reddens the same probe. Proves this cell tests the
+// schedule and not e.g. the broker's grace period.
+console.log("[cell 2/2] --mutant reverts interval to TTL/2: must FAIL the boundary");
+const mutant = await runProbe("--mutant");
+check("BOUNDARY_RESULT=FAILED with interval=TTL/2 (the parent's schedule)", mutant.verdict === "FAILED",
+  { rc: mutant.rc, tail: mutant.stdout.split("\n").slice(-6).join(" | ") });
+check("mutant probe exited non-zero when the schedule misses the window", mutant.rc !== 0, { rc: mutant.rc });
+
+console.log(`\n== #457 renewal-boundary: ${pass} pass, ${fail} fail ==`);
+if (fail > 0) process.exit(1);
+process.exit(0);

--- a/implementations/manager/smoke/manager-renewal-boundary.smoke.ts
+++ b/implementations/manager/smoke/manager-renewal-boundary.smoke.ts
@@ -37,7 +37,12 @@ async function runProbe(flag?: "--mutant" | "--control"): Promise<ProbeResult> {
   return await new Promise((resolve, reject) => {
     const args = ["tsx", PROBE];
     if (flag) args.push(flag);
-    const child = spawn("pnpm", args, { stdio: ["ignore", "pipe", "pipe"], env: { ...process.env, TMPDIR: process.env.TMPDIR ?? "/var/tmp" } });
+    // The probe boots its own broker and mints its own creds; nothing from an ambient seat may reach it.
+    // suite-ambient-env grades this shape: strip COTAL_ from the copy before the copy is spread.
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    for (const k of Object.keys(env)) if (k.startsWith("COTAL_")) delete env[k];
+    env.TMPDIR = process.env.TMPDIR ?? "/var/tmp";
+    const child = spawn("pnpm", args, { stdio: ["ignore", "pipe", "pipe"], env });
     let stdout = ""; let stderr = "";
     child.stdout.on("data", (b) => { stdout += b.toString(); });
     child.stderr.on("data", (b) => { stderr += b.toString(); });

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -190,6 +190,24 @@ const DELIVERY_ADMIN_RELOAD_TIMEOUT_MS = 15_000;
 /** A hard preservation stop should settle quickly. The manager still waits and reports a partial
  * cut rather than pretending a child is gone. Held in ManagerOptions so fake runtimes can shorten it. */
 const PRESERVE_STOP_TIMEOUT_MS = 10_000;
+/** Pick a `setInterval` period for {@link Manager.renewDaemonCreds} that guarantees at least one
+ * tick lands inside every renewal owner's `[renewAt, exp)` window.
+ *
+ * `inspectCredHealth` marks a credential `near-expiry` at 75% of its iat-to-exp lifetime and
+ * `expired` at 100%, so the window width is TTL/4. Ticks TTL/4 apart therefore land at least once
+ * inside every window; ticks TTL/2 apart (the old schedule) can miss it entirely for any TTL. That
+ * is the cause of Cotal #457, reproduced at both TTL=86400 and TTL=20 (the compressed-ratio probe).
+ *
+ * Deriving from the caller's TTL keeps the schedule correct for any credential class: the 24h
+ * `STANDING_RENEWABLE_TTL_SEC` and the 30-day `ROTATION_RENEWED_TTL_SEC` both get a tick inside
+ * their own renewal window without a hardcoded number. Post-boot responsiveness is already
+ * covered by the caller invoking `renewDaemonCreds` once synchronously before starting the timer,
+ * so no separate floor is needed. The pass is idempotent, since `renewDaemonCreds` no-ops each
+ * credential when its state is `healthy`, so a tick that lands before the window costs one health
+ * check per owner. */
+export function credRenewIntervalMs(ttlSeconds: number): number {
+  return Math.max(1, Math.floor((ttlSeconds / 4) * 1000));
+}
 /** Startup reconciliation overlaps control-service registration. A spawn or attach for one of
  * these aliases must wait until THAT alias's exact-op terminal attempt returns rather than racing
  * a reuse. */
@@ -1105,7 +1123,7 @@ export class Manager {
     // `reloadCreds` adoption on the delivery-admin rail, and persist the audit record doctor renders.
     if (this.auth) {
       await this.renewDaemonCreds();
-      this.credRenewTimer = setInterval(() => { void this.renewDaemonCreds(); }, (STANDING_RENEWABLE_TTL_SEC / 2) * 1000);
+      this.credRenewTimer = setInterval(() => { void this.renewDaemonCreds(); }, credRenewIntervalMs(STANDING_RENEWABLE_TTL_SEC));
       this.credRenewTimer.unref?.();
     }
     // P2 item 1: register the manager as an ordinary v0.4 `service` endpoint (SPEC §13.7/§13.9)
@@ -1479,7 +1497,7 @@ export class Manager {
     this.preservationInventory = undefined;
     this.preservationFailures = [];
     if (this.auth && !this.credRenewTimer) {
-      this.credRenewTimer = setInterval(() => { void this.renewDaemonCreds(); }, (STANDING_RENEWABLE_TTL_SEC / 2) * 1000);
+      this.credRenewTimer = setInterval(() => { void this.renewDaemonCreds(); }, credRenewIntervalMs(STANDING_RENEWABLE_TTL_SEC));
       this.credRenewTimer.unref?.();
     }
     // Exit watchers were suppressed while the fence stood: reconcile every child that died during

--- a/package.json
+++ b/package.json
@@ -363,6 +363,7 @@
     "smoke:unfenced-responder": "tsx packages/core/smoke/unfenced-responder.smoke.ts",
     "smoke:ep-serve-gate": "tsx packages/core/smoke/endpoint-serve-gate.smoke.ts",
     "smoke:manager-service": "tsx implementations/manager/smoke/manager-service.smoke.ts",
+    "smoke:manager-renewal-boundary": "tsx implementations/manager/smoke/manager-renewal-boundary.smoke.ts",
     "smoke:manager-harness-boot": "tsx implementations/manager/smoke/harness-boot.smoke.ts",
     "smoke:manager-service-ops": "tsx implementations/manager/smoke/manager-service-ops.smoke.ts",
     "smoke:manager-persona-show-auth": "tsx implementations/manager/smoke/persona-show-auth.smoke.ts",


### PR DESCRIPTION
Fixes the credential-schedule half of #457. The frozen-gate / ambiguous re-registration half is #1243
and the seat-side twin (a seat never adopting its renewed file) is #1189; neither is touched here.

## What was wrong

The manager renews every daemon credential it owns on a timer of `(STANDING_RENEWABLE_TTL_SEC / 2) *
1000`. `inspectCredHealth` (`packages/core/src/provision.ts:265-268`) reports `healthy` until 75% of
the iat-to-exp lifetime, `near-expiry` from 75% to 100%, `expired` after. With a 24h credential the
ticks therefore land at 12h (`healthy`, no-op) and 24h (`expired`, connection already refused), and
the renewal window at 18h to 24h is never sampled. The field report on #457 is this exactly: the
manager's own connection dies at 24h to the second, on a ~24h cadence, with the signer present.

## What this changes

One commit over `7f3a8a03`, six files, +277/-2. Merges clean.

`implementations/manager/src/manager.ts` gains `credRenewIntervalMs(ttlSeconds) = max(1, floor(ttl/4 *
1000))` and routes both timer sites (`:1126` initial start, `:1500` preservation abort) through it. The
window is TTL/4 wide, so ticks TTL/4 apart land inside it at least once for any TTL; ticks TTL/2 apart
can miss it for any TTL. Derived from the caller's TTL rather than a constant, so the 30-day rotation
family gets a tick inside its own window too. Post-boot responsiveness is the pre-existing synchronous
`await this.renewDaemonCreds()` before `setInterval`. The pass stays idempotent (no-op on `healthy`).

`provision.ts` is untouched: the 75% threshold is not moved to paper over the timer.

## Measured, before and after, same compressed-ratio probe (TTL 20s) on an isolated broker

```
BEFORE (parent 7f3a8a03, interval TTL/2 = 10s)
  TIMER_TICK {"t":10,"changed":false,"stateBefore":"healthy"}
  TIMER_TICK {"t":20,"changed":true, "stateBefore":"expired"}
  POST_EXPIRY {"closed":true,"error":"User Authentication Expired","publishOk":false}
  BOUNDARY_RESULT=FAILED

AFTER (this head, interval TTL/4 = 5s)
  TIMER_TICK {"t":5, "changed":false,"stateBefore":"healthy"}
  TIMER_TICK {"t":10,"changed":false,"stateBefore":"healthy"}
  TIMER_TICK {"t":15,"changed":true, "stateBefore":"near-expiry"}
  TIMER_TICK {"t":20,"changed":false,"stateBefore":"healthy"}
  POST_EXPIRY {"closed":false,"publishOk":true,"nearExpiryObserved":true}
  BOUNDARY_RESULT=SURVIVED
```

## Committed cell

`implementations/manager/smoke/manager-renewal-boundary.smoke.ts`, wired as `smoke:manager-renewal-boundary`
with its own `ci-suites.d` fragment. It drives the probe twice: the default arm reads the interval
from the **shipped** helper and must print SURVIVED; the `--mutant` arm hardcodes TTL/2 and must print
FAILED. Both the lane and the reviewer independently reverted the shipped helper to TTL/2 and observed
the default arm go FAILED (`PROBE_CONFIG intervalMs: 10000`), so the cell grades the product and not
only the probe's own knob. Restoring returns SURVIVED.

Also: `smoke:manager-service` 25/25, `smoke:session-ledger-family` 9/9, `pnpm typecheck` rc 0 on a
clean tree. Changeset `patch` on `@cotal-ai/manager`.

## Review

Independent exact-head review by a seat outside the authoring lane's model family (grok-4.6 against
claude-opus-4-7): **APPROVE at `e7687e7d0a6d0066401f846a92531b9ad1b61d74`**, published in full on #457
and copied below as the first comment before merge. It verified both timer sites, that no third
`renewDaemonCreds` interval exists, the boundary arithmetic for TTL=86400 and TTL=20 including
inclusivity at `renewAt` on a real minted JWT, the default/mutant pair, the helper-revert test, both
neighbouring suites, and that the probe boots its own broker on an OS-assigned port and tears it down.

One residual it recorded as non-blocking: several comments near the timer still say "half-TTL". The
executable sites are TTL/4. Worth a follow-up sweep of the prose; not a reason to hold the fix.

## Deploy

This is the fix David asked to ship as soon as possible. On merge and publish it goes into the next
fleet CLI upgrade on netcup, which reaps every seat, so that is scheduled for a quiet window and
announced first.
