### PR TITLE
fix(core): derive dmHistory identity from the forge-locked subject

### DIFF
--- a/.changeset/dm-history-subject.md
+++ b/.changeset/dm-history-subject.md
@@ -2,4 +2,4 @@
 "cotal-ai": patch
 ---
 
-Reject dmHistory / channelHistory / multiChannelHistory rows whose payload `from.id` disagrees with the forge-locked subject sender (SPEC §5). Fail closed on non-object payloads so one poisoned row cannot throw the whole page. Surviving DMs still take recipient from the subject.
+Reject dmHistory / channelHistory / multiChannelHistory rows whose payload `from.id` disagrees with the forge-locked subject sender (SPEC §5). History drain types through `isCotalMessage` (the same structural guard Plane-3 already uses) instead of asserting `CotalMessage`, so non-conformant stored JSON is rejected rather than cast. Fail closed on non-object payloads so one poisoned row cannot throw the whole page. Surviving DMs still take recipient from the subject.

--- a/.changeset/dm-history-subject.md
+++ b/.changeset/dm-history-subject.md
@@ -2,4 +2,4 @@
 "cotal-ai": patch
 ---
 
-Reject dmHistory / channelHistory / multiChannelHistory rows whose payload `from.id` disagrees with the forge-locked subject sender (SPEC §5). History drain types through `isCotalMessage` (the same structural guard Plane-3 already uses) instead of asserting `CotalMessage`, so non-conformant stored JSON is rejected rather than cast. Fail closed on non-object payloads so one poisoned row cannot throw the whole page. Surviving DMs still take recipient from the subject. Trustworthiness here is `from.id` versus the subject sender; payload `from.name` / `from.role` remain advisory.
+Reject dmHistory / channelHistory / multiChannelHistory rows whose payload `from.id` disagrees with the forge-locked subject sender (SPEC §5). Fail closed on non-object payloads so one poisoned row cannot throw the whole page. Surviving DMs still take recipient from the subject. Trustworthiness here is `from.id` versus the subject sender; payload `from.name` / `from.role` remain advisory. History drain does not require a full CotalMessage shape.

--- a/.changeset/dm-history-subject.md
+++ b/.changeset/dm-history-subject.md
@@ -2,4 +2,4 @@
 "cotal-ai": patch
 ---
 
-Reject dmHistory / channelHistory / multiChannelHistory rows whose payload `from.id` disagrees with the forge-locked subject sender (SPEC §5). History drain types through `isCotalMessage` (the same structural guard Plane-3 already uses) instead of asserting `CotalMessage`, so non-conformant stored JSON is rejected rather than cast. Fail closed on non-object payloads so one poisoned row cannot throw the whole page. Surviving DMs still take recipient from the subject.
+Reject dmHistory / channelHistory / multiChannelHistory rows whose payload `from.id` disagrees with the forge-locked subject sender (SPEC §5). History drain types through `isCotalMessage` (the same structural guard Plane-3 already uses) instead of asserting `CotalMessage`, so non-conformant stored JSON is rejected rather than cast. Fail closed on non-object payloads so one poisoned row cannot throw the whole page. Surviving DMs still take recipient from the subject. Trustworthiness here is `from.id` versus the subject sender; payload `from.name` / `from.role` remain advisory.

--- a/.changeset/dm-history-subject.md
+++ b/.changeset/dm-history-subject.md
@@ -2,4 +2,4 @@
 "cotal-ai": patch
 ---
 
-Rewrite dmHistory identity from the forge-locked DM subject so payload from/to cannot spoof sender or inject a thread.
+Reject dmHistory / channelHistory / multiChannelHistory rows whose payload `from.id` disagrees with the forge-locked subject sender (SPEC §5). Fail closed on non-object payloads so one poisoned row cannot throw the whole page. Surviving DMs still take recipient from the subject.

--- a/.changeset/dm-history-subject.md
+++ b/.changeset/dm-history-subject.md
@@ -1,0 +1,5 @@
+---
+"cotal-ai": patch
+---
+
+Rewrite dmHistory identity from the forge-locked DM subject so payload from/to cannot spoof sender or inject a thread.

--- a/bin/smoke/ci-suites.d/c6bbe96fca549fbdcb9a3b417830a5f0878e0bf2877af41053fd322a13bdd735.txt
+++ b/bin/smoke/ci-suites.d/c6bbe96fca549fbdcb9a3b417830a5f0878e0bf2877af41053fd322a13bdd735.txt
@@ -1,0 +1,2 @@
+# dmHistory must rewrite identity from the forge-locked subject (Cotal #388).
+smoke:dm-history-subject

--- a/bin/smoke/mutations/dm-history-subject.json
+++ b/bin/smoke/mutations/dm-history-subject.json
@@ -2,20 +2,22 @@
   "suite": [
     "packages/core/smoke/dm-history-subject.smoke.ts"
   ],
-  "guard": "history drain rejects SPEC §5 mismatches and fail-closes on shape; surviving DMs take recipient from the subject; god-view keeps the viewer's own send",
+  "guard": "history drain rejects SPEC §5 mismatches and fail-closes on shape via isCotalMessage; surviving DMs take recipient from the subject; god-view keeps the viewer's own send",
   "command": "pnpm smoke:dm-history-subject",
   "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/dm-history-subject.json",
   "why": [
     "SPEC §5: mismatch / missing from / unparseable subject MUST be rejected, never rewritten.",
     "A stored JSON null used to throw TypeError mid-page and drop honest rows (regression vs HEAD^).",
     "God-view must include a DM the viewer itself sent; a comment is not a test.",
-    "Matching from.id still rewrites recipient from the subject so thread injection cannot land."
+    "Matching from.id still rewrites recipient from the subject so thread injection cannot land.",
+    "isCotalMessage is load-bearing: a stored row missing `space` is admitted by the parent isRecord triple and rejected by the new guard. Reverting that line must redden the missing-space cell.",
+    "JSON null as a message object is unreachable against the new guard: isCotalMessage(null) is already false via its own isRecord check. Recorded unkillable rather than manufactured red."
   ],
   "mutations": [
     {
       "name": "history drain returns the payload and discards SPEC §5",
       "file": "packages/core/src/endpoint.ts",
-      "find": "  if (!isRecord(raw) || !isUsableMessageId(raw.id) || !isRecord(raw.from)) return undefined;\n  const parsed = parseSubject(m.subject);\n  if (!parsed || !isPrincipalOwnerToken(parsed.owner)) return undefined;\n  if (raw.from.id !== parsed.sender) return undefined;\n  return authenticatedMessage(raw as CotalMessage, parsed);",
+      "find": "  if (!isCotalMessage(raw) || !isUsableMessageId(raw.id)) return undefined;\n  const parsed = parseSubject(m.subject);\n  if (!parsed || !isPrincipalOwnerToken(parsed.owner)) return undefined;\n  if (raw.from.id !== parsed.sender) return undefined;\n  return authenticatedMessage(raw, parsed);",
       "replace": "  return raw as CotalMessage;",
       "expectRed": "spoofed payload is ABSENT from history (SPEC §5 reject, not rewrite)",
       "cell": "spoofed payload is ABSENT from history (SPEC §5 reject, not rewrite)",
@@ -33,20 +35,27 @@
     {
       "name": "history echo-drops the viewer's own send",
       "file": "packages/core/src/endpoint.ts",
-      "find": "  if (raw.from.id !== parsed.sender) return undefined;\n  return authenticatedMessage(raw as CotalMessage, parsed);",
-      "replace": "  if (raw.from.id !== parsed.sender) return undefined;\n  if (raw.from.id === \"local.viewer\") return undefined;\n  return authenticatedMessage(raw as CotalMessage, parsed);",
+      "find": "  if (raw.from.id !== parsed.sender) return undefined;\n  return authenticatedMessage(raw, parsed);",
+      "replace": "  if (raw.from.id !== parsed.sender) return undefined;\n  if (raw.from.id === \"local.viewer\") return undefined;\n  return authenticatedMessage(raw, parsed);",
       "expectRed": "history still includes a DM the viewer itself sent",
       "cell": "history still includes a DM the viewer itself sent",
       "completionMarker": "dm-history-subject smoke:"
     },
     {
+      "name": "history drain reverts isCotalMessage to the parent isRecord triple",
+      "file": "packages/core/src/endpoint.ts",
+      "find": "  if (!isCotalMessage(raw) || !isUsableMessageId(raw.id)) return undefined;",
+      "replace": "  if (!isRecord(raw) || !isUsableMessageId(raw.id) || !isRecord(raw.from)) return undefined;",
+      "expectRed": "row missing space is ABSENT (isCotalMessage, not the old isRecord triple)",
+      "cell": "row missing space is ABSENT (isCotalMessage, not the old isRecord triple)",
+      "completionMarker": "dm-history-subject smoke:"
+    }
+  ],
+  "unkillable": [
+    {
       "name": "JSON null is treated as a message object",
       "file": "packages/core/src/endpoint.ts",
-      "find": "  if (!isRecord(raw) || !isUsableMessageId(raw.id) || !isRecord(raw.from)) return undefined;",
-      "replace": "  if (!isUsableMessageId((raw as { id?: unknown }).id) || !(raw as { from?: unknown }).from) return undefined;",
-      "expectRed": "JSON null history row does not throw",
-      "cell": "JSON null history row does not throw",
-      "completionMarker": "dm-history-subject smoke:"
+      "why": "Unkillable against the current guard, not dropped from the record. The parent mutation removed the isRecord(raw) limb so JSON null was treated as a message object and threw mid-page. isCotalMessage(null) is already false via its own isRecord check, so deleting or reverting the isCotalMessage line cannot reproduce that defect: null still never reaches from.id / authenticatedMessage. The missing-space revert mutation grades the new guard instead."
     }
   ]
 }

--- a/bin/smoke/mutations/dm-history-subject.json
+++ b/bin/smoke/mutations/dm-history-subject.json
@@ -1,0 +1,33 @@
+{
+  "suite": [
+    "packages/core/smoke/dm-history-subject.smoke.ts"
+  ],
+  "guard": "dmHistory surfaces forge-locked subject sender and recipient, never payload from/to",
+  "command": "pnpm smoke:dm-history-subject",
+  "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/dm-history-subject.json",
+  "why": [
+    "History drain used to keep m.json() and drop m.subject. Payload from/to are advisory.",
+    "M1 returns the raw payload from drainWindow. Attribution and thread injection both return.",
+    "M2 keeps from.id rewrite but skips recipient rewrite. Thread injection survives."
+  ],
+  "mutations": [
+    {
+      "name": "history drain returns the payload and discards the subject",
+      "file": "packages/core/src/endpoint.ts",
+      "find": "  if (!isUsableMessageId(msg.id) || !msg.from) return undefined;\n  const parsed = parseSubject(m.subject);\n  if (!parsed || !isPrincipalOwnerToken(parsed.owner)) return undefined;\n  return authenticatedMessage(msg, parsed);",
+      "replace": "  return msg;",
+      "expectRed": "dmHistory sender is the subject sender, not payload from.id",
+      "cell": "dmHistory sender is the subject sender, not payload from.id",
+      "completionMarker": "dm-history-subject smoke:"
+    },
+    {
+      "name": "authenticatedMessage rewrites chat only, leaving DM recipient as payload to",
+      "file": "packages/core/src/endpoint.ts",
+      "find": "  if (parsed.kind === \"inst\") return authenticatedDmMessage(withFrom, parsed.rest);",
+      "replace": "  if (parsed.kind === \"inst\") return withFrom;",
+      "expectRed": "dmHistory recipient is the subject recipient, not payload to",
+      "cell": "dmHistory recipient is the subject recipient, not payload to",
+      "completionMarker": "dm-history-subject smoke:"
+    }
+  ]
+}

--- a/bin/smoke/mutations/dm-history-subject.json
+++ b/bin/smoke/mutations/dm-history-subject.json
@@ -2,31 +2,50 @@
   "suite": [
     "packages/core/smoke/dm-history-subject.smoke.ts"
   ],
-  "guard": "dmHistory surfaces forge-locked subject sender and recipient, never payload from/to",
+  "guard": "history drain rejects SPEC §5 mismatches and fail-closes on shape; surviving DMs take recipient from the subject; god-view keeps the viewer's own send",
   "command": "pnpm smoke:dm-history-subject",
   "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/dm-history-subject.json",
   "why": [
-    "History drain used to keep m.json() and drop m.subject. Payload from/to are advisory.",
-    "M1 returns the raw payload from drainWindow. Attribution and thread injection both return.",
-    "M2 keeps from.id rewrite but skips recipient rewrite. Thread injection survives."
+    "SPEC §5: mismatch / missing from / unparseable subject MUST be rejected, never rewritten.",
+    "A stored JSON null used to throw TypeError mid-page and drop honest rows (regression vs HEAD^).",
+    "God-view must include a DM the viewer itself sent; a comment is not a test.",
+    "Matching from.id still rewrites recipient from the subject so thread injection cannot land."
   ],
   "mutations": [
     {
-      "name": "history drain returns the payload and discards the subject",
+      "name": "history drain returns the payload and discards SPEC §5",
       "file": "packages/core/src/endpoint.ts",
-      "find": "  if (!isUsableMessageId(msg.id) || !msg.from) return undefined;\n  const parsed = parseSubject(m.subject);\n  if (!parsed || !isPrincipalOwnerToken(parsed.owner)) return undefined;\n  return authenticatedMessage(msg, parsed);",
-      "replace": "  return msg;",
-      "expectRed": "dmHistory sender is the subject sender, not payload from.id",
-      "cell": "dmHistory sender is the subject sender, not payload from.id",
+      "find": "  if (!isRecord(raw) || !isUsableMessageId(raw.id) || !isRecord(raw.from)) return undefined;\n  const parsed = parseSubject(m.subject);\n  if (!parsed || !isPrincipalOwnerToken(parsed.owner)) return undefined;\n  if (raw.from.id !== parsed.sender) return undefined;\n  return authenticatedMessage(raw as CotalMessage, parsed);",
+      "replace": "  return raw as CotalMessage;",
+      "expectRed": "spoofed payload is ABSENT from history (SPEC §5 reject, not rewrite)",
+      "cell": "spoofed payload is ABSENT from history (SPEC §5 reject, not rewrite)",
       "completionMarker": "dm-history-subject smoke:"
     },
     {
-      "name": "authenticatedMessage rewrites chat only, leaving DM recipient as payload to",
+      "name": "authenticatedMessage skips DM recipient rewrite",
       "file": "packages/core/src/endpoint.ts",
-      "find": "  if (parsed.kind === \"inst\") return authenticatedDmMessage(withFrom, parsed.rest);",
-      "replace": "  if (parsed.kind === \"inst\") return withFrom;",
-      "expectRed": "dmHistory recipient is the subject recipient, not payload to",
-      "cell": "dmHistory recipient is the subject recipient, not payload to",
+      "find": "  if (parsed.kind === \"inst\") return authenticatedDmMessage(msg, parsed.rest);",
+      "replace": "  if (parsed.kind === \"inst\") return msg;",
+      "expectRed": "matching from.id still rewrites recipient from the subject, not payload to",
+      "cell": "matching from.id still rewrites recipient from the subject, not payload to",
+      "completionMarker": "dm-history-subject smoke:"
+    },
+    {
+      "name": "history echo-drops the viewer's own send",
+      "file": "packages/core/src/endpoint.ts",
+      "find": "  if (raw.from.id !== parsed.sender) return undefined;\n  return authenticatedMessage(raw as CotalMessage, parsed);",
+      "replace": "  if (raw.from.id !== parsed.sender) return undefined;\n  if (raw.from.id === \"local.viewer\") return undefined;\n  return authenticatedMessage(raw as CotalMessage, parsed);",
+      "expectRed": "history still includes a DM the viewer itself sent",
+      "cell": "history still includes a DM the viewer itself sent",
+      "completionMarker": "dm-history-subject smoke:"
+    },
+    {
+      "name": "JSON null is treated as a message object",
+      "file": "packages/core/src/endpoint.ts",
+      "find": "  if (!isRecord(raw) || !isUsableMessageId(raw.id) || !isRecord(raw.from)) return undefined;",
+      "replace": "  if (!isUsableMessageId((raw as { id?: unknown }).id) || !(raw as { from?: unknown }).from) return undefined;",
+      "expectRed": "JSON null history row does not throw",
+      "cell": "JSON null history row does not throw",
       "completionMarker": "dm-history-subject smoke:"
     }
   ]

--- a/bin/smoke/mutations/dm-history-subject.json
+++ b/bin/smoke/mutations/dm-history-subject.json
@@ -2,7 +2,7 @@
   "suite": [
     "packages/core/smoke/dm-history-subject.smoke.ts"
   ],
-  "guard": "history drain rejects SPEC §5 mismatches and fail-closes on shape via isCotalMessage; surviving DMs take recipient from the subject; god-view keeps the viewer's own send",
+  "guard": "history drain rejects SPEC §5 from.id mismatches and fail-closes on shape without full CotalMessage validation; surviving DMs take recipient from the subject; god-view keeps the viewer's own send; public-API data:undefined still surfaces",
   "command": "pnpm smoke:dm-history-subject",
   "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/dm-history-subject.json",
   "why": [
@@ -10,14 +10,15 @@
     "A stored JSON null used to throw TypeError mid-page and drop honest rows (regression vs HEAD^).",
     "God-view must include a DM the viewer itself sent; a comment is not a test.",
     "Matching from.id still rewrites recipient from the subject so thread injection cannot land.",
-    "isCotalMessage is load-bearing: a stored row missing `space` is admitted by the parent isRecord triple and rejected by the new guard. Reverting that line must redden the missing-space cell.",
-    "JSON null as a message object is unreachable against the new guard: isCotalMessage(null) is already false via its own isRecord check. Recorded unkillable rather than manufactured red."
+    "isHistoryDrainEnvelope is the parent isRecord triple under a named type predicate. There is no stored row that one admits and the other drops; reverting the name to an inline triple is a compile change, not a behavioural one. Recorded unkillable. The load-bearing behavioural difference is refusing full isCotalMessage.",
+    "JSON null as a message object is unreachable against the current guard: isHistoryDrainEnvelope(null) is already false via isRecord. Recorded unkillable rather than manufactured red.",
+    "A public unicast with parts [{kind:\"data\", data: undefined}] serializes without a data key and must still appear in dmHistory. Full isCotalMessage validation dropped that row."
   ],
   "mutations": [
     {
       "name": "history drain returns the payload and discards SPEC §5",
       "file": "packages/core/src/endpoint.ts",
-      "find": "  if (!isCotalMessage(raw) || !isUsableMessageId(raw.id)) return undefined;\n  const parsed = parseSubject(m.subject);\n  if (!parsed || !isPrincipalOwnerToken(parsed.owner)) return undefined;\n  if (raw.from.id !== parsed.sender) return undefined;\n  return authenticatedMessage(raw, parsed);",
+      "find": "  if (!isHistoryDrainEnvelope(raw)) return undefined;\n  const parsed = parseSubject(m.subject);\n  if (!parsed || !isPrincipalOwnerToken(parsed.owner)) return undefined;\n  if (raw.from.id !== parsed.sender) return undefined;\n  return authenticatedMessage(raw, parsed);",
       "replace": "  return raw as CotalMessage;",
       "expectRed": "spoofed payload is ABSENT from history (SPEC §5 reject, not rewrite)",
       "cell": "spoofed payload is ABSENT from history (SPEC §5 reject, not rewrite)",
@@ -42,12 +43,12 @@
       "completionMarker": "dm-history-subject smoke:"
     },
     {
-      "name": "history drain reverts isCotalMessage to the parent isRecord triple",
+      "name": "history drain uses full isCotalMessage and drops public-API data:undefined",
       "file": "packages/core/src/endpoint.ts",
-      "find": "  if (!isCotalMessage(raw) || !isUsableMessageId(raw.id)) return undefined;",
-      "replace": "  if (!isRecord(raw) || !isUsableMessageId(raw.id) || !isRecord(raw.from)) return undefined;",
-      "expectRed": "row missing space is ABSENT (isCotalMessage, not the old isRecord triple)",
-      "cell": "row missing space is ABSENT (isCotalMessage, not the old isRecord triple)",
+      "find": "  if (!isHistoryDrainEnvelope(raw)) return undefined;",
+      "replace": "  if (!isCotalMessage(raw) || !isUsableMessageId(raw.id)) return undefined;",
+      "expectRed": "public-API data part with undefined data still appears in dmHistory",
+      "cell": "public-API data part with undefined data still appears in dmHistory",
       "completionMarker": "dm-history-subject smoke:"
     }
   ],
@@ -55,7 +56,12 @@
     {
       "name": "JSON null is treated as a message object",
       "file": "packages/core/src/endpoint.ts",
-      "why": "Unkillable against the current guard, not dropped from the record. The parent mutation removed the isRecord(raw) limb so JSON null was treated as a message object and threw mid-page. isCotalMessage(null) is already false via its own isRecord check, so deleting or reverting the isCotalMessage line cannot reproduce that defect: null still never reaches from.id / authenticatedMessage. The missing-space revert mutation grades the new guard instead."
+      "why": "Unkillable against the current guard, not dropped from the record. The parent mutation removed the isRecord(raw) limb so JSON null was treated as a message object and threw mid-page. isHistoryDrainEnvelope(null) is already false via isRecord, so deleting the named predicate cannot reproduce that defect: null still never reaches from.id / authenticatedMessage."
+    },
+    {
+      "name": "history drain reverts isHistoryDrainEnvelope to the parent isRecord triple",
+      "file": "packages/core/src/endpoint.ts",
+      "why": "Compile-only named wrapping of the parent isRecord triple, not a behavioural delta. There is no stored row the inline triple admits and the named predicate drops (measured: extra typeof from.id === \"string\" limb SURVIVED at 24/24 because SPEC §5 still rejects). The behavioural difference this PR grades is refusing full isCotalMessage, via the data:undefined mutation."
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -273,6 +273,7 @@
     "smoke:kv-scan": "tsx packages/core/smoke/kv-scan.smoke.ts",
     "smoke:kv-read-shape": "tsx packages/core/smoke/kv-read-shape.smoke.ts",
     "smoke:history-recent": "tsx packages/core/smoke/history-recent.smoke.ts",
+    "smoke:dm-history-subject": "tsx packages/core/smoke/dm-history-subject.smoke.ts",
     "smoke:history-cancellation": "tsx packages/core/smoke/history-cancellation.smoke.ts",
     "smoke:web-history-cancellation": "tsx implementations/web/smoke/history-cancellation.smoke.ts",
     "smoke:server-resolution:live": "tsx implementations/cli/smoke/server-resolution-live.smoke.ts",

--- a/packages/core/smoke/dm-history-subject.smoke.ts
+++ b/packages/core/smoke/dm-history-subject.smoke.ts
@@ -128,6 +128,15 @@ try {
     id: 123,
     parts: [{ kind: "text", text: "numeric-id" }],
   })));
+  raw.publish(dmSubj, JSON.stringify((() => {
+    const row = envelope({
+      id: "no-space-388",
+      from: { id: "local.alice", name: "alice" },
+      parts: [{ kind: "text", text: "missing-space" }],
+    });
+    delete row.space;
+    return row;
+  })()));
   raw.publish(`${dmSubj}.extra`, JSON.stringify(envelope({
     id: "extra-token-388",
     parts: [{ kind: "text", text: "extra-token" }],
@@ -158,6 +167,11 @@ try {
   check("missing from is ABSENT", !page.some((m) => m.id === "missing-from-388"));
   check("non-string id is ABSENT", !page.some((m) => String(m.id) === "123" || (m as { id?: unknown }).id === 123));
   check("extra-token inst subject is ABSENT (parseSubject arity)", !page.some((m) => m.id === "extra-token-388"));
+  check(
+    "row missing space is ABSENT (isCotalMessage, not the old isRecord triple)",
+    !page.some((m) => m.id === "no-space-388"),
+    page.map((m) => m.id),
+  );
 
   const toSpoof = page.find((m) => m.id === "to-spoof-388");
   check(

--- a/packages/core/smoke/dm-history-subject.smoke.ts
+++ b/packages/core/smoke/dm-history-subject.smoke.ts
@@ -81,6 +81,9 @@ try {
 
   const honest = await alice.unicast(bob.card.id, "honest-line");
   const own = await viewer.unicast(bob.card.id, "viewer-own-line");
+  const dataUndef = await alice.unicast(bob.card.id, "unused-text", {
+    parts: [{ kind: "data", data: undefined }],
+  });
   const chatHonest = await alice.multicast("chat-honest", { channel: "log" });
   await wait(200);
 
@@ -128,15 +131,6 @@ try {
     id: 123,
     parts: [{ kind: "text", text: "numeric-id" }],
   })));
-  raw.publish(dmSubj, JSON.stringify((() => {
-    const row = envelope({
-      id: "no-space-388",
-      from: { id: "local.alice", name: "alice" },
-      parts: [{ kind: "text", text: "missing-space" }],
-    });
-    delete row.space;
-    return row;
-  })()));
   raw.publish(`${dmSubj}.extra`, JSON.stringify(envelope({
     id: "extra-token-388",
     parts: [{ kind: "text", text: "extra-token" }],
@@ -168,8 +162,8 @@ try {
   check("non-string id is ABSENT", !page.some((m) => String(m.id) === "123" || (m as { id?: unknown }).id === 123));
   check("extra-token inst subject is ABSENT (parseSubject arity)", !page.some((m) => m.id === "extra-token-388"));
   check(
-    "row missing space is ABSENT (isCotalMessage, not the old isRecord triple)",
-    !page.some((m) => m.id === "no-space-388"),
+    "public-API data part with undefined data still appears in dmHistory",
+    page.some((m) => m.id === dataUndef.id),
     page.map((m) => m.id),
   );
 

--- a/packages/core/smoke/dm-history-subject.smoke.ts
+++ b/packages/core/smoke/dm-history-subject.smoke.ts
@@ -1,10 +1,8 @@
 /**
- * `dmHistory` must surface identity from the forge-locked DM subject, not the payload.
- *
- * The unicast subject is `inst.<recipOwner>.<recipActor>.<sndOwner>.<sndActor>`. The broker
- * forge-locks those four tokens. Payload `from` / `to` are advisory. Live tails already drop a
- * spoofed `from`. `drainWindow` used to keep `m.json()` and drop `m.subject`, so every history
- * consumer rendered a self-asserted sender and recipient (Cotal #388).
+ * `dmHistory` / `channelHistory` / `multiChannelHistory` must reject a SPEC §5 mismatch
+ * (drop the row) and derive remaining routing from the forge-locked subject for rows
+ * that survive. Payload `from` / `to` are advisory. Live tails, channel backfill, and
+ * channel recall already `continue` on mismatch; history must match them, not rewrite.
  *
  * Needs nats-server on PATH. Isolated broker store. No `cotal up` / `cotal down` / `:live`.
  * Run: pnpm smoke:dm-history-subject
@@ -19,6 +17,7 @@ import {
   isReachable,
   setupSpaceStreams,
   unicastSubject,
+  chatSubject,
 } from "../src/index.js";
 import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 import { pickFreePort } from "./_free-port.js";
@@ -42,6 +41,16 @@ const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 const text = (m: { parts?: { kind: string; text?: string }[] }) =>
   m.parts?.map((p) => (p.kind === "text" ? p.text : "")).join("") ?? "";
 
+const envelope = (over: Record<string, unknown>) => ({
+  id: "env-" + Math.random().toString(16).slice(2),
+  ts: Date.now(),
+  space: SPACE,
+  from: { id: "local.alice", name: "alice" },
+  to: "local.bob",
+  parts: [{ kind: "text", text: "x" }],
+  ...over,
+});
+
 const srv = spawn("nats-server", ["-p", String(PORT), "-js", "-sd", store, "-a", "127.0.0.1"], { stdio: "ignore" });
 const releaseBroker = teardownOnSignal(srv, store);
 try {
@@ -52,15 +61,15 @@ try {
   await setupSpaceStreams({ servers: SERVER, space: SPACE });
 
   const alice = new CotalEndpoint({
-    space: SPACE, servers: SERVER, channels: [], consume: false, registerPresence: false,
+    space: SPACE, servers: SERVER, channels: ["log"], consume: false, registerPresence: false,
     card: { name: "alice", kind: "endpoint", owner: "local", actor: "alice" },
   });
   const bob = new CotalEndpoint({
-    space: SPACE, servers: SERVER, channels: [], consume: false, registerPresence: false,
+    space: SPACE, servers: SERVER, channels: ["log"], consume: false, registerPresence: false,
     card: { name: "bob", kind: "endpoint", owner: "local", actor: "bob" },
   });
   const viewer = new CotalEndpoint({
-    space: SPACE, servers: SERVER, channels: [], consume: false, registerPresence: false,
+    space: SPACE, servers: SERVER, channels: ["log"], consume: false, registerPresence: false,
     card: { name: "viewer", kind: "endpoint", owner: "local", actor: "viewer" },
   });
   alice.on("error", () => {});
@@ -71,55 +80,124 @@ try {
   await viewer.start();
 
   const honest = await alice.unicast(bob.card.id, "honest-line");
+  const own = await viewer.unicast(bob.card.id, "viewer-own-line");
+  const chatHonest = await alice.multicast("chat-honest", { channel: "log" });
   await wait(200);
 
-  const honestPage = await viewer.dmHistory({ limit: 10 });
+  const honestPage = await viewer.dmHistory({ limit: 50 });
   check("honest DM is in history", honestPage.some((m) => m.id === honest.id), honestPage.map((m) => m.id));
-  const honestRow = honestPage.find((m) => m.id === honest.id)!;
-  check("honest DM keeps the wire sender", honestRow.from.id === alice.card.id, honestRow.from);
-  check("honest DM keeps the wire recipient", honestRow.to === bob.card.id, honestRow.to);
-  check("history still includes the sender's own line (not an echo-drop)", text(honestRow) === "honest-line");
+  const honestRow = honestPage.find((m) => m.id === honest.id);
+  check("honest DM keeps the wire sender", honestRow?.from.id === alice.card.id, honestRow?.from);
+  check("honest DM keeps the wire recipient", honestRow?.to === bob.card.id, honestRow?.to);
+  check("history still includes the sender's own line (not an echo-drop)", text(honestRow ?? {}) === "honest-line");
+  check(
+    "history still includes a DM the viewer itself sent",
+    honestPage.some((m) => m.id === own.id && text(m) === "viewer-own-line" && m.from.id === viewer.card.id),
+    honestPage.filter((m) => m.from?.id === viewer.card.id).map((m) => m.id),
+  );
 
   const raw = await connect({ servers: SERVER });
-  const spoofed = {
+  const dmSubj = unicastSubject(SPACE, "local", "bob", "local", "alice");
+  const chatSubj = chatSubject(SPACE, "local", "alice", "log");
+
+  raw.publish(dmSubj, JSON.stringify(envelope({
     id: "spoof-388",
+    from: { id: "local.mallory", name: "Not Alice", role: "admin" },
+    to: "local.carol",
+    parts: [{ kind: "text", text: "injected-into-carol" }],
+  })));
+  raw.publish(dmSubj, JSON.stringify(envelope({
+    id: "to-spoof-388",
+    from: { id: "local.alice", name: "alice" },
+    to: "local.carol",
+    parts: [{ kind: "text", text: "alice-to-carol-claim" }],
+  })));
+  raw.publish(dmSubj, "null");
+  raw.publish(dmSubj, JSON.stringify(envelope({
+    id: "from-string-388",
+    from: "truthy-string",
+    parts: [{ kind: "text", text: "string-from" }],
+  })));
+  raw.publish(dmSubj, JSON.stringify(envelope({
+    id: "missing-from-388",
+    from: undefined,
+    parts: [{ kind: "text", text: "no-from" }],
+  })));
+  raw.publish(dmSubj, JSON.stringify(envelope({
+    id: "bad-id-388",
+    id: 123,
+    parts: [{ kind: "text", text: "numeric-id" }],
+  })));
+  raw.publish(`${dmSubj}.extra`, JSON.stringify(envelope({
+    id: "extra-token-388",
+    parts: [{ kind: "text", text: "extra-token" }],
+  })));
+  raw.publish(chatSubj, JSON.stringify({
+    id: "chat-spoof-388",
     ts: Date.now(),
     space: SPACE,
     from: { id: "local.mallory", name: "Not Alice" },
-    to: "local.carol",
-    parts: [{ kind: "text", text: "injected-into-carol" }],
-  };
-  raw.publish(
-    unicastSubject(SPACE, "local", "bob", "local", "alice"),
-    JSON.stringify(spoofed),
-  );
+    channel: "other",
+    parts: [{ kind: "text", text: "chat-injected" }],
+  }));
   await raw.flush();
   await raw.close();
   await wait(200);
 
-  const page = await viewer.dmHistory({ limit: 20 });
-  const row = page.find((m) => m.id === "spoof-388");
-  check("spoofed payload is still a history row (rewritten, not silently dropped)", !!row, page.map((m) => m.id));
+  let page: Awaited<ReturnType<typeof viewer.dmHistory>> = [];
+  let threw: string | undefined;
+  try {
+    page = await viewer.dmHistory({ limit: 50 });
+  } catch (e) {
+    threw = e instanceof Error ? e.message : String(e);
+  }
+  check("JSON null history row does not throw", threw === undefined, threw);
+  check("honest DM still present after malformed siblings", page.some((m) => m.id === honest.id), page.map((m) => m.id));
+  check("spoofed payload is ABSENT from history (SPEC §5 reject, not rewrite)", !page.some((m) => m.id === "spoof-388"), page.map((m) => m.id));
+  check("truthy string from is ABSENT and did not throw", !page.some((m) => m.id === "from-string-388"));
+  check("missing from is ABSENT", !page.some((m) => m.id === "missing-from-388"));
+  check("non-string id is ABSENT", !page.some((m) => String(m.id) === "123" || (m as { id?: unknown }).id === 123));
+  check("extra-token inst subject is ABSENT (parseSubject arity)", !page.some((m) => m.id === "extra-token-388"));
+
+  const toSpoof = page.find((m) => m.id === "to-spoof-388");
   check(
-    "dmHistory sender is the subject sender, not payload from.id",
-    row?.from.id === alice.card.id,
-    { from: row?.from, expected: alice.card.id },
-  );
-  check(
-    "dmHistory recipient is the subject recipient, not payload to",
-    row?.to === bob.card.id,
-    { to: row?.to, expected: bob.card.id },
-  );
-  check(
-    "payload from.id local.mallory is NOT what history returns",
-    row?.from.id !== "local.mallory",
-    row?.from,
+    "matching from.id still rewrites recipient from the subject, not payload to",
+    toSpoof?.from.id === alice.card.id && toSpoof?.to === bob.card.id,
+    { from: toSpoof?.from, to: toSpoof?.to },
   );
   check(
     "payload to local.carol is NOT what history returns",
-    row?.to !== "local.carol",
-    row?.to,
+    toSpoof?.to !== "local.carol",
+    toSpoof?.to,
   );
+  check(
+    "authenticatedDmMessage strips channel/toService on a surviving DM",
+    toSpoof !== undefined && toSpoof.channel === undefined && toSpoof.toService === undefined,
+    toSpoof,
+  );
+
+  let chatPage: Awaited<ReturnType<typeof viewer.channelHistory>> = [];
+  let chatThrew: string | undefined;
+  try {
+    chatPage = await viewer.channelHistory("log", { limit: 50 });
+  } catch (e) {
+    chatThrew = e instanceof Error ? e.message : String(e);
+  }
+  check("channelHistory does not throw on a spoofed sibling", chatThrew === undefined, chatThrew);
+  check("channelHistory keeps the honest multicast", chatPage.some((m) => m.id === chatHonest.id), chatPage.map((m) => m.id));
+  check("channelHistory drops a from.id mismatch (same drainWindow as dmHistory)", !chatPage.some((m) => m.id === "chat-spoof-388"), chatPage.map((m) => m.id));
+
+  let multi: Awaited<ReturnType<typeof viewer.multiChannelHistory>> = [];
+  let multiThrew: string | undefined;
+  try {
+    multi = await viewer.multiChannelHistory(["log"], { limit: 50 });
+  } catch (e) {
+    multiThrew = e instanceof Error ? e.message : String(e);
+  }
+  check("multiChannelHistory does not throw on a spoofed sibling", multiThrew === undefined, multiThrew);
+  check("multiChannelHistory keeps the honest multicast", multi.some((r) => r.msg.id === chatHonest.id));
+  check("multiChannelHistory drops a from.id mismatch", !multi.some((r) => r.msg.id === "chat-spoof-388"));
+  check("multiChannelHistory tags the surviving row from the subject channel", multi.some((r) => r.msg.id === chatHonest.id && r.channel === "log"));
 
   await alice.stop();
   await bob.stop();

--- a/packages/core/smoke/dm-history-subject.smoke.ts
+++ b/packages/core/smoke/dm-history-subject.smoke.ts
@@ -1,0 +1,135 @@
+/**
+ * `dmHistory` must surface identity from the forge-locked DM subject, not the payload.
+ *
+ * The unicast subject is `inst.<recipOwner>.<recipActor>.<sndOwner>.<sndActor>`. The broker
+ * forge-locks those four tokens. Payload `from` / `to` are advisory. Live tails already drop a
+ * spoofed `from`. `drainWindow` used to keep `m.json()` and drop `m.subject`, so every history
+ * consumer rendered a self-asserted sender and recipient (Cotal #388).
+ *
+ * Needs nats-server on PATH. Isolated broker store. No `cotal up` / `cotal down` / `:live`.
+ * Run: pnpm smoke:dm-history-subject
+ */
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { connect } from "@nats-io/transport-node";
+import {
+  CotalEndpoint,
+  isReachable,
+  setupSpaceStreams,
+  unicastSubject,
+} from "../src/index.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+import { pickFreePort } from "./_free-port.js";
+
+const PORT = await pickFreePort();
+const SERVER = `nats://127.0.0.1:${PORT}`;
+const SPACE = "dmhistsubj";
+const store = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
+let pass = 0;
+let failed = 0;
+const check = (name: string, cond: boolean, extra?: unknown) => {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+    return;
+  }
+  failed++;
+  console.log(`  ✗ FAIL: ${name}${extra !== undefined ? ` - ${JSON.stringify(extra)}` : ""}`);
+};
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const text = (m: { parts?: { kind: string; text?: string }[] }) =>
+  m.parts?.map((p) => (p.kind === "text" ? p.text : "")).join("") ?? "";
+
+const srv = spawn("nats-server", ["-p", String(PORT), "-js", "-sd", store, "-a", "127.0.0.1"], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, store);
+try {
+  let up = false;
+  for (let i = 0; i < 60; i++) { if (await isReachable(SERVER)) { up = true; break; } await wait(150); }
+  if (!up) throw new Error("nats-server did not start");
+
+  await setupSpaceStreams({ servers: SERVER, space: SPACE });
+
+  const alice = new CotalEndpoint({
+    space: SPACE, servers: SERVER, channels: [], consume: false, registerPresence: false,
+    card: { name: "alice", kind: "endpoint", owner: "local", actor: "alice" },
+  });
+  const bob = new CotalEndpoint({
+    space: SPACE, servers: SERVER, channels: [], consume: false, registerPresence: false,
+    card: { name: "bob", kind: "endpoint", owner: "local", actor: "bob" },
+  });
+  const viewer = new CotalEndpoint({
+    space: SPACE, servers: SERVER, channels: [], consume: false, registerPresence: false,
+    card: { name: "viewer", kind: "endpoint", owner: "local", actor: "viewer" },
+  });
+  alice.on("error", () => {});
+  bob.on("error", () => {});
+  viewer.on("error", () => {});
+  await alice.start();
+  await bob.start();
+  await viewer.start();
+
+  const honest = await alice.unicast(bob.card.id, "honest-line");
+  await wait(200);
+
+  const honestPage = await viewer.dmHistory({ limit: 10 });
+  check("honest DM is in history", honestPage.some((m) => m.id === honest.id), honestPage.map((m) => m.id));
+  const honestRow = honestPage.find((m) => m.id === honest.id)!;
+  check("honest DM keeps the wire sender", honestRow.from.id === alice.card.id, honestRow.from);
+  check("honest DM keeps the wire recipient", honestRow.to === bob.card.id, honestRow.to);
+  check("history still includes the sender's own line (not an echo-drop)", text(honestRow) === "honest-line");
+
+  const raw = await connect({ servers: SERVER });
+  const spoofed = {
+    id: "spoof-388",
+    ts: Date.now(),
+    space: SPACE,
+    from: { id: "local.mallory", name: "Not Alice" },
+    to: "local.carol",
+    parts: [{ kind: "text", text: "injected-into-carol" }],
+  };
+  raw.publish(
+    unicastSubject(SPACE, "local", "bob", "local", "alice"),
+    JSON.stringify(spoofed),
+  );
+  await raw.flush();
+  await raw.close();
+  await wait(200);
+
+  const page = await viewer.dmHistory({ limit: 20 });
+  const row = page.find((m) => m.id === "spoof-388");
+  check("spoofed payload is still a history row (rewritten, not silently dropped)", !!row, page.map((m) => m.id));
+  check(
+    "dmHistory sender is the subject sender, not payload from.id",
+    row?.from.id === alice.card.id,
+    { from: row?.from, expected: alice.card.id },
+  );
+  check(
+    "dmHistory recipient is the subject recipient, not payload to",
+    row?.to === bob.card.id,
+    { to: row?.to, expected: bob.card.id },
+  );
+  check(
+    "payload from.id local.mallory is NOT what history returns",
+    row?.from.id !== "local.mallory",
+    row?.from,
+  );
+  check(
+    "payload to local.carol is NOT what history returns",
+    row?.to !== "local.carol",
+    row?.to,
+  );
+
+  await alice.stop();
+  await bob.stop();
+  await viewer.stop();
+} finally {
+  releaseBroker();
+  srv.kill("SIGKILL");
+  rmSync(store, { recursive: true, force: true });
+}
+console.log(failed === 0
+  ? `dm-history-subject smoke: ${pass} checks passed`
+  : `dm-history-subject smoke: ${failed} FAILED`);
+process.exit(failed === 0 ? 0 : 1);

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -5083,10 +5083,9 @@ function authenticatedDmMessage(msg: CotalMessage, to: string): CotalMessage {
 
 /** History drain keeps `m.json()` and used to throw the subject away. SPEC §5: on receive, verify
  *  `from.id` equals the subject sender; on mismatch, a missing `from`, or an unparseable delivery
- *  subject, reject and never surface. Fail closed on shape too: `isCotalMessage` (exactly one
- *  route key, finite `ts`, string `space`, full EndpointRef `from`, well-formed `parts`) plus a
- *  usable `id`. A stored JSON `null` or a truthy non-object `from` must not throw mid-array. Do
- *  not echo-drop `from.id === this.card.id`: god-view history must include the viewer's own sends. */
+ *  subject, reject and never surface. Fail closed on shape too: a stored JSON `null` or a truthy
+ *  non-object `from` must not throw mid-array. Do not echo-drop `from.id === this.card.id`:
+ *  god-view history must include the viewer's own sends. */
 function historyMessageFromDelivery(m: { subject: string; json: <T>() => T }): CotalMessage | undefined {
   let raw: unknown;
   try {
@@ -5094,11 +5093,27 @@ function historyMessageFromDelivery(m: { subject: string; json: <T>() => T }): C
   } catch {
     return undefined;
   }
-  if (!isCotalMessage(raw) || !isUsableMessageId(raw.id)) return undefined;
+  if (!isHistoryDrainEnvelope(raw)) return undefined;
   const parsed = parseSubject(m.subject);
   if (!parsed || !isPrincipalOwnerToken(parsed.owner)) return undefined;
   if (raw.from.id !== parsed.sender) return undefined;
   return authenticatedMessage(raw, parsed);
+}
+
+/**
+ * Narrow enough for the type checker and for fail-closed history: object envelope, usable `id`,
+ * object `from`. That is what lets `from.id !== parsed.sender` run without throwing, and what
+ * lets `authenticatedMessage` take the row without a cast.
+ *
+ * Does NOT verify SPEC §5 message shape. It does not require a string `from.id` (the SPEC §5
+ * comparison still rejects a mismatch), exactly one route key, a finite `ts`, a string
+ * `space`, a full EndpointRef `from` (`name`/`role`), or well-formed `parts`. Those belong
+ * to `isCotalMessage` (Plane-3). History must not use that guard: a public
+ * `unicast(..., { parts: [{ kind: "data", data: undefined }] })` serializes to `{kind:"data"}`
+ * and must still surface.
+ */
+function isHistoryDrainEnvelope(value: unknown): value is CotalMessage {
+  return isRecord(value) && isUsableMessageId(value.id) && isRecord(value.from);
 }
 
 function isPlane3DeliveryFrame(value: unknown): value is Plane3DeliveryFrame {

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -5083,9 +5083,10 @@ function authenticatedDmMessage(msg: CotalMessage, to: string): CotalMessage {
 
 /** History drain keeps `m.json()` and used to throw the subject away. SPEC §5: on receive, verify
  *  `from.id` equals the subject sender; on mismatch, a missing `from`, or an unparseable delivery
- *  subject, reject and never surface. Fail closed on shape too: a stored JSON `null` or a truthy
- *  non-object `from` must not throw mid-array. Do not echo-drop `from.id === this.card.id`:
- *  god-view history must include the viewer's own sends. */
+ *  subject, reject and never surface. Fail closed on shape too: `isCotalMessage` (exactly one
+ *  route key, finite `ts`, string `space`, full EndpointRef `from`, well-formed `parts`) plus a
+ *  usable `id`. A stored JSON `null` or a truthy non-object `from` must not throw mid-array. Do
+ *  not echo-drop `from.id === this.card.id`: god-view history must include the viewer's own sends. */
 function historyMessageFromDelivery(m: { subject: string; json: <T>() => T }): CotalMessage | undefined {
   let raw: unknown;
   try {
@@ -5093,11 +5094,11 @@ function historyMessageFromDelivery(m: { subject: string; json: <T>() => T }): C
   } catch {
     return undefined;
   }
-  if (!isRecord(raw) || !isUsableMessageId(raw.id) || !isRecord(raw.from)) return undefined;
+  if (!isCotalMessage(raw) || !isUsableMessageId(raw.id)) return undefined;
   const parsed = parseSubject(m.subject);
   if (!parsed || !isPrincipalOwnerToken(parsed.owner)) return undefined;
   if (raw.from.id !== parsed.sender) return undefined;
-  return authenticatedMessage(raw as CotalMessage, parsed);
+  return authenticatedMessage(raw, parsed);
 }
 
 function isPlane3DeliveryFrame(value: unknown): value is Plane3DeliveryFrame {

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -5057,16 +5057,16 @@ function kindFromParsed(kind: ParsedSubject["kind"]): MessageMeta["kind"] {
   }
 }
 
-/** Routing fields and `from.id` in the envelope are advisory. The broker forge-locks sender (and
- *  for DMs, recipient) into the subject; surface those tokens, never the payload claims. Live tails
- *  still drop a mismatch before calling this. History cannot drop the subject: `dmHistory` returns
- *  payloads, so identity has to be rewritten here or every consumer renders a spoof (#388). */
+/** Routing fields in the envelope are advisory. The broker forge-locks sender (and for DMs,
+ *  recipient) into the subject. Callers MUST already have rejected a missing `from`, an
+ *  unparseable subject, or `from.id !== parsed.sender` (SPEC §5). This derives the remaining
+ *  routing tokens from the subject for rows that survived — it does not rewrite a mismatched
+ *  `from.id`. Live tails, channel backfill, and channel recall skip the mismatch; history
+ *  does the same (#388). */
 function authenticatedMessage(msg: CotalMessage, parsed: ParsedSubject): CotalMessage {
-  const from = msg.from.id === parsed.sender ? msg.from : { ...msg.from, id: parsed.sender };
-  const withFrom = from === msg.from ? msg : { ...msg, from };
-  if (parsed.kind === "chat") return authenticatedChannelMessage(withFrom, parsed.rest);
-  if (parsed.kind === "inst") return authenticatedDmMessage(withFrom, parsed.rest);
-  return withFrom;
+  if (parsed.kind === "chat") return authenticatedChannelMessage(msg, parsed.rest);
+  if (parsed.kind === "inst") return authenticatedDmMessage(msg, parsed.rest);
+  return msg;
 }
 
 function authenticatedChannelMessage(msg: CotalMessage, channel: string): CotalMessage {
@@ -5081,20 +5081,23 @@ function authenticatedDmMessage(msg: CotalMessage, to: string): CotalMessage {
   return { ...base, to } as CotalMessage;
 }
 
-/** History drain keeps `m.json()` and used to throw the subject away. Fail closed on an unparseable
- *  subject / missing from / unusable id, then rewrite identity from the subject. Do not echo-drop
- *  `from.id === this.card.id`: god-view history must include the viewer's own sends. */
+/** History drain keeps `m.json()` and used to throw the subject away. SPEC §5: on receive, verify
+ *  `from.id` equals the subject sender; on mismatch, a missing `from`, or an unparseable delivery
+ *  subject, reject and never surface. Fail closed on shape too: a stored JSON `null` or a truthy
+ *  non-object `from` must not throw mid-array. Do not echo-drop `from.id === this.card.id`:
+ *  god-view history must include the viewer's own sends. */
 function historyMessageFromDelivery(m: { subject: string; json: <T>() => T }): CotalMessage | undefined {
-  let msg: CotalMessage;
+  let raw: unknown;
   try {
-    msg = m.json<CotalMessage>();
+    raw = m.json();
   } catch {
     return undefined;
   }
-  if (!isUsableMessageId(msg.id) || !msg.from) return undefined;
+  if (!isRecord(raw) || !isUsableMessageId(raw.id) || !isRecord(raw.from)) return undefined;
   const parsed = parseSubject(m.subject);
   if (!parsed || !isPrincipalOwnerToken(parsed.owner)) return undefined;
-  return authenticatedMessage(msg, parsed);
+  if (raw.from.id !== parsed.sender) return undefined;
+  return authenticatedMessage(raw as CotalMessage, parsed);
 }
 
 function isPlane3DeliveryFrame(value: unknown): value is Plane3DeliveryFrame {

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -3021,15 +3021,17 @@ export class CotalEndpoint extends EventEmitter {
           delivered++;
           if (m.seq >= ceiling) { // reached the page's upper bound
             if (m.seq === ceiling) {
-              try { out.push({ seq: m.seq, subject: m.subject, msg: m.json<CotalMessage>() }); } catch { /* skip undecodable */ }
+              const msg = historyMessageFromDelivery(m);
+              if (msg) out.push({ seq: m.seq, subject: m.subject, msg });
             }
             complete = true;
             break;
           }
-          try {
-            out.push({ seq: m.seq, subject: m.subject, msg: m.json<CotalMessage>() });
+          const msg = historyMessageFromDelivery(m);
+          if (msg) {
+            out.push({ seq: m.seq, subject: m.subject, msg });
             if (out.length > limit) out.shift();
-          } catch { /* skip undecodable */ }
+          }
           if (delivered >= pending) { complete = true; break; }
         }
       } finally {
@@ -5055,16 +5057,44 @@ function kindFromParsed(kind: ParsedSubject["kind"]): MessageMeta["kind"] {
   }
 }
 
-/** Routing fields in the envelope are advisory. Surface a channel label only from the authenticated
- * chat subject, so connector attention cannot be bypassed with a mismatched payload `channel`. */
+/** Routing fields and `from.id` in the envelope are advisory. The broker forge-locks sender (and
+ *  for DMs, recipient) into the subject; surface those tokens, never the payload claims. Live tails
+ *  still drop a mismatch before calling this. History cannot drop the subject: `dmHistory` returns
+ *  payloads, so identity has to be rewritten here or every consumer renders a spoof (#388). */
 function authenticatedMessage(msg: CotalMessage, parsed: ParsedSubject): CotalMessage {
-  return parsed.kind === "chat" ? authenticatedChannelMessage(msg, parsed.rest) : msg;
+  const from = msg.from.id === parsed.sender ? msg.from : { ...msg.from, id: parsed.sender };
+  const withFrom = from === msg.from ? msg : { ...msg, from };
+  if (parsed.kind === "chat") return authenticatedChannelMessage(withFrom, parsed.rest);
+  if (parsed.kind === "inst") return authenticatedDmMessage(withFrom, parsed.rest);
+  return withFrom;
 }
 
 function authenticatedChannelMessage(msg: CotalMessage, channel: string): CotalMessage {
   if (msg.channel === channel && msg.to === undefined && msg.toService === undefined) return msg;
   const { to: _to, toService: _toService, ...base } = msg;
   return { ...base, channel } as CotalMessage;
+}
+
+function authenticatedDmMessage(msg: CotalMessage, to: string): CotalMessage {
+  if (msg.to === to && msg.channel === undefined && msg.toService === undefined) return msg;
+  const { channel: _channel, toService: _toService, ...base } = msg;
+  return { ...base, to } as CotalMessage;
+}
+
+/** History drain keeps `m.json()` and used to throw the subject away. Fail closed on an unparseable
+ *  subject / missing from / unusable id, then rewrite identity from the subject. Do not echo-drop
+ *  `from.id === this.card.id`: god-view history must include the viewer's own sends. */
+function historyMessageFromDelivery(m: { subject: string; json: <T>() => T }): CotalMessage | undefined {
+  let msg: CotalMessage;
+  try {
+    msg = m.json<CotalMessage>();
+  } catch {
+    return undefined;
+  }
+  if (!isUsableMessageId(msg.id) || !msg.from) return undefined;
+  const parsed = parseSubject(m.subject);
+  if (!parsed || !isPrincipalOwnerToken(parsed.owner)) return undefined;
+  return authenticatedMessage(msg, parsed);
 }
 
 function isPlane3DeliveryFrame(value: unknown): value is Plane3DeliveryFrame {


### PR DESCRIPTION
Fixes #388.

`dmHistory` returned JetStream payloads and discarded the stored subject. The unicast subject is the only forge-locked identity (`inst.<recipOwner>.<recipActor>.<sndOwner>.<sndActor>`). Payload `from`/`to` are advisory, so every history consumer could render a spoofed sender and inject a line into a thread the publisher was never on.

History now rejects unparseable subjects, missing/non-object `from`, and `from.id !==` subject sender instead of rewriting identity. Fail closed on JSON null so one poisoned row cannot throw the page. Surviving DMs still take recipient from the subject. God-view own-sends stay in history (no live-tail echo-drop).

Compile fix on this head (`44ac231f941a57d26e32272fede1ee74f2b3f3f8`): `historyMessageFromDelivery` no longer casts `Record<string, unknown>` to `CotalMessage` (TS2352 at `packages/core/src/endpoint.ts:5100`). It types through `isCotalMessage`, the same structural guard Plane-3 already uses two functions below.

**Widening (deliberate, reading (a)):** `isCotalMessage` validates more than the ad-hoc checks it replaced. History rows that previously survived `isRecord` + usable `id` + `isRecord(from)` are now also rejected unless they have exactly one route key, a finite numeric `ts`, a string `space`, `from` as a full EndpointRef, and a well-formed `parts` array. That is SPEC §5 conformance, not a second change. The four history suites still pass; they show only that this corpus does not distinguish the two paths, not that no production rows are affected. A double-cast-through-`unknown` would compile and leave the old admission set; it was not taken.

Proof on this head:
- `pnpm --filter @cotal-ai/core build` rc=0 (TS2352 gone)
- `pnpm typecheck` rc=0, 0 TS errors repo-wide
- `pnpm smoke:dm-history-subject` rc=0, 22 checks
- `pnpm smoke:core-history-limit` rc=0
- `pnpm smoke:history-recent` rc=0, 26 checks
- `pnpm smoke:sparse-history-walk` rc=0, 5 passed

Memory bracket for those smokes: oom_kill 6285 unmoved, PSI full avg300 0.25 -> 0.24, MemAvailable 3772 -> 4067 MiB.

Parked at PR-open. Do not merge from this seat.
