### PR TITLE
fix(smoke): enforce sandbox-down adoption in CI

### DIFF
--- a/.changeset/sandbox-guard-enforced.md
+++ b/.changeset/sandbox-guard-enforced.md
@@ -1,0 +1,5 @@
+---
+"cotal-ai": patch
+---
+
+Run the sandbox-down adoption scan in CI, and require the three remaining live `down` wrappers to prove the sandbox held before the destructive verb.

--- a/bin/smoke/ci-suites.d/34a43b526277cf311de9858e519c3d55e83454339225776c426c8a6d5cbc7164.txt
+++ b/bin/smoke/ci-suites.d/34a43b526277cf311de9858e519c3d55e83454339225776c426c8a6d5cbc7164.txt
@@ -1,0 +1,3 @@
+# Live CLI down must prove the sandbox held before the destructive verb (#884). This scan
+# is the adoption gate; without a CI shard it only ran from `pnpm check`, which no workflow invokes.
+smoke:sandbox-guard

--- a/implementations/cli/smoke/up-adopt-resume-lock-live.smoke.ts
+++ b/implementations/cli/smoke/up-adopt-resume-lock-live.smoke.ts
@@ -33,6 +33,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { createServer, type AddressInfo } from "node:net";
 import { join, resolve as resolvePath } from "node:path";
+import { assertSmokeSandboxDown, recordSmokeSandbox } from "@cotal-ai/smoke-kit";
 import { makeScratch, assertScratchHeld } from "../../../bin/smoke/_scratch.js";
 
 const freePort = (): Promise<number> =>
@@ -48,6 +49,8 @@ const freePort = (): Promise<number> =>
 const scratch = makeScratch("cotal-up-adopt-lock-");
 const home = mkdtempSync(join(scratch, "home-"));
 const root = mkdtempSync(join(scratch, "root-"));
+const configDir = join(home, "xdg");
+const sandbox = recordSmokeSandbox({ root, cotalHome: home, xdgConfigHome: configDir });
 process.env.COTAL_HOME = home;
 
 const WT = resolvePath(import.meta.dirname, "..", "..", "..");
@@ -76,17 +79,19 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 const baseEnv = (() => {
   const copy = { ...process.env };
   for (const key of Object.keys(copy)) if (key.startsWith("COTAL_")) delete copy[key];
-  return { ...copy, COTAL_HOME: home };
+  return { ...copy, COTAL_HOME: home, XDG_CONFIG_HOME: configDir };
 })();
 
 /** Blocking `cotal <args>`, the way an operator runs it. */
 function runSync(args: string[], extraEnv: Record<string, string> = {}) {
-  return spawnSync(TSX, [CLI, ...args], {
+  const options = {
     cwd: root,
     env: { ...baseEnv, ...extraEnv },
-    encoding: "utf8",
+    encoding: "utf8" as const,
     timeout: 240_000,
-  });
+  };
+  assertSmokeSandboxDown(sandbox, args, options);
+  return spawnSync(TSX, [CLI, ...args], options);
 }
 
 type Journal = {

--- a/implementations/cli/smoke/up-restore-reentry-live.smoke.ts
+++ b/implementations/cli/smoke/up-restore-reentry-live.smoke.ts
@@ -33,6 +33,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { createServer, type AddressInfo } from "node:net";
 import { join, resolve as resolvePath } from "node:path";
+import { assertSmokeSandboxDown, recordSmokeSandbox } from "@cotal-ai/smoke-kit";
 import { makeScratch, assertScratchHeld } from "../../../bin/smoke/_scratch.js";
 
 const freePort = (): Promise<number> =>
@@ -48,6 +49,8 @@ const freePort = (): Promise<number> =>
 const scratch = makeScratch("cotal-up-restore-reentry-");
 const home = mkdtempSync(join(scratch, "home-"));
 const root = mkdtempSync(join(scratch, "root-"));
+const configDir = join(home, "xdg");
+const sandbox = recordSmokeSandbox({ root, cotalHome: home, xdgConfigHome: configDir });
 process.env.COTAL_HOME = home;
 
 const WT = resolvePath(import.meta.dirname, "..", "..", "..");
@@ -77,17 +80,19 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 const baseEnv = (() => {
   const copy = { ...process.env };
   for (const key of Object.keys(copy)) if (key.startsWith("COTAL_")) delete copy[key];
-  return { ...copy, COTAL_HOME: home };
+  return { ...copy, COTAL_HOME: home, XDG_CONFIG_HOME: configDir };
 })();
 
 /** Blocking `cotal <args>`, the way an operator runs it. */
 function runSync(args: string[], extraEnv: Record<string, string> = {}) {
-  return spawnSync(TSX, [CLI, ...args], {
+  const options = {
     cwd: root,
     env: { ...baseEnv, ...extraEnv },
-    encoding: "utf8",
+    encoding: "utf8" as const,
     timeout: 240_000,
-  });
+  };
+  assertSmokeSandboxDown(sandbox, args, options);
+  return spawnSync(TSX, [CLI, ...args], options);
 }
 
 const tail = (r: { stdout?: string; stderr?: string }) => `${r.stdout ?? ""}${r.stderr ?? ""}`;

--- a/implementations/cli/smoke/up-resume-render-lock-live.smoke.ts
+++ b/implementations/cli/smoke/up-resume-render-lock-live.smoke.ts
@@ -40,6 +40,7 @@ import { once } from "node:events";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs";
 import { createServer, type AddressInfo } from "node:net";
 import { join, resolve as resolvePath } from "node:path";
+import { assertSmokeSandboxDown, recordSmokeSandbox } from "@cotal-ai/smoke-kit";
 import { makeScratch, assertScratchHeld } from "../../../bin/smoke/_scratch.js";
 
 const freePort = (): Promise<number> =>
@@ -55,6 +56,8 @@ const freePort = (): Promise<number> =>
 const scratch = makeScratch("cotal-up-resume-lock-");
 const home = mkdtempSync(join(scratch, "home-"));
 const root = mkdtempSync(join(scratch, "root-"));
+const configDir = join(home, "xdg");
+const sandbox = recordSmokeSandbox({ root, cotalHome: home, xdgConfigHome: configDir });
 process.env.COTAL_HOME = home;
 
 const { acquireMaintenanceLock, authDir, maintenancePaths, readMaintenanceJournal, releaseMaintenanceLock } =
@@ -86,18 +89,20 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 const sandboxEnv = (() => {
   const copy = { ...process.env };
   for (const key of Object.keys(copy)) if (key.startsWith("COTAL_")) delete copy[key];
-  return { ...copy, COTAL_HOME: home };
+  return { ...copy, COTAL_HOME: home, XDG_CONFIG_HOME: configDir };
 })();
 
 const output = new WeakMap<ChildProcess, () => string>();
 const logOf = (cp: ChildProcess) => output.get(cp)?.() ?? "";
 
 function run(args: string[]): ChildProcess {
-  const cp = spawn(TSX, [CLI, ...args], {
+  const options = {
     cwd: root,
     env: sandboxEnv,
-    stdio: ["ignore", "pipe", "pipe"],
-  });
+    stdio: ["ignore", "pipe", "pipe"] as ["ignore", "pipe", "pipe"],
+  };
+  assertSmokeSandboxDown(sandbox, args, options);
+  const cp = spawn(TSX, [CLI, ...args], options);
   kids.push(cp);
   let log = "";
   cp.stdout?.on("data", (b: Buffer) => { log += b.toString(); });

--- a/packages/smoke-kit/smoke/sandbox-guard.smoke.ts
+++ b/packages/smoke-kit/smoke/sandbox-guard.smoke.ts
@@ -188,8 +188,191 @@ try {
 
   const semanticDownOnly = new Set([
     "implementations/runtime/smoke/mesh-wait.smoke.ts",
+    "implementations/runtime/smoke/mesh-monitor.smoke.ts",
     "packages/lang/smoke/engine.smoke.ts",
   ]);
+
+  /** Keep line numbers. Drop comments and templates so `down` inside a string is not a CLI verb. */
+  const codeOf = (source: string): string => {
+    let out = "";
+    let i = 0;
+    const blank = (from: number, to: number): void => {
+      for (let j = from; j < to; j++) out += source[j] === "\n" ? "\n" : " ";
+    };
+    while (i < source.length) {
+      const c = source[i];
+      const n = source[i + 1];
+      if (c === "/" && n === "/") {
+        const start = i;
+        i += 2;
+        while (i < source.length && source[i] !== "\n") i++;
+        blank(start, i);
+        continue;
+      }
+      if (c === "/" && n === "*") {
+        const start = i;
+        i += 2;
+        while (i < source.length && !(source[i] === "*" && source[i + 1] === "/")) i++;
+        i = Math.min(source.length, i + 2);
+        blank(start, i);
+        continue;
+      }
+      if (c === "`") {
+        const start = i;
+        i++;
+        while (i < source.length) {
+          if (source[i] === "\\") { i += 2; continue; }
+          if (source[i] === "`") { i++; break; }
+          i++;
+        }
+        blank(start, i);
+        continue;
+      }
+      if (c === '"' || c === "'") {
+        out += c;
+        i++;
+        while (i < source.length) {
+          if (source[i] === "\\") { out += source[i] + (source[i + 1] ?? ""); i += 2; continue; }
+          out += source[i];
+          if (source[i] === c) { i++; break; }
+          i++;
+        }
+        continue;
+      }
+      out += c;
+      i++;
+    }
+    return out;
+  };
+
+  const lineOf = (source: string, index: number): number => source.slice(0, index).split("\n").length;
+  const windowBefore = (source: string, index: number): string =>
+    source.slice(0, index).split("\n").slice(-5).join("\n");
+
+  const extractFunctions = (source: string): Map<string, string> => {
+    const fns = new Map<string, string>();
+    const header =
+      /(?:function\s+([A-Za-z_][\w]*)\s*\(|const\s+([A-Za-z_][\w]*)\s*=\s*(?:async\s*)?(?:\(|[A-Za-z_][\w]*\s*=>))/g;
+    let match: RegExpExecArray | null;
+    while ((match = header.exec(source))) {
+      const name = match[1] ?? match[2];
+      if (!name) continue;
+      let i = match.index + match[0].length;
+      const fromArrow = match[0].endsWith("=>");
+      if (!fromArrow) {
+        let depth = 1;
+        while (i < source.length && depth > 0) {
+          if (source[i] === "(") depth++;
+          else if (source[i] === ")") depth--;
+          i++;
+        }
+        while (i < source.length && /\s/.test(source[i])) i++;
+        if (source[i] === ":") {
+          i++;
+          let paren = 0;
+          let brace = 0;
+          let angle = 0;
+          while (i < source.length) {
+            const ch = source[i];
+            if (ch === "=" && source[i + 1] === ">" && paren === 0 && brace === 0 && angle === 0) break;
+            if (ch === "{" && paren === 0 && brace === 0 && angle === 0) break;
+            if (ch === "(") paren++;
+            else if (ch === ")") paren--;
+            else if (ch === "{") brace++;
+            else if (ch === "}") brace--;
+            else if (ch === "<") angle++;
+            else if (ch === ">") angle--;
+            i++;
+          }
+        }
+        while (i < source.length && source[i] !== "{" && !(source[i] === "=" && source[i + 1] === ">")) i++;
+        if (source[i] === "=" && source[i + 1] === ">") {
+          i += 2;
+          while (i < source.length && /\s/.test(source[i])) i++;
+        }
+      } else {
+        while (i < source.length && /\s/.test(source[i])) i++;
+      }
+      if (source[i] === "{") {
+        let depth = 1;
+        const start = i;
+        i++;
+        while (i < source.length && depth > 0) {
+          if (source[i] === "{") depth++;
+          else if (source[i] === "}") depth--;
+          i++;
+        }
+        fns.set(name, source.slice(start, i));
+      } else {
+        const start = i;
+        while (i < source.length && source[i] !== ";" && source[i] !== "\n") i++;
+        fns.set(name, source.slice(start, i));
+      }
+    }
+    return fns;
+  };
+
+  const spawnsImmediatelyGuarded = (body: string): boolean => {
+    const spawns = [...body.matchAll(/\b(?:spawnSync|spawn)\s*\(/g)];
+    if (spawns.length === 0) return false;
+    return spawns.every((spawn) => windowBefore(body, spawn.index ?? 0).includes("assertSmokeSandboxDown"));
+  };
+
+  const wrapperReachesSpawn = (name: string, fns: Map<string, string>, seen = new Set<string>()): boolean => {
+    if (name === "spawn" || name === "spawnSync") return true;
+    if (seen.has(name)) return false;
+    seen.add(name);
+    const body = fns.get(name);
+    if (!body) return false;
+    if (/\b(?:spawnSync|spawn)\s*\(/.test(body)) return true;
+    for (const callee of body.matchAll(/\b([A-Za-z_][\w]*)\s*\(/g)) {
+      if (callee[1] && wrapperReachesSpawn(callee[1], fns, seen)) return true;
+    }
+    return false;
+  };
+
+  const wrapperGuardsDown = (name: string, fns: Map<string, string>, seen = new Set<string>()): boolean => {
+    if (name === "assertSmokeSandboxDown" || name === "assertSmokeSandboxTargetDown") return true;
+    if (seen.has(name)) return false;
+    seen.add(name);
+    const body = fns.get(name);
+    if (!body) return false;
+    if (/\b(?:spawnSync|spawn)\s*\(/.test(body)) return spawnsImmediatelyGuarded(body);
+    for (const callee of body.matchAll(/\b([A-Za-z_][\w]*)\s*\(/g)) {
+      const next = callee[1];
+      if (next && wrapperGuardsDown(next, fns, seen)) return true;
+    }
+    return false;
+  };
+
+  const callNameAt = (source: string, downIndex: number): { name: string; callStart: number } | undefined => {
+    let i = downIndex;
+    let paren = 0;
+    let bracket = 0;
+    let brace = 0;
+    while (i > 0) {
+      i--;
+      const ch = source[i];
+      if (ch === ")") paren++;
+      else if (ch === "]") bracket++;
+      else if (ch === "}") brace++;
+      else if (ch === "(") {
+        if (paren === 0 && bracket === 0 && brace === 0) {
+          const before = source.slice(0, i).match(/([A-Za-z_][\w]*)\s*$/);
+          if (!before || before.index === undefined) return undefined;
+          return { name: before[1]!, callStart: before.index };
+        }
+        paren--;
+      } else if (ch === "[") {
+        if (bracket > 0) bracket--;
+      } else if (ch === "{") {
+        if (brace === 0) return undefined;
+        brace--;
+      }
+    }
+    return undefined;
+  };
+
   const files: string[] = [];
   const walk = (dir: string): void => {
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -201,17 +384,34 @@ try {
   };
   walk(repo);
   const unguarded: string[] = [];
+  const downArg = /(?<=[\[,(]\s*)["']down["']/g;
   for (const file of files) {
     const relative = file.slice(repo.length + 1);
     const source = readFileSync(file, "utf8");
-    if (!source.includes('"down"') && !source.includes("'down'")) continue;
+    const code = codeOf(source);
     if (semanticDownOnly.has(relative)) continue;
+    const sites = [...code.matchAll(downArg)];
+    if (sites.length === 0) continue;
+    const fns = extractFunctions(code);
+    const cliSites = sites.flatMap((site) => {
+      if (site.index === undefined) return [];
+      const call = callNameAt(code, site.index);
+      if (!call) return [];
+      if (call.name === "assertSmokeSandboxDown" || call.name === "assertSmokeSandboxTargetDown") return [];
+      return [{ ...call, index: site.index }];
+    });
+    if (cliSites.length === 0) continue;
     const guardCalls = [...source.matchAll(/assertSmokeSandboxDown\s*\(/g)];
     if (guardCalls.length < 1) unguarded.push(`${relative}: no shared guard call`);
-    for (const match of source.matchAll(/^(.*(?:spawnSync|spawn)\(.*["']down["'].*)$/gm)) {
-      const before = source.slice(0, match.index).split("\n").slice(-5).join("\n");
-      if (!before.includes("assertSmokeSandboxDown"))
-        unguarded.push(`${relative}:${source.slice(0, match.index).split("\n").length}: raw down spawn is not immediately guarded`);
+    for (const site of cliSites) {
+      const line = lineOf(code, site.index);
+      if (site.name === "spawn" || site.name === "spawnSync") {
+        if (!windowBefore(code, site.callStart).includes("assertSmokeSandboxDown"))
+          unguarded.push(`${relative}:${line}: raw down spawn is not immediately guarded`);
+        continue;
+      }
+      if (wrapperReachesSpawn(site.name, fns) && !wrapperGuardsDown(site.name, fns))
+        unguarded.push(`${relative}:${line}: down wrapper call is not immediately guarded`);
     }
   }
   assert.deepEqual(unguarded, [], `unguarded smoke cotal down call sites:\n${unguarded.join("\n")}`);


### PR DESCRIPTION
#884 shipped `assertSmokeSandboxDown` and a scan that requires live CLI `down` to prove the sandbox held. At the base of this branch that scan was red, and it ran in no CI job (only from `pnpm check`, which no workflow invokes). This PR does the three things that make that gate real, in one self-proving diff: the suite is green, the scan still names an unguarded call, and CI now runs it.

Closes #1279.

## A. Adopt the shared guard in the three real offenders

`implementations/cli/smoke/up-adopt-resume-lock-live.smoke.ts`, `up-restore-reentry-live.smoke.ts`, and `up-resume-render-lock-live.smoke.ts` already set `COTAL_HOME` and created a `.cotal` marker. That is not enough: `findCotalRoot` fails open, so a `down` whose sandbox silently failed still walks into whatever mesh it finds and reports success.

Each wrapper now records the sandbox with `recordSmokeSandbox`, pins `XDG_CONFIG_HOME` in the child env, and calls `assertSmokeSandboxDown` on the exact spawn options immediately before the CLI process starts.

## B. Tighten the scan so false positives stop matching

In `packages/smoke-kit/smoke/sandbox-guard.smoke.ts`:

- allowlist `implementations/runtime/smoke/mesh-monitor.smoke.ts` the same way `mesh-wait` already is (`wait(down)` is cotal-lang liveness, not a CLI verb)
- ignore `down` inside comments and template strings (the `migrate-run.smoke.ts:225` `record(\`… log("down" …)\`)` false positive)
- match local wrapper calls (`runSync(["down"])`, `run(["down"])`, and the same-line `spawn`/`spawnSync` form) so the three real sites are named by a precise cell, not only by the coarse file-level "no shared guard call"

A tightening that merely deletes cells is not this change. After the rule change, a scratch copy of one unguarded shape (`runSync(["down"])` plus a raw `spawnSync(..., ["down"])`) was named as:

- `…: no shared guard call`
- `…:7: down wrapper call is not immediately guarded`
- `…:8: raw down spawn is not immediately guarded`

That scratch file was then deleted and is not in this PR.

## C. Put `smoke:sandbox-guard` into a CI shard

Added exactly one fragment:

`bin/smoke/ci-suites.d/34a43b526277cf311de9858e519c3d55e83454339225776c426c8a6d5cbc7164.txt`

Filename verified with `printf 'smoke:sandbox-guard' | sha256sum`. `ci-suites.mjs` reads `ci-suites.d/` at runtime; the frozen `bin/smoke/ci-suites.txt` is not touched. After adding the fragment, `git status` showed only that file plus the intended source/changeset files.

## Changeset

`.changeset/sandbox-guard-enforced.md` bumps `cotal-ai` (lockstep `fixed` group) at patch. The change is test/CI adoption, not a published API, but the freeze-guard precedent also used a `cotal-ai` patch for a CI-only gate. `pnpm changeset status` was run against the dirty tree; it also listed other already-pending changesets on main.

## Verified (exact commands, this worktree)

- `pnpm smoke:sandbox-guard` — empty offender set, `sandbox guard smoke: PASS`, exit 0
- `pnpm smoke:ci-suites` — `SUITE COMPLETE: 25 passed, 0 failed`
- `pnpm smoke:ci-suites-freeze` — `CI SUITES FREEZE SMOKE OK (9 passed, 0 failed)`
- `pnpm smoke:gate-inventory` — `GATE INVENTORY OK` (569 scripts, 549 reached, 20 not run; no stale UNGATED for this suite)
- `pnpm typecheck` — green at this head
- `git show HEAD --name-only` — the six files above are the commit

## Deliberately unverified

The three `up-*-live` suites were **not** run. They call the real CLI `down`. On this machine that can stop the live fleet. Their change is graded by reading the wrappers against the existing adopted pattern (`recordSmokeSandbox` + `assertSmokeSandboxDown` immediately before spawn) and by CI.

Also not run: any other `*-live` suite, `pnpm check`, `pnpm cotal` / `tsx bin/cotal.ts`.