### PR TITLE
fix(release): republish the seat package with its compiled distribution

### DIFF
--- a/.changeset/seat-dist-republish.md
+++ b/.changeset/seat-dist-republish.md
@@ -1,0 +1,14 @@
+---
+"@cotal-ai/seat": patch
+---
+
+Republish `@cotal-ai/seat` with its compiled `dist/`.
+
+The 0.47.0 tarball was produced by the emergency bootstrap path before the workspace build had
+run, so it shipped `package.json`, the README, the licence and the two native helpers, and no
+`dist/`. Its export map targets `./dist/index.js`, so `@cotal-ai/manager` fails at load and the
+`cotal` binary does not start. npm does not allow replacing a published version, so the working
+distribution ships as a new one.
+
+This carries no source change. `ci:publish` builds the workspace before packing, so the
+republished tarball contains the declared entrypoints.


### PR DESCRIPTION
Customers installing `cotal-ai@0.47.0` today get a CLI that cannot start.

`@cotal-ai/seat@0.47.0` was published by the emergency bootstrap path in attempt 2 of the 0.47.0 release, before the workspace build had run. The tarball is five files: `package.json`, `README.md`, `LICENSE`, and the two native `peercred.node` helpers. It contains no `dist/`, while the package declares `main`, `types` and `exports` all pointing at `./dist/index.js`. npm silently omits a `files` entry that does not exist, so both pack guards passed and the publish reported success.

`@cotal-ai/manager@0.47.0` statically imports the seat package, so resolution fails at load, and `cotal-ai@0.47.0` depends on manager:

```
npm i cotal-ai@0.47.0 && node_modules/.bin/cotal --version
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
  .../node_modules/@cotal-ai/seat/dist/index.js
  imported from .../node_modules/@cotal-ai/manager/dist/runtime/custodial-pty.js
```

npm does not allow replacing a published version, so the working distribution has to ship as a new one. This PR carries a single patch changeset and no source change. The `fixed` group versions all packages in lockstep, so it releases 0.47.1 across the set.

## Why a version bump is sufficient

`ci:publish` on main is `pnpm build && node scripts/seat-assemble-natives.mjs && pnpm publish -r`. The build runs before packing, so seat has its compiled output by pack time. Verified in a clean detached worktree at this base: after the shipped `pnpm build`, `packages/seat/dist/index.js` and `packages/seat/dist/index.d.ts` are present, 32 entries in `dist`. The reason 0.47.0 is broken is that it was packed outside that path, and the 00:36Z recursive publish could not repair it because the version already existed.

## What this does not do

It does not fix the underlying defect. `@cotal-ai/seat` is the only package in the group whose `prepack` and `prepublishOnly` do not compile: both are `node scripts/assert-shipped-natives.mjs`, whose own docblock states that it does not compile. Every other package compiles in its own pack hook. Seat is currently protected only by the `pnpm build` prefix in `ci:publish`, so any change that removes or reorders that prefix reproduces this. Issue #1369 tracks the durable repair, which makes the package self-sufficient at pack time and adds an installed-distribution regression. That work is reviewed and approved but blocked on push authority for its CI registration.

This PR is the bleeding-stop and is deliberately minimal so it can be reviewed quickly and carries no risk of its own.