### PR TITLE
fix(smoke): grade ambient env spreads per child

### DIFF
--- a/.changeset/ambient-env-per-spread.md
+++ b/.changeset/ambient-env-per-spread.md
@@ -1,0 +1,6 @@
+---
+"cotal-ai": patch
+"@cotal-ai/auth": patch
+---
+
+Grade each ambient `process.env` spread on its own, and strip `COTAL_` from the user-spawn auth-service child.

--- a/bin/smoke/mutations/suite-ambient-env.mutations.json
+++ b/bin/smoke/mutations/suite-ambient-env.mutations.json
@@ -104,7 +104,7 @@
     {
       "name": "N7 regex literal braces regain structural meaning",
       "file": "bin/smoke/suite-ambient-env.smoke.ts",
-      "find": "      // REGEX-LITERAL REGION: braces here are data, not structural nesting.\n      if (node.kind === ts.SyntaxKind.RegularExpressionLiteral) {\n        mark(offset + node.getStart(file), offset + node.end, nextRegion++);\n        return;\n      }\n",
+      "find": "      if (node.kind === ts.SyntaxKind.RegularExpressionLiteral) {\n        mark(offset + node.getStart(file), offset + node.end, nextRegion++);\n        return;\n      }\n",
       "replace": "",
       "expectRed": "a regex close brace must not hide nested scrub depth",
       "note": "Proves regex-literal tokenization excludes brace data from structural depth while the separate division control remains green at baseline."
@@ -120,15 +120,15 @@
     {
       "name": "N9 interpolation expressions inherit the template raw-text region",
       "file": "bin/smoke/suite-ambient-env.smoke.ts",
-      "find": "            baseRegion,\n          ); // interpolation executes in the containing code region\n",
-      "replace": "            childRegion,\n          ); // interpolation executes in the containing code region\n",
+      "find": "            baseRegion,\n          );\n",
+      "replace": "            childRegion,\n          );\n",
       "expectRed": "a module scrub must clear a spread inside template interpolation code",
       "note": "Proves interpolation expressions inherit the containing code owner instead of the template raw-text owner."
     },
     {
       "name": "N10 interpolation contents stop receiving recursive lexical regions",
       "file": "bin/smoke/suite-ambient-env.smoke.ts",
-      "find": "          parseRegion(\n            text.slice(expressionStart, span.expression.end),\n            offset + expressionStart,\n            baseRegion,\n          ); // interpolation executes in the containing code region\n",
+      "find": "          parseRegion(\n            text.slice(expressionStart, span.expression.end),\n            offset + expressionStart,\n            baseRegion,\n          );\n",
       "replace": "",
       "expectRed": "an unused nested template scrub must not clear a module-code spread",
       "note": "Proves nested literals inside interpolation code are recursively discovered and assigned their own child-script regions."

--- a/bin/smoke/mutations/suite-ambient-env.mutations.json
+++ b/bin/smoke/mutations/suite-ambient-env.mutations.json
@@ -52,7 +52,10 @@
     "an inner template scrub can be mistaken for containing module code.",
     "",
     "N11 PROVES EVERY SIBLING INTERPOLATION IS PARSED. Limiting recursion to the final span must red",
-    "before a nested template scrub in one interpolation can clear a spread in its sibling."
+    "before a nested template scrub in one interpolation can clear a spread in its sibling.",
+    "",
+    "N12 PROVES COOKED CHILD-SCRIPT MATCHES KEEP SOURCE COORDINATES. Replacing the mapping with",
+    "linear cooked offsets must red where an earlier escape would move a top-level scrub inside a brace."
   ],
   "mutations": [
     {
@@ -91,23 +94,23 @@
     {
       "name": "N5 process.env ownership regresses from structural depth to column zero",
       "file": "bin/smoke/suite-ambient-env.smoke.ts",
-      "find": "  return [...code.slice(0, index).matchAll(PROCESS_ENV_STRIP)].some((m) =>\n    regions[m.index ?? -1] === region && braceDepthAt(code, regions, m.index ?? -1, region) === 0,\n  );\n",
-      "replace": "  return [...code.slice(0, index).matchAll(PROCESS_ENV_STRIP)].some((m) =>\n    regions[m.index ?? -1] === region && code.lastIndexOf(\"\\n\", m.index ?? -1) + 1 === (m.index ?? -1),\n  );\n",
+      "find": "  return lexical.processEnvStrips.some(\n    (strip) =>\n      strip.end <= index &&\n      strip.region === region &&\n      lexical.regions[strip.start] === region &&\n      lexical.regions[strip.deleteStart] === region &&\n      braceDepthAt(code, lexical.regions, strip.start, region) === 0,\n  );\n",
+      "replace": "  return lexical.processEnvStrips.some(\n    (strip) =>\n      strip.end <= index &&\n      strip.region === region &&\n      lexical.regions[strip.start] === region &&\n      lexical.regions[strip.deleteStart] === region &&\n      code.lastIndexOf(\"\\n\", strip.start) + 1 === strip.start,\n  );\n",
       "expectRed": "a regex close brace must not hide nested scrub depth",
       "note": "Proves structural brace depth remains part of ownership after regex-region tokenization: replacing it with a column-zero test falsely accepts the nested close-brace control."
     },
     {
       "name": "N6 process.env ownership loses its lexical-region boundary",
       "file": "bin/smoke/suite-ambient-env.smoke.ts",
-      "find": "    regions[m.index ?? -1] === region && braceDepthAt(code, regions, m.index ?? -1, region) === 0,\n",
-      "replace": "    braceDepthAt(code, regions, m.index ?? -1, regions[m.index ?? -1]) === 0,\n",
+      "find": "      strip.region === region &&\n      lexical.regions[strip.start] === region &&\n      lexical.regions[strip.deleteStart] === region &&\n",
+      "replace": "      true &&\n",
       "expectRed": "an unused nested template scrub must not clear a module-code spread",
       "note": "Proves scrub ownership cannot cross from a nested or top-level string/template region into module code or another child-script literal."
     },
     {
       "name": "N7 regex literal braces regain structural meaning",
       "file": "bin/smoke/suite-ambient-env.smoke.ts",
-      "find": "      if (node.kind === ts.SyntaxKind.RegularExpressionLiteral) {\n        mark(offset + node.getStart(file), offset + node.end, nextRegion++);\n        return;\n      }\n",
+      "find": "      if (node.kind === ts.SyntaxKind.RegularExpressionLiteral) {\n        mark(sourceOffsets[node.getStart(file)], sourceOffsets[node.end], nextRegion++);\n        return;\n      }\n",
       "replace": "",
       "expectRed": "a regex close brace must not hide nested scrub depth",
       "note": "Proves regex-literal tokenization excludes brace data from structural depth while the separate division control remains green at baseline."
@@ -115,8 +118,8 @@
     {
       "name": "N8 template raw text loses its separate lexical region",
       "file": "bin/smoke/suite-ambient-env.smoke.ts",
-      "find": "        const childRegion = nextRegion++;\n        const headStart = node.head.getStart(file);\n        mark(offset + headStart, offset + node.head.end, childRegion);\n",
-      "replace": "        const childRegion = baseRegion;\n        const headStart = node.head.getStart(file);\n        mark(offset + headStart, offset + node.head.end, childRegion);\n",
+      "find": "        const childRegion = nextRegion++;\n        const headStart = node.head.getStart(file);\n        mark(sourceOffsets[headStart], sourceOffsets[node.head.end], childRegion);\n",
+      "replace": "        const childRegion = baseRegion;\n        const headStart = node.head.getStart(file);\n        mark(sourceOffsets[headStart], sourceOffsets[node.head.end], childRegion);\n",
       "expectRed": "a raw-template scrub must not clear a spread inside interpolation code",
       "note": "Proves template raw text has a distinct child-script owner while interpolation code keeps the containing region; flattening the two falsely lets raw scrub text license interpolation."
     },
@@ -131,7 +134,7 @@
     {
       "name": "N10 interpolation contents stop receiving recursive lexical regions",
       "file": "bin/smoke/suite-ambient-env.smoke.ts",
-      "find": "          parseRegion(\n            text.slice(expressionStart, span.expression.end),\n            offset + expressionStart,\n            baseRegion,\n          );\n",
+      "find": "          parseRegion(\n            text.slice(expressionStart, span.expression.end),\n            sourceOffsets.slice(expressionStart, span.expression.end + 1),\n            baseRegion,\n          );\n",
       "replace": "",
       "expectRed": "an unused nested template scrub must not clear a module-code spread",
       "note": "Proves nested literals inside interpolation code are recursively discovered and assigned their own child-script regions."
@@ -139,10 +142,18 @@
     {
       "name": "N11 every sibling interpolation receives recursive lexical regions",
       "file": "bin/smoke/suite-ambient-env.smoke.ts",
-      "find": "          parseRegion(\n            text.slice(expressionStart, span.expression.end),\n            offset + expressionStart,\n            baseRegion,\n          );\n",
-      "replace": "          if (span === node.templateSpans[node.templateSpans.length - 1]) parseRegion(\n            text.slice(expressionStart, span.expression.end),\n            offset + expressionStart,\n            baseRegion,\n          );\n",
+      "find": "          parseRegion(\n            text.slice(expressionStart, span.expression.end),\n            sourceOffsets.slice(expressionStart, span.expression.end + 1),\n            baseRegion,\n          );\n",
+      "replace": "          if (span === node.templateSpans[node.templateSpans.length - 1]) parseRegion(\n            text.slice(expressionStart, span.expression.end),\n            sourceOffsets.slice(expressionStart, span.expression.end + 1),\n            baseRegion,\n          );\n",
       "expectRed": "a nested template scrub must not clear a sibling interpolation spread",
       "note": "Proves recursive parsing covers every interpolation span; parsing only the final span falsely lets a nested scrub clear a spread in an earlier sibling."
+    },
+    {
+      "name": "N12 child-script source mapping regresses to linear cooked offsets",
+      "file": "bin/smoke/suite-ambient-env.smoke.ts",
+      "find": "          const cookedSourceOffsets = sourceOffsetsForCookedText(rawText, node.text, rawSourceOffsets);\n",
+      "replace": "          const cookedSourceOffsets = rawSourceOffsets.slice(0, node.text.length + 1);\n",
+      "expectRed": "an escaped child-script scrub must retain its source brace depth",
+      "note": "Proves cooked child-script matches retain original source coordinates: a linear cooked offset lands before the closing brace and falsely treats this top-level scrub as nested."
     }
   ]
 }

--- a/bin/smoke/mutations/suite-ambient-env.mutations.json
+++ b/bin/smoke/mutations/suite-ambient-env.mutations.json
@@ -24,7 +24,33 @@
     "",
     "N3 IS THE MIXED-FILE CASE. A file can strip one child and still spread ambient identity into another.",
     "Per-file STRIP+DELETE treated that as clean, including when `delete` only appeared in comments.",
-    "Removing the auth-service strip while the CLI child still filters COTAL_ must redden user-spawn."
+    "Removing the auth-service strip while the CLI child still filters COTAL_ must redden user-spawn.",
+    "",
+    "N4 PROVES THE REAL POPULATION IS ENUMERATED. Embedded examples can pass while the repository scan",
+    "quietly grades only the first spread in every file. Truncating spreadIndexes must red at the real",
+    "spread-count sentinel because real multi-spread files contain more spreads than classified files.",
+    "",
+    "N5 PROVES OWNERSHIP IS STRUCTURAL, NOT INDENTATION. A process.env scrub at column zero can still",
+    "be nested inside an uncalled function or conditional block. Replacing brace-depth zero with a",
+    "column-zero test must red on the adversarial nested controls.",
+    "",
+    "N6 PROVES LEXICAL-REGION OWNERSHIP. A scrub embedded in an unused child-script template cannot",
+    "license a later module-code spread, and a module scrub cannot license a spread in another literal.",
+    "Removing the same-region check must red on the unused-template control.",
+    "",
+    "N7 PROVES REGEX LITERALS ARE TOKENIZED. Braces inside /{/, /}/, and /[{}]/ are data, while a",
+    "division slash remains code. Removing regex-region handling must red on the close-brace nested",
+    "control before a regex can collapse structural depth.",
+    "",
+    "N8 PROVES TEMPLATE REGIONS RECURSE. An inner unused template inside an outer interpolation gets",
+    "its own child-script region. Dropping recursive literal parsing must red on the nested-template",
+    "control, while interpolation remains in the containing code region.",
+    "",
+    "N8 PROVES TEMPLATE RAW TEXT HAS ITS OWN OWNER. Flattening raw text into interpolation code must",
+    "red before a raw-template scrub can license an interpolation spread.",
+    "",
+    "N9 PROVES INTERPOLATION IS RECURSIVELY PARSED. Dropping recursive interpolation parsing must red",
+    "before a nested template scrub can be mistaken for module code."
   ],
   "mutations": [
     {
@@ -51,6 +77,54 @@
       "replace": "  const env = { ...process.env, COTAL_HOME: home };\n",
       "expectRed": "implementations/auth/smoke/user-spawn.smoke.ts (unstripped spread",
       "note": "The mixed-file regression: one stripped child plus a comment containing delete used to clear this file. The census must fail on the remaining unstripped spread."
+    },
+    {
+      "name": "N4 real suite population loses every spread after the first per file",
+      "file": "bin/smoke/suite-ambient-env.smoke.ts",
+      "find": "  return [...code.matchAll(SPREAD)].map((m) => m.index ?? -1).filter((i) => i >= 0);\n",
+      "replace": "  return [...code.matchAll(SPREAD)].slice(0, 1).map((m) => m.index ?? -1).filter((i) => i >= 0);\n",
+      "expectRed": "spread enumeration was truncated or the multi-spread population disappeared",
+      "note": "Proves the shipped census enumerates the real multi-spread repository population, rather than only satisfying embedded classifier examples."
+    },
+    {
+      "name": "N5 process.env ownership regresses from structural depth to column zero",
+      "file": "bin/smoke/suite-ambient-env.smoke.ts",
+      "find": "  return [...code.slice(0, index).matchAll(PROCESS_ENV_STRIP)].some((m) =>\n    regions[m.index ?? -1] === region && braceDepthAt(code, regions, m.index ?? -1, region) === 0,\n  );\n",
+      "replace": "  return [...code.slice(0, index).matchAll(PROCESS_ENV_STRIP)].some((m) =>\n    regions[m.index ?? -1] === region && code.lastIndexOf(\"\\n\", m.index ?? -1) + 1 === (m.index ?? -1),\n  );\n",
+      "expectRed": "a regex close brace must not hide nested scrub depth",
+      "note": "Proves structural brace depth remains part of ownership after regex-region tokenization: replacing it with a column-zero test falsely accepts the nested close-brace control."
+    },
+    {
+      "name": "N6 process.env ownership loses its lexical-region boundary",
+      "file": "bin/smoke/suite-ambient-env.smoke.ts",
+      "find": "    regions[m.index ?? -1] === region && braceDepthAt(code, regions, m.index ?? -1, region) === 0,\n",
+      "replace": "    braceDepthAt(code, regions, m.index ?? -1, regions[m.index ?? -1]) === 0,\n",
+      "expectRed": "an unused nested template scrub must not clear a module-code spread",
+      "note": "Proves scrub ownership cannot cross from a nested or top-level string/template region into module code or another child-script literal."
+    },
+    {
+      "name": "N7 regex literal braces regain structural meaning",
+      "file": "bin/smoke/suite-ambient-env.smoke.ts",
+      "find": "      // REGEX-LITERAL REGION: braces here are data, not structural nesting.\n      if (node.kind === ts.SyntaxKind.RegularExpressionLiteral) {\n        mark(offset + node.getStart(file), offset + node.end, nextRegion++);\n        return;\n      }\n",
+      "replace": "",
+      "expectRed": "a regex close brace must not hide nested scrub depth",
+      "note": "Proves regex-literal tokenization excludes brace data from structural depth while the separate division control remains green at baseline."
+    },
+    {
+      "name": "N8 template raw text loses its separate lexical region",
+      "file": "bin/smoke/suite-ambient-env.smoke.ts",
+      "find": "        const childRegion = nextRegion++;\n        const headStart = node.head.getStart(file);\n        mark(offset + headStart, offset + node.head.end, childRegion);\n",
+      "replace": "        const childRegion = baseRegion;\n        const headStart = node.head.getStart(file);\n        mark(offset + headStart, offset + node.head.end, childRegion);\n",
+      "expectRed": "a raw-template scrub must not clear a spread inside interpolation code",
+      "note": "Proves template raw text has a distinct child-script owner while interpolation code keeps the containing region; flattening the two falsely lets raw scrub text license interpolation."
+    },
+    {
+      "name": "N9 interpolation expressions stop receiving recursive lexical regions",
+      "file": "bin/smoke/suite-ambient-env.smoke.ts",
+      "find": "          parseRegion(\n            text.slice(expressionStart, span.expression.end),\n            offset + expressionStart,\n            baseRegion,\n          ); // interpolation executes in the containing code region\n",
+      "replace": "",
+      "expectRed": "a nested template scrub must not clear a sibling interpolation spread",
+      "note": "Proves nested literals inside interpolation code receive their own regions while sibling interpolation code keeps the containing owner."
     }
   ]
 }

--- a/bin/smoke/mutations/suite-ambient-env.mutations.json
+++ b/bin/smoke/mutations/suite-ambient-env.mutations.json
@@ -20,7 +20,11 @@
     "spread away must therefore go RED on the stale-baseline assertion, not quietly pass.",
     "",
     "NO BUILD STEP: the suite reads source files off disk and imports nothing from a built package, so",
-    "there is no dist/ copy that could disagree with the mutation."
+    "there is no dist/ copy that could disagree with the mutation.",
+    "",
+    "N3 IS THE MIXED-FILE CASE. A file can strip one child and still spread ambient identity into another.",
+    "Per-file STRIP+DELETE treated that as clean, including when `delete` only appeared in comments.",
+    "Removing the auth-service strip while the CLI child still filters COTAL_ must redden user-spawn."
   ],
   "mutations": [
     {
@@ -39,6 +43,14 @@
       "allowMultiple": true,
       "expectRed": "FROZEN still lists file(s) that no longer spread",
       "note": "Proves the baseline can only shrink. Without this the frozen list would be a permanent waiver that no assertion ever revisits."
+    },
+    {
+      "name": "N3 user-spawn auth-service child loses its COTAL_ strip while another child in the same file still strips",
+      "file": "implementations/auth/smoke/user-spawn.smoke.ts",
+      "find": "  const env = { ...process.env };\n  for (const key of Object.keys(env)) if (key.startsWith(\"COTAL_\")) delete env[key];\n  env.COTAL_HOME = home;\n",
+      "replace": "  const env = { ...process.env, COTAL_HOME: home };\n",
+      "expectRed": "implementations/auth/smoke/user-spawn.smoke.ts (unstripped spread",
+      "note": "The mixed-file regression: one stripped child plus a comment containing delete used to clear this file. The census must fail on the remaining unstripped spread."
     }
   ]
 }

--- a/bin/smoke/mutations/suite-ambient-env.mutations.json
+++ b/bin/smoke/mutations/suite-ambient-env.mutations.json
@@ -55,7 +55,13 @@
     "before a nested template scrub in one interpolation can clear a spread in its sibling.",
     "",
     "N12 PROVES COOKED CHILD-SCRIPT MATCHES KEEP SOURCE COORDINATES. Replacing the mapping with",
-    "linear cooked offsets must red where an earlier escape would move a top-level scrub inside a brace."
+    "linear cooked offsets must red where an earlier escape would move a top-level scrub inside a brace.",
+    "",
+    "N13 PROVES TEMPLATE-HEAD COOKED TEXT KEEPS SOURCE COORDINATES. Replacing the mapper with",
+    "raw offsets must red where an earlier escape would move a top-level scrub inside a brace.",
+    "",
+    "N14 PROVES TEMPLATE-SPAN COOKED TEXT KEEPS SOURCE COORDINATES. Replacing the mapper with",
+    "raw offsets must red where an earlier escape would move a top-level scrub inside a brace."
   ],
   "mutations": [
     {
@@ -154,6 +160,22 @@
       "replace": "          const cookedSourceOffsets = rawSourceOffsets.slice(0, node.text.length + 1);\n",
       "expectRed": "an escaped child-script scrub must retain its source brace depth",
       "note": "Proves cooked child-script matches retain original source coordinates: a linear cooked offset lands before the closing brace and falsely treats this top-level scrub as nested."
+    },
+    {
+      "name": "N13 template-head source mapping is bypassed",
+      "file": "bin/smoke/suite-ambient-env.smoke.ts",
+      "find": "            sourceOffsetsForCookedText(rawText, node.head.text, rawSourceOffsets),\n",
+      "replace": "            rawSourceOffsets,\n",
+      "expectRed": "an escaped template-head scrub must retain its source brace depth",
+      "note": "Proves escaped cooked text in a template head retains original source coordinates instead of using raw offsets directly."
+    },
+    {
+      "name": "N14 template-span source mapping is bypassed",
+      "file": "bin/smoke/suite-ambient-env.smoke.ts",
+      "find": "              sourceOffsetsForCookedText(rawText, span.literal.text, rawSourceOffsets),\n",
+      "replace": "              rawSourceOffsets,\n",
+      "expectRed": "an escaped template-span scrub must retain its source brace depth",
+      "note": "Proves escaped cooked text in a template span retains original source coordinates instead of using raw offsets directly."
     }
   ]
 }

--- a/bin/smoke/mutations/suite-ambient-env.mutations.json
+++ b/bin/smoke/mutations/suite-ambient-env.mutations.json
@@ -42,15 +42,14 @@
     "division slash remains code. Removing regex-region handling must red on the close-brace nested",
     "control before a regex can collapse structural depth.",
     "",
-    "N8 PROVES TEMPLATE REGIONS RECURSE. An inner unused template inside an outer interpolation gets",
-    "its own child-script region. Dropping recursive literal parsing must red on the nested-template",
-    "control, while interpolation remains in the containing code region.",
-    "",
     "N8 PROVES TEMPLATE RAW TEXT HAS ITS OWN OWNER. Flattening raw text into interpolation code must",
     "red before a raw-template scrub can license an interpolation spread.",
     "",
-    "N9 PROVES INTERPOLATION IS RECURSIVELY PARSED. Dropping recursive interpolation parsing must red",
-    "before a nested template scrub can be mistaken for module code."
+    "N9 PROVES INTERPOLATION RECURSIVELY PARSES ITS NESTED LITERALS. Removing that recursion must red",
+    "on the sibling-interpolation control before an inner scrub can license a later interpolation spread.",
+    "",
+    "N10 PROVES A NESTED NO-SUBSTITUTION TEMPLATE KEEPS ITS OWN OWNER. Ignoring that literal kind",
+    "must red before its scrub can license a later module-code spread."
   ],
   "mutations": [
     {
@@ -125,6 +124,14 @@
       "replace": "",
       "expectRed": "a nested template scrub must not clear a sibling interpolation spread",
       "note": "Proves nested literals inside interpolation code receive their own regions while sibling interpolation code keeps the containing owner."
+    },
+    {
+      "name": "N10 nested no-substitution templates lose their lexical region",
+      "file": "bin/smoke/suite-ambient-env.smoke.ts",
+      "find": "      if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {\n",
+      "replace": "      if (ts.isStringLiteral(node)) {\n",
+      "expectRed": "an unused nested template scrub must not clear a module-code spread",
+      "note": "Proves an inner no-substitution template is assigned a child-script region instead of inheriting the containing interpolation's module region."
     }
   ]
 }

--- a/bin/smoke/mutations/suite-ambient-env.mutations.json
+++ b/bin/smoke/mutations/suite-ambient-env.mutations.json
@@ -45,11 +45,11 @@
     "N8 PROVES TEMPLATE RAW TEXT HAS ITS OWN OWNER. Flattening raw text into interpolation code must",
     "red before a raw-template scrub can license an interpolation spread.",
     "",
-    "N9 PROVES INTERPOLATION RECURSIVELY PARSES ITS NESTED LITERALS. Removing that recursion must red",
-    "on the sibling-interpolation control before an inner scrub can license a later interpolation spread.",
+    "N9 PROVES INTERPOLATION EXECUTES IN THE CONTAINING CODE REGION. Assigning it to the template's",
+    "raw-text owner must red before a module scrub can stop licensing its interpolation spread.",
     "",
-    "N10 PROVES A NESTED NO-SUBSTITUTION TEMPLATE KEEPS ITS OWN OWNER. Ignoring that literal kind",
-    "must red before its scrub can license a later module-code spread."
+    "N10 PROVES INTERPOLATION CONTENTS ARE PARSED RECURSIVELY. Dropping that recursion must red before",
+    "an inner template scrub can be mistaken for containing module code."
   ],
   "mutations": [
     {
@@ -118,20 +118,20 @@
       "note": "Proves template raw text has a distinct child-script owner while interpolation code keeps the containing region; flattening the two falsely lets raw scrub text license interpolation."
     },
     {
-      "name": "N9 interpolation expressions stop receiving recursive lexical regions",
+      "name": "N9 interpolation expressions inherit the template raw-text region",
+      "file": "bin/smoke/suite-ambient-env.smoke.ts",
+      "find": "            baseRegion,\n          ); // interpolation executes in the containing code region\n",
+      "replace": "            childRegion,\n          ); // interpolation executes in the containing code region\n",
+      "expectRed": "a module scrub must clear a spread inside template interpolation code",
+      "note": "Proves interpolation expressions inherit the containing code owner instead of the template raw-text owner."
+    },
+    {
+      "name": "N10 interpolation contents stop receiving recursive lexical regions",
       "file": "bin/smoke/suite-ambient-env.smoke.ts",
       "find": "          parseRegion(\n            text.slice(expressionStart, span.expression.end),\n            offset + expressionStart,\n            baseRegion,\n          ); // interpolation executes in the containing code region\n",
       "replace": "",
-      "expectRed": "a nested template scrub must not clear a sibling interpolation spread",
-      "note": "Proves nested literals inside interpolation code receive their own regions while sibling interpolation code keeps the containing owner."
-    },
-    {
-      "name": "N10 nested no-substitution templates lose their lexical region",
-      "file": "bin/smoke/suite-ambient-env.smoke.ts",
-      "find": "      if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {\n",
-      "replace": "      if (ts.isStringLiteral(node)) {\n",
       "expectRed": "an unused nested template scrub must not clear a module-code spread",
-      "note": "Proves an inner no-substitution template is assigned a child-script region instead of inheriting the containing interpolation's module region."
+      "note": "Proves nested literals inside interpolation code are recursively discovered and assigned their own child-script regions."
     }
   ]
 }

--- a/bin/smoke/mutations/suite-ambient-env.mutations.json
+++ b/bin/smoke/mutations/suite-ambient-env.mutations.json
@@ -49,7 +49,10 @@
     "raw-text owner must red before a module scrub can stop licensing its interpolation spread.",
     "",
     "N10 PROVES INTERPOLATION CONTENTS ARE PARSED RECURSIVELY. Dropping that recursion must red before",
-    "an inner template scrub can be mistaken for containing module code."
+    "an inner template scrub can be mistaken for containing module code.",
+    "",
+    "N11 PROVES EVERY SIBLING INTERPOLATION IS PARSED. Limiting recursion to the final span must red",
+    "before a nested template scrub in one interpolation can clear a spread in its sibling."
   ],
   "mutations": [
     {
@@ -132,6 +135,14 @@
       "replace": "",
       "expectRed": "an unused nested template scrub must not clear a module-code spread",
       "note": "Proves nested literals inside interpolation code are recursively discovered and assigned their own child-script regions."
+    },
+    {
+      "name": "N11 every sibling interpolation receives recursive lexical regions",
+      "file": "bin/smoke/suite-ambient-env.smoke.ts",
+      "find": "          parseRegion(\n            text.slice(expressionStart, span.expression.end),\n            offset + expressionStart,\n            baseRegion,\n          );\n",
+      "replace": "          if (span === node.templateSpans[node.templateSpans.length - 1]) parseRegion(\n            text.slice(expressionStart, span.expression.end),\n            offset + expressionStart,\n            baseRegion,\n          );\n",
+      "expectRed": "a nested template scrub must not clear a sibling interpolation spread",
+      "note": "Proves recursive parsing covers every interpolation span; parsing only the final span falsely lets a nested scrub clear a spread in an earlier sibling."
     }
   ]
 }

--- a/bin/smoke/suite-ambient-env.smoke.ts
+++ b/bin/smoke/suite-ambient-env.smoke.ts
@@ -14,9 +14,10 @@
  * only shape that can fail a future suite which reintroduces the spread is a static census over the
  * suite sources, which is what this is. The idea is a reviewer's, not mine.
  *
- * THE RULE. Every suite file that spreads `...process.env` into a child environment must either
- * strip the `COTAL_` variables from the copy first, or appear in {@link EXEMPT} with a measured
- * reason. Exempt is not "we looked away": each entry names why that file's child cannot capture an
+ * THE RULE. Every `...process.env` spread into a child environment must either strip the `COTAL_`
+ * variables from that copy first, or the file must appear in {@link REVIEWED} with a measured
+ * reason. A strip on a different child in the same file does not clear an unstripped spread.
+ * Exempt is not "we looked away": each entry names why that file's child cannot capture an
  * identity, and adding one is a conscious edit in a file a reviewer reads.
  *
  * Run: `pnpm smoke:suite-ambient-env`
@@ -46,11 +47,158 @@ function* suiteSources(dir: string): Generator<string> {
 }
 
 /** The spread, written the way people write it. */
-const SPREAD = /\.\.\.process\.env\b/;
+const SPREAD = /\.\.\.process\.env\b/g;
 /** A strip: a loop that deletes the `COTAL_` keys from a copy before the copy is spread. Matched on
  *  the two halves together, so a file that merely MENTIONS the prefix does not pass. */
 const STRIP = /startsWith\(["']COTAL_["']\)/;
 const DELETE = /\bdelete\b/;
+/** A file that mutates `process.env` itself, then later spreads it, has already dropped the ambient
+ *  keys from what the child will inherit. The mutation has to be a keys-loop that deletes `COTAL_`,
+ *  not a mention of those tokens in a comment or a different object. */
+const PROCESS_ENV_STRIP =
+  /for\s*\(\s*const\s+\w+\s+of\s+Object\.keys\(\s*process\.env\s*\)\)[\s\S]{0,160}?startsWith\(\s*["']COTAL_["']\s*\)[\s\S]{0,80}?delete\s+process\.env/;
+
+/** Comments are not child env. The census used to treat a `delete` in prose plus a `startsWith("COTAL_")`
+ *  on a different child as a strip of every spread in the file. */
+function codeWithoutComments(src: string): string {
+  let out = "";
+  let i = 0;
+  let state: "code" | "sq" | "dq" | "bt" | "line" | "block" = "code";
+  while (i < src.length) {
+    const c = src[i];
+    const n = src[i + 1];
+    if (state === "line") {
+      if (c === "\n") {
+        state = "code";
+        out += c;
+      } else out += " ";
+      i++;
+      continue;
+    }
+    if (state === "block") {
+      if (c === "*" && n === "/") {
+        state = "code";
+        out += "  ";
+        i += 2;
+        continue;
+      }
+      out += c === "\n" ? "\n" : " ";
+      i++;
+      continue;
+    }
+    if (state === "sq" || state === "dq") {
+      if (c === "\\") {
+        out += c + (n ?? "");
+        i += 2;
+        continue;
+      }
+      out += c;
+      if ((state === "sq" && c === "'") || (state === "dq" && c === '"')) state = "code";
+      i++;
+      continue;
+    }
+    if (state === "bt") {
+      if (c === "\\") {
+        out += c + (n ?? "");
+        i += 2;
+        continue;
+      }
+      if (c === "`") state = "code";
+      out += c;
+      i++;
+      continue;
+    }
+    if (c === "/" && n === "/") {
+      state = "line";
+      out += "  ";
+      i += 2;
+      continue;
+    }
+    if (c === "/" && n === "*") {
+      state = "block";
+      out += "  ";
+      i += 2;
+      continue;
+    }
+    if (c === "'") state = "sq";
+    else if (c === '"') state = "dq";
+    else if (c === "`") state = "bt";
+    out += c;
+    i++;
+  }
+  return out;
+}
+
+function lineOf(src: string, index: number): number {
+  return src.slice(0, index).split("\n").length;
+}
+
+function windowAfter(src: string, index: number, lines: number): string {
+  let end = index;
+  for (let n = 0; n < lines; n++) {
+    const nl = src.indexOf("\n", end + 1);
+    if (nl < 0) return src.slice(index);
+    end = nl;
+  }
+  return src.slice(index, end);
+}
+
+function spreadIndexes(code: string): number[] {
+  return [...code.matchAll(SPREAD)].map((m) => m.index ?? -1).filter((i) => i >= 0);
+}
+
+function regexEscape(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** True when THIS spread is assigned to a copy which is then scrubbed, or `process.env` was already
+ *  stripped in this file. Matching the copied variable prevents a later child's strip from clearing
+ *  an earlier unstripped spread. */
+function spreadStripped(code: string, index: number): boolean {
+  if (PROCESS_ENV_STRIP.test(code.slice(0, index))) return true;
+  const before = code.slice(Math.max(0, index - 320), index);
+  const assignment = /(?:const|let|var)\s+([A-Za-z_$][\w$]*)(?:\s*:[^=;\n]+)?\s*=\s*\{[^{}]*$/.exec(before);
+  if (!assignment) return false;
+  const name = regexEscape(assignment[1]);
+  const after = windowAfter(code, index, 12);
+  const copyStrip = new RegExp(
+    `^\\.\\.\\.process\\.env\\b[^}]*}\\s*;[\\s\\S]{0,240}?Object\\.keys\\(\\s*${name}\\s*\\)[\\s\\S]{0,160}?startsWith\\(\\s*["']COTAL_["']\\s*\\)[\\s\\S]{0,80}?delete\\s+${name}\\s*\\[`,
+  );
+  return copyStrip.test(after);
+}
+
+function unstrippedSpreadLines(src: string): number[] {
+  const code = codeWithoutComments(src);
+  return spreadIndexes(code).filter((index) => !spreadStripped(code, index)).map((index) => lineOf(code, index));
+}
+
+// Regression cell: one stripped child cannot clear another unstripped child, and a comment that says
+// `delete` is not a mechanism. Put the unsafe child first so the following child's real strip is also
+// inside the matching window. The same file shape passes when every spread is followed by its strip.
+assert.deepEqual(
+  unstrippedSpreadLines(`
+const first = { ...process.env };
+// delete is prose, not a stripping mechanism.
+spawn("first", { env: first });
+const second = { ...process.env };
+for (const key of Object.keys(second)) if (key.startsWith("COTAL_")) delete second[key];
+spawn("second", { env: second });
+`),
+  [2],
+  "a mixed file must fail when one child spread is unstripped",
+);
+assert.deepEqual(
+  unstrippedSpreadLines(`
+const first = { ...process.env };
+for (const key of Object.keys(first)) if (key.startsWith("COTAL_")) delete first[key];
+spawn("first", { env: first });
+const second = { ...process.env };
+for (const key of Object.keys(second)) if (key.startsWith("COTAL_")) delete second[key];
+spawn("second", { env: second });
+`),
+  [],
+  "a file must pass when every child spread is stripped",
+);
 
 /**
  * Files that spread the ambient environment and are graded SAFE, each with the measurement.
@@ -60,13 +208,13 @@ const DELETE = /\bdelete\b/;
  * shape has to be re-measured, which is why the reason and not just the path is recorded.
  */
 const REVIEWED: Record<string, string> = {
+  "bin/smoke/suite-ambient-env.smoke.ts": "this census itself: its ambient spreads occur only in fixture strings and it spawns nothing",
   "implementations/cli/smoke/command-kernel.smoke.ts":
     "spawns the cotal CLI for an ext-update path; the child consumes COTAL_UPDATE_* and COTAL_SKIP_CONNECTOR_SEED and never calls configFromEnv/controlFromEnv",
   "implementations/cli/smoke/update-concurrency.smoke.ts":
     "same ext-update shape: self-reentered node helpers reading COTAL_UPDATE_* / XDG_CONFIG_HOME, no connection material read",
   "bin/smoke/herdr-e2e-live.smoke.ts":
     "spawns herdr-e2e-manager-child.mjs, which builds its OWN stub identity from HE2E_* and sets the COTAL_ vars itself rather than reading the inherited ones",
-  "bin/smoke/suite-ambient-env.smoke.ts": "this census itself: it reads suite sources and spawns nothing",
 };
 
 /**
@@ -144,12 +292,15 @@ const exempted: string[] = [];
 for (const file of suiteSources(repoRoot)) {
   const rel = relative(repoRoot, file).split("\\").join("/");
   const body = readFileSync(file, "utf8");
-  if (!SPREAD.test(body)) continue;
+  const code = codeWithoutComments(body);
+  const spreads = spreadIndexes(code);
+  if (spreads.length === 0) continue;
   if (rel in REVIEWED) {
     exempted.push(rel);
     continue;
   }
-  if (STRIP.test(body) && DELETE.test(body)) {
+  const unstripped = spreads.filter((index) => !spreadStripped(code, index));
+  if (unstripped.length === 0) {
     stripped.push(rel);
     continue;
   }
@@ -157,7 +308,9 @@ for (const file of suiteSources(repoRoot)) {
     frozen.push(rel);
     continue;
   }
-  offenders.push(rel);
+  offenders.push(
+    `${rel} (unstripped spread at line ${unstripped.map((i) => lineOf(code, i)).join(", ")})`,
+  );
 }
 
 console.log(

--- a/bin/smoke/suite-ambient-env.smoke.ts
+++ b/bin/smoke/suite-ambient-env.smoke.ts
@@ -176,11 +176,12 @@ function lexicalRegions(src: string): Int32Array {
         if (node.head.text) parseRegion(node.head.text, offset + headStart + 1, childRegion);
         for (const span of node.templateSpans) {
           const expressionStart = span.expression.getStart(file);
+          // Interpolation executes in the containing code region.
           parseRegion(
             text.slice(expressionStart, span.expression.end),
             offset + expressionStart,
             baseRegion,
-          ); // interpolation executes in the containing code region
+          );
           const literalStart = span.literal.getStart(file);
           mark(offset + literalStart, offset + span.literal.end, childRegion);
           if (span.literal.text) parseRegion(span.literal.text, offset + literalStart + 1, childRegion);

--- a/bin/smoke/suite-ambient-env.smoke.ts
+++ b/bin/smoke/suite-ambient-env.smoke.ts
@@ -147,50 +147,174 @@ function spreadIndexes(code: string): number[] {
   return [...code.matchAll(SPREAD)].map((m) => m.index ?? -1).filter((i) => i >= 0);
 }
 
+interface ProcessEnvStrip {
+  start: number;
+  deleteStart: number;
+  end: number;
+  region: number;
+}
+
+interface LexicalRegions {
+  regions: Int32Array;
+  processEnvStrips: ProcessEnvStrip[];
+}
+
+function sourceOffsetsForCookedText(
+  rawText: string,
+  cookedText: string,
+  rawSourceOffsets: Int32Array,
+): Int32Array {
+  assert.equal(rawSourceOffsets.length, rawText.length + 1);
+  if (rawText === cookedText) return rawSourceOffsets;
+
+  const cookedSourceOffsets = new Int32Array(cookedText.length + 1);
+  cookedSourceOffsets[0] = rawSourceOffsets[0];
+  let rawIndex = 0;
+  let cookedIndex = 0;
+  while (rawIndex < rawText.length) {
+    if (rawText[rawIndex] !== "\\") {
+      const rawWidth = rawText[rawIndex] === "\r" && rawText[rawIndex + 1] === "\n" ? 2 : 1;
+      const cookedCharacter = rawText[rawIndex] === "\r" ? "\n" : rawText[rawIndex];
+      assert.equal(
+        cookedText[cookedIndex],
+        cookedCharacter,
+        "cooked literal text diverged from its source",
+      );
+      rawIndex += rawWidth;
+      cookedIndex++;
+      cookedSourceOffsets[cookedIndex] = rawSourceOffsets[rawIndex];
+      continue;
+    }
+
+    const escapeStart = rawIndex;
+    const escape = rawText[rawIndex + 1];
+    let rawEnd = rawIndex + 2;
+    let cookedWidth = 1;
+    if (escape === "\r" || escape === "\n" || escape === "\u2028" || escape === "\u2029") {
+      if (escape === "\r" && rawText[rawIndex + 2] === "\n") rawEnd++;
+      cookedWidth = 0;
+    } else if (escape === "x") {
+      rawEnd = rawIndex + 4;
+    } else if (escape === "u" && rawText[rawIndex + 2] === "{") {
+      rawEnd = rawText.indexOf("}", rawIndex + 3) + 1;
+      assert.ok(rawEnd > 0, "unterminated Unicode code-point escape in parsed literal");
+      cookedWidth = Number.parseInt(rawText.slice(rawIndex + 3, rawEnd - 1), 16) > 0xffff ? 2 : 1;
+    } else if (escape === "u") {
+      rawEnd = rawIndex + 6;
+    } else if (escape >= "0" && escape <= "7") {
+      const maxDigits = escape <= "3" ? 3 : 2;
+      while (
+        rawEnd < rawText.length &&
+        rawEnd - escapeStart - 1 < maxDigits &&
+        /[0-7]/.test(rawText[rawEnd])
+      )
+        rawEnd++;
+    }
+    assert.ok(rawEnd <= rawText.length, "escape extends beyond parsed literal text");
+    rawIndex = rawEnd;
+    for (let i = 0; i < cookedWidth; i++) {
+      cookedIndex++;
+      assert.ok(
+        cookedIndex <= cookedText.length,
+        "source escape produced more cooked text than TypeScript parsed",
+      );
+      cookedSourceOffsets[cookedIndex] = rawSourceOffsets[i + 1 === cookedWidth ? rawEnd : escapeStart];
+    }
+    if (cookedWidth === 0) cookedSourceOffsets[cookedIndex] = rawSourceOffsets[rawEnd];
+  }
+  assert.equal(
+    cookedIndex,
+    cookedText.length,
+    `source escape produced less cooked text than TypeScript parsed: raw=${JSON.stringify(rawText)} cooked=${JSON.stringify(cookedText)}`,
+  );
+  return cookedSourceOffsets;
+}
+
 /** Region 0 is module code. Each literal is its own child-script region. Parsing each region's
- *  contents recursively gives nested templates their own identity, returns `${...}` interpolation to
- *  the containing code region, and lets TypeScript distinguish regex literals from division. */
-function lexicalRegions(src: string): Int32Array {
+ *  cooked contents recursively gives nested templates their own identity, returns `${...}`
+ *  interpolation to the containing code region, and maps child-script matches back to source. */
+function lexicalRegions(src: string): LexicalRegions {
   const regions = new Int32Array(src.length);
+  const processEnvStrips: ProcessEnvStrip[] = [];
   let nextRegion = 1;
   const mark = (start: number, end: number, region: number): void => {
     regions.fill(region, start, end);
   };
 
-  const parseRegion = (text: string, offset: number, baseRegion: number): void => {
-    mark(offset, offset + text.length, baseRegion);
+  const parseRegion = (text: string, sourceOffsets: Int32Array, baseRegion: number): void => {
+    mark(sourceOffsets[0], sourceOffsets[text.length], baseRegion);
+    for (const match of text.matchAll(PROCESS_ENV_STRIP)) {
+      const start = match.index ?? -1;
+      if (start < 0) continue;
+      processEnvStrips.push({
+        start: sourceOffsets[start],
+        deleteStart: sourceOffsets[start + match[0].lastIndexOf("delete")],
+        end: sourceOffsets[start + match[0].length],
+        region: baseRegion,
+      });
+    }
     const file = ts.createSourceFile("region.ts", text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
     const visit = (node: ts.Node): void => {
       if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
         const start = node.getStart(file);
         const end = node.end;
         const childRegion = nextRegion++;
-        mark(offset + start, offset + end, childRegion);
-        if (end - start > 2) parseRegion(text.slice(start + 1, end - 1), offset + start + 1, childRegion);
+        mark(sourceOffsets[start], sourceOffsets[end], childRegion);
+        const endTrim = node.isUnterminated ? 0 : 1;
+        if (end - start > 1 + endTrim) {
+          const rawText = text.slice(start + 1, end - endTrim);
+          const rawSourceOffsets = sourceOffsets.slice(start + 1, end - endTrim + 1);
+          const cookedSourceOffsets = sourceOffsetsForCookedText(rawText, node.text, rawSourceOffsets);
+          parseRegion(node.text, cookedSourceOffsets, childRegion);
+        }
         return;
       }
       if (ts.isTemplateExpression(node)) {
         const childRegion = nextRegion++;
         const headStart = node.head.getStart(file);
-        mark(offset + headStart, offset + node.head.end, childRegion);
-        if (node.head.text) parseRegion(node.head.text, offset + headStart + 1, childRegion);
+        mark(sourceOffsets[headStart], sourceOffsets[node.head.end], childRegion);
+        if (node.head.text) {
+          const rawText = text.slice(headStart + 1, node.head.end - 2);
+          const rawSourceOffsets = sourceOffsets.slice(headStart + 1, node.head.end - 1);
+          parseRegion(
+            node.head.text,
+            sourceOffsetsForCookedText(rawText, node.head.text, rawSourceOffsets),
+            childRegion,
+          );
+        }
         for (const span of node.templateSpans) {
           const expressionStart = span.expression.getStart(file);
           // Interpolation executes in the containing code region.
           parseRegion(
             text.slice(expressionStart, span.expression.end),
-            offset + expressionStart,
+            sourceOffsets.slice(expressionStart, span.expression.end + 1),
             baseRegion,
           );
           const literalStart = span.literal.getStart(file);
-          mark(offset + literalStart, offset + span.literal.end, childRegion);
-          if (span.literal.text) parseRegion(span.literal.text, offset + literalStart + 1, childRegion);
+          mark(sourceOffsets[literalStart], sourceOffsets[span.literal.end], childRegion);
+          if (span.literal.text) {
+            const literalEndTrim = ts.isTemplateTail(span.literal)
+              ? span.literal.isUnterminated
+                ? 0
+                : 1
+              : 2;
+            const rawText = text.slice(literalStart + 1, span.literal.end - literalEndTrim);
+            const rawSourceOffsets = sourceOffsets.slice(
+              literalStart + 1,
+              span.literal.end - literalEndTrim + 1,
+            );
+            parseRegion(
+              span.literal.text,
+              sourceOffsetsForCookedText(rawText, span.literal.text, rawSourceOffsets),
+              childRegion,
+            );
+          }
         }
         return;
       }
       // REGEX-LITERAL REGION: braces here are data, not structural nesting.
       if (node.kind === ts.SyntaxKind.RegularExpressionLiteral) {
-        mark(offset + node.getStart(file), offset + node.end, nextRegion++);
+        mark(sourceOffsets[node.getStart(file)], sourceOffsets[node.end], nextRegion++);
         return;
       }
       ts.forEachChild(node, visit);
@@ -198,8 +322,8 @@ function lexicalRegions(src: string): Int32Array {
     visit(file);
   };
 
-  parseRegion(src, 0, 0);
-  return regions;
+  parseRegion(src, Int32Array.from({ length: src.length + 1 }, (_, index) => index), 0);
+  return { regions, processEnvStrips };
 }
 
 /** Structural brace depth inside one lexical region. Module braces ignore embedded child scripts;
@@ -214,10 +338,15 @@ function braceDepthAt(src: string, regions: Int32Array, index: number, region: n
   return depth;
 }
 
-function processEnvStrippedBefore(code: string, regions: Int32Array, index: number): boolean {
-  const region = regions[index];
-  return [...code.slice(0, index).matchAll(PROCESS_ENV_STRIP)].some((m) =>
-    regions[m.index ?? -1] === region && braceDepthAt(code, regions, m.index ?? -1, region) === 0,
+function processEnvStrippedBefore(code: string, lexical: LexicalRegions, index: number): boolean {
+  const region = lexical.regions[index];
+  return lexical.processEnvStrips.some(
+    (strip) =>
+      strip.end <= index &&
+      strip.region === region &&
+      lexical.regions[strip.start] === region &&
+      lexical.regions[strip.deleteStart] === region &&
+      braceDepthAt(code, lexical.regions, strip.start, region) === 0,
   );
 }
 
@@ -228,9 +357,10 @@ function regexEscape(s: string): string {
 /** True when THIS spread is assigned to a copy which is then scrubbed, or `process.env` was already
  *  stripped in this file. Matching the copied variable prevents a later child's strip from clearing
  *  an earlier unstripped spread. */
-function spreadStripped(code: string, regions: Int32Array, index: number): boolean {
+function spreadStripped(code: string, lexical: LexicalRegions, index: number): boolean {
+  const { regions } = lexical;
   const region = regions[index];
-  if (processEnvStrippedBefore(code, regions, index)) return true;
+  if (processEnvStrippedBefore(code, lexical, index)) return true;
   const before = code.slice(Math.max(0, index - 320), index);
   const assignment = /(?:const|let|var)\s+([A-Za-z_$][\w$]*)(?:\s*:[^=;\n]+)?\s*=\s*\{[^{}]*$/.exec(before);
   if (!assignment) return false;
@@ -250,8 +380,8 @@ function spreadStripped(code: string, regions: Int32Array, index: number): boole
 
 function unstrippedSpreadLines(src: string): number[] {
   const code = codeWithoutComments(src);
-  const regions = lexicalRegions(code);
-  return spreadIndexes(code).filter((index) => !spreadStripped(code, regions, index)).map((index) => lineOf(code, index));
+  const lexical = lexicalRegions(code);
+  return spreadIndexes(code).filter((index) => !spreadStripped(code, lexical, index)).map((index) => lineOf(code, index));
 }
 
 assert.deepEqual(
@@ -468,6 +598,62 @@ spawn("second", { env: second });
   "a file must pass when every child spread is stripped",
 );
 
+function assertFixtureParses(name: string, source: string): void {
+  const parsed = ts.createSourceFile("fixture.ts", source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const diagnostics = (parsed as unknown as { parseDiagnostics?: readonly ts.Diagnostic[] }).parseDiagnostics ?? [];
+  assert.equal(diagnostics.length, 0, `${name} must parse before its classification is trusted`);
+}
+
+const childScriptScrubTail =
+  ' (const key of Object.keys(process.env)) if (key.startsWith("COTAL_")) delete process.env[key];';
+const childScriptSpreadTail = ' const safe = { ...process.env }; spawn("safe", { env: safe });';
+const childScriptScrubSpellings = [
+  ["plain child-script scrub", "for"],
+  ["hex-escaped child-script scrub", "\\x66or"],
+  ["Unicode-escaped child-script scrub", "\\u0066or"],
+  ["split Unicode-escaped child-script scrub", "f\\u006fr"],
+] as const;
+
+const noScrubChildScript =
+  'const CHILD = `const unsafe = { ...process.env }; spawn("unsafe", { env: unsafe });`;';
+assertFixtureParses("the no-scrub child-script fixture", noScrubChildScript);
+assert.deepEqual(
+  unstrippedSpreadLines(noScrubChildScript),
+  [1],
+  "a child-script spread without a scrub must remain unsafe",
+);
+
+for (const [name, keyword] of childScriptScrubSpellings) {
+  const source = `const CHILD = \`${keyword}${childScriptScrubTail}${childScriptSpreadTail}\`;`;
+  assertFixtureParses(`the ${name} fixture`, source);
+  assert.deepEqual(
+    unstrippedSpreadLines(source),
+    [],
+    `a ${name} must clear a later spread in the same template`,
+  );
+}
+
+const sourceMappedEscapedScrub =
+  `const CHILD = \`{\\u0030} ${childScriptScrubSpellings[2][1]}${childScriptScrubTail}${childScriptSpreadTail}\`;`;
+assertFixtureParses("the source-mapped escaped-scrub fixture", sourceMappedEscapedScrub);
+assert.deepEqual(
+  unstrippedSpreadLines(sourceMappedEscapedScrub),
+  [],
+  "an escaped child-script scrub must retain its source brace depth",
+);
+
+const unusedEscapedScrub = [
+  `const UNUSED = \`${childScriptScrubSpellings[2][1]}${childScriptScrubTail}\`;`,
+  'const unsafe = { ...process.env };',
+  'spawn("unsafe", { env: unsafe });',
+].join("\n");
+assertFixtureParses("the unused escaped-scrub fixture", unusedEscapedScrub);
+assert.deepEqual(
+  unstrippedSpreadLines(unusedEscapedScrub),
+  [2],
+  "an escaped scrub in an unused template must not clear a module-code spread",
+);
+
 /**
  * Files that spread the ambient environment and are graded SAFE, each with the measurement.
  *
@@ -579,7 +765,7 @@ for (const file of suiteSources(repoRoot)) {
   const rel = relative(repoRoot, file).split("\\").join("/");
   const body = readFileSync(file, "utf8");
   const code = codeWithoutComments(body);
-  const regions = lexicalRegions(code);
+  const lexical = lexicalRegions(code);
   const spreads = spreadIndexes(code);
   if (spreads.length === 0) continue;
   totalSpreads += spreads.length;
@@ -587,7 +773,7 @@ for (const file of suiteSources(repoRoot)) {
     exempted.push(rel);
     continue;
   }
-  const stripStates = spreads.map((index) => spreadStripped(code, regions, index));
+  const stripStates = spreads.map((index) => spreadStripped(code, lexical, index));
   if (spreads.length > 1) multiSpreadFiles.push(rel);
   if (FILTERED_COPY.test(code)) mixedPathFiles.push(rel);
   if (REAL_PROCESS_ENV_SCRUB_FILES.has(rel)) {

--- a/bin/smoke/suite-ambient-env.smoke.ts
+++ b/bin/smoke/suite-ambient-env.smoke.ts
@@ -26,6 +26,7 @@ import assert from "node:assert/strict";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
+import ts from "typescript";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const SKIP = new Set(["node_modules", "dist", ".git", ".pnpm-store", "coverage", "reserved"]);
@@ -48,15 +49,14 @@ function* suiteSources(dir: string): Generator<string> {
 
 /** The spread, written the way people write it. */
 const SPREAD = /\.\.\.process\.env\b/g;
-/** A strip: a loop that deletes the `COTAL_` keys from a copy before the copy is spread. Matched on
- *  the two halves together, so a file that merely MENTIONS the prefix does not pass. */
-const STRIP = /startsWith\(["']COTAL_["']\)/;
-const DELETE = /\bdelete\b/;
-/** A file that mutates `process.env` itself, then later spreads it, has already dropped the ambient
- *  keys from what the child will inherit. The mutation has to be a keys-loop that deletes `COTAL_`,
- *  not a mention of those tokens in a comment or a different object. */
+/** A file that mutates `process.env` itself at module scope, then later spreads it, has already
+ *  dropped the ambient keys from what the child will inherit. Function-local and branch-local scrubs
+ *  are not ownership: they may never execute before the spread. */
 const PROCESS_ENV_STRIP =
-  /for\s*\(\s*const\s+\w+\s+of\s+Object\.keys\(\s*process\.env\s*\)\)[\s\S]{0,160}?startsWith\(\s*["']COTAL_["']\s*\)[\s\S]{0,80}?delete\s+process\.env/;
+  /for\s*\(\s*const\s+\w+\s+of\s+Object\.keys\(\s*process\.env\s*\)\)[^\n]{0,160}?startsWith\(\s*["']COTAL_["']\s*\)[^\n]{0,80}?delete\s+process\.env/g;
+/** A second real child-env construction path filters the ambient entries while copying them. It is
+ *  not a SPREAD match, but files combining it with a spread are the real mixed-path population. */
+const FILTERED_COPY = /Object\.entries\(\s*process\.env\s*\)\.filter\([\s\S]{0,160}?startsWith\(\s*["']COTAL_["']\s*\)/;
 
 /** Comments are not child env. The census used to treat a `delete` in prose plus a `startsWith("COTAL_")`
  *  on a different child as a strip of every spread in the file. */
@@ -147,6 +147,77 @@ function spreadIndexes(code: string): number[] {
   return [...code.matchAll(SPREAD)].map((m) => m.index ?? -1).filter((i) => i >= 0);
 }
 
+/** Region 0 is module code. Each literal is its own child-script region. Parsing each region's
+ *  contents recursively gives nested templates their own identity, returns `${...}` interpolation to
+ *  the containing code region, and lets TypeScript distinguish regex literals from division. */
+function lexicalRegions(src: string): Int32Array {
+  const regions = new Int32Array(src.length);
+  let nextRegion = 1;
+  const mark = (start: number, end: number, region: number): void => regions.fill(region, start, end);
+
+  const parseRegion = (text: string, offset: number, baseRegion: number): void => {
+    mark(offset, offset + text.length, baseRegion);
+    const file = ts.createSourceFile("region.ts", text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+    const visit = (node: ts.Node): void => {
+      if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+        const start = node.getStart(file);
+        const end = node.end;
+        const childRegion = nextRegion++;
+        mark(offset + start, offset + end, childRegion);
+        if (end - start > 2) parseRegion(text.slice(start + 1, end - 1), offset + start + 1, childRegion);
+        return;
+      }
+      if (ts.isTemplateExpression(node)) {
+        const childRegion = nextRegion++;
+        const headStart = node.head.getStart(file);
+        mark(offset + headStart, offset + node.head.end, childRegion);
+        if (node.head.text) parseRegion(node.head.text, offset + headStart + 1, childRegion);
+        for (const span of node.templateSpans) {
+          const expressionStart = span.expression.getStart(file);
+          parseRegion(
+            text.slice(expressionStart, span.expression.end),
+            offset + expressionStart,
+            baseRegion,
+          ); // interpolation executes in the containing code region
+          const literalStart = span.literal.getStart(file);
+          mark(offset + literalStart, offset + span.literal.end, childRegion);
+          if (span.literal.text) parseRegion(span.literal.text, offset + literalStart + 1, childRegion);
+        }
+        return;
+      }
+      // REGEX-LITERAL REGION: braces here are data, not structural nesting.
+      if (node.kind === ts.SyntaxKind.RegularExpressionLiteral) {
+        mark(offset + node.getStart(file), offset + node.end, nextRegion++);
+        return;
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(file);
+  };
+
+  parseRegion(src, 0, 0);
+  return regions;
+}
+
+/** Structural brace depth inside one lexical region. Module braces ignore embedded child scripts;
+ *  child-script braces are counted within that literal. */
+function braceDepthAt(src: string, regions: Int32Array, index: number, region: number): number {
+  let depth = 0;
+  for (let i = 0; i < index; i++) {
+    if (regions[i] !== region) continue;
+    if (src[i] === "{") depth++;
+    else if (src[i] === "}") depth = Math.max(0, depth - 1);
+  }
+  return depth;
+}
+
+function processEnvStrippedBefore(code: string, regions: Int32Array, index: number): boolean {
+  const region = regions[index];
+  return [...code.slice(0, index).matchAll(PROCESS_ENV_STRIP)].some((m) =>
+    regions[m.index ?? -1] === region && braceDepthAt(code, regions, m.index ?? -1, region) === 0,
+  );
+}
+
 function regexEscape(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -154,23 +225,220 @@ function regexEscape(s: string): string {
 /** True when THIS spread is assigned to a copy which is then scrubbed, or `process.env` was already
  *  stripped in this file. Matching the copied variable prevents a later child's strip from clearing
  *  an earlier unstripped spread. */
-function spreadStripped(code: string, index: number): boolean {
-  if (PROCESS_ENV_STRIP.test(code.slice(0, index))) return true;
+function spreadStripped(code: string, regions: Int32Array, index: number): boolean {
+  const region = regions[index];
+  if (processEnvStrippedBefore(code, regions, index)) return true;
   const before = code.slice(Math.max(0, index - 320), index);
   const assignment = /(?:const|let|var)\s+([A-Za-z_$][\w$]*)(?:\s*:[^=;\n]+)?\s*=\s*\{[^{}]*$/.exec(before);
   if (!assignment) return false;
+  const assignmentIndex = Math.max(0, index - 320) + (assignment.index ?? 0);
+  if (regions[assignmentIndex] !== region) return false;
   const name = regexEscape(assignment[1]);
   const after = windowAfter(code, index, 12);
   const copyStrip = new RegExp(
     `^\\.\\.\\.process\\.env\\b[^}]*}\\s*;[\\s\\S]{0,240}?Object\\.keys\\(\\s*${name}\\s*\\)[\\s\\S]{0,160}?startsWith\\(\\s*["']COTAL_["']\\s*\\)[\\s\\S]{0,80}?delete\\s+${name}\\s*\\[`,
   );
-  return copyStrip.test(after);
+  const match = copyStrip.exec(after);
+  if (!match) return false;
+  const keysOffset = match[0].indexOf("Object.keys");
+  const deleteOffset = match[0].lastIndexOf("delete");
+  return regions[index + keysOffset] === region && regions[index + deleteOffset] === region;
 }
 
 function unstrippedSpreadLines(src: string): number[] {
   const code = codeWithoutComments(src);
-  return spreadIndexes(code).filter((index) => !spreadStripped(code, index)).map((index) => lineOf(code, index));
+  const regions = lexicalRegions(code);
+  return spreadIndexes(code).filter((index) => !spreadStripped(code, regions, index)).map((index) => lineOf(code, index));
 }
+
+assert.deepEqual(
+  unstrippedSpreadLines(`
+function neverCalled() {
+/}/;
+for (const key of Object.keys(process.env)) if (key.startsWith("COTAL_")) delete process.env[key];
+}
+const unsafe = { ...process.env };
+spawn("unsafe", { env: unsafe });
+`),
+  [6],
+  "a regex close brace must not hide nested scrub depth",
+);
+for (const keywordRegex of ["return /}/;", "throw /}/;", "void /}/;", "delete /}/;"]) {
+  assert.deepEqual(
+    unstrippedSpreadLines([
+      "function neverCalled() {",
+      keywordRegex,
+      "for (const key of Object.keys(process.env)) if (key.startsWith(\"COTAL_\")) delete process.env[key];",
+      "}",
+      "const unsafe = { ...process.env };",
+      "spawn(\"unsafe\", { env: unsafe });",
+    ].join("\n")),
+    [5],
+    `a keyword-prefixed regex must not hide nested scrub depth: ${keywordRegex}`,
+  );
+}
+assert.deepEqual(
+  unstrippedSpreadLines(`
+/{/;
+for (const key of Object.keys(process.env)) if (key.startsWith("COTAL_")) delete process.env[key];
+const safe = { ...process.env };
+spawn("safe", { env: safe });
+`),
+  [],
+  "a regex open brace must not invent module scrub depth",
+);
+assert.deepEqual(
+  unstrippedSpreadLines(`
+/[{}]/;
+for (const key of Object.keys(process.env)) if (key.startsWith("COTAL_")) delete process.env[key];
+const safe = { ...process.env };
+spawn("safe", { env: safe });
+`),
+  [],
+  "regex character-class braces must not alter module scrub depth",
+);
+assert.deepEqual(
+  unstrippedSpreadLines(`
+const quotient = numerator / denominator;
+for (const key of Object.keys(process.env)) if (key.startsWith("COTAL_")) delete process.env[key];
+const safe = { ...process.env };
+spawn("safe", { env: safe });
+`),
+  [],
+  "division must not be classified as a regex literal",
+);
+assert.deepEqual(
+  unstrippedSpreadLines([
+    "const OUTER = `head ${(() => {",
+    "  const INNER = `for (const key of Object.keys(process.env)) if (key.startsWith(\"COTAL_\")) delete process.env[key];`;",
+    "  return INNER;",
+    "})()} tail`;",
+    "const unsafe = { ...process.env };",
+    "spawn(\"unsafe\", { env: unsafe });",
+  ].join("\n")),
+  [5],
+  "an unused nested template scrub must not clear a module-code spread",
+);
+assert.deepEqual(
+  unstrippedSpreadLines([
+    "const child = `head ${`for (const key of Object.keys(process.env)) if (key.startsWith(\"COTAL_\")) delete process.env[key];`} middle ${{ ...process.env }} tail`;",
+  ].join("\n")),
+  [1],
+  "a nested template scrub must not clear a sibling interpolation spread",
+);
+assert.deepEqual(
+  unstrippedSpreadLines([
+    "const child = `raw { ${value / 2} tail }`;",
+    "for (const key of Object.keys(process.env)) if (key.startsWith(\"COTAL_\")) delete process.env[key];",
+    "const safe = { ...process.env };",
+    "spawn(\"safe\", { env: safe });",
+  ].join("\n")),
+  [],
+  "template interpolation must restore the module region before later tokens",
+);
+assert.deepEqual(
+  unstrippedSpreadLines([
+    "for (const key of Object.keys(process.env)) if (key.startsWith(\"COTAL_\")) delete process.env[key];",
+    "const child = `raw ${(() => { const safe = { ...process.env }; spawn(\"safe\", { env: safe }); })()} tail`;",
+  ].join("\n")),
+  [],
+  "a module scrub must clear a spread inside template interpolation code",
+);
+assert.deepEqual(
+  unstrippedSpreadLines([
+    "const child = `for (const key of Object.keys(process.env)) if (key.startsWith(\"COTAL_\")) delete process.env[key]; ${(() => { const unsafe = { ...process.env }; spawn(\"unsafe\", { env: unsafe }); })()}`;",
+  ].join("\n")),
+  [1],
+  "a raw-template scrub must not clear a spread inside interpolation code",
+);
+assert.deepEqual(
+  unstrippedSpreadLines([
+    "// stray ` / } { in comment",
+    "const noise = \"stray ` / } { in string\";",
+    "for (const key of Object.keys(process.env)) if (key.startsWith(\"COTAL_\")) delete process.env[key];",
+    "const safe = { ...process.env };",
+    "spawn(\"safe\", { env: safe });",
+  ].join("\n")),
+  [],
+  "comment and string slash or backtick noise must not corrupt later module tokens",
+);
+assert.deepEqual(
+  unstrippedSpreadLines(`
+const UNUSED = \`for (const key of Object.keys(process.env)) if (key.startsWith("COTAL_")) delete process.env[key];\`;
+const unsafe = { ...process.env };
+spawn("unsafe", { env: unsafe });
+`),
+  [3],
+  "an unused child-script template scrub must not clear a module-code spread",
+);
+assert.deepEqual(
+  unstrippedSpreadLines(`
+for (const key of Object.keys(process.env)) if (key.startsWith("COTAL_")) delete process.env[key];
+const CHILD = \`const unsafe = { ...process.env }; spawn("unsafe", { env: unsafe });\`;
+`),
+  [3],
+  "a module-code scrub must not clear a child-script template spread",
+);
+assert.deepEqual(
+  unstrippedSpreadLines(`
+const CHILD = \`for (const key of Object.keys(process.env)) if (key.startsWith("COTAL_")) delete process.env[key]; const safe = { ...process.env }; spawn("safe", { env: safe });\`;
+`),
+  [],
+  "a child-script template scrub must clear a later spread in the same template",
+);
+assert.deepEqual(
+  unstrippedSpreadLines(`
+for (const key of Object.keys(process.env)) if (key.startsWith("COTAL_")) delete process.env[key];
+const safe = { ...process.env };
+spawn("safe", { env: safe });
+`),
+  [],
+  "an unconditional module-scope process.env scrub must clear later direct spreads",
+);
+assert.deepEqual(
+  unstrippedSpreadLines(`
+function neverCalled() {
+for (const key of Object.keys(process.env)) if (key.startsWith("COTAL_")) delete process.env[key];
+}
+const unsafe = { ...process.env };
+spawn("unsafe", { env: unsafe });
+`),
+  [5],
+  "an uncalled function scrub must not clear a later unsafe spread",
+);
+assert.deepEqual(
+  unstrippedSpreadLines(`
+function neverCalled() {
+  for (const key of Object.keys(process.env)) if (key.startsWith("COTAL_")) delete process.env[key];
+}
+const unsafe = { ...process.env };
+spawn("unsafe", { env: unsafe });
+`),
+  [5],
+  "an indented uncalled function scrub must not clear a later unsafe spread",
+);
+assert.deepEqual(
+  unstrippedSpreadLines(`
+if (shouldScrub) {
+for (const key of Object.keys(process.env)) if (key.startsWith("COTAL_")) delete process.env[key];
+}
+const unsafe = { ...process.env };
+spawn("unsafe", { env: unsafe });
+`),
+  [5],
+  "a conditional process.env scrub must not clear a later unsafe spread",
+);
+assert.deepEqual(
+  unstrippedSpreadLines(`
+if (shouldScrub) {
+  for (const key of Object.keys(process.env)) if (key.startsWith("COTAL_")) delete process.env[key];
+}
+const unsafe = { ...process.env };
+spawn("unsafe", { env: unsafe });
+`),
+  [5],
+  "an indented conditional process.env scrub must not clear a later unsafe spread",
+);
 
 // Regression cell: one stripped child cannot clear another unstripped child, and a comment that says
 // `delete` is not a mechanism. Put the unsafe child first so the following child's real strip is also
@@ -284,22 +552,49 @@ const FROZEN: readonly string[] = [
   "packages/core/smoke/presence-ttl-refresh-cli.smoke.ts",
 ];
 
+const REAL_PROCESS_ENV_SCRUB_FILES = new Set([
+  "bin/smoke/manager-stop-reaps-agents.smoke.ts",
+  "bin/smoke/persona-agent.smoke.ts",
+  "extensions/connector-opencode/smoke/events-release.smoke.ts",
+  "implementations/cli/smoke/up-multi-space-render-live.smoke.ts",
+  "implementations/cli/smoke/up-per-space-membership-live.smoke.ts",
+  "implementations/manager/smoke/_probe-late-delivery.ts",
+  "implementations/manager/smoke/_probe-live-socket-gap.ts",
+  "implementations/manager/smoke/_probe-missed-handoff.ts",
+  "implementations/manager/smoke/_probe-pipe-oneshot-exit.ts",
+  "implementations/manager/smoke/_probe-stdin-window.ts",
+  "implementations/manager/smoke/attach-stdin.smoke.ts",
+]);
+
 const offenders: string[] = [];
 const frozen: string[] = [];
 const stripped: string[] = [];
 const exempted: string[] = [];
+let totalSpreads = 0;
+const multiSpreadFiles: string[] = [];
+const mixedPathFiles: string[] = [];
+let realProcessEnvScrubSpreads = 0;
 
 for (const file of suiteSources(repoRoot)) {
   const rel = relative(repoRoot, file).split("\\").join("/");
   const body = readFileSync(file, "utf8");
   const code = codeWithoutComments(body);
+  const regions = lexicalRegions(code);
   const spreads = spreadIndexes(code);
   if (spreads.length === 0) continue;
+  totalSpreads += spreads.length;
   if (rel in REVIEWED) {
     exempted.push(rel);
     continue;
   }
-  const unstripped = spreads.filter((index) => !spreadStripped(code, index));
+  const stripStates = spreads.map((index) => spreadStripped(code, regions, index));
+  if (spreads.length > 1) multiSpreadFiles.push(rel);
+  if (FILTERED_COPY.test(code)) mixedPathFiles.push(rel);
+  if (REAL_PROCESS_ENV_SCRUB_FILES.has(rel)) {
+    assert.ok(stripStates.every(Boolean), `${rel} stopped being protected by its module-scope process.env scrub`);
+    realProcessEnvScrubSpreads += spreads.length;
+  }
+  const unstripped = spreads.filter((_, index) => !stripStates[index]);
   if (unstripped.length === 0) {
     stripped.push(rel);
     continue;
@@ -325,6 +620,29 @@ for (const f of exempted) console.log(`  · ${f} - reviewed safe: ${REVIEWED[f]}
 assert.ok(
   stripped.length + exempted.length + frozen.length + offenders.length > 0,
   "the census matched no suite files at all, which means the scan is broken rather than the tree being clean",
+);
+const classifiedFiles = stripped.length + exempted.length + frozen.length + offenders.length;
+assert.ok(
+  totalSpreads > classifiedFiles,
+  `the real census found ${totalSpreads} spread(s) across ${classifiedFiles} file(s); spread enumeration was truncated or the multi-spread population disappeared`,
+);
+assert.ok(
+  multiSpreadFiles.length > 0,
+  "the real census found no multi-spread suite files; spread enumeration or the population sentinel is broken",
+);
+assert.ok(
+  mixedPathFiles.length > 0,
+  "the real census found no files combining filtered ambient copies with spread copies; the mixed-path population sentinel is broken",
+);
+assert.equal(
+  realProcessEnvScrubSpreads,
+  14,
+  "the measured module-scope process.env scrub population changed from 11 files / 14 spreads",
+);
+assert.equal(
+  [...REAL_PROCESS_ENV_SCRUB_FILES].filter((file) => stripped.includes(file)).length,
+  11,
+  "the measured module-scope process.env scrub population no longer has 11 safe files",
 );
 // Every exemption must correspond to a file that still exists and still spreads; a stale entry is a
 // waiver nobody is checking.

--- a/bin/smoke/suite-ambient-env.smoke.ts
+++ b/bin/smoke/suite-ambient-env.smoke.ts
@@ -654,6 +654,52 @@ assert.deepEqual(
   "an escaped scrub in an unused template must not clear a module-code spread",
 );
 
+const sourceMappedTemplateHeadScrub =
+  "const CHILD = `" +
+  `{\\u0030} ${childScriptScrubSpellings[2][1]}${childScriptScrubTail}${childScriptSpreadTail}` +
+  "${0}`;";
+assertFixtureParses(
+  "the source-mapped template-head escaped-scrub fixture",
+  sourceMappedTemplateHeadScrub,
+);
+assert.deepEqual(
+  unstrippedSpreadLines(sourceMappedTemplateHeadScrub),
+  [],
+  "an escaped template-head scrub must retain its source brace depth",
+);
+
+const noScrubTemplateHead =
+  'const CHILD = `const unsafe = { ...process.env }; spawn("unsafe", { env: unsafe });${0}`;';
+assertFixtureParses("the no-scrub template-head fixture", noScrubTemplateHead);
+assert.deepEqual(
+  unstrippedSpreadLines(noScrubTemplateHead),
+  [1],
+  "a template-head spread without a scrub must remain unsafe",
+);
+
+const sourceMappedTemplateSpanScrub =
+  "const CHILD = `${0}" +
+  `{\\u0030} ${childScriptScrubSpellings[2][1]}${childScriptScrubTail}${childScriptSpreadTail}` +
+  "`;";
+assertFixtureParses(
+  "the source-mapped template-span escaped-scrub fixture",
+  sourceMappedTemplateSpanScrub,
+);
+assert.deepEqual(
+  unstrippedSpreadLines(sourceMappedTemplateSpanScrub),
+  [],
+  "an escaped template-span scrub must retain its source brace depth",
+);
+
+const noScrubTemplateSpan =
+  'const CHILD = `${0}const unsafe = { ...process.env }; spawn("unsafe", { env: unsafe });`;';
+assertFixtureParses("the no-scrub template-span fixture", noScrubTemplateSpan);
+assert.deepEqual(
+  unstrippedSpreadLines(noScrubTemplateSpan),
+  [1],
+  "a template-span spread without a scrub must remain unsafe",
+);
+
 /**
  * Files that spread the ambient environment and are graded SAFE, each with the measurement.
  *

--- a/bin/smoke/suite-ambient-env.smoke.ts
+++ b/bin/smoke/suite-ambient-env.smoke.ts
@@ -153,7 +153,9 @@ function spreadIndexes(code: string): number[] {
 function lexicalRegions(src: string): Int32Array {
   const regions = new Int32Array(src.length);
   let nextRegion = 1;
-  const mark = (start: number, end: number, region: number): void => regions.fill(region, start, end);
+  const mark = (start: number, end: number, region: number): void => {
+    regions.fill(region, start, end);
+  };
 
   const parseRegion = (text: string, offset: number, baseRegion: number): void => {
     mark(offset, offset + text.length, baseRegion);
@@ -309,14 +311,11 @@ spawn("safe", { env: safe });
 );
 assert.deepEqual(
   unstrippedSpreadLines([
-    "const OUTER = `head ${(() => {",
-    "  const INNER = `for (const key of Object.keys(process.env)) if (key.startsWith(\"COTAL_\")) delete process.env[key];`;",
-    "  return INNER;",
-    "})()} tail`;",
+    "const OUTER = `head ${`for (const key of Object.keys(process.env)) if (key.startsWith(\"COTAL_\")) delete process.env[key];`} tail`;",
     "const unsafe = { ...process.env };",
     "spawn(\"unsafe\", { env: unsafe });",
   ].join("\n")),
-  [5],
+  [2],
   "an unused nested template scrub must not clear a module-code spread",
 );
 assert.deepEqual(

--- a/implementations/auth/smoke/user-spawn.smoke.ts
+++ b/implementations/auth/smoke/user-spawn.smoke.ts
@@ -349,9 +349,12 @@ function spawnAuthService(): ChildProcess {
   // Re-exec THIS file (tsx) → the self-dispatch runs the real `auth-service` command. cwd=root so the
   // daemon's findCotalRoot() resolves the space-scoped state dir; ephemeral port (it writes its bound
   // url+pid+cap into the discovery file).
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) if (key.startsWith("COTAL_")) delete env[key];
+  env.COTAL_HOME = home;
   return spawn(process.execPath, [...process.execArgv, SELF, "auth-service", "--space", SPACE, "--server", SERVER], {
     cwd: root,
-    env: { ...process.env, COTAL_HOME: home },
+    env,
     stdio: process.env.SMOKE_AUTH_SERVICE_DEBUG ? ["ignore", "inherit", "inherit"] : "ignore",
   });
 }


### PR DESCRIPTION
## Summary

- classify each ambient `process.env` spread independently so one child's strip cannot clear another child
- bind copied-environment stripping to the exact copied variable and ignore comment prose when checking the delete mechanism
- require direct `process.env` scrubs to share structural execution scope and lexical code or child-script region with the spread they protect
- parse string and template contents recursively, preserve interpolation as containing code, and keep template raw text in a separate child-script region
- reject function-local, conditional, unused-template, cross-template, regex-brace, and nested-interpolation false ownership while preserving valid module and same-template scrubs
- strip inherited `COTAL_*` values from the user-spawn auth-service child, preserve non-Cotal environment, and restore its required sandbox `COTAL_HOME`
- guard the real census population with measured module-scope, multi-spread, and mixed-construction sentinels

## Validation

- reproduced the current-main false green, including the semantics-equivalent CLI filter that exposed `implementations/auth/smoke/user-spawn.smoke.ts` as the sole offender
- reproduced function-local, conditional, first-spread-only, unused-template, regex-brace, raw-template/interpolation, and recursive nested-template false greens on prior heads
- verified the existing unconditional module-scope scrub population remains 11 files and 14 spreads
- final census: 105 files, 60 stripped, 4 reviewed-safe, 41 frozen
- `node bin/smoke/suite-ambient-env.smoke.ts`
- `node scripts/mutation-proof.mjs --config bin/smoke/mutations/suite-ambient-env.mutations.json`
- all nine mutations were killed; named failures cover the user-spawn spread, truncated enumeration, structural depth, lexical ownership, regex braces, template raw/interpolation separation, and recursive interpolation parsing