### PR TITLE
fix(connector-jcode): preserve unprovable bridge identity

### DIFF
--- a/.changeset/calm-badgers-prove.md
+++ b/.changeset/calm-badgers-prove.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/connector-jcode": patch
+---
+
+Treat an unreadable or empty Linux process environment as an unprovable launch identity during Jcode bridge teardown, while continuing to refuse readable environments that lack the launch identity.

--- a/bin/smoke/mutations/jcode-launch-identity-proof.json
+++ b/bin/smoke/mutations/jcode-launch-identity-proof.json
@@ -1,0 +1,18 @@
+{
+  "suite": "extensions/connector-jcode/smoke/private-lifecycle.smoke.ts",
+  "guard": "a live bridge whose launch identity is unprovable during the process exit window proceeds through teardown, while readable broken wiring still refuses",
+  "command": "pnpm smoke:jcode-private-lifecycle",
+  "progressPattern": "^  ✓ ",
+  "minTicks": 2,
+  "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/jcode-launch-identity-proof.json",
+  "mutations": [
+    {
+      "name": "the exit window is convicted from the ownership scan again",
+      "file": "extensions/connector-jcode/src/private-lifecycle.ts",
+      "find": "  if (alive(launch.pid) && processMatches(launch) && launchIdentityProof(launch.pid, identityValue, identityProbe) === false)\n    throw new Error(`jcode connector: spawned Jcode bridge ${launch.pid} does not carry its launch-bound identity — refusing unsafe teardown`);",
+      "replace": "  if (alive(launch.pid) && processMatches(launch) && !owned.has(launch.pid))\n    throw new Error(`jcode connector: spawned Jcode bridge ${launch.pid} does not carry its launch-bound identity — refusing unsafe teardown`);",
+      "expectRed": "exit window: an unprovable launch identity does not refuse and teardown returns",
+      "cell": "exit window: an unprovable launch identity does not refuse and teardown returns"
+    }
+  ]
+}

--- a/extensions/connector-jcode/smoke/private-lifecycle.smoke.ts
+++ b/extensions/connector-jcode/smoke/private-lifecycle.smoke.ts
@@ -4,7 +4,15 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { chmodSync, mkdtempSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { captureProcessIdentity, processHasLaunchIdentityForTest, readLaunchRecord, recordLaunch, stopOrphanedTree } from "../src/private-lifecycle.js";
+import {
+  captureProcessIdentity,
+  processHasLaunchIdentityForTest,
+  readLaunchRecord,
+  recordLaunch,
+  stopOrphanedTree,
+  stopPrivateTree,
+  type ProcessIdentityProbe,
+} from "../src/private-lifecycle.js";
 
 const operationalFailure = Object.assign(new Error("ps policy denied"), { status: 1 });
 
@@ -19,6 +27,106 @@ assert.throws(
   (error) => error === operationalFailure,
   "a status-1 ps failure for a PID independently proven present must stay loud",
 );
+
+const stopped = async (child: ChildProcess, timeoutMs = 5_000): Promise<boolean> => {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      process.kill(child.pid!, 0);
+    } catch {
+      return true;
+    }
+    if (Date.now() > deadline) return false;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+};
+
+// #1179. Drive the ownership decision through a proof source instead of racing a real process's
+// dying /proc environ. The bridge stays genuinely alive with the same immutable start token while
+// the injected answer selects each state of the proof.
+if (process.platform === "linux") {
+  const root = mkdtempSync(join(tmpdir(), "cotal-jcode-identity-proof-"));
+  const identity = `smoke-${randomBytes(12).toString("base64url")}`;
+  const started: ChildProcess[] = [];
+  const bridge = (): ChildProcess => {
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1 << 30)"], { stdio: "ignore" });
+    started.push(child);
+    return child;
+  };
+  const proof = (readEnviron: ProcessIdentityProbe["readEnviron"]): ProcessIdentityProbe => ({
+    readEnviron,
+    ps: () => "",
+    pidExists: () => true,
+  });
+  const check = (name: string): void => console.log(`  ✓ ${name}`);
+
+  try {
+    const broken = bridge();
+    const brokenLaunch = captureProcessIdentity(broken.pid!);
+    const refusal = `jcode connector: spawned Jcode bridge ${broken.pid} does not carry its launch-bound identity — refusing unsafe teardown`;
+    await assert.rejects(
+      stopPrivateTree({
+        jcodeHome: root,
+        launch: brokenLaunch,
+        identityValue: identity,
+        settleMs: 0,
+        identityProbe: proof(() => "PATH=/usr/bin\0"),
+      }),
+      (error: Error) => error.message === refusal,
+      "broken wiring: readable environ without the launch identity refuses with the exact sentence",
+    );
+    assert.equal(await stopped(broken, 0), false, "the broken-wiring refusal must not signal the unowned bridge");
+    check("broken wiring: readable environ without the launch identity refuses with the exact sentence");
+
+    const owned = bridge();
+    const ownedLaunch = captureProcessIdentity(owned.pid!);
+    await assert.doesNotReject(
+      stopPrivateTree({
+        jcodeHome: root,
+        launch: ownedLaunch,
+        identityValue: identity,
+        settleMs: 0,
+        identityProbe: proof((pid) => pid === owned.pid ? `JCODE_COTAL_LAUNCH_IDENTITY=${identity}\0` : "PATH=/usr/bin\0"),
+      }),
+      "happy path: readable environ with the launch identity is owned, signalled, and settles",
+    );
+    assert.ok(await stopped(owned), "the owned bridge must be gone when teardown returns");
+    check("happy path: readable environ with the launch identity is owned, signalled, and settles");
+
+    const unprovable: Array<[string, ProcessIdentityProbe["readEnviron"]]> = [
+      ["empty environ", () => ""],
+      ...(["ENOENT", "ESRCH", "EACCES", "EPERM"] as const).map((code): [string, ProcessIdentityProbe["readEnviron"]] => [
+        code,
+        () => { throw Object.assign(new Error("environ unavailable during exit"), { code }); },
+      ]),
+    ];
+    for (const [source, readEnviron] of unprovable) {
+      const exiting = bridge();
+      const exitingLaunch = captureProcessIdentity(exiting.pid!);
+      await assert.doesNotReject(
+        stopPrivateTree({
+          jcodeHome: root,
+          launch: exitingLaunch,
+          identityValue: identity,
+          settleMs: 0,
+          identityProbe: proof(readEnviron),
+        }),
+        `exit window: an unprovable launch identity does not refuse and teardown returns (${source})`,
+      );
+      assert.ok(await stopped(exiting), `the exiting bridge must be gone when teardown returns (${source})`);
+    }
+    check("exit window: an unprovable launch identity does not refuse and teardown returns");
+  } finally {
+    for (const child of started) {
+      try {
+        process.kill(child.pid!, "SIGKILL");
+      } catch {
+        /* already gone */
+      }
+    }
+    rmSync(root, { recursive: true, force: true });
+  }
+}
 
 // #1211. A seat killed without its connector's teardown leaves its Jcode server alive: the server
 // setsids into a group of its own and carries no COTAL_NAME, so neither the manager's signal nor a
@@ -103,4 +211,4 @@ if (process.platform !== "win32") {
   }
 }
 
-console.log("PRIVATE LIFECYCLE SMOKE PASSED (status-1 failure for live PID stays loud; a dead lifecycle's Jcode tree is adopted, a live seat's is not)");
+console.log("PRIVATE LIFECYCLE SMOKE PASSED (launch identity has owned, missing, and unprovable states; status-1 ps failure stays loud; only a dead lifecycle's Jcode tree is adopted)");

--- a/extensions/connector-jcode/src/private-lifecycle.ts
+++ b/extensions/connector-jcode/src/private-lifecycle.ts
@@ -81,12 +81,14 @@ function processPids(): number[] {
   throw new Error(`jcode connector: cannot prove Jcode process ownership on unsupported platform ${process.platform}`);
 }
 
-interface ProcessIdentityProbe {
+export interface ProcessIdentityProbe {
+  readEnviron: (pid: number) => string;
   ps: (pid: number) => string;
   pidExists: (pid: number) => boolean;
 }
 
 const processIdentityProbe: ProcessIdentityProbe = {
+  readEnviron: (pid) => readFileSync(`/proc/${pid}/environ`, "utf8"),
   ps: (pid) => execFileSync("/bin/ps", ["eww", "-p", String(pid), "-o", "command="], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "ignore"],
@@ -104,7 +106,11 @@ const processIdentityProbe: ProcessIdentityProbe = {
   },
 };
 
-function processHasLaunchIdentityFromPs(pid: number, identityValue: string, probe: ProcessIdentityProbe): boolean {
+function processHasLaunchIdentityFromPs(
+  pid: number,
+  identityValue: string,
+  probe: Pick<ProcessIdentityProbe, "ps" | "pidExists">,
+): boolean {
   try {
     const out = probe.ps(pid);
     return out.includes(`${LAUNCH_IDENTITY_ENV}=${identityValue}`);
@@ -118,25 +124,43 @@ function processHasLaunchIdentityFromPs(pid: number, identityValue: string, prob
   }
 }
 
-function processHasLaunchIdentity(pid: number, identityValue: string): boolean {
-  if (process.platform === "linux")
-    return readFileSync(`/proc/${pid}/environ`, "utf8").split("\0").includes(`${LAUNCH_IDENTITY_ENV}=${identityValue}`);
+/** Whether `pid` carries this launch's identity, or `undefined` when the kernel cannot answer.
+ *
+ * A process releases the mm backing /proc/<pid>/environ as it exits, before it becomes the zombie
+ * that `alive` reads as dead. In that window the environ read fails or returns empty while
+ * /proc/<pid>/stat still reports a live state and the same start token. Reporting that as a missing
+ * identity would convict a bridge that is merely dying, so it is answered as unprovable. */
+function launchIdentityProof(pid: number, identityValue: string, probe: ProcessIdentityProbe): boolean | undefined {
+  if (process.platform === "linux") {
+    let environ: string;
+    try {
+      environ = probe.readEnviron(pid);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "ENOENT" || code === "ESRCH" || code === "EACCES" || code === "EPERM") return undefined;
+      throw error;
+    }
+    // An exec fixes the environ block for the life of the process, so a non-empty read against an
+    // unchanged start token is authoritative; only an empty one means the mm is already gone.
+    if (environ.length === 0) return undefined;
+    return environ.split("\0").includes(`${LAUNCH_IDENTITY_ENV}=${identityValue}`);
+  }
   if (process.platform === "darwin" || process.platform.endsWith("bsd"))
-    return processHasLaunchIdentityFromPs(pid, identityValue, processIdentityProbe);
+    return processHasLaunchIdentityFromPs(pid, identityValue, probe);
   throw new Error(`jcode connector: launch-bound process identity is unavailable on ${process.platform}`);
 }
 
 export const processHasLaunchIdentityForTest = (
   pid: number,
   identityValue: string,
-  probe: ProcessIdentityProbe,
+  probe: Pick<ProcessIdentityProbe, "ps" | "pidExists">,
 ): boolean => processHasLaunchIdentityFromPs(pid, identityValue, probe);
 
-function captureLaunchProcesses(identityValue: string): ProcessIdentity[] {
+function captureLaunchProcesses(identityValue: string, probe: ProcessIdentityProbe = processIdentityProbe): ProcessIdentity[] {
   const owned: ProcessIdentity[] = [];
   for (const pid of processPids()) {
     try {
-      if (!processHasLaunchIdentity(pid, identityValue)) continue;
+      if (launchIdentityProof(pid, identityValue, probe) !== true) continue;
       const stat = processStat(pid);
       if (stat) owned.push({ pid: stat.pid, start: stat.start });
     } catch (error) {
@@ -320,24 +344,36 @@ export interface StopPrivateTreeOptions {
   killWaitMs?: number;
   /** Records must remain absent for this long after the bridge is gone (default 500ms). */
   settleMs?: number;
+  /** Injectable process proof source for direct lifecycle tests. */
+  identityProbe?: ProcessIdentityProbe;
 }
 
 /** SIGTERM the launch-owned tree, escalate survivors to SIGKILL, and only return once its records
  * remain quiescent after the bridge is gone. A stale or reused registry PID is skipped, never
  * signalled; an unprovable live process is not converted into ownership by location alone. */
 export async function stopPrivateTree(options: StopPrivateTreeOptions): Promise<void> {
-  const { jcodeHome, launch, identityValue, gracefulWaitMs = 3_000, killWaitMs = 2_000, settleMs = 500 } = options;
+  const {
+    jcodeHome,
+    launch,
+    identityValue,
+    gracefulWaitMs = 3_000,
+    killWaitMs = 2_000,
+    settleMs = 500,
+    identityProbe = processIdentityProbe,
+  } = options;
   const owned = new Map<number, ProcessIdentity>();
   const refreshOwned = (): void => {
-    for (const identity of captureLaunchProcesses(identityValue)) owned.set(identity.pid, identity);
+    for (const identity of captureLaunchProcesses(identityValue, identityProbe)) owned.set(identity.pid, identity);
   };
   refreshOwned();
   // A bridge that already died (provider stall, crash) or whose PID was reused is a legal teardown
   // state: there is nothing safe to signal, and the record scan below still owns any survivors. The
   // refusal is reserved for a live bridge matching its captured start token that does not carry the
   // launch identity — broken launch wiring, where ownership cannot be proved for a process that
-  // must be stopped.
-  if (alive(launch.pid) && processMatches(launch) && !owned.has(launch.pid))
+  // must be stopped. A bridge exiting under us reads as identity-less for a moment (#1179), so the
+  // refusal takes a direct proof that the environment is readable and lacks the identity, rather
+  // than the scan's absence, which cannot tell that window apart from broken wiring.
+  if (alive(launch.pid) && processMatches(launch) && launchIdentityProof(launch.pid, identityValue, identityProbe) === false)
     throw new Error(`jcode connector: spawned Jcode bridge ${launch.pid} does not carry its launch-bound identity — refusing unsafe teardown`);
 
   if (processMatches(launch)) {


### PR DESCRIPTION
Closes #1179.

## Hosted-runner reproduction

The repro venue named in the diagnosis produced the same shard-1 refusal six times on 2026-09-04. Each failure stopped the shard before 84 of 120 planned suites ran:

- Run 33871554730, attempt 1, main `28a1063ba`
- Run 33871554730, attempt 2, main `28a1063ba`
- Run 33914094490, attempt 1, main `b9180cb47`
- Run 33906897016, attempt 1, PR #1255
- Run 33914203181, attempt 1, PR #1258
- Run 33871865216, attempt 2, PR #1204

## Identity proof

`launchIdentityProof` now answers three states:

- `true`: the environment is readable and carries this launch identity. The process is owned, signalled, and teardown settles.
- `false`: the environment is readable and lacks this launch identity. The existing unsafe-teardown refusal remains exact and loud for broken launch wiring.
- `undefined`: `/proc/<pid>/environ` is empty or cannot be read with ENOENT, ESRCH, EACCES, or EPERM. The exit window is unprovable, so scan absence cannot convict the bridge and teardown proceeds.

The Linux proof reads through the same `ProcessIdentityProbe` seam used by the Darwin/BSD path, which lets the lifecycle smoke drive `stopPrivateTree` directly without a real dying-process race.

## Cells and gates

- Broken wiring: readable environ without identity refuses with the exact sentence.
- Happy path: readable environ with identity is owned, signalled, and settles.
- Exit window: empty environ plus ENOENT, ESRCH, EACCES, and EPERM do not refuse, and teardown returns.
- Regression mutant restoring `!owned.has(launch.pid)` is KILLED by `exit window: an unprovable launch identity does not refuse and teardown returns`.
- Mutation fixture census: OK.
- Shard stability: STABLE, 0 existing suites moved.
- Ambient environment census: PASS.
- `smoke:jcode-host`: 56 checks green.
- `pnpm typecheck`: rc 0.
