### PR TITLE
test(smoke): opt the ps and presence-ttl fixtures out of the connector seed

### DIFF
--- a/.changeset/skip-connector-seed-in-two-suites.md
+++ b/.changeset/skip-connector-seed-in-two-suites.md
@@ -1,0 +1,5 @@
+---
+"cotal-ai": patch
+---
+
+The `ps-operator-path` and `presence-ttl-refresh-cli` smoke suites opt their CLI out of the connector seed reconcile, as fifteen sibling suites already do and as `up` does for the daemons it launches. Neither suite exercises the seeder, and on a cold npm cache the reconcile can consume the whole `cotal up` budget the fixtures allow.

--- a/implementations/auth/smoke/ps-operator-path.smoke.ts
+++ b/implementations/auth/smoke/ps-operator-path.smoke.ts
@@ -81,7 +81,10 @@ type Run = {
 };
 function cotal(args: string[], timeoutMs = 120_000): Promise<Run> {
   return new Promise((res) => {
-    const options = { cwd: root, env: { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: configDir }, stdio: ["ignore", "pipe", "pipe"] as const };
+    // This suite grades the operator `ps` path and never exercises the connector seeder, so its
+    // CLI opts out of the seed reconcile the way `up` does for the daemons it launches. On a cold
+    // npm cache that reconcile can spend the whole `cotal up` budget this fixture allows (#1245).
+    const options = { cwd: root, env: { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: configDir, COTAL_SKIP_CONNECTOR_SEED: "1" }, stdio: ["ignore", "pipe", "pipe"] as const };
     assertSmokeSandboxDown(sandbox, args, options);
     const child = spawn(TSX, [BIN, ...args], options);
     let out = "";

--- a/packages/core/smoke/presence-ttl-refresh-cli.smoke.ts
+++ b/packages/core/smoke/presence-ttl-refresh-cli.smoke.ts
@@ -73,7 +73,10 @@ const check = (n: string, v: boolean, x?: unknown) => { v ? (pass++, console.log
 type Run = { status: number | null; out: string; timedOut: boolean; signal: NodeJS.Signals | null; launchError?: string };
 function cotal(args: string[], timeoutMs = 120_000): Promise<Run> {
   return new Promise((res) => {
-    const options = { cwd: root, env: { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: configDir }, stdio: ["ignore", "pipe", "pipe"] as const };
+    // This suite grades presence TTL refresh across restarts and never exercises the connector
+    // seeder, so its CLI opts out of the seed reconcile the way `up` does for the daemons it
+    // launches. On a cold npm cache that reconcile can spend the whole `cotal up` budget (#1245).
+    const options = { cwd: root, env: { ...process.env, COTAL_HOME: home, XDG_CONFIG_HOME: configDir, COTAL_SKIP_CONNECTOR_SEED: "1" }, stdio: ["ignore", "pipe", "pipe"] as const };
     assertSmokeSandboxDown(sandbox, args, options);
     const child = spawn(TSX, [BIN, ...args], options);
     let out = "", timedOut = false, settled = false, exited = false;


### PR DESCRIPTION
Closes #1245.

`ps-operator-path` and `presence-ttl-refresh-cli` bound `cotal up` at 120 seconds and neither grades the connector seeder, but neither sets `COTAL_SKIP_CONNECTOR_SEED`. Each therefore pays a seven-payload seed reconcile inside that budget. Fifteen sibling suites already opt out, and `up` itself sets the flag for the daemons it launches, so this brings the two into line with the convention rather than introducing one.

## Both suites pass today

This is margin, not a repair. Nothing is broken on `main` and this PR unblocks nothing.

The case for it is the spread. `cotal up` wall time in `ps-operator-path`, bracketed from the fixture's last anchor check to the next printed line:

| commit | wall | outcome |
| --- | --- | --- |
| `3aba994a3` (this base) | 34s | green |
| `917eb61a` | 36s | green |
| `dced13d3f` | 68s | green |
| `7f3a8a03` attempt 2 | 75s | green |
| `7f3a8a03` attempt 1 | 120s | SIGKILLed |
| `24b3d9281` | 120s | SIGKILLed |
| `a43a127f4` | 120s | SIGKILLed |

Passing runs span 34s to 75s against a fixed 120s wall, and the failures sit exactly at the wall because that number is the fixture's SIGKILL rather than a measured duration. The spread tracks npm cache state rather than anything in the tree, so a green run is not evidence that the budget is comfortable.

A sibling harness with the same defect, `delivery-timer-writer`, went from 8/4 failing to 12/0 passing on an unchanged cold cache once the flag was set (`a43a127f4`). That is the same change in the same shape, measured as an intervention.

## How to verify this, which is not the shard colour

A green shard cannot separate a suite that stopped paying the cost from one that fit inside the budget that day. Measure `cotal up` wall time with the bracket above. Before, on this base: `ps-operator-path` 34s, `presence-ttl-refresh-cli` 38s. After, both should sit at or below those and stop moving with cache state.

Do **not** verify by the absence of `wrote operator-global seed store payload (web)` in the log. That line reaches the log only when a subprocess's output is printed, which happens only on failure, so a passing run shows zero of them whether or not it seeded. An earlier version of #1245 was built on that signal and it was withdrawn.

## Scope

Two suites and a changeset. No product code, no other suite, and no change to the seeder itself. Whether other suites carry the same omission was not surveyed here.
