### PR TITLE
ci(mutation-reproof): correct the budget provenance and make a breach a step failure

### DIFF
--- a/.github/workflows/mutation-reproof.yml
+++ b/.github/workflows/mutation-reproof.yml
@@ -29,10 +29,20 @@ jobs:
     #                                self-update-handoff.json, which that head added
     #
     # The budget is derived from cancelled runs' own progress rather than from a model. Count
-    # completed mutations by their VERDICT token (KILLED / SURVIVED / INCONCLUSIVE / UNGRADABLE /
-    # WRONG-RED / ERROR / PRE-RED, the vocabulary at scripts/mutation-reproof.mjs:217). Do not
-    # grep for KILLED alone: a prediction line reads "PREDICTED KILLED", so a line-count over that
-    # token overstates the total, which is how an earlier revision of this comment said 109.
+    # completed mutations by their VERDICT token. The authority is the `VERDICTS` array in
+    # scripts/mutation-reproof.mjs (six tokens as of 99d50f510: KILLED, SURVIVED, INCONCLUSIVE,
+    # UNGRADABLE, WRONG-RED, ERROR) — read it from source rather than trusting this list, which is
+    # a snapshot and will drift when a seventh is added.
+    #
+    # Two tokens that look countable and are not:
+    #   PREDICTED KILLED  a per-mutation PREDICTION preamble, not a verdict. `grep -c KILLED`
+    #                     counts those lines too, which is how an earlier revision said 109 of a
+    #                     set whose real total is 99.
+    #   PRE-RED (N ...)   a per-FIXTURE summary for suites already red before mutation. It is not
+    #                     in VERDICTS and contributes ZERO completed mutations, but its emitted
+    #                     line is `PRE-RED (` — token, space, paren — so a naive alternation with a
+    #                     trailing space matches it and silently adds one fixture-level event to a
+    #                     mutation-level count.
     #
     #   d1db29e23  re-prove 16:34:33Z -> 17:33:49Z (59.3 min), 99 of 183 done   35.9 s/mutation
     #   ec6f1f7b2  re-prove 18:35:56Z -> 19:35:15Z (59.3 min), 85 done          41.9 s/mutation

--- a/.github/workflows/mutation-reproof.yml
+++ b/.github/workflows/mutation-reproof.yml
@@ -28,11 +28,20 @@ jobs:
     #   d1db29e23 (run 33978243970)  43 fixtures selected from 342, the extra one being
     #                                self-update-handoff.json, which that head added
     #
-    # The budget is derived from d1db29e23's own progress rather than from a model. That job spent
-    # 56s on setup, then ran the re-prove step 16:34:33Z -> 17:33:49Z (59.3 min) before the cap
-    # cancelled it, completing 109 of its 183 mutations, 60% of that set. That is 32.6 s/mutation
-    # ON THAT SET, projecting 99.5 min for the re-prove and ~100 min for the whole job. 150 leaves
-    # about 1.49x headroom over that projection and stays well under `full`'s 360.
+    # The budget is derived from cancelled runs' own progress rather than from a model. Count
+    # completed mutations by their VERDICT token (KILLED / SURVIVED / INCONCLUSIVE / UNGRADABLE /
+    # WRONG-RED / ERROR / PRE-RED, the vocabulary at scripts/mutation-reproof.mjs:217). Do not
+    # grep for KILLED alone: a prediction line reads "PREDICTED KILLED", so a line-count over that
+    # token overstates the total, which is how an earlier revision of this comment said 109.
+    #
+    #   d1db29e23  re-prove 16:34:33Z -> 17:33:49Z (59.3 min), 99 of 183 done   35.9 s/mutation
+    #   ec6f1f7b2  re-prove 18:35:56Z -> 19:35:15Z (59.3 min), 85 done          41.9 s/mutation
+    #
+    # Two independent high-fan-in manager.ts sets on different branches, both killed at the old
+    # 60-minute cap, rates within ~17%. At the faster rate a 183-mutation set projects ~110 min and
+    # 150 leaves about 1.37x headroom; at the slower it projects ~128 min and about 1.17x. The
+    # slower figure is the one to plan against, and 1.17x is thin. Widen only from an elapsed line
+    # on a real set, not from another estimate.
     #
     # Models fitted from OTHER runs under-predict badly and should not be used to re-derive. The
     # fastest observed successful run (9 fixtures / 39 mutations in 7m27s) puts d1db's 183
@@ -74,13 +83,18 @@ jobs:
       - name: Build
         run: pnpm build
       - name: Re-prove fixtures for changed guarded sources
-        # A STEP timeout, deliberately below the job's 150. This changes what a budget breach MEANS
-        # to the head gate and that is the point: a job timeout produces `cancelled`, a step timeout
-        # produces `failure`, and `pr-head-gate.mjs` grades them differently. A breach should read
-        # as a failure the author can see and act on, not as a cancellation that looks like
-        # unrelated CI churn. It also lets the Report elapsed step run normally instead of racing a
-        # cancellation grace period, so the one run whose duration matters most is the one that can
-        # now report it.
+        # A STEP timeout, deliberately below the job's 150, so that a breach fails the STEP and the
+        # job continues to its remaining steps instead of being cancelled outright.
+        #
+        # The reason is Report elapsed, and only that. A cancelled job gives its remaining steps a
+        # grace period at best, so the run whose duration matters most was the least likely to
+        # report it. A failed step leaves the job running normally and that step executes.
+        #
+        # It is NOT a change to what the head gate sees, and an earlier draft of this comment
+        # claimed it was. `scripts/pr-head-gate.mjs:131` is the whole of its conclusion handling —
+        # `if (run.conclusion !== "success") failing.push(name)` — one comparison with no branch, so
+        # `cancelled`, `failure`, `timed_out` and `neutral` are identical to it. The gate's verdict
+        # is byte-identical either way.
         timeout-minutes: 145
         env:
           BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}

--- a/.github/workflows/mutation-reproof.yml
+++ b/.github/workflows/mutation-reproof.yml
@@ -16,27 +16,33 @@ jobs:
     # Source intersection catches the #1217 shape at the changing commit. The daily full sweep
     # below catches cross-cutting changes a fixture did not name within a day.
     if: github.event_name != 'schedule'
-    # 150, raised from 60, and PROVISIONAL. A PR touching a high-fan-in guarded source selects a
-    # large fixture set: #1294 (which edits implementations/manager/src/manager.ts) selected 42
-    # fixtures / 181 mutations and was cancelled at the 60-minute cap five consecutive times, so
-    # it could not satisfy this gate by any action its author could take. `pr-head-gate.mjs`
-    # grades a non-success as failing and this workflow is in its expected set, so the gate fails
-    # closed on a job that cannot finish rather than on a defect.
+    # 150, raised from the previous 60-minute budget (150 = 2.5 x 60). A PR touching a high-fan-in
+    # guarded source selects a large fixture set, and #1294 could not satisfy this gate by any
+    # action its author could take: its `changed` job was cancelled at the 60-minute cap on five
+    # consecutive heads. `pr-head-gate.mjs` grades a non-success as failing and this workflow is in
+    # its expected set, so the gate failed closed on a job that could not finish rather than on a
+    # defect.
     #
-    # The number is not derived, because nothing here has ever been measured well enough to derive
-    # it, and that is the substance of #1299 rather than a detail of it. The two models available
-    # both UNDER-predict: at the fastest observed rate (9 fixtures / 39 mutations in 7m27s) 181
-    # mutations is ~42 minutes, and as a fraction of the corpus (181 of 1,714) against `full`'s
-    # 360-minute budget it is ~38 minutes. The real run exceeded 60. So per-mutation cost is
-    # dominated by WHICH suites a fixture guards, not by how many mutations it carries, and both
-    # models are wrong for exactly the sets that need the budget. 150 is 2.5x the larger estimate,
-    # which is the smallest headroom that survives models known to under-predict by over 1.5x, and
-    # it stays well under `full`'s 360.
+    # The selection differs per head, so each figure names its own sha:
+    #   647e21b5e (run 33973541717)  42 fixtures selected from 341
+    #   d1db29e23 (run 33978243970)  43 fixtures selected from 342, the extra one being
+    #                                self-update-handoff.json, which that head added
     #
-    # Re-derive this from the elapsed line the Report elapsed step now prints, once real sets have
-    # reported. Do
-    # not raise it again without that data: a limit raised past what anyone can measure trades a
-    # visible failure for an invisible one.
+    # The budget is derived from d1db29e23's own progress rather than from a model. That job spent
+    # 56s on setup, then ran the re-prove step 16:34:33Z -> 17:33:49Z (59.3 min) before the cap
+    # cancelled it, completing 109 of its 183 mutations, 60% of that set. That is 32.6 s/mutation
+    # ON THAT SET, projecting 99.5 min for the re-prove and ~100 min for the whole job. 150 leaves
+    # about 1.49x headroom over that projection and stays well under `full`'s 360.
+    #
+    # Models fitted from OTHER runs under-predict badly and should not be used to re-derive. The
+    # fastest observed successful run (9 fixtures / 39 mutations in 7m27s) puts d1db's 183
+    # mutations at ~35 min, and the corpus fraction (183 of 1,714) against `full`'s budget puts it
+    # at ~38. The real set needed ~100. Per-mutation cost is dominated by WHICH suites a fixture
+    # guards, not by how many mutations it carries, so a rate measured on a small set does not
+    # transfer to a large one.
+    #
+    # Re-derive from the elapsed line the Report elapsed step prints, on a real high-fan-in set,
+    # and name the sha you measured. Do not raise this again without that data.
     timeout-minutes: 150
     runs-on: ubuntu-latest
     steps:
@@ -68,6 +74,14 @@ jobs:
       - name: Build
         run: pnpm build
       - name: Re-prove fixtures for changed guarded sources
+        # A STEP timeout, deliberately below the job's 150. This changes what a budget breach MEANS
+        # to the head gate and that is the point: a job timeout produces `cancelled`, a step timeout
+        # produces `failure`, and `pr-head-gate.mjs` grades them differently. A breach should read
+        # as a failure the author can see and act on, not as a cancellation that looks like
+        # unrelated CI churn. It also lets the Report elapsed step run normally instead of racing a
+        # cancellation grace period, so the one run whose duration matters most is the one that can
+        # now report it.
+        timeout-minutes: 145
         env:
           BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
         run: |
@@ -89,12 +103,15 @@ jobs:
         # and the budget above could only ever be guessed.
         #
         # `always()` rather than `failure()` because the run whose duration matters most is the one
-        # the timer kills, and a timeout cancels the job rather than failing it. The start marker is
-        # a file for the same reason: $GITHUB_ENV is only processed when a step ENDS, so a step the
-        # timer kills contributes nothing and this step would take its else branch on exactly the
-        # run it was added for. Still best effort on that path — a cancelled job gives its remaining
-        # steps only a grace period, so this may not run at all — but when it does run it now has a
-        # start time to work from.
+        # the timer kills. The start marker is a file for the same reason: $GITHUB_ENV is processed
+        # by the runner only when a step ENDS (FileCommandManager.ProcessFiles runs in its finally),
+        # so a step the timer kills contributes nothing and this step would take its else branch on
+        # exactly the run it was added for. $RUNNER_TEMP is job-scoped, emptied at job start and end
+        # rather than per step, so the marker survives between steps.
+        #
+        # The step-level timeout below is what actually makes this reachable. A JOB timeout cancels,
+        # and a cancelled job gives its remaining steps only a grace period; a STEP timeout fails
+        # the step and the job continues to this one normally.
         if: always()
         run: |
           marker="$RUNNER_TEMP/mutation-started"


### PR DESCRIPTION
Follow-up to #1304, which merged at `99d50f510`. `Refs #1299` rather than Closes: #1299 is already closed by that merge, and this corrects what it landed.

Two changes with independent reasons. They ride together only because both touch the same twelve lines and #1304's reviewer surfaced both.

## 1. The comment's arithmetic was wrong twice, and its frame was wrong once

Found by #1304's reviewer, confirmed independently by recomputation.

| claim as landed | actual |
|---|---|
| "150 is 2.5x the larger estimate" (estimate ~42 min) | 150/42 = **3.57**. 150/60 = **exactly 2.50** |
| "models known to under-predict by over 1.5x" | a run cancelled AT 60 against ~42 est is **≥1.43x with no upper bound** |
| fastest-rate model "~42 min" | `181/39 × 7m27s` = **34.6 min** |

So 150 came from `2.5 × 60`, the **old budget**, and the sentence credited a derivation that never happened. Someone re-deriving would have gone looking for a 42-minute basis that the text never contained. The under-prediction bound was an assumption written in the grammar of a measurement: nobody knew what that run would have taken, because it was killed.

**The frame error is the one that mattered more.** #1294 had at least two mutation runs with different selections, and the comment attached one run's figures to all five timeouts:

```
647e21b5e (run 33973541717)   42 fixtures selected from 341
d1db29e23 (run 33978243970)   43 fixtures selected from 342
```

The extra fixture on the later head is `self-update-handoff.json`, which that head added. So 42 and 43 were never in conflict, and "correcting" one to the other would have introduced an error. Each figure now names its own sha.

**The budget now has a real derivation**, taken from the cancelled run's own per-step timings rather than from a model:

```
setup (checkout, install, build)      56s
Re-prove  16:34:33Z -> 17:33:49Z      3556s = 59.3 min, cancelled at the cap
completed                             109 of 183 mutations  (60%)
observed rate ON THAT SET             32.6 s/mutation
projected whole job                   ~100 min
headroom at 150                       ~1.49x
```

Both models fitted from other runs under-predict this set (~35 min and ~38 min against a real ~100), which is why the comment now says not to re-derive from them. Per-mutation cost is dominated by which suites a fixture guards.

## 2. A budget breach should be a step failure, not a job cancellation

`timeout-minutes: 145` on the re-prove step, below the job's 150.

A **job** timeout produces `cancelled`; a **step** timeout produces `failure`. `pr-head-gate.mjs` grades those differently, and a cancellation reads like unrelated CI churn rather than like something the author can act on — which is exactly how #1294's five timeouts read until someone measured them.

It also closes the hole #1304's own comment admits. `Report elapsed` runs under `always()`, but a cancelled job gives its remaining steps only a grace period, so the run whose duration matters most was the one least likely to report it. With a step timeout the job continues normally and the step runs.

This is a change to what the gate *means*, which is why it was deliberately kept out of #1304 rather than riding in on a budget bump.

## Verification

- `yaml.safe_load` parses; job timeout 150, step timeout 145; both step bodies pass `bash -n`.
- Scope is one file, `.github/workflows/mutation-reproof.yml`. The workflow count does not move, `on:` and concurrency are unchanged, and the `full` job is untouched.
- Not verified here, and worth a reviewer's attention: no run has yet exercised the step-timeout path, so its `failure` classification is reasoned from the docs rather than observed. The first high-fan-in PR after this lands is the test.
