### PR TITLE
fix(manager): re-anchor late-yield mutation finds on code, not comments

### DIFF
--- a/.changeset/fix-1262-mutation-anchors.md
+++ b/.changeset/fix-1262-mutation-anchors.md
@@ -1,0 +1,7 @@
+---
+"@cotal-ai/manager": patch
+---
+
+Re-anchor the late-yield mutation `find` on the durable-read code block, not the neighbouring comment.
+
+`smoke:mutation-fixtures` refuses a `find` that spans prose. The #1265 guard used three comment lines to make the window unique; a comment-only tidy would have disarmed it silently. The durable `readGoalResult` block is unique on its own.

--- a/implementations/manager/smoke/mutations/late-turn-yield.json
+++ b/implementations/manager/smoke/mutations/late-turn-yield.json
@@ -7,8 +7,8 @@
     {
       "name": "a late yield after the deadline committed hears not-found instead of the deny",
       "file": "implementations/manager/src/manager.ts",
-      "find": "        if (settled.settled !== undefined) return { goalId, state: settled.settled.state };\n        // The in-memory answer is not yet remembered (pending deleted before the terminal CAS,\n        // or a concurrent sweep dropped `settled` while the commit was still in flight). The\n        // durable terminal is the one the run already has; name it, never `not-found`.\n        if (settled.ref !== undefined) {\n          const ended = await readGoalResult(gw.ctx, settled.ref);\n          if (ended !== undefined) {\n            this.rememberSettledTurn(goalId, ended.state, ended.ts);\n            return { goalId, state: ended.state };\n          }\n        }",
-      "replace": "        if (settled.settled !== undefined) return { goalId, state: settled.settled.state };",
+      "find": "        if (settled.ref !== undefined) {\n          const ended = await readGoalResult(gw.ctx, settled.ref);\n          if (ended !== undefined) {\n            this.rememberSettledTurn(goalId, ended.state, ended.ts);\n            return { goalId, state: ended.state };\n          }\n        }",
+      "replace": "        if (settled.ref !== undefined) {\n          void settled.ref;\n        }",
       "expectRed": "a yield after the deny committed, before the index drop, is told the turn ended failed, never `not-found`",
       "cell": "a yield after the deny committed, before the index drop, is told the turn ended failed, never `not-found`",
       "note": "#1262. After commitTurnDeadline deletes pending (the latch, before the terminal CAS) the only in-memory answer a late yield could find was turnAcceptances.settled. When that field was not yet written, or a concurrent sweep dropped it, the yield heard not-found for a deny the run already has. The durable terminal is the answer; the index drop is not the cause (the yield path never consults it)."

--- a/implementations/manager/smoke/mutations/reconcile-startup.json
+++ b/implementations/manager/smoke/mutations/reconcile-startup.json
@@ -138,8 +138,8 @@
     {
       "name": "a late yield after the deadline committed hears not-found instead of the deny",
       "file": "implementations/manager/src/manager.ts",
-      "find": "        if (settled.settled !== undefined) return { goalId, state: settled.settled.state };\n        // The in-memory answer is not yet remembered (pending deleted before the terminal CAS,\n        // or a concurrent sweep dropped `settled` while the commit was still in flight). The\n        // durable terminal is the one the run already has; name it, never `not-found`.\n        if (settled.ref !== undefined) {\n          const ended = await readGoalResult(gw.ctx, settled.ref);\n          if (ended !== undefined) {\n            this.rememberSettledTurn(goalId, ended.state, ended.ts);\n            return { goalId, state: ended.state };\n          }\n        }",
-      "replace": "        if (settled.settled !== undefined) return { goalId, state: settled.settled.state };",
+      "find": "        if (settled.ref !== undefined) {\n          const ended = await readGoalResult(gw.ctx, settled.ref);\n          if (ended !== undefined) {\n            this.rememberSettledTurn(goalId, ended.state, ended.ts);\n            return { goalId, state: ended.state };\n          }\n        }",
+      "replace": "        if (settled.ref !== undefined) {\n          void settled.ref;\n        }",
       "expectRed": "a yield after the deny committed, before the index drop, is told the turn ended failed, never `not-found`",
       "cell": "a yield after the deny committed, before the index drop, is told the turn ended failed, never `not-found`",
       "note": "#1262. After commitTurnDeadline deletes pending (the latch, before the terminal CAS) the only in-memory answer a late yield could find was turnAcceptances.settled. When that field was not yet written, or a concurrent sweep dropped it, the yield heard not-found for a deny the run already has. The durable terminal is the answer; the index drop is not the cause (the yield path never consults it)."


### PR DESCRIPTION
Main is red on `pnpm smoke:mutation-fixtures` from #1265. Dedicated minimal repair; not folded into #1268.

## What failed

Two mutation `find` values spanned the same three comment lines:

- `implementations/manager/smoke/mutations/late-turn-yield.json` [0]
- `implementations/manager/smoke/mutations/reconcile-startup.json` [13]

They are the same mutation (same target, same cell, same 11-line window). The comments were never doing disambiguation: the durable-read block is unique on its own, and so is the `settled.settled` return line.

## What this does

Both `find`s now target the 7-line code-only durable-read block. `replace` is a non-empty compile-clean no-op of that block (`void settled.ref`), not a deletion.

## Proof

`pnpm smoke:mutation-fixtures` green: 0 prose anchors.

`pnpm mutation-proof --config implementations/manager/smoke/mutations/late-turn-yield.json` KILLED. The two fixtures are the same mutation, so this is both cells.

Earliest FAIL from the mutant's raw output (suite is not fail-fast; it logged both and continued):

```
FAIL: a yield after the deny committed, before the index drop, is told the turn ended failed, never `not-found` {"code":"not-found","message":"no pending turn \"ddd…\""}
FAIL: a yield after the deny committed AND the index dropped is still told the turn ended failed, never `not-found` {"code":"not-found","message":"no pending turn \"eee…\""}
```

Same earliest cell as before the re-anchor. Not SURVIVED. Did not redden a different cell.

Did not run `cotal up`/`cotal down`, `pnpm cotal`, or any `*-live` suite.
