### PR TITLE
fix(connector-codex): wait for the tui event the codex-host cells count

### DIFF
--- a/.changeset/fix-1280-codex-host-tui-ordering.md
+++ b/.changeset/fix-1280-codex-host-tui-ordering.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/connector-codex": patch
+---
+
+Stabilize the codex host smoke: two checks that count the launch tail's TUI log line now wait for that line to be written before counting, so a slow TUI child can no longer red the shard on a scheduling accident. The exact-count check waits for the superseded launch tail to stand down before counting so it still catches a launch that attaches more than one TUI, and the replacement-TUI check waits for the second TUI with the timeout as its failure.

--- a/bin/smoke/mutations/codex-host-tui-ordering.json
+++ b/bin/smoke/mutations/codex-host-tui-ordering.json
@@ -1,0 +1,34 @@
+{
+  "suite": "extensions/connector-codex/smoke/codex-host.smoke.ts",
+  "guard": "the two codex-host cells that count the launch tail's `tui` log line wait for the event that bounds the count before counting, so a scheduling accident cannot read the count before the tail's TUI child has journalled its line (#1280)",
+  "command": "pnpm smoke:codex-host",
+  "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/codex-host-tui-ordering.json",
+  "why": [
+    "#1280: two cells counted a `tui` line without ever waiting for it to be written. Both were confirmed to fail live by delaying the tail's TUI-child `tui` write past the point each cell read the count. The fix makes each cell wait on the event that bounds its count, so the ordering the cell assumed is enforced rather than assumed.",
+    "The suite spawns the REAL host (`../src/host-main.ts`) with `tsx`, which loads `host.ts` from source — no build step participates, so a mutation to `host.ts` is read directly by the run and no `command` build/afterRestore is needed.",
+    "BOTH mutations anchor on the SAME code line — the restart tail's `startTui()` that attaches the replacement UI on the new listener — because that single call is what both cells ultimately observe: cell B (tuicrash, earlier in the file) counts its replacement `tui`, and cell A (genpeer, later) counts the recovered launch's one `tui`.",
+    "CELL A asserts an EXACT count (one TUI, not one per generation). Duplicating the restart's `startTui()` makes the recovered launch attach two TUIs, so two `tui` lines are journalled and the exact count is 2. It reddens FIRST at cell A: the cells above it in the genpeer block (`recovered by the restart`) still pass, and cell A is the earliest assertion the extra TUI reaches. This is the property the cell guards — a launch that attaches more than one TUI — and it is exactly the case a `wait for the count to reach 1, then assert === 1` would have blessed when the second `tui` lagged the first.",
+    "CELL B asserts a LOWER bound (a replacement TUI attaches, >= 2). Deleting the restart's `startTui()` suppresses the replacement UI entirely; the tuicrash scenario's initial TUI still attaches (a different, earlier `startTui()`), so the cell above it (`a TUI dying ... does NOT shut the agent down`) passes and cell B is the earliest red — it times out waiting for the second `tui`, which is exactly the timeout-is-the-failure the fix installs.",
+    "The two mutations are opposite edits of one line (duplicate vs delete), so each also serves as the other's proof that the suite reaches this file at runtime."
+  ],
+  "mutations": [
+    {
+      "name": "the recovered launch attaches TWO TUIs (exact-count cell A must fall)",
+      "file": "extensions/connector-codex/src/host.ts",
+      "find": "      startTui();\n      await safeStatus(\"idle\");",
+      "replace": "      startTui();\n      startTui();\n      await safeStatus(\"idle\");",
+      "expectRed": "exactly one launch tail finished: one TUI, not one per generation",
+      "cell": "exactly one launch tail finished: one TUI, not one per generation",
+      "note": "Two `startTui()` calls on the recovered generation journal two `tui` lines. The fix waits for the superseded tail to stand down and settles before counting, so the second TUI is present when the exact count runs and cell A reddens at 2. A `wait for 1 then assert === 1` would have passed the instant the first landed."
+    },
+    {
+      "name": "the replacement TUI is never attached (lower-bound cell B must fall)",
+      "file": "extensions/connector-codex/src/host.ts",
+      "find": "      startTui();\n      await safeStatus(\"idle\");",
+      "replace": "      await safeStatus(\"idle\");",
+      "expectRed": "a replacement TUI is attached to the new listener",
+      "cell": "a replacement TUI is attached to the new listener",
+      "note": "With no replacement `startTui()` the tuicrash scenario never journals a second `tui`. The fix waits for the count to REACH 2 with the timeout as the failure, so the cell times out naming itself instead of reading a stale count and passing."
+    }
+  ]
+}

--- a/extensions/connector-codex/smoke/codex-host.smoke.ts
+++ b/extensions/connector-codex/smoke/codex-host.smoke.ts
@@ -641,11 +641,15 @@ try {
   );
   await sleep(1500); // a mis-classified TUI exit would have called shutdown() by now
   check("a TUI dying with its crashed app-server does NOT shut the agent down", tcExited === "alive", tcExited);
-  check(
+  // `>= 2` is a lower bound, so waiting for the count to REACH 2 is sound: the replacement TUI is
+  // spawned asynchronously after the respawn, and nothing above waited on its `tui` line landing.
+  // The timeout is the failure — a replacement that never attaches never reaches 2.
+  const tcTuis = await waitFor(
     "a replacement TUI is attached to the new listener",
-    tcEntries().filter((e) => e.ev === "tui").length >= 2,
-    tcEntries().filter((e) => e.ev === "tui").length,
+    () => (tcEntries().filter((e) => e.ev === "tui").length >= 2 ? tcEntries().filter((e) => e.ev === "tui").length : undefined),
+    30_000,
   );
+  check("a replacement TUI is attached to the new listener", tcTuis >= 2, tcTuis);
   tuiCrash.kill("SIGTERM");
   await Promise.race([once(tuiCrash, "exit"), sleep(8_000)]);
 
@@ -777,6 +781,33 @@ try {
   );
   operator.off("presence", genWatch);
   check("a crash mid-launch is recovered by the restart, and the peer is fully online", genDriven !== undefined);
+  // EXACTLY ONE, so a "wait for the count to reach 1" is unsound: it would pass the instant the
+  // first `tui` lands, blessing the very bug this cell guards (one TUI per generation) whenever the
+  // second `tui` is merely a few ms behind. An exact count must wait on the event that BOUNDS it.
+  //
+  // The bound is the SUPERSEDED tail standing down. In this scenario there are two launch tails —
+  // the initial one whose child died before its tools were ready, and the restart that recovered
+  // it — and only ONE of them may reach `startTui()`. The restart is the live tail (its `startTui`
+  // precedes the drive we already waited on above, so it has been invoked). The initial tail is the
+  // only other possible `tui` emitter, and it logs its stand-down on the host's stderr the moment it
+  // returns without touching `startTui`. Once that line is present the emitter set is closed at one,
+  // so counting after it is exact — and a mutant that let the superseded tail carry on into
+  // `startTui` either never logs the stand-down (this wait times out, red here) or emits its extra
+  // `tui` around the same time (the count below is 2, red here). Either way THIS cell is the failure.
+  await waitFor(
+    "the superseded launch tail stood down (no further TUI can be emitted)",
+    () => (/superseded|initial launch did not finish/.test(genErr) ? true : undefined),
+    25_000,
+  );
+  // The live restart's `startTui()` was invoked before the drive above, but its child writes the
+  // `tui` line asynchronously; wait for that one to land so the count is a settled lower bound too.
+  await waitFor("the recovered peer's TUI attached", () => (genEntries().some((e) => e.ev === "tui") ? true : undefined), 25_000);
+  // Both launch tails have now reached a terminal state — the restart drove a turn (above) and the
+  // initial tail logged its stand-down — so every `startTui()` this scenario will ever call has been
+  // called. A settle lets any second child's `tui` write flush before the exact count: it closes the
+  // "the extra TUI is 50ms behind the assertion" window that a bare "wait for 1, assert === 1" leaves
+  // open, without which this exact-count cell could bless the one-TUI-per-generation bug it guards.
+  await sleep(1500);
   check(
     "exactly one launch tail finished: one TUI, not one per generation",
     genEntries().filter((e) => e.ev === "tui").length === 1,


### PR DESCRIPTION
## What

`extensions/connector-codex/smoke/codex-host.smoke.ts` had two cells that counted a `tui` log
line without ever waiting for that line to be written. The launch tail attaches the Codex TUI
by spawning `codex resume --remote`, and the fake codex journals its `tui` line only once that
child starts, asynchronously. A scheduling accident could let each cell read the count before
the line landed, reddening a fail-fast shard and stranding the rest of its partition.

This is an ordering defect, not a torn read: `readJsonLines` already drops a trailing partial
line (#400). This change does not touch parsing.

## The two cells, each on its own reasoning

**Cell B, "a replacement TUI is attached to the new listener"** (tuicrash scenario) asserts a
lower bound (`>= 2`). The prior code waited for the app-server to respawn, then slept a fixed
1500ms and counted, so a replacement TUI that attached late was missed. It now waits for the
`tui` count to reach 2, with the timeout as the failure. The `sleep(1500)` is kept for the
adjacent check it actually serves (a mis-classified TUI exit would have shut the agent down by
then).

**Cell A, "exactly one launch tail finished: one TUI, not one per generation"** (genpeer
scenario) asserts an exact count. Waiting until the count reaches 1 and then asserting `=== 1`
would be unsound: it passes the instant the first `tui` lands and would bless the very bug the
cell guards (a superseded tail attaching a second TUI) whenever that second `tui` is a few ms
behind. So the fix waits on the event that BOUNDS the count instead: the superseded launch
tail standing down (logged on the host's stderr the moment it returns without touching
`startTui()`). In this scenario exactly two launch tails exist — the initial one whose child
died before its tools were ready, and the restart that recovered it — and only one may reach
`startTui()`. Once the superseded tail has logged its stand-down, the set of possible `tui`
emitters is closed at one; the cell then waits for the live restart's TUI to attach, settles so
any second child's write would flush, and counts. A second TUI reddens this cell rather than
slipping past it.

## Reproduction

Both cells were confirmed to fail live, not just in reasoning, by delaying the tail's TUI-child
`tui` write past the point each cell read the count (a temporary `FAKE_CODEX_TUI_SLOW` knob in
the fixture, reverted before committing):

- Cell A: with the genpeer `tui` write delayed, `genDriven` resolved first and the count read 0,
  so `=== 1` failed — `AssertionError: exactly one launch tail finished: one TUI, not one per
  generation — 0`.
- Cell B: with the tuicrash replacement `tui` delayed past the 1500ms settle, the count read 0
  and `>= 2` failed — `AssertionError: a replacement TUI is attached to the new listener — 0`.

## Proof the fixed cells can still fail

`bin/smoke/mutations/codex-host-tui-ordering.json`, run with
`node scripts/mutation-proof.mjs --config bin/smoke/mutations/codex-host-tui-ordering.json`.
Both mutations anchor on the same code line — the restart tail's `startTui()` — and both were
KILLED, each as the earliest named failure:

- duplicating the restart's `startTui()` makes the recovered launch attach two TUIs → cell A
  reddens naming `exactly one launch tail finished: one TUI, not one per generation`;
- deleting the restart's `startTui()` suppresses the replacement UI → cell B reddens naming
  `a replacement TUI is attached to the new listener`.

The two mutations are opposite edits of one line, so each is also the other's positive control
that the suite reaches `host.ts` at runtime.

## Verification

- `pnpm smoke:codex-host` green (95 checks) with the fix.
- `pnpm typecheck`: `Scope: 27 of 28 workspace projects`. The 28th,
  `@cotal-ai/example-04-frontier-faces`, is JS-only with no `typecheck` script and is skipped;
  no errors.
- `pnpm changeset status`: my entry is `patch` on `@cotal-ai/connector-codex`; the `fixed` group
  rolls up to minor because of pre-existing changesets on the base, not this one.

## What this leaves unproven

The mutations recreate a second TUI by editing the live restart tail's `startTui()`, which is
the property cell A asserts (a launch that attaches more than one TUI). They do not recreate the
exact historical "one TUI per generation" path in the genpeer scenario, because that path
requires two independent fences to fail at once (a superseded tail adopting a successor's
readiness and then passing the supersede guard); the genpeer child dies before its tools are
ready, so no single-location mutation routes it into a second `startTui()`. The cell's guarantee
is nonetheless deterministic: the superseded stand-down bounds the count before it is read.

Closes #1280
