### PR TITLE
fix(manager): late turn-yield names the deadline terminal, not not-found

### DIFF
--- a/.changeset/fix-1262-late-turn-yield.md
+++ b/.changeset/fix-1262-late-turn-yield.md
@@ -1,0 +1,7 @@
+---
+"@cotal-ai/manager": patch
+---
+
+A late `turn-yield` after the deadline deny has committed is told the turn ended `failed`, never `not-found`.
+
+The deny itself held: first-terminal-wins still refused a success over it. What failed was the diagnostic. `commitTurnDeadline` deletes the pending entry (its idempotency latch) *before* the terminal CAS, then remembers the settled answer only after. A yield in that window, or after a concurrent sweep dropped `turnAcceptances.settled`, heard `no pending turn` — which a seat reads as an addressing fault, not "the run moved on". The durable terminal is the answer the run already has; the yield now reads it when the in-memory settled field is missing, and the sweep no longer wipes an unsettled acceptance the moment pending is empty.

--- a/implementations/manager/smoke/manager-reconcile-startup.smoke.ts
+++ b/implementations/manager/smoke/manager-reconcile-startup.smoke.ts
@@ -41,6 +41,8 @@ import {
   bindGoal,
   createGoal,
   recordGoalIndex,
+  readGoalResult,
+  clearGoalIndex,
   type GoalRef,
   epAuthBucket,
   epCall,
@@ -435,6 +437,124 @@ try {
     check("a turn whose hold was never minted is not adopted as pending: nothing could settle it",
       !doors.pendingTurns.has(holdless) && !(adopting as unknown as { turnAcceptances: Map<string, unknown> }).turnAcceptances.has(holdless),
       { pending: doors.pendingTurns.has(holdless) });
+
+    // #1262: a late yield after the deadline committed. The CI flake is not "the deny lost to a
+    // success" — the deny held — and it is not the durable goal-index drop itself: the yield path
+    // never consults that index. After commitTurnDeadline deletes the pending entry (the latch is
+    // the delete, BEFORE the terminal CAS) the only in-memory answer a late yield can find is
+    // turnAcceptances.settled. Two orderings both happen on a live manager and both have to name
+    // the terminal the goal actually reached, never `not-found`:
+    //
+    //   1. terminal committed, index still present, settled answer not yet remembered
+    //      (the window between pendingTurns.delete and rememberSettledTurn; also the window a
+    //      concurrent sweep's maybeStopTurnSweep can clear turnAcceptances while the commit is
+    //      still in flight, so rememberSettledTurn no-ops)
+    //   2. terminal committed AND the index already cleared (the state the auth-mesh smoke's
+    //      resultOf wait actually observes before it yields)
+    //
+    // Forced here through the same serveTurnYield door, after the durable deny is on the plane,
+    // by dropping the in-memory maps the yield currently consults. No live timer, no broker
+    // perturbation: the hold is minted already-due so expireCheckpoint is the shipped owner
+    // expiry, and commitTurnDeadline is the shipped deny. Two goal ids, because the index
+    // entry is create-only and cannot be restored after a clear.
+    const LATE_ACCEPTED = Date.now() - 5_000;
+    const LATE_DEADLINE = Date.now() - 1_000;
+    const lateDoors = adopting as unknown as {
+      pendingTurns: Map<string, {
+        ref: GoalRef; goalId: string;
+        seat: { name: string; owner: string; actor: string; uid: string };
+        payload: string; acceptedAt: number; deadlineAt: number;
+        holdToken: string; holdEpoch: number;
+      }>;
+      turnAcceptances: Map<string, { acceptance: Record<string, unknown>; ref?: GoalRef; settled?: { state: string; at: number } }>;
+      expireTurnHold: (p: { ref: GoalRef; goalId: string; holdToken: string }) => Promise<{ settle?: string } | undefined>;
+      commitTurnDeadline: (p: { ref: GoalRef; goalId: string; holdToken: string; seat: { name: string; owner: string; actor: string; uid: string }; payload: string; acceptedAt: number; deadlineAt: number; holdEpoch: number }) => Promise<void>;
+      serveTurnYield: (c: { owner: string; actor: string; uid: string }, raw: Record<string, unknown>) => Promise<{ goalId: string; state: string }>;
+    };
+    const armLate = async (goalId: string, fingerprint: string) => {
+      const ref: GoalRef = { endpoint: MANAGER_ENDPOINT, caller: runner, goalId };
+      const lateNote = JSON.stringify({ payload: "too late", deadlineAt: LATE_DEADLINE, holdEpoch: serveEpoch, owner: "local" });
+      await bindGoal(actx, ref, fingerprint);
+      await createGoal(actx, ref, {
+        fingerprint, command: "turn",
+        caller: { id: `${runner.owner}.${runner.actor}`, lifecycleUid: runner.uid },
+        acceptedEpoch: 0, requestId: goalId, sourceSeq: 0, acceptedAt: LATE_ACCEPTED, readinessDeadlineMs: 1_000,
+        target: { owner: "local", actor: allocated.actor, lifecycleUid: seatUid, mappingRevision: 0 },
+      });
+      await recordGoalIndex(actx, ref, doors.managerInstanceId, allocated, lateNote);
+      const holdToken = createHash("sha256").update(`${goalId}:turn-deadline`, "utf8").digest("base64url").slice(0, 43);
+      await mintCheckpoint(actx.kv, serveJs, space, {
+        ref: { endpoint: MANAGER_ENDPOINT, token: holdToken },
+        instanceId: doors.managerInstanceId, epoch: serveEpoch,
+        goal: { caller: runner, goalId },
+        holder: { id: MANAGER_ENDPOINT, lifecycleUid: doors.managerInstanceId },
+        deadline: LATE_DEADLINE, now: LATE_ACCEPTED,
+      });
+      const pending = {
+        ref, goalId,
+        seat: { name: allocated.name, owner: "local" as const, actor: allocated.actor, uid: seatUid },
+        payload: "too late", acceptedAt: LATE_ACCEPTED, deadlineAt: LATE_DEADLINE,
+        holdToken, holdEpoch: serveEpoch,
+      };
+      lateDoors.pendingTurns.set(goalId, pending);
+      lateDoors.turnAcceptances.set(goalId, {
+        acceptance: {
+          name: allocated.name, owner: "local", actor: allocated.actor, uid: seatUid, goalId,
+          fingerprint, deadlineAt: LATE_DEADLINE,
+          executor: { lifecycleUid: doors.managerInstanceId, epoch: serveEpoch },
+        },
+        ref,
+      });
+      return { ref, pending };
+    };
+
+    {
+      const lateId = "d".repeat(43);
+      const { ref, pending } = await armLate(lateId, "fp-late-1");
+      const expired = await lateDoors.expireTurnHold(pending);
+      check("a due hold the manager owns expires as `expired` (the deny's predicate)",
+        expired?.settle === "expired", expired);
+      await lateDoors.commitTurnDeadline(pending);
+      const deniedLate = await readGoalResult(actx, ref);
+      check("the deadline deny is the goal's terminal, reason `turn-deadline`; no success over it",
+        deniedLate?.state === "failed" && (deniedLate.data as { reason?: string } | undefined)?.reason === "turn-deadline",
+        deniedLate);
+      // Ordering 1: terminal committed, index still present (we skip the clear), settled
+      // answer not remembered. This is the window between pendingTurns.delete and
+      // rememberSettledTurn (and the window a concurrent sweep's maybeStopTurnSweep can
+      // drop the settled field while leaving the acceptance the yield still addresses).
+      lateDoors.pendingTurns.delete(lateId);
+      const kept1 = lateDoors.turnAcceptances.get(lateId);
+      if (kept1) delete kept1.settled;
+      const afterCommitBeforeIndexDrop = await lateDoors.serveTurnYield(adoptedSeat, { goalId: lateId, status: "done" }).then((r) => r, asValue);
+      check("a yield after the deny committed, before the index drop, is told the turn ended failed, never `not-found`",
+        (afterCommitBeforeIndexDrop as { state?: string }).state === "failed"
+          && (afterCommitBeforeIndexDrop as { code?: string }).code !== "not-found",
+        afterCommitBeforeIndexDrop);
+      check("and that late yield did not record a success over the deny",
+        (await readGoalResult(actx, ref))?.state === "failed", await readGoalResult(actx, ref));
+    }
+
+    {
+      const lateId = "e".repeat(43);
+      const { ref, pending } = await armLate(lateId, "fp-late-2");
+      await lateDoors.expireTurnHold(pending);
+      await lateDoors.commitTurnDeadline(pending);
+      // Ordering 2: terminal committed AND the index already cleared — the auth-mesh smoke's
+      // observed state when it yields after resultOf returns the deny.
+      await clearGoalIndex(actx, ref);
+      lateDoors.pendingTurns.delete(lateId);
+      const kept2 = lateDoors.turnAcceptances.get(lateId);
+      if (kept2) delete kept2.settled;
+      const afterIndexDrop = await lateDoors.serveTurnYield(adoptedSeat, { goalId: lateId, status: "done" }).then((r) => r, asValue);
+      check("a yield after the deny committed AND the index dropped is still told the turn ended failed, never `not-found`",
+        (afterIndexDrop as { state?: string }).state === "failed"
+          && (afterIndexDrop as { code?: string }).code !== "not-found",
+        afterIndexDrop);
+      check("and that late yield did not record a success over the deny either",
+        (await readGoalResult(actx, ref))?.state === "failed", await readGoalResult(actx, ref));
+    }
+
     await adopting.stop().catch(() => {});
   }
 
@@ -447,7 +567,7 @@ try {
   await broker.stop().catch(() => {});
 }
 
-const EXPECTED_CELLS = 17;
+const EXPECTED_CELLS = 23;
 console.log(`\n${fail === 0 ? "MANAGER RECONCILE STARTUP SMOKE OK ✅" : "MANAGER RECONCILE STARTUP SMOKE FAILED"}  (${pass} passed, ${fail} failed)`);
 if (pass + fail !== EXPECTED_CELLS) {
   console.log(`SUITE INCOMPLETE — ran ${pass + fail} of ${EXPECTED_CELLS} cells; a partial run is not a pass`);

--- a/implementations/manager/smoke/mutations/late-turn-yield.json
+++ b/implementations/manager/smoke/mutations/late-turn-yield.json
@@ -1,0 +1,17 @@
+{
+  "suite": "implementations/manager/smoke/manager-reconcile-startup.smoke.ts",
+  "guard": "A late turn-yield after the deadline deny has committed names the terminal the goal reached, never not-found.",
+  "command": "pnpm smoke:manager-reconcile-startup",
+  "completionMarker": "MANAGER RECONCILE STARTUP SMOKE",
+  "mutations": [
+    {
+      "name": "a late yield after the deadline committed hears not-found instead of the deny",
+      "file": "implementations/manager/src/manager.ts",
+      "find": "        if (settled.settled !== undefined) return { goalId, state: settled.settled.state };\n        // The in-memory answer is not yet remembered (pending deleted before the terminal CAS,\n        // or a concurrent sweep dropped `settled` while the commit was still in flight). The\n        // durable terminal is the one the run already has; name it, never `not-found`.\n        if (settled.ref !== undefined) {\n          const ended = await readGoalResult(gw.ctx, settled.ref);\n          if (ended !== undefined) {\n            this.rememberSettledTurn(goalId, ended.state, ended.ts);\n            return { goalId, state: ended.state };\n          }\n        }",
+      "replace": "        if (settled.settled !== undefined) return { goalId, state: settled.settled.state };",
+      "expectRed": "a yield after the deny committed, before the index drop, is told the turn ended failed, never `not-found`",
+      "cell": "a yield after the deny committed, before the index drop, is told the turn ended failed, never `not-found`",
+      "note": "#1262. After commitTurnDeadline deletes pending (the latch, before the terminal CAS) the only in-memory answer a late yield could find was turnAcceptances.settled. When that field was not yet written, or a concurrent sweep dropped it, the yield heard not-found for a deny the run already has. The durable terminal is the answer; the index drop is not the cause (the yield path never consults it)."
+    }
+  ]
+}

--- a/implementations/manager/smoke/mutations/reconcile-startup.json
+++ b/implementations/manager/smoke/mutations/reconcile-startup.json
@@ -84,8 +84,8 @@
     {
       "name": "a retried yield hears not-found for work that committed",
       "file": "implementations/manager/src/manager.ts",
-      "find": "      const settled = this.turnAcceptances.get(goalId);\n      if (settled?.settled !== undefined) {",
-      "replace": "      const settled = this.turnAcceptances.get(goalId);\n      if (false && settled?.settled !== undefined) {",
+      "find": "      const settled = this.turnAcceptances.get(goalId);\n      if (settled !== undefined) {",
+      "replace": "      const settled = this.turnAcceptances.get(goalId);\n      if (false && settled !== undefined) {",
       "expectRed": "a retried yield is served the answer the lost reply carried, never `not-found`",
       "cell": "a retried yield is served the answer the lost reply carried, never `not-found`",
       "note": "The commit deletes the pending turn, so a retry after a lost reply found nothing and the seat read `not-found` as 'drop it': failure reported for work the run already has."
@@ -134,6 +134,15 @@
       "expectRed": "an adopted turn yields, and a retry of that yield is served the answer it earned, never `not-found`",
       "cell": "an adopted turn yields, and a retry of that yield is served the answer it earned, never `not-found`",
       "note": "rememberSettledTurn writes only against an acceptance this incarnation holds. Adoption rebuilt pendingTurns alone, so a yield whose reply was lost after a restart still heard not-found on the one path adoption exists for."
+    },
+    {
+      "name": "a late yield after the deadline committed hears not-found instead of the deny",
+      "file": "implementations/manager/src/manager.ts",
+      "find": "        if (settled.settled !== undefined) return { goalId, state: settled.settled.state };\n        // The in-memory answer is not yet remembered (pending deleted before the terminal CAS,\n        // or a concurrent sweep dropped `settled` while the commit was still in flight). The\n        // durable terminal is the one the run already has; name it, never `not-found`.\n        if (settled.ref !== undefined) {\n          const ended = await readGoalResult(gw.ctx, settled.ref);\n          if (ended !== undefined) {\n            this.rememberSettledTurn(goalId, ended.state, ended.ts);\n            return { goalId, state: ended.state };\n          }\n        }",
+      "replace": "        if (settled.settled !== undefined) return { goalId, state: settled.settled.state };",
+      "expectRed": "a yield after the deny committed, before the index drop, is told the turn ended failed, never `not-found`",
+      "cell": "a yield after the deny committed, before the index drop, is told the turn ended failed, never `not-found`",
+      "note": "#1262. After commitTurnDeadline deletes pending (the latch, before the terminal CAS) the only in-memory answer a late yield could find was turnAcceptances.settled. When that field was not yet written, or a concurrent sweep dropped it, the yield heard not-found for a deny the run already has. The durable terminal is the answer; the index drop is not the cause (the yield path never consults it)."
     }
   ]
 }

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -913,8 +913,13 @@ export class Manager {
    * hear `not-found`, which a seat reads as "drop it": failure reported for work that committed.
    * The settled answer lives here for a bounded window instead, and the sweep drops it after,
    * which is also what keeps this map from being one entry per turn for the process lifetime.
+   *
+   * `ref` is the goal coordinates the durable terminal is published under. A late yield that
+   * arrives after pendingTurns is gone and before `settled` is remembered (or after a concurrent
+   * sweep dropped the settled field) still has to name that terminal, never `not-found`. The
+   * index entry is not that answer: it is cleared at commit, and the yield path never consults it.
    */
-  private turnAcceptances = new Map<string, { acceptance: TurnAcceptance; settled?: { state: string; at: number } }>();
+  private turnAcceptances = new Map<string, { acceptance: TurnAcceptance; ref?: GoalRef; settled?: { state: string; at: number } }>();
   /** Every relayed turn awaiting its seat's yield, by goal id. The seat's `turn-pending` pull
    *  scans it; the deadline sweep drives expiry; a seat reap stamps its entries `seatDiedAt`, which
    *  the deadline terminal carries as `agentDownAt` so the run reads that death as L4002.
@@ -6051,7 +6056,7 @@ export class Manager {
     this.pendingTurns.set(goalId, pending);
     this.ensureTurnSweep();
     const acceptance: TurnAcceptance = { name: a.name, owner: t.owner, actor: t.actor, uid: t.lifecycleUid, goalId, fingerprint, deadlineAt, executor };
-    this.turnAcceptances.set(goalId, { acceptance });
+    this.turnAcceptances.set(goalId, { acceptance, ref });
     this.emitGoalProgress(ref, executor.epoch, { phase: "relayed" });
     return acceptance;
   }
@@ -6106,11 +6111,21 @@ export class Manager {
       // reporting failure for work the run already has. The answer the first reply carried is
       // served again instead, to the addressee it was addressed to and nobody else.
       const settled = this.turnAcceptances.get(goalId);
-      if (settled?.settled !== undefined) {
+      if (settled !== undefined) {
         const a = settled.acceptance;
         if (a.owner !== c.owner || a.actor !== c.actor || a.uid !== c.uid)
           throw new EpEnvelopeError("permission-denied", `turn "${goalId}" was addressed to ${a.owner}.${a.actor}/${a.uid}; a yield is the addressee's own (SPEC 13.6)`);
-        return { goalId, state: settled.settled.state };
+        if (settled.settled !== undefined) return { goalId, state: settled.settled.state };
+        // The in-memory answer is not yet remembered (pending deleted before the terminal CAS,
+        // or a concurrent sweep dropped `settled` while the commit was still in flight). The
+        // durable terminal is the one the run already has; name it, never `not-found`.
+        if (settled.ref !== undefined) {
+          const ended = await readGoalResult(gw.ctx, settled.ref);
+          if (ended !== undefined) {
+            this.rememberSettledTurn(goalId, ended.state, ended.ts);
+            return { goalId, state: ended.state };
+          }
+        }
       }
       throw new EpEnvelopeError("not-found", `no pending turn "${goalId}" on this manager`);
     }
@@ -6164,12 +6179,12 @@ export class Manager {
       await this.assertGoalWriterEpochCurrent(epoch);
       const { fact } = await commitGoalResult(gw.ctx, { ref: p.ref, now: Date.now(), cause: "deny", denial: { kind: "hold-expired", token: p.holdToken }, data: { reason: "turn-deadline", ...(p.seatDiedAt !== undefined ? { agentDownAt: p.seatDiedAt } : {}), ...(p.handoffFrom !== undefined ? { handoffFrom: p.handoffFrom } : {}) }, committer: { instanceId: this.managerInstanceId, epoch } });
       this.emitGoalProgress(p.ref, epoch, { phase: "terminal", state: fact.state, ...(fact.data !== undefined ? { data: fact.data } : {}) });
-      await clearGoalIndex(gw.ctx, p.ref);
-      // The SAME order the yield path keeps: remember, then ask whether the sweep may stop. Asked
-      // first, the stop saw no pending turn and no settled answer, cleared the acceptance map, and
-      // the remember below found nothing to write to; a yield whose reply was lost then heard
-      // `not-found` for the last expired turn, which the seat reads as "drop it".
+      // Remember BEFORE the index clear: a late yield that arrives after the pending latch
+      // (the delete at the top of this function) and after this CAS has to name this terminal.
+      // Clearing first, then remembering, left a window where maybeStopTurnSweep saw no pending
+      // turn and no settled answer, wiped the acceptance, and rememberSettledTurn no-op'd.
       this.rememberSettledTurn(p.goalId, fact.state, Date.now());
+      await clearGoalIndex(gw.ctx, p.ref);
     } catch (e) { console.error(`! turn deadline terminal for ${p.goalId}: ${(e as Error).message}`); }
     this.maybeStopTurnSweep();
   }
@@ -6219,8 +6234,12 @@ export class Manager {
    *  second is still owed would leave one entry per turn for the process lifetime. */
   private maybeStopTurnSweep(): void {
     if (this.pendingTurns.size > 0) return;
-    for (const e of this.turnAcceptances.values()) if (e.settled !== undefined) return;
-    this.turnAcceptances.clear();
+    // An acceptance with no `settled` yet is the in-flight deadline commit: pending was the
+    // latch and is already gone, the terminal CAS has not returned, and a concurrent sweep
+    // tick used to clear the map here, so rememberSettledTurn no-op'd and a late yield heard
+    // `not-found` for a deny the run already has. Prune is the only deleter; stop only when
+    // it has left nothing.
+    if (this.turnAcceptances.size > 0) return;
     this.stopTurnSweep();
   }
 
@@ -6308,6 +6327,7 @@ export class Manager {
         fingerprint: spec.value.fingerprint, deadlineAt: p.deadlineAt,
         executor: { lifecycleUid: this.managerInstanceId, epoch: p.holdEpoch },
       },
+      ref: p.ref,
     });
     // NO LIVENESS VERDICT AT BOOT. The agents map is empty here: seats are re-registered later,
     // by the resume path, so `not in the map` at this moment means "not yet re-registered", never


### PR DESCRIPTION
Closes #1262

## What failed

`smoke:turn-relay-auth` flake on the deadline arm, same product source on two CI heads ~13 minutes apart. The deny itself held (`turn-deadline`). The late yield after that terminal was visible heard:

```
{"ok":false,"error":{"code":"not-found","message":"no pending turn \"g2bbb…\""}}
```

A seat that yields a moment late has to distinguish **the turn hit its deadline and was denied** (the run moved on) from **no such turn ever existed for me**. `not-found` collapses both.

## Mechanism (the index-drop lead is wrong)

The yield path never consults the durable goal index. After `commitTurnDeadline` deletes the pending entry (its idempotency latch, *before* the terminal CAS) the only in-memory answer a late yield could find was `turnAcceptances.settled`. Two orderings both produce `not-found` while the deny is already on the plane:

1. Terminal committed, index still present, settled answer not yet remembered (the window between `pendingTurns.delete` and `rememberSettledTurn`; also a concurrent sweep's `maybeStopTurnSweep` wiping the acceptance map while the commit is still in flight, so `rememberSettledTurn` no-ops).
2. Terminal committed *and* the index already cleared (the state the auth-mesh smoke's `resultOf` wait actually observes before it yields).

Nothing recorded a success over the deny on the red CI run, and the fixture confirms that: both late yields leave the terminal `failed` / `turn-deadline`.

## What this does

- `serveTurnYield` still serves a remembered settled answer. When that field is missing but this incarnation accepted the turn, it reads the durable terminal and names that state instead of `not-found`.
- The acceptance map keeps the goal `ref` so that read has coordinates after pending is gone.
- `maybeStopTurnSweep` no longer clears the acceptance map the moment pending is empty. An unsettled acceptance is the in-flight deadline commit; prune is the only deleter.
- `commitTurnDeadline` remembers the settled answer before it clears the index.

## Proof

Failing cells first, in `manager-reconcile-startup.smoke.ts`, driving `serveTurnYield` after a shipped `expireTurnHold` + `commitTurnDeadline`. Two goal ids (the index is create-only and cannot be restored after a clear). Both orderings forced by dropping `settled` after the deny is on the plane, not by live timers or broker perturbation.

On today's main those two cells reddened for the CI reason:

```
FAIL ... never `not-found` {"code":"not-found","message":"no pending turn \"ddd…\""}
FAIL ... never `not-found` {"code":"not-found","message":"no pending turn \"eee…\""}
```

After the fix: `MANAGER RECONCILE STARTUP SMOKE OK (23 passed, 0 failed)`.

`pnpm mutation-proof --config implementations/manager/smoke/mutations/late-turn-yield.json` **KILLED** on the earliest named cell:

`a yield after the deny committed, before the index drop, is told the turn ended failed, never \`not-found\``

`pnpm typecheck` green in this worktree.

Did not run `cotal up`/`cotal down`, `pnpm cotal`, or any `*-live` suite.

## Unverified

The original auth-mesh smoke's section 4 is still timing-sensitive (it waits for the terminal then yields, which is usually after remember). The new cells force the window it only hit intermittently. A live multi-manager / successor-incarnation late yield is not covered here.
