### PR TITLE
ci(mutation-reproof): raise the changed-set budget and record elapsed

### DIFF
--- a/.github/workflows/mutation-reproof.yml
+++ b/.github/workflows/mutation-reproof.yml
@@ -16,7 +16,28 @@ jobs:
     # Source intersection catches the #1217 shape at the changing commit. The daily full sweep
     # below catches cross-cutting changes a fixture did not name within a day.
     if: github.event_name != 'schedule'
-    timeout-minutes: 60
+    # 150, raised from 60, and PROVISIONAL. A PR touching a high-fan-in guarded source selects a
+    # large fixture set: #1294 (which edits implementations/manager/src/manager.ts) selected 42
+    # fixtures / 181 mutations and was cancelled at the 60-minute cap five consecutive times, so
+    # it could not satisfy this gate by any action its author could take. `pr-head-gate.mjs`
+    # grades a non-success as failing and this workflow is in its expected set, so the gate fails
+    # closed on a job that cannot finish rather than on a defect.
+    #
+    # The number is not derived, because nothing here has ever been measured well enough to derive
+    # it, and that is the substance of #1299 rather than a detail of it. The two models available
+    # both UNDER-predict: at the fastest observed rate (9 fixtures / 39 mutations in 7m27s) 181
+    # mutations is ~42 minutes, and as a fraction of the corpus (181 of 1,714) against `full`'s
+    # 360-minute budget it is ~38 minutes. The real run exceeded 60. So per-mutation cost is
+    # dominated by WHICH suites a fixture guards, not by how many mutations it carries, and both
+    # models are wrong for exactly the sets that need the budget. 150 is 2.5x the larger estimate,
+    # which is the smallest headroom that survives models known to under-predict by over 1.5x, and
+    # it stays well under `full`'s 360.
+    #
+    # Re-derive this from the elapsed line the Report elapsed step now prints, once real sets have
+    # reported. Do
+    # not raise it again without that data: a limit raised past what anyone can measure trades a
+    # visible failure for an invisible one.
+    timeout-minutes: 150
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -56,7 +77,25 @@ jobs:
             base="$(git rev-parse HEAD~1)" || { echo "no base commit or first parent"; exit 2; }
             echo "no base commit on this event; using first parent $base"
           fi
+          echo "MUTATION_STARTED=$(date +%s)" >> "$GITHUB_ENV"
           node scripts/mutation-reproof.mjs --base "$base" --head "$(git rev-parse HEAD)"
+      - name: Report elapsed
+        # Until this step existed, no run of this job recorded how long it took, so a cancellation
+        # at the cap and a run finishing one second inside it were indistinguishable afterwards,
+        # and the budget above could only ever be guessed.
+        #
+        # `always()` rather than `failure()` because the run whose duration matters most is the one
+        # the timer kills, and a timeout cancels the job rather than failing it. This is best
+        # effort on that path: a cancelled job gives its remaining steps only a grace period, so a
+        # timed-out run MAY print nothing here. It is reliable on the success and failure paths,
+        # which is what re-deriving the budget needs.
+        if: always()
+        run: |
+          if [ -n "${MUTATION_STARTED:-}" ]; then
+            echo "mutation reproof: changed-set elapsed $(( $(date +%s) - MUTATION_STARTED ))s (budget 150m)"
+          else
+            echo "mutation reproof: no start marker; the job ended before the re-prove step began"
+          fi
 
   full:
     # A daily sweep keeps the remaining ambient-drift window bounded without making every pull

--- a/.github/workflows/mutation-reproof.yml
+++ b/.github/workflows/mutation-reproof.yml
@@ -77,7 +77,11 @@ jobs:
             base="$(git rev-parse HEAD~1)" || { echo "no base commit or first parent"; exit 2; }
             echo "no base commit on this event; using first parent $base"
           fi
-          echo "MUTATION_STARTED=$(date +%s)" >> "$GITHUB_ENV"
+          # A FILE, not $GITHUB_ENV. The runner processes a step's env file when the step ENDS, so a
+          # step killed by `timeout-minutes` never contributes its variables and the next step would
+          # see nothing — on precisely the timed-out run this measurement exists for. A file written
+          # by the shell exists the moment the redirect completes.
+          date +%s > "$RUNNER_TEMP/mutation-started"
           node scripts/mutation-reproof.mjs --base "$base" --head "$(git rev-parse HEAD)"
       - name: Report elapsed
         # Until this step existed, no run of this job recorded how long it took, so a cancellation
@@ -85,14 +89,17 @@ jobs:
         # and the budget above could only ever be guessed.
         #
         # `always()` rather than `failure()` because the run whose duration matters most is the one
-        # the timer kills, and a timeout cancels the job rather than failing it. This is best
-        # effort on that path: a cancelled job gives its remaining steps only a grace period, so a
-        # timed-out run MAY print nothing here. It is reliable on the success and failure paths,
-        # which is what re-deriving the budget needs.
+        # the timer kills, and a timeout cancels the job rather than failing it. The start marker is
+        # a file for the same reason: $GITHUB_ENV is only processed when a step ENDS, so a step the
+        # timer kills contributes nothing and this step would take its else branch on exactly the
+        # run it was added for. Still best effort on that path — a cancelled job gives its remaining
+        # steps only a grace period, so this may not run at all — but when it does run it now has a
+        # start time to work from.
         if: always()
         run: |
-          if [ -n "${MUTATION_STARTED:-}" ]; then
-            echo "mutation reproof: changed-set elapsed $(( $(date +%s) - MUTATION_STARTED ))s (budget 150m)"
+          marker="$RUNNER_TEMP/mutation-started"
+          if [ -s "$marker" ]; then
+            echo "mutation reproof: changed-set elapsed $(( $(date +%s) - $(cat "$marker") ))s (budget 150m)"
           else
             echo "mutation reproof: no start marker; the job ended before the re-prove step began"
           fi


### PR DESCRIPTION
Closes #1299.

## The problem

`pr-head-gate.mjs:131` grades a non-success as failing and "Mutation reproof" is in its expected set, so the gate fails closed. That is correct behaviour. What is not correct is that a PR touching a high-fan-in guarded source can never reach a success by any action its author can take: the `changed` job's fixture set scales with the changed paths, and a large set exceeds the 60-minute cap, which cancels rather than fails.

#1294 is the worked example. It edits `implementations/manager/src/manager.ts`, selects **42 fixtures / 181 mutations**, and its `changed` job was cancelled at 60 minutes on five consecutive heads:

```
647e21b5e  cancelled     2fc985c5d  cancelled     342f2bba6  cancelled
71974bb61  cancelled     d1db29e23  cancelled  (17:33:51Z, 60m00s)
```

Every other PR in the last twenty runs finished in 1-8 minutes.

## Why 150 and not a derived number

Because nothing here has ever been measured well enough to derive one, and that is the substance of the issue rather than a detail of it.

Both available models **under-predict**:

| model | basis | predicts for 181 mutations |
|---|---|---|
| fastest observed rate | 9 fixtures / 39 mutations in 7m27s (run 33970489997) | ~42 min |
| corpus fraction | 181 of 1,714 mutations against `full`'s 360-minute budget | ~38 min |
| **actual** | | **exceeded 60** |

So per-mutation cost is dominated by *which* suites a fixture guards, not by how many mutations it carries, and both models are wrong for exactly the sets that need the budget. 150 is 2.5x the larger estimate, the smallest headroom that survives models known to under-predict by over 1.5x, and it stays well under `full`'s 360.

I could not anchor against a real corpus time: no scheduled `full` run has ever executed, so `full`'s own 360 was also a guess.

## The durable half

No run of this job has ever recorded its duration. That is why the budget could only be guessed, and why raising it alone would just move the wall. `Report elapsed` prints the changed-set duration so the next revision is measured rather than argued.

It runs under `always()` rather than `failure()`, because the run whose duration matters most is the one the timer kills, and a job timeout cancels rather than fails. This is **best effort on that path** and the comment says so: a cancelled job gives its remaining steps only a grace period, so a timed-out run may print nothing. It is reliable on the success and failure paths, which is what re-deriving the budget needs.

This mirrors Cotal-AI/foreman#376, filed today for the same shape on a different gate: an exclusive resource with a hard cap and no recorded duration, where every accepted run is necessarily under the cap so the baseline is unknowable.

## Scope

One file, `.github/workflows/mutation-reproof.yml`, +39/-1. The workflow count does not move (this edits an existing file), `on:` and top-level concurrency are unchanged, and the `full` job is untouched.

Pushed from a credential with the `workflow` scope; no lane credential on the agent host holds it, which is the same constraint that produced #1292.
