### PR TITLE
Add glama.json for the Glama listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["davidfarah2003", "Lanzelot1"]
+}


### PR DESCRIPTION
Glama already lists this repo at https://glama.ai/mcp/servers/Cotal-AI/Cotal. Repos owned by an organization can only be claimed through a `glama.json` in the repo root that names the maintainers; this adds it with both of us. After the merge, the Claim button on the Glama page links the listing to our accounts, and Glama re-reads the license (it currently shows none, GitHub detects Apache-2.0).

Merge with `[skip ci]` in the squash title while the publish fence is pending, same as the last two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)