### PR TITLE
fix(manager): age leftover turn acceptances off latch-drop, not deadline

### DIFF
--- a/.changeset/fix-1262-leftover-since.md
+++ b/.changeset/fix-1262-leftover-since.md
@@ -1,0 +1,7 @@
+---
+"@cotal-ai/manager": patch
+---
+
+A leftover turn acceptance whose deadline commit never remembered is aged off `leftoverSince` (when the pending latch dropped), not off the original deadline.
+
+Aging off `deadlineAt` would prune a long-outage leftover on the first sweep tick and take the GoalRef a late yield still needs. `commitTurnDeadline` stamps that clock when it deletes pending.

--- a/implementations/manager/smoke/manager-reconcile-startup.smoke.ts
+++ b/implementations/manager/smoke/manager-reconcile-startup.smoke.ts
@@ -275,7 +275,7 @@ try {
     // the run already has. The answer the first reply carried is served again instead.
     const retryDoors = seeded as unknown as {
       goalWriter?: unknown;
-      turnAcceptances: Map<string, { acceptance: Record<string, unknown>; settled?: { state: string; at: number } }>;
+      turnAcceptances: Map<string, { acceptance: Record<string, unknown>; leftoverSince?: number; settled?: { state: string; at: number } }>;
       sweepTurnDeadlines: () => Promise<void>;
     };
     retryDoors.goalWriter = { ctx: {} };
@@ -306,6 +306,25 @@ try {
     check("the sweep drops a settled answer once its retry window has passed, and keeps a fresh one",
       !retryDoors.turnAcceptances.has("long-done") && retryDoors.turnAcceptances.has("done-already"),
       [...retryDoors.turnAcceptances.keys()]);
+    // A FAILED DEADLINE COMMIT leaves an acceptance with no `settled` (pending was the latch
+    // and is already gone). That entry used to pin the sweep forever once maybeStopTurnSweep
+    // stopped wiping the map. Age it off leftoverSince (when the latch dropped), NEVER off
+    // deadlineAt: a turn that expired after a long outage would otherwise be pruned on the
+    // first tick and take the GoalRef with it. The two clocks are inverted so aging off
+    // deadlineAt cannot pass.
+    retryDoors.turnAcceptances.set("stale-unsettled", {
+      acceptance: { name: "s", owner: seat.owner, actor: seat.actor, uid: seat.uid, goalId: "stale-unsettled", fingerprint: "f", deadlineAt: Date.now() + 60_000, executor: { lifecycleUid: "x", epoch: 0 } },
+      leftoverSince: Date.now() - 10 * 60_000,
+    });
+    retryDoors.turnAcceptances.set("fresh-unsettled", {
+      acceptance: { name: "s", owner: seat.owner, actor: seat.actor, uid: seat.uid, goalId: "fresh-unsettled", fingerprint: "f", deadlineAt: t0 - 10 * 60_000, executor: { lifecycleUid: "x", epoch: 0 } },
+      leftoverSince: Date.now(),
+    });
+    await retryDoors.sweepTurnDeadlines();
+    check("the sweep drops a stale unsettled acceptance once its retry window has passed, and keeps a fresh one",
+      !retryDoors.turnAcceptances.has("stale-unsettled") && retryDoors.turnAcceptances.has("fresh-unsettled"),
+      [...retryDoors.turnAcceptances.keys()]);
+    retryDoors.turnAcceptances.delete("fresh-unsettled");
     // AND THE SWEEP STOPS ONCE THE LAST ANSWER IS GONE. The settle-time callers of the stop check
     // run when an answer has just been remembered, so they never see the map empty; the prune is
     // the one event after which nothing is owed, and it is the sweep's own to notice.
@@ -466,7 +485,7 @@ try {
         payload: string; acceptedAt: number; deadlineAt: number;
         holdToken: string; holdEpoch: number;
       }>;
-      turnAcceptances: Map<string, { acceptance: Record<string, unknown>; ref?: GoalRef; settled?: { state: string; at: number } }>;
+      turnAcceptances: Map<string, { acceptance: Record<string, unknown>; ref?: GoalRef; leftoverSince?: number; settled?: { state: string; at: number } }>;
       expireTurnHold: (p: { ref: GoalRef; goalId: string; holdToken: string }) => Promise<{ settle?: string } | undefined>;
       commitTurnDeadline: (p: { ref: GoalRef; goalId: string; holdToken: string; seat: { name: string; owner: string; actor: string; uid: string }; payload: string; acceptedAt: number; deadlineAt: number; holdEpoch: number }) => Promise<void>;
       serveTurnYield: (c: { owner: string; actor: string; uid: string }, raw: Record<string, unknown>) => Promise<{ goalId: string; state: string }>;
@@ -519,6 +538,10 @@ try {
       check("the deadline deny is the goal's terminal, reason `turn-deadline`; no success over it",
         deniedLate?.state === "failed" && (deniedLate.data as { reason?: string } | undefined)?.reason === "turn-deadline",
         deniedLate);
+      const stamped = lateDoors.turnAcceptances.get(lateId);
+      check("commitTurnDeadline stamps leftoverSince when the pending latch drops, not the original deadline",
+        typeof stamped?.leftoverSince === "number" && stamped.leftoverSince > LATE_DEADLINE,
+        stamped);
       // Ordering 1: terminal committed, index still present (we skip the clear), settled
       // answer not remembered. This is the window between pendingTurns.delete and
       // rememberSettledTurn (and the window a concurrent sweep's maybeStopTurnSweep can
@@ -567,7 +590,7 @@ try {
   await broker.stop().catch(() => {});
 }
 
-const EXPECTED_CELLS = 23;
+const EXPECTED_CELLS = 25;
 console.log(`\n${fail === 0 ? "MANAGER RECONCILE STARTUP SMOKE OK ✅" : "MANAGER RECONCILE STARTUP SMOKE FAILED"}  (${pass} passed, ${fail} failed)`);
 if (pass + fail !== EXPECTED_CELLS) {
   console.log(`SUITE INCOMPLETE — ran ${pass + fail} of ${EXPECTED_CELLS} cells; a partial run is not a pass`);

--- a/implementations/manager/smoke/mutations/reconcile-startup.json
+++ b/implementations/manager/smoke/mutations/reconcile-startup.json
@@ -102,8 +102,8 @@
     {
       "name": "settled answers are kept for the process lifetime",
       "file": "implementations/manager/src/manager.ts",
-      "find": "      if (this.pendingTurns.has(goalId)) continue;\n      // Unsettled leftovers age off the latch-drop stamp, never `deadlineAt`.\n      const at = e.settled?.at ?? e.leftoverSince;\n      if (at !== undefined && now - at >= TURN_ANSWER_RETENTION_MS) this.turnAcceptances.delete(goalId);",
-      "replace": "      if (this.pendingTurns.has(goalId)) continue;\n      // Unsettled leftovers age off the latch-drop stamp, never `deadlineAt`.\n      const at = e.settled?.at ?? e.leftoverSince;\n      if (e.settled !== undefined && at !== undefined && now - at >= TURN_ANSWER_RETENTION_MS) void goalId;",
+      "find": "      if (this.pendingTurns.has(goalId)) continue;\n      const at = e.settled?.at ?? e.leftoverSince;\n      if (at !== undefined && now - at >= TURN_ANSWER_RETENTION_MS) this.turnAcceptances.delete(goalId);",
+      "replace": "      if (this.pendingTurns.has(goalId)) continue;\n      const at = e.settled?.at ?? e.leftoverSince;\n      if (e.settled !== undefined && at !== undefined && now - at >= TURN_ANSWER_RETENTION_MS) void goalId;",
       "expectRed": "the sweep drops a settled answer once its retry window has passed",
       "cell": "the sweep drops a settled answer once its retry window has passed, and keeps a fresh one",
       "note": "The map had no eviction at all: one entry per turn for the life of the process. The mutant keeps the loop and its scope intact and only removes the delete; a first draft replaced the whole if with statements that referenced the loop bindings OUTSIDE the loop, which is a ReferenceError every sweep tick and graded WRONG-RED about nothing."
@@ -111,8 +111,8 @@
     {
       "name": "an unsettled leftover acceptance is kept for the process lifetime",
       "file": "implementations/manager/src/manager.ts",
-      "find": "      // Unsettled leftovers age off the latch-drop stamp, never `deadlineAt`.\n      const at = e.settled?.at ?? e.leftoverSince;\n      if (at !== undefined && now - at >= TURN_ANSWER_RETENTION_MS) this.turnAcceptances.delete(goalId);",
-      "replace": "      // Unsettled leftovers age off the latch-drop stamp, never `deadlineAt`.\n      const at = e.settled?.at ?? e.leftoverSince;\n      if (e.settled !== undefined && at !== undefined && now - at >= TURN_ANSWER_RETENTION_MS) this.turnAcceptances.delete(goalId);",
+      "find": "      const at = e.settled?.at ?? e.leftoverSince;\n      if (at !== undefined && now - at >= TURN_ANSWER_RETENTION_MS) this.turnAcceptances.delete(goalId);",
+      "replace": "      const at = e.settled?.at ?? e.leftoverSince;\n      if (e.settled !== undefined && at !== undefined && now - at >= TURN_ANSWER_RETENTION_MS) this.turnAcceptances.delete(goalId);",
       "expectRed": "the sweep drops a stale unsettled acceptance once its retry window has passed",
       "cell": "the sweep drops a stale unsettled acceptance once its retry window has passed, and keeps a fresh one",
       "note": "#1262 follow-through. maybeStopTurnSweep used to wipe the map the moment pending was empty, which is the in-flight deadline window. After that wipe was removed, an acceptance whose deadline commit never remembered would pin the 5s sweep forever."

--- a/implementations/manager/smoke/mutations/reconcile-startup.json
+++ b/implementations/manager/smoke/mutations/reconcile-startup.json
@@ -102,8 +102,8 @@
     {
       "name": "settled answers are kept for the process lifetime",
       "file": "implementations/manager/src/manager.ts",
-      "find": "      if (this.pendingTurns.has(goalId)) continue;\n      const at = e.settled?.at ?? e.leftoverSince;\n      if (at !== undefined && now - at >= TURN_ANSWER_RETENTION_MS) this.turnAcceptances.delete(goalId);",
-      "replace": "      if (this.pendingTurns.has(goalId)) continue;\n      const at = e.settled?.at ?? e.leftoverSince;\n      if (e.settled !== undefined && at !== undefined && now - at >= TURN_ANSWER_RETENTION_MS) void goalId;",
+      "find": "      if (at !== undefined && now - at >= TURN_ANSWER_RETENTION_MS) this.turnAcceptances.delete(goalId);",
+      "replace": "      if (e.settled !== undefined && at !== undefined && now - at >= TURN_ANSWER_RETENTION_MS) void goalId;",
       "expectRed": "the sweep drops a settled answer once its retry window has passed",
       "cell": "the sweep drops a settled answer once its retry window has passed, and keeps a fresh one",
       "note": "The map had no eviction at all: one entry per turn for the life of the process. The mutant keeps the loop and its scope intact and only removes the delete; a first draft replaced the whole if with statements that referenced the loop bindings OUTSIDE the loop, which is a ReferenceError every sweep tick and graded WRONG-RED about nothing."

--- a/implementations/manager/smoke/mutations/reconcile-startup.json
+++ b/implementations/manager/smoke/mutations/reconcile-startup.json
@@ -102,11 +102,38 @@
     {
       "name": "settled answers are kept for the process lifetime",
       "file": "implementations/manager/src/manager.ts",
-      "find": "      if (e.settled !== undefined && now - e.settled.at >= TURN_ANSWER_RETENTION_MS) this.turnAcceptances.delete(goalId);",
-      "replace": "      if (e.settled !== undefined && now - e.settled.at >= TURN_ANSWER_RETENTION_MS) void goalId;",
+      "find": "      if (this.pendingTurns.has(goalId)) continue;\n      // Unsettled leftovers age off the latch-drop stamp, never `deadlineAt`.\n      const at = e.settled?.at ?? e.leftoverSince;\n      if (at !== undefined && now - at >= TURN_ANSWER_RETENTION_MS) this.turnAcceptances.delete(goalId);",
+      "replace": "      if (this.pendingTurns.has(goalId)) continue;\n      // Unsettled leftovers age off the latch-drop stamp, never `deadlineAt`.\n      const at = e.settled?.at ?? e.leftoverSince;\n      if (e.settled !== undefined && at !== undefined && now - at >= TURN_ANSWER_RETENTION_MS) void goalId;",
       "expectRed": "the sweep drops a settled answer once its retry window has passed",
       "cell": "the sweep drops a settled answer once its retry window has passed, and keeps a fresh one",
       "note": "The map had no eviction at all: one entry per turn for the life of the process. The mutant keeps the loop and its scope intact and only removes the delete; a first draft replaced the whole if with statements that referenced the loop bindings OUTSIDE the loop, which is a ReferenceError every sweep tick and graded WRONG-RED about nothing."
+    },
+    {
+      "name": "an unsettled leftover acceptance is kept for the process lifetime",
+      "file": "implementations/manager/src/manager.ts",
+      "find": "      // Unsettled leftovers age off the latch-drop stamp, never `deadlineAt`.\n      const at = e.settled?.at ?? e.leftoverSince;\n      if (at !== undefined && now - at >= TURN_ANSWER_RETENTION_MS) this.turnAcceptances.delete(goalId);",
+      "replace": "      // Unsettled leftovers age off the latch-drop stamp, never `deadlineAt`.\n      const at = e.settled?.at ?? e.leftoverSince;\n      if (e.settled !== undefined && at !== undefined && now - at >= TURN_ANSWER_RETENTION_MS) this.turnAcceptances.delete(goalId);",
+      "expectRed": "the sweep drops a stale unsettled acceptance once its retry window has passed",
+      "cell": "the sweep drops a stale unsettled acceptance once its retry window has passed, and keeps a fresh one",
+      "note": "#1262 follow-through. maybeStopTurnSweep used to wipe the map the moment pending was empty, which is the in-flight deadline window. After that wipe was removed, an acceptance whose deadline commit never remembered would pin the 5s sweep forever."
+    },
+    {
+      "name": "an unsettled leftover ages off the original deadline, not the latch-drop stamp",
+      "file": "implementations/manager/src/manager.ts",
+      "find": "      const at = e.settled?.at ?? e.leftoverSince;",
+      "replace": "      const at = e.settled?.at ?? e.acceptance.deadlineAt;",
+      "expectRed": "the sweep drops a stale unsettled acceptance once its retry window has passed",
+      "cell": "the sweep drops a stale unsettled acceptance once its retry window has passed, and keeps a fresh one",
+      "note": "Aging off deadlineAt drops a leftover immediately after a long outage (deadline already elapsed) and keeps one whose deadline is still in the future. leftoverSince is when the pending latch dropped; the cell inverts the two clocks so this mutant cannot hide."
+    },
+    {
+      "name": "commitTurnDeadline never stamps leftoverSince",
+      "file": "implementations/manager/src/manager.ts",
+      "find": "    if (!this.pendingTurns.delete(p.goalId)) return;\n    this.markTurnLatchDropped(p.goalId);",
+      "replace": "    if (!this.pendingTurns.delete(p.goalId)) return;",
+      "expectRed": "commitTurnDeadline stamps leftoverSince when the pending latch drops",
+      "cell": "commitTurnDeadline stamps leftoverSince when the pending latch drops, not the original deadline",
+      "note": "Without this stamp a failed deadline commit leaves an acceptance with no settled and no leftoverSince, so the sweep never ages it off."
     },
     {
       "name": "the sweep never re-checks its stop after pruning the last answer",

--- a/implementations/manager/smoke/mutations/unsettled-turn-prune.json
+++ b/implementations/manager/smoke/mutations/unsettled-turn-prune.json
@@ -1,0 +1,16 @@
+{
+  "suite": "implementations/manager/smoke/manager-reconcile-startup.smoke.ts",
+  "guard": "A leftover unsettled turn acceptance whose pending latch is gone is aged off leftoverSince, never the original deadline, so a failed deadline commit cannot pin the sweep forever and a long-outage leftover is not pruned on the first tick.",
+  "command": "pnpm smoke:manager-reconcile-startup",
+  "completionMarker": "MANAGER RECONCILE STARTUP SMOKE",
+  "mutations": [
+    {
+      "name": "an unsettled leftover ages off the original deadline, not the latch-drop stamp",
+      "file": "implementations/manager/src/manager.ts",
+      "find": "      const at = e.settled?.at ?? e.leftoverSince;",
+      "replace": "      const at = e.settled?.at ?? e.acceptance.deadlineAt;",
+      "expectRed": "the sweep drops a stale unsettled acceptance once its retry window has passed",
+      "cell": "the sweep drops a stale unsettled acceptance once its retry window has passed, and keeps a fresh one"
+    }
+  ]
+}

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -6274,7 +6274,6 @@ export class Manager {
     // terminal, then drop it so a commit that never remembered cannot pin the sweep forever.
     for (const [goalId, e] of [...this.turnAcceptances.entries()]) {
       if (this.pendingTurns.has(goalId)) continue;
-      // Unsettled leftovers age off the latch-drop stamp, never `deadlineAt`.
       const at = e.settled?.at ?? e.leftoverSince;
       if (at !== undefined && now - at >= TURN_ANSWER_RETENTION_MS) this.turnAcceptances.delete(goalId);
     }

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -918,8 +918,13 @@ export class Manager {
    * arrives after pendingTurns is gone and before `settled` is remembered (or after a concurrent
    * sweep dropped the settled field) still has to name that terminal, never `not-found`. The
    * index entry is not that answer: it is cleared at commit, and the yield path never consults it.
+   *
+   * `leftoverSince` is when the pending latch dropped. An unsettled leftover ages off that stamp,
+   * never off `acceptance.deadlineAt`: a turn that expired after a long outage would otherwise be
+   * pruned on the first sweep tick, taking the GoalRef with it, and a late yield in the retry
+   * window would hear `not-found` again.
    */
-  private turnAcceptances = new Map<string, { acceptance: TurnAcceptance; ref?: GoalRef; settled?: { state: string; at: number } }>();
+  private turnAcceptances = new Map<string, { acceptance: TurnAcceptance; ref?: GoalRef; leftoverSince?: number; settled?: { state: string; at: number } }>();
   /** Every relayed turn awaiting its seat's yield, by goal id. The seat's `turn-pending` pull
    *  scans it; the deadline sweep drives expiry; a seat reap stamps its entries `seatDiedAt`, which
    *  the deadline terminal carries as `agentDownAt` so the run reads that death as L4002.
@@ -6161,6 +6166,7 @@ export class Manager {
     this.emitGoalProgress(p.ref, epoch, { phase: "terminal", state: fact.state, ...(fact.data !== undefined ? { data: fact.data } : {}) });
     await clearGoalIndex(gw.ctx, p.ref);
     this.pendingTurns.delete(goalId);
+    this.markTurnLatchDropped(goalId, at);
     this.rememberSettledTurn(goalId, fact.state, at);
     this.maybeStopTurnSweep();
     return { goalId, state: fact.state };
@@ -6174,6 +6180,7 @@ export class Manager {
     const gw = this.goalWriter;
     if (!gw) return;
     if (!this.pendingTurns.delete(p.goalId)) return;
+    this.markTurnLatchDropped(p.goalId);
     const epoch = this.serviceServe?.grant.epoch ?? 0;
     try {
       await this.assertGoalWriterEpochCurrent(epoch);
@@ -6229,6 +6236,14 @@ export class Manager {
     entry.settled = { state, at };
   }
 
+  /** Stamp when the pending latch dropped, so an unsettled leftover ages off that instant rather
+   *  than the original deadline. Idempotent: the first drop is the one the retry window starts at. */
+  private markTurnLatchDropped(goalId: string, at = Date.now()): void {
+    const entry = this.turnAcceptances.get(goalId);
+    if (entry === undefined || entry.leftoverSince !== undefined) return;
+    entry.leftoverSince = at;
+  }
+
   /** Stop the sweep only when it has nothing left to do. It drives elapsed turns to their deadline
    *  terminals AND drops settled answers once their retry window has passed, so a stop while the
    *  second is still owed would leave one entry per turn for the process lifetime. */
@@ -6254,8 +6269,15 @@ export class Manager {
   private async sweepTurnDeadlines(): Promise<void> {
     const now = Date.now();
     // A settled answer is kept only as long as a lost reply could still be retried under it.
-    for (const [goalId, e] of [...this.turnAcceptances.entries()])
-      if (e.settled !== undefined && now - e.settled.at >= TURN_ANSWER_RETENTION_MS) this.turnAcceptances.delete(goalId);
+    // An UNSETTLED acceptance whose pending latch is already gone is the in-flight (or failed)
+    // deadline commit: keep it for the same window so a late yield can still read the durable
+    // terminal, then drop it so a commit that never remembered cannot pin the sweep forever.
+    for (const [goalId, e] of [...this.turnAcceptances.entries()]) {
+      if (this.pendingTurns.has(goalId)) continue;
+      // Unsettled leftovers age off the latch-drop stamp, never `deadlineAt`.
+      const at = e.settled?.at ?? e.leftoverSince;
+      if (at !== undefined && now - at >= TURN_ANSWER_RETENTION_MS) this.turnAcceptances.delete(goalId);
+    }
     // The prune above is the one event after which the sweep may have nothing left to do, and
     // the settle-time callers cannot see it: they run when an answer has just been remembered.
     this.maybeStopTurnSweep();

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -6274,6 +6274,7 @@ export class Manager {
     // terminal, then drop it so a commit that never remembered cannot pin the sweep forever.
     for (const [goalId, e] of [...this.turnAcceptances.entries()]) {
       if (this.pendingTurns.has(goalId)) continue;
+      // Unsettled leftovers age off the latch-drop stamp, never `deadlineAt`.
       const at = e.settled?.at ?? e.leftoverSince;
       if (at !== undefined && now - at >= TURN_ANSWER_RETENTION_MS) this.turnAcceptances.delete(goalId);
     }


### PR DESCRIPTION
Follow-up to #1265.

#1265 stopped `maybeStopTurnSweep` from wiping unsettled acceptances the moment pending is empty. That is the in-flight (or failed) deadline commit. Without a prune, a leftover whose terminal CAS never remembered pins the 5s sweep for the process lifetime.

Aging those leftovers off `deadlineAt` is the wrong clock. A turn that expired after a long outage would be pruned on the first sweep tick and take the GoalRef a late yield still needs. Stamp `leftoverSince` when `commitTurnDeadline` drops the pending latch, and age off that.

## Proof

`manager-reconcile-startup.smoke.ts` 25/25.

The prune cell inverts the two clocks: a stale leftover has a *future* deadline and an old `leftoverSince`; a fresh leftover has an elapsed deadline and a now stamp. Aging off `deadlineAt` cannot pass. `commitTurnDeadline` stamps `leftoverSince` on the shipped deny path.

`pnpm mutation-proof --config implementations/manager/smoke/mutations/unsettled-turn-prune.json` KILLED on:

`the sweep drops a stale unsettled acceptance once its retry window has passed`

The leftoverSince stamp mutant in `reconcile-startup.json` KILLED on:

`commitTurnDeadline stamps leftoverSince when the pending latch drops`

`pnpm --filter @cotal-ai/manager typecheck` green.

Did not run `cotal up`/`cotal down`, `pnpm cotal`, or any `*-live` suite.
