### PR TITLE
test(manager): detect overlapping lease renewals

### DIFF
--- a/.changeset/lease-renew-manager-control.md
+++ b/.changeset/lease-renew-manager-control.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add a manager runtime reachability control to the lease-renew mutation fixture.

--- a/.changeset/lease-renew-manager-control.md
+++ b/.changeset/lease-renew-manager-control.md
@@ -1,4 +1,4 @@
 ---
 ---
 
-Add a manager runtime reachability control to the lease-renew mutation fixture.
+Add a manager runtime reachability control and direct overlap check to the lease-renew mutation fixture.

--- a/implementations/manager/smoke/fixtures/lease-renew.mutations.json
+++ b/implementations/manager/smoke/fixtures/lease-renew.mutations.json
@@ -3,6 +3,13 @@
   "progressPattern": "^  ok   ",
   "mutations": [
     {
+      "name": "PREDICTED KILLED (1 red) - POSITIVE CONTROL: an idle renew tick returns before doing any work, so the manager never renews its lease once",
+      "file": "implementations/manager/src/manager.ts",
+      "find": "    if (this.leaseRenewInFlight) return;\n",
+      "replace": "    if (!this.leaseRenewInFlight) return;\n",
+      "expectRed": "[acklost] the child manager started, acquired its own per-instance lease, and renewed it at least once"
+    },
+    {
       "name": "PREDICTED KILLED (1 red) - D3: the next tick may start a second renew while one is in flight, on the same cached revision",
       "file": "implementations/manager/src/manager.ts",
       "find": "    if (this.leaseRenewInFlight) return;\n",
@@ -26,5 +33,5 @@
       "afterRestore": "pnpm --filter @cotal-ai/core build"
     }
   ],
-  "_note": "THE SUITE LOADS dist FOR CORE. It imports `@cotal-ai/core`, whose exports point at ./dist/index.js, so mutating packages/core/src leaves the module the run actually uses untouched; the command rebuilds core from the mutated source, and `afterRestore` rebuilds it from the restored source so dist is not left carrying the last mutant. The manager mutation needs no build: the child loads ../src/manager.js through tsx. D2a and D2b are graded on the numbers rather than on behaviour ON PURPOSE: each leaves the reconcile in place, so the manager still survives the stall and every behavioural cell still passes while the slack needed for several timely attempts is gone. Arithmetic is the only thing that catches that. The old fail-close and unconfirmed-TTL-budget mutations were removed with the behaviour they graded: lease loss no longer ends this process or consumes a local serving budget."
+  "_note": "THE SUITE LOADS dist FOR CORE. It imports `@cotal-ai/core`, whose exports point at ./dist/index.js, so mutating packages/core/src leaves the module the run actually uses untouched; the command rebuilds core from the mutated source, and `afterRestore` rebuilds it from the restored source so dist is not left carrying the last mutant. The manager mutations need no build: the child loads ../src/manager.js through tsx. The positive control inverts the in-flight guard so every ordinary timer tick returns before renewing; the first child-start cell must therefore redden, proving this suite executes the same manager.ts lease path that D3 mutates. D2a and D2b are graded on the numbers rather than on behaviour ON PURPOSE: each leaves the reconcile in place, so the manager still survives the stall and every behavioural cell still passes while the slack needed for several timely attempts is gone. Arithmetic is the only thing that catches that. The old fail-close and unconfirmed-TTL-budget mutations were removed with the behaviour they graded: lease loss no longer ends this process or consumes a local serving budget."
 }

--- a/implementations/manager/smoke/lease-renew-no-answer.smoke.ts
+++ b/implementations/manager/smoke/lease-renew-no-answer.smoke.ts
@@ -90,6 +90,8 @@ const check = (name: string, ok: boolean, detail?: unknown): void => {
 interface Relay {
   /** Start/stop holding that direction, for windows the caller times itself. */
   setStalled: (on: boolean) => void;
+  /** Every client-to-broker publish observed by the frame parser. */
+  publishes: () => ReadonlyArray<{ subject: string; atMs: number }>;
   /** Silently discard client-to-broker publishes whose subject matches. The broker never sees them,
    *  so the effect never happens and the caller's request simply never gets an answer. */
   dropPublishes: (match: ((subject: string) => boolean) | undefined) => void;
@@ -99,6 +101,7 @@ function relay(targetPort: number, listenPort: number): Relay {
   let stalled = false;
   let dropMatch: ((subject: string) => boolean) | undefined;
   const flushers: Array<() => void> = [];
+  const publishes: Array<{ subject: string; atMs: number }> = [];
   const server = net.createServer((client) => {
     const up = net.connect(targetPort, "127.0.0.1");
     const queued: Buffer[] = [];
@@ -108,7 +111,6 @@ function relay(targetPort: number, listenPort: number): Relay {
     // Client to broker, parsed frame by frame so a publish can be dropped whole.
     let pending = Buffer.alloc(0);
     client.on("data", (b: Buffer) => {
-      if (!dropMatch) { up.write(b); return; }
       pending = Buffer.concat([pending, b]);
       for (;;) {
         const eol = pending.indexOf("\r\n");
@@ -123,7 +125,8 @@ function relay(targetPort: number, listenPort: number): Relay {
         if (!Number.isFinite(bodyLen)) { up.write(pending.subarray(0, eol + 2)); pending = pending.subarray(eol + 2); continue; }
         const frameEnd = eol + 2 + bodyLen + 2;
         if (pending.length < frameEnd) return; // wait for the rest of the payload
-        if (!dropMatch(verb[2])) up.write(pending.subarray(0, frameEnd));
+        publishes.push({ subject: verb[2], atMs: Date.now() });
+        if (!dropMatch || !dropMatch(verb[2])) up.write(pending.subarray(0, frameEnd));
         pending = pending.subarray(frameEnd);
       }
     });
@@ -134,6 +137,7 @@ function relay(targetPort: number, listenPort: number): Relay {
   server.listen(listenPort, "127.0.0.1");
   return {
     setStalled: (on: boolean) => { stalled = on; if (!on) for (const f of flushers) f(); },
+    publishes: () => publishes,
     dropPublishes: (match) => { dropMatch = match; },
     close: () => server.close(),
   };
@@ -232,6 +236,9 @@ try {
   // prove it in a way that reads the same whether or not the defect is fixed.
   const duringStall = samples.filter((s) => s.atMs > stallStart + 500 && s.atMs <= stallEnd);
   const learnedDuringStall = reported().filter((r) => r.atMs > stallStart + 500 && r.atMs < stallEnd);
+  const leaseSubject = `$KV.${managerBucket(space)}.${managerLeaseKey(instanceId)}`;
+  const renewAttemptsDuringStall = proxy.publishes().filter((p) =>
+    p.subject === leaseSubject && p.atMs > stallStart && p.atMs <= stallEnd);
   const storedLast = duringStall.at(-1);
 
   // What the manager itself said about the incident. Printed rather than asserted: the cells grade
@@ -259,9 +266,13 @@ try {
   // D3, and it is not hypothetical: a renew whose reply is late runs past the next tick, because the
   // re-read that follows it has a deadline of its own. A second renew started there reads the SAME
   // cached revision, CASes against a sequence the first one legitimately moved, and is refused — a
-  // conflict this instance manufactured about itself. Measured at 3 runs out of 3 before the guard.
+  // conflict this instance manufactured about itself. Count the requests at the relay rather than
+  // looking for an error string: the broker's rejection is itself held during this window, and the
+  // manager deliberately suppresses repeated same-state diagnostics. Measured at 3 runs out of 3
+  // before the guard.
   check("NO SELF-INFLICTED CAS CONFLICT: only one renew is ever in flight, so the manager never CASes against a sequence it moved itself",
-    !/wrong last sequence/.test(err0()), err0().slice(-400));
+    renewAttemptsDuringStall.length === 1,
+    { leaseSubject, renewAttemptsDuringStall });
 
   // The budget as a budget, graded on the numbers rather than on behaviour — and deliberately so.
   // Reverting either number leaves the reconcile in place, so the cells above still pass while the


### PR DESCRIPTION
## Summary

The `lease-renew` D3 cell was ungradable on `main`, not only on a pull request. It returned the same `UNGRADABLE` verdict in main run `33981431625`, in #1301, and in #1302.

The first commit adds a positive control against the same `manager.ts` guard line. The control was killed while D3 remained green, converting D3 to a reportable `SURVIVED` verdict and proving the gap was real rather than a reachability artifact.

The second commit closes that coverage gap. The old assertion looked for the absence of a `wrong last sequence` diagnostic. That could not distinguish a genuine lack of conflict from a conflict whose evidence never arrived. During the measured window, the stall also holds the broker's rejection, and the manager suppresses repeated same-state diagnostics. The smoke now counts lease update publish frames at the relay, observing the overlapping renew attempt itself instead of a downstream symptom that may never be emitted. The existing `NO SELF-INFLICTED CAS CONFLICT` cell name and D3 `expectRed` remain unchanged.

This unblocks #1301 and #1302. Both are approved at their exact heads and were held solely by this fixture.

## Validation

The unmutated suite passes all 17 checks. The final committed whole-fixture reproof reports:

- Positive control: `KILLED`, 7 marks against baseline 17, at `[acklost] the child manager started, acquired its own per-instance lease, and renewed it at least once`
- D3: `KILLED`, 16 marks against baseline 17, at `NO SELF-INFLICTED CAS CONFLICT`
- D2a: `KILLED`, 16 marks against baseline 17, at `THE RENEW BUDGET HAS SLACK`
- D2b: `KILLED`, 16 marks against baseline 17, at `THE RENEW BUDGET HAS SLACK`

Also run:

- `pnpm build`
- `pnpm smoke:lease-renew`
- `pnpm smoke:mutation-fixtures`
- `pnpm changeset status`

A `mutation-proof` process terminated by an outer harness timeout leaves the current mutation applied because restoration only runs when the mutation runner finishes. Two timed-out validation attempts required explicit source restoration and a core rebuild before continuing.

Closes #1320
