### PR TITLE
fix(release): bootstrap seat publication

### DIFF
--- a/.github/workflows/bootstrap-seat.yml
+++ b/.github/workflows/bootstrap-seat.yml
@@ -1,0 +1,154 @@
+name: Bootstrap @cotal-ai/seat
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type: publish @cotal-ai/seat@0.47.0 from artifact 10001064028"
+        required: true
+        type: string
+
+concurrency:
+  group: bootstrap-cotal-ai-seat-0.47.0
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+
+jobs:
+  publish:
+    name: Publish exact CI-tested seat tarball
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.repository == 'Cotal-AI/Cotal' &&
+      github.repository_id == '1256708592' &&
+      github.actor == 'davidfarah2003' &&
+      github.actor_id == '37240868' &&
+      github.ref == 'refs/heads/main' &&
+      inputs.confirm == 'publish @cotal-ai/seat@0.47.0 from artifact 10001064028'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: seat-bootstrap
+    permissions:
+      actions: read
+      id-token: write
+    steps:
+      - name: Verify immutable source artifact
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_ARTIFACT_ID: "10001064028"
+          EXPECTED_ARTIFACT_NAME: seat-npm-pack
+          EXPECTED_ARTIFACT_ZIP_SHA256: 8da2dbd67a9a2252b0729fdb3919481a223a0e6e94d4fe268bb411b44fd7d179
+          EXPECTED_HEAD_SHA: 609ce674235e32517a7d726585d2f736d629a77e
+          EXPECTED_REPOSITORY_ID: "1256708592"
+          EXPECTED_RUN_ID: "34072874022"
+        run: |
+          set -eu
+          artifact=$(gh api "repos/Cotal-AI/Cotal/actions/artifacts/$EXPECTED_ARTIFACT_ID")
+          test "$(printf '%s' "$artifact" | jq -r .id)" = "$EXPECTED_ARTIFACT_ID"
+          test "$(printf '%s' "$artifact" | jq -r .name)" = "$EXPECTED_ARTIFACT_NAME"
+          test "$(printf '%s' "$artifact" | jq -r .expired)" = "false"
+          test "$(printf '%s' "$artifact" | jq -r .digest)" = "sha256:$EXPECTED_ARTIFACT_ZIP_SHA256"
+          test "$(printf '%s' "$artifact" | jq -r .workflow_run.id)" = "$EXPECTED_RUN_ID"
+          test "$(printf '%s' "$artifact" | jq -r .workflow_run.repository_id)" = "$EXPECTED_REPOSITORY_ID"
+          test "$(printf '%s' "$artifact" | jq -r .workflow_run.head_repository_id)" = "$EXPECTED_REPOSITORY_ID"
+          test "$(printf '%s' "$artifact" | jq -r .workflow_run.head_branch)" = "main"
+          test "$(printf '%s' "$artifact" | jq -r .workflow_run.head_sha)" = "$EXPECTED_HEAD_SHA"
+
+          zip="$RUNNER_TEMP/seat-npm-pack.zip"
+          gh api "repos/Cotal-AI/Cotal/actions/artifacts/$EXPECTED_ARTIFACT_ID/zip" > "$zip"
+          echo "$EXPECTED_ARTIFACT_ZIP_SHA256  $zip" | sha256sum --check --strict
+          mkdir "$RUNNER_TEMP/seat-npm-pack"
+          python3 - "$zip" "$RUNNER_TEMP/seat-npm-pack" <<'PY'
+          import sys
+          from pathlib import Path
+          from zipfile import ZipFile
+
+          archive = Path(sys.argv[1])
+          destination = Path(sys.argv[2]).resolve()
+          with ZipFile(archive) as source:
+              for entry in source.infolist():
+                  target = (destination / entry.filename).resolve()
+                  if destination not in target.parents and target != destination:
+                      raise SystemExit(f"artifact zip has unsafe path: {entry.filename}")
+              source.extractall(destination)
+          PY
+
+          tarball="$RUNNER_TEMP/seat-npm-pack/cotal-ai-seat-0.47.0.tgz"
+          test -f "$tarball"
+          test "$(find "$RUNNER_TEMP/seat-npm-pack" -maxdepth 1 -type f | wc -l)" -eq 1
+          echo "ab8c3309f1effb9eb5bda7b59076f1662c5642b74becc674e46813bc5ab86c0f  $tarball" |
+            sha256sum --check --strict
+          test "$(tar -xOzf "$tarball" package/package.json | jq -r .name)" = "@cotal-ai/seat"
+          test "$(tar -xOzf "$tarball" package/package.json | jq -r .version)" = "0.47.0"
+          test "$(tar -xOzf "$tarball" package/package.json | jq -r .repository.url)" = \
+            "https://github.com/Cotal-AI/Cotal.git"
+          test "$(tar -xOzf "$tarball" package/package.json | jq -r .repository.directory)" = \
+            "packages/seat"
+          test "$(tar -xOzf "$tarball" package/package.json | jq -r .publishConfig.access)" = "public"
+
+          status=$(curl --silent --show-error --output "$RUNNER_TEMP/seat-existing.json" \
+            --write-out '%{http_code}' https://registry.npmjs.org/%40cotal-ai%2fseat/0.47.0)
+          case "$status" in
+            404)
+              echo "publish=true" >> "$GITHUB_OUTPUT"
+              ;;
+            200)
+              version=$(jq -r .version "$RUNNER_TEMP/seat-existing.json")
+              integrity=$(jq -r .dist.integrity "$RUNNER_TEMP/seat-existing.json")
+              test "$version" = "0.47.0"
+              test "$integrity" = \
+                "sha512-2waXKc5uvZ+J4H8GzTQaokudZYJMb2pRnks7XikE4dyD5q2UTwmQIMER5qynD0nbmjrYhjmbKUYYV/PnmuUzPw=="
+              echo "@cotal-ai/seat@0.47.0 already matches the approved tarball. Nothing to publish."
+              echo "publish=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Registry lookup returned unexpected status $status."
+              exit 1
+              ;;
+          esac
+
+      - name: Publish the approved tarball once
+        if: steps.gate.outputs.publish == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_SEAT_BOOTSTRAP_TOKEN }}
+        run: |
+          set -eu
+          test -n "$NODE_AUTH_TOKEN" || {
+            echo "The protected seat-bootstrap environment has no NPM_SEAT_BOOTSTRAP_TOKEN secret."
+            exit 1
+          }
+          npmrc="$RUNNER_TEMP/seat-bootstrap.npmrc"
+          trap 'rm -f "$npmrc"' EXIT
+          umask 077
+          printf '//registry.npmjs.org/:_authToken=%s\n' "$NODE_AUTH_TOKEN" > "$npmrc"
+          export NPM_CONFIG_USERCONFIG="$npmrc"
+          npm publish "$RUNNER_TEMP/seat-npm-pack/cotal-ai-seat-0.47.0.tgz" \
+            --access public \
+            --ignore-scripts \
+            --provenance
+
+      - name: Verify registry integrity
+        env:
+          EXPECTED_INTEGRITY: sha512-2waXKc5uvZ+J4H8GzTQaokudZYJMb2pRnks7XikE4dyD5q2UTwmQIMER5qynD0nbmjrYhjmbKUYYV/PnmuUzPw==
+        run: |
+          set -eu
+          settled=
+          for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
+            metadata=$(curl --fail --silent --show-error \
+              https://registry.npmjs.org/%40cotal-ai%2fseat/0.47.0 2>/dev/null || true)
+            version=$(printf '%s' "$metadata" | jq -r '.version // empty' 2>/dev/null || true)
+            integrity=$(printf '%s' "$metadata" | jq -r '.dist.integrity // empty' 2>/dev/null || true)
+            if [ "$version" = "0.47.0" ] && [ "$integrity" = "$EXPECTED_INTEGRITY" ]; then
+              settled=1
+              break
+            fi
+            echo "Registry metadata not settled (attempt $attempt/12)."
+            sleep 5
+          done
+          test -n "$settled" || {
+            echo "Registry metadata does not match the approved tarball after 60 seconds."
+            exit 1
+          }
+          echo "@cotal-ai/seat@0.47.0 matches the approved CI tarball."

--- a/docs/release-seat-bootstrap.md
+++ b/docs/release-seat-bootstrap.md
@@ -1,0 +1,49 @@
+# One-time `@cotal-ai/seat` bootstrap
+
+This runbook is for npm and repository owners recovering release `0.47.0`. It is temporary. Do not use it for another package or version.
+
+The Changesets run `34072874048` published `@cotal-ai/lang@0.47.0`, then stopped because npm trusted publishing cannot create the missing `@cotal-ai/seat` package. The bootstrap workflow publishes only the tarball already built and tested by CI run `34072874022` from commit `609ce674235e32517a7d726585d2f736d629a77e`.
+
+## Owner setup
+
+1. Merge the workflow and this runbook to `main` with `[skip ci]` in the merge commit subject. The workflow itself pins the source artifact to CI run `34072874022` and release commit `609ce674`; adoption must not start the normal Changesets publisher.
+2. On npmjs.com, create a granular access token with:
+   - the shortest available expiration;
+   - **Read and write** access to the `@cotal-ai` scope only;
+   - no organization-management permission;
+   - **Bypass 2FA** enabled for this initial publication only.
+
+   Stop if npm does not offer scope-only package access. Do not grant all-package write access.
+3. In GitHub, create the `seat-bootstrap` environment. Allow deployments only from `main`, add a required owner reviewer, prevent self-review, and disable administrator bypass.
+4. Add the token as the environment secret `NPM_SEAT_BOOTSTRAP_TOKEN`. Do not create a repository or organization secret.
+
+No token value belongs in a workflow input, command argument, file committed to git, issue, pull request, or Actions log.
+
+## Owner publication
+
+1. Open **Actions → Bootstrap @cotal-ai/seat → Run workflow** on `main`.
+2. Enter `publish @cotal-ai/seat@0.47.0 from artifact 10001064028`.
+3. Confirm the pending deployment shows the `seat-bootstrap` environment, the expected workflow commit, and actor `davidfarah2003`. Approve it.
+4. Wait for the workflow to verify the artifact and registry integrity. Do not rerun Changesets yet.
+
+The workflow refuses any other repository, repository ID, actor, actor ID, event, ref, confirmation string, source run, source commit, artifact, package, version, zip digest, tarball digest, or existing mismatched registry version. The only step that receives the secret writes it to a temporary `0600` npm userconfig, runs one fixed `npm publish` command against that tarball with provenance, and removes the file on exit. The run is idempotent after the exact tarball is live.
+
+## Finish the recovery
+
+Perform these steps in order after every run attempt, including failure or cancellation:
+
+1. On npmjs.com, revoke the granular access token.
+2. In GitHub, delete `NPM_SEAT_BOOTSTRAP_TOKEN` from the `seat-bootstrap` environment.
+3. On the new `@cotal-ai/seat` package, add the trusted publisher:
+   - provider: **GitHub Actions**;
+   - organization: `Cotal-AI`;
+   - repository: `Cotal`;
+   - workflow filename: `changesets.yml`;
+   - environment: blank;
+   - allowed actions: enable direct `npm publish`, matching the existing release workflow.
+4. Delete the `seat-bootstrap` environment.
+5. Remove `.github/workflows/bootstrap-seat.yml` and this runbook in a `[skip ci]` commit. Do not let either adoption or removal trigger Changesets.
+6. Rerun failed Changesets run `34072874048`. Existing packages continue using their unchanged `changesets.yml` OIDC publishers.
+7. Run `node scripts/verify-publish-closure.mjs 0.47.0` and require `PUBLISHED/22`. Do not accept or create the GitHub release before that result.
+
+The initial `@cotal-ai/seat@0.47.0` publication uses a granular token for npm authentication. Its provenance identifies the emergency bootstrap workflow. The workflow's pinned IDs and digest checks are what bind the published bytes to the earlier CI artifact. Later versions use `changesets.yml` with token-free trusted publishing. Do not republish or bump the version to conceal the authentication exception.


### PR DESCRIPTION
## Scope

- add a one-time, manual GitHub workflow that publishes only the immutable `@cotal-ai/seat@0.47.0` tarball from successful CI run `34072874022`
- bind the source run, commit, artifact ID, zip digest, tarball digest, package metadata, repository, actor, branch, protected environment, and confirmation string before the publish step
- keep the temporary npm credential in one protected-environment step and a temporary mode-0600 npm userconfig
- document the owner-only token, environment, trusted publisher, cleanup, rerun, and 22-package closure checkpoints

## Safety

The workflow does not change `changesets.yml`, existing trusted publishers, repository secrets, npm settings, or package versions. It has no automatic trigger. The temporary credential must be an owner-created, short-lived granular token scoped to `@cotal-ai`, stored only in the protected `seat-bootstrap` environment, then revoked and deleted before the unchanged OIDC Changesets workflow is rerun.

The initial seat publication has provenance for the emergency workflow. Pinned IDs and digests bind those published bytes to the tarball that CI built and loaded on both supported Linux architectures. Later releases use the normal `changesets.yml` trusted publisher.

Merge this PR with `[skip ci]` in the merge commit subject so adding the temporary workflow does not trigger the partially blocked Changesets publisher. Remove the workflow and runbook with `[skip ci]` after the owner bootstrap.

## Verification

- YAML parse and `actionlint` passed
- `git diff --check` passed
- `node scripts/check-docs-voice.mjs docs/release-seat-bootstrap.md` passed
- live artifact metadata matches run `34072874022`, commit `609ce674235e32517a7d726585d2f736d629a77e`, artifact `10001064028`, and the pinned archive digest
- downloaded zip and tarball match both pinned SHA-256 values
- `npm publish --dry-run --json` processed the exact tarball without registry writes and reported the pinned integrity
- toolchain-blocked install/import and a real `launchSeat`/`adoptSeat` lifecycle exercised the shipped linux-x64 native; the source CI run passed the same-tarball linux-arm64 load job
- tampered artifacts, altered dispatch contexts, mismatched registry state, and post-secret boundary checks were refused
- live npm registry still returns 404 for `@cotal-ai/seat@0.47.0`

The credentialed dispatch was not run because it requires owner settings and can publish.

Closes #1359 after the owner runbook completes the unchanged Changesets rerun and reports `PUBLISHED/22`.
