### PR TITLE
fix(ci): attribute pre-red command transitions

### DIFF
--- a/bin/smoke/mutation-reproof.smoke.ts
+++ b/bin/smoke/mutation-reproof.smoke.ts
@@ -16,7 +16,7 @@
  *   - a guarded source RENAMED away (a dangling fixture — the fixture still points at the old path).
  */
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { mkdtempSync, readFileSync, realpathSync, writeFileSync, rmSync, mkdirSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -40,14 +40,28 @@ const selectedPaths = (out: string): string[] => {
 /** Parse the dangling-fixture set the scan names when it refuses an unrunnable proof. */
 const danglingPaths = (out: string): string[] =>
   [...out.matchAll(/^ {2}(\S+\.json) -> missing:/gm)].map((m) => m[1]);
-/** Parse the offender set when a re-proven fixture's mutant survives. */
-const offenderPaths = (out: string): string[] =>
-  [...out.matchAll(/MUTATION REPROOF FAILED \(\d+ fixture\(s\)\): (.+)/g)].flatMap((m) => m[1].split(", "));
-/** Parse the pre-red set: a selected fixture whose suite was already red before mutation. */
+/** Parse the inherited pre-red set: the same command was red at base and at head. */
 const preRedPaths = (out: string): string[] => {
-  const m = out.match(/^PRE-RED \(\d+ fixture\(s\)\)[^:]*: (.+)$/m);
-  return m ? m[1].split(", ") : [];
+  const block = out.match(/^PRE-RED \(\d+ fixture\(s\)\)[^\n]*\n((?:  .+\n?)+)/m);
+  return block ? [...block[1].matchAll(/^ {2}(\S+\.json) -> command:/gm)].map((m) => m[1]) : [];
 };
+/** Parse pre-red proofs attributed by the same command's base-GREEN -> head-RED transition. */
+const attributablePreRedPaths = (out: string): string[] => {
+  const block = out.match(/^PRE-RED TRANSITION FAILED \(\d+ fixture\(s\)\)[^\n]*\n((?:  .+\n?)+)/m);
+  return block ? [...block[1].matchAll(/^ {2}(\S+\.json) -> command:/gm)].map((m) => m[1]) : [];
+};
+/** Parse base comparisons the gate could not measure and therefore refuses loudly. */
+const unmeasuredPreRedPaths = (out: string): string[] => {
+  const block = out.match(/^PRE-RED TRANSITION UNMEASURED \(\d+ fixture\(s\)\)[^\n]*\n((?:  .+\n?)+)/m);
+  return block ? [...block[1].matchAll(/^ {2}(\S+\.json) -> command:/gm)].map((m) => m[1]) : [];
+};
+/** Parse every fatal offender, retaining PRE-RED transition states as distinct output categories. */
+const offenderPaths = (out: string): string[] => [
+  ...[...out.matchAll(/^MUTATION REPROOF FAILED \(\d+ fixture\(s\)\): (.+)$/gm)]
+    .flatMap((m) => m[1].split(", ")),
+  ...attributablePreRedPaths(out),
+  ...unmeasuredPreRedPaths(out),
+];
 /** Parse the inconclusive set: a selected fixture whose proof produced no evidence either way. */
 const inconclusivePaths = (out: string): string[] => {
   const m = out.match(/^INCONCLUSIVE \(\d+ fixture\(s\)\)[^:]*: (.+)$/m);
@@ -55,12 +69,22 @@ const inconclusivePaths = (out: string): string[] => {
 };
 /** Parse the machine-readable outcome counts from the final OK summary. Null when the gate failed. */
 const okCounts = (out: string): { discriminated: number; preRed: number; inconclusive: number } | null => {
-  const m = out.match(/MUTATION REPROOF OK \(\d+ fixture\(s\) selected; (\d+) discriminated, (\d+) pre-red, (\d+) inconclusive\)/);
+  const m = out.match(/MUTATION REPROOF OK \(\d+ fixture\(s\) selected; (\d+) discriminated, (\d+) inherited pre-red, 0 attributable pre-red, 0 unmeasured pre-red, (\d+) inconclusive\)/);
   return m ? { discriminated: Number(m[1]), preRed: Number(m[2]), inconclusive: Number(m[3]) } : null;
 };
 
-const scan = (root: string, base: string, head: string): { status: number | null; out: string } => {
-  const run = spawnSync(process.execPath, [SCAN, "--root", root, "--base", base, "--head", head], { encoding: "utf8" });
+const cleanAmbientEnv = (): NodeJS.ProcessEnv => {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) if (key.startsWith("COTAL_")) delete env[key];
+  return env;
+};
+
+const scan = (root: string, base: string, head: string, env = cleanAmbientEnv()): { status: number | null; out: string } => {
+  const run = spawnSync(process.execPath, [SCAN, "--root", root, "--base", base, "--head", head], { encoding: "utf8", env });
+  return { status: run.status, out: `${run.stdout ?? ""}${run.stderr ?? ""}` };
+};
+const scanAll = (root: string): { status: number | null; out: string } => {
+  const run = spawnSync(process.execPath, [SCAN, "--root", root, "--all"], { encoding: "utf8", env: cleanAmbientEnv() });
   return { status: run.status, out: `${run.stdout ?? ""}${run.stderr ?? ""}` };
 };
 
@@ -267,11 +291,8 @@ try {
     );
   }
 
-  // 6. A selected fixture whose suite is ALREADY RED before any mutation. a.mjs changes (so a's
-  //    fixture is selected) but a's suite fails unconditionally, so mutation-proof refuses at its
-  //    baseline (exit 4). That is the suite's own defect, not this diff's — the #1279/sandbox-guard
-  //    shape the reviewer reproduced. The gate must report it as PRE-RED, name exactly that fixture,
-  //    and NOT fail: collapsing pre-red into a blocker is a false blocker.
+  // 6. A configured suite changed by this diff becomes red before mutation. The SAME command is green
+  //    at base and red at head, so the transition — not the selected path — attributes the failure.
   {
     const { root, base, head } = build((r) => {
       writeFileSync(join(r, "a.suite.mjs"), [
@@ -279,30 +300,679 @@ try {
         "process.exit(1);",
         "",
       ].join("\n"));
-      writeFileSync(join(r, "a.mjs"), [
-        "export function capped_a(input) {",
-        "  const normalized = input; // touched so a's fixture is selected",
-        "  return Math.min(normalized, 32);",
-        "}",
-        "",
-      ].join("\n"));
-      git(r, ["add", "a.mjs", "a.suite.mjs"]);
-      git(r, ["commit", "--quiet", "-m", "a's suite goes red before mutation"]);
+      git(r, ["add", "a.suite.mjs"]);
+      git(r, ["commit", "--quiet", "-m", "a's suite goes red"]);
     });
     const { status, out } = scan(root, base, head);
     check(
-      "a pre-red selected fixture is reported as PRE-RED, names exactly that fixture, and does NOT fail the gate",
-      status === 0 && eq(preRedPaths(out), ["smoke/mutations/a.mutations.json"]) && offenderPaths(out).length === 0,
-      `status=${status} preRed=${JSON.stringify(preRedPaths(out))} offenders=${JSON.stringify(offenderPaths(out))}\n${out}`,
-    );
-    check(
-      "an all-pre-red run is machine-distinguishable from a real all-clear in its summary counts",
-      JSON.stringify(okCounts(out)) === JSON.stringify({ discriminated: 0, preRed: 1, inconclusive: 0 }),
-      `counts=${JSON.stringify(okCounts(out))}\n${out}`,
+      "a changed configured suite that becomes red FAILS and names exactly that fixture without selecting its sibling",
+      status === 1
+        && eq(selectedPaths(out), ["smoke/mutations/a.mutations.json"])
+        && eq(attributablePreRedPaths(out), ["smoke/mutations/a.mutations.json"])
+        && eq(offenderPaths(out), ["smoke/mutations/a.mutations.json"]),
+      `status=${status} selected=${JSON.stringify(selectedPaths(out))} attributable=${JSON.stringify(attributablePreRedPaths(out))} offenders=${JSON.stringify(offenderPaths(out))}\n${out}`,
     );
   }
 
-  // 7. INCONCLUSIVE (not a timeout — deterministic): a mutation that leaves the suite exiting 0 but
+  // 7. Deleting the configured suite selects its fixture through the deleted suite path. The proof's
+  //    missing-command baseline exits 4, which is still attributable to this diff and must fail.
+  {
+    const { root, base, head } = build((r) => {
+      git(r, ["rm", "--quiet", "a.suite.mjs"]);
+      git(r, ["commit", "--quiet", "-m", "delete a's configured suite"]);
+    });
+    const { status, out } = scan(root, base, head);
+    check(
+      "a deleted configured suite FAILS and names exactly that fixture",
+      status === 1
+        && eq(selectedPaths(out), ["smoke/mutations/a.mutations.json"])
+        && eq(attributablePreRedPaths(out), ["smoke/mutations/a.mutations.json"])
+        && eq(offenderPaths(out), ["smoke/mutations/a.mutations.json"])
+        && out.includes("smoke/mutations/a.mutations.json -> command: node a.suite.mjs")
+        && out.includes("base GREEN (exit 0) -> head RED (exit 1)"),
+      `status=${status} selected=${JSON.stringify(selectedPaths(out))} attributable=${JSON.stringify(attributablePreRedPaths(out))} offenders=${JSON.stringify(offenderPaths(out))}\n${out}`,
+    );
+  }
+
+  // 8. Renaming the configured suite away selects through the old path. Its missing-command baseline
+  //    is attributed to this diff just like deletion, while the untouched sibling stays unselected.
+  {
+    const { root, base, head } = build((r) => {
+      git(r, ["mv", "a.suite.mjs", "renamed.suite.mjs"]);
+      git(r, ["commit", "--quiet", "-m", "rename a's configured suite away"]);
+    });
+    const { status, out } = scan(root, base, head);
+    check(
+      "a renamed-away configured suite FAILS and names exactly that fixture",
+      status === 1
+        && eq(selectedPaths(out), ["smoke/mutations/a.mutations.json"])
+        && eq(attributablePreRedPaths(out), ["smoke/mutations/a.mutations.json"])
+        && eq(offenderPaths(out), ["smoke/mutations/a.mutations.json"])
+        && out.includes("smoke/mutations/a.mutations.json -> command: node a.suite.mjs")
+        && out.includes("base GREEN (exit 0) -> head RED (exit 1)"),
+      `status=${status} selected=${JSON.stringify(selectedPaths(out))} attributable=${JSON.stringify(attributablePreRedPaths(out))} offenders=${JSON.stringify(offenderPaths(out))}\n${out}`,
+    );
+  }
+
+  // 9. A suite that was already red at the base remains non-fatal when an unchanged guarded source is
+  //    the only reason its fixture was selected. This preserves the unrelated PRE-RED behavior.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "p.mjs"), "export const p = () => 1;\n");
+        writeFileSync(join(r, "p.suite.mjs"), "console.error('pre-existing red');\nprocess.exit(1);\n");
+        writeFileSync(join(r, "smoke", "mutations", "p.mutations.json"), JSON.stringify({
+          suite: "p.suite.mjs",
+          command: "node p.suite.mjs",
+          mutations: [{
+            name: "p returns two",
+            file: "p.mjs",
+            find: "export const p = () => 1;",
+            replace: "export const p = () => 2;",
+            expectRed: "p is one",
+          }],
+        }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "p.mjs"), "// guarded-source-only change\nexport const p = () => 1;\n"),
+    );
+    const { status, out } = scan(root, base, head);
+    check(
+      "an unchanged pre-red suite selected only by a guarded-source change remains nonfatal",
+      status === 0
+        && eq(selectedPaths(out), ["smoke/mutations/p.mutations.json"])
+        && eq(preRedPaths(out), ["smoke/mutations/p.mutations.json"])
+        && attributablePreRedPaths(out).length === 0
+        && JSON.stringify(okCounts(out)) === JSON.stringify({ discriminated: 0, preRed: 1, inconclusive: 0 }),
+      `status=${status} selected=${JSON.stringify(selectedPaths(out))} preRed=${JSON.stringify(preRedPaths(out))} attributable=${JSON.stringify(attributablePreRedPaths(out))} counts=${JSON.stringify(okCounts(out))}\n${out}`,
+    );
+  }
+
+  // 10. The blocked-head regression. The fixture declares GREEN suite A and a comment-only edit
+  //     selects it, but the FIRST refusing command is an untouched suite B that was already red at
+  //     base. Re-running THAT SAME command proves RED -> RED, so the result is inherited/nonfatal.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "a.mjs"), "export const a = () => 1;\n");
+        writeFileSync(join(r, "a.suite.mjs"), "import { a } from './a.mjs';\nif (a() !== 1) process.exit(1);\nconsole.log('✓ a is one');\n");
+        writeFileSync(join(r, "b.mjs"), "export const b = () => 1;\n");
+        writeFileSync(join(r, "b.suite.mjs"), "console.error('pre-existing B red');\nprocess.exit(1);\n");
+        writeFileSync(join(r, "smoke", "mutations", "a.mutations.json"), JSON.stringify({
+          suite: "a.suite.mjs",
+          command: "node a.suite.mjs",
+          mutations: [{
+            name: "a returns two", file: "a.mjs", find: "export const a = () => 1;",
+            replace: "export const a = () => 2;", expectRed: "a is one",
+          }, {
+            name: "b returns two", file: "b.mjs", find: "export const b = () => 1;",
+            replace: "export const b = () => 2;", command: "node b.suite.mjs", expectRed: "B red",
+          }],
+        }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "a.suite.mjs"), "// comment-only edit; A remains green\nimport { a } from './a.mjs';\nif (a() !== 1) process.exit(1);\nconsole.log('✓ a is one');\n"),
+    );
+    const { status, out } = scan(root, base, head);
+    check(
+      "an untouched already-red per-mutation command stays nonfatal when only the declared GREEN suite changed",
+      status === 0
+        && eq(preRedPaths(out), ["smoke/mutations/a.mutations.json"])
+        && attributablePreRedPaths(out).length === 0
+        && !out.includes("suite: a.suite.mjs"),
+      `status=${status} preRed=${JSON.stringify(preRedPaths(out))} attributable=${JSON.stringify(attributablePreRedPaths(out))}\n${out}`,
+    );
+    check(
+      "the inherited transition names the command that actually refused, never the healthy declared suite",
+      out.includes("command: node b.suite.mjs")
+        && out.includes("base RED (exit 1) -> head RED (exit 1)")
+        && !out.includes("command: node a.suite.mjs; transition:"),
+      out,
+    );
+  }
+
+  // 11. Production-shaped base preparation. The command imports a package's built dist, while the
+  //     committed base contains source only. Head is installed/built before the scan just like CI;
+  //     the disposable base starts unbuilt. Its own frozen install + full build makes the inherited
+  //     RED -> RED command comparable instead of failing infrastructure with MODULE_NOT_FOUND.
+  {
+    const { root, base } = makeSingle(
+      (r) => {
+        mkdirSync(join(r, "packages", "built-lib", "src"), { recursive: true });
+        mkdirSync(join(r, "packages", "fake-tsx"), { recursive: true });
+        writeFileSync(join(r, "package.json"), JSON.stringify({
+          private: true,
+          scripts: { build: "pnpm --filter built-lib build", red: "tsx built.suite.mjs" },
+          dependencies: { "built-lib": "workspace:*" },
+          devDependencies: { "fake-tsx": "workspace:*" },
+        }, null, 2));
+        writeFileSync(join(r, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n");
+        writeFileSync(join(r, "packages", "built-lib", "package.json"), JSON.stringify({
+          name: "built-lib", type: "module", exports: "./dist/index.mjs",
+          scripts: { build: "node -e \"require('node:fs').mkdirSync('dist',{recursive:true});require('node:fs').copyFileSync('src/index.mjs','dist/index.mjs')\"" },
+        }, null, 2));
+        writeFileSync(join(r, "packages", "built-lib", "src", "index.mjs"), "export const value = 1;\n");
+        writeFileSync(join(r, "packages", "fake-tsx", "package.json"), JSON.stringify({
+          name: "fake-tsx", bin: { tsx: "./tsx.mjs" }, type: "module",
+        }, null, 2));
+        writeFileSync(join(r, "packages", "fake-tsx", "tsx.mjs"), "#!/usr/bin/env node\nawait import(new URL('../../' + process.argv[2], import.meta.url));\n");
+        execFileSync("chmod", ["+x", join(r, "packages", "fake-tsx", "tsx.mjs")]);
+        writeFileSync(join(r, "built.mjs"), "export const guarded = 1;\n");
+        writeFileSync(join(r, "built.suite.mjs"), "import 'built-lib';\nconsole.error('dist-backed inherited red');\nprocess.exit(1);\n");
+        writeFileSync(join(r, "smoke", "mutations", "built.mutations.json"), JSON.stringify({
+          suite: "built.suite.mjs", command: "pnpm red", mutations: [{
+            name: "guarded changes", file: "built.mjs", find: "export const guarded = 1;",
+            replace: "export const guarded = 2;", expectRed: "dist-backed inherited red",
+          }],
+        }, null, 2));
+        execFileSync("pnpm", ["install", "--lockfile-only"], { cwd: r, stdio: "ignore" });
+      },
+      (r) => writeFileSync(join(r, "built.mjs"), "// select fixture\nexport const guarded = 1;\n"),
+    );
+    writeFileSync(join(root, ".gitignore"), "node_modules/\ndist/\npackages/*/dist/\n");
+    git(root, ["add", ".gitignore"]);
+    git(root, ["commit", "--quiet", "--amend", "--no-edit"]);
+    execFileSync("pnpm", ["install", "--lockfile-only"], { cwd: root, stdio: "ignore" });
+    git(root, ["add", "pnpm-lock.yaml"]);
+    git(root, ["commit", "--quiet", "--amend", "--no-edit"]);
+    const installedHead = git(root, ["rev-parse", "HEAD"]);
+    execFileSync("pnpm", ["install", "--frozen-lockfile"], { cwd: root, stdio: "ignore" });
+    execFileSync("pnpm", ["build"], { cwd: root, stdio: "ignore" });
+    const { status, out } = scan(root, base, installedHead);
+    check(
+      "a dist-backed inherited red command is comparable after the disposable base performs its own install and build",
+      status === 0
+        && eq(preRedPaths(out), ["smoke/mutations/built.mutations.json"])
+        && !/ERR_MODULE_NOT_FOUND|MODULE_NOT_FOUND/.test(out),
+      `status=${status} preRed=${JSON.stringify(preRedPaths(out))}\n${out}`,
+    );
+  }
+
+  // 12. An inherited red command running first must not hide a later attributable red command. The
+  //     reverse-order control proves classification is set-based rather than first-command based.
+  for (const reverse of [false, true]) {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "inherited.mjs"), "export const inherited = 1;\n");
+        writeFileSync(join(r, "inherited.suite.mjs"), "console.error('inherited command red');\nprocess.exit(1);\n");
+        writeFileSync(join(r, "caused.mjs"), "export const caused = 1;\n");
+        writeFileSync(join(r, "caused.suite.mjs"), "console.log('caused command green');\n");
+        const inheritedMutation = {
+          name: "inherited changes", file: "inherited.mjs", find: "export const inherited = 1;",
+          replace: "export const inherited = 2;", command: "node inherited.suite.mjs", expectRed: "inherited command red",
+        };
+        const causedMutation = {
+          name: "caused changes", file: "caused.mjs", find: "export const caused = 1;",
+          replace: "export const caused = 2;", command: "node caused.suite.mjs", expectRed: "caused command red",
+        };
+        writeFileSync(join(r, "smoke", "mutations", "order.mutations.json"), JSON.stringify({
+          suite: "caused.suite.mjs", command: "node inherited.suite.mjs",
+          mutations: reverse ? [causedMutation, inheritedMutation] : [inheritedMutation, causedMutation],
+        }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "caused.suite.mjs"), "console.error('caused command red');\nprocess.exit(1);\n"),
+    );
+    const { status, out } = scan(root, base, head);
+    check(
+      reverse
+        ? "reversing command order still reports the later inherited and attributable transitions without clearing"
+        : "an inherited first command cannot hide a later attributable command",
+      status === 1
+        && eq(attributablePreRedPaths(out), ["smoke/mutations/order.mutations.json"])
+        && eq(preRedPaths(out), ["smoke/mutations/order.mutations.json"])
+        && out.includes("command: node caused.suite.mjs; transition: base GREEN (exit 0) -> head RED (exit 1)")
+        && out.includes("command: node inherited.suite.mjs; transition: base RED (exit 1) -> head RED (exit 1)"),
+      `reverse=${reverse} status=${status}\n${out}`,
+    );
+  }
+
+  // 14. Snapshot commands must not inherit head-only PATH/NODE_PATH entries. Keep the external pnpm
+  //     and nats-server toolchain while refusing an executable that exists only under root.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, ".gitignore"), "node_modules/\n");
+        writeFileSync(join(r, "sentinel.mjs"), "export const sentinel = 1;\n");
+        writeFileSync(join(r, "sentinel.suite.mjs"), [
+          "import { spawnSync } from 'node:child_process';",
+          "const leaked = spawnSync('cotal-head-sentinel', { shell: true, encoding: 'utf8' });",
+          "if (leaked.status === 0) { console.error('HEAD_SENTINEL_REACHED'); process.exit(1); }",
+          "if (spawnSync('pnpm', ['--version']).status !== 0) { console.error('pnpm missing'); process.exit(1); }",
+          "if (spawnSync('nats-server', ['--version']).status !== 0) { console.error('nats-server missing'); process.exit(1); }",
+          "console.error('snapshot environment red'); process.exit(1);",
+          "",
+        ].join("\n"));
+        writeFileSync(join(r, "smoke", "mutations", "sentinel.mutations.json"), JSON.stringify({
+          suite: "sentinel.suite.mjs", command: "node sentinel.suite.mjs", mutations: [{
+            name: "sentinel changes", file: "sentinel.mjs", find: "export const sentinel = 1;",
+            replace: "export const sentinel = 2;", expectRed: "snapshot environment red",
+          }],
+        }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "sentinel.mjs"), "// select\nexport const sentinel = 1;\n"),
+    );
+    const headBin = join(root, "node_modules", ".bin");
+    mkdirSync(headBin, { recursive: true });
+    writeFileSync(join(headBin, "cotal-head-sentinel"), "#!/bin/sh\necho HEAD_SENTINEL_REACHED\n");
+    execFileSync("chmod", ["+x", join(headBin, "cotal-head-sentinel")]);
+    const toolBin = mkdtempSync(join(tmpdir(), "mutation-reproof-tools-")); repos.push(toolBin);
+    writeFileSync(join(toolBin, "nats-server"), "#!/bin/sh\necho nats-server-test\n");
+    execFileSync("chmod", ["+x", join(toolBin, "nats-server")]);
+    const contaminatedEnv = cleanAmbientEnv();
+    const { status, out } = scan(root, base, head, {
+      ...contaminatedEnv, PATH: `${headBin}:${toolBin}:${contaminatedEnv.PATH}`,
+      NODE_PATH: `${join(root, "node_modules")}:${contaminatedEnv.NODE_PATH ?? ""}`,
+    });
+    check(
+      "prepared snapshots scrub head-only PATH and NODE_PATH entries while preserving pnpm and nats-server",
+      status === 0 && !out.includes("HEAD_SENTINEL_REACHED") && !out.includes("pnpm missing") && !out.includes("nats-server missing"),
+      `status=${status}\n${out}`,
+    );
+  }
+
+  // 15. A genuinely broken frozen install stays UNMEASURED and fatal.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "package.json"), JSON.stringify({ private: true, scripts: { build: "node -e \"\"" }, dependencies: { absent: "1.0.0" } }, null, 2));
+        writeFileSync(join(r, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\nsettings: { autoInstallPeers: true, excludeLinksFromLockfile: false }\nimporters:\n  .:\n    dependencies:\n      absent:\n        specifier: 1.0.0\n        version: 1.0.0\npackages: {}\nsnapshots: {}\n");
+        writeFileSync(join(r, "broken.mjs"), "export const broken = 1;\n");
+        writeFileSync(join(r, "broken.suite.mjs"), "console.error('broken install red'); process.exit(1);\n");
+        writeFileSync(join(r, "smoke", "mutations", "broken.mutations.json"), JSON.stringify({ suite: "broken.suite.mjs", command: "node broken.suite.mjs", mutations: [{ name: "broken", file: "broken.mjs", find: "export const broken = 1;", replace: "export const broken = 2;", expectRed: "broken install red" }] }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "broken.mjs"), "// select\nexport const broken = 1;\n"),
+    );
+    const { status, out } = scan(root, base, head);
+    check("a genuine snapshot install failure is UNMEASURED and fatal", status === 1 && out.includes("dependency install failed") && !out.includes("MUTATION REPROOF OK"), `status=${status}\n${out}`);
+  }
+
+  // 16. The root can be red from ignored execution state while both committed snapshots are green.
+  //     That is contamination, never an attributable diff transition.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, ".gitignore"), "poison/\n");
+        writeFileSync(join(r, "poison.mjs"), "export const poison = 1;\n");
+        writeFileSync(join(r, "poison.suite.mjs"), "import { existsSync } from 'node:fs';\nif (existsSync('poison/root-only')) { console.error('root poison red'); process.exit(1); }\nconsole.log('clean snapshot green');\n");
+        writeFileSync(join(r, "smoke", "mutations", "poison.mutations.json"), JSON.stringify({ suite: "poison.suite.mjs", command: "node poison.suite.mjs", mutations: [{ name: "poison", file: "poison.mjs", find: "export const poison = 1;", replace: "export const poison = 2;", expectRed: "root poison red" }] }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "poison.mjs"), "// select\nexport const poison = 1;\n"),
+    );
+    mkdirSync(join(root, "poison"), { recursive: true }); writeFileSync(join(root, "poison", "root-only"), "poison\n");
+    const { status, out } = scan(root, base, head);
+    check("root-only poisoned execution state is UNMEASURED, never attributed to the diff", status === 1 && out.includes("execution-state contamination") && attributablePreRedPaths(out).length === 0, `status=${status}\n${out}`);
+  }
+
+  // 17. Symmetric sequence needs observable cross-command state. Green command A writes a marker;
+  //     red command B reports whether it saw it. Both snapshots must run A before comparing B.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, ".gitignore"), "state-marker\n");
+        writeFileSync(join(r, "state.mjs"), "export const state = 1;\n");
+        writeFileSync(join(r, "write-marker.mjs"), "import { writeFileSync } from 'node:fs'; writeFileSync('state-marker','yes'); console.log('marker written');\n");
+        writeFileSync(join(r, "read-marker.mjs"), "import { existsSync } from 'node:fs'; console.error(existsSync('state-marker') ? 'B saw marker' : 'B saw NO marker'); process.exit(1);\n");
+        writeFileSync(join(r, "smoke", "mutations", "state.mutations.json"), JSON.stringify({ suite: "read-marker.mjs", command: "node write-marker.mjs", mutations: [{ name: "write", file: "state.mjs", find: "export const state = 1;", replace: "export const state = 2;", expectRed: "state" }, { name: "read", file: "state.mjs", find: "export const state = 1;", replace: "export const state = 3;", command: "node read-marker.mjs", allowMultiple: false, expectRed: "B saw marker" }] }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "state.mjs"), "// select\nexport const state = 1;\n"),
+    );
+    const { status, out } = scan(root, base, head);
+    check("head and base run every command in the same order before comparing stateful red output", status === 0 && out.includes("base RED (exit 1) -> head RED (exit 1)") && !out.includes("B saw NO marker"), `status=${status}\n${out}`);
+  }
+
+  // 18. Failure signatures retain first-party file/function origin, ignore line/column displacement,
+  //     and drop dependency loader frames. These are real Node transcripts, not hand-written stacks.
+  const stackRepo = (variant: "line" | "file" | "function" | "loader" | "semantic-number", caught = false): { root: string; base: string; head: string } => makeSingle(
+    (r) => {
+      writeFileSync(join(r, "stack.mjs"), "export const stack = 1;\n");
+      writeFileSync(join(r, "origin.mjs"), variant === "semantic-number"
+        ? "export function origin() { throw new Error('connect ECONNREFUSED 127.0.0.1:4222'); }\norigin();\n"
+        : "export function origin() { throw new Error('same stack message'); }\norigin();\n");
+      writeFileSync(join(r, "stack.suite.mjs"), caught
+        ? "try { await import('./origin.mjs'); } catch (error) { console.error(error.stack); process.exit(1); }\n"
+        : "import './origin.mjs';\n");
+      writeFileSync(join(r, "smoke", "mutations", "stack.mutations.json"), JSON.stringify({ suite: "stack.suite.mjs", command: "node stack.suite.mjs", mutations: [{ name: "stack", file: "stack.mjs", find: "export const stack = 1;", replace: "export const stack = 2;", expectRed: "same stack message" }] }, null, 2));
+    },
+    (r) => {
+      writeFileSync(join(r, "stack.mjs"), "// select\nexport const stack = 1;\n");
+      if (variant === "line") writeFileSync(join(r, "origin.mjs"), "\n\nexport function origin() { throw new Error('same stack message'); }\norigin();\n");
+      if (variant === "file") {
+        writeFileSync(join(r, "other.mjs"), "export function origin() { throw new Error('same stack message'); }\norigin();\n");
+        writeFileSync(join(r, "stack.suite.mjs"), caught
+          ? "try { await import('./other.mjs'); } catch (error) { console.error(error.stack); process.exit(1); }\n"
+          : "import './other.mjs';\n");
+      }
+      if (variant === "function") writeFileSync(join(r, "origin.mjs"), "export function differentOrigin() { throw new Error('same stack message'); }\ndifferentOrigin();\n");
+      if (variant === "loader") writeFileSync(join(r, "stack.mjs"), "// clone-local loader paths may differ\nexport const stack = 1;\n");
+      if (variant === "semantic-number") writeFileSync(join(r, "origin.mjs"), "export function origin() { throw new Error('connect ECONNREFUSED 127.0.0.1:4333'); }\norigin();\n");
+    },
+  );
+  {
+    const { root, base, head } = stackRepo("line"); const { status, out } = scan(root, base, head);
+    check("an uncaught throw shifted only by line and column remains inherited", status === 0 && eq(preRedPaths(out), ["smoke/mutations/stack.mutations.json"]), `status=${status}\n${out}`);
+  }
+  {
+    const { root, base, head } = stackRepo("file"); const { status, out } = scan(root, base, head);
+    check("the same error message from a different first-party file does not clear as inherited", status === 1 && unmeasuredPreRedPaths(out).length === 1, `status=${status}\n${out}`);
+  }
+  {
+    const { root, base, head } = stackRepo("function"); const { status, out } = scan(root, base, head);
+    check("the same error message from a different first-party function does not clear as inherited", status === 1 && unmeasuredPreRedPaths(out).length === 1, `status=${status}\n${out}`);
+  }
+  {
+    const { root, base, head } = stackRepo("line", true); const { status, out } = scan(root, base, head);
+    check("a caught throw shifted only by line and column remains inherited", status === 0 && eq(preRedPaths(out), ["smoke/mutations/stack.mutations.json"]), `status=${status}\n${out}`);
+  }
+  {
+    const { root, base, head } = stackRepo("file", true); const { status, out } = scan(root, base, head);
+    // This caught await-import transcript and E-prime below are the only guards for parsing
+    // `at async <path>` as an origin; without them every async frame can disappear silently.
+    check("a caught error stack from a different first-party file does not clear as inherited", status === 1 && unmeasuredPreRedPaths(out).length === 1, `status=${status}\n${out}`);
+  }
+  {
+    const { root, base, head } = stackRepo("function", true); const { status, out } = scan(root, base, head);
+    // This caught arm is the only guard for retaining function identity. The uncaught arm also
+    // differs in its source echo, so it stays green even if function names are discarded.
+    check("a caught error stack from a different first-party function does not clear as inherited", status === 1 && unmeasuredPreRedPaths(out).length === 1, `status=${status}\n${out}`);
+  }
+  {
+    const { root, base, head } = stackRepo("loader"); const { status, out } = scan(root, base, head);
+    check("clone-local dependency and loader frame differences do not change a first-party failure signature", status === 0 && eq(preRedPaths(out), ["smoke/mutations/stack.mutations.json"]), `status=${status}\n${out}`);
+  }
+  {
+    const { root, base, head } = stackRepo("semantic-number"); const { status, out } = scan(root, base, head);
+    check("uncaught semantic failure text ending in a colon-number remains attributable", status === 1 && unmeasuredPreRedPaths(out).length === 1, `status=${status}\n${out}`);
+  }
+  for (const errorClass of ["ECONNREFUSED", "ETIMEDOUT"]) {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "stack.mjs"), "export const stack = 1;\n");
+        writeFileSync(join(r, "caught.suite.mjs"), [
+          "console.error('not ok 1 - nats connect');",
+          `console.error('connect ${errorClass === "ETIMEDOUT" ? "ECONNREFUSED" : errorClass} 127.0.0.1:4222');`,
+          "console.error('    at connect (' + process.cwd() + '/packages/core/src/nats.ts:88:11)');",
+          "console.error('FAILED 1 of 1'); process.exit(1);",
+          "",
+        ].join("\n"));
+        writeFileSync(join(r, "smoke", "mutations", "caught.mutations.json"), JSON.stringify({ suite: "caught.suite.mjs", command: "node caught.suite.mjs", mutations: [{ name: "caught", file: "stack.mjs", find: "export const stack = 1;", replace: "export const stack = 2;", expectRed: "nats connect" }] }, null, 2));
+      },
+      (r) => {
+        writeFileSync(join(r, "stack.mjs"), "// select\nexport const stack = 1;\n");
+        const message = errorClass === "ETIMEDOUT" ? "connect ETIMEDOUT 127.0.0.1:4333" : "connect ECONNREFUSED 127.0.0.1:4333";
+        writeFileSync(join(r, "caught.suite.mjs"), [
+          "console.error('not ok 1 - nats connect');",
+          `console.error('${message}');`,
+          "console.error('    at connect (' + process.cwd() + '/packages/core/src/nats.ts:88:11)');",
+          "console.error('FAILED 1 of 1'); process.exit(1);",
+          "",
+        ].join("\n"));
+      },
+    );
+    const { status, out } = scan(root, base, head);
+    // The caught port arm is the only guard for preserving non-path text ending in `:number`.
+    // The uncaught and changed-class arms differ elsewhere even if this line is erased.
+    check(
+      errorClass === "ETIMEDOUT"
+        ? "caught semantic failure text preserves a changed error class ending in a colon-number"
+        : "caught semantic failure text preserves a changed port ending in a colon-number",
+      status === 1 && unmeasuredPreRedPaths(out).length === 1,
+      `status=${status}\n${out}`,
+    );
+  }
+
+  const externalOriginRepo = (kind: "frame" | "header", variant: "file" | "line"): { root: string; base: string; head: string } => makeSingle(
+    (r) => {
+      writeFileSync(join(r, "external.mjs"), "export const external = 1;\n");
+      const origin = kind === "frame" ? "    at work (/usr/lib/tool/foo.js:2:3)" : "/usr/lib/tool/foo.js:2";
+      writeFileSync(join(r, "external.suite.mjs"), `console.error('not ok 1 - external');\nconsole.error(${JSON.stringify(origin)});\nconsole.error('FAILED 1 of 1'); process.exit(1);\n`);
+      writeFileSync(join(r, "smoke", "mutations", "external.mutations.json"), JSON.stringify({ suite: "external.suite.mjs", command: "node external.suite.mjs", mutations: [{ name: "external", file: "external.mjs", find: "export const external = 1;", replace: "export const external = 2;", expectRed: "external" }] }, null, 2));
+    },
+    (r) => {
+      writeFileSync(join(r, "external.mjs"), "// select\nexport const external = 1;\n");
+      const origin = kind === "frame"
+        ? `    at work (/usr/lib/tool/${variant === "file" ? "bar.js:2:3" : "foo.js:10:30"})`
+        : `/usr/lib/tool/${variant === "file" ? "bar.js:2" : "foo.js:10"}`;
+      writeFileSync(join(r, "external.suite.mjs"), `console.error('not ok 1 - external');\nconsole.error(${JSON.stringify(origin)});\nconsole.error('FAILED 1 of 1'); process.exit(1);\n`);
+    },
+  );
+  for (const kind of ["frame", "header"] as const) {
+    const file = externalOriginRepo(kind, "file"); const fileRun = scan(file.root, file.base, file.head);
+    // P1a is one of only two guards, with P5b below, against erasing unrecognized origins.
+    // Without a DIFFER arm, dropping the carrier makes every MATCH arm pass for the wrong reason.
+    check(`a different external ${kind} file remains attributable`, fileRun.status === 1 && unmeasuredPreRedPaths(fileRun.out).length === 1, fileRun.out);
+    const line = externalOriginRepo(kind, "line"); const lineRun = scan(line.root, line.base, line.head);
+    check(`an external ${kind} line shift remains inherited`, lineRun.status === 0 && eq(preRedPaths(lineRun.out), ["smoke/mutations/external.mutations.json"]), lineRun.out);
+  }
+
+  const scratchOriginRepo = (variant: "same" | "file", symlinked = false): { root: string; base: string; head: string; env?: NodeJS.ProcessEnv } => {
+    let tempRoot = tmpdir();
+    if (symlinked) {
+      // This cell can only red when the classifier's temp-root anchors stop normalizing both emitted
+      // spellings to the same stable remainder. While both sides emit the raw spelling, any policy
+      // that normalizes that shared spelling identically is invisible here, including deleting the
+      // resolved entry as redundant. Emitting the resolved spelling on the head side is what makes
+      // deletion of the resolved entry observable.
+      const tempBase = mkdtempSync(join(tmpdir(), "mutation-reproof-temp-root-")); repos.push(tempBase);
+      const linkParent = mkdtempSync(join(tmpdir(), "mutation-reproof-temp-link-")); repos.push(linkParent);
+      tempRoot = join(linkParent, "linked");
+      symlinkSync(tempBase, tempRoot, "junction");
+    }
+    const headTempRoot = symlinked ? realpathSync(tempRoot) : tempRoot;
+    const result = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "scratch.mjs"), "export const scratch = 1;\n");
+        writeFileSync(join(r, "scratch.suite.mjs"), `console.error('not ok 1 - scratch');\nconsole.error('    at work (${tempRoot}/base-random/helper.mjs:2:3)');\nconsole.error('FAILED 1 of 1'); process.exit(1);\n`);
+        writeFileSync(join(r, "smoke", "mutations", "scratch.mutations.json"), JSON.stringify({ suite: "scratch.suite.mjs", command: "node scratch.suite.mjs", mutations: [{ name: "scratch", file: "scratch.mjs", find: "export const scratch = 1;", replace: "export const scratch = 2;", expectRed: "scratch" }] }, null, 2));
+      },
+      (r) => {
+        writeFileSync(join(r, "scratch.mjs"), "// select\nexport const scratch = 1;\n");
+        const file = variant === "file" ? "other.mjs" : "helper.mjs";
+        writeFileSync(join(r, "scratch.suite.mjs"), `console.error('not ok 1 - scratch');\nconsole.error('    at work (${headTempRoot}/head-random/${file}:10:30)');\nconsole.error('FAILED 1 of 1'); process.exit(1);\n`);
+      },
+    );
+    return { ...result, env: symlinked ? { ...cleanAmbientEnv(), TMPDIR: tempRoot } : undefined };
+  };
+  for (const symlinked of [false, true]) {
+    const same = scratchOriginRepo("same", symlinked); const sameRun = scan(same.root, same.base, same.head, same.env);
+    check(`${symlinked ? "raw and resolved temp spellings" : "per-run temp directories"} collapse the randomized segment`, sameRun.status === 0 && eq(preRedPaths(sameRun.out), ["smoke/mutations/scratch.mutations.json"]), sameRun.out);
+    const file = scratchOriginRepo("file", symlinked); const fileRun = scan(file.root, file.base, file.head, file.env);
+    // P5b is the other sole guard, with P1a above, against erasing external origins entirely.
+    check(`a different file within ${symlinked ? "a symlinked temp root" : "per-run temp directories"} remains attributable`, fileRun.status === 1 && unmeasuredPreRedPaths(fileRun.out).length === 1, fileRun.out);
+  }
+
+  {
+    const externalRoot = mkdtempSync(join(tmpdir(), "mutation-reproof-contamination-")); repos.push(externalRoot);
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "contamination.mjs"), "export const contamination = 1;\n");
+        writeFileSync(join(r, "contamination.suite.mjs"), `console.error('not ok 1 - contamination');\nconsole.error('    at work (${externalRoot}/origin.mjs:2:3)');\nconsole.error('FAILED 1 of 1'); process.exit(1);\n`);
+        writeFileSync(join(r, "smoke", "mutations", "contamination.mutations.json"), JSON.stringify({ suite: "contamination.suite.mjs", command: "node contamination.suite.mjs", mutations: [{ name: "contamination", file: "contamination.mjs", find: "export const contamination = 1;", replace: "export const contamination = 2;", expectRed: "contamination" }] }, null, 2));
+      },
+      (r) => {
+        writeFileSync(join(r, "contamination.mjs"), "// select\nexport const contamination = 1;\n");
+        writeFileSync(join(r, "contamination.suite.mjs"), "console.error('not ok 1 - contamination');\nconsole.error('    at work (' + process.cwd() + '/origin.mjs:2:3)');\nconsole.error('FAILED 1 of 1'); process.exit(1);\n");
+      },
+    );
+    const { status, out } = scan(root, base, head);
+    check("a cross-snapshot external origin is not laundered into a matching repository origin", status === 1 && unmeasuredPreRedPaths(out).length === 1, out);
+  }
+
+  // A dependency-origin header is volatile store layout, just like a dependency frame. Both layouts
+  // are tracked here so the clean snapshots execute real Node throws from different `.pnpm` paths.
+  // This cell is the sole guard for dependency-origin dropping and for repository classification
+  // preceding temp-root collapse; it also shares sole async-frame coverage with the caught cell above.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "dep.mjs"), "export const suffix = 'base';\n");
+        writeFileSync(join(r, "caller.mjs"), "import { suffix } from './dep.mjs';\nawait import(`./.pnpm/pkg@${suffix}/pkg/throw.mjs`);\n");
+        for (const suffix of ["base", "peer"]) {
+          mkdirSync(join(r, ".pnpm", `pkg@${suffix}`, "pkg"), { recursive: true });
+          writeFileSync(join(r, ".pnpm", `pkg@${suffix}`, "pkg", "throw.mjs"), "throw new Error('dependency-origin red');\n");
+        }
+        writeFileSync(join(r, "smoke", "mutations", "dep.mutations.json"), JSON.stringify({ suite: "caller.mjs", command: "node caller.mjs", mutations: [{ name: "dep", file: "dep.mjs", find: "export const suffix = 'peer';", replace: "export const suffix = 'mutant';", expectRed: "dependency-origin red" }] }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "dep.mjs"), "export const suffix = 'peer';\n"),
+    );
+    const { status, out } = scan(root, base, head);
+    check("dependency-origin source headers with divergent .pnpm layouts remain inherited", status === 0 && eq(preRedPaths(out), ["smoke/mutations/dep.mutations.json"]), `status=${status}\n${out}`);
+  }
+
+  // 22. A fixture and red command introduced only at head have no runnable base command. That is not
+  //     evidence of inherited red; the transition is UNMEASURED and must fail loud, never clear.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => writeFileSync(join(r, "placeholder"), "base\n"),
+      (r) => {
+        writeFileSync(join(r, "new.mjs"), "export const value = 1;\n");
+        writeFileSync(join(r, "new.suite.mjs"), "console.error('new suite red');\nprocess.exit(1);\n");
+        writeFileSync(join(r, "smoke", "mutations", "new.mutations.json"), JSON.stringify({
+          suite: "new.suite.mjs", command: "node new.suite.mjs", mutations: [{
+            name: "new value changes", file: "new.mjs", find: "export const value = 1;",
+            replace: "export const value = 2;", expectRed: "new suite red",
+          }],
+        }, null, 2));
+      },
+    );
+    const { status, out } = scan(root, base, head);
+    check(
+      "a head-only red command with no runnable base comparison FAILS loud and is never cleared",
+      status === 1
+        && eq(unmeasuredPreRedPaths(out), ["smoke/mutations/new.mutations.json"])
+        && !out.includes("MUTATION REPROOF OK")
+        && out.includes("command: node new.suite.mjs"),
+      `status=${status} unmeasured=${JSON.stringify(unmeasuredPreRedPaths(out))}\n${out}`,
+    );
+  }
+
+  // 15. Under --all there is no base comparison. Even a head-red command remains ordinary nonfatal
+  //     PRE-RED, with no attribution heading or transition claim.
+  {
+    const { root } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "all.mjs"), "export const all = 1;\n");
+        writeFileSync(join(r, "all.suite.mjs"), "console.error('all sweep red');\nprocess.exit(1);\n");
+        writeFileSync(join(r, "smoke", "mutations", "all.mutations.json"), JSON.stringify({
+          suite: "all.suite.mjs", command: "node all.suite.mjs", mutations: [{
+            name: "all changes", file: "all.mjs", find: "export const all = 1;",
+            replace: "export const all = 2;", expectRed: "all sweep red",
+          }],
+        }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "head-note"), "head\n"),
+    );
+    const { status, out } = scanAll(root);
+    check(
+      "--all keeps every pre-red nonfatal because no base transition can be measured",
+      status === 0
+        && eq(preRedPaths(out), ["smoke/mutations/all.mutations.json"])
+        && attributablePreRedPaths(out).length === 0
+        && unmeasuredPreRedPaths(out).length === 0,
+      `status=${status} preRed=${JSON.stringify(preRedPaths(out))}\n${out}`,
+    );
+  }
+  {
+    const { root } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "ambient.mjs"), "export const ambient = 1;\n");
+        writeFileSync(join(r, "ambient.suite.mjs"), "const leaked = Object.keys(process.env).filter((key) => key.startsWith('COTAL_'));\nif (leaked.length) { console.error('COTAL ambient leaked: ' + leaked.join(',')); process.exit(2); }\nconsole.error('ambient clean red'); process.exit(1);\n");
+        writeFileSync(join(r, "smoke", "mutations", "ambient.mutations.json"), JSON.stringify({ suite: "ambient.suite.mjs", command: "node ambient.suite.mjs", mutations: [{ name: "ambient", file: "ambient.mjs", find: "export const ambient = 1;", replace: "export const ambient = 2;", expectRed: "ambient clean red" }] }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "head-note"), "head\n"),
+    );
+    const observer = mkdtempSync(join(tmpdir(), "mutation-reproof-observer-")); repos.push(observer);
+    const preload = join(observer, "observe.cjs");
+    writeFileSync(preload, "if (process.env.COTAL_MUTATION_REPROOF_SENTINEL) { console.error('COTAL_SCAN_PROCESS_LEAKED'); process.exit(97); }\n");
+    const previous = process.env.COTAL_MUTATION_REPROOF_SENTINEL;
+    const previousNodeOptions = process.env.NODE_OPTIONS;
+    process.env.COTAL_MUTATION_REPROOF_SENTINEL = "must-not-reach-scan-all";
+    process.env.NODE_OPTIONS = `${previousNodeOptions ?? ""} --require=${preload}`.trim();
+    const { status, out } = scanAll(root);
+    if (previous === undefined) delete process.env.COTAL_MUTATION_REPROOF_SENTINEL;
+    else process.env.COTAL_MUTATION_REPROOF_SENTINEL = previous;
+    if (previousNodeOptions === undefined) delete process.env.NODE_OPTIONS;
+    else process.env.NODE_OPTIONS = previousNodeOptions;
+    check("the --all scan child strips parent COTAL_ material through the shared ambient-env chokepoint", status === 0 && !out.includes("COTAL_SCAN_PROCESS_LEAKED") && !out.includes("COTAL ambient leaked"), `status=${status}\n${out}`);
+  }
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "proof-env.mjs"), "export const value = 1;\n");
+        writeFileSync(join(r, "proof-env.suite.mjs"), "import { value } from './proof-env.mjs';\nif (process.env.COTAL_MUTATION_REPROOF_SENTINEL) { console.error('mutation-proof child leaked COTAL ambient'); process.exit(1); }\nif (value === 2) { console.error('proof env mutation killed'); process.exit(1); }\n");
+        writeFileSync(join(r, "smoke", "mutations", "proof-env.mutations.json"), JSON.stringify({ suite: "proof-env.suite.mjs", command: "node proof-env.suite.mjs", mutations: [{ name: "proof env", file: "proof-env.mjs", find: "export const value = 1;", replace: "export const value = 2;", expectRed: "proof env mutation killed" }] }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "proof-env.mjs"), "// select\nexport const value = 1;\n"),
+    );
+    const { status, out } = scan(root, base, head, { ...cleanAmbientEnv(), COTAL_MUTATION_REPROOF_SENTINEL: "must-not-reach-proof-child" });
+    check(
+      "mutation-proof fixture children strip parent COTAL_ material before executing commands",
+      status === 0
+        && eq(selectedPaths(out), ["smoke/mutations/proof-env.mutations.json"])
+        && out.includes("proof env mutation killed")
+        && !out.includes("mutation-proof child leaked COTAL ambient"),
+      `status=${status}\n${out}`,
+    );
+  }
+
+  // 16. A regular fatal finding and an attributable PRE-RED in one invocation retain separate
+  //     headings and both fixture names. Exit 1 alone is not evidence here: the fatal arm makes both
+  //     old and new designs fail, so this cell specifically proves classification without masking.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "fatal.mjs"), "export const fatal = () => 1;\n");
+        writeFileSync(join(r, "fatal.suite.mjs"), "import { fatal } from './fatal.mjs';\nif (fatal() !== 1) process.exit(1);\nconsole.log('✓ fatal is one');\n");
+        writeFileSync(join(r, "red.mjs"), "export const red = () => 1;\n");
+        writeFileSync(join(r, "red.suite.mjs"), "import { red } from './red.mjs';\nif (red() !== 1) process.exit(1);\nconsole.log('✓ red is one');\n");
+        writeFileSync(join(r, "smoke", "mutations", "fatal.mutations.json"), JSON.stringify({
+          suite: "fatal.suite.mjs", command: "node fatal.suite.mjs", mutations: [{
+            name: "equivalent fatal mutant", file: "fatal.mjs", find: "export const fatal = () => 1;",
+            replace: "export const fatal = () => 1 + 0;", expectRed: "fatal is one",
+          }],
+        }, null, 2));
+        writeFileSync(join(r, "smoke", "mutations", "red.mutations.json"), JSON.stringify({
+          suite: "red.suite.mjs", command: "node red.suite.mjs", mutations: [{
+            name: "red returns two", file: "red.mjs", find: "export const red = () => 1;",
+            replace: "export const red = () => 2;", expectRed: "red is one",
+          }],
+        }, null, 2));
+      },
+      (r) => {
+        writeFileSync(join(r, "fatal.mjs"), "// select fatal fixture\nexport const fatal = () => 1;\n");
+        writeFileSync(join(r, "red.suite.mjs"), "console.error('red suite now fails');\nprocess.exit(1);\n");
+      },
+    );
+    const { status, out } = scan(root, base, head);
+    check(
+      "an ordinary fatal finding and attributable pre-red are both reported without masking either category",
+      status === 1
+        && /^MUTATION REPROOF FAILED /m.test(out)
+        && eq(attributablePreRedPaths(out), ["smoke/mutations/red.mutations.json"])
+        && out.includes("smoke/mutations/fatal.mutations.json")
+        && out.includes("smoke/mutations/red.mutations.json -> command: node red.suite.mjs"),
+      `status=${status} attributable=${JSON.stringify(attributablePreRedPaths(out))}\n${out}`,
+    );
+  }
+
+  // 17. A fixture-config-only change still selects and re-proves exactly that fixture.
+  {
+    const { root, base, head } = build((r) => {
+      const path = join(r, "smoke", "mutations", "a.mutations.json");
+      const config = JSON.parse(readFileSync(path, "utf8"));
+      config._note = "config-only change";
+      writeFileSync(path, JSON.stringify(config, null, 2));
+      git(r, ["add", "smoke/mutations/a.mutations.json"]);
+      git(r, ["commit", "--quiet", "-m", "change only a's fixture config"]);
+    });
+    const { status, out } = scan(root, base, head);
+    check(
+      "a config-only change selects exactly its fixture",
+      status === 0
+        && eq(selectedPaths(out), ["smoke/mutations/a.mutations.json"])
+        && JSON.stringify(okCounts(out)) === JSON.stringify({ discriminated: 1, preRed: 0, inconclusive: 0 }),
+      `status=${status} selected=${JSON.stringify(selectedPaths(out))} counts=${JSON.stringify(okCounts(out))}\n${out}`,
+    );
+  }
+
+  // 18. INCONCLUSIVE (not a timeout — deterministic): a mutation that leaves the suite exiting 0 but
   //    never printing its named assertion. mutation-proof grades that INCONCLUSIVE, "a green status
   //    is not a pass". The gate must report it as INCONCLUSIVE, not fail, and NOT collapse it into
   //    SURVIVED (false blocker) or KILLED (false clearance). This is the outcome the reviewer flagged
@@ -342,7 +1012,7 @@ try {
     );
   }
 
-  // 8. A real all-clear that reaches the OK summary (a fixture whose mutant is genuinely killed).
+  // 19. A real all-clear that reaches the OK summary (a fixture whose mutant is genuinely killed).
   //    Its counts must read `discriminated > 0, pre-red 0, inconclusive 0` — the positive contrast to
   //    cases 5 and 6, so "the gate worked and everything was clean" is not the same output as "every
   //    selected fixture was pre-red or inconclusive".

--- a/bin/smoke/mutation-reproof.smoke.ts
+++ b/bin/smoke/mutation-reproof.smoke.ts
@@ -78,6 +78,15 @@ const cleanAmbientEnv = (): NodeJS.ProcessEnv => {
   for (const key of Object.keys(env)) if (key.startsWith("COTAL_")) delete env[key];
   return env;
 };
+const networkSetupEnv = (): NodeJS.ProcessEnv => {
+  const env = cleanAmbientEnv();
+  delete env.pnpm_config_offline;
+  // The normalized parent also forces frozen-lockfile. Synthetic lockfile generation necessarily
+  // starts before that lockfile exists, so opt out for setup; an explicit --frozen-lockfile command
+  // below still supplies the verification policy at the command line.
+  env.pnpm_config_frozen_lockfile = "false";
+  return env;
+};
 
 const scan = (root: string, base: string, head: string, env = cleanAmbientEnv()): { status: number | null; out: string } => {
   const run = spawnSync(process.execPath, [SCAN, "--root", root, "--base", base, "--head", head], { encoding: "utf8", env });
@@ -463,18 +472,18 @@ try {
             replace: "export const guarded = 2;", expectRed: "dist-backed inherited red",
           }],
         }, null, 2));
-        execFileSync("pnpm", ["install", "--lockfile-only"], { cwd: r, stdio: "ignore" });
+        execFileSync("pnpm", ["install", "--lockfile-only"], { cwd: r, stdio: "ignore", env: networkSetupEnv() });
       },
       (r) => writeFileSync(join(r, "built.mjs"), "// select fixture\nexport const guarded = 1;\n"),
     );
     writeFileSync(join(root, ".gitignore"), "node_modules/\ndist/\npackages/*/dist/\n");
     git(root, ["add", ".gitignore"]);
     git(root, ["commit", "--quiet", "--amend", "--no-edit"]);
-    execFileSync("pnpm", ["install", "--lockfile-only"], { cwd: root, stdio: "ignore" });
+    execFileSync("pnpm", ["install", "--lockfile-only"], { cwd: root, stdio: "ignore", env: networkSetupEnv() });
     git(root, ["add", "pnpm-lock.yaml"]);
     git(root, ["commit", "--quiet", "--amend", "--no-edit"]);
     const installedHead = git(root, ["rev-parse", "HEAD"]);
-    execFileSync("pnpm", ["install", "--frozen-lockfile"], { cwd: root, stdio: "ignore" });
+    execFileSync("pnpm", ["install", "--frozen-lockfile"], { cwd: root, stdio: "ignore", env: networkSetupEnv() });
     execFileSync("pnpm", ["build"], { cwd: root, stdio: "ignore" });
     const { status, out } = scan(root, base, installedHead);
     check(
@@ -1057,6 +1066,206 @@ try {
         && offenderPaths(out).length === 0
         && JSON.stringify(okCounts(out)) === JSON.stringify({ discriminated: 1, preRed: 0, inconclusive: 0 }),
       `status=${status} offenders=${JSON.stringify(offenderPaths(out))} counts=${JSON.stringify(okCounts(out))}\n${out}`,
+    );
+  }
+
+  // 20. Exact refused provenance, not merely the status: root fails X while both independently
+  //     committed snapshots fail Y with the same exit code. This was the live false green at d2427c51.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, ".gitignore"), "root-only-marker\n");
+        writeFileSync(join(r, "xyy.mjs"), "export const value = 1;\n");
+        writeFileSync(join(r, "xyy.suite.mjs"), "import { existsSync } from 'node:fs';\nif (existsSync('root-only-marker')) console.error('root contamination failure X');\nelse console.error('clean snapshot failure Y');\nprocess.exit(1);\n");
+        writeFileSync(join(r, "smoke", "mutations", "xyy.mutations.json"), JSON.stringify({ suite: "xyy.suite.mjs", command: "node xyy.suite.mjs", mutations: [{ name: "xyy", file: "xyy.mjs", find: "export const value = 1;", replace: "export const value = 2;", expectRed: "clean snapshot failure Y" }] }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "xyy.mjs"), "// select\nexport const value = 1;\n"),
+    );
+    writeFileSync(join(root, "root-only-marker"), "root X\n");
+    const { status, out } = scan(root, base, head);
+    check(
+      "a different root refusal signature cannot clear as inherited merely because both snapshots are red with the same status",
+      status === 1
+        && eq(unmeasuredPreRedPaths(out), ["smoke/mutations/xyy.mutations.json"])
+        && out.includes("root execution-state contamination detected")
+        && !out.includes("MUTATION REPROOF OK"),
+      `status=${status}\n${out}`,
+    );
+  }
+
+  // 21. Snapshot-side COTAL_ normalization is independently guarded. Root-side normalization has
+  //     its own green-baseline cell above, where snapshots never run. The caller injects its own
+  //     sentinel so this MATCH arm cannot pass merely because the ambient runner happened to be clean.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "env-match.mjs"), "export const value = 1;\n");
+        writeFileSync(join(r, "env-match.suite.mjs"), "console.error(process.env.COTAL_MUTATION_REPROOF_SENTINEL ? 'snapshot inherited COTAL sentinel' : 'normalized env red'); process.exit(1);\n");
+        writeFileSync(join(r, "smoke", "mutations", "env-match.mutations.json"), JSON.stringify({ suite: "env-match.suite.mjs", command: "node env-match.suite.mjs", mutations: [{ name: "env match", file: "env-match.mjs", find: "export const value = 1;", replace: "export const value = 2;", expectRed: "normalized env red" }] }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "env-match.mjs"), "// select\nexport const value = 1;\n"),
+    );
+    const { status, out } = scan(root, base, head, { ...cleanAmbientEnv(), COTAL_MUTATION_REPROOF_SENTINEL: "opposite-host-value" });
+    check(
+      "clean snapshot commands strip injected parent COTAL_ material independently of the root proof child",
+      status === 0
+        && eq(preRedPaths(out), ["smoke/mutations/env-match.mutations.json"])
+        && !out.includes("snapshot inherited COTAL sentinel"),
+      `status=${status}\n${out}`,
+    );
+  }
+
+  // 22. SOLE GUARD for classification ordering. An unavailable command has matching status and text
+  //     at both endpoints, so the unmeasurable call AND return must precede signature comparison.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "unavailable.mjs"), "export const value = 1;\n");
+        writeFileSync(join(r, "smoke", "mutations", "unavailable.mutations.json"), JSON.stringify({ command: "definitely-not-a-real-binary-1344 unavailable.suite.mjs", mutations: [{ name: "unavailable", file: "unavailable.mjs", find: "export const value = 1;", replace: "export const value = 2;", expectRed: "unavailable" }] }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "unavailable.mjs"), "// select\nexport const value = 1;\n"),
+    );
+    const { status, out } = scan(root, base, head);
+    check(
+      "an unresolvable command is UNMEASURED with its unavailable reason and exits 1 before signature matching can clear it",
+      status === 1
+        && eq(unmeasuredPreRedPaths(out), ["smoke/mutations/unavailable.mutations.json"])
+        && out.includes("UNMEASURED (command was unavailable (exit 127))")
+        && !out.includes("MUTATION REPROOF OK"),
+      `status=${status}\n${out}`,
+    );
+  }
+
+  // 23. Provenance introduces a root-vs-clean-head pair. Root deliberately lacks node_modules while
+  //     snapshot preparation installs it. Pnpm's anchored environment warning must not alter the
+  //     stable signature, while semantic [WARN] text later in a suite line remains part of the verdict.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        mkdirSync(join(r, "vendor", "probe"), { recursive: true });
+        writeFileSync(join(r, "vendor", "probe", "package.json"), JSON.stringify({ name: "probe-dep", version: "1.0.0" }, null, 2));
+        // A committed lockfile makes frozen preparation satisfiable. The local dependency is
+        // deliberate: without a dependency, pnpm has no missing-node_modules environment to warn
+        // about and this cell would exercise the filter without guarding it.
+        writeFileSync(join(r, "package.json"), JSON.stringify({ private: true, scripts: { build: "node -e \"\"", red: "node stale.suite.mjs" }, dependencies: { "probe-dep": "file:vendor/probe" } }, null, 2));
+        writeFileSync(join(r, "stale.mjs"), "export const value = 1;\n");
+        writeFileSync(join(r, "stale.suite.mjs"), "console.error('not ok 1 - semantic [WARN] flag remains suite evidence'); process.exit(1);\n");
+        writeFileSync(join(r, "smoke", "mutations", "stale.mutations.json"), JSON.stringify({ suite: "stale.suite.mjs", command: "pnpm red", mutations: [{ name: "stale", file: "stale.mjs", find: "export const value = 1;", replace: "export const value = 2;", expectRed: "semantic [WARN] flag remains suite evidence" }] }, null, 2));
+        execFileSync("pnpm", ["install", "--lockfile-only"], { cwd: r, stdio: "ignore", env: networkSetupEnv() });
+      },
+      (r) => writeFileSync(join(r, "stale.mjs"), "// select\nexport const value = 1;\n"),
+    );
+    rmSync(join(root, "node_modules"), { recursive: true, force: true });
+    const { status, out } = scan(root, base, head);
+    check(
+      "a pinned root lacking node_modules matches the prepared clean-head verdict instead of false-blocking on pnpm's environment warning",
+      status === 0
+        && eq(preRedPaths(out), ["smoke/mutations/stale.mutations.json"])
+        && !out.includes("root execution-state contamination detected"),
+      `status=${status}\n${out}`,
+    );
+  }
+
+  // 24. Line-initial [WARN] can be suite verdict text. Root X and clean-head Y share the same stable
+  //     sibling lines, so dropping the warning token broadly recreates the exact-signature false green.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, ".gitignore"), "root-warn-marker\n");
+        writeFileSync(join(r, "warn-differ.mjs"), "export const value = 1;\n");
+        writeFileSync(join(r, "warn-differ.suite.mjs"), "import { existsSync } from 'node:fs';\nconsole.error(existsSync('root-warn-marker') ? '[WARN] semantic root X' : '[WARN] semantic snapshot Y');\nconsole.error('not ok 1 - same assertion');\nconsole.error('FAILED 1 of 1');\nprocess.exit(1);\n");
+        writeFileSync(join(r, "smoke", "mutations", "warn-differ.mutations.json"), JSON.stringify({ suite: "warn-differ.suite.mjs", command: "node warn-differ.suite.mjs", mutations: [{ name: "warn differ", file: "warn-differ.mjs", find: "export const value = 1;", replace: "export const value = 2;", expectRed: "same assertion" }] }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "warn-differ.mjs"), "// select\nexport const value = 1;\n"),
+    );
+    writeFileSync(join(root, "root-warn-marker"), "root warning\n");
+    const { status, out } = scan(root, base, head);
+    check(
+      "different line-initial semantic [WARN] failures remain different when stable sibling assertion lines match",
+      status === 1
+        && eq(unmeasuredPreRedPaths(out), ["smoke/mutations/warn-differ.mutations.json"])
+        && out.includes("root execution-state contamination detected"),
+      `status=${status}\n${out}`,
+    );
+  }
+
+  // 25. Root provenance can be infrastructure-only while both clean snapshots produce a measurable
+  //     suite failure. This independently guards the narrow rootContaminationReason seam rather than
+  //     relying on the snapshot-vs-snapshot unavailable-command ordering cell.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, ".gitignore"), "root-infra-marker\n");
+        writeFileSync(join(r, "root-infra.mjs"), "export const value = 1;\n");
+        // The root-only line is infrastructure to unmeasurableFailure and pnpm chrome to the stable
+        // signature. Removing the root classification therefore makes the otherwise identical
+        // measurable suite failure clear as inherited, isolating this seam from signature mismatch.
+        writeFileSync(join(r, "root-infra.suite.mjs"), "import { existsSync } from 'node:fs';\nif (existsSync('root-infra-marker')) console.error('pnpm Missing script root-only-infrastructure');\nconsole.error('measurable clean suite failure');\nprocess.exit(1);\n");
+        writeFileSync(join(r, "smoke", "mutations", "root-infra.mutations.json"), JSON.stringify({ suite: "root-infra.suite.mjs", command: "node root-infra.suite.mjs", mutations: [{ name: "root infra", file: "root-infra.mjs", find: "export const value = 1;", replace: "export const value = 2;", expectRed: "measurable clean suite failure" }] }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "root-infra.mjs"), "// select\nexport const value = 1;\n"),
+    );
+    writeFileSync(join(root, "root-infra-marker"), "root infrastructure\n");
+    const { status, out } = scan(root, base, head);
+    check(
+      "root-only infrastructure output is UNMEASURED even when clean head and base have a measurable inherited failure",
+      status === 1
+        && eq(unmeasuredPreRedPaths(out), ["smoke/mutations/root-infra.mutations.json"])
+        && out.includes("command could not run: Missing script")
+        && !out.includes("MUTATION REPROOF OK"),
+      `status=${status}\n${out}`,
+    );
+  }
+
+  // 26. Clean-head confirmation must run in the clean snapshot, not merely under a normalized env.
+  //     The first command refuses identically everywhere; mutation-proof stops there. A later command
+  //     is green in both snapshots but red only from ignored root cwd state. Reusing root makes that
+  //     later command falsely attributable, so this cell guards cwd isolation independently of PATH.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, ".gitignore"), "root-cwd-marker\n");
+        writeFileSync(join(r, "cwd-isolation.mjs"), "export const value = 1;\n");
+        writeFileSync(join(r, "inherited-red.suite.mjs"), "console.error('inherited first command red'); process.exit(1);\n");
+        writeFileSync(join(r, "root-cwd.suite.mjs"), "import { existsSync } from 'node:fs';\nif (existsSync('root-cwd-marker')) { console.error('root cwd leaked into head confirmation'); process.exit(1); }\nconsole.log('clean snapshot cwd');\n");
+        writeFileSync(join(r, "smoke", "mutations", "cwd-isolation.mutations.json"), JSON.stringify({ suite: "inherited-red.suite.mjs", command: "node inherited-red.suite.mjs", mutations: [{ name: "first", file: "cwd-isolation.mjs", find: "export const value = 1;", replace: "export const value = 2;", expectRed: "inherited first command red" }, { name: "later", file: "cwd-isolation.mjs", find: "export const value = 1;", replace: "export const value = 3;", command: "node root-cwd.suite.mjs", expectRed: "root cwd leaked into head confirmation" }] }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "cwd-isolation.mjs"), "// select\nexport const value = 1;\n"),
+    );
+    writeFileSync(join(root, "root-cwd-marker"), "ignored root state\n");
+    const { status, out } = scan(root, base, head);
+    check(
+      "clean-head command confirmation uses the snapshot cwd rather than ignored root execution state",
+      status === 0
+        && eq(preRedPaths(out), ["smoke/mutations/cwd-isolation.mutations.json"])
+        && attributablePreRedPaths(out).length === 0
+        && !out.includes("root cwd leaked into head confirmation"),
+      `status=${status}\n${out}`,
+    );
+  }
+
+  // 27. A file directly under the OS temp root has no randomized directory segment to erase. Preserve
+  //     its filename so root alpha and clean-head omega remain different even when sibling lines match.
+  {
+    const alpha = join(tmpdir(), "mutation-reproof-depth-zero-alpha.mjs");
+    const omega = join(tmpdir(), "mutation-reproof-depth-zero-omega.mjs");
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, ".gitignore"), "root-depth-zero-marker\n");
+        writeFileSync(join(r, "depth-zero.mjs"), "export const value = 1;\n");
+        writeFileSync(join(r, "depth-zero.suite.mjs"), `import { existsSync } from 'node:fs';\nconsole.error('Error: depth-zero origin');\nconsole.error('    at go (' + (existsSync('root-depth-zero-marker') ? ${JSON.stringify(alpha)} : ${JSON.stringify(omega)}) + ':2:3)');\nconsole.error('not ok 1 - same depth-zero assertion');\nprocess.exit(1);\n`);
+        writeFileSync(join(r, "smoke", "mutations", "depth-zero.mutations.json"), JSON.stringify({ suite: "depth-zero.suite.mjs", command: "node depth-zero.suite.mjs", mutations: [{ name: "depth zero", file: "depth-zero.mjs", find: "export const value = 1;", replace: "export const value = 2;", expectRed: "same depth-zero assertion" }] }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "depth-zero.mjs"), "// select\nexport const value = 1;\n"),
+    );
+    writeFileSync(join(root, "root-depth-zero-marker"), "root alpha\n");
+    const { status, out } = scan(root, base, head);
+    check(
+      "different depth-zero temp-root filenames remain different root and clean-head failure origins",
+      status === 1
+        && eq(unmeasuredPreRedPaths(out), ["smoke/mutations/depth-zero.mutations.json"])
+        && out.includes("root execution-state contamination detected"),
+      `status=${status}\n${out}`,
     );
   }
 } finally {

--- a/bin/smoke/mutations/mutation-reproof.json
+++ b/bin/smoke/mutations/mutation-reproof.json
@@ -24,8 +24,8 @@
     {
       "name": "a changed configured suite is ignored by changed-set selection",
       "file": "scripts/mutation-reproof.mjs",
-      "find": "  || (typeof suite === \"string\" && changed.has(suite))\n",
-      "replace": "",
+      "find": "    config: changed.has(fixture.path),\n    suite: typeof fixture.suite === \"string\" && changed.has(fixture.suite),\n    mutation: fixture.mutations.some((mutation) =>",
+      "replace": "    config: changed.has(fixture.path),\n    suite: false,\n    mutation: fixture.mutations.some((mutation) =>",
       "expectRed": "a suite-only change selects exactly the fixture that names that suite",
       "cell": "a suite-only change selects exactly the fixture that names that suite"
     },
@@ -40,10 +40,58 @@
     {
       "name": "a pre-red suite is blamed as a fatal finding instead of reported as its own state",
       "file": "scripts/mutation-reproof.mjs",
-      "find": "{ preRed.push(path); continue; }",
-      "replace": "{ fatal.push(path); continue; }",
-      "expectRed": "a pre-red selected fixture is reported as PRE-RED, names exactly that fixture, and does NOT fail the gate",
-      "cell": "a pre-red selected fixture is reported as PRE-RED, names exactly that fixture, and does NOT fail the gate"
+      "find": "      else if (transition.kind === \"inherited\") preRed.push(finding);",
+      "replace": "      else if (transition.kind === \"inherited\") fatal.push(path);",
+      "expectRed": "an unchanged pre-red suite selected only by a guarded-source change remains nonfatal",
+      "cell": "an unchanged pre-red suite selected only by a guarded-source change remains nonfatal"
+    },
+    {
+      "name": "pre-red attribution ignores the same command's base-to-head transition",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "      const transition = compareSnapshots(headRun, baseRun);\n      const finding = { path, command: fixtureCommand, headStatus: headRun.status, ...transition };\n      if (transition.kind === \"attributable\") attributablePreRed.push(finding);\n      else if (transition.kind === \"inherited\") preRed.push(finding);\n      else unmeasuredPreRed.push(finding);",
+      "replace": "      preRed.push({ path, command: fixtureCommand, headStatus: headRun.status, baseStatus: undefined });",
+      "expectRed": "a changed configured suite that becomes red FAILS and names exactly that fixture without selecting its sibling",
+      "cell": "a changed configured suite that becomes red FAILS and names exactly that fixture without selecting its sibling"
+    },
+    {
+      "name": "the disposable base skips its frozen install and full build before comparison",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "  const install = runCommand(\"pnpm install --frozen-lockfile\", snapshot.path, snapshotEnv(), { offline: false });\n  snapshot.preparationError = preparationFailure(`${label} dependency install`, install);\n  if (snapshot.preparationError) return;\n  const build = runCommand(\"pnpm build\", snapshot.path, snapshotEnv());\n  snapshot.preparationError = preparationFailure(`${label} build`, build);\n  if (!snapshot.preparationError) snapshot.prepared = true;",
+      "replace": "  snapshot.prepared = true;",
+      "expectRed": "a dist-backed inherited red command is comparable after the disposable base performs its own install and build",
+      "cell": "a dist-backed inherited red command is comparable after the disposable base performs its own install and build"
+    },
+    {
+      "name": "pre-red classification inspects only the first distinct fixture command",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "    const headRedCommands = commandMatrix.filter(({ headRun }) => headRun.status !== 0);",
+      "replace": "    const headRedCommands = commandMatrix.filter(({ headRun }) => headRun.status !== 0).slice(0, 1);",
+      "expectRed": "reversing command order still reports the later inherited and attributable transitions without clearing",
+      "cell": "reversing command order still reports the later inherited and attributable transitions without clearing"
+    },
+    {
+      "name": "pre-red head commands reuse the possibly poisoned root instead of the clean head snapshot",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "      const headRun = runCommand(fixtureCommand, snapshots.head.path, snapshotEnv());",
+      "replace": "      const headRun = runCommand(fixtureCommand, root);",
+      "expectRed": "prepared snapshots scrub head-only PATH and NODE_PATH entries while preserving pnpm and nats-server",
+      "cell": "prepared snapshots scrub head-only PATH and NODE_PATH entries while preserving pnpm and nats-server"
+    },
+    {
+      "name": "the base skips commands that are green in the head snapshot, breaking symmetric state evolution",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "      const baseRun = runCommand(fixtureCommand, snapshots.base.path, snapshotEnv());",
+      "replace": "      const baseRun = headRun.status === 0 ? headRun : runCommand(fixtureCommand, snapshots.base.path, snapshotEnv());",
+      "expectRed": "head and base run every command in the same order before comparing stateful red output",
+      "cell": "head and base run every command in the same order before comparing stateful red output"
+    },
+    {
+      "name": "first-party stack frames are dropped, so different error origins collapse to one signature",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "      const classified = classifyLocation(location);\n      if (classified.kind === \"origin\")\n        signature.push(paren ? `at ${paren[1]} (${classified.value})` : `at ${classified.value}`);\n      else if (classified.kind === \"verbatim\") signature.push(line);\n      continue;",
+      "replace": "      const classified = classifyLocation(location);\n      void classified;\n      continue;",
+      "expectRed": "a caught error stack from a different first-party file does not clear as inherited",
+      "cell": "a caught error stack from a different first-party file does not clear as inherited"
     },
     {
       "name": "verdict lines are matched without stripping ANSI colour, so every verdict reads as absent",

--- a/bin/smoke/mutations/mutation-reproof.json
+++ b/bin/smoke/mutations/mutation-reproof.json
@@ -48,15 +48,15 @@
     {
       "name": "pre-red attribution ignores the same command's base-to-head transition",
       "file": "scripts/mutation-reproof.mjs",
-      "find": "      const transition = compareSnapshots(headRun, baseRun);\n      const finding = { path, command: fixtureCommand, headStatus: headRun.status, ...transition };\n      if (transition.kind === \"attributable\") attributablePreRed.push(finding);\n      else if (transition.kind === \"inherited\") preRed.push(finding);\n      else unmeasuredPreRed.push(finding);",
-      "replace": "      preRed.push({ path, command: fixtureCommand, headStatus: headRun.status, baseStatus: undefined });",
+      "find": "      const transition = compareSnapshots(headRun, baseRun);",
+      "replace": "      const transition = { kind: \"inherited\", baseStatus: baseRun.status };",
       "expectRed": "a changed configured suite that becomes red FAILS and names exactly that fixture without selecting its sibling",
       "cell": "a changed configured suite that becomes red FAILS and names exactly that fixture without selecting its sibling"
     },
     {
       "name": "the disposable base skips its frozen install and full build before comparison",
       "file": "scripts/mutation-reproof.mjs",
-      "find": "  const install = runCommand(\"pnpm install --frozen-lockfile\", snapshot.path, snapshotEnv(), { offline: false });\n  snapshot.preparationError = preparationFailure(`${label} dependency install`, install);\n  if (snapshot.preparationError) return;\n  const build = runCommand(\"pnpm build\", snapshot.path, snapshotEnv());\n  snapshot.preparationError = preparationFailure(`${label} build`, build);\n  if (!snapshot.preparationError) snapshot.prepared = true;",
+      "find": "  const install = runCommand(\"pnpm install --frozen-lockfile\", snapshot.path, snapshotComparisonEnv({ offline: false }));\n  snapshot.preparationError = preparationFailure(`${label} dependency install`, install);\n  if (snapshot.preparationError) return;\n  const build = runCommand(\"pnpm build\", snapshot.path, snapshotComparisonEnv());\n  snapshot.preparationError = preparationFailure(`${label} build`, build);\n  if (!snapshot.preparationError) snapshot.prepared = true;",
       "replace": "  snapshot.prepared = true;",
       "expectRed": "a dist-backed inherited red command is comparable after the disposable base performs its own install and build",
       "cell": "a dist-backed inherited red command is comparable after the disposable base performs its own install and build"
@@ -72,22 +72,22 @@
     {
       "name": "pre-red head commands reuse the possibly poisoned root instead of the clean head snapshot",
       "file": "scripts/mutation-reproof.mjs",
-      "find": "      const headRun = runCommand(fixtureCommand, snapshots.head.path, snapshotEnv());",
-      "replace": "      const headRun = runCommand(fixtureCommand, root);",
-      "expectRed": "prepared snapshots scrub head-only PATH and NODE_PATH entries while preserving pnpm and nats-server",
-      "cell": "prepared snapshots scrub head-only PATH and NODE_PATH entries while preserving pnpm and nats-server"
+      "find": "      const headRun = runCommand(fixtureCommand, snapshots.head.path, snapshotComparisonEnv());",
+      "replace": "      const headRun = runCommand(fixtureCommand, root, rootComparisonEnv());",
+      "expectRed": "clean-head command confirmation uses the snapshot cwd rather than ignored root execution state",
+      "cell": "clean-head command confirmation uses the snapshot cwd rather than ignored root execution state"
     },
     {
       "name": "the base skips commands that are green in the head snapshot, breaking symmetric state evolution",
       "file": "scripts/mutation-reproof.mjs",
-      "find": "      const baseRun = runCommand(fixtureCommand, snapshots.base.path, snapshotEnv());",
-      "replace": "      const baseRun = headRun.status === 0 ? headRun : runCommand(fixtureCommand, snapshots.base.path, snapshotEnv());",
+      "find": "      const baseRun = runCommand(fixtureCommand, snapshots.base.path, snapshotComparisonEnv());",
+      "replace": "      const baseRun = headRun.status === 0 ? headRun : runCommand(fixtureCommand, snapshots.base.path, snapshotComparisonEnv());",
       "expectRed": "head and base run every command in the same order before comparing stateful red output",
       "cell": "head and base run every command in the same order before comparing stateful red output"
     },
     {
       "name": "first-party stack frames are dropped, so different error origins collapse to one signature",
-      "file": "scripts/mutation-reproof.mjs",
+      "file": "scripts/mutation-failure-signature.mjs",
       "find": "      const classified = classifyLocation(location);\n      if (classified.kind === \"origin\")\n        signature.push(paren ? `at ${paren[1]} (${classified.value})` : `at ${classified.value}`);\n      else if (classified.kind === \"verbatim\") signature.push(line);\n      continue;",
       "replace": "      const classified = classifyLocation(location);\n      void classified;\n      continue;",
       "expectRed": "a caught error stack from a different first-party file does not clear as inherited",
@@ -108,6 +108,62 @@
       "replace": "fatal.push(path);",
       "expectRed": "an INCONCLUSIVE proof is reported as INCONCLUSIVE, does NOT fail the gate, and is not treated as SURVIVED",
       "cell": "an INCONCLUSIVE proof is reported as INCONCLUSIVE, does NOT fail the gate, and is not treated as SURVIVED"
+    },
+    {
+      "name": "root contamination comparison checks only exit status and ignores the exact refused failure signature",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "  if (provenance.status !== cleanHeadRun.status || provenance.signatureHash === null\n      || cleanHash === undefined || provenance.signatureHash !== cleanHash) {",
+      "replace": "  if (provenance.status !== cleanHeadRun.status || provenance.signatureHash === null\n      || cleanHash === undefined) {",
+      "expectRed": "a different root refusal signature cannot clear as inherited merely because both snapshots are red with the same status",
+      "cell": "a different root refusal signature cannot clear as inherited merely because both snapshots are red with the same status"
+    },
+    {
+      "name": "root-side proof execution bypasses the comparison environment normalization",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "const rootComparisonEnv = () => comparisonEnv();",
+      "replace": "const rootComparisonEnv = () => ({ ...process.env });",
+      "expectRed": "mutation-proof fixture children strip parent COTAL_ material before executing commands",
+      "cell": "mutation-proof fixture children strip parent COTAL_ material before executing commands"
+    },
+    {
+      "name": "snapshot-side execution bypasses the comparison environment normalization",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "const snapshotComparisonEnv = (options) => comparisonEnv(options);",
+      "replace": "const snapshotComparisonEnv = () => ({ ...process.env });",
+      "expectRed": "clean snapshot commands strip injected parent COTAL_ material independently of the root proof child",
+      "cell": "clean snapshot commands strip injected parent COTAL_ material independently of the root proof child"
+    },
+    {
+      "name": "root provenance ignores its exact infrastructure classification and falls through to signature comparison",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "  const rootInfrastructureReason = provenance.unmeasurableReason;\n  if (rootInfrastructureReason) return rootInfrastructureReason;",
+      "replace": "  const rootInfrastructureReason = provenance.unmeasurableReason;\n  void rootInfrastructureReason;",
+      "expectRed": "root-only infrastructure output is UNMEASURED even when clean head and base have a measurable inherited failure",
+      "cell": "root-only infrastructure output is UNMEASURED even when clean head and base have a measurable inherited failure"
+    },
+    {
+      "name": "the exact pnpm missing-node_modules environment warning enters the stable signature again",
+      "file": "scripts/mutation-failure-signature.mjs",
+      "find": "    if (/^\\[WARN\\]\\s+Local package\\.json exists, but node_modules missing, did you mean to install\\?$/i.test(line)) continue;",
+      "replace": "    if (false && /^\\[WARN\\]\\s+Local package\\.json exists, but node_modules missing, did you mean to install\\?$/i.test(line)) continue;",
+      "expectRed": "a pinned root lacking node_modules matches the prepared clean-head verdict instead of false-blocking on pnpm's environment warning",
+      "cell": "a pinned root lacking node_modules matches the prepared clean-head verdict instead of false-blocking on pnpm's environment warning"
+    },
+    {
+      "name": "line-initial semantic WARN failures are broadly dropped again",
+      "file": "scripts/mutation-failure-signature.mjs",
+      "find": "    if (!line || /^(?:Node\\.js v|npm |pnpm |Scope:|Lockfile |Progress:|Packages:|Done in |\\[?ELIFECYCLE\\]?|Command failed)/i.test(line)) continue;",
+      "replace": "    if (!line || /^(?:Node\\.js v|npm |pnpm |Scope:|Lockfile |Progress:|Packages:|Done in |\\[?ELIFECYCLE\\]?|\\[WARN\\]|Command failed)/i.test(line)) continue;",
+      "expectRed": "different line-initial semantic [WARN] failures remain different when stable sibling assertion lines match",
+      "cell": "different line-initial semantic [WARN] failures remain different when stable sibling assertion lines match"
+    },
+    {
+      "name": "a depth-zero temp-root filename is erased as though it were a randomized directory",
+      "file": "scripts/mutation-failure-signature.mjs",
+      "find": "      return { kind: \"origin\", value: separator === -1 ? `<TMP>/${remainder}` : `<TMP>/${remainder.slice(separator + 1)}` };",
+      "replace": "      return { kind: \"origin\", value: separator === -1 ? \"<TMP>\" : `<TMP>/${remainder.slice(separator + 1)}` };",
+      "expectRed": "different depth-zero temp-root filenames remain different root and clean-head failure origins",
+      "cell": "different depth-zero temp-root filenames remain different root and clean-head failure origins"
     }
   ]
 }

--- a/packages/core/smoke/mutations/tool-list-announce.json
+++ b/packages/core/smoke/mutations/tool-list-announce.json
@@ -1,7 +1,7 @@
 {
   "suite": "packages/core/smoke/tool-list-announce.smoke.ts",
   "guard": "a connection-changing op branches on supportsToolListAnnounce, never on a connector name; undeclared is refuse, not a no-op; the refusal names no connector",
-  "command": "tsx packages/core/smoke/tool-list-announce.smoke.ts",
+  "command": "pnpm smoke:tool-list-announce",
   "proveWith": "node scripts/mutation-proof.mjs --config packages/core/smoke/mutations/tool-list-announce.json",
   "why": [
     "Issue #1004. The advertised tool list depends on the connection. Some hosts can announce",
@@ -18,7 +18,9 @@
     "NO connector name at all must redden. That is the ruling's own cell.",
     "",
     "NO BUILD STEP: the suite imports ../src, so the mutated source is the source it runs.",
-    "The command calls tsx directly so pnpm does not try to install in this worktree."
+    "The no-install concern is real and is now handled by mutation-proof forcing",
+    "pnpm_config_verify_deps_before_run=false: pnpm resolves tsx from each prepared cwd's own .bin",
+    "without installing into the mutation worktree."
   ],
   "mutations": [
     {

--- a/scripts/mutation-failure-signature.mjs
+++ b/scripts/mutation-failure-signature.mjs
@@ -1,0 +1,89 @@
+import { createHash } from "node:crypto";
+import { realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const ANSI = /\x1b\[[0-9;]*m/g;
+
+export function unmeasurableFailure(run) {
+  if (run.error) return `command could not start: ${run.error.message}`;
+  if (run.status === null || run.signal)
+    return `command did not produce an exit status${run.signal ? ` (signal ${run.signal})` : ""}`;
+  if (run.status === 126 || run.status === 127) return `command was unavailable (exit ${run.status})`;
+  const infrastructureFailure = /(?:ERR_MODULE_NOT_FOUND|MODULE_NOT_FOUND|Cannot find module|ERR_PNPM[A-Z0-9_]*|Missing script|command not found|\b[^:\s]+: not found\b|is not recognized as an internal or external command)/i
+    .exec(run.output);
+  if (infrastructureFailure) return `command could not run: ${infrastructureFailure[0]}`;
+  if (run.status !== 0 && run.output.trim() === "")
+    return "red command produced no output, so its verdict is ambiguous";
+  return undefined;
+}
+
+export function comparableFailure(output, cwd) {
+  const slash = (value) => value.replace(/\\/g, "/");
+  const projectRoot = slash(realpathSync(cwd)).replace(/\/$/, "");
+  const projectPrefix = `${projectRoot}/`;
+  const dependencyPath = /(?:^|[/\\])(?:node_modules|\.pnpm)(?:[/\\]|$)/;
+  const tempRoots = [...new Set([tmpdir(), realpathSync(tmpdir())]
+    .map((entry) => slash(entry).replace(/\/$/, "")))];
+  const classifyLocation = (location) => {
+    const withoutCoordinates = location.replace(/:\d+(?::\d+)?$/, "");
+    const fileUrl = withoutCoordinates.startsWith("file://");
+    let path = withoutCoordinates;
+    if (fileUrl) {
+      try { path = fileURLToPath(withoutCoordinates); }
+      catch { path = withoutCoordinates.slice(7); }
+    }
+    path = slash(path);
+    const pathShaped = fileUrl || path.startsWith("/") || /^[A-Za-z]:\//.test(path);
+    if (!pathShaped) return { kind: "verbatim" };
+    if (path === projectRoot || path.startsWith(projectPrefix)) {
+      if (dependencyPath.test(path)) return { kind: "drop" };
+      const relativePath = path === projectRoot ? "" : path.slice(projectPrefix.length);
+      return { kind: "origin", value: relativePath ? `<ROOT>/${relativePath}` : "<ROOT>" };
+    }
+    if (dependencyPath.test(path)) return { kind: "drop" };
+    for (const tempRoot of tempRoots) {
+      if (!path.startsWith(`${tempRoot}/`)) continue;
+      const remainder = path.slice(tempRoot.length + 1);
+      const separator = remainder.indexOf("/");
+      // A one-segment remainder is the filename itself, not a randomized directory to erase. At
+      // greater depth, discard only the first per-run segment and retain the stable path beneath it.
+      return { kind: "origin", value: separator === -1 ? `<TMP>/${remainder}` : `<TMP>/${remainder.slice(separator + 1)}` };
+    }
+    return { kind: "origin", value: path };
+  };
+  const signature = [];
+  for (const raw of output.replace(ANSI, "").split("\n")) {
+    const line = raw.trim();
+    // This exact pnpm warning describes only the execution environment. Do not generalize it to every
+    // line-initial [WARN]: suites use that token semantically, and different warnings are different
+    // failures even when their sibling assertion lines happen to match.
+    if (/^\[WARN\]\s+Local package\.json exists, but node_modules missing, did you mean to install\?$/i.test(line)) continue;
+    if (!line || /^(?:Node\.js v|npm |pnpm |Scope:|Lockfile |Progress:|Packages:|Done in |\[?ELIFECYCLE\]?|Command failed)/i.test(line)) continue;
+    if (/^at\s/.test(line)) {
+      const paren = line.match(/^at\s+(.+?)\s+\((.+)\)$/);
+      const bare = line.match(/^at\s+(?:async\s+)?(.+)$/);
+      const location = paren?.[2] ?? bare?.[1];
+      if (!location || location.startsWith("node:")) continue;
+      const classified = classifyLocation(location);
+      if (classified.kind === "origin")
+        signature.push(paren ? `at ${paren[1]} (${classified.value})` : `at ${classified.value}`);
+      else if (classified.kind === "verbatim") signature.push(line);
+      continue;
+    }
+    const header = line.match(/^(file:\/\/)?(.+?):\d+(?::\d+)?$/);
+    if (header) {
+      const classified = classifyLocation(`${header[1] ?? ""}${header[2]}`);
+      if (classified.kind === "origin") signature.push(classified.value);
+      if (classified.kind !== "verbatim") continue;
+    }
+    signature.push(line.split(`file://${projectPrefix}`).join("file://<ROOT>/")
+      .split(projectRoot).join("<ROOT>"));
+  }
+  return signature.length ? signature.join("\n") : undefined;
+}
+
+export function failureSignatureHash(output, cwd) {
+  const signature = comparableFailure(output, cwd);
+  return signature === undefined ? undefined : createHash("sha256").update(signature).digest("hex");
+}

--- a/scripts/mutation-proof.mjs
+++ b/scripts/mutation-proof.mjs
@@ -51,6 +51,7 @@ import { execSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { failureSignatureHash, unmeasurableFailure } from "./mutation-failure-signature.mjs";
 
 const C = { red: "\x1b[31m", green: "\x1b[32m", yellow: "\x1b[33m", dim: "\x1b[2m", off: "\x1b[0m" };
 /** Lines of transcript to echo from each end. Enough to carry a stack or an early exit, short
@@ -158,7 +159,7 @@ function run(command, cwd, timeoutMs) {
   }
   const output = `${r.stdout ?? ""}${r.stderr ?? ""}`;
   // A timeout kills the child and leaves status null; that is not a red, it is an unknown.
-  return { status: r.status, timedOut: r.error?.code === "ETIMEDOUT" || r.signal === "SIGKILL" || r.signal === "SIGTERM", output };
+  return { status: r.status, signal: r.signal, timedOut: r.error?.code === "ETIMEDOUT" || r.signal === "SIGKILL" || r.signal === "SIGTERM", output };
 }
 
 /**
@@ -499,6 +500,16 @@ for (const cmd of commands) {
   const base = run(cmd, cwd, opts.timeoutMs);
   const ticks = progressCount(base.output, opts.progressPattern);
   if (base.status !== 0) {
+    // Bounded machine-readable provenance from the exact run that refused. Re-running after exit 4
+    // could observe different root state, so mutation-reproof compares this hash instead. The raw
+    // transcript stays private to this process and the long-standing human REFUSING banner survives.
+    say(`MUTATION-PROOF BASELINE PROVENANCE ${JSON.stringify({
+      command: cmd,
+      status: base.status,
+      signal: base.signal ?? null,
+      unmeasurableReason: unmeasurableFailure(base) ?? null,
+      signatureHash: failureSignatureHash(base.output, cwd) ?? null,
+    })}`);
     say(`${C.red}REFUSING: \`${cmd}\` is red BEFORE any mutation (exit ${base.status}).${C.off}`);
     say("Every mutation running it would grade as KILLED for a reason that has nothing to do with the mutation.");
     process.exit(4);

--- a/scripts/mutation-reproof.mjs
+++ b/scripts/mutation-reproof.mjs
@@ -23,10 +23,11 @@
  * dangling fixture is a loud failure, not a silent skip.
  */
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { delimiter, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
+import { comparableFailure, failureSignatureHash, unmeasurableFailure } from "./mutation-failure-signature.mjs";
 
 const SCRIPT = fileURLToPath(import.meta.url);
 const PROOF = resolve(dirname(SCRIPT), "mutation-proof.mjs");
@@ -56,15 +57,11 @@ function git(root, argv) {
   return execFileSync("git", argv, { cwd: root, encoding: "utf8" });
 }
 
-function runCommand(command, cwd, env = process.env, { offline = true } = {}) {
-  const commandEnv = { ...env, CI: "true", pnpm_config_frozen_lockfile: "true",
-    pnpm_config_verify_deps_before_run: "false" };
-  if (offline) commandEnv.pnpm_config_offline = "true";
-  else delete commandEnv.pnpm_config_offline;
+function runCommand(command, cwd, env) {
   const run = spawnSync(command, {
     cwd, shell: true, encoding: "utf8", timeout: COMMAND_TIMEOUT_MS,
     maxBuffer: 64 * 1024 * 1024, killSignal: "SIGKILL",
-    env: commandEnv,
+    env,
   });
   return { ...run, output: `${run.stdout ?? ""}${run.stderr ?? ""}` };
 }
@@ -267,6 +264,14 @@ function refusedCommand(output) {
   return { command: matches[0][1], headStatus: matches[0][2] };
 }
 
+function refusedProvenance(output) {
+  const prefix = "MUTATION-PROOF BASELINE PROVENANCE ";
+  const lines = output.replace(ANSI, "").split("\n").filter((line) => line.startsWith(prefix));
+  if (lines.length !== 1) return { error: `expected exactly one baseline provenance record, found ${lines.length}` };
+  try { return JSON.parse(lines[0].slice(prefix.length)); }
+  catch (err) { return { error: `invalid baseline provenance record: ${err.message}` }; }
+}
+
 const snapshots = {
   base: { revision: a.base, path: undefined, error: undefined, prepared: false, preparationError: undefined },
   head: { revision: head, path: undefined, error: undefined, prepared: false, preparationError: undefined },
@@ -305,18 +310,25 @@ const insideRoot = (entry) => {
   const rel = relative(root, resolve(entry));
   return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
 };
-function snapshotEnv() {
-  const env = { ...process.env };
-  for (const key of ["PATH", "NODE_PATH"])
-    if (env[key]) env[key] = env[key].split(delimiter).filter((entry) => !insideRoot(entry)).join(delimiter);
-  return env;
-}
-
-function proofEnv() {
+function comparisonEnv({ offline = true } = {}) {
   const env = { ...process.env };
   for (const key of Object.keys(env)) if (key.startsWith("COTAL_")) delete env[key];
+  for (const key of ["PATH", "NODE_PATH"])
+    if (env[key]) env[key] = env[key].split(delimiter).filter((entry) => !insideRoot(entry)).join(delimiter);
+  env.CI = "true";
+  env.pnpm_config_frozen_lockfile = "true";
+  // Load-bearing on both paths: three selftest fixtures assert this value; it prevents pnpm from
+  // installing into the mutation worktree, makes the tool-list pnpm wrapper safe, and prevents the
+  // install result block from entering only one failure signature. It must never inherit a host value.
+  env.pnpm_config_verify_deps_before_run = "false";
+  if (offline) env.pnpm_config_offline = "true";
+  else delete env.pnpm_config_offline;
   return env;
 }
+// Separate call sites are intentional mutation seams. Both delegate to one policy, but the smoke
+// suite proves that neither the root proof child nor snapshot commands may bypass normalization.
+const rootComparisonEnv = () => comparisonEnv();
+const snapshotComparisonEnv = (options) => comparisonEnv(options);
 
 function preparationFailure(label, run) {
   if (run.error) return `${label} could not start: ${run.error.message}`;
@@ -333,92 +345,20 @@ function ensureSnapshotPrepared(snapshot, label) {
   // package manager contract to prepare. Production repositories declare package.json; those always
   // take the frozen-install/full-build path below.
   if (!existsSync(join(snapshot.path, "package.json"))) { snapshot.prepared = true; return; }
-  const install = runCommand("pnpm install --frozen-lockfile", snapshot.path, snapshotEnv(), { offline: false });
+  const install = runCommand("pnpm install --frozen-lockfile", snapshot.path, snapshotComparisonEnv({ offline: false }));
   snapshot.preparationError = preparationFailure(`${label} dependency install`, install);
   if (snapshot.preparationError) return;
-  const build = runCommand("pnpm build", snapshot.path, snapshotEnv());
+  const build = runCommand("pnpm build", snapshot.path, snapshotComparisonEnv());
   snapshot.preparationError = preparationFailure(`${label} build`, build);
   if (!snapshot.preparationError) snapshot.prepared = true;
 }
 
-function unmeasurableBaseRun(run) {
-  if (run.error) return `command could not start: ${run.error.message}`;
-  if (run.status === null || run.signal) return `command did not produce an exit status${run.signal ? ` (signal ${run.signal})` : ""}`;
-  if (run.status === 126 || run.status === 127) return `command was unavailable (exit ${run.status})`;
-  const infrastructureFailure = /(?:ERR_MODULE_NOT_FOUND|MODULE_NOT_FOUND|Cannot find module|ERR_PNPM[A-Z0-9_]*|Missing script|command not found|\b[^:\s]+: not found\b|is not recognized as an internal or external command)/i
-    .exec(run.output);
-  if (infrastructureFailure) return `command could not run: ${infrastructureFailure[0]}`;
-  if (run.status !== 0 && run.output.trim() === "") return "red command produced no output, so its verdict is ambiguous";
-  return undefined;
-}
-
-function comparableFailure(output, cwd) {
-  const slash = (value) => value.replace(/\\/g, "/");
-  const projectRoot = slash(realpathSync(cwd)).replace(/\/$/, "");
-  const projectPrefix = `${projectRoot}/`;
-  const dependencyPath = /(?:^|[/\\])(?:node_modules|\.pnpm)(?:[/\\]|$)/;
-  const tempRoots = [...new Set([tmpdir(), realpathSync(tmpdir())]
-    .map((entry) => slash(entry).replace(/\/$/, "")))];
-  const classifyLocation = (location) => {
-    const withoutCoordinates = location.replace(/:\d+(?::\d+)?$/, "");
-    const fileUrl = withoutCoordinates.startsWith("file://");
-    let path = withoutCoordinates;
-    if (fileUrl) {
-      try { path = fileURLToPath(withoutCoordinates); }
-      catch { path = withoutCoordinates.slice(7); }
-    }
-    path = slash(path);
-    const pathShaped = fileUrl || path.startsWith("/") || /^[A-Za-z]:\//.test(path);
-    if (!pathShaped) return { kind: "verbatim" };
-    if (path === projectRoot || path.startsWith(projectPrefix)) {
-      if (dependencyPath.test(path)) return { kind: "drop" };
-      const relativePath = path === projectRoot ? "" : path.slice(projectPrefix.length);
-      return { kind: "origin", value: relativePath ? `<ROOT>/${relativePath}` : "<ROOT>" };
-    }
-    if (dependencyPath.test(path)) return { kind: "drop" };
-    for (const tempRoot of tempRoots) {
-      if (!path.startsWith(`${tempRoot}/`)) continue;
-      const remainder = path.slice(tempRoot.length + 1);
-      const separator = remainder.indexOf("/");
-      return { kind: "origin", value: separator === -1 ? "<TMP>" : `<TMP>/${remainder.slice(separator + 1)}` };
-    }
-    return { kind: "origin", value: path };
-  };
-  const signature = [];
-  for (const raw of output.replace(ANSI, "").split("\n")) {
-    const line = raw.trim();
-    if (!line || /^(?:Node\.js v|npm |pnpm |Scope:|Lockfile |Progress:|Packages:|Done in |\[?ELIFECYCLE\]?|Command failed)/i.test(line)) continue;
-    // Real uncaught Node/tsx errors also print a project source header before the snippet. Normalize
-    // its trailing line/column like a frame; retaining the number turns harmless line shifts fatal.
-    if (/^at\s/.test(line)) {
-      const paren = line.match(/^at\s+(.+?)\s+\((.+)\)$/);
-      const bare = line.match(/^at\s+(?:async\s+)?(.+)$/);
-      const location = paren?.[2] ?? bare?.[1];
-      if (!location || location.startsWith("node:")) continue;
-      const classified = classifyLocation(location);
-      if (classified.kind === "origin")
-        signature.push(paren ? `at ${paren[1]} (${classified.value})` : `at ${classified.value}`);
-      else if (classified.kind === "verbatim") signature.push(line);
-      continue;
-    }
-    const header = line.match(/^(file:\/\/)?(.+?):\d+(?::\d+)?$/);
-    if (header) {
-      const classified = classifyLocation(`${header[1] ?? ""}${header[2]}`);
-      if (classified.kind === "origin") signature.push(classified.value);
-      if (classified.kind !== "verbatim") continue;
-    }
-    signature.push(line.split(`file://${projectPrefix}`).join("file://<ROOT>/")
-      .split(projectRoot).join("<ROOT>"));
-  }
-  return signature.length ? signature.join("\n") : undefined;
-}
-
 function compareSnapshots(headRun, baseRun) {
-  const reason = unmeasurableBaseRun(baseRun);
+  const reason = unmeasurableFailure(baseRun);
   if (reason) return { kind: "unmeasured", reason };
   if (baseRun.status === 0) return { kind: "attributable", baseStatus: baseRun.status };
 
-  const headReason = unmeasurableBaseRun(headRun);
+  const headReason = unmeasurableFailure(headRun);
   if (headReason) return { kind: "unmeasured", reason: `head command ${headReason}` };
 
   // A bare non-zero cannot distinguish a suite verdict from broken setup. Only an identical,
@@ -433,6 +373,21 @@ function compareSnapshots(headRun, baseRun) {
   return { kind: "inherited", baseStatus: baseRun.status };
 }
 
+function rootContaminationReason(provenance, cleanHeadRun) {
+  // Infrastructure classification precedes status/signature comparison. Otherwise two unavailable
+  // commands (exit 127 with identical "not found" text) look inherited and earn a false green.
+  const rootInfrastructureReason = provenance.unmeasurableReason;
+  if (rootInfrastructureReason) return rootInfrastructureReason;
+  const headReason = unmeasurableFailure(cleanHeadRun);
+  if (headReason) return `head confirmation ${headReason}`;
+  const cleanHash = failureSignatureHash(cleanHeadRun.output, snapshots.head.path);
+  if (provenance.status !== cleanHeadRun.status || provenance.signatureHash === null
+      || cleanHash === undefined || provenance.signatureHash !== cleanHash) {
+    return "root PRE-RED was not reproduced in the clean head snapshot; root execution-state contamination detected";
+  }
+  return undefined;
+}
+
 const fatal = [];       // SURVIVED / UNGRADABLE / WRONG-RED / ERROR — the gate's real findings
 const preRed = [];      // exit 4 + base RED, or any exit 4 under --all — inherited/non-attributed
 const attributablePreRed = []; // exit 4 + the SAME command base GREEN -> head RED
@@ -441,7 +396,7 @@ const inconclusive = []; // INCONCLUSIVE only — unmeasured, evidence in neithe
 for (const { path, command, mutations } of selected) {
   console.log(`\n===== ${path} =====`);
   const run = spawnSync(process.execPath, [PROOF, "--config", path], {
-    cwd: root, encoding: "utf8", maxBuffer: 64 * 1024 * 1024, env: proofEnv(),
+    cwd: root, encoding: "utf8", maxBuffer: 64 * 1024 * 1024, env: rootComparisonEnv(),
   });
   const output = `${run.stdout ?? ""}${run.stderr ?? ""}`;
   process.stdout.write(run.stdout ?? "");
@@ -453,6 +408,12 @@ for (const { path, command, mutations } of selected) {
   if (run.status === 4) {
     const refused = refusedCommand(output);
     if (refused.error) { unmeasuredPreRed.push({ path, command: "unknown", reason: refused.error }); continue; }
+    const provenance = refusedProvenance(output);
+    if (provenance.error || provenance.command !== refused.command) {
+      unmeasuredPreRed.push({ path, command: refused.command,
+        reason: provenance.error ?? "baseline provenance did not name the refused command" });
+      continue;
+    }
     const commands = [...new Set([command, ...mutations.map((mutation) => mutation.command)]
       .filter((fixtureCommand) => typeof fixtureCommand === "string"))];
     if (a.all) { preRed.push({ path, ...refused, baseStatus: undefined }); continue; }
@@ -463,21 +424,30 @@ for (const { path, command, mutations } of selected) {
     if (preparationError) { unmeasuredPreRed.push({ path, command: refused.command, reason: preparationError }); continue; }
     const commandMatrix = [];
     for (const fixtureCommand of commands) {
-      const headRun = runCommand(fixtureCommand, snapshots.head.path, snapshotEnv());
-      const baseRun = runCommand(fixtureCommand, snapshots.base.path, snapshotEnv());
+      const headRun = runCommand(fixtureCommand, snapshots.head.path, snapshotComparisonEnv());
+      const baseRun = runCommand(fixtureCommand, snapshots.base.path, snapshotComparisonEnv());
       commandMatrix.push({ command: fixtureCommand, headRun, baseRun });
     }
     const cleanRefusal = commandMatrix.find(({ command: fixtureCommand }) => fixtureCommand === refused.command)?.headRun;
-    if (!cleanRefusal || cleanRefusal.status === 0) unmeasuredPreRed.push({ path, command: refused.command,
-      reason: "root PRE-RED was not reproduced in the clean head snapshot; root execution-state contamination detected" });
+    const refusalReason = cleanRefusal
+      ? rootContaminationReason(provenance, cleanRefusal)
+      : "root PRE-RED was not reproduced in the clean head snapshot; root execution-state contamination detected";
+    if (!cleanRefusal || cleanRefusal.status === 0) {
+      unmeasuredPreRed.push({ path, command: refused.command, reason: refusalReason });
+      continue;
+    }
     const headRedCommands = commandMatrix.filter(({ headRun }) => headRun.status !== 0);
     for (const { command: fixtureCommand, headRun, baseRun } of headRedCommands) {
-      const headReason = unmeasurableBaseRun(headRun);
+      const headReason = unmeasurableFailure(headRun);
       if (headRun.error || headRun.status === null || headRun.signal) {
         unmeasuredPreRed.push({ path, command: fixtureCommand, reason: `head confirmation ${headReason}` });
         continue;
       }
       const transition = compareSnapshots(headRun, baseRun);
+      if (fixtureCommand === refused.command && transition.kind === "inherited" && refusalReason) {
+        unmeasuredPreRed.push({ path, command: fixtureCommand, reason: refusalReason });
+        continue;
+      }
       const finding = { path, command: fixtureCommand, headStatus: headRun.status, ...transition };
       if (transition.kind === "attributable") attributablePreRed.push(finding);
       else if (transition.kind === "inherited") preRed.push(finding);

--- a/scripts/mutation-reproof.mjs
+++ b/scripts/mutation-reproof.mjs
@@ -14,18 +14,23 @@
  *     path was never selected;
  *   - a selected count of zero exited 0 unconditionally, whether the tree was clean or the selector
  *     had been handed nothing to look at.
+ *   - a head PRE-RED was classified from a declared suite PATH even though mutation-proof may have
+ *     refused a different per-mutation command. Attribution now follows that exact command's
+ *     base-to-head transition instead of inferring causation from selection provenance.
  *
  * A fixture whose guarded source was deleted or renamed away is a DANGLING fixture: its anchor can
  * no longer resolve, so its proof is unrunnable. That is precisely the state this gate refuses, so a
  * dangling fixture is a loud failure, not a silent skip.
  */
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
+import { delimiter, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
 const SCRIPT = fileURLToPath(import.meta.url);
 const PROOF = resolve(dirname(SCRIPT), "mutation-proof.mjs");
+const COMMAND_TIMEOUT_MS = 900_000;
 
 function usage(message) {
   if (message) console.error(message);
@@ -49,6 +54,19 @@ function args(argv) {
 
 function git(root, argv) {
   return execFileSync("git", argv, { cwd: root, encoding: "utf8" });
+}
+
+function runCommand(command, cwd, env = process.env, { offline = true } = {}) {
+  const commandEnv = { ...env, CI: "true", pnpm_config_frozen_lockfile: "true",
+    pnpm_config_verify_deps_before_run: "false" };
+  if (offline) commandEnv.pnpm_config_offline = "true";
+  else delete commandEnv.pnpm_config_offline;
+  const run = spawnSync(command, {
+    cwd, shell: true, encoding: "utf8", timeout: COMMAND_TIMEOUT_MS,
+    maxBuffer: 64 * 1024 * 1024, killSignal: "SIGKILL",
+    env: commandEnv,
+  });
+  return { ...run, output: `${run.stdout ?? ""}${run.stderr ?? ""}` };
 }
 
 /**
@@ -81,7 +99,7 @@ function loadCorpus(root, paths) {
       errors.push(`${path}: no top-level "mutations" array`);
       continue;
     }
-    fixtures.push({ path, suite: config.suite, mutations: config.mutations });
+    fixtures.push({ path, suite: config.suite, command: config.command, mutations: config.mutations });
   }
   return { fixtures, errors };
 }
@@ -137,6 +155,15 @@ if (!a.all) {
     console.error(`${a.base} is not an ancestor of ${head}; refuse a comparison that includes another branch's changes`);
     process.exit(2);
   }
+  const dirty = git(root, ["status", "--porcelain"]);
+  const actualHead = git(root, ["rev-parse", "HEAD"]).trim();
+  const requestedHead = git(root, ["rev-parse", head]).trim();
+  if (dirty || actualHead !== requestedHead) {
+    console.error("mutation reproof: UNMEASURED — root must be clean and checked out at the requested head before comparison");
+    if (dirty) console.error(dirty.trimEnd());
+    if (actualHead !== requestedHead) console.error(`  checked out: ${actualHead}\n  requested:   ${requestedHead}`);
+    process.exit(1);
+  }
 }
 
 // UNMEASURED, exit 1: the corpus is empty. There is nothing this gate could have proven, which is
@@ -158,9 +185,16 @@ if (errors.length) {
 
 const { changed, diffSize } = a.all ? { changed: new Set(), diffSize: 0 } : changedSet(root, a.base, head);
 
-let selected = fixtures.filter(({ path, suite, mutations }) => a.all || changed.has(path)
-  || (typeof suite === "string" && changed.has(suite))
-  || mutations.some((mutation) => typeof mutation?.file === "string" && changed.has(mutation.file)));
+let selected = fixtures.map((fixture) => ({
+  ...fixture,
+  selectedBy: {
+    all: Boolean(a.all),
+    config: changed.has(fixture.path),
+    suite: typeof fixture.suite === "string" && changed.has(fixture.suite),
+    mutation: fixture.mutations.some((mutation) =>
+      typeof mutation?.file === "string" && changed.has(mutation.file)),
+  },
+})).filter(({ selectedBy }) => Object.values(selectedBy).some(Boolean));
 if (shard) selected = selected.filter(({ path }) => shardOf(path, Number(shard[2])) === Number(shard[1]));
 
 // UNMEASURED, exit 1: a selected fixture's guarded file does not exist at head — a dangling fixture.
@@ -195,10 +229,12 @@ console.log(`selected fixture paths:\n${selected.map(({ path }) => `  ${path}`).
 // A fixture's proof has more than two outcomes, and collapsing any of them is itself a silent
 // failure. mutation-proof grades each mutation and encodes the run in its exit code:
 //   exit 0  — every mutation KILLED: the guard discriminates. PASS.
-//   exit 4  — the suite was RED BEFORE any mutation (pre-red). That is a defect in the suite's
-//             current state, not in this diff, and blaming this diff for it is a false blocker.
-//             It is also not a clean bill of health, so it is reported as its own state and does
-//             NOT fail the gate — sequence the suite's own fix, do not carry it here.
+//   exit 4  — one of the fixture's distinct baseline COMMANDS was RED BEFORE any mutation. Path
+//             provenance cannot say whether the diff caused that red: a fixture may declare suite A
+//             while a per-mutation command runs suite B. In diff mode, re-run the exact command that
+//             refused against the base tree. GREEN -> RED is attributable and fatal; RED -> RED is
+//             inherited and non-fatal. An absent or unmeasurable base comparison fails loud. Under
+//             --all there is deliberately no base comparison, so PRE-RED remains non-fatal.
 //   exit 1  — at least one mutation did not produce a clean, named red. That splits again:
 //               SURVIVED / UNGRADABLE — the guard does not discriminate. A real finding. FAIL.
 //               ERROR                 — a dead or ambiguous anchor: the fixture is broken. FAIL.
@@ -221,23 +257,234 @@ const verdictRe = new RegExp(`^(${VERDICTS.join("|")}) `, "gm");
 const verdictsIn = (output) =>
   [...output.replace(ANSI, "").matchAll(verdictRe)].map((m) => m[1]);
 
+/** mutation-proof aborts at its first red distinct command, so exactly one refusal is its contract.
+ *  The all-command matrix below comes from fixture config without changing that contract. */
+function refusedCommand(output) {
+  const matches = [...output.replace(ANSI, "").matchAll(
+    /^REFUSING: `(.*)` is red BEFORE any mutation \(exit ([^)]+)\)\.$/gm,
+  )];
+  if (matches.length !== 1) return { error: `expected exactly one baseline refusal, found ${matches.length}` };
+  return { command: matches[0][1], headStatus: matches[0][2] };
+}
+
+const snapshots = {
+  base: { revision: a.base, path: undefined, error: undefined, prepared: false, preparationError: undefined },
+  head: { revision: head, path: undefined, error: undefined, prepared: false, preparationError: undefined },
+};
+const snapshotHolders = [];
+process.on("exit", () => {
+  for (const holder of snapshotHolders) rmSync(holder, { recursive: true, force: true });
+});
+
+function ensureSnapshot(snapshot, label) {
+  if (snapshot.path || snapshot.error) return;
+  const holder = mkdtempSync(join(tmpdir(), `mutation-reproof-${label}-`));
+  snapshotHolders.push(holder);
+  snapshot.path = join(holder, "repo");
+  if (insideRoot(snapshot.path)) {
+    snapshot.error = `refusing ${label} snapshot inside root: ${snapshot.path}`;
+    snapshot.path = undefined;
+    return;
+  }
+  try {
+    // A separate clone is the correctness boundary: commands must resolve first-party workspace
+    // packages from BASE, never through node_modules links into the head worktree. With no copied
+    // node_modules, pnpm may populate this disposable clone from its store; nothing is installed into
+    // or retained in any lane tree.
+    execFileSync("git", ["clone", "--quiet", "--shared", "--no-checkout", root, snapshot.path],
+      { encoding: "utf8" });
+    git(snapshot.path, ["checkout", "--quiet", "--detach", snapshot.revision]);
+  } catch (err) {
+    snapshot.error = `could not materialize ${label} ${snapshot.revision}: ${err.message}`;
+    snapshot.path = undefined;
+  }
+}
+
+const insideRoot = (entry) => {
+  if (!entry) return false;
+  const rel = relative(root, resolve(entry));
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+};
+function snapshotEnv() {
+  const env = { ...process.env };
+  for (const key of ["PATH", "NODE_PATH"])
+    if (env[key]) env[key] = env[key].split(delimiter).filter((entry) => !insideRoot(entry)).join(delimiter);
+  return env;
+}
+
+function proofEnv() {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) if (key.startsWith("COTAL_")) delete env[key];
+  return env;
+}
+
+function preparationFailure(label, run) {
+  if (run.error) return `${label} could not start: ${run.error.message}`;
+  if (run.status === null || run.signal)
+    return `${label} produced no exit status${run.signal ? ` (signal ${run.signal})` : ""}`;
+  if (run.status !== 0) return `${label} failed (exit ${run.status})`;
+  return undefined;
+}
+
+function ensureSnapshotPrepared(snapshot, label) {
+  ensureSnapshot(snapshot, label);
+  if (snapshot.error || snapshot.prepared || snapshot.preparationError) return;
+  // A minimal fixture repository may intentionally exercise a direct `node` command and have no
+  // package manager contract to prepare. Production repositories declare package.json; those always
+  // take the frozen-install/full-build path below.
+  if (!existsSync(join(snapshot.path, "package.json"))) { snapshot.prepared = true; return; }
+  const install = runCommand("pnpm install --frozen-lockfile", snapshot.path, snapshotEnv(), { offline: false });
+  snapshot.preparationError = preparationFailure(`${label} dependency install`, install);
+  if (snapshot.preparationError) return;
+  const build = runCommand("pnpm build", snapshot.path, snapshotEnv());
+  snapshot.preparationError = preparationFailure(`${label} build`, build);
+  if (!snapshot.preparationError) snapshot.prepared = true;
+}
+
+function unmeasurableBaseRun(run) {
+  if (run.error) return `command could not start: ${run.error.message}`;
+  if (run.status === null || run.signal) return `command did not produce an exit status${run.signal ? ` (signal ${run.signal})` : ""}`;
+  if (run.status === 126 || run.status === 127) return `command was unavailable (exit ${run.status})`;
+  const infrastructureFailure = /(?:ERR_MODULE_NOT_FOUND|MODULE_NOT_FOUND|Cannot find module|ERR_PNPM[A-Z0-9_]*|Missing script|command not found|\b[^:\s]+: not found\b|is not recognized as an internal or external command)/i
+    .exec(run.output);
+  if (infrastructureFailure) return `command could not run: ${infrastructureFailure[0]}`;
+  if (run.status !== 0 && run.output.trim() === "") return "red command produced no output, so its verdict is ambiguous";
+  return undefined;
+}
+
+function comparableFailure(output, cwd) {
+  const slash = (value) => value.replace(/\\/g, "/");
+  const projectRoot = slash(realpathSync(cwd)).replace(/\/$/, "");
+  const projectPrefix = `${projectRoot}/`;
+  const dependencyPath = /(?:^|[/\\])(?:node_modules|\.pnpm)(?:[/\\]|$)/;
+  const tempRoots = [...new Set([tmpdir(), realpathSync(tmpdir())]
+    .map((entry) => slash(entry).replace(/\/$/, "")))];
+  const classifyLocation = (location) => {
+    const withoutCoordinates = location.replace(/:\d+(?::\d+)?$/, "");
+    const fileUrl = withoutCoordinates.startsWith("file://");
+    let path = withoutCoordinates;
+    if (fileUrl) {
+      try { path = fileURLToPath(withoutCoordinates); }
+      catch { path = withoutCoordinates.slice(7); }
+    }
+    path = slash(path);
+    const pathShaped = fileUrl || path.startsWith("/") || /^[A-Za-z]:\//.test(path);
+    if (!pathShaped) return { kind: "verbatim" };
+    if (path === projectRoot || path.startsWith(projectPrefix)) {
+      if (dependencyPath.test(path)) return { kind: "drop" };
+      const relativePath = path === projectRoot ? "" : path.slice(projectPrefix.length);
+      return { kind: "origin", value: relativePath ? `<ROOT>/${relativePath}` : "<ROOT>" };
+    }
+    if (dependencyPath.test(path)) return { kind: "drop" };
+    for (const tempRoot of tempRoots) {
+      if (!path.startsWith(`${tempRoot}/`)) continue;
+      const remainder = path.slice(tempRoot.length + 1);
+      const separator = remainder.indexOf("/");
+      return { kind: "origin", value: separator === -1 ? "<TMP>" : `<TMP>/${remainder.slice(separator + 1)}` };
+    }
+    return { kind: "origin", value: path };
+  };
+  const signature = [];
+  for (const raw of output.replace(ANSI, "").split("\n")) {
+    const line = raw.trim();
+    if (!line || /^(?:Node\.js v|npm |pnpm |Scope:|Lockfile |Progress:|Packages:|Done in |\[?ELIFECYCLE\]?|Command failed)/i.test(line)) continue;
+    // Real uncaught Node/tsx errors also print a project source header before the snippet. Normalize
+    // its trailing line/column like a frame; retaining the number turns harmless line shifts fatal.
+    if (/^at\s/.test(line)) {
+      const paren = line.match(/^at\s+(.+?)\s+\((.+)\)$/);
+      const bare = line.match(/^at\s+(?:async\s+)?(.+)$/);
+      const location = paren?.[2] ?? bare?.[1];
+      if (!location || location.startsWith("node:")) continue;
+      const classified = classifyLocation(location);
+      if (classified.kind === "origin")
+        signature.push(paren ? `at ${paren[1]} (${classified.value})` : `at ${classified.value}`);
+      else if (classified.kind === "verbatim") signature.push(line);
+      continue;
+    }
+    const header = line.match(/^(file:\/\/)?(.+?):\d+(?::\d+)?$/);
+    if (header) {
+      const classified = classifyLocation(`${header[1] ?? ""}${header[2]}`);
+      if (classified.kind === "origin") signature.push(classified.value);
+      if (classified.kind !== "verbatim") continue;
+    }
+    signature.push(line.split(`file://${projectPrefix}`).join("file://<ROOT>/")
+      .split(projectRoot).join("<ROOT>"));
+  }
+  return signature.length ? signature.join("\n") : undefined;
+}
+
+function compareSnapshots(headRun, baseRun) {
+  const reason = unmeasurableBaseRun(baseRun);
+  if (reason) return { kind: "unmeasured", reason };
+  if (baseRun.status === 0) return { kind: "attributable", baseStatus: baseRun.status };
+
+  const headReason = unmeasurableBaseRun(headRun);
+  if (headReason) return { kind: "unmeasured", reason: `head command ${headReason}` };
+
+  // A bare non-zero cannot distinguish a suite verdict from broken setup. Only an identical,
+  // non-infrastructure red from the independently run head command proves RED -> RED. Any difference
+  // is ambiguity and therefore UNMEASURED, never a silent inherited clearance.
+  const baseFailure = comparableFailure(baseRun.output, snapshots.base.path);
+  const headFailure = comparableFailure(headRun.output, snapshots.head.path);
+  if (headRun.status !== baseRun.status || baseFailure === undefined || headFailure === undefined
+      || headFailure !== baseFailure) {
+    return { kind: "unmeasured", reason: "base and head were both red but did not produce the same stable failure signature" };
+  }
+  return { kind: "inherited", baseStatus: baseRun.status };
+}
+
 const fatal = [];       // SURVIVED / UNGRADABLE / WRONG-RED / ERROR — the gate's real findings
-const preRed = [];      // exit 4 — the suite was red before mutation; not this diff's defect
+const preRed = [];      // exit 4 + base RED, or any exit 4 under --all — inherited/non-attributed
+const attributablePreRed = []; // exit 4 + the SAME command base GREEN -> head RED
+const unmeasuredPreRed = []; // exit 4 + absent/ambiguous/unrunnable base comparison — loud failure
 const inconclusive = []; // INCONCLUSIVE only — unmeasured, evidence in neither direction
-for (const { path } of selected) {
+for (const { path, command, mutations } of selected) {
   console.log(`\n===== ${path} =====`);
   const run = spawnSync(process.execPath, [PROOF, "--config", path], {
-    cwd: root, encoding: "utf8", maxBuffer: 64 * 1024 * 1024,
+    cwd: root, encoding: "utf8", maxBuffer: 64 * 1024 * 1024, env: proofEnv(),
   });
   const output = `${run.stdout ?? ""}${run.stderr ?? ""}`;
   process.stdout.write(run.stdout ?? "");
   process.stderr.write(run.stderr ?? "");
   if (run.status === 0) continue; // every mutation KILLED
   // Pre-red is keyed on exit 4 ALONE, the code mutation-proof sets only in its pre-mutation baseline
-  // refusal and nowhere a mutation actually ran. A genuine SURVIVED requires a green baseline and a
-  // completed mutation, so it can never carry exit 4 — the two states are exit-code-disjoint, not
-  // distinguished by prose that a suite could coincidentally print.
-  if (run.status === 4) { preRed.push(path); continue; }
+  // refusal and nowhere a mutation actually ran. Attribute it by the SAME command's base-to-head
+  // transition, never by a declared suite path that may name a different command.
+  if (run.status === 4) {
+    const refused = refusedCommand(output);
+    if (refused.error) { unmeasuredPreRed.push({ path, command: "unknown", reason: refused.error }); continue; }
+    const commands = [...new Set([command, ...mutations.map((mutation) => mutation.command)]
+      .filter((fixtureCommand) => typeof fixtureCommand === "string"))];
+    if (a.all) { preRed.push({ path, ...refused, baseStatus: undefined }); continue; }
+    ensureSnapshotPrepared(snapshots.head, "head");
+    ensureSnapshotPrepared(snapshots.base, "base");
+    const preparationError = snapshots.head.error ?? snapshots.head.preparationError
+      ?? snapshots.base.error ?? snapshots.base.preparationError;
+    if (preparationError) { unmeasuredPreRed.push({ path, command: refused.command, reason: preparationError }); continue; }
+    const commandMatrix = [];
+    for (const fixtureCommand of commands) {
+      const headRun = runCommand(fixtureCommand, snapshots.head.path, snapshotEnv());
+      const baseRun = runCommand(fixtureCommand, snapshots.base.path, snapshotEnv());
+      commandMatrix.push({ command: fixtureCommand, headRun, baseRun });
+    }
+    const cleanRefusal = commandMatrix.find(({ command: fixtureCommand }) => fixtureCommand === refused.command)?.headRun;
+    if (!cleanRefusal || cleanRefusal.status === 0) unmeasuredPreRed.push({ path, command: refused.command,
+      reason: "root PRE-RED was not reproduced in the clean head snapshot; root execution-state contamination detected" });
+    const headRedCommands = commandMatrix.filter(({ headRun }) => headRun.status !== 0);
+    for (const { command: fixtureCommand, headRun, baseRun } of headRedCommands) {
+      const headReason = unmeasurableBaseRun(headRun);
+      if (headRun.error || headRun.status === null || headRun.signal) {
+        unmeasuredPreRed.push({ path, command: fixtureCommand, reason: `head confirmation ${headReason}` });
+        continue;
+      }
+      const transition = compareSnapshots(headRun, baseRun);
+      const finding = { path, command: fixtureCommand, headStatus: headRun.status, ...transition };
+      if (transition.kind === "attributable") attributablePreRed.push(finding);
+      else if (transition.kind === "inherited") preRed.push(finding);
+      else unmeasuredPreRed.push(finding);
+    }
+    continue;
+  }
   const verdicts = verdictsIn(output);
   // A single adverse verdict anywhere in the fixture is a finding: SURVIVED does not become benign
   // because another mutation in the same file was INCONCLUSIVE. INCONCLUSIVE is non-fatal ONLY when
@@ -249,14 +496,36 @@ for (const { path } of selected) {
   else fatal.push(path);
 }
 
+const fixtureCount = (findings) => new Set(findings.map(({ path }) => path)).size;
 if (preRed.length) {
-  console.log(`\nPRE-RED (${preRed.length} fixture(s)) — suite already red before mutation, not this diff's defect; sequence the suite's own fix: ${preRed.join(", ")}`);
+  console.log(`\nPRE-RED (${fixtureCount(preRed)} fixture(s)) INHERITED — ${a.all
+    ? "--all supplied no base comparison; kept nonfatal"
+    : "the same command was already red at base; not caused by this diff"}:`);
+  for (const { path, command, baseStatus, headStatus } of preRed) {
+    console.log(baseStatus === undefined
+      ? `  ${path} -> command: ${command}; head RED (exit ${headStatus}), base NOT COMPARED (--all)`
+      : `  ${path} -> command: ${command}; transition: base RED (exit ${baseStatus}) -> head RED (exit ${headStatus})`);
+  }
 }
 if (inconclusive.length) {
   console.log(`\nINCONCLUSIVE (${inconclusive.length} fixture(s)) — a timeout, a teardown hang, or a swallowed exit code left no evidence either way; not treated as SURVIVED and not treated as KILLED: ${inconclusive.join(", ")}`);
 }
+if (attributablePreRed.length) {
+  console.error(`\nPRE-RED TRANSITION FAILED (${fixtureCount(attributablePreRed)} fixture(s)) — the same command was green at base and red at head:`);
+  for (const { path, command, baseStatus, headStatus } of attributablePreRed)
+    console.error(`  ${path} -> command: ${command}; transition: base GREEN (exit ${baseStatus}) -> head RED (exit ${headStatus})`);
+}
+if (unmeasuredPreRed.length) {
+  console.error(`\nPRE-RED TRANSITION UNMEASURED (${fixtureCount(unmeasuredPreRed)} fixture(s)) — base comparison was absent or could not run; refusing to clear:`);
+  for (const { path, command, reason } of unmeasuredPreRed)
+    console.error(`  ${path} -> command: ${command}; transition: UNMEASURED (${reason}) -> head RED`);
+}
 if (fatal.length) {
   console.error(`\nMUTATION REPROOF FAILED (${fatal.length} fixture(s)): ${fatal.join(", ")}`);
+}
+if (attributablePreRed.length || unmeasuredPreRed.length || fatal.length) {
   process.exit(1);
 }
-console.log(`\nMUTATION REPROOF OK (${selected.length} fixture(s) selected; ${selected.length - preRed.length - inconclusive.length} discriminated, ${preRed.length} pre-red, ${inconclusive.length} inconclusive)`);
+console.log(a.all
+  ? `\nMUTATION REPROOF OK (${selected.length} fixture(s) selected; ${selected.length - preRed.length - inconclusive.length} discriminated, ${preRed.length} pre-red, ${inconclusive.length} inconclusive; base not compared under --all)`
+  : `\nMUTATION REPROOF OK (${selected.length} fixture(s) selected; ${selected.length - fixtureCount(preRed) - inconclusive.length} discriminated, ${fixtureCount(preRed)} inherited pre-red, 0 attributable pre-red, 0 unmeasured pre-red, ${inconclusive.length} inconclusive)`);


### PR DESCRIPTION
## Summary

A mutation fixture may declare one suite while its mutations run several distinct commands. `mutation-proof` stops at the first red command, so attributing PRE-RED from the declared suite path or from only that first refusal can blame a healthy suite or hide a later attributable regression.

This change classifies every distinct fixture command by its actual base-to-head transition on the differential `--base`/`--head` path used by the pull-request gate:

- retain and deduplicate the top-level command plus every per-mutation override
- after any head PRE-RED, run every command in the same deterministic order in independently prepared head and base snapshots
- green at base and red at head is attributable and fatal
- matching red failures at base and head are inherited and nonfatal
- absent, contaminated, ambiguous, or unmeasurable comparisons fail loud and never clear
- report the actual fixture, command, and transition rather than asserting that the declared suite is red

Each disposable snapshot performs its own network-capable frozen install and full build. Fixture commands then run offline with root-local `PATH` and `NODE_PATH` entries removed. Preparation failures are unmeasured and fatal. Root-only execution-state red is reported as contamination rather than attributed to the diff. Mutation-proof children also receive a copy of the environment with inherited `COTAL_*` material removed.

Failure comparison retains stable origin identity without treating volatile layout as causation. One shared classifier handles source headers and stack frames: repository files become `<ROOT>` paths, dependency origins are dropped, OS-temp paths collapse their per-run segment using both raw and resolved temp-root spellings, external files retain their path and function identity, and line/column coordinates are removed. Non-path semantic text remains verbatim.

## Regression coverage

- changed green suite A with untouched inherited-red command B stays nonfatal, names B, and never claims A is red
- inherited-first and attributable-later commands remain fatal in both command orders
- dist-backed commands are compared after independent frozen install and full build
- snapshot preparation failure, root poisoning, asymmetric sequencing, and root-local executable leakage fail loud
- real caught and uncaught transcripts preserve repository file/function identity while tolerating coordinate changes
- external frame/header pairs distinguish different files while tolerating line shifts
- realistic semantic `:number` and changed-error-class transcripts remain different
- dependency-origin headers tolerate `.pnpm` store-layout differences
- ordinary and symlinked OS-temp roots collapse only their randomized segment, while different files and cross-snapshot contamination remain different
- the symlinked TMPDIR control emits raw and resolved spellings so removing either spelling, or anchoring on literal `/tmp`, fails the MATCH arm
- `--all`, deletion, rename, masking, INCONCLUSIVE, and ordinary mutation findings remain pinned
- thirteen code mutations cover selection, transition causation, preparation, isolation, symmetric ordering, stack origins, and verdict parsing

## Deliberate boundaries

- Differential attribution applies to `--base`/`--head`, which is the path used by the PR gate. `--all` remains the pre-existing uncompared inventory used by the scheduled sweep: it reports PRE-RED without a base comparison. Closing that floor is separate work.
- Suite-only selection is unchanged. The corpus is the 351 fixtures matched by the two globs in `fixtureConfigPaths` (`*/mutations/*.json` and `*.mutations.json`), carrying 1797 `expectRed` anchors. The suite trigger fires by set membership, `changed.has(fixture.suite)`, so it works for the 292 fixtures whose `suite` is an exact repository path. The remaining 59 have no usable suite trigger: 51 declare no `suite` key and 8 carry prose rather than a path, each naming either zero files or two. Those diffs are not selected by the PR gate and rely on the scheduled `--all` sweep. Deriving suite paths from commands is separate work.
- Live-fixture identification must follow the resolved command rather than a substring or a declared-field shortcut. 24 of the 351 fixtures run a command whose resolved form matches `/[-:]live(?![A-Za-z0-9-])/`, resolving every `pnpm` invocation in the chain, including per-mutation `command` overrides. The trailing guard keeps `-liveness` out; requiring `live` to end the segment keeps a leading subject word such as `smoke:live-job-conclusion` out, which runs no broker.
- Dist comparison assumes fixed, non-hashed output paths. The repository includes esbuild users, but the covered outputs are fixed-name, non-minified, non-hashed emits.
- Preparation may use the network. Fixture commands remain offline.

## Verification

- `npx tsx bin/smoke/mutation-reproof.smoke.ts` (49 passed, 0 failed)
- independent acceptance battery for #1344 (12 passed, 0 failed)
- mutation anchor gate: zero dead, ambiguous, prose-spanning, missing, or walk failures
- mutation partitions 1-7 and 7-13 each completed on this commit's tree, overlap at the install/build mutation, every mutation killed at its named red, clean restoration and empty porcelain asserted before and after each
- the suite's own `expectRed` labels were counted against the green baseline transcript, the artifact the grader consults: 13 lookups over 11 distinct labels, each matching exactly one line
- end-to-end paired defect matrix: erasing and over-retaining origin policies red their paired arms; tmpdir-only, realpath-only, and literal-`/tmp` policies each red the raw/resolved MATCH arm; fixed code returns 49/49 green
- first-command-only and stack-origin mutations also killed alone against their observed named red cells
- targeted TypeScript diagnostics for the changed smoke file passed with unused checks enabled
- the repository CLI-only typecheck's missing workspace declaration failure reproduces on untouched `52901c629`
- `pnpm smoke:suite-ambient-env` passed with an inherited `COTAL_*` sentinel

Closes #1344