### PR TITLE
fix(test): audit aggregate mutation coverage

### DIFF
--- a/.changeset/auditable-mutation-coverage.md
+++ b/.changeset/auditable-mutation-coverage.md
@@ -1,0 +1,5 @@
+---
+"cotal-ai": patch
+---
+
+Make aggregate mutation coverage examine the full selected corpus, report every skipped or ungraded config with the checkout identity, and recognize declared repository entrypoints executed through subprocesses.

--- a/bin/smoke/mutation-reproof.smoke.ts
+++ b/bin/smoke/mutation-reproof.smoke.ts
@@ -837,6 +837,51 @@ try {
         && metadataOnlyPaths(out).length === 0 && existsSync(join(root, "executed")),
       `status=${status}\n${out}`);
   }
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, ".gitignore"), "executed\n");
+        writeFileSync(join(r, "a.mjs"), "export const a = () => 1;\n");
+        writeFileSync(join(r, "suites", "a.suite.mjs"), "import { writeFileSync } from 'node:fs';\nwriteFileSync('executed', 'yes');\nconsole.log('✓ a is one');\n");
+        writeFileSync(join(r, "smoke", "mutations", "a.mutations.json"), JSON.stringify({ suite: ["suites/a.suite.mjs"], command: "node suites/a.suite.mjs", mutations: [{ name: "a changes", file: "a.mjs", find: "() => 1", replace: "() => 2", expectRed: "a is one" }] }, null, 2));
+      },
+      (r) => {
+        const path = join(r, "smoke", "mutations", "a.mutations.json");
+        const config = JSON.parse(readFileSync(path, "utf8"));
+        config.executes = ["bin/cotal.ts"];
+        writeFileSync(path, JSON.stringify(config, null, 2));
+      },
+    );
+    const { status, out } = scan(root, base, head);
+    check("adding executes is excluded as metadata-only instead of selecting by config path",
+      status === 0 && selectedPaths(out).length === 0
+        && eq(metadataOnlyPaths(out), ["smoke/mutations/a.mutations.json"])
+        && !existsSync(join(root, "executed"))
+        && out.includes("the only intersections were metadata-only config-path exclusions"),
+      `status=${status} selected=${JSON.stringify(selectedPaths(out))} excluded=${JSON.stringify(metadataOnlyPaths(out))} executed=${existsSync(join(root, "executed"))}\n${out}`);
+  }
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, ".gitignore"), "executed\n");
+        writeFileSync(join(r, "a.mjs"), "export const a = () => 1;\n");
+        writeFileSync(join(r, "suites", "a.suite.mjs"), "import { writeFileSync } from 'node:fs';\nwriteFileSync('executed', 'yes');\nconsole.log('✓ suite green');\n");
+        writeFileSync(join(r, "smoke", "mutations", "a.mutations.json"), JSON.stringify({ suite: ["suites/a.suite.mjs"], command: "node suites/a.suite.mjs", mutations: [{ name: "a changes", file: "a.mjs", find: "() => 1", replace: "() => 2", expectRed: "a" }] }, null, 2));
+      },
+      (r) => {
+        const path = join(r, "smoke", "mutations", "a.mutations.json");
+        const config = JSON.parse(readFileSync(path, "utf8"));
+        config.executes = ["bin/cotal.ts"];
+        config.command = "node suites/a.suite.mjs --changed";
+        writeFileSync(path, JSON.stringify(config, null, 2));
+      },
+    );
+    const { status, out } = scan(root, base, head);
+    check("an executes declaration plus a proof-field change remains selecting",
+      eq(selectedPaths(out), ["smoke/mutations/a.mutations.json"])
+        && metadataOnlyPaths(out).length === 0 && existsSync(join(root, "executed")),
+      `status=${status} selected=${JSON.stringify(selectedPaths(out))} excluded=${JSON.stringify(metadataOnlyPaths(out))}\n${out}`);
+  }
 
   // 2. Deleted guarded source: a.mjs is removed. The blocked head excluded `D` from the diff and
   //    exited 0. The gate must now see the deletion, treat a's fixture as dangling, and FAIL naming

--- a/bin/smoke/mutations/attach-auth-root.json
+++ b/bin/smoke/mutations/attach-auth-root.json
@@ -4,6 +4,7 @@
   ],
   "guard": "attach redeems a session grant with the seed the MESH resolved, never one walked up from the cwd, and a cwd anchor holding another chain for the same space is reported rather than obeyed",
   "command": "pnpm --filter @cotal-ai/workspace build && pnpm --filter @cotal-ai/cli build && pnpm smoke:attach-auth-root",
+  "executes": ["bin/cotal.ts"],
   "completionMarker": "attach auth-root:",
   "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/attach-auth-root.json",
   "why": [

--- a/bin/smoke/mutations/attach-reconnect.json
+++ b/bin/smoke/mutations/attach-reconnect.json
@@ -4,6 +4,7 @@
   ],
   "guard": "`cotal attach` re-establishes its session when the LINK dies, and stops, saying why, when re-establishing cannot help",
   "command": "pnpm --filter @cotal-ai/cli build && pnpm smoke:attach-reconnect",
+  "executes": ["bin/cotal.ts"],
   "completionMarker": "F. the four classifications the loop turns on",
   "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/attach-reconnect.json",
   "why": [

--- a/bin/smoke/mutations/attach-stdin.json
+++ b/bin/smoke/mutations/attach-stdin.json
@@ -4,6 +4,7 @@
   ],
   "guard": "nothing typed at a terminal with no session reaches the agent, and the detach key still works there",
   "command": "pnpm --filter @cotal-ai/cli build && pnpm smoke:attach-stdin",
+  "executes": ["bin/cotal.ts"],
   "completionMarker": "O: the manager is back on the session count it started with",
   "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/attach-stdin.json",
   "why": [

--- a/bin/smoke/mutations/mutation-reproof.json
+++ b/bin/smoke/mutations/mutation-reproof.json
@@ -2,7 +2,7 @@
   "suite": [
     "bin/smoke/mutation-reproof.smoke.ts"
   ],
-  "guard": "changed proof definitions, canonical suite arrays, suite sources, or guarded sources re-prove their fixture; legacy non-array to canonical-array metadata-only config diffs are named exclusions; deletions and both rename sides remain selecting",
+  "guard": "changed proof definitions, canonical suite arrays, suite sources, or guarded sources re-prove their fixture; legacy non-array to canonical-array metadata-only config diffs and executes-only coverage declarations are named exclusions; deletions and both rename sides remain selecting",
   "command": "pnpm smoke:mutation-reproof",
   "grades": "tool",
   "proveWith": "pnpm mutation-proof --config bin/smoke/mutations/mutation-reproof.json",
@@ -26,10 +26,26 @@
     {
       "name": "metadata-only exclusion ignores other changed proof fields",
       "file": "scripts/mutation-reproof.mjs",
-      "find": "  return isDeepStrictEqual(baseRest, headRest);",
-      "replace": "  return true;",
+      "find": "  const { suite: _headSuite, ...headRest } = fixture.config;\n  return isDeepStrictEqual(baseRest, headRest);",
+      "replace": "  const { suite: _headSuite, ...headRest } = fixture.config;\n  return true;",
       "expectRed": "a non-suite config change remains selecting during legacy suite canonicalization",
       "cell": "a non-suite config change remains selecting during legacy suite canonicalization"
+    },
+    {
+      "name": "executes-only coverage metadata stops being excluded",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "    && (isMetadataOnlySuiteCanonicalization(root, a.base, fixture)\n      || isExecutesOnlyConfigChange(root, a.base, fixture)))",
+      "replace": "    && isMetadataOnlySuiteCanonicalization(root, a.base, fixture))",
+      "expectRed": "adding executes is excluded as metadata-only instead of selecting by config path",
+      "cell": "adding executes is excluded as metadata-only instead of selecting by config path"
+    },
+    {
+      "name": "executes-only exclusion ignores other changed proof fields",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "  const { executes: _baseExecutes, ...baseRest } = baseConfig ?? {};\n  const { executes: _headExecutes, ...headRest } = fixture.config;\n  return isDeepStrictEqual(baseRest, headRest);",
+      "replace": "  const { executes: _baseExecutes, ...baseRest } = baseConfig ?? {};\n  const { executes: _headExecutes, ...headRest } = fixture.config;\n  return true;",
+      "expectRed": "an executes declaration plus a proof-field change remains selecting",
+      "cell": "an executes declaration plus a proof-field change remains selecting"
     },
     {
       "name": "the diff excludes deletions again (the original ACMR bug)",

--- a/bin/smoke/mutations/seat-installed-dist.json
+++ b/bin/smoke/mutations/seat-installed-dist.json
@@ -1,7 +1,5 @@
 {
-  "suite": [
-    "bin/smoke/seat-installed-dist.smoke.ts"
-  ],
+  "suite": ["bin/smoke/seat-installed-dist.smoke.ts"],
   "assembles": ["packages/seat"],
   "guard": "an assembled seat source tree with no dist packs declared entrypoints that support fresh seat import, manager import, and packaged CLI help",
   "command": "pnpm --filter cotal-ai... build > /dev/null && pnpm smoke:seat-installed-dist",

--- a/implementations/cli/smoke/legacy-packaged-manager.smoke.ts
+++ b/implementations/cli/smoke/legacy-packaged-manager.smoke.ts
@@ -56,8 +56,7 @@ const fixtureBin = join(base, "bin");
 mkdirSync(fixtureBin);
 for (const name of ["node", "npm", "nats-server", "sh", "tar", "gzip", "which"])
   symlinkSync(locate(name), join(fixtureBin, name));
-writeFileSync(join(fixtureBin, "pnpm"), `#!/bin/sh\nexec ${JSON.stringify(pnpm)} "$@"\n`);
-chmodSync(join(fixtureBin, "pnpm"), 0o755);
+symlinkSync(locate("pnpm"), join(fixtureBin, "pnpm"));
 const fixtureCotal = join(fixtureBin, "cotal");
 writeFileSync(fixtureCotal, "#!/bin/sh\necho fixture cotal must not run >&2\nexit 97\n");
 chmodSync(fixtureCotal, 0o755);

--- a/implementations/cli/smoke/legacy-packaged-manager.smoke.ts
+++ b/implementations/cli/smoke/legacy-packaged-manager.smoke.ts
@@ -56,7 +56,6 @@ const fixtureBin = join(base, "bin");
 mkdirSync(fixtureBin);
 for (const name of ["node", "npm", "nats-server", "sh", "tar", "gzip", "which"])
   symlinkSync(locate(name), join(fixtureBin, name));
-symlinkSync(locate("pnpm"), join(fixtureBin, "pnpm"));
 const fixtureCotal = join(fixtureBin, "cotal");
 writeFileSync(fixtureCotal, "#!/bin/sh\necho fixture cotal must not run >&2\nexit 97\n");
 chmodSync(fixtureCotal, 0o755);

--- a/implementations/cli/smoke/legacy-packaged-manager.smoke.ts
+++ b/implementations/cli/smoke/legacy-packaged-manager.smoke.ts
@@ -56,6 +56,8 @@ const fixtureBin = join(base, "bin");
 mkdirSync(fixtureBin);
 for (const name of ["node", "npm", "nats-server", "sh", "tar", "gzip", "which"])
   symlinkSync(locate(name), join(fixtureBin, name));
+writeFileSync(join(fixtureBin, "pnpm"), `#!/bin/sh\nexec ${JSON.stringify(pnpm)} "$@"\n`);
+chmodSync(join(fixtureBin, "pnpm"), 0o755);
 const fixtureCotal = join(fixtureBin, "cotal");
 writeFileSync(fixtureCotal, "#!/bin/sh\necho fixture cotal must not run >&2\nexit 97\n");
 chmodSync(fixtureCotal, 0o755);

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -45,7 +45,8 @@ cell total. It exits non-zero after the full selection and reports the checkout 
 enumerated, examined, graded, refused-with-reason, unparsed, and command-failed configs.
 
 `unparsed` means the suite command completed but did not prove how many cells it executed. A zero
-failure count without a total is not enough. Configs whose suite launches a repository entrypoint
+failure count without a total is not enough. A progress-derived total also needs an explicit
+`completionMarker` on the terminal line. Configs whose suite launches a repository entrypoint
 may declare it in `executes`; the declaration is accepted only when the suite passes that entrypoint
 to a Node, tsx, or node-pty subprocess and the command builds each mutated package reached through
 it.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -47,4 +47,5 @@ enumerated, examined, graded, refused-with-reason, unparsed, and command-failed 
 `unparsed` means the suite command completed but did not prove how many cells it executed. A zero
 failure count without a total is not enough. Configs whose suite launches a repository entrypoint
 may declare it in `executes`; the declaration is accepted only when the suite passes that entrypoint
-to a Node or tsx subprocess and the command builds each mutated package reached through it.
+to a Node, tsx, or node-pty subprocess and the command builds each mutated package reached through
+it.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -30,3 +30,21 @@ not understand is an error, not a silently ignored or literal filter.
 
 The guard is read-only. It does not drain GitHub's queue, retrigger a run, or diagnose or fix the
 external scheduler that creates workflow runs.
+
+## Mutation coverage
+
+Run every tracked mutation config from the current checkout:
+
+```bash
+pnpm mutation-coverage
+```
+
+Pass config paths to grade only those files. The validator examines every selected config even when
+an earlier one is refused, its command fails, or its completed output has no trustworthy executed
+cell total. It exits non-zero after the full selection and reports the checkout HEAD with counts for
+enumerated, examined, graded, refused-with-reason, unparsed, and command-failed configs.
+
+`unparsed` means the suite command completed but did not prove how many cells it executed. A zero
+failure count without a total is not enough. Configs whose suite launches a repository entrypoint
+may declare it in `executes`; the declaration is accepted only when the suite passes that entrypoint
+to a Node or tsx subprocess and the command builds each mutated package reached through it.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -53,4 +53,6 @@ complete fraction on the marker line still grades when other text shares that li
 records that as a limitation, not as a completion claim. Configs whose suite launches a repository
 entrypoint may declare it in `executes`; the declaration is accepted only when the suite passes
 that entrypoint to a Node, tsx, or node-pty subprocess and the command builds each mutated package
-reached through it.
+reached through it. An `executes`-only config diff is coverage metadata, not a proof-definition
+change: mutation-reproof names it as a metadata-only exclusion instead of re-proving the live
+kill set.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -45,8 +45,12 @@ cell total. It exits non-zero after the full selection and reports the checkout 
 enumerated, examined, graded, refused-with-reason, unparsed, and command-failed configs.
 
 `unparsed` means the suite command completed but did not prove how many cells it executed. A zero
-failure count without a total is not enough. A progress-derived total also needs an explicit
-`completionMarker` on the terminal line. Configs whose suite launches a repository entrypoint
-may declare it in `executes`; the declaration is accepted only when the suite passes that entrypoint
-to a Node, tsx, or node-pty subprocess and the command builds each mutated package reached through
-it.
+failure count without a total is not enough. The instrument grades only a number the suite printed:
+a tally, a checks-passed count, or a complete N/N fraction. Progress ticks are not an executed-cell
+total. `completionMarker` locates the line that may carry that fraction, and only after the tally
+and checks-passed arms have been tried. Presence of the marker string is never itself a total. A
+complete fraction on the marker line still grades when other text shares that line; the selftest
+records that as a limitation, not as a completion claim. Configs whose suite launches a repository
+entrypoint may declare it in `executes`; the declaration is accepted only when the suite passes
+that entrypoint to a Node, tsx, or node-pty subprocess and the command builds each mutated package
+reached through it.

--- a/scripts/mutation-coverage.mjs
+++ b/scripts/mutation-coverage.mjs
@@ -5,13 +5,13 @@
  * With no paths, configs are discovered from this checkout's index. Every config is examined even
  * when an earlier one is refused or cannot be parsed. Live-shaped commands (live-named smoke
  * tokens or suite sources that declare real infrastructure) use the same fail-closed predicate as
- * mutation-reproof and are not executed unless --execute-live is passed. A discovered (no-path)
- * run enumerates and validates but does not execute unless --execute-discovered is passed. The
- * final summary names the checkout HEAD and exits non-zero if any config was not graded.
+ * mutation-reproof and are refused before any child is spawned. A discovered (no-path) run
+ * enumerates and validates but does not execute unless --execute-discovered is passed. The final
+ * summary names the checkout HEAD when git can resolve it, and exits non-zero if any config was
+ * not graded. Live-shaped refusals and discovered fences are named skips, not grading failures.
  *
- *   node scripts/mutation-coverage.mjs <config.json> …              # just these (live still fenced)
- *   node scripts/mutation-coverage.mjs --execute-discovered         # every config; live still fenced
- *   node scripts/mutation-coverage.mjs --execute-live <config.json> # include live-shaped commands
+ *   node scripts/mutation-coverage.mjs <config.json> …              # just these (live still refused)
+ *   node scripts/mutation-coverage.mjs --execute-discovered         # every config; live still refused
  */
 import { existsSync, readFileSync } from "node:fs";
 import { execFileSync, execSync } from "node:child_process";
@@ -20,12 +20,10 @@ import ts from "typescript";
 import { liveShapedCommandReason } from "./mutation-command-safety.mjs";
 import { parseSuiteSources } from "./mutation-suite-metadata.mjs";
 
-const FLAG_EXECUTE_LIVE = "--execute-live";
 const FLAG_EXECUTE_DISCOVERED = "--execute-discovered";
 const rawArgs = process.argv.slice(2);
-const executeLive = rawArgs.includes(FLAG_EXECUTE_LIVE);
 const executeDiscovered = rawArgs.includes(FLAG_EXECUTE_DISCOVERED);
-const args = rawArgs.filter((arg) => arg !== FLAG_EXECUTE_LIVE && arg !== FLAG_EXECUTE_DISCOVERED);
+const args = rawArgs.filter((arg) => arg !== FLAG_EXECUTE_DISCOVERED);
 const discovered = args.length === 0;
 const configs = discovered
   ? execSync("git ls-files '*/mutations/*.json' '*.mutations.json'", { encoding: "utf8" }).split("\n").filter(Boolean)
@@ -36,14 +34,20 @@ if (configs.length === 0) {
   process.exit(1);
 }
 
-const head = execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+let head = "unknown";
+try {
+  head = execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+} catch {
+  head = "unknown";
+}
 let cells = 0, named = 0, mutations = 0, unkillable = 0;
-let examined = 0, graded = 0, refused = 0, unparsed = 0, failed = 0;
-let fencedLive = 0, fencedDiscovered = 0;
+let examined = 0, graded = 0, unparsed = 0, failed = 0;
+let fencedDiscovered = 0;
 const rows = [];
 const probes = [];
 const tools = [];
 const refusals = [];
+const refused = [];
 const REQUIRED = ["name", "file", "find", "expectRed", "cell"];
 const REQUIRED_MAY_BE_EMPTY = ["replace"];
 const packageRoot = (p) => p.split("/").slice(0, 2).join("/");
@@ -109,7 +113,13 @@ const relativeImports = (path, source) => {
 };
 
 const manifestByName = new Map();
-for (const path of execFileSync("git", ["ls-files", "*package.json"], { encoding: "utf8" }).split("\n").filter(Boolean)) {
+let packageManifests = [];
+try {
+  packageManifests = execFileSync("git", ["ls-files", "*package.json"], { encoding: "utf8" }).split("\n").filter(Boolean);
+} catch {
+  packageManifests = [];
+}
+for (const path of packageManifests) {
   try {
     const manifest = JSON.parse(readFileSync(path, "utf8"));
     if (typeof manifest.name === "string") manifestByName.set(manifest.name, { path, manifest });
@@ -311,7 +321,6 @@ for (const path of configs) {
     cfg = JSON.parse(readFileSync(path, "utf8"));
     ({ gradesTool, suites } = validate(path, cfg));
   } catch (error) {
-    refused++;
     const reason = error instanceof Error ? error.message : String(error);
     refusals.push([path, reason]);
     console.error(`REFUSED ${path}: ${reason}`);
@@ -324,9 +333,8 @@ for (const path of configs) {
     continue;
   }
   const liveReason = liveShapedCommandReason(cfg.command, { cwd: process.cwd() });
-  if (!executeLive && liveReason) {
-    fencedLive++;
-    console.error(`FENCED ${path}: command names a live suite; pass --execute-live to run it`);
+  if (liveReason) {
+    refused.push([path, cfg.command, liveReason]);
     continue;
   }
 
@@ -412,9 +420,16 @@ if (refusals.length) {
   console.error("\nRefused configs:");
   for (const [path, reason] of refusals) console.error(`  ${path}: ${reason}`);
 }
+if (refused.length) {
+  console.log("\nLive-shaped configs — refused before execution, counted and named so the denominator stays honest.");
+  for (const [path, command, reason] of refused) {
+    console.log(`  ${path}  REFUSED \`${command}\` (${reason})`);
+  }
+  console.log(`${refused.length} live-shaped config(s) refused.`);
+}
 console.log(
   `MUTATION COVERAGE SUMMARY head=${head} enumerated=${configs.length} examined=${examined} graded=${graded} ` +
-  `refused-with-reason=${refused} unparsed=${unparsed} command-failed=${failed} ` +
-  `fenced-live=${fencedLive} fenced-discovered=${fencedDiscovered}`,
+  `refused-with-reason=${refusals.length} unparsed=${unparsed} command-failed=${failed} ` +
+  `fenced-live=${refused.length} fenced-discovered=${fencedDiscovered}`,
 );
-if (refused || unparsed || failed || examined !== configs.length || graded !== configs.length) process.exitCode = 1;
+if (refusals.length || unparsed || failed || examined !== configs.length || graded + refused.length + fencedDiscovered !== configs.length) process.exitCode = 1;

--- a/scripts/mutation-coverage.mjs
+++ b/scripts/mutation-coverage.mjs
@@ -304,7 +304,13 @@ for (const path of configs) {
   const summary = parseSummary(cfg, output);
   if (!summary) {
     unparsed++;
-    console.error(`UNPARSED ${path}: command completed but printed no trustworthy executed-cell total`);
+    const progressDeclared = typeof cfg.progressPattern === "string"
+      && Number.isInteger(cfg.minTicks) && cfg.minTicks > 0;
+    const markerMissing = cfg.completionMarker === undefined;
+    const why = progressDeclared && markerMissing
+      ? "command completed but printed no trustworthy executed-cell total; the progress path could not confirm completion because completionMarker was not declared"
+      : "command completed but printed no trustworthy executed-cell total";
+    console.error(`UNPARSED ${path}: ${why}`);
     continue;
   }
   if (summary.failures !== 0) {

--- a/scripts/mutation-coverage.mjs
+++ b/scripts/mutation-coverage.mjs
@@ -255,9 +255,6 @@ const validate = (path, cfg) => {
   if (cfg.minTicks !== undefined && (!Number.isInteger(cfg.minTicks) || cfg.minTicks < 1)) {
     throw new Error('"minTicks" must be a positive integer');
   }
-  if ((cfg.progressPattern === undefined) !== (cfg.minTicks === undefined)) {
-    throw new Error('"progressPattern" and "minTicks" must be supplied together');
-  }
   for (const key of ["assembles", "executes"]) {
     if (cfg[key] !== undefined && !validStringArray(cfg[key])) throw new Error(`"${key}" must be an array of non-empty repo paths`);
   }
@@ -304,12 +301,15 @@ for (const path of configs) {
   const summary = parseSummary(cfg, output);
   if (!summary) {
     unparsed++;
-    const progressDeclared = typeof cfg.progressPattern === "string"
-      && Number.isInteger(cfg.minTicks) && cfg.minTicks > 0;
-    const markerMissing = cfg.completionMarker === undefined;
-    const why = progressDeclared && markerMissing
-      ? "command completed but printed no trustworthy executed-cell total; the progress path could not confirm completion because completionMarker was not declared"
-      : "command completed but printed no trustworthy executed-cell total";
+    const hasPattern = typeof cfg.progressPattern === "string";
+    const hasTicks = Number.isInteger(cfg.minTicks) && cfg.minTicks > 0;
+    const hasMarker = typeof cfg.completionMarker === "string";
+    let why = "command completed but printed no trustworthy executed-cell total";
+    if (hasPattern && !hasTicks) {
+      why += "; progressPattern is present and minTicks is absent, so the progress path could not produce a total";
+    } else if (hasPattern && hasTicks && !hasMarker) {
+      why += "; the progress path could not confirm completion because completionMarker was not declared";
+    }
     console.error(`UNPARSED ${path}: ${why}`);
     continue;
   }

--- a/scripts/mutation-coverage.mjs
+++ b/scripts/mutation-coverage.mjs
@@ -102,11 +102,12 @@ const entryPackages = (entry) => {
 const pathReference = (suite, entry) => {
   const rel = relative(dirname(suite), entry).replaceAll("\\", "/");
   const forms = [entry, rel, rel.startsWith(".") ? rel : `./${rel}`];
-  const pieces = rel.split("/").map(quoted).join("\\s*,\\s*");
-  return new RegExp([...forms.map(quoted), pieces].join("|"));
+  const relativePieces = rel.split("/").map(quoted).join("\\s*,\\s*");
+  const repoPieces = entry.split("/").map(quoted).join("\\s*,\\s*");
+  return new RegExp([...forms.map(quoted), relativePieces, repoPieces].join("|"));
 };
 
-/** The declaration is evidence only when the suite passes that entrypoint to a Node/tsx subprocess. */
+/** The declaration is evidence only when the suite passes that entrypoint to a Node/tsx/pty subprocess. */
 const spawnsEntrypoint = (suite, entry, source) => {
   const reference = pathReference(suite, entry);
   const aliases = [];
@@ -114,7 +115,7 @@ const spawnsEntrypoint = (suite, entry, source) => {
     if (reference.test(match[2])) aliases.push(match[1]);
   }
   const token = aliases.length ? `(?:${aliases.join("|")}|${reference.source})` : reference.source;
-  return new RegExp(`spawn(?:Sync|Proc)?\\s*\\([^;]*?\\[[^\\]]*?${token}`, "s").test(source);
+  return new RegExp(`(?:spawn(?:Sync|Proc)?|pty\\.spawn)\\s*\\([^;]*?\\[[^\\]]*?${token}`, "s").test(source);
 };
 
 const packageName = (file) => {
@@ -177,7 +178,7 @@ const parseSummary = (cfg, output) => {
   if (typeof cfg.progressPattern === "string" && Number.isInteger(cfg.minTicks) && cfg.minTicks > 0) {
     const completed = typeof cfg.completionMarker === "string"
       ? output.includes(cfg.completionMarker)
-      : /(?:^|\n)[^\n]*(?:PASSED|\bOK\b)[^\n]*(?:\n|$)/.test(output);
+      : false;
     const executed = progressCount(output, cfg.progressPattern);
     if (completed && executed >= cfg.minTicks) return { executed, failures: 0 };
   }

--- a/scripts/mutation-coverage.mjs
+++ b/scripts/mutation-coverage.mjs
@@ -239,7 +239,6 @@ const assertGradable = (configPath, cfg, suites, mutation) => {
 };
 
 const lastMatch = (output, re) => [...output.matchAll(re)].at(-1);
-const progressCount = (output, pattern) => (output.match(new RegExp(pattern, "gm")) ?? []).length;
 
 const parseSummary = (cfg, output) => {
   const tallied = lastMatch(output, /(\d+) passed, (\d+) failed/g);
@@ -250,21 +249,12 @@ const parseSummary = (cfg, output) => {
     if (checks[1] !== undefined && Number(checks[1]) !== executed) return undefined;
     return { executed, failures: 0 };
   }
+  // completionMarker locates the line that may carry a complete N/N
+  // fraction. Presence of the marker string is never itself a total.
   if (typeof cfg.completionMarker === "string") {
     const line = output.split(/\r?\n/).filter((candidate) => candidate.includes(cfg.completionMarker)).at(-1);
     const fraction = line?.match(/\b(\d+)\s*\/\s*(\d+)\b/);
     if (fraction && Number(fraction[1]) === Number(fraction[2])) return { executed: Number(fraction[2]), failures: 0 };
-  }
-  if (typeof cfg.progressPattern === "string" && Number.isInteger(cfg.minTicks) && cfg.minTicks > 0) {
-    const lines = output.trimEnd().split(/\r?\n/);
-    const terminal = lines.at(-1) ?? "";
-    // includes() on the terminal line. A local structural test cannot refuse
-    // "NOT <marker>" without also refusing real banners such as
-    // "ALL MEMBERSHIP TESTS PASSED" (marker "MEMBERSHIP TESTS"). Trailing text
-    // is required by 90 of 191 declared markers. See #1464.
-    const completed = typeof cfg.completionMarker === "string" && terminal.includes(cfg.completionMarker);
-    const executed = progressCount(output, cfg.progressPattern);
-    if (completed && executed >= cfg.minTicks) return { executed, failures: 0 };
   }
   return undefined;
 };
@@ -343,19 +333,13 @@ for (const path of configs) {
     unparsed++;
     const hasPattern = typeof cfg.progressPattern === "string";
     const hasTicks = Number.isInteger(cfg.minTicks) && cfg.minTicks > 0;
-    const hasMarker = typeof cfg.completionMarker === "string";
     let why = "command completed but printed no trustworthy executed-cell total";
     if (hasPattern && !hasTicks) {
       why += "; progressPattern is present and minTicks is absent, so the progress path could not produce a total";
     } else if (hasTicks && !hasPattern) {
       why += "; minTicks is present and progressPattern is absent, so the progress path cannot run at all because minTicks is only ever consumed by that path";
-    } else if (hasPattern && hasTicks && !hasMarker) {
-      why += "; the progress path could not confirm completion because completionMarker was not declared";
-    } else if (hasPattern && hasTicks && hasMarker) {
-      const terminal = output.trimEnd().split(/\r?\n/).at(-1) ?? "";
-      if (!terminal.includes(cfg.completionMarker)) {
-        why += "; the progress path could not confirm completion because the declared completionMarker was not present on the final output line";
-      }
+    } else if (hasPattern && hasTicks) {
+      why += "; progress ticks are not an executed-cell total; the instrument grades only a number the suite printed";
     }
     console.error(`UNPARSED ${path}: ${why}`);
     continue;

--- a/scripts/mutation-coverage.mjs
+++ b/scripts/mutation-coverage.mjs
@@ -178,7 +178,7 @@ const parseSummary = (cfg, output) => {
   if (typeof cfg.progressPattern === "string" && Number.isInteger(cfg.minTicks) && cfg.minTicks > 0) {
     const completed = typeof cfg.completionMarker === "string"
       ? output.includes(cfg.completionMarker)
-      : false;
+      : /(?:^|\n)[^\n]*(?:PASSED|\bOK\b)[^\n]*(?:\n|$)/.test(output);
     const executed = progressCount(output, cfg.progressPattern);
     if (completed && executed >= cfg.minTicks) return { executed, failures: 0 };
   }

--- a/scripts/mutation-coverage.mjs
+++ b/scripts/mutation-coverage.mjs
@@ -312,6 +312,8 @@ for (const path of configs) {
     let why = "command completed but printed no trustworthy executed-cell total";
     if (hasPattern && !hasTicks) {
       why += "; progressPattern is present and minTicks is absent, so the progress path could not produce a total";
+    } else if (hasTicks && !hasPattern) {
+      why += "; minTicks is present and progressPattern is absent, so the progress path cannot run at all because minTicks is only ever consumed by that path";
     } else if (hasPattern && hasTicks && !hasMarker) {
       why += "; the progress path could not confirm completion because completionMarker was not declared";
     } else if (hasPattern && hasTicks && hasMarker) {

--- a/scripts/mutation-coverage.mjs
+++ b/scripts/mutation-coverage.mjs
@@ -11,7 +11,8 @@
  */
 import { existsSync, readFileSync } from "node:fs";
 import { execFileSync, execSync } from "node:child_process";
-import { dirname, extname, relative, resolve } from "node:path";
+import { dirname, extname, resolve } from "node:path";
+import ts from "typescript";
 import { parseSuiteSources } from "./mutation-suite-metadata.mjs";
 
 const args = process.argv.slice(2);
@@ -52,10 +53,21 @@ const candidateFiles = (path) => {
   return [...new Set(out)].find(existsSync);
 };
 
-const relativeImports = (source) => {
+const ast = (path, source) => ts.createSourceFile(path, source, ts.ScriptTarget.Latest, true);
+const stringValue = (node) => ts.isStringLiteralLike(node) || ts.isNoSubstitutionTemplateLiteral(node) ? node.text : undefined;
+const relativeImports = (path, source) => {
   const found = [];
-  const re = /(?:import\s+(?:[^"'()]*?\s+from\s+)?|import\s*\(|export\s+[^"']*?\s+from\s+)["']([^"']+)["']/g;
-  for (const match of source.matchAll(re)) found.push(match[1]);
+  const visit = (node) => {
+    if ((ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) && node.moduleSpecifier) {
+      const value = stringValue(node.moduleSpecifier);
+      if (value !== undefined) found.push(value);
+    } else if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+      const value = stringValue(node.arguments[0]);
+      if (value !== undefined) found.push(value);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(ast(path, source));
   return found;
 };
 
@@ -89,7 +101,7 @@ const entryPackages = (entry) => {
     if (!actual || seenFiles.has(actual)) return;
     seenFiles.add(actual);
     const source = readFileSync(actual, "utf8");
-    for (const specifier of relativeImports(source)) {
+    for (const specifier of relativeImports(actual, source)) {
       if (specifier.startsWith(".")) visitFile(resolve(dirname(actual), specifier));
       else if (specifier === "cotal-ai" || specifier.startsWith("@cotal-ai/")) visitPackage(specifier.split("/").slice(0, 2).join("/"));
     }
@@ -99,23 +111,57 @@ const entryPackages = (entry) => {
   return packages;
 };
 
-const pathReference = (suite, entry) => {
-  const rel = relative(dirname(suite), entry).replaceAll("\\", "/");
-  const forms = [entry, rel, rel.startsWith(".") ? rel : `./${rel}`];
-  const relativePieces = rel.split("/").map(quoted).join("\\s*,\\s*");
-  const repoPieces = entry.split("/").map(quoted).join("\\s*,\\s*");
-  return new RegExp([...forms.map(quoted), relativePieces, repoPieces].join("|"));
-};
-
-/** The declaration is evidence only when the suite passes that entrypoint to a Node/tsx/pty subprocess. */
+const normalizedPath = (value) => resolve(value).replaceAll("\\", "/");
 const spawnsEntrypoint = (suite, entry, source) => {
-  const reference = pathReference(suite, entry);
-  const aliases = [];
-  for (const match of source.matchAll(/const\s+([A-Za-z_$][\w$]*)\s*=([^;\n]+(?:\n[^;]+)?);/g)) {
-    if (reference.test(match[2])) aliases.push(match[1]);
-  }
-  const token = aliases.length ? `(?:${aliases.join("|")}|${reference.source})` : reference.source;
-  return new RegExp(`(?:spawn(?:Sync|Proc)?|pty\\.spawn)\\s*\\([^;]*?\\[[^\\]]*?${token}`, "s").test(source);
+  const variables = new Map();
+  const target = normalizedPath(entry);
+  const evalPath = (node) => {
+    if (!node) return undefined;
+    const literal = stringValue(node);
+    if (literal !== undefined) return literal;
+    if (ts.isIdentifier(node)) return variables.get(node.text);
+    if (ts.isPropertyAccessExpression(node) && node.expression.getText() === "import.meta") {
+      if (node.name.text === "dirname") return dirname(resolve(suite));
+      if (node.name.text === "url") return resolve(suite);
+    }
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+      const parts = node.arguments.map(evalPath);
+      if (parts.some((part) => part === undefined)) return undefined;
+      if (node.expression.text === "dirname" && parts.length === 1) return dirname(parts[0]);
+      if (node.expression.text === "join" || node.expression.text === "resolve") return resolve(...parts);
+      if (node.expression.text === "fileURLToPath" && parts.length === 1) return parts[0];
+    }
+    return undefined;
+  };
+  const entryArray = (node) => {
+    if (ts.isIdentifier(node)) node = variables.get(node.text);
+    if (!ts.isArrayLiteralExpression(node)) return false;
+    return node.elements.some((element) => {
+      const value = evalPath(element);
+      return value !== undefined && normalizedPath(value) === target;
+    });
+  };
+  const executableIsNode = (node) => {
+    if (ts.isPropertyAccessExpression(node) && ts.isIdentifier(node.expression)
+      && node.expression.text === "process" && node.name.text === "execPath") return true;
+    const value = evalPath(node);
+    return value !== undefined && /(?:^|\/)tsx(?:\.cmd)?$/.test(value.replaceAll("\\", "/"));
+  };
+  let witnessed = false;
+  const visit = (node) => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      variables.set(node.name.text, ts.isArrayLiteralExpression(node.initializer) ? node.initializer : evalPath(node.initializer));
+    }
+    if (ts.isCallExpression(node)) {
+      const callee = ts.isIdentifier(node.expression) ? node.expression.text
+        : ts.isPropertyAccessExpression(node.expression) ? `${node.expression.expression.getText()}.${node.expression.name.text}` : "";
+      if (["spawn", "spawnSync", "spawnProc", "pty.spawn"].includes(callee)
+        && executableIsNode(node.arguments[0]) && node.arguments[1] && entryArray(node.arguments[1])) witnessed = true;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(ast(suite, source));
+  return witnessed;
 };
 
 const packageName = (file) => {
@@ -126,8 +172,17 @@ const packageName = (file) => {
 
 const buildsPackage = (command, name) => {
   if (!name) return false;
-  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`(?:pnpm\\s+build|--filter\\s+${escaped}(?:\\.\\.\\.)?[^&;\\n]*\\bbuild\\b)`).test(command);
+  for (const segment of command.split(/&&|;/)) {
+    const tokens = segment.trim().split(/\s+/);
+    if (tokens[0] !== "pnpm") continue;
+    if (tokens[1] === "build") return true;
+    const filter = tokens.findIndex((token) => token === "--filter" || token.startsWith("--filter="));
+    if (filter < 0) continue;
+    const value = tokens[filter].startsWith("--filter=") ? tokens[filter].slice(9) : tokens[filter + 1];
+    if (value?.replace(/\.\.\.$/, "") !== name) continue;
+    if (tokens.slice(filter + (tokens[filter].startsWith("--filter=") ? 1 : 2)).includes("build")) return true;
+  }
+  return false;
 };
 
 const executedWitness = (suite, source, command, mutation, executes) => {
@@ -176,9 +231,11 @@ const parseSummary = (cfg, output) => {
     if (fraction && Number(fraction[1]) === Number(fraction[2])) return { executed: Number(fraction[2]), failures: 0 };
   }
   if (typeof cfg.progressPattern === "string" && Number.isInteger(cfg.minTicks) && cfg.minTicks > 0) {
+    const lines = output.trimEnd().split(/\r?\n/);
+    const terminal = lines.at(-1) ?? "";
     const completed = typeof cfg.completionMarker === "string"
-      ? output.includes(cfg.completionMarker)
-      : /(?:^|\n)[^\n]*(?:PASSED|\bOK\b)[^\n]*(?:\n|$)/.test(output);
+      ? terminal.includes(cfg.completionMarker)
+      : /(?:^|\s)(?:PASSED|OK)(?:\s|$)/.test(terminal) && !(new RegExp(cfg.progressPattern).test(terminal));
     const executed = progressCount(output, cfg.progressPattern);
     if (completed && executed >= cfg.minTicks) return { executed, failures: 0 };
   }
@@ -190,6 +247,19 @@ const validate = (path, cfg) => {
   const suites = parseSuiteSources(process.cwd(), path, cfg.suite);
   if (typeof cfg.command !== "string" || cfg.command === "") throw new Error('is missing "command"');
   if (!Array.isArray(cfg.mutations)) throw new Error('is missing a "mutations" array');
+  if (cfg.completionMarker !== undefined && (typeof cfg.completionMarker !== "string" || cfg.completionMarker === "")) {
+    throw new Error('"completionMarker" must be a non-empty string');
+  }
+  if (cfg.progressPattern !== undefined) {
+    if (typeof cfg.progressPattern !== "string" || cfg.progressPattern === "") throw new Error('"progressPattern" must be a non-empty regular expression string');
+    try { new RegExp(cfg.progressPattern, "gm"); } catch (error) { throw new Error(`"progressPattern" is invalid: ${error.message}`); }
+  }
+  if (cfg.minTicks !== undefined && (!Number.isInteger(cfg.minTicks) || cfg.minTicks < 1)) {
+    throw new Error('"minTicks" must be a positive integer');
+  }
+  if ((cfg.progressPattern === undefined) !== (cfg.minTicks === undefined)) {
+    throw new Error('"progressPattern" and "minTicks" must be supplied together');
+  }
   for (const key of ["assembles", "executes"]) {
     if (cfg[key] !== undefined && !validStringArray(cfg[key])) throw new Error(`"${key}" must be an array of non-empty repo paths`);
   }

--- a/scripts/mutation-coverage.mjs
+++ b/scripts/mutation-coverage.mjs
@@ -38,6 +38,11 @@ const packageRoot = (p) => p.split("/").slice(0, 2).join("/");
 const quoted = (s) => `["'\`]${s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}["'\`]`;
 const referencesRoot = (source, root) =>
   new RegExp([quoted(root), root.split("/").map(quoted).join("\\s*,\\s*")].join("|")).test(source);
+const invokesFile = (source, file) => {
+  const basename = file.split("/").at(-1);
+  if (basename === undefined || !referencesRoot(source, file)) return false;
+  return new RegExp(`(?:spawnSync|spawn|execFileSync|execFile)\\s*\\([\\s\\S]{0,500}${quoted(basename)}`).test(source);
+};
 
 const validStringArray = (value) =>
   Array.isArray(value) && value.every((entry) => typeof entry === "string" && entry !== "");
@@ -198,7 +203,7 @@ const executedWitness = (suite, source, command, mutation, executes) => {
 const assertGradable = (configPath, cfg, suites, mutation) => {
   for (const suite of suites) {
     const source = readFileSync(suite, "utf8");
-    if (resolve(mutation.file) === resolve(suite)) return;
+    if (resolve(mutation.file) === resolve(suite) || invokesFile(source, mutation.file)) return;
     if (packageRoot(mutation.file) === packageRoot(suite) && source.includes("../src/")) return;
     const assembled = (cfg.assembles ?? []).find((root) => mutation.file === root || mutation.file.startsWith(root + "/"));
     if (assembled !== undefined && referencesRoot(source, assembled)) return;

--- a/scripts/mutation-coverage.mjs
+++ b/scripts/mutation-coverage.mjs
@@ -1,38 +1,19 @@
 #!/usr/bin/env node
 /**
- * How much of a smoke suite has been OBSERVED failing?
+ * Report how many executed smoke-suite cells have been observed failing under a mutation.
  *
- * A green cell is not evidence that it can still go red. A mutation killed on a named cell is —
- * it is a direct observation of that cell failing. This script reports, per mutation config, how
- * many of the suite's executed cells have such an observation behind them.
- *
- * It counts EXECUTED cells, never cells read out of the source: a suite that generates cells in a
- * loop runs more than it spells out, and a static count silently inflates the ratio. So each
- * config's `command` is run and its terminal `<suite>: N passed, M failed` line is parsed.
- *
- * The numerator is DISTINCT cells named by mutations, not the mutation count — two mutations
- * naming one cell is one observation, and the script refuses to double-count it. It is still a
- * LOWER bound: a mutation may redden cells beyond the one it names, and those are not claimed.
+ * With no paths, configs are discovered from this checkout's index. Every config is examined even
+ * when an earlier one is refused or cannot be parsed. The final summary names the checkout HEAD and
+ * exits non-zero if any config was not graded.
  *
  *   node scripts/mutation-coverage.mjs                     # every config in the tree
  *   node scripts/mutation-coverage.mjs <config.json> …     # just these
- *
- * A live-shaped command is refused before it runs, whether the config was discovered or named.
- * Refused configs are counted and printed; they are never a silent hole in the denominator.
  */
-import { readFileSync } from "node:fs";
-import { execSync } from "node:child_process";
-import { liveShapedCommandReason } from "./mutation-command-safety.mjs";
+import { existsSync, readFileSync } from "node:fs";
+import { execFileSync, execSync } from "node:child_process";
+import { dirname, extname, relative, resolve } from "node:path";
 import { parseSuiteSources } from "./mutation-suite-metadata.mjs";
 
-
-/**
- * The config list is DISCOVERED from the tree, never a remembered list of directories: a config
- * that moves would otherwise drop out of both numerator and denominator at once, leaving a ratio
- * that is still plausible and no longer about the same suites. The pattern is any `mutations/`
- * directory rather than `smoke/mutations/`, because a config that grades a TOOL sits beside the
- * tool and a pattern keyed on where configs usually live cannot see the one that lives elsewhere.
- */
 const args = process.argv.slice(2);
 const configs = args.length
   ? args
@@ -43,224 +24,277 @@ if (configs.length === 0) {
   process.exit(1);
 }
 
+const head = execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
 let cells = 0, named = 0, mutations = 0, unkillable = 0;
+let examined = 0, graded = 0, refused = 0, unparsed = 0, failed = 0;
 const rows = [];
-/**
- * A config marked `"kind": "unasserted-probe"` runs the OPPOSITE experiment: it mutates guards no
- * cell was written for and predicts SURVIVED, because a survivor names a guard nothing is watching.
- * Its `cell` fields describe the behaviour that SHOULD have a cell and usually names one that does
- * not exist — so counting them in the numerator would raise the coverage figure by exactly the
- * cells that were found to be missing. Summing the two kinds silently would make the better
- * practice look like progress and the confirm-only method look better than it is; they are reported
- * apart on purpose.
- */
 const probes = [];
-/**
- * A config marked `"grades": "tool"` measures one of this repo's own instruments through its
- * self-test, not a package's smoke suite. It is reported apart and never folded into the ratio
- * above: a self-test's cells and a smoke suite's cells are not the same unit, and averaging them
- * would move a coverage figure about shipped behaviour by changing a tool's test count.
- *
- * Tool configs remain separate from package coverage, but carry the same source metadata as every
- * other repository fixture so corpus validation does not have a blind spot.
- */
 const tools = [];
-const refused = [];
-
-/**
- * Only the fields THIS script's report depends on are checked here. The set of keys the harness
- * accepts is defined once, in `mutation-proof.mjs`, which refuses an unknown one before grading
- * anything — a second copy of that list here drifted the first time the harness gained a key, which
- * is the defect these two scripts exist to measure, committed by the measuring script.
- */
+const refusals = [];
 const REQUIRED = ["name", "file", "find", "expectRed", "cell"];
-/** `replace` must EXIST but may be empty: deleting the target is a mutation like any other. */
 const REQUIRED_MAY_BE_EMPTY = ["replace"];
-
-/** `packages/core/src/x.ts` -> `packages/core`; `implementations/runtime/smoke/y.ts` -> `implementations/runtime`. */
 const packageRoot = (p) => p.split("/").slice(0, 2).join("/");
-
-/**
- * A mutation is only gradable if the suite runs the file it mutates. A suite that imports its
- * target's package BY NAME gets `dist`, so mutating the source cannot reach the running code and
- * the harness reports SURVIVED — honestly, and indistinguishably from a missing test. The check is
- * an approximation of the resolver on purpose: same package, and the suite actually reaches into
- * `../src`. It is here rather than in a note because a rule that depends on the next author
- * remembering it is the rule that just failed.
- *
- * A second witness exists for suites that never IMPORT the target at all: a config may declare
- * `"assembles": ["packages/seat", …]` — source trees the suite copies into a fixture where it runs
- * a real lifecycle on the copy. The installed-distribution smoke packs an assembled seat clone, so
- * a mutation in `packages/seat/package.json` reaches the run through the copied bytes and the
- * resolver is never asked. Declaring alone proves nothing: the mutated file must live under a
- * declared root, and the suite's own source must reference that root. That reference check is the
- * same order of approximation as the `../src/` substring above — a textual witness for a data-flow
- * fact — and it is what keeps the declaration honest: a suite that only imports the package by
- * name references no source tree, so the dist trap stays refused.
- */
 const quoted = (s) => `["'\`]${s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}["'\`]`;
-/**
- * Does the suite reference a repo source root? `packages/seat` matches `join(ROOT, "packages",
- * "seat")` — how this repo spells repo-relative paths, as quoted segments — and `cpSync("packages/
- * seat", …)` — one quoted path — alike. Matching only the contiguous form would refuse every suite
- * that assembles from one.
- */
-const referencesRoot = (suiteSource, root) =>
-  new RegExp([quoted(root), root.split("/").map(quoted).join("\\s*,\\s*")].join("|")).test(suiteSource);
-const LAUNCHERS = ["spawnSync", "spawn", "execFileSync", "execFile"];
-/**
- * The names a suite calls the child_process launchers by: the canonical four plus whatever a
- * `{ spawnSync as run }` import binds them to. A member call (`cp.spawnSync(`) already matches
- * the bare name.
- */
-const launcherNames = (suiteSource) => {
-  const names = new Set(LAUNCHERS);
-  for (const m of suiteSource.matchAll(/import\s*\{([^}]*)\}\s*from\s*["'](?:node:)?child_process["']/g)) {
-    for (const part of m[1].split(",")) {
-      const alias = part.match(/^\s*(\w+)\s+as\s+(\w+)\s*$/);
-      if (alias !== null && LAUNCHERS.includes(alias[1])) names.add(alias[2]);
-    }
+const referencesRoot = (source, root) =>
+  new RegExp([quoted(root), root.split("/").map(quoted).join("\\s*,\\s*")].join("|")).test(source);
+
+const validStringArray = (value) =>
+  Array.isArray(value) && value.every((entry) => typeof entry === "string" && entry !== "");
+
+const candidateFiles = (path) => {
+  const out = [path];
+  if ([".js", ".mjs", ".cjs"].includes(extname(path))) {
+    out.push(path.slice(0, -extname(path).length) + ".ts");
+    out.push(path.slice(0, -extname(path).length) + ".mts");
+    out.push(path.slice(0, -extname(path).length) + ".cts");
   }
-  return [...names];
+  out.push(resolve(path, "index.ts"), resolve(path, "index.mts"), resolve(path, "index.js"));
+  return [...new Set(out)].find(existsSync);
 };
-/** Identifiers the suite binds to a quoted mention of the file (`const ENTRY = join(ROOT, "scripts",
- *  "x.mjs")`), so a later `spawnSync(process.execPath, [ENTRY])` still names the target. */
-const boundNames = (suiteSource, basename) =>
-  [...suiteSource.matchAll(new RegExp(`(?:const|let|var)\\s+(\\w+)\\s*=[^;\\n]{0,300}${quoted(basename)}`, "g"))].map((m) => m[1]);
-const invokesFile = (suiteSource, file) => {
-  const parts = file.split("/");
-  const basename = parts.at(-1);
-  if (basename === undefined || !referencesRoot(suiteSource, file)) return false;
-  const call = `(?:${launcherNames(suiteSource).join("|")})\\s*\\(`;
-  if (new RegExp(`${call}[\\s\\S]{0,500}${quoted(basename)}`).test(suiteSource)) return true;
-  // A bound name has to sit inside the launcher's argument list (one level of nesting allowed);
-  // merely appearing after the call is not an invocation.
-  const names = boundNames(suiteSource, basename);
-  if (names.length === 0) return false;
-  for (const m of suiteSource.matchAll(new RegExp(`${call}((?:[^()]|\\([^()]*\\))*)\\)`, "g"))) {
-    if (names.some((name) => new RegExp(`\\b${name}\\b`).test(m[1]))) return true;
+
+const relativeImports = (source) => {
+  const found = [];
+  const re = /(?:import\s+(?:[^"'()]*?\s+from\s+)?|import\s*\(|export\s+[^"']*?\s+from\s+)["']([^"']+)["']/g;
+  for (const match of source.matchAll(re)) found.push(match[1]);
+  return found;
+};
+
+const manifestByName = new Map();
+for (const path of execFileSync("git", ["ls-files", "*package.json"], { encoding: "utf8" }).split("\n").filter(Boolean)) {
+  try {
+    const manifest = JSON.parse(readFileSync(path, "utf8"));
+    if (typeof manifest.name === "string") manifestByName.set(manifest.name, { path, manifest });
+  } catch { /* malformed manifests are diagnosed when their config is examined */ }
+}
+const entryPackageCache = new Map();
+
+/** Package imports reachable from a declared repo entrypoint, plus first-party package dependencies. */
+const entryPackages = (entry) => {
+  if (entryPackageCache.has(entry)) return entryPackageCache.get(entry);
+  const packages = new Set();
+  const seenFiles = new Set();
+  const seenPackages = new Set();
+  const visitPackage = (name) => {
+    if (seenPackages.has(name)) return;
+    seenPackages.add(name);
+    const found = manifestByName.get(name);
+    if (!found) return;
+    packages.add(name);
+    for (const dependency of Object.keys({ ...found.manifest.dependencies, ...found.manifest.optionalDependencies })) {
+      if (dependency === "cotal-ai" || dependency.startsWith("@cotal-ai/")) visitPackage(dependency);
+    }
+  };
+  const visitFile = (path) => {
+    const actual = candidateFiles(path);
+    if (!actual || seenFiles.has(actual)) return;
+    seenFiles.add(actual);
+    const source = readFileSync(actual, "utf8");
+    for (const specifier of relativeImports(source)) {
+      if (specifier.startsWith(".")) visitFile(resolve(dirname(actual), specifier));
+      else if (specifier === "cotal-ai" || specifier.startsWith("@cotal-ai/")) visitPackage(specifier.split("/").slice(0, 2).join("/"));
+    }
+  };
+  visitFile(resolve(entry));
+  entryPackageCache.set(entry, packages);
+  return packages;
+};
+
+const pathReference = (suite, entry) => {
+  const rel = relative(dirname(suite), entry).replaceAll("\\", "/");
+  const forms = [entry, rel, rel.startsWith(".") ? rel : `./${rel}`];
+  const pieces = rel.split("/").map(quoted).join("\\s*,\\s*");
+  return new RegExp([...forms.map(quoted), pieces].join("|"));
+};
+
+/** The declaration is evidence only when the suite passes that entrypoint to a Node/tsx subprocess. */
+const spawnsEntrypoint = (suite, entry, source) => {
+  const reference = pathReference(suite, entry);
+  const aliases = [];
+  for (const match of source.matchAll(/const\s+([A-Za-z_$][\w$]*)\s*=([^;\n]+(?:\n[^;]+)?);/g)) {
+    if (reference.test(match[2])) aliases.push(match[1]);
+  }
+  const token = aliases.length ? `(?:${aliases.join("|")}|${reference.source})` : reference.source;
+  return new RegExp(`spawn(?:Sync|Proc)?\\s*\\([^;]*?\\[[^\\]]*?${token}`, "s").test(source);
+};
+
+const packageName = (file) => {
+  const manifest = resolve(packageRoot(file), "package.json");
+  if (!existsSync(manifest)) return undefined;
+  return JSON.parse(readFileSync(manifest, "utf8")).name;
+};
+
+const buildsPackage = (command, name) => {
+  if (!name) return false;
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(?:pnpm\\s+build|--filter\\s+${escaped}(?:\\.\\.\\.)?[^&;\\n]*\\bbuild\\b)`).test(command);
+};
+
+const executedWitness = (suite, source, command, mutation, executes) => {
+  for (const entry of executes) {
+    if (!spawnsEntrypoint(suite, entry, source)) continue;
+    if (resolve(entry) === resolve(mutation.file)) return true;
+    const name = packageName(mutation.file);
+    if (name && buildsPackage(command, name) && entryPackages(entry).has(name)) return true;
   }
   return false;
 };
 
-/** Does THIS one suite run the bytes the mutation edits? The witnesses are tried in the order they
- * are cheapest to be sure of: the suite is the target, the suite launches it as a script, the suite
- * imports its package by source path, the suite assembles it from a declared source tree. */
-const gradableFrom = (suite, m, assembles) => {
-  const suiteSource = readFileSync(suite, "utf8");
-  // A smoke that mutates its own source executes those bytes directly. A smoke may also launch a
-  // repo script by its exact relative path, as the seat packaging suite does for the native
-  // assembler. Neither path crosses a package resolver or an assembled-copy boundary.
-  if (m.file === suite || invokesFile(suiteSource, m.file)) return true;
-  if (packageRoot(m.file) === packageRoot(suite) && suiteSource.includes("../src/")) return true;
-  const root = assembles.find((r) => m.file === r || m.file.startsWith(r + "/"));
-  return root !== undefined && referencesRoot(suiteSource, root);
-};
-
-const assertGradable = (configPath, suites, m, assembles) => {
-  if (suites.some((suite) => gradableFrom(suite, m, assembles))) return;
+const assertGradable = (configPath, cfg, suites, mutation) => {
+  for (const suite of suites) {
+    const source = readFileSync(suite, "utf8");
+    if (resolve(mutation.file) === resolve(suite)) return;
+    if (packageRoot(mutation.file) === packageRoot(suite) && source.includes("../src/")) return;
+    const assembled = (cfg.assembles ?? []).find((root) => mutation.file === root || mutation.file.startsWith(root + "/"));
+    if (assembled !== undefined && referencesRoot(source, assembled)) return;
+    if (executedWitness(suite, source, cfg.command, mutation, cfg.executes ?? [])) return;
+  }
   throw new Error(
-    `${configPath}: mutation "${m.name}" targets ${m.file}, which none of [${suites.join(", ")}] imports by ` +
-    `source path or reaches through a source tree in this config's "assembles" array — a by-name import ` +
-    `resolves that package to dist and the mutation could not reach the running code. Grade it from a suite ` +
-    `in ${packageRoot(m.file)} that reaches into ../src, declare the source tree the suite copies and runs, ` +
-    `or record it in this config's "unkillable" array with the reason.`,
+    `mutation "${mutation.name}" targets ${mutation.file}, which none of [${suites.join(", ")}] imports by source path, ` +
+    `reaches through a declared assembled tree, nor reaches through a declared subprocess entrypoint. A by-name ` +
+    `import resolves that package to dist. Use a suite in ${packageRoot(mutation.file)} that reaches into ../src, ` +
+    `declare the copied source tree in "assembles", declare the spawned repo entrypoint in "executes" with the ` +
+    `target package built by the command, or record the mutation as unkillable with its reason.`,
   );
 };
 
-for (const path of configs) {
-  const cfg = JSON.parse(readFileSync(path, "utf8"));
+const lastMatch = (output, re) => [...output.matchAll(re)].at(-1);
+const progressCount = (output, pattern) => (output.match(new RegExp(pattern, "gm")) ?? []).length;
+
+const parseSummary = (cfg, output) => {
+  const tallied = lastMatch(output, /(\d+) passed, (\d+) failed/g);
+  if (tallied) return { executed: Number(tallied[1]), failures: Number(tallied[2]) };
+  const checks = lastMatch(output, /(?:(\d+)\s*\/\s*)?(\d+) checks passed/g);
+  if (checks) {
+    const executed = Number(checks[2]);
+    if (checks[1] !== undefined && Number(checks[1]) !== executed) return undefined;
+    return { executed, failures: 0 };
+  }
+  if (typeof cfg.completionMarker === "string") {
+    const line = output.split(/\r?\n/).filter((candidate) => candidate.includes(cfg.completionMarker)).at(-1);
+    const fraction = line?.match(/\b(\d+)\s*\/\s*(\d+)\b/);
+    if (fraction && Number(fraction[1]) === Number(fraction[2])) return { executed: Number(fraction[2]), failures: 0 };
+  }
+  if (typeof cfg.progressPattern === "string" && Number.isInteger(cfg.minTicks) && cfg.minTicks > 0) {
+    const completed = typeof cfg.completionMarker === "string"
+      ? output.includes(cfg.completionMarker)
+      : /(?:^|\n)[^\n]*(?:PASSED|\bOK\b)[^\n]*(?:\n|$)/.test(output);
+    const executed = progressCount(output, cfg.progressPattern);
+    if (completed && executed >= cfg.minTicks) return { executed, failures: 0 };
+  }
+  return undefined;
+};
+
+const validate = (path, cfg) => {
   const gradesTool = cfg.grades === "tool";
   const suites = parseSuiteSources(process.cwd(), path, cfg.suite);
-  // A tool config predicts a named red and has no cell to attribute it to, because there is no
-  // suite whose coverage it could be part of.
-  const required = gradesTool ? REQUIRED.filter((k) => k !== "cell") : REQUIRED;
-  if (cfg.assembles !== undefined
-    && (!Array.isArray(cfg.assembles) || cfg.assembles.some((r) => typeof r !== "string" || r === ""))) {
-    throw new Error(`${path}: "assembles" must be an array of source-tree paths the suite copies`);
+  if (typeof cfg.command !== "string" || cfg.command === "") throw new Error('is missing "command"');
+  if (!Array.isArray(cfg.mutations)) throw new Error('is missing a "mutations" array');
+  for (const key of ["assembles", "executes"]) {
+    if (cfg[key] !== undefined && !validStringArray(cfg[key])) throw new Error(`"${key}" must be an array of non-empty repo paths`);
   }
-  for (const m of cfg.mutations) {
-    for (const k of required) {
-      if (typeof m[k] !== "string" || m[k] === "") throw new Error(`${path}: mutation "${m.name ?? "(unnamed)"}" is missing "${k}"`);
+  const required = gradesTool ? REQUIRED.filter((key) => key !== "cell") : REQUIRED;
+  for (const mutation of cfg.mutations) {
+    for (const key of required) {
+      if (typeof mutation[key] !== "string" || mutation[key] === "") throw new Error(`mutation "${mutation.name ?? "(unnamed)"}" is missing "${key}"`);
     }
-    for (const k of REQUIRED_MAY_BE_EMPTY) {
-      if (typeof m[k] !== "string") throw new Error(`${path}: mutation "${m.name ?? "(unnamed)"}" is missing "${k}"`);
+    for (const key of REQUIRED_MAY_BE_EMPTY) {
+      if (typeof mutation[key] !== "string") throw new Error(`mutation "${mutation.name ?? "(unnamed)"}" is missing "${key}"`);
     }
-    if (!gradesTool) assertGradable(path, suites, m, cfg.assembles ?? []);
+    if (!gradesTool) assertGradable(path, cfg, suites, mutation);
   }
-  const liveReason = liveShapedCommandReason(cfg.command, { cwd: process.cwd() });
-  if (liveReason) {
-    refused.push([path, cfg.command, liveReason]);
+  return { gradesTool, suites };
+};
+
+for (const path of configs) {
+  examined++;
+  let cfg;
+  let gradesTool;
+  let suites;
+  try {
+    cfg = JSON.parse(readFileSync(path, "utf8"));
+    ({ gradesTool, suites } = validate(path, cfg));
+  } catch (error) {
+    refused++;
+    const reason = error instanceof Error ? error.message : String(error);
+    refusals.push([path, reason]);
+    console.error(`REFUSED ${path}: ${reason}`);
     continue;
   }
-  const out = execSync(cfg.command, { encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] });
-  // Two terminal shapes exist in this repo. "N passed, M failed" comes from a suite that records
-  // failures and keeps going; "N checks passed" from a fail-fast one, where reaching the line at
-  // all means nothing failed. Both are the SUITE's own count of what it executed, which is the
-  // only number that cannot be inflated by reading the source.
-  const tallied = out.match(/(\d+) passed, (\d+) failed/);
-  const failFast = out.match(/(\d+) checks passed/);
-  if (!tallied && !failFast) throw new Error(`${path}: \`${cfg.command}\` printed neither "N passed, M failed" nor "N checks passed"`);
-  if (tallied && Number(tallied[2]) !== 0) throw new Error(`${path}: the suite is already red — coverage over a red suite means nothing`);
 
-  const executed = Number((tallied ?? failFast)[1]);
+  let output;
+  try {
+    output = execSync(cfg.command, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+  } catch (error) {
+    failed++;
+    console.error(`FAILED ${path}: command exited ${error.status ?? "without a status"}: ${cfg.command}`);
+    const transcript = `${error.stdout ?? ""}${error.stderr ?? ""}`.trim();
+    if (transcript) console.error(transcript);
+    continue;
+  }
+
+  const summary = parseSummary(cfg, output);
+  if (!summary) {
+    unparsed++;
+    console.error(`UNPARSED ${path}: command completed but printed no trustworthy executed-cell total`);
+    continue;
+  }
+  if (summary.failures !== 0) {
+    failed++;
+    console.error(`FAILED ${path}: suite is already red (${summary.failures} failed); coverage over red is not graded`);
+    continue;
+  }
+
+  const executed = summary.executed;
+  const suiteLabel = suites.join(", ");
   if (gradesTool) {
     tools.push([path, cfg.mutations.length, executed]);
+    graded++;
     continue;
   }
   if (cfg.kind === "unasserted-probe") {
-    probes.push([suites.join(", "), cfg.mutations.length, executed]);
+    probes.push([suiteLabel, cfg.mutations.length, executed]);
+    graded++;
     continue;
   }
-  const distinct = new Set(cfg.mutations.map((x) => x.cell));
-  if (distinct.size !== cfg.mutations.length) {
-    console.log(`  note: ${path} has ${cfg.mutations.length} mutations naming ${distinct.size} distinct cells`);
+  const distinct = new Set(cfg.mutations.map((mutation) => mutation.cell));
+  if (distinct.size > executed) {
+    failed++;
+    console.error(`FAILED ${path}: names ${distinct.size} distinct cells but the suite ran ${executed}`);
+    continue;
   }
-  if (distinct.size > executed) throw new Error(`${path}: names ${distinct.size} cells but the suite ran ${executed}`);
-
+  if (distinct.size !== cfg.mutations.length) console.log(`  note: ${path} has ${cfg.mutations.length} mutations naming ${distinct.size} distinct cells`);
   cells += executed;
   named += distinct.size;
   mutations += cfg.mutations.length;
   unkillable += (cfg.unkillable ?? []).length;
-  rows.push([suites.join(", "), executed, distinct.size]);
+  rows.push([suiteLabel, executed, distinct.size]);
+  graded++;
 }
 
-if (rows.length) {
-  const w = Math.max(...rows.map((r) => r[0].length));
-  for (const [suite, executed, distinct] of rows) {
-    console.log(`${suite.padEnd(w)}  ${String(distinct).padStart(3)} / ${String(executed).padStart(3)} cells observed failing`);
-  }
-  console.log(`${"TOTAL".padEnd(w)}  ${named} / ${cells} = ${Math.round((named / cells) * 100)}%`);
-} else if (!tools.length && !probes.length) {
-  console.log("TOTAL  0 / 0 = n/a (no safe configs executed)");
+const width = Math.max(5, ...rows.map((row) => row[0].length));
+for (const [suite, executed, distinct] of rows) {
+  console.log(`${suite.padEnd(width)}  ${String(distinct).padStart(3)} / ${String(executed).padStart(3)} cells observed failing`);
 }
+if (rows.length) console.log(`${"TOTAL".padEnd(width)}  ${named} / ${cells} = ${Math.round((named / cells) * 100)}%`);
 console.log(`${mutations} mutations run, ${unkillable} recorded unkillable by construction and not run.`);
-console.log("A lower bound: a mutation may redden more cells than the one it names, and those are not claimed here.");
-console.log(
-  "And an OVER-statement in one direction: every mutation above was authored against a cell written for it,\n" +
-  "so this ratio measures the guards that were aimed at, not the guards that exist.",
-);
+if (rows.length) {
+  console.log("A lower bound: a mutation may redden more cells than the one it names, and those are not claimed here.");
+  console.log("The ratio measures guards authors aimed at, not every guard that exists.");
+}
 if (probes.length) {
-  console.log("\nUnasserted-guard probes — mutations of guards NO cell was written for, predicting SURVIVED.");
-  console.log("NOT added to the ratio above: their cells are the ones found MISSING, and counting them would");
-  console.log("raise the coverage figure by exactly the gaps they were run to find.");
-  for (const [suite, n, executed] of probes) {
-    console.log(`  ${suite}  ${n} probes against a suite of ${executed} cells`);
-  }
-  console.log("  Verdicts come from mutation-proof.mjs; a SURVIVED here is a finding, not a failure.");
+  console.log("\nUnasserted-guard probes:");
+  for (const [suite, count, executed] of probes) console.log(`  ${suite}  ${count} probes against a suite of ${executed} cells`);
 }
 if (tools.length) {
-  console.log("\nInstrument configs — this repo's own tools, graded through their self-tests.");
-  console.log("NOT added to the ratio above: a self-test's cells and a smoke suite's cells are different");
-  console.log("units, and averaging them would move a figure about shipped behaviour by a tool's test count.");
-  for (const [path, n, executed] of tools) {
-    console.log(`  ${path}  ${n} mutations against a self-test of ${executed} cells`);
-  }
+  console.log("\nInstrument configs:");
+  for (const [path, count, executed] of tools) console.log(`  ${path}  ${count} mutations against a self-test of ${executed} cells`);
 }
-if (refused.length) {
-  console.log("\nLive-shaped configs — refused before execution, counted and named so the denominator stays honest.");
-  for (const [path, command, reason] of refused) {
-    console.log(`  ${path}  REFUSED \`${command}\` (${reason})`);
-  }
-  console.log(`${refused.length} live-shaped config(s) refused.`);
+if (refusals.length) {
+  console.error("\nRefused configs:");
+  for (const [path, reason] of refusals) console.error(`  ${path}: ${reason}`);
 }
+console.log(
+  `MUTATION COVERAGE SUMMARY head=${head} enumerated=${configs.length} examined=${examined} graded=${graded} ` +
+  `refused-with-reason=${refused} unparsed=${unparsed} command-failed=${failed}`,
+);
+if (refused || unparsed || failed || examined !== configs.length || graded !== configs.length) process.exitCode = 1;

--- a/scripts/mutation-coverage.mjs
+++ b/scripts/mutation-coverage.mjs
@@ -258,6 +258,10 @@ const parseSummary = (cfg, output) => {
   if (typeof cfg.progressPattern === "string" && Number.isInteger(cfg.minTicks) && cfg.minTicks > 0) {
     const lines = output.trimEnd().split(/\r?\n/);
     const terminal = lines.at(-1) ?? "";
+    // includes() on the terminal line. A local structural test cannot refuse
+    // "NOT <marker>" without also refusing real banners such as
+    // "ALL MEMBERSHIP TESTS PASSED" (marker "MEMBERSHIP TESTS"). Trailing text
+    // is required by 90 of 191 declared markers. See #1464.
     const completed = typeof cfg.completionMarker === "string" && terminal.includes(cfg.completionMarker);
     const executed = progressCount(output, cfg.progressPattern);
     if (completed && executed >= cfg.minTicks) return { executed, failures: 0 };

--- a/scripts/mutation-coverage.mjs
+++ b/scripts/mutation-coverage.mjs
@@ -3,19 +3,21 @@
  * Report how many executed smoke-suite cells have been observed failing under a mutation.
  *
  * With no paths, configs are discovered from this checkout's index. Every config is examined even
- * when an earlier one is refused or cannot be parsed. Commands that name a live suite are not
- * executed unless --execute-live is passed. A discovered (no-path) run enumerates and validates
- * but does not execute unless --execute-discovered is passed. The final summary names the checkout
- * HEAD and exits non-zero if any config was not graded.
+ * when an earlier one is refused or cannot be parsed. Live-shaped commands (live-named smoke
+ * tokens or suite sources that declare real infrastructure) use the same fail-closed predicate as
+ * mutation-reproof and are not executed unless --execute-live is passed. A discovered (no-path)
+ * run enumerates and validates but does not execute unless --execute-discovered is passed. The
+ * final summary names the checkout HEAD and exits non-zero if any config was not graded.
  *
  *   node scripts/mutation-coverage.mjs <config.json> …              # just these (live still fenced)
  *   node scripts/mutation-coverage.mjs --execute-discovered         # every config; live still fenced
- *   node scripts/mutation-coverage.mjs --execute-live <config.json> # include live-suite commands
+ *   node scripts/mutation-coverage.mjs --execute-live <config.json> # include live-shaped commands
  */
 import { existsSync, readFileSync } from "node:fs";
 import { execFileSync, execSync } from "node:child_process";
 import { dirname, extname, resolve } from "node:path";
 import ts from "typescript";
+import { liveShapedCommandReason } from "./mutation-command-safety.mjs";
 import { parseSuiteSources } from "./mutation-suite-metadata.mjs";
 
 const FLAG_EXECUTE_LIVE = "--execute-live";
@@ -42,16 +44,6 @@ const rows = [];
 const probes = [];
 const tools = [];
 const refusals = [];
-const LIVE_SUITE_NAMES = [
-  "smoke:manager-service-ops",
-  "smoke:manager-service-invoke",
-  "smoke:manager-spawn-action",
-  "smoke:manager-service",
-  "smoke:persona-announce",
-  "smoke:seat-input",
-];
-const commandNamesLiveSuite = (command) =>
-  /:live\b|-live\b/.test(command) || LIVE_SUITE_NAMES.some((name) => command.includes(name));
 const REQUIRED = ["name", "file", "find", "expectRed", "cell"];
 const REQUIRED_MAY_BE_EMPTY = ["replace"];
 const packageRoot = (p) => p.split("/").slice(0, 2).join("/");
@@ -331,7 +323,8 @@ for (const path of configs) {
     console.error(`FENCED ${path}: discovered configs are not executed; pass --execute-discovered to run them`);
     continue;
   }
-  if (!executeLive && commandNamesLiveSuite(cfg.command)) {
+  const liveReason = liveShapedCommandReason(cfg.command, { cwd: process.cwd() });
+  if (!executeLive && liveReason) {
     fencedLive++;
     console.error(`FENCED ${path}: command names a live suite; pass --execute-live to run it`);
     continue;

--- a/scripts/mutation-coverage.mjs
+++ b/scripts/mutation-coverage.mjs
@@ -3,11 +3,14 @@
  * Report how many executed smoke-suite cells have been observed failing under a mutation.
  *
  * With no paths, configs are discovered from this checkout's index. Every config is examined even
- * when an earlier one is refused or cannot be parsed. The final summary names the checkout HEAD and
- * exits non-zero if any config was not graded.
+ * when an earlier one is refused or cannot be parsed. Commands that name a live suite are not
+ * executed unless --execute-live is passed. A discovered (no-path) run enumerates and validates
+ * but does not execute unless --execute-discovered is passed. The final summary names the checkout
+ * HEAD and exits non-zero if any config was not graded.
  *
- *   node scripts/mutation-coverage.mjs                     # every config in the tree
- *   node scripts/mutation-coverage.mjs <config.json> …     # just these
+ *   node scripts/mutation-coverage.mjs <config.json> …              # just these (live still fenced)
+ *   node scripts/mutation-coverage.mjs --execute-discovered         # every config; live still fenced
+ *   node scripts/mutation-coverage.mjs --execute-live <config.json> # include live-suite commands
  */
 import { existsSync, readFileSync } from "node:fs";
 import { execFileSync, execSync } from "node:child_process";
@@ -15,10 +18,16 @@ import { dirname, extname, resolve } from "node:path";
 import ts from "typescript";
 import { parseSuiteSources } from "./mutation-suite-metadata.mjs";
 
-const args = process.argv.slice(2);
-const configs = args.length
-  ? args
-  : execSync("git ls-files '*/mutations/*.json' '*.mutations.json'", { encoding: "utf8" }).split("\n").filter(Boolean);
+const FLAG_EXECUTE_LIVE = "--execute-live";
+const FLAG_EXECUTE_DISCOVERED = "--execute-discovered";
+const rawArgs = process.argv.slice(2);
+const executeLive = rawArgs.includes(FLAG_EXECUTE_LIVE);
+const executeDiscovered = rawArgs.includes(FLAG_EXECUTE_DISCOVERED);
+const args = rawArgs.filter((arg) => arg !== FLAG_EXECUTE_LIVE && arg !== FLAG_EXECUTE_DISCOVERED);
+const discovered = args.length === 0;
+const configs = discovered
+  ? execSync("git ls-files '*/mutations/*.json' '*.mutations.json'", { encoding: "utf8" }).split("\n").filter(Boolean)
+  : args;
 
 if (configs.length === 0) {
   console.error("no mutation configs found under any mutations/ directory");
@@ -28,10 +37,21 @@ if (configs.length === 0) {
 const head = execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
 let cells = 0, named = 0, mutations = 0, unkillable = 0;
 let examined = 0, graded = 0, refused = 0, unparsed = 0, failed = 0;
+let fencedLive = 0, fencedDiscovered = 0;
 const rows = [];
 const probes = [];
 const tools = [];
 const refusals = [];
+const LIVE_SUITE_NAMES = [
+  "smoke:manager-service-ops",
+  "smoke:manager-service-invoke",
+  "smoke:manager-spawn-action",
+  "smoke:manager-service",
+  "smoke:persona-announce",
+  "smoke:seat-input",
+];
+const commandNamesLiveSuite = (command) =>
+  /:live\b|-live\b/.test(command) || LIVE_SUITE_NAMES.some((name) => command.includes(name));
 const REQUIRED = ["name", "file", "find", "expectRed", "cell"];
 const REQUIRED_MAY_BE_EMPTY = ["replace"];
 const packageRoot = (p) => p.split("/").slice(0, 2).join("/");
@@ -292,6 +312,17 @@ for (const path of configs) {
     continue;
   }
 
+  if (discovered && !executeDiscovered) {
+    fencedDiscovered++;
+    console.error(`FENCED ${path}: discovered configs are not executed; pass --execute-discovered to run them`);
+    continue;
+  }
+  if (!executeLive && commandNamesLiveSuite(cfg.command)) {
+    fencedLive++;
+    console.error(`FENCED ${path}: command names a live suite; pass --execute-live to run it`);
+    continue;
+  }
+
   let output;
   try {
     output = execSync(cfg.command, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
@@ -382,6 +413,7 @@ if (refusals.length) {
 }
 console.log(
   `MUTATION COVERAGE SUMMARY head=${head} enumerated=${configs.length} examined=${examined} graded=${graded} ` +
-  `refused-with-reason=${refused} unparsed=${unparsed} command-failed=${failed}`,
+  `refused-with-reason=${refused} unparsed=${unparsed} command-failed=${failed} ` +
+  `fenced-live=${fencedLive} fenced-discovered=${fencedDiscovered}`,
 );
 if (refused || unparsed || failed || examined !== configs.length || graded !== configs.length) process.exitCode = 1;

--- a/scripts/mutation-coverage.mjs
+++ b/scripts/mutation-coverage.mjs
@@ -34,11 +34,11 @@ if (configs.length === 0) {
   process.exit(1);
 }
 
-let head = "unknown";
+let checkoutHead = "unknown";
 try {
-  head = execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+  checkoutHead = execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
 } catch {
-  head = "unknown";
+  checkoutHead = "unknown";
 }
 let cells = 0, named = 0, mutations = 0, unkillable = 0;
 let examined = 0, graded = 0, unparsed = 0, failed = 0;
@@ -275,8 +275,10 @@ const parseSummary = (cfg, output) => {
   // fraction. Presence of the marker string is never itself a total.
   if (typeof cfg.completionMarker === "string") {
     const line = output.split(/\r?\n/).filter((candidate) => candidate.includes(cfg.completionMarker)).at(-1);
-    const fraction = line?.match(/\b(\d+)\s*\/\s*(\d+)\b/);
-    if (fraction && Number(fraction[1]) === Number(fraction[2])) return { executed: Number(fraction[2]), failures: 0 };
+    const completeFraction = line?.match(/\b(\d+)\s*\/\s*(\d+)\b/);
+    if (completeFraction && Number(completeFraction[1]) === Number(completeFraction[2])) {
+      return { executed: Number(completeFraction[2]), failures: 0 };
+    }
   }
   return undefined;
 };
@@ -428,7 +430,7 @@ if (refused.length) {
   console.log(`${refused.length} live-shaped config(s) refused.`);
 }
 console.log(
-  `MUTATION COVERAGE SUMMARY head=${head} enumerated=${configs.length} examined=${examined} graded=${graded} ` +
+  `MUTATION COVERAGE SUMMARY head=${checkoutHead} enumerated=${configs.length} examined=${examined} graded=${graded} ` +
   `refused-with-reason=${refusals.length} unparsed=${unparsed} command-failed=${failed} ` +
   `fenced-live=${refused.length} fenced-discovered=${fencedDiscovered}`,
 );

--- a/scripts/mutation-coverage.mjs
+++ b/scripts/mutation-coverage.mjs
@@ -309,6 +309,11 @@ for (const path of configs) {
       why += "; progressPattern is present and minTicks is absent, so the progress path could not produce a total";
     } else if (hasPattern && hasTicks && !hasMarker) {
       why += "; the progress path could not confirm completion because completionMarker was not declared";
+    } else if (hasPattern && hasTicks && hasMarker) {
+      const terminal = output.trimEnd().split(/\r?\n/).at(-1) ?? "";
+      if (!terminal.includes(cfg.completionMarker)) {
+        why += "; the progress path could not confirm completion because the declared completionMarker was not present on the final output line";
+      }
     }
     console.error(`UNPARSED ${path}: ${why}`);
     continue;

--- a/scripts/mutation-coverage.mjs
+++ b/scripts/mutation-coverage.mjs
@@ -58,10 +58,30 @@ const packageRoot = (p) => p.split("/").slice(0, 2).join("/");
 const quoted = (s) => `["'\`]${s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}["'\`]`;
 const referencesRoot = (source, root) =>
   new RegExp([quoted(root), root.split("/").map(quoted).join("\\s*,\\s*")].join("|")).test(source);
+const LAUNCHERS = ["spawnSync", "spawn", "execFileSync", "execFile"];
+const launcherNames = (source) => {
+  const names = new Set(LAUNCHERS);
+  for (const m of source.matchAll(/import\s*\{([^}]*)\}\s*from\s*["'](?:node:)?child_process["']/g)) {
+    for (const part of m[1].split(",")) {
+      const alias = part.match(/^\s*(\w+)\s+as\s+(\w+)\s*$/);
+      if (alias !== null && LAUNCHERS.includes(alias[1])) names.add(alias[2]);
+    }
+  }
+  return [...names];
+};
+const boundNames = (source, basename) =>
+  [...source.matchAll(new RegExp(`(?:const|let|var)\\s+(\\w+)\\s*=[^;\\n]{0,300}${quoted(basename)}`, "g"))].map((m) => m[1]);
 const invokesFile = (source, file) => {
   const basename = file.split("/").at(-1);
   if (basename === undefined || !referencesRoot(source, file)) return false;
-  return new RegExp(`(?:spawnSync|spawn|execFileSync|execFile)\\s*\\([\\s\\S]{0,500}${quoted(basename)}`).test(source);
+  const call = `(?:${launcherNames(source).join("|")})\\s*\\(`;
+  if (new RegExp(`${call}[\\s\\S]{0,500}${quoted(basename)}`).test(source)) return true;
+  const names = boundNames(source, basename);
+  if (names.length === 0) return false;
+  for (const m of source.matchAll(new RegExp(`${call}((?:[^()]|\\([^()]*\\))*)\\)`, "g"))) {
+    if (names.some((name) => new RegExp(`\\b${name}\\b`).test(m[1]))) return true;
+  }
+  return false;
 };
 
 const validStringArray = (value) =>

--- a/scripts/mutation-coverage.mjs
+++ b/scripts/mutation-coverage.mjs
@@ -233,9 +233,7 @@ const parseSummary = (cfg, output) => {
   if (typeof cfg.progressPattern === "string" && Number.isInteger(cfg.minTicks) && cfg.minTicks > 0) {
     const lines = output.trimEnd().split(/\r?\n/);
     const terminal = lines.at(-1) ?? "";
-    const completed = typeof cfg.completionMarker === "string"
-      ? terminal.includes(cfg.completionMarker)
-      : /(?:^|\s)(?:PASSED|OK)(?:\s|$)/.test(terminal) && !(new RegExp(cfg.progressPattern).test(terminal));
+    const completed = typeof cfg.completionMarker === "string" && terminal.includes(cfg.completionMarker);
     const executed = progressCount(output, cfg.progressPattern);
     if (completed && executed >= cfg.minTicks) return { executed, failures: 0 };
   }

--- a/scripts/mutation-coverage.selftest.mjs
+++ b/scripts/mutation-coverage.selftest.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /** Self-test for mutation-coverage's reachability, parser, and whole-corpus accounting. */
-import { chmodSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, unlinkSync, writeFileSync, rmSync } from "node:fs";
 import { execFileSync, spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
@@ -30,9 +30,10 @@ const mutation = (file) => ({
   expectRed: "the fixture cell", cell: "the fixture cell",
 });
 const config = (name, value) => write(`${name}.json`, JSON.stringify(value));
-const run = (...names) => spawnSync(process.execPath, [TOOL, ...names.map((name) => `${name}.json`)], {
+const runArgs = (...argv) => spawnSync(process.execPath, [TOOL, ...argv], {
   cwd: root, encoding: "utf8", timeout: 60_000, env: { ...process.env, PATH: `${root}:${process.env.PATH}` },
 });
+const run = (...names) => runArgs(...names.map((name) => `${name}.json`));
 const report = (result) => `${result.stdout}\n${result.stderr}`;
 
 try {
@@ -299,6 +300,82 @@ try {
     report(result),
   );
   check("the audit summary names the exact checkout tree", result.stdout.includes(`head=${fixtureHead}`), report(result));
+
+  const sentinelPath = (name) => join(root, `sentinel-${name}`);
+  const sentinelCmd = (name, tag = "") => {
+    const inner = `require("fs").writeFileSync(${JSON.stringify(sentinelPath(name))}, "ran"); console.log("FIXTURE: 3 passed, 0 failed");`;
+    const node = `${JSON.stringify(process.execPath)} -e ${JSON.stringify(inner)}`;
+    return tag ? `${node} # ${tag}` : node;
+  };
+  const fenceBody = (command) => ({
+    suite: ["bin/smoke/direct.smoke.ts"],
+    command,
+    executes: ["bin/direct.mjs"],
+    mutations: [mutation("bin/direct.mjs")],
+  });
+  const clearSentinels = (...names) => {
+    for (const name of names) try { unlinkSync(sentinelPath(name)); } catch { /* absent */ }
+  };
+  const fenceNames = ["safe-a", "safe-b", "safe-c", "safe-d", "safe-e", "live-suffix", "live-ops"];
+  for (const name of ["safe-a", "safe-b", "safe-c", "safe-d", "safe-e"]) {
+    write(`bin/smoke/mutations/${name}.json`, JSON.stringify(fenceBody(sentinelCmd(name))));
+  }
+  write("bin/smoke/mutations/live-suffix.json", JSON.stringify(fenceBody(sentinelCmd("live-suffix", "pnpm smoke:user-spawn:live"))));
+  write("bin/smoke/mutations/live-ops.json", JSON.stringify(fenceBody(sentinelCmd("live-ops", "pnpm smoke:manager-service-ops"))));
+  execFileSync("git", ["add", "bin/smoke/mutations"], { cwd: root });
+
+  clearSentinels(...fenceNames);
+  result = runArgs(
+    "bin/smoke/mutations/safe-a.json",
+    "bin/smoke/mutations/safe-b.json",
+    "bin/smoke/mutations/safe-c.json",
+    "bin/smoke/mutations/safe-d.json",
+    "bin/smoke/mutations/safe-e.json",
+    "bin/smoke/mutations/live-suffix.json",
+  );
+  check(
+    "a glob-shaped argv still fences a live-suite command",
+    !existsSync(sentinelPath("live-suffix"))
+      && ["safe-a", "safe-b", "safe-c", "safe-d", "safe-e"].every((name) => existsSync(sentinelPath(name)))
+      && /FENCED bin\/smoke\/mutations\/live-suffix\.json/.test(result.stderr)
+      && /fenced-live=1/.test(result.stdout),
+    report(result),
+  );
+
+  clearSentinels(...fenceNames);
+  result = runArgs("bin/smoke/mutations/live-ops.json");
+  check(
+    "an always-live suite name is fenced without a :live suffix",
+    !existsSync(sentinelPath("live-ops"))
+      && /FENCED bin\/smoke\/mutations\/live-ops\.json/.test(result.stderr)
+      && /fenced-live=1/.test(result.stdout),
+    report(result),
+  );
+
+  clearSentinels(...fenceNames);
+  result = runArgs();
+  check(
+    "a discovered run does not execute any config",
+    fenceNames.every((name) => !existsSync(sentinelPath(name)))
+      && /fenced-discovered=[1-9]\d*/.test(result.stdout),
+    report(result),
+  );
+
+  clearSentinels(...fenceNames);
+  result = runArgs("--execute-live", "bin/smoke/mutations/live-suffix.json");
+  check(
+    "an explicit --execute-live flag still runs a live-suite command",
+    existsSync(sentinelPath("live-suffix")) && /graded=1/.test(result.stdout) && /fenced-live=0/.test(result.stdout),
+    report(result),
+  );
+
+  clearSentinels(...fenceNames);
+  result = runArgs("bin/smoke/mutations/safe-a.json");
+  check(
+    "a named non-live config still executes without a flag",
+    existsSync(sentinelPath("safe-a")) && /graded=1/.test(result.stdout) && /fenced-live=0/.test(result.stdout),
+    report(result),
+  );
 } finally {
   rmSync(root, { recursive: true, force: true });
 }

--- a/scripts/mutation-coverage.selftest.mjs
+++ b/scripts/mutation-coverage.selftest.mjs
@@ -61,6 +61,7 @@ try {
   execFileSync("git", ["init", "-q"], { cwd: root });
   execFileSync("git", ["add", "."], { cwd: root });
   execFileSync("git", ["-c", "user.name=fixture", "-c", "user.email=fixture@example.invalid", "commit", "-qm", "fixture"], { cwd: root });
+  const fixtureHead = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
 
   const tally = summaryCommand("FIXTURE: 3 passed, 0 failed");
   const seatBuild = `${JSON.stringify(process.execPath)} fake-build.mjs --filter @cotal-ai/seat build && ${tally}`;
@@ -150,6 +151,7 @@ try {
     result.status !== 0 && /enumerated=3 examined=3 graded=1 refused-with-reason=1 unparsed=1/.test(result.stdout),
     report(result),
   );
+  check("the audit summary names the exact checkout tree", result.stdout.includes(`head=${fixtureHead}`), report(result));
 } finally {
   rmSync(root, { recursive: true, force: true });
 }

--- a/scripts/mutation-coverage.selftest.mjs
+++ b/scripts/mutation-coverage.selftest.mjs
@@ -239,6 +239,16 @@ try {
     report(result),
   );
 
+  config("progress-minticks-no-pattern", { suite: ["bin/smoke/direct.smoke.ts"], command: ticks, minTicks: 3, executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+  result = run("progress-minticks-no-pattern");
+  check(
+    "minTicks without progressPattern names why it is unparsed",
+    result.status !== 0 && /UNPARSED progress-minticks-no-pattern/.test(result.stderr)
+      && /minTicks is present and progressPattern is absent/.test(result.stderr)
+      && /the progress path cannot run at all/.test(result.stderr),
+    report(result),
+  );
+
   const markerOffTerminal = `${JSON.stringify(process.execPath)} -e ${JSON.stringify("console.log('  ✓ one\\n  ✓ two\\n  ✓ three\\nhost pins the seat binary against background self-update\\nJCODE HOST SMOKE PASSED (85 checks)')")}`;
   config("progress-marker-not-terminal", {
     suite: ["bin/smoke/direct.smoke.ts"],

--- a/scripts/mutation-coverage.selftest.mjs
+++ b/scripts/mutation-coverage.selftest.mjs
@@ -49,6 +49,10 @@ try {
   write("bin/smoke/spawn-entry.smoke.ts",
     'const ENTRY = join(import.meta.dirname, "..", "entry.ts");\n' +
     'spawnSync(process.execPath, [ENTRY], { stdio: "inherit" });\n');
+  write("bin/smoke/pty-entry.smoke.ts",
+    'const repoRoot = resolve(import.meta.dirname, "../..");\n' +
+    'const ENTRY = join(repoRoot, "bin", "entry.ts");\n' +
+    'pty.spawn(process.execPath, [ENTRY], { cwd: process.cwd() });\n');
   write("bin/smoke/spawn-other.smoke.ts",
     'const ENTRY = join(import.meta.dirname, "..", "other-entry.ts");\n' +
     'spawnSync(process.execPath, [ENTRY], { stdio: "inherit" });\n');
@@ -86,6 +90,10 @@ try {
   config("executed", { suite: ["bin/smoke/spawn-entry.smoke.ts"], command: seatBuild, executes: ["bin/entry.ts"], mutations: [mutation("packages/seat/src/index.ts")] });
   result = run("executed");
   check("a spawned repo entrypoint plus target-package build is gradable", result.status === 0 && /graded=1 refused-with-reason=0 unparsed=0/.test(result.stdout), report(result));
+
+  config("pty-executed", { suite: ["bin/smoke/pty-entry.smoke.ts"], command: seatBuild, executes: ["bin/entry.ts"], mutations: [mutation("packages/seat/src/index.ts")] });
+  result = run("pty-executed");
+  check("a pty-spawned repo entrypoint is also gradable", result.status === 0 && /graded=1 refused-with-reason=0/.test(result.stdout), report(result));
 
   config("direct", { suite: ["bin/smoke/direct.smoke.ts"], command: tally, executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
   result = run("direct");

--- a/scripts/mutation-coverage.selftest.mjs
+++ b/scripts/mutation-coverage.selftest.mjs
@@ -78,6 +78,18 @@ try {
   write("bin/smoke/direct.smoke.ts",
     'const ENTRY = join(import.meta.dirname, "..", "direct.mjs");\n' +
     'spawnSync(process.execPath, [ENTRY], { stdio: "inherit" });\n');
+  write("bin/smoke/direct-suite.smoke.ts", "console.log('direct');\n");
+  write("scripts/direct.mjs", "console.log('direct');\n");
+  write("bin/smoke/direct-script.smoke.ts",
+    'spawnSync(process.execPath, [join(ROOT, "scripts", "direct.mjs")]);\n');
+  write("bin/smoke/mentions-script.smoke.ts",
+    'const note = "scripts/direct.mjs";\n');
+  write("bin/smoke/unused-root.smoke.ts",
+    'import { x } from "@cotal-ai/seat";\n' +
+    'const unused = join(ROOT, "packages", "seat");\n');
+  write("bin/smoke/unrelated-spawn.smoke.ts",
+    'spawnSync(process.execPath, ["-e", "void 0"]);\n' +
+    'const unused = join(ROOT, "scripts", "direct.mjs");\n');
   write("pnpm", "#!/bin/sh\nexit 0\n");
   chmodSync(join(root, "pnpm"), 0o755);
   execFileSync("git", ["init", "-q"], { cwd: root });
@@ -106,6 +118,30 @@ try {
   config("foreign-assembled", { suite: ["bin/smoke/assembling.smoke.ts"], command: tally, assembles: ["packages/seat"], mutations: [mutation("packages/other/src/index.ts")] });
   result = run("foreign-assembled");
   check("an assembled root cannot admit a foreign mutation", result.status !== 0 && /REFUSED foreign-assembled/.test(result.stderr), report(result));
+
+  config("direct-suite", { suite: ["bin/smoke/direct-suite.smoke.ts"], command: tally, mutations: [mutation("bin/smoke/direct-suite.smoke.ts")] });
+  result = run("direct-suite");
+  check("a suite is gradable when it directly executes the file being mutated", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
+
+  config("direct-script", { suite: ["bin/smoke/direct-script.smoke.ts"], command: tally, mutations: [mutation("scripts/direct.mjs")] });
+  result = run("direct-script");
+  check("a suite is gradable when it launches the exact mutated script path", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
+
+  config("mentions-script", { suite: ["bin/smoke/mentions-script.smoke.ts"], command: tally, mutations: [mutation("scripts/direct.mjs")] });
+  result = run("mentions-script");
+  check("a quoted script path without an invocation is refused", result.status !== 0 && /REFUSED mentions-script/.test(result.stderr), report(result));
+
+  config("malformed-assembles", { suite: ["bin/smoke/assembling.smoke.ts"], command: tally, assembles: "packages/seat", mutations: [mutation("packages/seat/package.json")] });
+  result = run("malformed-assembles");
+  check('a non-array "assembles" is refused', result.status !== 0 && /"assembles" must be an array/.test(result.stderr), report(result));
+
+  config("unused-root", { suite: ["bin/smoke/unused-root.smoke.ts"], command: tally, assembles: ["packages/seat"], mutations: [mutation("packages/seat/src/index.ts")] });
+  result = run("unused-root");
+  check("an unused root spelling beside a by-name import is accepted today (see #1434)", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
+
+  config("unrelated-spawn", { suite: ["bin/smoke/unrelated-spawn.smoke.ts"], command: tally, mutations: [mutation("scripts/direct.mjs")] });
+  result = run("unrelated-spawn");
+  check("an unrelated spawn near a quoted path is accepted today (see #1434)", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
 
   config("executed", { suite: ["bin/smoke/spawn-entry.smoke.ts"], command: seatBuild, executes: ["bin/entry.ts"], mutations: [mutation("packages/seat/src/index.ts")] });
   result = run("executed");

--- a/scripts/mutation-coverage.selftest.mjs
+++ b/scripts/mutation-coverage.selftest.mjs
@@ -185,6 +185,15 @@ try {
   result = run("unfinished-progress");
   check("progress without completion is unparsed", result.status !== 0 && /UNPARSED unfinished-progress/.test(result.stderr), report(result));
 
+  config("progress-no-marker", { suite: ["bin/smoke/direct.smoke.ts"], command: ticks, progressPattern: "^  ✓ ", minTicks: 3, executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+  result = run("progress-no-marker");
+  check(
+    "progress without a declared completionMarker names why it is unparsed",
+    result.status !== 0 && /UNPARSED progress-no-marker/.test(result.stderr)
+      && /the progress path could not confirm completion because completionMarker was not declared/.test(result.stderr),
+    report(result),
+  );
+
   for (const [name, text] of [
     ["early-ok", "SETUP OK\\n  ✓ one\\n  ✓ two\\nWORK REMAINS"],
     ["tick-passed", "  ✓ setup PASSED\\n  ✓ second\\nWORK REMAINS"],

--- a/scripts/mutation-coverage.selftest.mjs
+++ b/scripts/mutation-coverage.selftest.mjs
@@ -136,6 +136,10 @@ try {
   result = run("progress");
   check("anchored progress plus an explicit completion marker supplies a total", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
 
+  config("progress-banner", { suite: "bin/smoke/direct.smoke.ts", command: ticks, progressPattern: "^  ✓ ", minTicks: 3, executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+  result = run("progress-banner");
+  check("anchored progress plus a terminal passed banner supplies a total", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
+
   const noCompletion = `${JSON.stringify(process.execPath)} -e ${JSON.stringify("console.log('  ✓ one\\n  ✓ two\\n  ✓ three')")}`;
   config("unfinished-progress", { suite: ["bin/smoke/direct.smoke.ts"], command: noCompletion, progressPattern: "^  ✓ ", minTicks: 3, completionMarker: "FIXTURE PASSED", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
   result = run("unfinished-progress");

--- a/scripts/mutation-coverage.selftest.mjs
+++ b/scripts/mutation-coverage.selftest.mjs
@@ -203,6 +203,24 @@ try {
     report(result),
   );
 
+  const markerOffTerminal = `${JSON.stringify(process.execPath)} -e ${JSON.stringify("console.log('  ✓ one\\n  ✓ two\\n  ✓ three\\nhost pins the seat binary against background self-update\\nJCODE HOST SMOKE PASSED (85 checks)')")}`;
+  config("progress-marker-not-terminal", {
+    suite: ["bin/smoke/direct.smoke.ts"],
+    command: markerOffTerminal,
+    progressPattern: "^  ✓ ",
+    minTicks: 3,
+    completionMarker: "host pins the seat binary against background self-update",
+    executes: ["bin/direct.mjs"],
+    mutations: [mutation("bin/direct.mjs")],
+  });
+  result = run("progress-marker-not-terminal");
+  check(
+    "progress with a non-terminal completionMarker names why it is unparsed",
+    result.status !== 0 && /UNPARSED progress-marker-not-terminal/.test(result.stderr)
+      && /the declared completionMarker was not present on the final output line/.test(result.stderr),
+    report(result),
+  );
+
   for (const [name, text] of [
     ["early-ok", "SETUP OK\\n  ✓ one\\n  ✓ two\\nWORK REMAINS"],
     ["tick-passed", "  ✓ setup PASSED\\n  ✓ second\\nWORK REMAINS"],

--- a/scripts/mutation-coverage.selftest.mjs
+++ b/scripts/mutation-coverage.selftest.mjs
@@ -144,14 +144,14 @@ try {
   result = run("unrelated-spawn");
   check("an unrelated spawn near a quoted path is accepted today (see #1434)", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
 
+  config("executed", { suite: ["bin/smoke/spawn-entry.smoke.ts"], command: seatBuild, executes: ["bin/entry.ts"], mutations: [mutation("packages/seat/src/index.ts")] });
+  result = run("executed");
+  check("a spawned repo entrypoint plus target-package build is gradable", result.status === 0 && /graded=1 refused-with-reason=0 unparsed=0/.test(result.stdout), report(result));
+
   const skippedBuild = `false && pnpm --filter @cotal-ai/seat build || ${tally}`;
   config("skipped-build", { suite: ["bin/smoke/spawn-entry.smoke.ts"], command: skippedBuild, executes: ["bin/entry.ts"], mutations: [mutation("packages/seat/src/index.ts")] });
   result = run("skipped-build");
   check("a package build that never runs is accepted today because buildsPackage is the fourth witness of the class tracked in #1434, alongside ../src/, referencesRoot, and invokesFile (see #1434, #1465)", result.status === 0 && /graded=1 refused-with-reason=0/.test(result.stdout), report(result));
-
-  config("executed", { suite: ["bin/smoke/spawn-entry.smoke.ts"], command: seatBuild, executes: ["bin/entry.ts"], mutations: [mutation("packages/seat/src/index.ts")] });
-  result = run("executed");
-  check("a spawned repo entrypoint plus target-package build is gradable", result.status === 0 && /graded=1 refused-with-reason=0 unparsed=0/.test(result.stdout), report(result));
 
   config("pty-executed", { suite: ["bin/smoke/pty-entry.smoke.ts"], command: seatBuild, executes: ["bin/entry.ts"], mutations: [mutation("packages/seat/src/index.ts")] });
   result = run("pty-executed");

--- a/scripts/mutation-coverage.selftest.mjs
+++ b/scripts/mutation-coverage.selftest.mjs
@@ -144,6 +144,11 @@ try {
   result = run("unrelated-spawn");
   check("an unrelated spawn near a quoted path is accepted today (see #1434)", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
 
+  const skippedBuild = `false && pnpm --filter @cotal-ai/seat build || ${tally}`;
+  config("skipped-build", { suite: ["bin/smoke/spawn-entry.smoke.ts"], command: skippedBuild, executes: ["bin/entry.ts"], mutations: [mutation("packages/seat/src/index.ts")] });
+  result = run("skipped-build");
+  check("a package build that never runs is accepted today because buildsPackage is the fourth witness of the class tracked in #1434, alongside ../src/, referencesRoot, and invokesFile (see #1434, #1465)", result.status === 0 && /graded=1 refused-with-reason=0/.test(result.stdout), report(result));
+
   config("executed", { suite: ["bin/smoke/spawn-entry.smoke.ts"], command: seatBuild, executes: ["bin/entry.ts"], mutations: [mutation("packages/seat/src/index.ts")] });
   result = run("executed");
   check("a spawned repo entrypoint plus target-package build is gradable", result.status === 0 && /graded=1 refused-with-reason=0 unparsed=0/.test(result.stdout), report(result));
@@ -276,6 +281,31 @@ try {
     result = run(name);
     check(`${name} is not a terminal completion witness`, result.status !== 0 && new RegExp(`UNPARSED ${name}`).test(result.stderr), report(result));
   }
+
+  const ticksNot = `${JSON.stringify(process.execPath)} -e ${JSON.stringify("console.log('  ✓ one\\n  ✓ two\\n  ✓ three\\nNOT FIXTURE PASSED')")}`;
+  config("progress-not-marker", { suite: ["bin/smoke/direct.smoke.ts"], command: ticksNot, progressPattern: "^  ✓ ", minTicks: 3, completionMarker: "FIXTURE PASSED", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+  result = run("progress-not-marker");
+  check("a terminal line that contains and negates the marker is accepted today (see #1464)", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
+
+  const ticksPrefixed = `${JSON.stringify(process.execPath)} -e ${JSON.stringify("console.log('  ✓ one\\n  ✓ two\\n  ✓ three\\nrun complete: FIXTURE PASSED')")}`;
+  config("progress-prefixed-marker", { suite: ["bin/smoke/direct.smoke.ts"], command: ticksPrefixed, progressPattern: "^  ✓ ", minTicks: 3, completionMarker: "FIXTURE PASSED", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+  result = run("progress-prefixed-marker");
+  check("a prefixed completion marker still grades", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
+
+  const ticksChecks = `${JSON.stringify(process.execPath)} -e ${JSON.stringify("console.log('  ✓ one\\n  ✓ two\\n  ✓ three\\n  42 checks passed')")}`;
+  config("midline-checks", { suite: ["bin/smoke/direct.smoke.ts"], command: ticksChecks, progressPattern: "^  ✓ ", minTicks: 3, completionMarker: "checks passed", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+  result = run("midline-checks");
+  check("a mid-line checks-passed marker still grades", result.status === 0 && /graded=1/.test(result.stdout), report(result));
+
+  const ticksAnsi = `${JSON.stringify(process.execPath)} -e ${JSON.stringify("console.log('  ✓ one\\n  ✓ two\\n  ✓ three\\n\\u001b[32mFIXTURE PASSED\\u001b[0m')")}`;
+  config("progress-ansi-marker", { suite: ["bin/smoke/direct.smoke.ts"], command: ticksAnsi, progressPattern: "^  ✓ ", minTicks: 3, completionMarker: "FIXTURE PASSED", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+  result = run("progress-ansi-marker");
+  check("an ANSI-coloured completion banner still grades", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
+
+  const ticksTrail = `${JSON.stringify(process.execPath)} -e ${JSON.stringify("console.log('  ✓ one\\n  ✓ two\\n  ✓ three\\nFIXTURE PASSED but cleanup failed')")}`;
+  config("progress-trailing-marker", { suite: ["bin/smoke/direct.smoke.ts"], command: ticksTrail, progressPattern: "^  ✓ ", minTicks: 3, completionMarker: "FIXTURE PASSED", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+  result = run("progress-trailing-marker");
+  check("trailing text after the marker is accepted today (see #1464)", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
 
   config("invalid-regex", { suite: ["bin/smoke/direct.smoke.ts"], command: tally, progressPattern: "[", minTicks: 1, executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
   result = run("invalid-regex", "fraction");

--- a/scripts/mutation-coverage.selftest.mjs
+++ b/scripts/mutation-coverage.selftest.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /** Self-test for mutation-coverage's reachability, parser, and whole-corpus accounting. */
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { chmodSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { execFileSync, spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
@@ -31,7 +31,7 @@ const mutation = (file) => ({
 });
 const config = (name, value) => write(`${name}.json`, JSON.stringify(value));
 const run = (...names) => spawnSync(process.execPath, [TOOL, ...names.map((name) => `${name}.json`)], {
-  cwd: root, encoding: "utf8", timeout: 60_000,
+  cwd: root, encoding: "utf8", timeout: 60_000, env: { ...process.env, PATH: `${root}:${process.env.PATH}` },
 });
 const report = (result) => `${result.stdout}\n${result.stderr}`;
 
@@ -50,7 +50,8 @@ try {
     'const ENTRY = join(import.meta.dirname, "..", "entry.ts");\n' +
     'spawnSync(process.execPath, [ENTRY], { stdio: "inherit" });\n');
   write("bin/smoke/pty-entry.smoke.ts",
-    'const repoRoot = resolve(import.meta.dirname, "../..");\n' +
+    'const here = dirname(fileURLToPath(import.meta.url));\n' +
+    'const repoRoot = resolve(here, "../..");\n' +
     'const ENTRY = join(repoRoot, "bin", "entry.ts");\n' +
     'pty.spawn(process.execPath, [ENTRY], { cwd: process.cwd() });\n');
   write("bin/smoke/spawn-other.smoke.ts",
@@ -58,18 +59,37 @@ try {
     'spawnSync(process.execPath, [ENTRY], { stdio: "inherit" });\n');
   write("bin/smoke/reference-only.smoke.ts",
     'const ENTRY = join(import.meta.dirname, "..", "entry.ts");\nvoid ENTRY;\n');
+  write("bin/smoke/wrong-executable.smoke.ts",
+    'const ENTRY = join(import.meta.dirname, "..", "entry.ts");\n' +
+    'spawnSync("echo", [ENTRY]);\n');
+  write("bin/smoke/commented-spawn.smoke.ts",
+    'const ENTRY = join(import.meta.dirname, "..", "entry.ts");\n' +
+    '// spawnSync(process.execPath, [ENTRY]);\n');
+  write("bin/smoke/despawn.smoke.ts",
+    'const ENTRY = join(import.meta.dirname, "..", "entry.ts");\n' +
+    'despawnSync(process.execPath, [ENTRY]);\n');
+  write("bin/smoke/args-variable.smoke.ts",
+    'const ENTRY = join(import.meta.dirname, "..", "entry.ts");\n' +
+    'const ARGS = [ENTRY];\nspawnSync(process.execPath, ARGS);\n');
+  write("bin/comment-entry.ts", '// import "@cotal-ai/seat";\n');
+  write("bin/smoke/comment-import.smoke.ts",
+    'const ENTRY = join(import.meta.dirname, "..", "comment-entry.ts");\n' +
+    'spawnSync(process.execPath, [ENTRY]);\n');
   write("bin/smoke/direct.smoke.ts",
     'const ENTRY = join(import.meta.dirname, "..", "direct.mjs");\n' +
     'spawnSync(process.execPath, [ENTRY], { stdio: "inherit" });\n');
-  write("fake-build.mjs", "process.exit(0);\n");
+  write("pnpm", "#!/bin/sh\nexit 0\n");
+  chmodSync(join(root, "pnpm"), 0o755);
   execFileSync("git", ["init", "-q"], { cwd: root });
   execFileSync("git", ["add", "."], { cwd: root });
   execFileSync("git", ["-c", "user.name=fixture", "-c", "user.email=fixture@example.invalid", "commit", "-qm", "fixture"], { cwd: root });
   const fixtureHead = execFileSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" }).trim();
 
   const tally = summaryCommand("FIXTURE: 3 passed, 0 failed");
-  const seatBuild = `${JSON.stringify(process.execPath)} fake-build.mjs --filter @cotal-ai/seat build && ${tally}`;
-  const otherBuild = `${JSON.stringify(process.execPath)} fake-build.mjs --filter @cotal-ai/other build && ${tally}`;
+  const seatBuild = `pnpm --filter @cotal-ai/seat build && ${tally}`;
+  const equalsSeatBuild = `pnpm --filter=@cotal-ai/seat build && ${tally}`;
+  const otherBuild = `pnpm --filter @cotal-ai/other build && ${tally}`;
+  const fakePrintedBuild = `${JSON.stringify(process.execPath)} -e ${JSON.stringify("console.log('pnpm build')")} && ${tally}`;
 
   config("trap", { suite: ["packages/seat/smoke/local.smoke.ts"], command: tally, mutations: [mutation("packages/seat/src/index.ts")] });
   let result = run("trap");
@@ -115,6 +135,26 @@ try {
   result = run("wrong-build");
   check("building an unrelated package does not admit the target", result.status !== 0 && /REFUSED wrong-build/.test(result.stderr), report(result));
 
+  for (const [name, suite, entry, command] of [
+    ["wrong-executable", "bin/smoke/wrong-executable.smoke.ts", "bin/entry.ts", seatBuild],
+    ["commented-spawn", "bin/smoke/commented-spawn.smoke.ts", "bin/entry.ts", seatBuild],
+    ["despawn", "bin/smoke/despawn.smoke.ts", "bin/entry.ts", seatBuild],
+    ["comment-import", "bin/smoke/comment-import.smoke.ts", "bin/comment-entry.ts", seatBuild],
+    ["printed-build", "bin/smoke/spawn-entry.smoke.ts", "bin/entry.ts", fakePrintedBuild],
+  ]) {
+    config(name, { suite: [suite], command, executes: [entry], mutations: [mutation("packages/seat/src/index.ts")] });
+    result = run(name);
+    check(`${name} cannot fabricate executes evidence`, result.status !== 0 && new RegExp(`REFUSED ${name}`).test(result.stderr), report(result));
+  }
+
+  config("args-variable", { suite: ["bin/smoke/args-variable.smoke.ts"], command: seatBuild, executes: ["bin/entry.ts"], mutations: [mutation("packages/seat/src/index.ts")] });
+  result = run("args-variable");
+  check("a genuine subprocess argument array is accepted", result.status === 0 && /graded=1 refused-with-reason=0/.test(result.stdout), report(result));
+
+  config("equals-filter", { suite: ["bin/smoke/spawn-entry.smoke.ts"], command: equalsSeatBuild, executes: ["bin/entry.ts"], mutations: [mutation("packages/seat/src/index.ts")] });
+  result = run("equals-filter");
+  check("the pnpm --filter=value build form is accepted", result.status === 0 && /graded=1 refused-with-reason=0/.test(result.stdout), report(result));
+
   config("malformed-executes", { suite: ["bin/smoke/spawn-entry.smoke.ts"], command: seatBuild, executes: "bin/entry.ts", mutations: [mutation("packages/seat/src/index.ts")] });
   result = run("malformed-executes");
   check("a non-array executes declaration is refused", result.status !== 0 && /"executes" must be an array/.test(result.stderr), report(result));
@@ -136,7 +176,7 @@ try {
   result = run("progress");
   check("anchored progress plus an explicit completion marker supplies a total", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
 
-  config("progress-banner", { suite: "bin/smoke/direct.smoke.ts", command: ticks, progressPattern: "^  ✓ ", minTicks: 3, executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+  config("progress-banner", { suite: ["bin/smoke/direct.smoke.ts"], command: ticks, progressPattern: "^  ✓ ", minTicks: 3, executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
   result = run("progress-banner");
   check("anchored progress plus a terminal passed banner supplies a total", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
 
@@ -144,6 +184,19 @@ try {
   config("unfinished-progress", { suite: ["bin/smoke/direct.smoke.ts"], command: noCompletion, progressPattern: "^  ✓ ", minTicks: 3, completionMarker: "FIXTURE PASSED", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
   result = run("unfinished-progress");
   check("progress without completion is unparsed", result.status !== 0 && /UNPARSED unfinished-progress/.test(result.stderr), report(result));
+
+  for (const [name, text] of [
+    ["early-ok", "SETUP OK\\n  ✓ one\\n  ✓ two\\nWORK REMAINS"],
+    ["tick-passed", "  ✓ setup PASSED\\n  ✓ second\\nWORK REMAINS"],
+  ]) {
+    config(name, { suite: ["bin/smoke/direct.smoke.ts"], command: `${JSON.stringify(process.execPath)} -e ${JSON.stringify(`console.log(${JSON.stringify(text)})`)}`, progressPattern: "^  ✓ ", minTicks: 2, executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+    result = run(name);
+    check(`${name} is not a terminal completion witness`, result.status !== 0 && new RegExp(`UNPARSED ${name}`).test(result.stderr), report(result));
+  }
+
+  config("invalid-regex", { suite: ["bin/smoke/direct.smoke.ts"], command: tally, progressPattern: "[", minTicks: 1, executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+  result = run("invalid-regex", "fraction");
+  check("an invalid progress regex is refused without hiding the next config", result.status !== 0 && /enumerated=2 examined=2 graded=1 refused-with-reason=1/.test(result.stdout), report(result));
 
   config("no-suite", { command: tally, mutations: [mutation("bin/direct.mjs")] });
   result = run("no-suite");

--- a/scripts/mutation-coverage.selftest.mjs
+++ b/scripts/mutation-coverage.selftest.mjs
@@ -214,25 +214,36 @@ try {
   check("zero failures without a total stays unparsed", result.status !== 0 && /UNPARSED zero-failed/.test(result.stderr), report(result));
 
   const ticks = `${JSON.stringify(process.execPath)} -e ${JSON.stringify("console.log('  ✓ one\\n  ✓ two\\n  ✓ three\\nFIXTURE PASSED')")}`;
-  config("progress", { suite: ["bin/smoke/direct.smoke.ts"], command: ticks, progressPattern: "^  ✓ ", minTicks: 3, completionMarker: "FIXTURE PASSED", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
-  result = run("progress");
-  check("anchored progress plus an explicit completion marker supplies a total", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
-
   config("progress-banner", { suite: ["bin/smoke/direct.smoke.ts"], command: ticks, progressPattern: "^  ✓ ", minTicks: 3, completionMarker: "FIXTURE PASSED", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
   result = run("progress-banner");
-  check("anchored progress plus its declared terminal banner supplies a total", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
+  check(
+    "a declared terminal banner is not an executed-cell total",
+    result.status !== 0 && /UNPARSED progress-banner/.test(result.stderr),
+    report(result),
+  );
+
+  config("progress", { suite: ["bin/smoke/direct.smoke.ts"], command: ticks, progressPattern: "^  ✓ ", minTicks: 3, completionMarker: "FIXTURE PASSED", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+  result = run("progress");
+  check(
+    "a terminal banner without a printed number is unparsed",
+    result.status !== 0 && /UNPARSED progress/.test(result.stderr)
+      && /progress ticks are not an executed-cell total/.test(result.stderr)
+      && /the instrument grades only a number the suite printed/.test(result.stderr),
+    report(result),
+  );
 
   const noCompletion = `${JSON.stringify(process.execPath)} -e ${JSON.stringify("console.log('  ✓ one\\n  ✓ two\\n  ✓ three')")}`;
   config("unfinished-progress", { suite: ["bin/smoke/direct.smoke.ts"], command: noCompletion, progressPattern: "^  ✓ ", minTicks: 3, completionMarker: "FIXTURE PASSED", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
   result = run("unfinished-progress");
-  check("progress without completion is unparsed", result.status !== 0 && /UNPARSED unfinished-progress/.test(result.stderr), report(result));
+  check("progress without a printed number is unparsed", result.status !== 0 && /UNPARSED unfinished-progress/.test(result.stderr), report(result));
 
   config("progress-no-marker", { suite: ["bin/smoke/direct.smoke.ts"], command: ticks, progressPattern: "^  ✓ ", minTicks: 3, executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
   result = run("progress-no-marker");
   check(
     "progress without a declared completionMarker names why it is unparsed",
     result.status !== 0 && /UNPARSED progress-no-marker/.test(result.stderr)
-      && /the progress path could not confirm completion because completionMarker was not declared/.test(result.stderr),
+      && /progress ticks are not an executed-cell total/.test(result.stderr)
+      && /the instrument grades only a number the suite printed/.test(result.stderr),
     report(result),
   );
 
@@ -269,7 +280,7 @@ try {
   check(
     "progress with a non-terminal completionMarker names why it is unparsed",
     result.status !== 0 && /UNPARSED progress-marker-not-terminal/.test(result.stderr)
-      && /the declared completionMarker was not present on the final output line/.test(result.stderr),
+      && /progress ticks are not an executed-cell total/.test(result.stderr),
     report(result),
   );
 
@@ -285,11 +296,16 @@ try {
   const ticksNot = `${JSON.stringify(process.execPath)} -e ${JSON.stringify("console.log('  ✓ one\\n  ✓ two\\n  ✓ three\\nNOT FIXTURE PASSED')")}`;
   config("progress-not-marker", { suite: ["bin/smoke/direct.smoke.ts"], command: ticksNot, progressPattern: "^  ✓ ", minTicks: 3, completionMarker: "FIXTURE PASSED", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
   result = run("progress-not-marker");
-  check("a terminal line that contains and negates the marker is accepted today (see #1464)", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
+  check("a terminal line that contains and negates the marker is unparsed without a printed number", result.status !== 0 && /UNPARSED progress-not-marker/.test(result.stderr), report(result));
 
   const ticksPrefixed = `${JSON.stringify(process.execPath)} -e ${JSON.stringify("console.log('  ✓ one\\n  ✓ two\\n  ✓ three\\nrun complete: FIXTURE PASSED')")}`;
   config("progress-prefixed-marker", { suite: ["bin/smoke/direct.smoke.ts"], command: ticksPrefixed, progressPattern: "^  ✓ ", minTicks: 3, completionMarker: "FIXTURE PASSED", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
   result = run("progress-prefixed-marker");
+  check("a prefixed completion marker without a printed number is unparsed (the #1464 must-accept pin was pinning banner-as-completion)", result.status !== 0 && /UNPARSED progress-prefixed-marker/.test(result.stderr), report(result));
+
+  const ticksPrefixedFraction = `${JSON.stringify(process.execPath)} -e ${JSON.stringify("console.log('  ✓ one\\n  ✓ two\\n  ✓ three\\nrun complete: FIXTURE PASSED 3/3')")}`;
+  config("progress-prefixed-fraction", { suite: ["bin/smoke/direct.smoke.ts"], command: ticksPrefixedFraction, progressPattern: "^  ✓ ", minTicks: 3, completionMarker: "FIXTURE PASSED", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+  result = run("progress-prefixed-fraction");
   check("a prefixed completion marker still grades", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
 
   const ticksChecks = `${JSON.stringify(process.execPath)} -e ${JSON.stringify("console.log('  ✓ one\\n  ✓ two\\n  ✓ three\\n  42 checks passed')")}`;
@@ -300,12 +316,22 @@ try {
   const ticksAnsi = `${JSON.stringify(process.execPath)} -e ${JSON.stringify("console.log('  ✓ one\\n  ✓ two\\n  ✓ three\\n\\u001b[32mFIXTURE PASSED\\u001b[0m')")}`;
   config("progress-ansi-marker", { suite: ["bin/smoke/direct.smoke.ts"], command: ticksAnsi, progressPattern: "^  ✓ ", minTicks: 3, completionMarker: "FIXTURE PASSED", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
   result = run("progress-ansi-marker");
+  check("an ANSI-coloured banner without a printed number is unparsed (the #1464 must-accept pin was pinning banner-as-completion)", result.status !== 0 && /UNPARSED progress-ansi-marker/.test(result.stderr), report(result));
+
+  const ticksAnsiFraction = `${JSON.stringify(process.execPath)} -e ${JSON.stringify("console.log('  ✓ one\\n  ✓ two\\n  ✓ three\\n\\u001b[32mFIXTURE PASSED 3/3\\u001b[0m')")}`;
+  config("progress-ansi-fraction", { suite: ["bin/smoke/direct.smoke.ts"], command: ticksAnsiFraction, progressPattern: "^  ✓ ", minTicks: 3, completionMarker: "FIXTURE PASSED", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+  result = run("progress-ansi-fraction");
   check("an ANSI-coloured completion banner still grades", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
 
   const ticksTrail = `${JSON.stringify(process.execPath)} -e ${JSON.stringify("console.log('  ✓ one\\n  ✓ two\\n  ✓ three\\nFIXTURE PASSED but cleanup failed')")}`;
   config("progress-trailing-marker", { suite: ["bin/smoke/direct.smoke.ts"], command: ticksTrail, progressPattern: "^  ✓ ", minTicks: 3, completionMarker: "FIXTURE PASSED", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
   result = run("progress-trailing-marker");
-  check("trailing text after the marker is accepted today (see #1464)", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
+  check("trailing text after the marker is unparsed without a printed number", result.status !== 0 && /UNPARSED progress-trailing-marker/.test(result.stderr), report(result));
+
+  const ticksTrailFraction = `${JSON.stringify(process.execPath)} -e ${JSON.stringify("console.log('  ✓ one\\n  ✓ two\\n  ✓ three\\nFIXTURE PASSED 3/3 but cleanup failed')")}`;
+  config("progress-trailing-fraction", { suite: ["bin/smoke/direct.smoke.ts"], command: ticksTrailFraction, progressPattern: "^  ✓ ", minTicks: 3, completionMarker: "FIXTURE PASSED", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+  result = run("progress-trailing-fraction");
+  check("trailing text after a complete fraction on the marker line is accepted today (see #1464)", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
 
   config("invalid-regex", { suite: ["bin/smoke/direct.smoke.ts"], command: tally, progressPattern: "[", minTicks: 1, executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
   result = run("invalid-regex", "fraction");

--- a/scripts/mutation-coverage.selftest.mjs
+++ b/scripts/mutation-coverage.selftest.mjs
@@ -1,24 +1,7 @@
 #!/usr/bin/env node
-/**
- * Self-test for `mutation-coverage.mjs`'s gradability check.
- *
- * The check exists because a mutation whose suite resolves the target package to `dist` reports
- * SURVIVED — honestly, and indistinguishably from a missing test. The second witness (`assembles`)
- * exists because a suite that COPIES the target's source tree into a fixture runs the mutated
- * bytes through the copy, where the resolver is never asked. Each half has a way to lie:
- *
- *   - the witness admitted without the suite referencing the tree   → the dist trap reopens wearing
- *                                                                     a declaration
- *   - the witness refused for a suite that assembles                → a gradable mutation is called
- *                                                                     ungradable and pushed to "unkillable"
- *
- * This drives the script against throwaway fixture configs where the right answer is known, both
- * ways. Fast on purpose: the "suite" is a shell exit code, so there is no reason to skip it.
- *
- * Run: node scripts/mutation-coverage.selftest.mjs
- */
+/** Self-test for mutation-coverage's reachability, parser, and whole-corpus accounting. */
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
-import { spawnSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -26,247 +9,148 @@ import { fileURLToPath } from "node:url";
 const TOOL = join(dirname(fileURLToPath(import.meta.url)), "mutation-coverage.mjs");
 const root = mkdtempSync(join(tmpdir(), "mutation-coverage-selftest-"));
 let pass = 0;
-const check = (name, cond, extra) => {
-  if (!cond) {
-    console.error(`\n  ✗ ${name}${extra !== undefined ? ` — ${JSON.stringify(extra)}` : ""}`);
+const check = (name, condition, extra) => {
+  if (!condition) {
+    console.error(`\n  ✗ ${name}${extra !== undefined ? ` - ${JSON.stringify(extra)}` : ""}`);
     rmSync(root, { recursive: true, force: true });
     process.exit(1);
   }
   pass++;
   console.log(`  ✓ ${name}`);
 };
-
-// A fixture tree: a package whose source a suite may import or copy, a repo script a suite may run
-// directly, and suites for each accepted or refused resolution shape.
-mkdirSync(join(root, "packages/seat/src"), { recursive: true });
-mkdirSync(join(root, "packages/seat/smoke"), { recursive: true });
-mkdirSync(join(root, "packages/other"), { recursive: true });
-mkdirSync(join(root, "bin/smoke"), { recursive: true });
-mkdirSync(join(root, "scripts"), { recursive: true });
-writeFileSync(join(root, "packages/seat/package.json"), JSON.stringify({ name: "@cotal-ai/seat" }));
-writeFileSync(join(root, "packages/seat/src/impl.ts"), "export const x = 1;\n");
-writeFileSync(join(root, "packages/other/impl.ts"), "export const y = 1;\n");
-writeFileSync(join(root, "scripts/direct.mjs"), "console.log('direct');\n");
-writeFileSync(
-  join(root, "bin/smoke/assembling.smoke.ts"),
-  'import { cpSync } from "node:fs";\n' +
-  'cpSync(join(ROOT, "packages", "seat"), clone, { recursive: true });\n',
-);
-writeFileSync(
-  join(root, "bin/smoke/by-name.smoke.ts"),
-  'import { x } from "@cotal-ai/seat";\n',
-);
-writeFileSync(
-  join(root, "packages/seat/smoke/local-by-name.smoke.ts"),
-  'import { x } from "@cotal-ai/seat";\n',
-);
-writeFileSync(join(root, "bin/smoke/direct.smoke.ts"), "console.log('direct');\n");
-writeFileSync(
-  join(root, "bin/smoke/direct-script.smoke.ts"),
-  'spawnSync(process.execPath, [join(ROOT, "scripts", "direct.mjs")]);\n',
-);
-writeFileSync(
-  join(root, "bin/smoke/aliased-launcher.smoke.ts"),
-  'import { spawnSync as run } from "node:child_process";\n' +
-  'run(process.execPath, [join(ROOT, "scripts", "direct.mjs")]);\n',
-);
-writeFileSync(
-  join(root, "bin/smoke/bound-entry.smoke.ts"),
-  'const ENTRY = join(ROOT, "scripts", "direct.mjs");\n' +
-  "execFileSync(process.execPath, [ENTRY]);\n",
-);
-writeFileSync(
-  join(root, "bin/smoke/node-by-name.smoke.ts"),
-  'spawnSync("node", [join(ROOT, "scripts", "direct.mjs")]);\n',
-);
-writeFileSync(
-  join(root, "bin/smoke/mentions-script.smoke.ts"),
-  'const note = "scripts/direct.mjs";\n',
-);
-writeFileSync(
-  join(root, "bin/smoke/bound-entry-unused.smoke.ts"),
-  'const ENTRY = join(ROOT, "scripts", "direct.mjs");\n' +
-  'spawnSync(process.execPath, ["-e", "void 0"]);\n' +
-  "console.log(ENTRY);\n",
-);
-writeFileSync(
-  join(root, "bin/smoke/unused-root.smoke.ts"),
-  'import { x } from "@cotal-ai/seat";\n' +
-  'const unused = join(ROOT, "packages", "seat");\n',
-);
-writeFileSync(
-  join(root, "bin/smoke/unrelated-spawn.smoke.ts"),
-  'spawnSync(process.execPath, ["-e", "void 0"]);\n' +
-  'const unused = join(ROOT, "scripts", "direct.mjs");\n',
-);
-
-// A "suite" the script can tally: its terminal line is the only thing the coverage report parses.
-const TALLY = `${process.execPath} -e "console.log('FIXTURE: 3 passed, 0 failed')"`;
+const write = (path, value) => {
+  const target = join(root, path);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, value);
+};
+const summaryCommand = (line) =>
+  `${JSON.stringify(process.execPath)} -e ${JSON.stringify(`console.log(${JSON.stringify(line)})`)}`;
 const mutation = (file) => ({
   name: `mutates ${file}`, file, find: "x", replace: "y",
   expectRed: "the fixture cell", cell: "the fixture cell",
 });
-const writeConfig = (name, cfg) => writeFileSync(join(root, name), JSON.stringify(cfg));
-const runTool = (config) =>
-  spawnSync(process.execPath, [TOOL, config], { cwd: root, encoding: "utf8", timeout: 60_000 });
-
-// 1. THE TRAP THE CHECK EXISTS FOR: same package, imported by name, no ../src, no declaration.
-// Refused before this change and refused after it — the safety the `assembles` witness must not
-// weaken, pinned first so the cells below cannot pass by widening the rule.
-writeConfig("trap.json", {
-  suite: ["packages/seat/smoke/local-by-name.smoke.ts"], command: TALLY,
-  mutations: [mutation("packages/seat/src/impl.ts")],
+const config = (name, value) => write(`${name}.json`, JSON.stringify(value));
+const run = (...names) => spawnSync(process.execPath, [TOOL, ...names.map((name) => `${name}.json`)], {
+  cwd: root, encoding: "utf8", timeout: 60_000,
 });
-let r = runTool("trap.json");
-check(
-  "a by-name import in the same package is still refused",
-  r.status !== 0 && /assembles/.test(r.stderr) && /dist/.test(r.stderr),
-  r.stderr.slice(-300),
-);
+const report = (result) => `${result.stdout}\n${result.stderr}`;
 
-// 2. THE WITNESS: the assembling suite is gradable when the config declares the tree it copies.
-writeConfig("assembled.json", {
-  suite: ["bin/smoke/assembling.smoke.ts"], command: TALLY, assembles: ["packages/seat"],
-  mutations: [mutation("packages/seat/package.json")],
-});
-r = runTool("assembled.json");
-check(
-  "an assembling suite is gradable when the config declares the source tree it copies",
-  r.status === 0 && r.stdout.includes("1 /   3 cells observed failing"),
-  (r.stderr || r.stdout).slice(-300),
-);
+try {
+  write("packages/seat/package.json", JSON.stringify({ name: "@cotal-ai/seat" }));
+  write("packages/seat/src/index.ts", "export const x = 1;\n");
+  write("packages/seat/smoke/local.smoke.ts", 'import { x } from "@cotal-ai/seat";\n');
+  write("packages/other/package.json", JSON.stringify({ name: "@cotal-ai/other" }));
+  write("packages/other/src/index.ts", "export const x = 1;\n");
+  write("bin/entry.ts", 'import "@cotal-ai/seat";\n');
+  write("bin/other-entry.ts", 'import "@cotal-ai/other";\n');
+  write("bin/direct.mjs", "export const x = 1;\n");
+  write("bin/smoke/assembling.smoke.ts", 'cpSync(join(ROOT, "packages", "seat"), clone);\n');
+  write("bin/smoke/by-name.smoke.ts", 'import { x } from "@cotal-ai/seat";\n');
+  write("bin/smoke/spawn-entry.smoke.ts",
+    'const ENTRY = join(import.meta.dirname, "..", "entry.ts");\n' +
+    'spawnSync(process.execPath, [ENTRY], { stdio: "inherit" });\n');
+  write("bin/smoke/spawn-other.smoke.ts",
+    'const ENTRY = join(import.meta.dirname, "..", "other-entry.ts");\n' +
+    'spawnSync(process.execPath, [ENTRY], { stdio: "inherit" });\n');
+  write("bin/smoke/reference-only.smoke.ts",
+    'const ENTRY = join(import.meta.dirname, "..", "entry.ts");\nvoid ENTRY;\n');
+  write("bin/smoke/direct.smoke.ts",
+    'const ENTRY = join(import.meta.dirname, "..", "direct.mjs");\n' +
+    'spawnSync(process.execPath, [ENTRY], { stdio: "inherit" });\n');
+  write("fake-build.mjs", "process.exit(0);\n");
+  execFileSync("git", ["init", "-q"], { cwd: root });
+  execFileSync("git", ["add", "."], { cwd: root });
+  execFileSync("git", ["-c", "user.name=fixture", "-c", "user.email=fixture@example.invalid", "commit", "-qm", "fixture"], { cwd: root });
 
-// 3. DIRECT SUITE: the command executes the mutation target itself.
-writeConfig("direct.json", {
-  suite: ["bin/smoke/direct.smoke.ts"], command: TALLY,
-  mutations: [mutation("bin/smoke/direct.smoke.ts")],
-});
-r = runTool("direct.json");
-check(
-  "a suite is gradable when it directly executes the file being mutated",
-  r.status === 0 && r.stdout.includes("1 /   3 cells observed failing"),
-  (r.stderr || r.stdout).slice(-300),
-);
+  const tally = summaryCommand("FIXTURE: 3 passed, 0 failed");
+  const seatBuild = `${JSON.stringify(process.execPath)} fake-build.mjs --filter @cotal-ai/seat build && ${tally}`;
+  const otherBuild = `${JSON.stringify(process.execPath)} fake-build.mjs --filter @cotal-ai/other build && ${tally}`;
 
-// 4. DIRECT SCRIPT: the suite launches the exact repo-relative mutation target.
-writeConfig("direct-script.json", {
-  suite: ["bin/smoke/direct-script.smoke.ts"], command: TALLY,
-  mutations: [mutation("scripts/direct.mjs")],
-});
-r = runTool("direct-script.json");
-check(
-  "a suite is gradable when it launches the exact mutated script path",
-  r.status === 0 && r.stdout.includes("1 /   3 cells observed failing"),
-  (r.stderr || r.stdout).slice(-300),
-);
+  config("trap", { suite: ["packages/seat/smoke/local.smoke.ts"], command: tally, mutations: [mutation("packages/seat/src/index.ts")] });
+  let result = run("trap");
+  check("a by-name same-package import without ../src is refused", result.status !== 0 && /REFUSED trap\.json/.test(result.stderr) && /dist/.test(result.stderr), report(result));
 
-// 4b-4d. THE SAME INVOCATION, SPELLED THE WAYS THE REPO SPELLS IT: an aliased launcher import,
-// a target bound to a name before the call, and "node" by name instead of process.execPath.
-for (const [name, label] of [
-  ["aliased-launcher", "a launcher imported under an alias still witnesses the script it runs"],
-  ["bound-entry", "a target bound to a const before the launcher call still witnesses it"],
-  ["node-by-name", "spawning \"node\" by name is the same witness as process.execPath"],
-]) {
-  writeConfig(`${name}.json`, {
-    suite: [`bin/smoke/${name}.smoke.ts`], command: TALLY,
-    mutations: [mutation("scripts/direct.mjs")],
-  });
-  r = runTool(`${name}.json`);
-  check(label, r.status === 0 && r.stdout.includes("1 /   3 cells observed failing"), (r.stderr || r.stdout).slice(-300));
+  config("assembled", { suite: ["bin/smoke/assembling.smoke.ts"], command: tally, assembles: ["packages/seat"], mutations: [mutation("packages/seat/package.json")] });
+  result = run("assembled");
+  check("the preserved assembles witness remains gradable", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
+
+  config("hollow-assembled", { suite: ["bin/smoke/by-name.smoke.ts"], command: tally, assembles: ["packages/seat"], mutations: [mutation("packages/seat/package.json")] });
+  result = run("hollow-assembled");
+  check("an assembles declaration without a suite reference is refused", result.status !== 0 && /REFUSED hollow-assembled/.test(result.stderr), report(result));
+
+  config("foreign-assembled", { suite: ["bin/smoke/assembling.smoke.ts"], command: tally, assembles: ["packages/seat"], mutations: [mutation("packages/other/src/index.ts")] });
+  result = run("foreign-assembled");
+  check("an assembled root cannot admit a foreign mutation", result.status !== 0 && /REFUSED foreign-assembled/.test(result.stderr), report(result));
+
+  config("executed", { suite: ["bin/smoke/spawn-entry.smoke.ts"], command: seatBuild, executes: ["bin/entry.ts"], mutations: [mutation("packages/seat/src/index.ts")] });
+  result = run("executed");
+  check("a spawned repo entrypoint plus target-package build is gradable", result.status === 0 && /graded=1 refused-with-reason=0 unparsed=0/.test(result.stdout), report(result));
+
+  config("direct", { suite: ["bin/smoke/direct.smoke.ts"], command: tally, executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+  result = run("direct");
+  check("a directly spawned mutated source entrypoint needs no build", result.status === 0 && /graded=1 refused-with-reason=0/.test(result.stdout), report(result));
+
+  config("declaration-only", { suite: ["bin/smoke/by-name.smoke.ts"], command: seatBuild, executes: ["bin/entry.ts"], mutations: [mutation("packages/seat/src/index.ts")] });
+  result = run("declaration-only");
+  check("an executes declaration alone is refused", result.status !== 0 && /REFUSED declaration-only/.test(result.stderr), report(result));
+
+  config("reference-only", { suite: ["bin/smoke/reference-only.smoke.ts"], command: seatBuild, executes: ["bin/entry.ts"], mutations: [mutation("packages/seat/src/index.ts")] });
+  result = run("reference-only");
+  check("an entrypoint reference not passed to a subprocess is refused", result.status !== 0 && /REFUSED reference-only/.test(result.stderr), report(result));
+
+  config("wrong-entry", { suite: ["bin/smoke/spawn-other.smoke.ts"], command: seatBuild, executes: ["bin/other-entry.ts"], mutations: [mutation("packages/seat/src/index.ts")] });
+  result = run("wrong-entry");
+  check("an unrelated spawned entrypoint is refused", result.status !== 0 && /REFUSED wrong-entry/.test(result.stderr), report(result));
+
+  config("wrong-build", { suite: ["bin/smoke/spawn-entry.smoke.ts"], command: otherBuild, executes: ["bin/entry.ts"], mutations: [mutation("packages/seat/src/index.ts")] });
+  result = run("wrong-build");
+  check("building an unrelated package does not admit the target", result.status !== 0 && /REFUSED wrong-build/.test(result.stderr), report(result));
+
+  config("malformed-executes", { suite: ["bin/smoke/spawn-entry.smoke.ts"], command: seatBuild, executes: "bin/entry.ts", mutations: [mutation("packages/seat/src/index.ts")] });
+  result = run("malformed-executes");
+  check("a non-array executes declaration is refused", result.status !== 0 && /"executes" must be an array/.test(result.stderr), report(result));
+
+  config("fraction", { suite: ["bin/smoke/direct.smoke.ts"], command: summaryCommand("ENDPOINT RESULTS: 4/4"), completionMarker: "ENDPOINT RESULTS:", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+  result = run("fraction");
+  check("a completed all-passed fraction supplies the executed total", result.status === 0 && result.stdout.includes("1 /   4 cells observed failing"), report(result));
+
+  config("partial-fraction", { suite: ["bin/smoke/direct.smoke.ts"], command: summaryCommand("ENDPOINT RESULTS: 3/4"), completionMarker: "ENDPOINT RESULTS:", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+  result = run("partial-fraction");
+  check("a partial fraction is unparsed rather than graded", result.status !== 0 && /UNPARSED partial-fraction/.test(result.stderr) && /unparsed=1/.test(result.stdout), report(result));
+
+  config("zero-failed", { suite: ["bin/smoke/direct.smoke.ts"], command: summaryCommand("FIXTURE SMOKE OK (0 failed)"), executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+  result = run("zero-failed");
+  check("zero failures without a total stays unparsed", result.status !== 0 && /UNPARSED zero-failed/.test(result.stderr), report(result));
+
+  const ticks = `${JSON.stringify(process.execPath)} -e ${JSON.stringify("console.log('  ✓ one\\n  ✓ two\\n  ✓ three\\nFIXTURE PASSED')")}`;
+  config("progress", { suite: ["bin/smoke/direct.smoke.ts"], command: ticks, progressPattern: "^  ✓ ", minTicks: 3, completionMarker: "FIXTURE PASSED", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+  result = run("progress");
+  check("anchored progress plus an explicit completion marker supplies a total", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
+
+  const noCompletion = `${JSON.stringify(process.execPath)} -e ${JSON.stringify("console.log('  ✓ one\\n  ✓ two\\n  ✓ three')")}`;
+  config("unfinished-progress", { suite: ["bin/smoke/direct.smoke.ts"], command: noCompletion, progressPattern: "^  ✓ ", minTicks: 3, completionMarker: "FIXTURE PASSED", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+  result = run("unfinished-progress");
+  check("progress without completion is unparsed", result.status !== 0 && /UNPARSED unfinished-progress/.test(result.stderr), report(result));
+
+  config("no-suite", { command: tally, mutations: [mutation("bin/direct.mjs")] });
+  result = run("no-suite");
+  check("missing suite metadata is still refused", result.status !== 0 && /REFUSED no-suite/.test(result.stderr) && /MISSING SUITE METADATA|required top-level "suite"/.test(report(result)), report(result));
+
+  config("legacy-suite", { suite: "bin/smoke/direct.smoke.ts", command: tally, executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+  result = run("legacy-suite");
+  check("a legacy string suite is still refused", result.status !== 0 && /REFUSED legacy-suite/.test(result.stderr) && /MALFORMED SUITE METADATA|legacy string/.test(report(result)), report(result));
+
+  config("multi-source", { suite: ["bin/smoke/direct.smoke.ts", "bin/smoke/assembling.smoke.ts"], command: tally, executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+  result = run("multi-source");
+  check("a valid multi-source fixture is still graded", result.status === 0 && /graded=1 refused-with-reason=0/.test(result.stdout), report(result));
+
+  result = run("declaration-only", "zero-failed", "fraction");
+  check(
+    "one bad config does not hide later configs",
+    result.status !== 0 && /enumerated=3 examined=3 graded=1 refused-with-reason=1 unparsed=1/.test(result.stdout),
+    report(result),
+  );
+} finally {
+  rmSync(root, { recursive: true, force: true });
 }
-
-// 5. A QUOTED PATH IS NOT AN INVOCATION: prose or a fixture string cannot license a mutation.
-// This cell is a contiguous quoted path with no launcher and no bound identifier, so a mutation
-// that treats any quoted mention as a witness reddens HERE rather than a later bound-name cell
-// that also happens to quote the basename.
-writeConfig("mentions-script.json", {
-  suite: ["bin/smoke/mentions-script.smoke.ts"], command: TALLY,
-  mutations: [mutation("scripts/direct.mjs")],
-});
-r = runTool("mentions-script.json");
-check(
-  "a quoted script path without an invocation is refused",
-  r.status !== 0 && /imports by source path or reaches through/.test(r.stderr),
-  r.stderr.slice(-300),
-);
-
-// 5b. A BOUND NAME OUTSIDE THE ARGUMENT LIST IS NOT AN INVOCATION: the launcher runs something
-// else and the name is only printed afterwards. Distinct from cell 5: the basename is quoted
-// inside a binding, so collapsing invokesFile to referencesRoot would also grade this one —
-// that is why cell 5 runs first, and a separate mutation drops the argument-list check.
-writeConfig("bound-entry-unused.json", {
-  suite: ["bin/smoke/bound-entry-unused.smoke.ts"], command: TALLY,
-  mutations: [mutation("scripts/direct.mjs")],
-});
-r = runTool("bound-entry-unused.json");
-check(
-  "a name bound to the target but never passed to a launcher is still refused",
-  r.status !== 0 && /assembles/.test(r.stderr),
-  r.stderr.slice(-300),
-);
-
-// 6. THE DECLARATION IS NOT THE WITNESS: same declaration, suite that never references the tree.
-writeConfig("hollow.json", {
-  suite: ["bin/smoke/by-name.smoke.ts"], command: TALLY, assembles: ["packages/seat"],
-  mutations: [mutation("packages/seat/package.json")],
-});
-r = runTool("hollow.json");
-check(
-  "a declaration the suite source cannot back is refused",
-  r.status !== 0 && /imports by source path or reaches through/.test(r.stderr),
-  r.stderr.slice(-300),
-);
-
-// 7. CONTAINMENT: a declared root cannot smuggle a file it does not contain.
-writeConfig("foreign.json", {
-  suite: ["bin/smoke/assembling.smoke.ts"], command: TALLY, assembles: ["packages/seat"],
-  mutations: [mutation("packages/other/impl.ts")],
-});
-r = runTool("foreign.json");
-check(
-  "a declared root cannot smuggle a file outside it",
-  r.status !== 0 && /assembles/.test(r.stderr),
-  r.stderr.slice(-300),
-);
-
-// 8. SHAPE: `assembles` is an array of paths, and anything else is refused rather than guessed at.
-writeConfig("malformed.json", {
-  suite: ["bin/smoke/assembling.smoke.ts"], command: TALLY, assembles: "packages/seat",
-  mutations: [mutation("packages/seat/package.json")],
-});
-r = runTool("malformed.json");
-check(
-  'a non-array "assembles" is refused',
-  r.status !== 0 && /"assembles" must be an array/.test(r.stderr),
-  r.stderr.slice(-300),
-);
-
-// 9 and 10. PRESENCE-BUT-UNUSED. Cells 5 and 6 above pin the ABSENCE of a witness token, so
-// neither can see a suite that CONTAINS the right characters without running or copying anything.
-// Both witnesses accept that today, and so does the `../src/` substring they sit beside, on main and
-// independently of this file. These two cells pin what the tool actually does, so #1434 has a cell
-// to flip when it tightens all three witnesses together rather than a cell to invent.
-writeConfig("unused-root.json", {
-  suite: ["bin/smoke/unused-root.smoke.ts"], command: TALLY, assembles: ["packages/seat"],
-  mutations: [mutation("packages/seat/src/impl.ts")],
-});
-r = runTool("unused-root.json");
-check(
-  "an unused root spelling beside a by-name import is accepted today (see #1434)",
-  r.status === 0 && r.stdout.includes("1 /   3 cells observed failing"),
-  (r.stderr || r.stdout).slice(-300),
-);
-
-writeConfig("unrelated-spawn.json", {
-  suite: ["bin/smoke/unrelated-spawn.smoke.ts"], command: TALLY,
-  mutations: [mutation("scripts/direct.mjs")],
-});
-r = runTool("unrelated-spawn.json");
-check(
-  "an unrelated spawn near a quoted path is accepted today (see #1434)",
-  r.status === 0 && r.stdout.includes("1 /   3 cells observed failing"),
-  (r.stderr || r.stdout).slice(-300),
-);
-
-rmSync(root, { recursive: true, force: true });
 console.log(`\nMUTATION-COVERAGE SELF-TEST: ${pass} passed, 0 failed`);

--- a/scripts/mutation-coverage.selftest.mjs
+++ b/scripts/mutation-coverage.selftest.mjs
@@ -301,7 +301,7 @@ try {
   );
   check("the audit summary names the exact checkout tree", result.stdout.includes(`head=${fixtureHead}`), report(result));
 
-  const sentinelPath = (name) => join(root, `sentinel-${name}`);
+  const sentinelPath = (name) => join(root, `mark-${name}`);
   const sentinelCmd = (name, tag = "") => {
     const inner = `require("fs").writeFileSync(${JSON.stringify(sentinelPath(name))}, "ran"); console.log("FIXTURE: 3 passed, 0 failed");`;
     const node = `${JSON.stringify(process.execPath)} -e ${JSON.stringify(inner)}`;
@@ -316,12 +316,12 @@ try {
   const clearSentinels = (...names) => {
     for (const name of names) try { unlinkSync(sentinelPath(name)); } catch { /* absent */ }
   };
-  const fenceNames = ["safe-a", "safe-b", "safe-c", "safe-d", "safe-e", "live-suffix", "live-ops"];
+  const fenceNames = ["safe-a", "safe-b", "safe-c", "safe-d", "safe-e", "suffix", "ops"];
   for (const name of ["safe-a", "safe-b", "safe-c", "safe-d", "safe-e"]) {
     write(`bin/smoke/mutations/${name}.json`, JSON.stringify(fenceBody(sentinelCmd(name))));
   }
-  write("bin/smoke/mutations/live-suffix.json", JSON.stringify(fenceBody(sentinelCmd("live-suffix", "pnpm smoke:user-spawn:live"))));
-  write("bin/smoke/mutations/live-ops.json", JSON.stringify(fenceBody(sentinelCmd("live-ops", "pnpm smoke:manager-service-ops"))));
+  write("bin/smoke/mutations/suffix.json", JSON.stringify(fenceBody(sentinelCmd("suffix", "pnpm smoke:user-spawn:live"))));
+  write("bin/smoke/mutations/ops.json", JSON.stringify(fenceBody(sentinelCmd("ops", "pnpm smoke:manager-service-ops"))));
   execFileSync("git", ["add", "bin/smoke/mutations"], { cwd: root });
 
   clearSentinels(...fenceNames);
@@ -331,23 +331,23 @@ try {
     "bin/smoke/mutations/safe-c.json",
     "bin/smoke/mutations/safe-d.json",
     "bin/smoke/mutations/safe-e.json",
-    "bin/smoke/mutations/live-suffix.json",
+    "bin/smoke/mutations/suffix.json",
   );
   check(
     "a glob-shaped argv still fences a live-suite command",
-    !existsSync(sentinelPath("live-suffix"))
+    !existsSync(sentinelPath("suffix"))
       && ["safe-a", "safe-b", "safe-c", "safe-d", "safe-e"].every((name) => existsSync(sentinelPath(name)))
-      && /FENCED bin\/smoke\/mutations\/live-suffix\.json/.test(result.stderr)
+      && /FENCED bin\/smoke\/mutations\/suffix\.json/.test(result.stderr)
       && /fenced-live=1/.test(result.stdout),
     report(result),
   );
 
   clearSentinels(...fenceNames);
-  result = runArgs("bin/smoke/mutations/live-ops.json");
+  result = runArgs("bin/smoke/mutations/ops.json");
   check(
     "an always-live suite name is fenced without a :live suffix",
-    !existsSync(sentinelPath("live-ops"))
-      && /FENCED bin\/smoke\/mutations\/live-ops\.json/.test(result.stderr)
+    !existsSync(sentinelPath("ops"))
+      && /FENCED bin\/smoke\/mutations\/ops\.json/.test(result.stderr)
       && /fenced-live=1/.test(result.stdout),
     report(result),
   );
@@ -362,10 +362,10 @@ try {
   );
 
   clearSentinels(...fenceNames);
-  result = runArgs("--execute-live", "bin/smoke/mutations/live-suffix.json");
+  result = runArgs("--execute-live", "bin/smoke/mutations/suffix.json");
   check(
     "an explicit --execute-live flag still runs a live-suite command",
-    existsSync(sentinelPath("live-suffix")) && /graded=1/.test(result.stdout) && /fenced-live=0/.test(result.stdout),
+    existsSync(sentinelPath("suffix")) && /graded=1/.test(result.stdout) && /fenced-live=0/.test(result.stdout),
     report(result),
   );
 

--- a/scripts/mutation-coverage.selftest.mjs
+++ b/scripts/mutation-coverage.selftest.mjs
@@ -83,6 +83,18 @@ try {
   write("scripts/direct.mjs", "console.log('direct');\n");
   write("bin/smoke/direct-script.smoke.ts",
     'spawnSync(process.execPath, [join(ROOT, "scripts", "direct.mjs")]);\n');
+  write("bin/smoke/aliased-launcher.smoke.ts",
+    'import { spawnSync as run } from "node:child_process";\n' +
+    'run(process.execPath, [join(ROOT, "scripts", "direct.mjs")]);\n');
+  write("bin/smoke/bound-entry.smoke.ts",
+    'const ENTRY = join(ROOT, "scripts", "direct.mjs");\n' +
+    'execFileSync(process.execPath, [ENTRY]);\n');
+  write("bin/smoke/node-by-name.smoke.ts",
+    'spawnSync("node", [join(ROOT, "scripts", "direct.mjs")]);\n');
+  write("bin/smoke/bound-entry-unused.smoke.ts",
+    'const ENTRY = join(ROOT, "scripts", "direct.mjs");\n' +
+    'spawnSync(process.execPath, ["-e", "void 0"]);\n' +
+    'console.log(ENTRY);\n');
   write("bin/smoke/mentions-script.smoke.ts",
     'const note = "scripts/direct.mjs";\n');
   write("bin/smoke/unused-root.smoke.ts",
@@ -128,9 +140,25 @@ try {
   result = run("direct-script");
   check("a suite is gradable when it launches the exact mutated script path", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
 
+  config("aliased-launcher", { suite: ["bin/smoke/aliased-launcher.smoke.ts"], command: tally, mutations: [mutation("scripts/direct.mjs")] });
+  result = run("aliased-launcher");
+  check("a launcher imported under an alias still witnesses the script it runs", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
+
+  config("bound-entry", { suite: ["bin/smoke/bound-entry.smoke.ts"], command: tally, mutations: [mutation("scripts/direct.mjs")] });
+  result = run("bound-entry");
+  check("a target bound to a const before the launcher call still witnesses it", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
+
+  config("node-by-name", { suite: ["bin/smoke/node-by-name.smoke.ts"], command: tally, mutations: [mutation("scripts/direct.mjs")] });
+  result = run("node-by-name");
+  check("spawning \"node\" by name is the same witness as process.execPath", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
+
   config("mentions-script", { suite: ["bin/smoke/mentions-script.smoke.ts"], command: tally, mutations: [mutation("scripts/direct.mjs")] });
   result = run("mentions-script");
   check("a quoted script path without an invocation is refused", result.status !== 0 && /REFUSED mentions-script/.test(result.stderr), report(result));
+
+  config("bound-entry-unused", { suite: ["bin/smoke/bound-entry-unused.smoke.ts"], command: tally, mutations: [mutation("scripts/direct.mjs")] });
+  result = run("bound-entry-unused");
+  check("a name bound to the target but never passed to a launcher is still refused", result.status !== 0 && /REFUSED bound-entry-unused/.test(result.stderr), report(result));
 
   config("malformed-assembles", { suite: ["bin/smoke/assembling.smoke.ts"], command: tally, assembles: "packages/seat", mutations: [mutation("packages/seat/package.json")] });
   result = run("malformed-assembles");

--- a/scripts/mutation-coverage.selftest.mjs
+++ b/scripts/mutation-coverage.selftest.mjs
@@ -419,9 +419,11 @@ try {
   );
   check(
     "a glob-shaped argv still fences a live-suite command",
-    !existsSync(sentinelPath("suffix"))
+    result.status === 0
+      && !existsSync(sentinelPath("suffix"))
       && ["safe-a", "safe-b", "safe-c", "safe-d", "safe-e"].every((name) => existsSync(sentinelPath(name)))
-      && /FENCED bin\/smoke\/mutations\/suffix\.json/.test(result.stderr)
+      && /bin\/smoke\/mutations\/suffix\.json\s+REFUSED `.*smoke:user-spawn:live`/.test(report(result))
+      && /1 live-shaped config\(s\) refused/.test(result.stdout)
       && /fenced-live=1/.test(result.stdout),
     report(result),
   );
@@ -430,8 +432,10 @@ try {
   result = runArgs("bin/smoke/mutations/ops.json");
   check(
     "an always-live suite name is fenced without a :live suffix",
-    !existsSync(sentinelPath("ops"))
-      && /FENCED bin\/smoke\/mutations\/ops\.json/.test(result.stderr)
+    result.status === 0
+      && !existsSync(sentinelPath("ops"))
+      && /bin\/smoke\/mutations\/ops\.json\s+REFUSED `/.test(report(result))
+      && /1 live-shaped config\(s\) refused/.test(result.stdout)
       && /fenced-live=1/.test(result.stdout),
     report(result),
   );
@@ -442,14 +446,6 @@ try {
     "a discovered run does not execute any config",
     fenceNames.every((name) => !existsSync(sentinelPath(name)))
       && /fenced-discovered=[1-9]\d*/.test(result.stdout),
-    report(result),
-  );
-
-  clearSentinels(...fenceNames);
-  result = runArgs("--execute-live", "bin/smoke/mutations/suffix.json");
-  check(
-    "an explicit --execute-live flag still runs a live-suite command",
-    existsSync(sentinelPath("suffix")) && /graded=1/.test(result.stdout) && /fenced-live=0/.test(result.stdout),
     report(result),
   );
 

--- a/scripts/mutation-coverage.selftest.mjs
+++ b/scripts/mutation-coverage.selftest.mjs
@@ -194,6 +194,15 @@ try {
     report(result),
   );
 
+  config("progress-no-minticks", { suite: ["bin/smoke/direct.smoke.ts"], command: ticks, progressPattern: "^  ✓ ", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+  result = run("progress-no-minticks");
+  check(
+    "progress without minTicks names why it is unparsed",
+    result.status !== 0 && /UNPARSED progress-no-minticks/.test(result.stderr)
+      && /progressPattern is present and minTicks is absent/.test(result.stderr),
+    report(result),
+  );
+
   for (const [name, text] of [
     ["early-ok", "SETUP OK\\n  ✓ one\\n  ✓ two\\nWORK REMAINS"],
     ["tick-passed", "  ✓ setup PASSED\\n  ✓ second\\nWORK REMAINS"],

--- a/scripts/mutation-coverage.selftest.mjs
+++ b/scripts/mutation-coverage.selftest.mjs
@@ -176,9 +176,9 @@ try {
   result = run("progress");
   check("anchored progress plus an explicit completion marker supplies a total", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
 
-  config("progress-banner", { suite: ["bin/smoke/direct.smoke.ts"], command: ticks, progressPattern: "^  ✓ ", minTicks: 3, executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
+  config("progress-banner", { suite: ["bin/smoke/direct.smoke.ts"], command: ticks, progressPattern: "^  ✓ ", minTicks: 3, completionMarker: "FIXTURE PASSED", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });
   result = run("progress-banner");
-  check("anchored progress plus a terminal passed banner supplies a total", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
+  check("anchored progress plus its declared terminal banner supplies a total", result.status === 0 && result.stdout.includes("1 /   3 cells observed failing"), report(result));
 
   const noCompletion = `${JSON.stringify(process.execPath)} -e ${JSON.stringify("console.log('  ✓ one\\n  ✓ two\\n  ✓ three')")}`;
   config("unfinished-progress", { suite: ["bin/smoke/direct.smoke.ts"], command: noCompletion, progressPattern: "^  ✓ ", minTicks: 3, completionMarker: "FIXTURE PASSED", executes: ["bin/direct.mjs"], mutations: [mutation("bin/direct.mjs")] });

--- a/scripts/mutation-proof.mjs
+++ b/scripts/mutation-proof.mjs
@@ -202,7 +202,7 @@ const CONFIG_KEYS = new Set([
   // Read by `mutation-coverage.mjs`, which grades the same configs from the other side. The
   // allowlist is the union across the toolchain, because a key this file ignores is not thereby
   // unused, and rejecting one would break the sibling rather than catch a typo.
-  "suite", "guard", "grades", "kind", "unkillable", "why", "proveWith", "assembles",
+  "suite", "guard", "grades", "kind", "unkillable", "why", "proveWith", "assembles", "executes",
   // Read by NOTHING, on purpose: prose an operator leaves for the next reader. Listed rather than
   // tolerated, so that "no tool reads this" is a stated property instead of the thing you discover
   // when you wonder why setting it changed nothing.

--- a/scripts/mutation-reproof.mjs
+++ b/scripts/mutation-reproof.mjs
@@ -173,6 +173,25 @@ function isMetadataOnlySuiteCanonicalization(root, base, fixture) {
   return isDeepStrictEqual(baseRest, headRest);
 }
 
+/**
+ * Declaring `executes` tells mutation-coverage which repository entrypoint a subprocess suite
+ * launches. That is a coverage witness, not a proof definition: the mutations, command, and
+ * suite are unchanged. Selecting those fixtures for re-proof would re-run live attach kill sets
+ * that already carry a documented SURVIVED (and can exhaust the 145-minute shard). Any other
+ * top-level field change stays a selecting config change.
+ */
+function isExecutesOnlyConfigChange(root, base, fixture) {
+  let baseConfig;
+  try {
+    baseConfig = JSON.parse(git(root, ["show", `${base}:${fixture.path}`]));
+  } catch {
+    return false;
+  }
+  const { executes: _baseExecutes, ...baseRest } = baseConfig ?? {};
+  const { executes: _headExecutes, ...headRest } = fixture.config;
+  return isDeepStrictEqual(baseRest, headRest);
+}
+
 const a = args(process.argv.slice(2));
 const root = resolve(a.root ?? process.cwd());
 const head = a.head ?? "HEAD";
@@ -224,7 +243,8 @@ const { changed, diffSize } = a.all ? { changed: new Set(), diffSize: 0 } : chan
 
 const metadataOnlyExclusions = new Set(a.all ? [] : fixtures
   .filter((fixture) => changed.has(fixture.path)
-    && isMetadataOnlySuiteCanonicalization(root, a.base, fixture))
+    && (isMetadataOnlySuiteCanonicalization(root, a.base, fixture)
+      || isExecutesOnlyConfigChange(root, a.base, fixture)))
   .map((fixture) => fixture.path));
 
 let selected = fixtures.map((fixture) => ({

--- a/scripts/mutations/mutation-coverage.json
+++ b/scripts/mutations/mutation-coverage.json
@@ -1,5 +1,6 @@
 {
   "grades": "tool",
+  "suite": ["scripts/mutation-coverage.selftest.mjs"],
   "guard": "aggregate mutation coverage examines the full selection, recognizes supported execution paths and summaries, reports every outcome with the exact tree, and fails after rather than during incomplete grading",
   "command": "node scripts/mutation-coverage.selftest.mjs",
   "progressPattern": "^  ✓ ",
@@ -20,8 +21,8 @@
     {
       "name": "declared subprocess entrypoints are ignored",
       "file": "scripts/mutation-coverage.mjs",
-      "find": "  if (executedWitness(cfg.suite, source, cfg.command, mutation, cfg.executes ?? [])) return;",
-      "replace": "  void executedWitness(cfg.suite, source, cfg.command, mutation, cfg.executes ?? []);",
+      "find": "    if (executedWitness(suite, source, cfg.command, mutation, cfg.executes ?? [])) return;",
+      "replace": "    void executedWitness(suite, source, cfg.command, mutation, cfg.executes ?? []);",
       "expectRed": "a spawned repo entrypoint plus target-package build is gradable",
       "cell": "a spawned repo entrypoint plus target-package build is gradable"
     },

--- a/scripts/mutations/mutation-coverage.json
+++ b/scripts/mutations/mutation-coverage.json
@@ -61,7 +61,7 @@
       "name": "progress totals no longer require an explicit completion marker",
       "file": "scripts/mutation-coverage.mjs",
       "find": "    const completed = typeof cfg.completionMarker === \"string\" && terminal.includes(cfg.completionMarker);",
-      "replace": "    const completed = output.includes(\"OK\") || output.includes(\"PASSED\");\n    if (completed && executed >= cfg.minTicks) return { executed, failures: 0 };",
+      "replace": "    const completed = output.includes(\"OK\") || output.includes(\"PASSED\");\n    if (completed && progressCount(output, cfg.progressPattern) >= cfg.minTicks) return { executed: progressCount(output, cfg.progressPattern), failures: 0 };",
       "expectRed": "early-ok is not a terminal completion witness",
       "cell": "early-ok is not a terminal completion witness"
     },

--- a/scripts/mutations/mutation-coverage.json
+++ b/scripts/mutations/mutation-coverage.json
@@ -61,9 +61,9 @@
       "name": "progress totals no longer require an explicit completion marker",
       "file": "scripts/mutation-coverage.mjs",
       "find": "    const completed = typeof cfg.completionMarker === \"string\" && terminal.includes(cfg.completionMarker);",
-      "replace": "    const completed = output.includes(\"OK\") || output.includes(\"PASSED\");\n    if (completed && progressCount(output, cfg.progressPattern) >= cfg.minTicks) return { executed: progressCount(output, cfg.progressPattern), failures: 0 };",
-      "expectRed": "early-ok is not a terminal completion witness",
-      "cell": "early-ok is not a terminal completion witness"
+      "replace": "    const completed = true;",
+      "expectRed": "progress without completion is unparsed",
+      "cell": "progress without completion is unparsed"
     },
     {
       "name": "an invalid progress regex escapes per-config validation",

--- a/scripts/mutations/mutation-coverage.json
+++ b/scripts/mutations/mutation-coverage.json
@@ -3,8 +3,6 @@
   "guard": "aggregate mutation coverage examines the full selection, recognizes supported execution paths and summaries, reports every outcome with the exact tree, and fails after rather than during incomplete grading",
   "command": "node scripts/mutation-coverage.selftest.mjs",
   "progressPattern": "^  ✓ ",
-  "minTicks": 18,
-  "completionMarker": "MUTATION-COVERAGE SELF-TEST:",
   "proveWith": "node scripts/mutation-proof.mjs --config scripts/mutations/mutation-coverage.json",
   "why": [
     "Each mutation removes one public guarantee from the aggregate validator. The self-test drives throwaway repositories through the real command entrypoint, so the mutated script is the code under test rather than a copied helper.",
@@ -48,8 +46,8 @@
       "file": "scripts/mutation-coverage.mjs",
       "find": "if (refused || unparsed || failed || examined !== configs.length || graded !== configs.length) process.exitCode = 1;",
       "replace": "void refused; void unparsed; void failed; void examined; void graded;",
-      "expectRed": "zero failures without a total stays unparsed",
-      "cell": "zero failures without a total stays unparsed"
+      "expectRed": "a by-name same-package import without ../src is refused",
+      "cell": "a by-name same-package import without ../src is refused"
     },
     {
       "name": "the audit summary omits the checkout tree",

--- a/scripts/mutations/mutation-coverage.json
+++ b/scripts/mutations/mutation-coverage.json
@@ -3,7 +3,6 @@
   "suite": ["scripts/mutation-coverage.selftest.mjs"],
   "guard": "aggregate mutation coverage examines the full selection, recognizes supported execution paths and summaries, reports every outcome with the exact tree, and fails after rather than during incomplete grading",
   "command": "node scripts/mutation-coverage.selftest.mjs",
-  "progressPattern": "^  ✓ ",
   "proveWith": "node scripts/mutation-proof.mjs --config scripts/mutations/mutation-coverage.json",
   "why": [
     "Each mutation removes one public guarantee from the aggregate validator. The self-test drives throwaway repositories through the real command entrypoint, so the mutated script is the code under test rather than a copied helper.",

--- a/scripts/mutations/mutation-coverage.json
+++ b/scripts/mutations/mutation-coverage.json
@@ -56,6 +56,62 @@
       "replace": "  `MUTATION COVERAGE SUMMARY head=unknown enumerated=${configs.length} examined=${examined} graded=${graded} ` +",
       "expectRed": "the audit summary names the exact checkout tree",
       "cell": "the audit summary names the exact checkout tree"
+    },
+    {
+      "name": "a non-terminal OK line is accepted as completion",
+      "file": "scripts/mutation-coverage.mjs",
+      "find": "    const lines = output.trimEnd().split(/\\r?\\n/);\n    const terminal = lines.at(-1) ?? \"\";",
+      "replace": "    const lines = output.split(/\\r?\\n/);\n    const terminal = lines.find((line) => /(?:PASSED|OK)/.test(line)) ?? \"\";",
+      "expectRed": "early-ok is not a terminal completion witness",
+      "cell": "early-ok is not a terminal completion witness"
+    },
+    {
+      "name": "an invalid progress regex escapes per-config validation",
+      "file": "scripts/mutation-coverage.mjs",
+      "find": "    try { new RegExp(cfg.progressPattern, \"gm\"); } catch (error) { throw new Error(`\"progressPattern\" is invalid: ${error.message}`); }",
+      "replace": "    void cfg.progressPattern;",
+      "expectRed": "an invalid progress regex is refused without hiding the next config",
+      "cell": "an invalid progress regex is refused without hiding the next config"
+    },
+    {
+      "name": "commented imports count as entrypoint dependencies",
+      "file": "scripts/mutation-coverage.mjs",
+      "find": "    for (const specifier of relativeImports(actual, source)) {",
+      "replace": "    for (const specifier of [...relativeImports(actual, source), ...(source.match(/@cotal-ai\\/[a-z-]+/g) ?? [])]) {",
+      "expectRed": "comment-import cannot fabricate executes evidence",
+      "cell": "comment-import cannot fabricate executes evidence"
+    },
+    {
+      "name": "non-Node executables count as source entrypoint launches",
+      "file": "scripts/mutation-coverage.mjs",
+      "find": "        && executableIsNode(node.arguments[0]) && node.arguments[1] && entryArray(node.arguments[1])) witnessed = true;",
+      "replace": "        && node.arguments[1] && entryArray(node.arguments[1])) witnessed = true;",
+           "expectRed": "wrong-executable cannot fabricate executes evidence",
+      "cell": "wrong-executable cannot fabricate executes evidence"
+    },
+    {
+      "name": "printed build text counts as a package build",
+      "file": "scripts/mutation-coverage.mjs",
+      "find": "    if (tokens[0] !== \"pnpm\") continue;",
+      "replace": "    if (!tokens.includes(\"pnpm\")) continue;",
+      "expectRed": "printed-build cannot fabricate executes evidence",
+      "cell": "printed-build cannot fabricate executes evidence"
+    },
+    {
+      "name": "a genuine variable argument array is refused",
+      "file": "scripts/mutation-coverage.mjs",
+      "find": "    if (ts.isIdentifier(node)) node = variables.get(node.text);",
+      "replace": "    if (ts.isIdentifier(node)) return false;",
+      "expectRed": "a genuine subprocess argument array is accepted",
+      "cell": "a genuine subprocess argument array is accepted"
+    },
+    {
+      "name": "the pnpm --filter=value form is refused",
+      "file": "scripts/mutation-coverage.mjs",
+      "find": "    const value = tokens[filter].startsWith(\"--filter=\") ? tokens[filter].slice(9) : tokens[filter + 1];",
+      "replace": "    const value = tokens[filter + 1];",
+      "expectRed": "the pnpm --filter=value build form is accepted",
+      "cell": "the pnpm --filter=value build form is accepted"
     }
   ]
 }

--- a/scripts/mutations/mutation-coverage.json
+++ b/scripts/mutations/mutation-coverage.json
@@ -92,8 +92,8 @@
     {
       "name": "incomplete aggregate grading exits successfully",
       "file": "scripts/mutation-coverage.mjs",
-      "find": "if (refused || unparsed || failed || examined !== configs.length || graded !== configs.length) process.exitCode = 1;",
-      "replace": "void refused; void unparsed; void failed; void examined; void graded;",
+      "find": "if (refusals.length || unparsed || failed || examined !== configs.length || graded + refused.length + fencedDiscovered !== configs.length) process.exitCode = 1;",
+      "replace": "void refusals; void unparsed; void failed; void examined; void graded; void refused; void fencedDiscovered;",
       "expectRed": "a by-name same-package import without ../src is refused",
       "cell": "a by-name same-package import without ../src is refused"
     },
@@ -162,10 +162,10 @@
       "cell": "the pnpm --filter=value build form is accepted"
     },
     {
-      "name": "a live-suite command is executed without --execute-live",
+      "name": "coverage executes a live-shaped command instead of refusing it",
       "file": "scripts/mutation-coverage.mjs",
-      "find": "  const liveReason = liveShapedCommandReason(cfg.command, { cwd: process.cwd() });\n  if (!executeLive && liveReason) {\n    fencedLive++;\n    console.error(`FENCED ${path}: command names a live suite; pass --execute-live to run it`);\n    continue;\n  }",
-      "replace": "  void executeLive; void liveShapedCommandReason;",
+      "find": "  if (liveReason) {\n    refused.push([path, cfg.command, liveReason]);\n    continue;\n  }\n",
+      "replace": "",
       "expectRed": "a glob-shaped argv still fences a live-suite command",
       "cell": "a glob-shaped argv still fences a live-suite command"
     },
@@ -184,14 +184,6 @@
       "replace": "  void discovered; void executeDiscovered;",
       "expectRed": "a discovered run does not execute any config",
       "cell": "a discovered run does not execute any config"
-    },
-    {
-      "name": "--execute-live is ignored so a live command cannot be opted in",
-      "file": "scripts/mutation-coverage.mjs",
-      "find": "const executeLive = rawArgs.includes(FLAG_EXECUTE_LIVE);",
-      "replace": "const executeLive = false;",
-      "expectRed": "an explicit --execute-live flag still runs a live-suite command",
-      "cell": "an explicit --execute-live flag still runs a live-suite command"
     }
   ]
 }

--- a/scripts/mutations/mutation-coverage.json
+++ b/scripts/mutations/mutation-coverage.json
@@ -76,16 +76,16 @@
     {
       "name": "completed all-passed fractions are not parsed",
       "file": "scripts/mutation-coverage.mjs",
-      "find": "    if (fraction && Number(fraction[1]) === Number(fraction[2])) return { executed: Number(fraction[2]), failures: 0 };",
-      "replace": "    void fraction;",
+      "find": "    if (completeFraction && Number(completeFraction[1]) === Number(completeFraction[2])) {\n      return { executed: Number(completeFraction[2]), failures: 0 };\n    }",
+      "replace": "    void completeFraction;",
       "expectRed": "a completed all-passed fraction supplies the executed total",
       "cell": "a completed all-passed fraction supplies the executed total"
     },
     {
       "name": "banner presence is restored as an executed-cell total",
       "file": "scripts/mutation-coverage.mjs",
-      "find": "  if (typeof cfg.completionMarker === \"string\") {\n    const line = output.split(/\\r?\\n/).filter((candidate) => candidate.includes(cfg.completionMarker)).at(-1);\n    const fraction = line?.match(/\\b(\\d+)\\s*\\/\\s*(\\d+)\\b/);\n    if (fraction && Number(fraction[1]) === Number(fraction[2])) return { executed: Number(fraction[2]), failures: 0 };\n  }\n  return undefined;\n};",
-      "replace": "  if (typeof cfg.completionMarker === \"string\") {\n    const line = output.split(/\\r?\\n/).filter((candidate) => candidate.includes(cfg.completionMarker)).at(-1);\n    const fraction = line?.match(/\\b(\\d+)\\s*\\/\\s*(\\d+)\\b/);\n    if (fraction && Number(fraction[1]) === Number(fraction[2])) return { executed: Number(fraction[2]), failures: 0 };\n  }\n  if (typeof cfg.progressPattern === \"string\" && Number.isInteger(cfg.minTicks) && cfg.minTicks > 0) {\n    const terminal = output.trimEnd().split(/\\r?\\n/).at(-1) ?? \"\";\n    const completed = typeof cfg.completionMarker === \"string\" && terminal.includes(cfg.completionMarker);\n    const executed = (output.match(new RegExp(cfg.progressPattern, \"gm\")) ?? []).length;\n    if (completed && executed >= cfg.minTicks) return { executed, failures: 0 };\n  }\n  return undefined;\n};",
+      "find": "  if (typeof cfg.completionMarker === \"string\") {\n    const line = output.split(/\\r?\\n/).filter((candidate) => candidate.includes(cfg.completionMarker)).at(-1);\n    const completeFraction = line?.match(/\\b(\\d+)\\s*\\/\\s*(\\d+)\\b/);\n    if (completeFraction && Number(completeFraction[1]) === Number(completeFraction[2])) {\n      return { executed: Number(completeFraction[2]), failures: 0 };\n    }\n  }\n  return undefined;\n};",
+      "replace": "  if (typeof cfg.completionMarker === \"string\") {\n    const line = output.split(/\\r?\\n/).filter((candidate) => candidate.includes(cfg.completionMarker)).at(-1);\n    const completeFraction = line?.match(/\\b(\\d+)\\s*\\/\\s*(\\d+)\\b/);\n    if (completeFraction && Number(completeFraction[1]) === Number(completeFraction[2])) {\n      return { executed: Number(completeFraction[2]), failures: 0 };\n    }\n  }\n  if (typeof cfg.progressPattern === \"string\" && Number.isInteger(cfg.minTicks) && cfg.minTicks > 0) {\n    const terminal = output.trimEnd().split(/\\r?\\n/).at(-1) ?? \"\";\n    const completed = typeof cfg.completionMarker === \"string\" && terminal.includes(cfg.completionMarker);\n    const executed = (output.match(new RegExp(cfg.progressPattern, \"gm\")) ?? []).length;\n    if (completed && executed >= cfg.minTicks) return { executed, failures: 0 };\n  }\n  return undefined;\n};",
       "expectRed": "a declared terminal banner is not an executed-cell total",
       "cell": "a declared terminal banner is not an executed-cell total"
     },
@@ -100,8 +100,8 @@
     {
       "name": "the audit summary omits the checkout tree",
       "file": "scripts/mutation-coverage.mjs",
-      "find": "  `MUTATION COVERAGE SUMMARY head=${head} enumerated=${configs.length} examined=${examined} graded=${graded} ` +",
-      "replace": "  `MUTATION COVERAGE SUMMARY head=unknown enumerated=${configs.length} examined=${examined} graded=${graded} ` +",
+      "find": "  checkoutHead = execFileSync(\"git\", [\"rev-parse\", \"HEAD\"], { encoding: \"utf8\" }).trim();",
+      "replace": "  checkoutHead = \"unknown\";",
       "expectRed": "the audit summary names the exact checkout tree",
       "cell": "the audit summary names the exact checkout tree"
     },

--- a/scripts/mutations/mutation-coverage.json
+++ b/scripts/mutations/mutation-coverage.json
@@ -1,58 +1,63 @@
 {
-  "suite": [
-    "scripts/mutation-coverage.selftest.mjs"
-  ],
   "grades": "tool",
-  "guard": "mutation coverage accepts only direct execution witnesses that reach the mutated file without a package resolver",
+  "guard": "aggregate mutation coverage examines the full selection, recognizes supported execution paths and summaries, reports every outcome with the exact tree, and fails after rather than during incomplete grading",
   "command": "node scripts/mutation-coverage.selftest.mjs",
   "progressPattern": "^  ✓ ",
+  "minTicks": 18,
+  "completionMarker": "MUTATION-COVERAGE SELF-TEST:",
   "proveWith": "node scripts/mutation-proof.mjs --config scripts/mutations/mutation-coverage.json",
   "why": [
-    "The seat packaging suite executes the root native assembler directly, while the launcher smoke executes its own mutated source. Both are stronger witnesses than a by-name package import, and neither should be rejected as a dist trap.",
-    "A quoted path in prose is not execution. The self-test keeps that negative control beside both accepted direct paths."
+    "Each mutation removes one public guarantee from the aggregate validator. The self-test drives throwaway repositories through the real command entrypoint, so the mutated script is the code under test rather than a copied helper.",
+    "The continuation mutation restores the first-error abort. The subprocess mutation restores the false refusal for declared entrypoints. The two parser mutations restore the completed-but-ungraded outputs reproduced by real suites. The final mutation makes incomplete grading look green again."
   ],
   "mutations": [
     {
-      "name": "a suite mutating its own directly executed source is rejected",
+      "name": "a refused config aborts the process before later configs are examined",
       "file": "scripts/mutation-coverage.mjs",
-      "find": "  if (m.file === suite || invokesFile(suiteSource, m.file)) return true;",
-      "replace": "  if (invokesFile(suiteSource, m.file)) return true;",
-      "expectRed": "a suite is gradable when it directly executes the file being mutated"
+      "find": "    refusals.push([path, reason]);\n    console.error(`REFUSED ${path}: ${reason}`);\n    continue;",
+      "replace": "    throw new Error(`REFUSED ${path}: ${reason}`);",
+      "expectRed": "one bad config does not hide later configs",
+      "cell": "one bad config does not hide later configs"
     },
     {
-      "name": "a suite launching the exact mutated repo script is rejected",
+      "name": "declared subprocess entrypoints are ignored",
       "file": "scripts/mutation-coverage.mjs",
-      "find": "  if (m.file === suite || invokesFile(suiteSource, m.file)) return true;",
-      "replace": "  if (m.file === suite) return true;",
-      "expectRed": "a suite is gradable when it launches the exact mutated script path"
+      "find": "  if (executedWitness(cfg.suite, source, cfg.command, mutation, cfg.executes ?? [])) return;",
+      "replace": "  void executedWitness(cfg.suite, source, cfg.command, mutation, cfg.executes ?? []);",
+      "expectRed": "a spawned repo entrypoint plus target-package build is gradable",
+      "cell": "a spawned repo entrypoint plus target-package build is gradable"
     },
     {
-      "name": "any quoted mutation path is treated as a direct execution witness",
+      "name": "completed all-passed fractions are not parsed",
       "file": "scripts/mutation-coverage.mjs",
-      "find": "  if (m.file === suite || invokesFile(suiteSource, m.file)) return true;",
-      "replace": "  if (m.file === suite || referencesRoot(suiteSource, m.file)) return true;",
-      "expectRed": "a quoted script path without an invocation is refused"
+      "find": "    if (fraction && Number(fraction[1]) === Number(fraction[2])) return { executed: Number(fraction[2]), failures: 0 };",
+      "replace": "    void fraction;",
+      "expectRed": "a completed all-passed fraction supplies the executed total",
+      "cell": "a completed all-passed fraction supplies the executed total"
     },
     {
-      "name": "launcher aliases are ignored",
+      "name": "completed progress-marker suites are not parsed",
       "file": "scripts/mutation-coverage.mjs",
-      "find": "      if (alias !== null && LAUNCHERS.includes(alias[1])) names.add(alias[2]);",
-      "replace": "      if (alias !== null && LAUNCHERS.includes(alias[1])) names.add(alias[1]);",
-      "expectRed": "a launcher imported under an alias still witnesses the script it runs"
+      "find": "    if (completed && executed >= cfg.minTicks) return { executed, failures: 0 };",
+      "replace": "    void completed; void executed;",
+      "expectRed": "anchored progress plus an explicit completion marker supplies a total",
+      "cell": "anchored progress plus an explicit completion marker supplies a total"
     },
     {
-      "name": "bound entry names are ignored",
+      "name": "incomplete aggregate grading exits successfully",
       "file": "scripts/mutation-coverage.mjs",
-      "find": "  const names = boundNames(suiteSource, basename);",
-      "replace": "  const names = [];",
-      "expectRed": "a target bound to a const before the launcher call still witnesses it"
+      "find": "if (refused || unparsed || failed || examined !== configs.length || graded !== configs.length) process.exitCode = 1;",
+      "replace": "void refused; void unparsed; void failed; void examined; void graded;",
+      "expectRed": "zero failures without a total stays unparsed",
+      "cell": "zero failures without a total stays unparsed"
     },
     {
-      "name": "a bound entry anywhere after a launcher is treated as its argument",
+      "name": "the audit summary omits the checkout tree",
       "file": "scripts/mutation-coverage.mjs",
-      "find": "  for (const m of suiteSource.matchAll(new RegExp(`${call}((?:[^()]|\\\\([^()]*\\\\))*)\\\\)`, \"g\"))) {",
-      "replace": "  for (const m of suiteSource.matchAll(new RegExp(`${call}([\\\\s\\\\S]{0,500})`, \"g\"))) {",
-      "expectRed": "a name bound to the target but never passed to a launcher is still refused"
+      "find": "  `MUTATION COVERAGE SUMMARY head=${head} enumerated=${configs.length} examined=${examined} graded=${graded} ` +",
+      "replace": "  `MUTATION COVERAGE SUMMARY head=unknown enumerated=${configs.length} examined=${examined} graded=${graded} ` +",
+      "expectRed": "the audit summary names the exact checkout tree",
+      "cell": "the audit summary names the exact checkout tree"
     }
   ]
 }

--- a/scripts/mutations/mutation-coverage.json
+++ b/scripts/mutations/mutation-coverage.json
@@ -164,16 +164,16 @@
     {
       "name": "a live-suite command is executed without --execute-live",
       "file": "scripts/mutation-coverage.mjs",
-      "find": "  if (!executeLive && commandNamesLiveSuite(cfg.command)) {\n    fencedLive++;\n    console.error(`FENCED ${path}: command names a live suite; pass --execute-live to run it`);\n    continue;\n  }",
-      "replace": "  void executeLive; void commandNamesLiveSuite;",
+      "find": "  const liveReason = liveShapedCommandReason(cfg.command, { cwd: process.cwd() });\n  if (!executeLive && liveReason) {\n    fencedLive++;\n    console.error(`FENCED ${path}: command names a live suite; pass --execute-live to run it`);\n    continue;\n  }",
+      "replace": "  void executeLive; void liveShapedCommandReason;",
       "expectRed": "a glob-shaped argv still fences a live-suite command",
       "cell": "a glob-shaped argv still fences a live-suite command"
     },
     {
       "name": "always-live suite names are ignored by the detector",
       "file": "scripts/mutation-coverage.mjs",
-      "find": "const commandNamesLiveSuite = (command) =>\n  /:live\\b|-live\\b/.test(command) || LIVE_SUITE_NAMES.some((name) => command.includes(name));",
-      "replace": "const commandNamesLiveSuite = (command) =>\n  /:live\\b|-live\\b/.test(command);",
+      "find": "  const liveReason = liveShapedCommandReason(cfg.command, { cwd: process.cwd() });",
+      "replace": "  const liveReason = /:live\\b|-live\\b/.test(cfg.command) ? \"live-named\" : null;",
       "expectRed": "an always-live suite name is fenced without a :live suffix",
       "cell": "an always-live suite name is fenced without a :live suffix"
     },

--- a/scripts/mutations/mutation-coverage.json
+++ b/scripts/mutations/mutation-coverage.json
@@ -61,7 +61,7 @@
       "name": "progress totals no longer require an explicit completion marker",
       "file": "scripts/mutation-coverage.mjs",
       "find": "    const completed = typeof cfg.completionMarker === \"string\" && terminal.includes(cfg.completionMarker);",
-      "replace": "    const completed = output.includes(\"OK\") || output.includes(\"PASSED\");",
+      "replace": "    const completed = output.includes(\"OK\") || output.includes(\"PASSED\");\n    if (completed && executed >= cfg.minTicks) return { executed, failures: 0 };",
       "expectRed": "early-ok is not a terminal completion witness",
       "cell": "early-ok is not a terminal completion witness"
     },
@@ -92,8 +92,8 @@
     {
       "name": "printed build text counts as a package build",
       "file": "scripts/mutation-coverage.mjs",
-      "find": "    if (tokens[0] !== \"pnpm\") continue;",
-      "replace": "    if (tokens[0] !== \"pnpm\" && !segment.includes(\"pnpm build\")) continue;",
+      "find": "  for (const segment of command.split(/&&|;/)) {",
+      "replace": "  if (command.includes(\"pnpm build\")) return true;\n  for (const segment of command.split(/&&|;/)) {",
       "expectRed": "printed-build cannot fabricate executes evidence",
       "cell": "printed-build cannot fabricate executes evidence"
     },

--- a/scripts/mutations/mutation-coverage.json
+++ b/scripts/mutations/mutation-coverage.json
@@ -14,8 +14,8 @@
       "file": "scripts/mutation-coverage.mjs",
       "find": "    refusals.push([path, reason]);\n    console.error(`REFUSED ${path}: ${reason}`);\n    continue;",
       "replace": "    throw new Error(`REFUSED ${path}: ${reason}`);",
-      "expectRed": "one bad config does not hide later configs",
-      "cell": "one bad config does not hide later configs"
+      "expectRed": "an invalid progress regex is refused without hiding the next config",
+      "cell": "an invalid progress regex is refused without hiding the next config"
     },
     {
       "name": "declared subprocess entrypoints are ignored",
@@ -60,8 +60,8 @@
     {
       "name": "a non-terminal OK line is accepted as completion",
       "file": "scripts/mutation-coverage.mjs",
-      "find": "    const lines = output.trimEnd().split(/\\r?\\n/);\n    const terminal = lines.at(-1) ?? \"\";",
-      "replace": "    const lines = output.split(/\\r?\\n/);\n    const terminal = lines.find((line) => /(?:PASSED|OK)/.test(line)) ?? \"\";",
+      "find": "      : /(?:^|\\s)(?:PASSED|OK)(?:\\s|$)/.test(terminal) && !(new RegExp(cfg.progressPattern).test(terminal));",
+      "replace": "      : /(?:^|\\n)[^\\n]*(?:PASSED|OK)/.test(output);",
       "expectRed": "early-ok is not a terminal completion witness",
       "cell": "early-ok is not a terminal completion witness"
     },
@@ -92,8 +92,8 @@
     {
       "name": "printed build text counts as a package build",
       "file": "scripts/mutation-coverage.mjs",
-      "find": "    if (tokens[0] !== \"pnpm\") continue;",
-      "replace": "    if (!tokens.includes(\"pnpm\")) continue;",
+      "find": "    if (tokens[0] !== \"pnpm\") continue;\n    if (tokens[1] === \"build\") return true;",
+      "replace": "    if (tokens.includes(\"pnpm\") && tokens.includes(\"build\")) return true;",
       "expectRed": "printed-build cannot fabricate executes evidence",
       "cell": "printed-build cannot fabricate executes evidence"
     },

--- a/scripts/mutations/mutation-coverage.json
+++ b/scripts/mutations/mutation-coverage.json
@@ -136,6 +136,38 @@
       "replace": "    const value = tokens[filter + 1];",
       "expectRed": "the pnpm --filter=value build form is accepted",
       "cell": "the pnpm --filter=value build form is accepted"
+    },
+    {
+      "name": "a live-suite command is executed without --execute-live",
+      "file": "scripts/mutation-coverage.mjs",
+      "find": "  if (!executeLive && commandNamesLiveSuite(cfg.command)) {\n    fencedLive++;\n    console.error(`FENCED ${path}: command names a live suite; pass --execute-live to run it`);\n    continue;\n  }",
+      "replace": "  void executeLive; void commandNamesLiveSuite;",
+      "expectRed": "a glob-shaped argv still fences a live-suite command",
+      "cell": "a glob-shaped argv still fences a live-suite command"
+    },
+    {
+      "name": "always-live suite names are ignored by the detector",
+      "file": "scripts/mutation-coverage.mjs",
+      "find": "const commandNamesLiveSuite = (command) =>\n  /:live\\b|-live\\b/.test(command) || LIVE_SUITE_NAMES.some((name) => command.includes(name));",
+      "replace": "const commandNamesLiveSuite = (command) =>\n  /:live\\b|-live\\b/.test(command);",
+      "expectRed": "an always-live suite name is fenced without a :live suffix",
+      "cell": "an always-live suite name is fenced without a :live suffix"
+    },
+    {
+      "name": "a discovered run executes configs without --execute-discovered",
+      "file": "scripts/mutation-coverage.mjs",
+      "find": "  if (discovered && !executeDiscovered) {\n    fencedDiscovered++;\n    console.error(`FENCED ${path}: discovered configs are not executed; pass --execute-discovered to run them`);\n    continue;\n  }",
+      "replace": "  void discovered; void executeDiscovered;",
+      "expectRed": "a discovered run does not execute any config",
+      "cell": "a discovered run does not execute any config"
+    },
+    {
+      "name": "--execute-live is ignored so a live command cannot be opted in",
+      "file": "scripts/mutation-coverage.mjs",
+      "find": "const executeLive = rawArgs.includes(FLAG_EXECUTE_LIVE);",
+      "replace": "const executeLive = false;",
+      "expectRed": "an explicit --execute-live flag still runs a live-suite command",
+      "cell": "an explicit --execute-live flag still runs a live-suite command"
     }
   ]
 }

--- a/scripts/mutations/mutation-coverage.json
+++ b/scripts/mutations/mutation-coverage.json
@@ -6,7 +6,7 @@
   "proveWith": "node scripts/mutation-proof.mjs --config scripts/mutations/mutation-coverage.json",
   "why": [
     "Each mutation removes one public guarantee from the aggregate validator. The self-test drives throwaway repositories through the real command entrypoint, so the mutated script is the code under test rather than a copied helper.",
-    "The continuation mutation restores the first-error abort. The subprocess mutation restores the false refusal for declared entrypoints. The two parser mutations restore the completed-but-ungraded outputs reproduced by real suites. The final mutation makes incomplete grading look green again."
+    "The continuation mutation restores the first-error abort. The subprocess mutation restores the false refusal for declared entrypoints. The fraction parser mutation restores a completed-but-ungraded N/N. The banner mutation restores presence-as-completion, which must stay unparsed. The final mutation makes incomplete grading look green again."
   ],
   "mutations": [
     {
@@ -58,12 +58,12 @@
       "cell": "a completed all-passed fraction supplies the executed total"
     },
     {
-      "name": "completed progress-marker suites are not parsed",
+      "name": "banner presence is restored as an executed-cell total",
       "file": "scripts/mutation-coverage.mjs",
-      "find": "    if (completed && executed >= cfg.minTicks) return { executed, failures: 0 };",
-      "replace": "    void completed; void executed;",
-      "expectRed": "anchored progress plus an explicit completion marker supplies a total",
-      "cell": "anchored progress plus an explicit completion marker supplies a total"
+      "find": "  if (typeof cfg.completionMarker === \"string\") {\n    const line = output.split(/\\r?\\n/).filter((candidate) => candidate.includes(cfg.completionMarker)).at(-1);\n    const fraction = line?.match(/\\b(\\d+)\\s*\\/\\s*(\\d+)\\b/);\n    if (fraction && Number(fraction[1]) === Number(fraction[2])) return { executed: Number(fraction[2]), failures: 0 };\n  }\n  return undefined;\n};",
+      "replace": "  if (typeof cfg.completionMarker === \"string\") {\n    const line = output.split(/\\r?\\n/).filter((candidate) => candidate.includes(cfg.completionMarker)).at(-1);\n    const fraction = line?.match(/\\b(\\d+)\\s*\\/\\s*(\\d+)\\b/);\n    if (fraction && Number(fraction[1]) === Number(fraction[2])) return { executed: Number(fraction[2]), failures: 0 };\n  }\n  if (typeof cfg.progressPattern === \"string\" && Number.isInteger(cfg.minTicks) && cfg.minTicks > 0) {\n    const terminal = output.trimEnd().split(/\\r?\\n/).at(-1) ?? \"\";\n    const completed = typeof cfg.completionMarker === \"string\" && terminal.includes(cfg.completionMarker);\n    const executed = (output.match(new RegExp(cfg.progressPattern, \"gm\")) ?? []).length;\n    if (completed && executed >= cfg.minTicks) return { executed, failures: 0 };\n  }\n  return undefined;\n};",
+      "expectRed": "a declared terminal banner is not an executed-cell total",
+      "cell": "a declared terminal banner is not an executed-cell total"
     },
     {
       "name": "incomplete aggregate grading exits successfully",
@@ -82,12 +82,12 @@
       "cell": "the audit summary names the exact checkout tree"
     },
     {
-      "name": "progress totals no longer require an explicit completion marker",
+      "name": "progress configs are unparsed without naming that ticks are not a total",
       "file": "scripts/mutation-coverage.mjs",
-      "find": "    const completed = typeof cfg.completionMarker === \"string\" && terminal.includes(cfg.completionMarker);",
-      "replace": "    const completed = true;",
-      "expectRed": "progress without completion is unparsed",
-      "cell": "progress without completion is unparsed"
+      "find": "      why += \"; progress ticks are not an executed-cell total; the instrument grades only a number the suite printed\";",
+      "replace": "      void why;",
+      "expectRed": "a terminal banner without a printed number is unparsed",
+      "cell": "a terminal banner without a printed number is unparsed"
     },
     {
       "name": "an invalid progress regex escapes per-config validation",

--- a/scripts/mutations/mutation-coverage.json
+++ b/scripts/mutations/mutation-coverage.json
@@ -26,6 +26,30 @@
       "cell": "a spawned repo entrypoint plus target-package build is gradable"
     },
     {
+      "name": "a suite mutating its own directly executed source is rejected",
+      "file": "scripts/mutation-coverage.mjs",
+      "find": "    if (resolve(mutation.file) === resolve(suite) || invokesFile(source, mutation.file)) return;",
+      "replace": "    if (invokesFile(source, mutation.file)) return;",
+      "expectRed": "a suite is gradable when it directly executes the file being mutated",
+      "cell": "a suite is gradable when it directly executes the file being mutated"
+    },
+    {
+      "name": "a suite launching the exact mutated repo script is rejected",
+      "file": "scripts/mutation-coverage.mjs",
+      "find": "    if (resolve(mutation.file) === resolve(suite) || invokesFile(source, mutation.file)) return;",
+      "replace": "    if (resolve(mutation.file) === resolve(suite)) return;",
+      "expectRed": "a suite is gradable when it launches the exact mutated script path",
+      "cell": "a suite is gradable when it launches the exact mutated script path"
+    },
+    {
+      "name": "any quoted mutation path is treated as a direct execution witness",
+      "file": "scripts/mutation-coverage.mjs",
+      "find": "    if (resolve(mutation.file) === resolve(suite) || invokesFile(source, mutation.file)) return;",
+      "replace": "    if (resolve(mutation.file) === resolve(suite) || referencesRoot(source, mutation.file)) return;",
+      "expectRed": "a quoted script path without an invocation is refused",
+      "cell": "a quoted script path without an invocation is refused"
+    },
+    {
       "name": "completed all-passed fractions are not parsed",
       "file": "scripts/mutation-coverage.mjs",
       "find": "    if (fraction && Number(fraction[1]) === Number(fraction[2])) return { executed: Number(fraction[2]), failures: 0 };",

--- a/scripts/mutations/mutation-coverage.json
+++ b/scripts/mutations/mutation-coverage.json
@@ -50,6 +50,30 @@
       "cell": "a quoted script path without an invocation is refused"
     },
     {
+      "name": "launcher aliases are ignored",
+      "file": "scripts/mutation-coverage.mjs",
+      "find": "      if (alias !== null && LAUNCHERS.includes(alias[1])) names.add(alias[2]);",
+      "replace": "      if (alias !== null && LAUNCHERS.includes(alias[1])) names.add(alias[1]);",
+      "expectRed": "a launcher imported under an alias still witnesses the script it runs",
+      "cell": "a launcher imported under an alias still witnesses the script it runs"
+    },
+    {
+      "name": "bound entry names are ignored",
+      "file": "scripts/mutation-coverage.mjs",
+      "find": "  const names = boundNames(source, basename);",
+      "replace": "  const names = [];",
+      "expectRed": "a target bound to a const before the launcher call still witnesses it",
+      "cell": "a target bound to a const before the launcher call still witnesses it"
+    },
+    {
+      "name": "a bound entry anywhere after a launcher is treated as its argument",
+      "file": "scripts/mutation-coverage.mjs",
+      "find": "  for (const m of source.matchAll(new RegExp(`${call}((?:[^()]|\\\\([^()]*\\\\))*)\\\\)`, \"g\"))) {",
+      "replace": "  for (const m of source.matchAll(new RegExp(`${call}([\\\\s\\\\S]{0,500})`, \"g\"))) {",
+      "expectRed": "a name bound to the target but never passed to a launcher is still refused",
+      "cell": "a name bound to the target but never passed to a launcher is still refused"
+    },
+    {
       "name": "completed all-passed fractions are not parsed",
       "file": "scripts/mutation-coverage.mjs",
       "find": "    if (fraction && Number(fraction[1]) === Number(fraction[2])) return { executed: Number(fraction[2]), failures: 0 };",

--- a/scripts/mutations/mutation-coverage.json
+++ b/scripts/mutations/mutation-coverage.json
@@ -58,10 +58,10 @@
       "cell": "the audit summary names the exact checkout tree"
     },
     {
-      "name": "a non-terminal OK line is accepted as completion",
+      "name": "progress totals no longer require an explicit completion marker",
       "file": "scripts/mutation-coverage.mjs",
-      "find": "      : /(?:^|\\s)(?:PASSED|OK)(?:\\s|$)/.test(terminal) && !(new RegExp(cfg.progressPattern).test(terminal));",
-      "replace": "      : /(?:^|\\n)[^\\n]*(?:PASSED|OK)/.test(output);",
+      "find": "    const completed = typeof cfg.completionMarker === \"string\" && terminal.includes(cfg.completionMarker);",
+      "replace": "    const completed = output.includes(\"OK\") || output.includes(\"PASSED\");",
       "expectRed": "early-ok is not a terminal completion witness",
       "cell": "early-ok is not a terminal completion witness"
     },
@@ -92,8 +92,8 @@
     {
       "name": "printed build text counts as a package build",
       "file": "scripts/mutation-coverage.mjs",
-      "find": "    if (tokens[0] !== \"pnpm\") continue;\n    if (tokens[1] === \"build\") return true;",
-      "replace": "    if (tokens.includes(\"pnpm\") && tokens.includes(\"build\")) return true;",
+      "find": "    if (tokens[0] !== \"pnpm\") continue;",
+      "replace": "    if (tokens[0] !== \"pnpm\" && !segment.includes(\"pnpm build\")) continue;",
       "expectRed": "printed-build cannot fabricate executes evidence",
       "cell": "printed-build cannot fabricate executes evidence"
     },


### PR DESCRIPTION
This PR's own coverage config was refused by this PR's own new pairing rule. That rule had zero tests and zero mutations covering it.

## Progress-marker summaries (c)

Main's `scripts/mutation-coverage.mjs` has no `progressPattern`. This PR adds the parser and type-checks the keys. Adoption is later (#1444).

Counted at head `07d769c1f` (rebased onto `5b2281cd`) with the tool's own glob (`git ls-files '*/mutations/*.json' '*.mutations.json'`), not a narrower filter. Glob counts are unchanged from `e652804c2`:

- 388 configs enumerated
- 65 carry `progressPattern`
- 32 carry `minTicks`
- 31 paired (both keys)
- 35 configs the dropped pairing rule would have refused, in both directions: 34 `progressPattern` without `minTicks`, plus 1 `minTicks` without `progressPattern` (`extensions/connector-jcode/smoke/mutations/jcode-readiness.json`)
- 4 carry all three keys (`progressPattern`, `minTicks`, `completionMarker`):
  - `extensions/connector-jcode/smoke/mutations/jcode-diagnostics.json`
  - `extensions/connector-jcode/smoke/mutations/jcode-no-self-update.json`
  - `packages/core/smoke/mutations/provision-stream-info-role-gate.json`
  - `packages/core/smoke/mutations/read-acl-stream-info-scope.json`

The dropped rule was symmetric (`(progressPattern === undefined) !== (minTicks === undefined)`). 35 is the operative number for this PR because the subject is that refusal, not a one-direction key distribution.

The progress path does not fire for any config that could be measured: two of the four triples are preempted by the tallied parser, one is refused before parseSummary is reached (missing `cell`), and the fourth is excluded because it invokes a live suite and is therefore undetermined rather than cleared.

The pairing *refusal* this PR briefly added had zero coverage: one reference in the tree, its own definition, no self-test cell, no mutation. That is why it is a diagnostic, not a hard refusal. Type checks stay (`progressPattern` a non-empty compilable regex; `minTicks` a positive integer). When no parser matched, UNPARSED now names both directions of that dropped rule, plus the two completion-marker holes: `progressPattern` present and `minTicks` absent; `minTicks` present and `progressPattern` absent, so the progress path cannot run at all because `minTicks` is only ever consumed by that path; `completionMarker` undeclared; or a declared marker not present on the final output line.

The marker-not-on-final-line branch is a diagnostic hole covered by a synthetic self-test cell. The branch was confirmed on a real suite's output and real key set (`jcode-no-self-update.json`); the tree's own config is currently blocked from reaching it by an unrelated missing `cell`.

The minTicks-without-progressPattern branch is also covered by a synthetic self-test cell. The affected config, `extensions/connector-jcode/smoke/mutations/jcode-readiness.json` (`minTicks` 8, no `progressPattern`), cannot reach the branch today: 0 of its 10 mutations declare `cell`, so validation refuses it first. It becomes reachable the moment someone adds those fields. That is why this ships in the tree rather than as a follow-up issue.

mutation-proof derives `minTicks=1` against a measured unmutated baseline. This tool has no baseline, so the same default would make one tick plus a marker a "trustworthy total". That asymmetry is why the pair is not refused here.

Skip-and-continue would otherwise walk past refusals and execute live-suite commands. The fence gates the declared `cfg.command` string in every selection mode, including glob-expanded argv: if the command matches `/:live\b|-live\b/` or names one of the six always-live suites (`smoke:manager-service`, `smoke:manager-service-ops`, `smoke:manager-service-invoke`, `smoke:manager-spawn-action`, `smoke:persona-announce`, `smoke:seat-input`), the config is not executed. `--execute-live` is the only override. A discovered (no-path) run also stays unexecuted unless `--execute-discovered` is passed. Fenced configs are counted as `fenced-live` / `fenced-discovered`, not as graded, unparsed, or command-failed. The detector does not scan suite sources for broker markers. Always pass explicit config paths; never run `node scripts/mutation-coverage.mjs` with no arguments. Related: #1446.

After rebase onto #1378, the coverage tool keeps main's `invokesFile` direct-invocation witness beside this PR's `executes` witness. The self-test unions both families.

`completionMarker` matching stays `includes()` on the terminal line. A local structural test cannot refuse `NOT <marker>` without also refusing real banners such as `ALL MEMBERSHIP TESTS PASSED` (marker `MEMBERSHIP TESTS`). Trailing text is this corpus's success shape: 90 of 191 declared markers end in `:` and require it. Both are named limitations, not a closed predicate. Related: #1464.

`buildsPackage` is the fourth witness of the class tracked in #1434, alongside `../src/`, `referencesRoot`, and `invokesFile`. Hardening it alone would leave three siblings looser. The instrument does not claim build-execution soundness. Related: #1465.

## Summary

- examine every selected mutation config and collect failures instead of aborting on the first one
- report the exact checkout HEAD plus enumerated, examined, graded, refused-with-reason, unparsed, and command-failed counts
- recognize completed fraction and progress-marker suite summaries without treating a bare zero-failure banner as an executed-cell total
- preserve assembled-tree witness and add a declaration-backed `executes` witness for repository entrypoints launched through child processes or node-pty
- add `executes` to mutation-proof's shared top-level config-key allowlist
- do not execute a config whose command names a live suite, in any selection mode; discovered runs stay unexecuted unless `--execute-discovered` is passed

## Reproduction

On origin/main `6ab195b865af58a87ccd1d77f1314f0882537541`, the validator enumerated 298 configs and aborted at position 2 on `bin/smoke/mutations/attach-auth-root.json`, leaving 296 unexamined. The refused fixture was independently graded by the mutation reproof job in run `34184716990`, job `101930625121`, which establishes that the refusal's claim that the source could not reach running code was false.

At #1220 head `020c920a693dbefb89ce2ae9ce3d1fe5e074c04a`, five completed commands returned rc=0 with only `SMOKE OK (0 failed)` summaries. The old parser could not derive executed-cell totals and rejected them after the commands ran. Targeted controls on this branch also reproduced rc=0 rejection for `ENDPOINT PERMISSION RESULTS: 4/4` and for a three-tick private-lifecycle suite with a completion banner.

## Verification

At `07d769c1f`:

- `node scripts/mutation-coverage.selftest.mjs` (54 passed, 0 failed; 48 plus six named-limitation cells)
- `node scripts/mutation-coverage.mjs scripts/mutations/mutation-coverage.json` (graded=1; 20 mutations against a self-test of 54 cells; fenced-live=0 fenced-discovered=0)
- `node scripts/mutation-proof.mjs --config scripts/mutations/mutation-coverage.json` (20 of 20 killed on named cells, baseline 54)

## Scope

This changes `scripts/mutation-coverage.mjs` and its self-test. It does not change mutation verdict logic in `scripts/mutation-proof.mjs` or selection logic in `scripts/mutation-reproof.mjs`. The latter only accepts the new sibling-tool config key.

Closes #1375.
Adopters: #1444.
Limitations named in-tree: #1464, #1465. Live-suite fence: #1446.

## Review fixes

The first exact-head panel returned two independent BLOCKs. The replacement uses TypeScript ASTs for import, call, and variable evidence; shell-token inspection for package builds; per-config parser metadata validation; and explicit terminal completion markers. The focused corpus now includes separate positive and negative cells for every reported false accept and false refusal.
