### PR TITLE
fix(manager): durable cleanup-complete marker on a terminalizing static slot

### DIFF
--- a/.changeset/static-slot-cleanup-marker.md
+++ b/.changeset/static-slot-cleanup-marker.md
@@ -1,0 +1,6 @@
+---
+"@cotal-ai/core": minor
+"@cotal-ai/manager": minor
+---
+
+Record a durable cleanup-complete marker on a terminalizing static managed slot before the final CAS to `retired`. A `terminalizing` row was previously consistent with three worlds (cleanup not started, cleanup in flight, or cleanup completed with the process dead before the CAS) that the state could not tell apart, so a resumed terminal always re-ran `cleanup()` as the only total option and the row could never assert cleanup was already done. `runStaticTerminal` now runs the footprint cleanup through one at-most-once helper that writes `cleanupComplete: true` on the `terminalizing` slot before the `retired` CAS; a resumed terminal reads it and skips a completed cleanup. The marker distinguishes the cleanup-completed world from the not-known-complete worlds (which keep the same remedy: re-run the idempotent cleanup) and adds no unrecoverable intermediate state.

--- a/bin/smoke/required-arg-seam.smoke.ts
+++ b/bin/smoke/required-arg-seam.smoke.ts
@@ -290,7 +290,10 @@ const SEAMS: Seam[] = [
   // records KV the lost-ack same-op recovery needs. It stays under smoke/ with the suite's other
   // three sites: the call is harness residue, not product connect, and it already states tls: false.
   // Every added site states the transport decision explicitly.
-  { fn: "standaloneConnectOpts", key: "tls", sites: 118, untypecheckedSites: 87 },
+  // 118/87 -> 119/88: static-lifecycle.smoke.ts's #1274 crash-resume cell (driveTerminalDirect) opens
+  // one more lifecycle-executor connection to plant a terminalizing slot and drive runStaticTerminal
+  // as a resume would. It is under smoke/, harness residue not product connect, and states tls: false.
+  { fn: "standaloneConnectOpts", key: "tls", sites: 119, untypecheckedSites: 88 },
 ];
 
 /**

--- a/implementations/manager/smoke/mutations/static-terminal-cleanup-marker.json
+++ b/implementations/manager/smoke/mutations/static-terminal-cleanup-marker.json
@@ -1,0 +1,37 @@
+{
+  "suite": "implementations/manager/smoke/static-lifecycle.smoke.ts",
+  "guard": "The static terminal records a durable cleanup-complete marker on the `terminalizing` slot BEFORE its final CAS to `retired` (#1274). A resumed terminal reads the marker and skips a completed cleanup instead of re-running it; a terminal that ran cleanup settles a row that carries the marker.",
+  "command": "pnpm smoke:static-lifecycle",
+  "completionMarker": "STATIC-LIFECYCLE SMOKE",
+  "proveWith": "pnpm mutation-proof --config implementations/manager/smoke/mutations/static-terminal-cleanup-marker.json",
+  "why": [
+    "§7c plants two crashed-terminal shapes over a real JWT broker and drives the real",
+    "runStaticTerminal as a resume would. `resumemarked` carries the durable cleanupComplete",
+    "marker already set (world 3: cleanup finished, the process died before the retired CAS);",
+    "`resumeplain` does not (worlds 1/2: cleanup never ran or was in flight).",
+    "",
+    "The two mutations are each other's control. Dropping the skip-when-marked branch makes the",
+    "resume re-run a cleanup it should have skipped, and the marked cell must notice. Dropping the",
+    "marker write leaves a completed cleanup unrecorded, and the plain cell (which asserts the",
+    "settled row carries the marker, written before the retired CAS) must notice. A repair that did",
+    "only one would have left the marker unreadable or unwritten one layer down."
+  ],
+  "mutations": [
+    {
+      "name": "the skip-when-cleanupComplete branch is removed, so a resume re-runs a completed cleanup",
+      "file": "implementations/manager/src/static-lifecycle.ts",
+      "find": "  if (slot.row.cleanupComplete === true) {\n    log(`footprint cleanup already recorded complete for uid ${args.lifecycleUid}; skipping the re-run (#1274 marker)`);\n    return { revision: slot.revision };\n  }\n",
+      "replace": "",
+      "expectRed": "SKIPS cleanup (world 3: already done)",
+      "cell": "a resume over a cleanupComplete=true terminalizing slot SKIPS cleanup (world 3: already done)"
+    },
+    {
+      "name": "the cleanup-complete marker write is dropped, so a completed cleanup is never recorded",
+      "file": "implementations/manager/src/static-lifecycle.ts",
+      "find": "  const revision = await casStaticSlot(t, { ...slot.row, cleanupComplete: true }, slot.revision);",
+      "replace": "  const revision = await casStaticSlot(t, { ...slot.row }, slot.revision);",
+      "expectRed": "then RETIRES marking cleanup complete",
+      "cell": "a resume over an UNMARKED terminalizing slot re-runs cleanup once, then RETIRES marking cleanup complete (write before the retired CAS)"
+    }
+  ]
+}

--- a/implementations/manager/smoke/static-lifecycle.smoke.ts
+++ b/implementations/manager/smoke/static-lifecycle.smoke.ts
@@ -75,6 +75,7 @@ import {
   casStaticSlot,
   recordSlotCredential,
   appendStaticCredentialRow,
+  runStaticTerminal,
 } from "../src/static-lifecycle.js";
 import { bootBroker } from "./_boot-broker.js";
 
@@ -95,7 +96,7 @@ let ran = 0;
  * when a `check` is deliberately added or removed, because completeness is something only this
  * suite knows, so it has to be the thing that says it.
  */
-const EXPECTED_CHECKS = 40;
+const EXPECTED_CHECKS = 43;
 function check(label: string, cond: boolean, extra?: unknown): void {
   console.log(`${cond ? "✓" : "✗"} ${label}${cond ? "" : ` — ${JSON.stringify(extra) ?? ""}`}`);
   ran++;
@@ -258,6 +259,44 @@ async function plantActiveOrphan(alias: string, actor: string, uid: string, ledg
   }
 }
 
+/** Plant a live static incarnation, latch it to `terminalizing` (optionally with the durable
+ *  `cleanupComplete` marker already set, modelling a crash AFTER cleanup finished but BEFORE the
+ *  `retired` CAS), then drive `runStaticTerminal` as a resume would — counting how many times the
+ *  footprint cleanup hook actually runs. Returns the cleanup-call count and the final slot. */
+async function driveTerminalDirect(
+  alias: string,
+  opts: { preMarkedCleanupComplete: boolean },
+): Promise<{ cleanupCalls: number; slot?: StaticManagedSlotRow }> {
+  const id = newIdentity();
+  const actor = id.id;
+  const uid = mintLifecycleUid();
+  const opId = retireOpId(uid);
+  let cleanupCalls = 0;
+  const creds = await mintCreds(auth, newIdentity(), "lifecycle-executor", {
+    lifecycleExecutor: { owner: DEV_OWNER, actor, lifecycleUid: uid, alias },
+  });
+  const nc = await connect({ servers: SERVERS, ...standaloneConnectOpts({ creds, tls: false }), maxReconnectAttempts: 0 });
+  try {
+    const kvm = new Kvm(nc);
+    const t = staticLifecycleTransport(await kvm.open(recordsBucket(space)), await kvm.open(epAuthBucket(space)));
+    await activateStaticLifecycle(t, { owner: DEV_OWNER, alias, actor, lifecycleUid: uid, managerInstance: "smoke", ownerInstanceId: M.managerInstanceId });
+    const credentialId = `cred-${alias}`;
+    await recordSlotCredential(t, DEV_OWNER, alias, uid, credentialId);
+    await appendStaticCredentialRow(t, { lifecycleUid: uid, credentialId, holderPrincipal: principalKey(DEV_OWNER, actor).key, exp: Math.floor(Date.now() / 1000) + 3600 });
+    // Latch the crashed-terminal shape: `terminalizing`, with the marker pre-set for the world-3 case.
+    const planted = await readStaticSlot(t, DEV_OWNER, alias);
+    await casStaticSlot(t, { ...planted!.row, phase: "terminalizing", ...(opts.preMarkedCleanupComplete ? { cleanupComplete: true } : {}) }, planted!.revision);
+    await runStaticTerminal(
+      t,
+      { owner: DEV_OWNER, alias, actor, lifecycleUid: uid, opId, managerInstance: "smoke", managerProcessUid: "smoke-proc" },
+      { cleanup: async () => { cleanupCalls++; }, evict: async (principal) => ({ principal, kicked: 1, remaining: 0, scanComplete: true, verifiedGone: true }), log: () => {} },
+    );
+    return { cleanupCalls, slot: (await readStaticSlot(t, DEV_OWNER, alias))?.row };
+  } finally {
+    await nc.drain().catch(() => nc.close());
+  }
+}
+
 try {
   await setupSpaceStreams({ servers: SERVERS, space, creds: await mintCreds(auth, newIdentity(), "provisioner") });
 
@@ -409,6 +448,20 @@ try {
   check("POST-ADOPTION sweep terminalized the unadopted active orphan (F3 resume-path fix)", rSettled);
   check("the resume-path orphan's principal now REFUSES at the control surface (F5(a) closed on resume)", typeof M.lifecycleMembershipRefusal(principalKey(DEV_OWNER, resOrphanId.id).key) === "string");
   check("worker B STILL survived both resume-path sweeps (live membership adopted)", M.agents.get("worker")?.lifecycleUid === uidB && (await readSlotOnly("worker"))?.phase === "active");
+
+  // ── 7c. #1274 durable cleanup-complete marker (crash between cleanup and the retired CAS) ──
+  // A `terminalizing` row whose `cleanupComplete` is already set models world 3: cleanup finished,
+  // the process died before the `retired` CAS. A resumed terminal must READ that marker and NOT
+  // re-run cleanup, yet still reach `retired`. A `terminalizing` row WITHOUT the marker is worlds
+  // 1/2 (cleanup never ran / in flight): the resume MUST re-run the idempotent cleanup, and on
+  // success the row it settles must carry the marker (written BEFORE the retired CAS).
+  const markedResume = await driveTerminalDirect("resumemarked", { preMarkedCleanupComplete: true });
+  check("a resume over a cleanupComplete=true terminalizing slot SKIPS cleanup (world 3: already done)", markedResume.cleanupCalls === 0, markedResume.cleanupCalls);
+  check("that resume still reaches RETIRED (the marker recovers, it does not wedge)", markedResume.slot?.phase === "retired" && markedResume.slot?.cleanupComplete === true, markedResume.slot);
+  const plainResume = await driveTerminalDirect("resumeplain", { preMarkedCleanupComplete: false });
+  check("a resume over an UNMARKED terminalizing slot re-runs cleanup once, then RETIRES marking cleanup complete (write before the retired CAS)",
+    plainResume.cleanupCalls === 1 && plainResume.slot?.phase === "retired" && plainResume.slot?.cleanupComplete === true,
+    { calls: plainResume.cleanupCalls, slot: plainResume.slot });
 
   // ── 8. F2: endpointCapabilities refusal ────────────────────────────────────
   const spawnEp = await mgr.startAgent({ name: "epcap", agent: "smoke-sl", ...({ endpointCapabilities: [{ endpoint: "x", verb: "call" }] } as Record<string, unknown>) });

--- a/implementations/manager/src/static-lifecycle.ts
+++ b/implementations/manager/src/static-lifecycle.ts
@@ -279,6 +279,42 @@ export async function activateStaticLifecycle(
   return { slotRevision: revision };
 }
 
+/** Run the terminal's footprint cleanup AT MOST ONCE across resumes, and record that it finished
+ *  DURABLY on the `terminalizing` slot BEFORE the caller's final CAS to `retired`.
+ *
+ *  This is the marker #1274 asks for. A row observed at `terminalizing` was previously consistent
+ *  with three worlds — cleanup not started, cleanup in flight, or cleanup COMPLETED with the process
+ *  dead before the `retired` CAS — with one remedy (re-run cleanup, the only total option) that could
+ *  never assert cleanup was already done. `cleanupComplete` on the row splits world 3 off: a resume
+ *  that reads it SKIPS the re-run.
+ *
+ *  Total, and it moves no ambiguity it cannot recover. The new durable point is AFTER cleanup and
+ *  BEFORE the marker CAS; a crash there re-enters here, reads `cleanupComplete` unset, and re-runs the
+ *  idempotent cleanup — the same total default as before, so worlds 1 and 2 stay merged (they share
+ *  that remedy) rather than the marker pretending to separate them. A crash AFTER the marker CAS but
+ *  before `retired` re-enters here, reads `cleanupComplete` set, skips cleanup, and the caller finishes
+ *  the `retired` CAS. No new unrecoverable state.
+ *
+ *  Returns the slot revision the marker CAS produced (or the observed revision when the marker was
+ *  already set), so a caller that CASes `retired` from a held revision advances off the right one. */
+async function cleanupStaticSlotOnce(
+  t: LifecycleStateTransport,
+  args: { owner: string; alias: string; lifecycleUid: string },
+  cleanup: () => Promise<void>,
+  log: (line: string) => void,
+): Promise<{ revision: number }> {
+  const slot = await readStaticSlot(t, args.owner, args.alias);
+  if (slot === undefined || slot.row.lifecycleUid !== args.lifecycleUid)
+    throw new EpEnvelopeError("internal", `the static slot for "${args.owner}/${args.alias}" ${slot === undefined ? "vanished" : `moved to uid ${slot.row.lifecycleUid}`} mid-terminal; a slot row is never deleted and a terminal never crosses incarnations`);
+  if (slot.row.cleanupComplete === true) {
+    log(`footprint cleanup already recorded complete for uid ${args.lifecycleUid}; skipping the re-run (#1274 marker)`);
+    return { revision: slot.revision };
+  }
+  await cleanup();
+  const revision = await casStaticSlot(t, { ...slot.row, cleanupComplete: true }, slot.revision);
+  return { revision };
+}
+
 /** The static TERMINAL (F1, the (b2) order): freeze-under-the-retirement-op -> head
  *  `active -> retiring` -> B1 ledger revoke -> broker connection eviction -> cleanup (the injected
  *  footprint teardown; on a normal stop the manager separately proves runtime exit) -> gate
@@ -302,10 +338,11 @@ export async function runStaticTerminal(
     throw new EpEnvelopeError("failed-precondition", `the static slot for "${args.owner}/${args.alias}" is at uid ${slot.row.lifecycleUid}, not ${args.lifecycleUid}; a terminal never addresses another incarnation (SPEC 13.1)`);
   if (slot.row.phase === "retired") return "retired"; // completed terminal, idempotent
   // Latch the DURABLE terminal intent first: after this CAS the slot can never mint again
-  // (recordSlotCredential refuses terminalizing), the exact window the F5 renewal gate needs.
-  let slotRevision = slot.revision;
+  // (recordSlotCredential refuses terminalizing), the exact window the F5 renewal gate needs. Every
+  // final `retired` CAS below re-reads the slot (or takes the marker CAS's revision), so this latch
+  // needs no return.
   if (slot.row.phase !== "terminalizing")
-    slotRevision = await casStaticSlot(t, { ...slot.row, phase: "terminalizing" }, slot.revision);
+    await casStaticSlot(t, { ...slot.row, phase: "terminalizing" }, slot.revision);
   const gate = await gateObserve(t, args.lifecycleUid);
   if (gate === undefined) {
     // Crash before the saga's first durable write (or before gate creation): only the intent
@@ -315,8 +352,10 @@ export async function runStaticTerminal(
       throw new EpEnvelopeError("internal", `the head for "${args.owner}/${args.actor}" names uid ${args.lifecycleUid} but its gate does not exist; an active head without a gate is corruption (SPEC 13.1)`);
     const preGateHolders = await revokeStaticCredentialRows(t, args.lifecycleUid, slot.row.credentialIds, hooks.log);
     await evictAndAudit(t, args, preGateHolders, hooks.evict, hooks.log);
-    await hooks.cleanup();
-    await casStaticSlot(t, { ...slot.row, phase: "retired" }, slotRevision);
+    await cleanupStaticSlotOnce(t, args, hooks.cleanup, hooks.log);
+    const cur = await readStaticSlot(t, args.owner, args.alias);
+    if (cur !== undefined && cur.row.lifecycleUid === args.lifecycleUid && cur.row.phase !== "retired")
+      await casStaticSlot(t, { ...cur.row, phase: "retired" }, cur.revision);
     return "retired";
   }
   if (gate.row.state === "frozen" && gate.row.op?.kind === "activation") {
@@ -333,7 +372,7 @@ export async function runStaticTerminal(
       await gateRetire(t, { lifecycleUid: args.lifecycleUid, revision: gate.revision, opId: gate.row.op.opId });
       const lostHeadHolders = await revokeStaticCredentialRows(t, args.lifecycleUid, slot.row.credentialIds, hooks.log);
       await evictAndAudit(t, args, lostHeadHolders, hooks.evict, hooks.log);
-      await hooks.cleanup();
+      await cleanupStaticSlotOnce(t, args, hooks.cleanup, hooks.log);
       const cur = await readStaticSlot(t, args.owner, args.alias);
       if (cur !== undefined && cur.row.lifecycleUid === args.lifecycleUid && cur.row.phase !== "retired")
         await casStaticSlot(t, { ...cur.row, phase: "retired" }, cur.revision);
@@ -382,7 +421,7 @@ export async function runStaticTerminal(
   for (const principal of holders) hooks.log(`verify-evicting orphan seat principal ${principal} before lifecycle cleanup`);
   await evictAndAudit(t, args, holders, hooks.evict, hooks.log);
   for (const principal of holders) hooks.log(`verified orphan seat principal gone: ${principal}`);
-  await hooks.cleanup();
+  await cleanupStaticSlotOnce(t, args, hooks.cleanup, hooks.log);
   // The terminal tail, in the (b2) order: gate frozen->retired FIRST (retains the opId, the
   // recovery coordinate), head retiring->retired LAST (drops the op; the alias frees only now).
   // gateRetire is called UNCONDITIONALLY: on a frozen gate it terminalizes; on an already-retired

--- a/packages/core/src/lifecycle-state.ts
+++ b/packages/core/src/lifecycle-state.ts
@@ -492,6 +492,13 @@ export interface StaticManagedSlotRow {
    *  it as its own (the single-manager past). An orphaned sibling row is claimed only by an explicit
    *  operator CAS takeover (ruling 1), never auto-adopted. */
   ownerInstanceId?: string;
+  /** Set true, on the `terminalizing` row, once the terminal's footprint cleanup has finished and
+   *  BEFORE the final CAS to `retired`. It lets a resumed terminal tell "cleanup already completed"
+   *  (the process died between cleanup and the `retired` CAS) from "cleanup never ran or was in
+   *  flight", so the resume skips a completed cleanup instead of re-running it as the only total
+   *  option. Absent on a legacy row and on every phase before the cleanup step, which a resume reads
+   *  as not-known-complete and re-runs the idempotent cleanup — the totality-preserving default. */
+  cleanupComplete?: boolean;
 }
 
 /** The slot key prefix in the records store. Core-owned so permission builders and the manager
@@ -513,16 +520,17 @@ export function parseStaticSlotRow(raw: Uint8Array, key: string): StaticManagedS
     throw new EpEnvelopeError("internal", `the static slot row ${key} is not JSON; garbled trusted-path state never drives supervision (SPEC 13.1)`);
   }
   if (!isRec(o)) throw new EpEnvelopeError("internal", `the static slot row ${key} is not an object`);
-  const allowed = new Set(["owner", "alias", "actor", "lifecycleUid", "phase", "credentialIds", "managerInstance", "ownerInstanceId"]);
+  const allowed = new Set(["owner", "alias", "actor", "lifecycleUid", "phase", "credentialIds", "managerInstance", "ownerInstanceId", "cleanupComplete"]);
   for (const k of Object.keys(o)) if (!allowed.has(k)) throw new EpEnvelopeError("internal", `the static slot row ${key} carries the unknown field "${k}" (closed schema)`);
   if (
     typeof o.owner !== "string" || typeof o.alias !== "string" || typeof o.actor !== "string" ||
     typeof o.lifecycleUid !== "string" || typeof o.managerInstance !== "string" || o.managerInstance.length === 0 ||
     typeof o.phase !== "string" || !STATIC_SLOT_PHASES.has(o.phase) ||
     (o.ownerInstanceId !== undefined && (typeof o.ownerInstanceId !== "string" || o.ownerInstanceId.length === 0)) ||
+    (o.cleanupComplete !== undefined && typeof o.cleanupComplete !== "boolean") ||
     !Array.isArray(o.credentialIds) || !o.credentialIds.every((c) => typeof c === "string" && c.length > 0)
   )
-    throw new EpEnvelopeError("internal", `the static slot row ${key} does not validate (owner/alias/actor/uid/phase/credentialIds/managerInstance/ownerInstanceId)`);
+    throw new EpEnvelopeError("internal", `the static slot row ${key} does not validate (owner/alias/actor/uid/phase/credentialIds/managerInstance/ownerInstanceId/cleanupComplete)`);
   assertLifecycleToken(o.lifecycleUid);
   for (const c of o.credentialIds) assertCredentialIdTail(c, `slot row ${key} credentialId`);
   if (staticSlotKey(o.owner, o.alias) !== key)


### PR DESCRIPTION
## What

A static managed slot observed at `terminalizing` was consistent with three different worlds, which durable state could not tell apart:

1. cleanup has not started;
2. cleanup is in flight;
3. cleanup **completed** and the process died before the CAS to `retired`.

`runStaticTerminal` wrote nothing durable between `hooks.cleanup()` and the final `casStaticSlot(..., phase: "retired")`, so a resumed terminal always re-ran `cleanup()` as the only total option, and the row could never assert that cleanup was already done.

This PR does the **durability half** of #1274.

## The marker

- Adds an optional `cleanupComplete?: boolean` to `StaticManagedSlotRow` (closed schema; validated in `parseStaticSlotRow`; absent on legacy rows and on every phase before the cleanup step).
- Routes every `runStaticTerminal` cleanup arm (pre-gate, lost-head, main) through one at-most-once helper, `cleanupStaticSlotOnce`, that:
  - reads the current `terminalizing` slot,
  - **skips** cleanup if `cleanupComplete === true`,
  - otherwise runs `hooks.cleanup()` then CASes `cleanupComplete: true` onto the `terminalizing` row **before** the final CAS to `retired`.

A resumed terminal reads the marker and skips a completed cleanup instead of re-running it.

## Revision discipline (two CAS operations where there was one)

The change turns one slot CAS into two — the `cleanupComplete` marker CAS, then the `retired` CAS — so stale-revision reuse would be the way it could introduce a lost update. It does not chain a captured revision across the marker CAS:

- `cleanupStaticSlotOnce` does its **own** fresh `readStaticSlot`, CASes the marker at that read's revision, and returns the new revision.
- Every arm then **re-reads** the slot (`cur = readStaticSlot(...)`) and CASes `retired` at `cur.revision`. No arm carries a pre-marker `slotRevision` into the `retired` CAS; the previously captured `slotRevision` local was removed. The terminalizing latch CAS at the top is likewise not reused.

Re-reading rather than threading the helper's returned revision is the equivalent safe discipline and is what the three arms already did before this change, so the marker CAS slots in without a revision hand-off. A CAS that loses to a concurrent writer throws rather than silently overwriting.

## Totality — which worlds it distinguishes

The marker splits **world 3** (cleanup completed, process died before the `retired` CAS) off from **worlds 1 + 2** (cleanup never ran / in flight). It deliberately does **not** separate world 1 from world 2, because they share one remedy: re-run the idempotent cleanup (`rmSync` force + secret delete + `deprovisionBroker`).

It adds no unrecoverable state. The new durable point is after cleanup and before the marker CAS; a crash there re-enters the helper, reads `cleanupComplete` unset, and re-runs the idempotent cleanup — the same total default as before. A crash after the marker CAS but before `retired` re-enters, reads the marker set, skips cleanup, and finishes the `retired` CAS. The resume path is the in-code reader of the marker, so it is not write-only at the mechanism layer.

## Scope: this closes the durability half only

Per the issue's own framing, a read projection alone would close the second half and not this one (there would be no field to render). This PR is the field. It uses **`Refs #1274`, not `Closes`**; the issue stays open owning the projection.

**What remains for #1274 (the read-projection half, a separate PR):** project `phase` / head / op through an operator read verb (`inspect` returns fifteen fields, none of them `phase`), and make the refusals discriminate a stranded retirement from a name that never existed (both currently return `not-found: no agent "<name>"`).

## Grading

- New smoke §7c in `static-lifecycle.smoke.ts` (an existing suite; drives the **real** `runStaticTerminal` over a real own-broker JWT stack, not the live fleet) for a marked `terminalizing` slot (world 3: skips cleanup, still reaches `retired`) and an unmarked one (re-runs cleanup once, settles a row carrying the marker). Green 43/43.
- `pnpm mutation-proof --config implementations/manager/smoke/mutations/static-terminal-cleanup-marker.json`: 2 mutants, both KILLED. The load-bearing one **drops the marker write** (`cleanupComplete: true` -> nothing persisted): the resumed terminal then settles a row with no marker and the §7c "then RETIRES marking cleanup complete" cell reddens — the earliest red, at 42 marks vs baseline 43. The second removes the skip-read branch and reddens "SKIPS cleanup (world 3: already done)", also earliest at 42 vs 43. Run after committing (its restore is `git checkout HEAD --`).
- Gating confirmed from the tool, not the file: `pnpm smoke:gate-inventory` -> `GATE INVENTORY OK`. This PR adds no new suite (it extends `smoke:static-lifecycle`), so no `ci-suites.d` fragment is needed; the inventory verdict is the confirmation that the extended suite still runs where CI reaches it, given #1283 changed how coverage is computed (`check` is no longer a root).
- `pnpm typecheck` clean (`Scope: 27 of 28`; the 28th, `@cotal-ai/example-04-frontier-faces`, is JS-only and skipped).
- `pnpm check:docs-voice` passes. Changeset bumps the fixed group at minor.

**Not verified:** graded by reading and non-live suites only. Per this machine's constraints I did not run `:live` stages, `pnpm check`, or the live audit that produced the issue, so behavior against the live mesh fleet is unverified here. The wire contract (gate/head/ledger, SPEC §13.1) is unchanged — the marker is a field on the manager-local `mgrslot` record, not a wire message — so `SPEC.md` does not move.
