### PR TITLE
test(core): pin thrown observeGeneration unavailable translation

### DIFF
--- a/.changeset/observe-generation-unavailable.md
+++ b/.changeset/observe-generation-unavailable.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/core": patch
+---
+
+Pin the unavailable translation for a thrown observeGeneration in deregisterServiceInstance. The new smoke:ep-traits cell holds the governance slot, throws from the observer, and asserts the envelope stays unavailable with the spec un-deleted.

--- a/bin/smoke/mutations/observe-generation-unavailable.json
+++ b/bin/smoke/mutations/observe-generation-unavailable.json
@@ -1,0 +1,31 @@
+{
+  "suite": "packages/core/smoke/endpoint-traits.smoke.ts",
+  "guard": "deregisterServiceInstance must translate a thrown observeGeneration into an unavailable envelope while the governance slot is held, and must not delete the spec",
+  "command": "pnpm smoke:ep-traits",
+  "completionMarker": "ENDPOINT TRAITS SMOKE",
+  "proveWith": "pnpm mutation-proof --config bin/smoke/mutations/observe-generation-unavailable.json",
+  "why": [
+    "The production-most failure form is a thrown observation (both manager call sites throw",
+    "`no issuance gate at ${key}` when the row is missing). Three of four observeGeneration",
+    "outcomes already have cells; this mutation is the one that used to leave the suite green.",
+    "",
+    "ANCHOR ON CODE ONLY. The `catch (e)` window plus the EpEnvelopeError throw is unique in",
+    "endpoint-service.ts. Do not widen it onto the comment above the function.",
+    "",
+    "The suite imports from ../src/index.js, so a src mutation is what the run sees. No core",
+    "build is required for the mutant to be visible.",
+    "",
+    "expectRed names the FIRST cell that reddens under `throw e`: the envelope-code assertion.",
+    "The spec-still-PUT cell stays green because rethrowing still aborts the delete."
+  ],
+  "mutations": [
+    {
+      "name": "observeGeneration catch rethrows instead of translating to unavailable",
+      "file": "packages/core/src/endpoint-service.ts",
+      "find": "      } catch (e) {\n        throw new EpEnvelopeError(\"unavailable\", `could not observe the issuance-gate generation for \"${args.endpoint}/${iId}\" while its governance slot is held; refusing the delete rather than racing an in-flight registration (SPEC 13.7): ${(e as Error)?.message ?? String(e)}`);\n      }",
+      "replace": "      } catch (e) {\n        throw e;\n      }",
+      "expectRed": "a thrown observeGeneration with a held slot FAILS CLOSED as unavailable",
+      "cell": "a thrown observeGeneration with a held slot FAILS CLOSED as unavailable"
+    }
+  ]
+}

--- a/packages/core/smoke/endpoint-traits.smoke.ts
+++ b/packages/core/smoke/endpoint-traits.smoke.ts
@@ -760,6 +760,30 @@ try {
       const spec = await kv.get(`svc.wundef.${IID_A}.spec`);
       c("the undefined observation left the spec in place", spec?.operation === "PUT", spec?.operation);
     }
+    const DC_THROW = register({ urn: "ai.cotal.wthrow", revision: 1, attributes: [], events: [], commands: W_GOV.map((m) => ({ ...m })) });
+    const throwSpec: ServiceSpec = { endpoint: "wthrow", owner: "u_op", clusterDigests: [DC_THROW], protocol: { v: 1 } };
+    let duringThrow: Awaited<ReturnType<typeof deregisterServiceInstance>> | undefined | "threw";
+    let throwErr: { code?: string; message?: string } | undefined;
+    const kvThrow = hookedKv({ beforeWrite: async (k) => {
+      if (k !== "govern.wthrow" || duringThrow !== undefined) return;
+      const spec = await kv.get(`svc.wthrow.${IID_A}.spec`);
+      if (!spec || spec.operation !== "PUT") return;
+      try {
+        duringThrow = await deregisterServiceInstance(kv, {
+          endpoint: "wthrow", instanceId: IID_A, observeGeneration: () => { throw new Error("no issuance gate at auth.wthrow"); },
+        });
+      } catch (e) {
+        duringThrow = "threw";
+        throwErr = { code: (e as EpEnvelopeError).code, message: (e as Error).message };
+      }
+    } });
+    await regOn(kvThrow, throwSpec, IID_A);
+    c("a thrown observeGeneration with a held slot FAILS CLOSED as unavailable",
+      duringThrow === "threw" && throwErr?.code === "unavailable" && /could not observe the issuance-gate generation/.test(throwErr.message ?? "") && /no issuance gate/.test(throwErr.message ?? ""), { duringThrow, throwErr });
+    {
+      const spec = await kv.get(`svc.wthrow.${IID_A}.spec`);
+      c("the thrown observation left the spec in place", spec?.operation === "PUT", spec?.operation);
+    }
     const DC_AHEAD = register({ urn: "ai.cotal.wahead", revision: 1, attributes: [], events: [], commands: W_GOV.map((m) => ({ ...m })) });
     const aheadSpec: ServiceSpec = { endpoint: "wahead", owner: "u_op", clusterDigests: [DC_AHEAD], protocol: { v: 1 } };
     await regOn(kv, aheadSpec, IID_A);


### PR DESCRIPTION
## Summary
- Add a `smoke:ep-traits` cell that holds the instance governance slot, throws from `observeGeneration`, and asserts `unavailable` plus an un-deleted spec (`PUT`).
- Add a mutation fixture that replaces the catch body with `throw e` and requires that new cell to redden.
- This is a cell in the existing `smoke:ep-traits` suite (already CI-reached). No `ci-suites.d` fragment is needed.

Closes #1273

## Test plan
- [x] `pnpm smoke:ep-traits` green (121 passed)
- [x] `pnpm mutation-proof --config bin/smoke/mutations/observe-generation-unavailable.json` KILLED on `a thrown observeGeneration with a held slot FAILS CLOSED as unavailable`
- [x] `pnpm smoke:gate-inventory` OK
- [x] `pnpm typecheck` Scope 27 of 28 (`@cotal-ai/example-04-frontier-faces` has no typecheck script)