### PR TITLE
fix(ci): fail a commit that adds a suite to the frozen list

### DIFF
--- a/.changeset/ci-suites-freeze-guard.md
+++ b/.changeset/ci-suites-freeze-guard.md
@@ -1,0 +1,7 @@
+---
+"cotal-ai": patch
+---
+
+Fail a commit that adds a suite line to the frozen `ci-suites.txt` list.
+
+The freeze has been a comment since #1052. A tail append is shard-stable and inventory-green, then conflicts the next PR. GitHub will not build a CONFLICTING PR, so that branch also gets zero CI. New suites go under `ci-suites.d/<sha256(name)>.txt`.

--- a/bin/smoke/ci-suites-freeze.smoke.ts
+++ b/bin/smoke/ci-suites-freeze.smoke.ts
@@ -1,0 +1,130 @@
+/**
+ * The freeze on `bin/smoke/ci-suites.txt` is a sentence in a comment. Since it landed, main has
+ * appended to that list anyway. A tail append looks correct, is shard-stable, and passes every
+ * existing gate. The cost is a CONFLICTING PR for someone else, which GitHub will not build, so
+ * that branch also gets zero CI.
+ *
+ * This suite grades the scan in `ci-suites.mjs`, not a copy of the rule. The positive control
+ * appends a suite line onto the real file and asserts the SET of names the scan returns.
+ * The required unit job reaches the same scan through `pnpm check:shard-stability`.
+ *
+ * Run: pnpm smoke:ci-suites-freeze
+ */
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { addedLegacySuites, fragmentFileName, parseCiSuites, CI_SUITES_PATH } from "./ci-suites.mjs";
+
+let pass = 0;
+let fail = 0;
+const check = (name: string, cond: boolean, extra?: unknown) => {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    fail++;
+    console.log(`  ✗ FAIL: ${name}`, extra ?? "");
+  }
+};
+
+const same = (a: unknown, b: unknown) => JSON.stringify(a) === JSON.stringify(b);
+
+console.log("ci-suites-freeze: added names on the frozen list");
+
+const real = readFileSync(CI_SUITES_PATH, "utf8");
+const control = "smoke:ci-suites-freeze-control";
+if (real.split("\n").some((line) => line.trim() === control)) {
+  throw new Error(`${CI_SUITES_PATH} already names ${control}; pick another control suite`);
+}
+const withNewline = real.endsWith("\n") ? real : `${real}\n`;
+
+check(
+  "identical frozen files add no suite names",
+  same(addedLegacySuites(real, real), []),
+  addedLegacySuites(real, real),
+);
+
+check(
+  "a comment-only edit of the frozen file adds no suite names",
+  same(addedLegacySuites(real, `${withNewline}# freeze note only\n`), []),
+  addedLegacySuites(real, `${withNewline}# freeze note only\n`),
+);
+
+const legacy = parseCiSuites(real) as string[];
+if (legacy.length < 2) throw new Error(`${CI_SUITES_PATH} parsed to fewer than two suites`);
+const last = legacy[legacy.length - 1];
+const deleted = withNewline
+  .split("\n")
+  .filter((line) => line.trim() !== last)
+  .join("\n");
+check(
+  "deleting a frozen suite adds no suite names",
+  same(addedLegacySuites(real, deleted), []),
+  addedLegacySuites(real, deleted),
+);
+
+const appended = `${withNewline}${control}\n`;
+check(
+  "an appended suite is named as the set of offenders",
+  same(addedLegacySuites(real, appended), [control]),
+  addedLegacySuites(real, appended),
+);
+
+const firstSuite = legacy[0];
+const inserted = withNewline.replace(`${firstSuite}\n`, `${firstSuite}\n${control}\n`);
+check(
+  "a mid-file insert is named as the set of offenders",
+  same(addedLegacySuites(real, inserted), [control]),
+  addedLegacySuites(real, inserted),
+);
+
+const second = "smoke:ci-suites-freeze-control-b";
+check(
+  "two appended suites are both named",
+  same(addedLegacySuites(real, `${appended}${second}\n`), [control, second]),
+  addedLegacySuites(real, `${appended}${second}\n`),
+);
+
+const expectedFragment = fragmentFileName(control);
+check(
+  "the named fragment for an added suite is a 64-hex digest of the public script name",
+  /^[0-9a-f]{64}\.txt$/.test(expectedFragment),
+  expectedFragment,
+);
+check(
+  "two different suite names cannot share a fragment path",
+  fragmentFileName("smoke:other") !== expectedFragment,
+);
+
+const base = process.env.BASE;
+const head = process.env.HEAD;
+if (base && head) {
+  const show = (sha: string): string =>
+    execFileSync("git", ["--no-replace-objects", "show", `${sha}:bin/smoke/ci-suites.txt`], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  let live: string[] | string;
+  try {
+    live = addedLegacySuites(show(base), show(head), `ci-suites.txt@${base}`, `ci-suites.txt@${head}`);
+  } catch (error) {
+    live = `THREW: ${(error as Error).message}`;
+  }
+  const offenders = Array.isArray(live) ? live : [];
+  check(
+    "the committed frozen list added no suite names versus base",
+    Array.isArray(live) && offenders.length === 0,
+    Array.isArray(live)
+      ? offenders.map((suite) => `${suite} -> bin/smoke/ci-suites.d/${fragmentFileName(suite)}`).join(", ")
+      : live,
+  );
+}
+
+const EXPECTED = base && head ? 9 : 8;
+check(
+  `every cell ran - ${EXPECTED} expected, so a cell that stops existing is not mistaken for one that passed`,
+  pass + fail === EXPECTED,
+  `${pass + fail} cells reported`,
+);
+
+console.log(`CI SUITES FREEZE SMOKE ${fail === 0 ? "OK" : "FAILED"} (${pass} passed, ${fail} failed)`);
+if (fail) process.exitCode = 1;

--- a/bin/smoke/ci-suites.d.mts
+++ b/bin/smoke/ci-suites.d.mts
@@ -13,6 +13,16 @@
  */
 /** @param {string} raw @param {string} [label] @returns {string[]} */
 export function parseCiSuites(raw: string, label?: string): string[];
+/** Filename a new suite must use under `ci-suites.d/`. Derived from the public script name so two
+ *  branches adding unrelated suites cannot share a path. */
+/** @param {string} suite @returns {string} */
+export function fragmentFileName(suite: string): string;
+/** Suite names present in `headRaw` that `baseRaw` does not already carry. Derived from the two
+ *  blobs with the same parser the chain uses: comment edits and deletions do not appear, a new
+ *  `smoke:*` line does. The frozen list is whatever suite names the file currently parses to, not a
+ *  copy of those names kept beside it. */
+/** @param {string} baseRaw @param {string} headRaw @param {string} [baseLabel] @param {string} [headLabel] @returns {string[]} */
+export function addedLegacySuites(baseRaw: string, headRaw: string, baseLabel?: string, headLabel?: string): string[];
 /** Reads the chain file. A MISSING or unreadable file throws here - it never yields an empty chain,
  *  because "the chain cannot be empty" is only a real guard if empty cannot be produced silently. */
 export function readCiSuites(path?: string): string[];

--- a/bin/smoke/ci-suites.d/34d152a08aab5eb86e2379988045986a0b48b326a26caee42b527065ecd19cf5.txt
+++ b/bin/smoke/ci-suites.d/34d152a08aab5eb86e2379988045986a0b48b326a26caee42b527065ecd19cf5.txt
@@ -1,0 +1,2 @@
+# Fail a commit that adds a suite line to the frozen ci-suites.txt list.
+smoke:ci-suites-freeze

--- a/bin/smoke/ci-suites.d/README.md
+++ b/bin/smoke/ci-suites.d/README.md
@@ -3,6 +3,10 @@
 Add each new `smoke:*` gate as its own `<sha256(suite-name)>.txt` file containing exactly that one
 script name. Derive the filename from the full public suite name; do not choose a shared topic slug.
 Do not append to `../ci-suites.txt`; that list is frozen to preserve its positional assignments.
+`pnpm smoke:ci-suites-freeze` fails a commit that adds a suite line there, and names the
+`<sha256(suite-name)>.txt` path to use instead. `pnpm check:shard-stability` runs the same scan
+on the two committed blobs, which is how the required unit job reaches it. Deletions and
+comment edits stay legal.
 
 Fragment suites use a stable hash of the script name for sharding, so concurrent file additions and
 filename ordering cannot move another suite between runners.

--- a/bin/smoke/ci-suites.mjs
+++ b/bin/smoke/ci-suites.mjs
@@ -46,6 +46,33 @@ export function parseCiSuites(raw, label = CI_SUITES_PATH) {
   return out;
 }
 
+/** Filename a new suite must use under `ci-suites.d/`. Derived from the public script name so two
+ *  branches adding unrelated suites cannot share a path. */
+/** @param {string} suite @returns {string} */
+export function fragmentFileName(suite) {
+  return `${createHash("sha256").update(suite).digest("hex")}.txt`;
+}
+
+/** Suite names present in `headRaw` that `baseRaw` does not already carry. Derived from the two
+ *  blobs with the same parser the chain uses: comment edits and deletions do not appear, a new
+ *  `smoke:*` line does. The frozen list is whatever suite names the file currently parses to, not a
+ *  copy of those names kept beside it. */
+/** @param {string} baseRaw @param {string} headRaw @param {string} [baseLabel] @param {string} [headLabel] @returns {string[]} */
+export function addedLegacySuites(
+  baseRaw,
+  headRaw,
+  baseLabel = "ci-suites.txt (base)",
+  headLabel = "ci-suites.txt (head)",
+) {
+  const base = new Set(parseCiSuites(baseRaw, baseLabel));
+  /** @type {string[]} */
+  const added = [];
+  for (const suite of parseCiSuites(headRaw, headLabel)) {
+    if (!base.has(suite) && !added.includes(suite)) added.push(suite);
+  }
+  return added;
+}
+
 /** Reads the chain file. A MISSING or unreadable file throws here - it never yields an empty chain,
  *  because "the chain cannot be empty" is only a real guard if empty cannot be produced silently. */
 export function readCiSuites(path = CI_SUITES_PATH) {
@@ -67,7 +94,7 @@ export function readCiSuiteFragments(dir = CI_SUITES_DIR) {
       const suites = parseCiSuites(readFileSync(path, "utf8"), path);
       if (suites.length !== 1)
         throw new Error(`${path}: a suite fragment must contain exactly one smoke script, got ${suites.length}`);
-      const expected = `${createHash("sha256").update(suites[0]).digest("hex")}.txt`;
+      const expected = fragmentFileName(suites[0]);
       if (entry.name !== expected)
         throw new Error(`${path}: fragment filename must be sha256(${suites[0]}) = ${expected}`);
       return suites;

--- a/bin/smoke/mutations/ci-suites-freeze.json
+++ b/bin/smoke/mutations/ci-suites-freeze.json
@@ -1,0 +1,23 @@
+{
+  "suite": "bin/smoke/ci-suites-freeze.smoke.ts",
+  "guard": "a new suite line on ci-suites.txt is named as an offender; comment edits and deletions are not",
+  "command": "pnpm smoke:ci-suites-freeze",
+  "completionMarker": "CI SUITES FREEZE SMOKE",
+  "proveWith": "pnpm mutation-proof --config bin/smoke/mutations/ci-suites-freeze.json",
+  "grades": "tool",
+  "why": [
+    "Issue #1237: the freeze on ci-suites.txt is a comment. A tail append is shard-stable and inventory-green, then conflicts the next PR on a line neither cares about. GitHub will not build a CONFLICTING PR, so that branch also gets zero CI.",
+    "",
+    "The scan is addedLegacySuites in ci-suites.mjs. The suite calls that function on a real file plus an appended line and asserts the SET of names it returns. Blinding the scan must redden the append cell; re-applying the rule in the test would stay green."
+  ],
+  "mutations": [
+    {
+      "name": "the freeze scan never reports an added suite",
+      "file": "bin/smoke/ci-suites.mjs",
+      "find": "    if (!base.has(suite) && !added.includes(suite)) added.push(suite);",
+      "replace": "    if (!base.has(suite) && !added.includes(suite)) void suite;",
+      "expectRed": "an appended suite is named as the set of offenders",
+      "cell": "an appended suite is named as the set of offenders"
+    }
+  ]
+}

--- a/bin/smoke/shard-stability.ts
+++ b/bin/smoke/shard-stability.ts
@@ -31,8 +31,10 @@
  * Run from inside a worktree of the repo. Exits 1 if any pre-existing suite changes shard,
  * and likewise when a NEW entry's comment claims "Appended" while the entry sits before a
  * pre-existing suite: the claim sentence is validated against position instead of trusted (#1011).
+ * It also exits 1 when head's frozen list names a suite the base list does not: a tail append
+ * is shard-stable and inventory-green, then CONFLICTS the next PR, which GitHub will not build.
  *
- * CONTROLS BUILT IN, because a bare zero is not evidence. All nineteen run on every invocation:
+ * CONTROLS BUILT IN, because a bare zero is not evidence. All twenty-two run on every invocation:
  *   - a forced mid-file insert must report non-zero (the instrument responds at all)
  *   - identity (base vs base) must report 0
  *   - an unchanged 20-item registry under 4 -> 5 shards must move 16 items
@@ -52,6 +54,9 @@
  *   - a NEW entry claiming "Appended" while inserted mid-file must be named as a violation
  *   - the same claim on a true tail append must report nothing
  *   - "Appended" claims on PRE-EXISTING entries must be ignored (history is not re-graded)
+ *   - a tail append of a new suite name must report that name
+ *   - a comment-only edit of the frozen list must report nothing
+ *   - a deletion from the frozen list must report nothing
  * Any failed control ABORTS with exit 2 rather than emitting a verdict.
  *
  * A third line once sat here claiming "the known production re-shard 7837b64c->d1aeafc3
@@ -69,6 +74,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { changedSuiteIndices } from "./shard-stability.mjs";
+import { addedLegacySuites, fragmentFileName } from "./ci-suites.mjs";
 
 // FIRST LINE OF OUTPUT, BEFORE ANY WORK: a gate can grep for this to prove the detector
 // actually ran. `npx tsx <missing-file>` exits 1, which is indistinguishable from
@@ -701,6 +707,9 @@ const claimTail = appendedClaimViolations(claimControlBase,
   `smoke:a\nsmoke:b\nsmoke:c\n\n${claimSentence}\nsmoke:NEW-CONTROL\n`);
 const claimHistorical = appendedClaimViolations(claimControlBase,
   `${claimSentence}\nsmoke:a\n${claimSentence}\nsmoke:b\n${claimSentence}\nsmoke:c\n`);
+const freezeTail = addedLegacySuites("smoke:a\nsmoke:b\n", "smoke:a\nsmoke:b\nsmoke:NEW\n") as string[];
+const freezeComment = addedLegacySuites("smoke:a\n", "smoke:a\n# freeze note only\n") as string[];
+const freezeDelete = addedLegacySuites("smoke:a\nsmoke:b\n", "smoke:a\n") as string[];
 console.log(`CONTROL forced mid-file insert -> ${forced.length} moved  (must be > 0)`);
 console.log(`CONTROL identity               -> ${identity.length} moved  (must be 0)`);
 console.log(`CONTROL same-shard reindex     -> ${indexRotation.changed.length} of ${indexRotation.examined} examined  (must be 20 of 20)`);
@@ -722,6 +731,9 @@ console.log(`CONTROL complete workflow ${headCount} -> ${headCount + 1} -> ${com
 console.log(`CONTROL mid-file "Appended" claim -> ${claimMidFile.length} named  (must be 1)`);
 console.log(`CONTROL tail "Appended" claim     -> ${claimTail.length} named  (must be 0)`);
 console.log(`CONTROL historical claims         -> ${claimHistorical.length} named  (must be 0)`);
+console.log(`CONTROL freeze tail append        -> ${JSON.stringify(freezeTail)}  (must be ["smoke:NEW"])`);
+console.log(`CONTROL freeze comment-only       -> ${JSON.stringify(freezeComment)}  (must be [])`);
+console.log(`CONTROL freeze deletion           -> ${JSON.stringify(freezeDelete)}  (must be [])`);
 if (
   forced.length === 0 || identity.length !== 0 ||
   indexRotation.changed.length !== 20 || indexRotation.examined !== 20 ||
@@ -732,7 +744,9 @@ if (
   !duplicateMappedIdControl.injected || duplicateMappedIdControl.count !== null ||
   !duplicateLeadingIdControl.injected || duplicateLeadingIdControl.count !== null ||
   completeTopologyCount !== headCount + 1 || !completeTopologyDuplicatesRefused ||
-  claimMidFile.length !== 1 || claimTail.length !== 0 || claimHistorical.length !== 0
+  claimMidFile.length !== 1 || claimTail.length !== 0 || claimHistorical.length !== 0 ||
+  freezeTail.length !== 1 || freezeTail[0] !== "smoke:NEW" ||
+  freezeComment.length !== 0 || freezeDelete.length !== 0
 ) {
   verdict("ABORT", "controls failed, this run cannot be trusted", 2);
 }
@@ -741,6 +755,16 @@ const allA = [...A, ...AF], allB = [...B, ...BF];
 const added = allB.filter((suite) => !allA.includes(suite));
 const removed = allA.filter((suite) => !allB.includes(suite));
 const claimViolations = appendedClaimViolations(A, readRaw(head));
+let freezeAdds: string[];
+try {
+  freezeAdds = addedLegacySuites(readRaw(base), readRaw(head), `ci-suites.txt@${base}`, `ci-suites.txt@${head}`) as string[];
+} catch (error) {
+  verdict(
+    "RESHARD",
+    `FROZEN LIST UNPARSEABLE at head: ${(error as Error).message}. Keep ci-suites.txt frozen; add new suites under ci-suites.d/<sha256(name)>.txt.`,
+    1,
+  );
+}
 console.log(`\n${base.slice(0, 8)} -> ${head.slice(0, 8)}  @${baseCount}->${headCount} shards`);
 console.log(`  suites: ${allA.length} -> ${allB.length} · added ${added.length} · removed ${removed.length}`);
 console.log(`  frozen legacy suites CHANGING INDEX: ${indices.changed.length} of ${indices.examined} examined`);
@@ -752,16 +776,26 @@ if (changed.length > 0) {
 if (claimViolations.length > 0) {
   console.log(`  NEW entries claiming "Appended" while mid-file: ${claimViolations.join(", ")}`);
 }
-if (indices.changed.length > 0 || removed.length > 0 || changed.length > 0 || claimViolations.length > 0) {
+if (freezeAdds.length > 0) {
+  console.log(
+    `  FROZEN LIST APPENDED: ${freezeAdds.map((suite) => `${suite} -> bin/smoke/ci-suites.d/${fragmentFileName(suite)}`).join(", ")}`,
+  );
+}
+if (indices.changed.length > 0 || removed.length > 0 || changed.length > 0 || claimViolations.length > 0 || freezeAdds.length > 0) {
   const remedy = baseCount === headCount
     ? "Keep ci-suites.txt frozen; add new suites as one-file fragments under ci-suites.d."
     : `The shard matrix changed ${baseCount} -> ${headCount}; review every reassignment as deliberate.`;
   const claimNote = claimViolations.length > 0
     ? ` FALSE "Appended" CLAIM on ${claimViolations.join(", ")}: the sentence is validated against position (#1011); a new entry carrying it must sit after every pre-existing suite.`
     : "";
+  const freezeNote = freezeAdds.length > 0
+    ? ` FROZEN LIST APPENDED ${freezeAdds.map((suite) => `${suite} -> bin/smoke/ci-suites.d/${fragmentFileName(suite)}`).join(", ")}. A CONFLICTING PR gets zero CI.`
+    : "";
   const headline = indices.changed.length > 0 || removed.length > 0 || changed.length > 0
     ? `RE-SHARD DETECTED. ${remedy}`
-    : "NO pre-existing suite moved, but the registry lies about how it grew.";
-  verdict("RESHARD", `${headline}${claimNote}`, 1);
+    : freezeAdds.length > 0
+      ? `FROZEN LIST APPENDED. ${remedy}`
+      : "NO pre-existing suite moved, but the registry lies about how it grew.";
+  verdict("RESHARD", `${headline}${claimNote}${freezeNote}`, 1);
 }
-verdict("STABLE", "STABLE - every frozen legacy suite keeps its index, every pre-existing suite keeps its runner, no false append claims.", 0);
+verdict("STABLE", "STABLE - every frozen legacy suite keeps its index, every pre-existing suite keeps its runner, no false append claims, no new suite on the frozen list.", 0);

--- a/package.json
+++ b/package.json
@@ -546,6 +546,7 @@
     "smoke:feed-agent": "pnpm --filter @cotal-ai/example-06-feed-agent test",
     "smoke:package-test-contract": "tsx bin/smoke/package-test-contract.smoke.ts",
     "smoke:ci-fragments": "tsx bin/smoke/ci-fragments.smoke.ts",
+    "smoke:ci-suites-freeze": "tsx bin/smoke/ci-suites-freeze.smoke.ts",
     "smoke:ci-declarations": "tsx bin/smoke/ci-declarations.smoke.ts",
     "smoke:shard-stability": "tsx bin/smoke/shard-stability.smoke.ts",
     "smoke:shard-never-ran": "tsx bin/smoke/shard-never-ran.smoke.ts",


### PR DESCRIPTION
## Summary
- The freeze on `bin/smoke/ci-suites.txt` was only a comment. A tail append is shard-stable and inventory-green, then CONFLICTS the next PR on a line neither branch cares about. GitHub will not build a CONFLICTING PR, so that branch also gets zero CI.
- `addedLegacySuites` now derives the offender set from the two committed blobs with the same parser the chain uses. Comment edits and deletions stay legal. The required unit job reaches that scan through `pnpm check:shard-stability`.
- New suites stay off the frozen list: this one is `bin/smoke/ci-suites.d/<sha256(smoke:ci-suites-freeze)>.txt`. Mutation-proof killed blinding the scan on `an appended suite is named as the set of offenders`.

Closes #1237

## Test plan
- [ ] `pnpm smoke:ci-suites-freeze` is green
- [ ] `pnpm check:shard-stability origin/main HEAD` is STABLE=0 (this branch added a fragment, not a frozen line)
- [ ] A commit that appends a suite name to `ci-suites.txt` is RESHARD=1 and names `ci-suites.d/<sha256(name)>.txt`
- [ ] `pnpm mutation-proof --config bin/smoke/mutations/ci-suites-freeze.json` KILLED
- [ ] Workflow files are unchanged vs base (`ci.yml` was not part of this PR)