### PR TITLE
npm: point package homepage at cotal.ai

### DIFF
--- a/bin/package.json
+++ b/bin/package.json
@@ -19,7 +19,7 @@
     "mcp",
     "a2a"
   ],
-  "homepage": "https://github.com/Cotal-AI/Cotal#readme",
+  "homepage": "https://cotal.ai",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Cotal-AI/Cotal.git",

--- a/implementations/cli/package.json
+++ b/implementations/cli/package.json
@@ -2,6 +2,7 @@
   "name": "@cotal-ai/cli",
   "description": "Cotal mesh CLI: up, join, watch, console, spawn, mint, channels, history, ext.",
   "version": "0.47.0",
+  "homepage": "https://cotal.ai",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The npm pages for `cotal-ai` and `@cotal-ai/cli` link to the GitHub readme as their homepage. Point them at https://cotal.ai, which is what npm's `homepage` field is for (the repository stays in `repository`). Takes effect on the next publish.

Also how agent-readiness scanners verify the package belongs to the domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
