### PR TITLE
fix(mutation): echo the run transcript under any non-kill verdict

### DIFF
--- a/scripts/mutation-proof.mjs
+++ b/scripts/mutation-proof.mjs
@@ -265,6 +265,12 @@ function proveOne(m, opts) {
     return ok;
   };
 
+  // Declared OUTSIDE the try so the catch can read it. `const` inside the block made the catch's
+  // `transcript` a ReferenceError, so a harness throw after the run would have been replaced by
+  // "transcript is not defined" and the original error lost (rel-b, #1328 re-grade). Undefined
+  // until the run happens, which is what the reporter reads as "no run" — correct for a throw
+  // before the run, and the excerpt for a throw after it.
+  let transcript;
   try {
     writeFileSync(path, before.split(m.find).join(m.replace));
     // Assert the mutation APPLIED. A no-op mutation makes a green uninterpretable and leaves a red
@@ -281,7 +287,7 @@ function proveOne(m, opts) {
     // there instead. `manager-runtime-deps` sat red on main and on a release PR for a day in
     // exactly that state: four cells at `0 marks (baseline 54)`, reproducible on nobody's machine,
     // and the one artifact that would have named the cause discarded on every run.
-    const transcript = excerpt(r.output);
+    transcript = excerpt(r.output);
     const ticks = progressCount(r.output, opts.progressPattern);
 
     const restored = restore();

--- a/scripts/mutation-proof.mjs
+++ b/scripts/mutation-proof.mjs
@@ -53,6 +53,11 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 const C = { red: "\x1b[31m", green: "\x1b[32m", yellow: "\x1b[33m", dim: "\x1b[2m", off: "\x1b[0m" };
+/** label -> the mutated run's combined stdout+stderr, echoed under any non-KILL verdict. */
+const transcripts = new Map();
+/** Lines of transcript to echo. Enough to carry a stack or an early exit, short enough that a
+ *  fixture with several non-kills does not bury the summary. */
+const TRANSCRIPT_TAIL = 20;
 const say = (s = "") => process.stdout.write(`${s}\n`);
 const sha = (p) => createHash("sha256").update(readFileSync(p)).digest("hex");
 
@@ -251,6 +256,12 @@ function proveOne(m, opts) {
     say(`${C.dim}  mutated ${hits}× · running: ${m.command ?? opts.command}${C.off}`);
 
     const r = run(m.command ?? opts.command, cwd, opts.timeoutMs);
+    // Keep the transcript for the report. Every verdict below is derived from `r.output` and none
+    // of them printed it, so a WRONG-RED said the expected string was absent and never what was
+    // there instead. `manager-runtime-deps` sat red on main and on a release PR for a day in
+    // exactly that state: four cells at `0 marks (baseline 54)`, reproducible on nobody's machine,
+    // and the one artifact that would have named the cause discarded on every run.
+    transcripts.set(label, r.output);
     const ticks = progressCount(r.output, opts.progressPattern);
 
     const restored = restore();
@@ -529,6 +540,21 @@ for (const r of results) {
   // report would be to write mutants that do nothing.
   say(`${colour}${r.verdict.padEnd(12)}${C.off} ${r.label}`);
   say(`  ${C.dim}${r.why}${r.ticks !== undefined ? ` · ${r.ticks} marks (baseline ${r.baseTicks ?? "?"})` : ""}${C.off}`);
+  // A KILL needs no transcript: the verdict already names the assertion that reddened. Every other
+  // verdict is a question — what DID the run print, if not that — and the answer was captured and
+  // then thrown away. Echo it, so a red fixture is diagnosable from the log instead of requiring
+  // someone to reproduce a CI environment. Costs nothing on a clean run, which prints none.
+  if (!good) {
+    const t = (transcripts.get(r.label) ?? "").replace(/\s+$/, "");
+    if (t === "") {
+      say(`  ${C.dim}  (the run produced NO output at all — it failed before writing anything)${C.off}`);
+    } else {
+      const lines = t.split("\n");
+      const tail = lines.slice(-TRANSCRIPT_TAIL);
+      if (lines.length > TRANSCRIPT_TAIL) say(`  ${C.dim}  … ${lines.length - TRANSCRIPT_TAIL} earlier line(s) omitted${C.off}`);
+      for (const l of tail) say(`  ${C.dim}  | ${l}${C.off}`);
+    }
+  }
 }
 say("");
 if (bad === 0) {

--- a/scripts/mutation-proof.mjs
+++ b/scripts/mutation-proof.mjs
@@ -53,11 +53,31 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 const C = { red: "\x1b[31m", green: "\x1b[32m", yellow: "\x1b[33m", dim: "\x1b[2m", off: "\x1b[0m" };
-/** label -> the mutated run's combined stdout+stderr, echoed under any non-KILL verdict. */
-const transcripts = new Map();
-/** Lines of transcript to echo. Enough to carry a stack or an early exit, short enough that a
- *  fixture with several non-kills does not bury the summary. */
-const TRANSCRIPT_TAIL = 20;
+/** Lines of transcript to echo from each end. Enough to carry a stack or an early exit, short
+ *  enough that a fixture with several non-kills does not bury the summary. HEAD AND TAIL, not tail
+ *  alone: the cause of a red is as often the first line (a throw before any cell ran, a missing
+ *  module, `0 marks (baseline 54)` with its reason printed once at the top) as the last, and a
+ *  tail-only echo prints twenty lines of teardown and omits the one line the feature exists for.
+ *  Measured by the #1328 reviewer: an early cause followed by 25 teardown lines echoed
+ *  `… 6 earlier line(s) omitted` and the cause was among the six. */
+const EXCERPT_HEAD = 10;
+const EXCERPT_TAIL = 10;
+/**
+ * Bound a run's combined output to head + tail lines, at capture time. Carried ON THE RESULT, not
+ * in a map keyed by label: duplicate mutation names are accepted by the fixture format, and a
+ * label-keyed map let a later mutation overwrite an earlier one's transcript, so two WRONG-REDs
+ * echoed the same (second) run's output. A diagnostic that attributes run A's evidence to run B is
+ * worse than the discarded transcript it replaced. Bounding at capture also caps retention: the
+ * old map held every KILL's full output until reporting, 99 mutations × a 64 MiB capture ceiling.
+ */
+const excerpt = (output) => {
+  const t = (output ?? "").replace(/\s+$/, "");
+  if (t === "") return { head: [], tail: [], omitted: 0, empty: true };
+  const lines = t.split("\n");
+  if (lines.length <= EXCERPT_HEAD + EXCERPT_TAIL) return { head: lines, tail: [], omitted: 0, empty: false };
+  return { head: lines.slice(0, EXCERPT_HEAD), tail: lines.slice(-EXCERPT_TAIL),
+    omitted: lines.length - EXCERPT_HEAD - EXCERPT_TAIL, empty: false };
+};
 const say = (s = "") => process.stdout.write(`${s}\n`);
 const sha = (p) => createHash("sha256").update(readFileSync(p)).digest("hex");
 
@@ -261,13 +281,13 @@ function proveOne(m, opts) {
     // there instead. `manager-runtime-deps` sat red on main and on a release PR for a day in
     // exactly that state: four cells at `0 marks (baseline 54)`, reproducible on nobody's machine,
     // and the one artifact that would have named the cause discarded on every run.
-    transcripts.set(label, r.output);
+    const transcript = excerpt(r.output);
     const ticks = progressCount(r.output, opts.progressPattern);
 
     const restored = restore();
-    if (!restored) return { label, verdict: "ERROR", why: `RESTORE FAILED for ${m.file} — backup at ${backup}`, ticks };
+    if (!restored) return { label, transcript, verdict: "ERROR", why: `RESTORE FAILED for ${m.file} — backup at ${backup}`, ticks };
 
-    if (r.timedOut) return { label, verdict: "INCONCLUSIVE", why: `run timed out; a hang is not a red`, ticks };
+    if (r.timedOut) return { label, transcript, verdict: "INCONCLUSIVE", why: `run timed out; a hang is not a red`, ticks };
 
     // ---- FIRST QUESTION, ON EVERY PATH: did this run actually execute the check being graded? ---
     //
@@ -317,16 +337,16 @@ function proveOne(m, opts) {
       // Green after barely running is not a survivor — it is a run that never reached the check,
       // which is the fourth lie listed at the top of this file.
       if (short) {
-        return { label, verdict: "INCONCLUSIVE",
+        return { label, transcript, verdict: "INCONCLUSIVE",
           why: `exited 0 but reached only ${ticks} progress marks (expected ≥ ${opts.minTicks}) — the suite did not run far enough for its pass to mean anything`, ticks };
       }
       if (baseHits.size > 0 && named.length === 0) {
-        return { label, verdict: "INCONCLUSIVE",
+        return { label, transcript, verdict: "INCONCLUSIVE",
           why: `exited 0 but never printed the named assertion at all (the green run prints it) — the cell did not run, so its "pass" is about nothing`, ticks };
       }
       const changed = named.find((l) => !baseHits.has(l));
       if (changed !== undefined) {
-        return { label, verdict: "INCONCLUSIVE",
+        return { label, transcript, verdict: "INCONCLUSIVE",
           why: `exited 0, but the named assertion did NOT print what it prints when green (${JSON.stringify(changed.trim())}) — the suite noticed and something swallowed the exit code; a green status is not a pass`, ticks };
       }
       // The remaining swallow: OTHER cells reddened, the NAMED one stayed green, and teardown
@@ -343,7 +363,7 @@ function proveOne(m, opts) {
       // produce. Mark count cannot tell "never saw the mutation" from "saw it and does not care";
       // both are silent by construction. That question is answered by the module SPECIFIER, not here.
       if (baseTicks > 0 && ticks < baseTicks) {
-        return { label, verdict: "INCONCLUSIVE",
+        return { label, transcript, verdict: "INCONCLUSIVE",
           why: `exited 0 with ${ticks} progress marks against the green run's ${baseTicks} — the named assertion held, but cells that print when green did not print here, so the suite did NOT pass and something swallowed the exit code`, ticks };
       }
       // A SURVIVED whose named assertion never appears in the GREEN run either is still a survivor
@@ -359,16 +379,16 @@ function proveOne(m, opts) {
           + " prints nothing on a pass (absence is normal) or it does not contain that cell at all"
           + " (wrong `command`, or a stale `expectRed`). Check before trusting this verdict."
         : "";
-      return { label, verdict: "SURVIVED",
+      return { label, transcript, verdict: "SURVIVED",
         why: `the suite PASSED with the implementation broken — it does not test this${blind}`, ticks };
     }
 
     if (named.length === 0) {
-      return { label, verdict: "WRONG-RED",
+      return { label, transcript, verdict: "WRONG-RED",
         why: `exited ${r.status} but never printed the expected failure: ${JSON.stringify(m.expectRed)}`, ticks };
     }
     if (baseHits.size > 0 && named.every((l) => baseHits.has(l))) {
-      return { label, verdict: "WRONG-RED",
+      return { label, transcript, verdict: "WRONG-RED",
         why: `exited ${r.status}, but the named assertion printed exactly what it prints when GREEN `
            + `(${JSON.stringify(named[0].trim())}) — it did not go red, so this red is some other failure`, ticks };
     }
@@ -409,10 +429,10 @@ function proveOne(m, opts) {
         ticks,
       };
     }
-    return { label, verdict: "KILLED", why: `red, and named: ${m.expectRed}`, ticks };
+    return { label, transcript, verdict: "KILLED", why: `red, and named: ${m.expectRed}`, ticks };
   } catch (e) {
     restore();
-    return { label, verdict: "ERROR", why: `harness threw: ${e.message}` };
+    return { label, transcript, verdict: "ERROR", why: `harness threw: ${e.message}` };
   }
 }
 
@@ -545,14 +565,17 @@ for (const r of results) {
   // then thrown away. Echo it, so a red fixture is diagnosable from the log instead of requiring
   // someone to reproduce a CI environment. Costs nothing on a clean run, which prints none.
   if (!good) {
-    const t = (transcripts.get(r.label) ?? "").replace(/\s+$/, "");
-    if (t === "") {
+    const t = r.transcript;
+    if (t === undefined) {
+      // ERROR verdicts raised before the run (target not found, no expectRed, identical file) never
+      // executed anything, so there is no transcript and saying so is the honest line.
+      say(`  ${C.dim}  (no run: this verdict was reached before the suite was executed)${C.off}`);
+    } else if (t.empty) {
       say(`  ${C.dim}  (the run produced NO output at all — it failed before writing anything)${C.off}`);
     } else {
-      const lines = t.split("\n");
-      const tail = lines.slice(-TRANSCRIPT_TAIL);
-      if (lines.length > TRANSCRIPT_TAIL) say(`  ${C.dim}  … ${lines.length - TRANSCRIPT_TAIL} earlier line(s) omitted${C.off}`);
-      for (const l of tail) say(`  ${C.dim}  | ${l}${C.off}`);
+      for (const l of t.head) say(`  ${C.dim}  | ${l}${C.off}`);
+      if (t.omitted > 0) say(`  ${C.dim}  … ${t.omitted} middle line(s) omitted${C.off}`);
+      for (const l of t.tail) say(`  ${C.dim}  | ${l}${C.off}`);
     }
   }
 }

--- a/scripts/mutation-proof.mjs
+++ b/scripts/mutation-proof.mjs
@@ -417,8 +417,12 @@ function proveOne(m, opts) {
     // fail-fast suite with no line common to both outcomes should not declare one at all.
     const marker = m.completionMarker ?? opts.completionMarker;
     if (marker !== undefined && !r.output.includes(marker)) {
+      // The run happened and its output is the evidence of WHERE it stopped, so it travels with
+      // this verdict like every other post-run return. Omitting it here made the reporter print
+      // "(no run: ...)" for a run that did execute and did print (found on the #1328 re-grade).
       return {
         label,
+        transcript,
         verdict: "INCONCLUSIVE",
         why: r.output.trim() === ""
           // Named apart from the general case on purpose. Folded together it reads "your assertion

--- a/scripts/mutation-proof.selftest.mjs
+++ b/scripts/mutation-proof.selftest.mjs
@@ -339,6 +339,15 @@ execSync("git add -A && git -c user.email=a@b -c user.name=c commit -qm completi
 r = runTool(["--config", "completion-optin.json"]);
 check("a suite that declared a completion marker gets INCONCLUSIVE, not KILLED, when the run stops early",
   r.status !== 0 && verdictIs(r.stdout, "INCONCLUSIVE") && r.stdout.includes("SELFTEST SUITE DONE"), r.stdout.slice(-400));
+// The unfinished run DID execute and DID print, and where it stopped is the evidence a reader needs.
+// The first excerpt release dropped `transcript` from this one return, so the report said
+// "(no run: ...)" about a run that had printed the red and the crash. Pinned here.
+{
+  const out = stripAnsi(r.stdout);
+  check("...and the echo shows WHERE the unfinished run stopped, instead of claiming there was no run",
+    out.includes("|   ✗ FAIL: the guard refuses an oversized value") && out.includes("and then a crash") && !out.includes("(no run:"),
+    out.slice(-900));
+}
 r = runTool(["--config", "completion-control.json"]);
 check("...and THE SAME RUN with no marker declared is still KILLED, so this is opt-in and not a new default",
   r.status === 0 && r.stdout.includes("KILLED"), r.stdout.slice(-400));

--- a/scripts/mutation-proof.selftest.mjs
+++ b/scripts/mutation-proof.selftest.mjs
@@ -609,5 +609,59 @@ check("a restored file keeps its original mtime, not the time of the restore",
 check("...and the content is unchanged too, so the time was not preserved by skipping the restore",
   readFileSync(timed, "utf8").includes("if (n > 10)"));
 
+// ---- the transcript echo attributes evidence to the RUN it came from, and keeps the cause ----
+//
+// The #1328 review reproduced two defects in the first version of this feature. (1) Transcripts
+// were held in a Map keyed by label, and duplicate mutation names are accepted, so two WRONG-REDs
+// both echoed the SECOND run's output. (2) The echo was tail-only, so an early cause followed by a
+// long teardown printed the teardown and omitted the cause. Both cells below fail against that
+// version and pass against the per-result head+tail excerpt.
+//
+// A suite that prints a run-specific first line and then a long tail. `TRIP` selects which
+// distinct red each mutant produces, so the two runs are distinguishable by content alone.
+writeFileSync(
+  join(root, "echo-suite.mjs"),
+  [
+    "import { admit } from './src/impl.js';",
+    "const v = admit(5);",
+    "const marker = v === 'A' ? 'CAUSE-ALPHA' : v === 'B' ? 'CAUSE-BETA' : 'CAUSE-NONE';",
+    "console.error('first line: ' + marker);",
+    "for (let i = 0; i < 30; i++) console.log('teardown line ' + i);",
+    "console.log('  ✓ tail cell');",
+    "// green when unmutated (the tool refuses a red baseline); red for either mutant",
+    "process.exit(v === true ? 0 : 1);",
+    "",
+  ].join("\n"),
+);
+// Two mutations with the SAME name, each turning `admit` into a different constant. Both are
+// WRONG-RED (the named assertion never prints), so both echo; the question is WHICH run each echoes.
+writeFileSync(join(root, "dup-labels.json"), JSON.stringify({
+  command: `${process.execPath} echo-suite.mjs`,
+  mutations: [
+    { name: "same name", file: "src/impl.js", find: "  return true;", replace: "  return 'A';", expectRed: "never printed" },
+    { name: "same name", file: "src/impl.js", find: "  return true;", replace: "  return 'B';", expectRed: "never printed" },
+  ],
+}));
+execSync("git add -A && git -c user.email=a@b -c user.name=c commit -qm echo-fixtures", { cwd: root });
+r = runTool(["--config", "dup-labels.json"]);
+{
+  const out = stripAnsi(r.stdout);
+  const alpha = out.indexOf("first line: CAUSE-ALPHA");
+  const beta = out.indexOf("first line: CAUSE-BETA");
+  check("two mutations sharing a label each echo THEIR OWN run, not the last one's",
+    alpha !== -1 && beta !== -1 && alpha < beta, out.slice(-900));
+  check("...and the cause on the FIRST line survives a 30-line teardown after it",
+    out.includes("| first line: CAUSE-ALPHA") && out.includes("middle line(s) omitted") && out.includes("| teardown line 29"),
+    out.slice(-900));
+}
+// A verdict reached BEFORE any run has no transcript, and must say so rather than claim an empty run.
+r = runTool([
+  "--command", `${process.execPath} suite.mjs`,
+  "--file", "src/impl.js", "--find", "this string is not in the file", "--replace", "x",
+  "--expect-red", "oversized values are refused",
+]);
+check("an ERROR raised before the run says there was no run, not that the run was silent",
+  stripAnsi(r.stdout).includes("(no run:") && !stripAnsi(r.stdout).includes("produced NO output"), r.stdout.slice(-400));
+
 rmSync(root, { recursive: true, force: true });
 console.log(`\nMUTATION-PROOF SELF-TEST PASSED ✅  (${pass} checks)`);


### PR DESCRIPTION
`Refs #1325`. **Narrowed: this is now the transcript echo only.** The launcher fix is #1326's, which is approved with a negative control and lands first. Earlier revisions of this branch also carried a fixture-level `command` change; that is dropped.

## What this changes

`mutation-proof.mjs` consumed each run's output for counting and filtering (`progressCount`, the `expectRed` filter, `completionMarker`) and **never printed it**. A `WRONG-RED` therefore reported that the expected string was absent and never what was there instead.

Non-KILL verdicts now echo the transcript, bounded to the last 20 lines, with a distinct line when the run produced nothing at all. A KILL prints none: its verdict already names the assertion that reddened, so a clean sweep is unchanged.

## Why it is worth landing on its own

This is what made #1325 cost a day. `manager-runtime-deps` sat red on `main`, on every PR selecting it, and on the 0.46.0 release PR, with all four cells at `0 marks (baseline 54)` and no way to tell from the log why. The cause turned out to be a pnpm frozen-lockfile abort, printed by the child and **already captured** by the runner (`output = stdout + stderr` at line 130) before being discarded.

Two people diagnosed it independently, from scratch, because the evidence was thrown away on every run. The next WRONG-RED costs whatever this one did unless the transcript is in the log.

## Controls, both directions

```
bogus expectRed  -> WRONG-RED, and beneath it:
                    | ✗ FAIL: published manager runtime dependency is installed: @nats-io/kv …
                    | SUITE COMPLETE: 53 passed, 1 failed
four real cells  -> KILLED, and nothing extra printed
```

## Scope

Deliberately does **not** fix the launcher defect behind #1325. I had a narrower fixture-level fix (invoke the suite binary directly, taking pnpm out of the path for that one fixture) and dropped it rather than keeping it as defence in depth: two mechanisms for one defect leaves the next reader unsure which is load-bearing, and it would have made `manager-runtime-deps` the only fixture of 342 invoking its suite differently from the rest — the kind of inconsistency someone tidies back, reintroducing the bug with no test to catch it. #1326 carries a self-test asserting the children receive the setting, which is the guard that makes the narrow fix redundant rather than complementary.

Rebuilt on `fc0589dcf`: one file, 26 insertions, zero deletions.
