### PR TITLE
fix(test): bypass pnpm dependency checks in mutations

### DIFF
--- a/scripts/mutation-proof.mjs
+++ b/scripts/mutation-proof.mjs
@@ -121,6 +121,10 @@ function run(command, cwd, timeoutMs) {
   // budget, one mutation into a sweep, with the tree mutated the whole time.
   const r = spawnSync(command, {
     cwd, shell: true, encoding: "utf8", timeout: timeoutMs, maxBuffer: 64 * 1024 * 1024,
+    // A mutation may deliberately desynchronize dependency metadata from pnpm-lock.yaml. pnpm's
+    // default pre-run check would install (or fail under CI's frozen lockfile) before the suite can
+    // observe that mutant. Disable only that check, and only in this child process tree.
+    env: { ...process.env, pnpm_config_verify_deps_before_run: "false" },
     detached: process.platform !== "win32",
     killSignal: "SIGKILL",
   });

--- a/scripts/mutation-proof.selftest.mjs
+++ b/scripts/mutation-proof.selftest.mjs
@@ -60,6 +60,7 @@ writeFileSync(
   join(root, "suite.mjs"),
   [
     "import { admit } from './src/impl.js';",
+    "if (process.env.pnpm_config_verify_deps_before_run !== 'false') { console.error('AssertionError: mutation child disables pnpm dependency verification'); process.exit(1); }",
     "console.log('  ✓ admits a small value');",
     "if (admit(5) !== true) { console.error('AssertionError: small values are admitted'); process.exit(1); }",
     "console.log('  ✓ the guard refuses an oversized value');",
@@ -71,7 +72,14 @@ writeFileSync(
 execSync("git init -q && git add -A && git -c user.email=a@b -c user.name=c commit -qm fixture", { cwd: root });
 
 const runTool = (args) =>
-  spawnSync(process.execPath, [TOOL, ...args], { cwd: root, encoding: "utf8", timeout: 120_000 });
+  spawnSync(process.execPath, [TOOL, ...args], {
+    cwd: root,
+    encoding: "utf8",
+    timeout: 120_000,
+    // Prove the tool overrides this only for commands it launches rather than relying on ambient
+    // configuration already carrying the desired value.
+    env: { ...process.env, pnpm_config_verify_deps_before_run: "install" },
+  });
 
 // 1. A mutation the suite DOES catch, named. The everyday case.
 let r = runTool([


### PR DESCRIPTION
## Summary

- disable pnpm's pre-run dependency verification only for commands launched by `mutation-proof`
- keep mutation fixture commands unchanged, so dependency-metadata mutants reach their real suites under CI
- pin the child-scoped override in the mutation-proof self-test

## Cause

pnpm 11 defaults `verifyDepsBeforeRun` to `install` for `pnpm run` and `pnpm exec`. A mutation that changes dependency metadata intentionally desynchronizes `package.json` from `pnpm-lock.yaml`. Under CI's frozen lockfile, pnpm aborts before the configured suite starts, so mutation-proof sees zero progress marks instead of the guard's verdict.

Without `CI` set, the same launcher silently rewrites `pnpm-lock.yaml` before running the suite. That side effect hid the failure locally and is recorded here as a tooling footgun. This change prevents it only inside mutation-proof child runs.

There are 9 mutation cells across 5 fixtures that target a `package.json`. Four manager-runtime-deps cells are demonstrably broken by dependency-metadata desynchronization. The remaining five are latent exposure, not known failures, because script-only manifest mutations can leave the lockfile consistent.

## Validation

- `node scripts/mutation-proof.selftest.mjs`: 33 checks passed
- `CI=1 node scripts/mutation-proof.mjs --config bin/smoke/mutations/manager-runtime-deps.json`: baseline 54 marks, all 4 mutations KILLED on their named dependency checks
- `CI=1 node scripts/mutation-proof.mjs --config bin/smoke/mutations/package-test-contract.json`: baseline 79 marks, all 4 mutations KILLED; the comparison cells remained at 76 and 77 marks

Closes #1325