### PR TITLE
fix(core): surface a refused instance-rail invoke as permission-denied

### DIFF
--- a/.changeset/ep-call-publish-denial.md
+++ b/.changeset/ep-call-publish-denial.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/core": patch
+---
+
+Surface a broker-refused instance-rail invoke as permission-denied naming the subject, instead of waiting out the call deadline.

--- a/bin/smoke/ci-suites.d/f91757baf108130e824aa63c88b332dc837c89e1b848b1579f379d038063ad4b.txt
+++ b/bin/smoke/ci-suites.d/f91757baf108130e824aa63c88b332dc837c89e1b848b1579f379d038063ad4b.txt
@@ -1,0 +1,2 @@
+# A broker-refused instance-rail invoke must be permission-denied, not a deadline.
+smoke:ep-publish-denial:auth

--- a/package.json
+++ b/package.json
@@ -374,6 +374,7 @@
     "smoke:ep-receipt": "tsx packages/core/smoke/endpoint-receipt.smoke.ts",
     "smoke:ep-contract-store": "tsx packages/core/smoke/endpoint-contract-store.smoke.ts",
     "smoke:ep-invoke": "tsx packages/core/smoke/endpoint-invoke.smoke.ts",
+    "smoke:ep-publish-denial:auth": "tsx packages/core/smoke/endpoint-publish-denial.smoke.ts",
     "smoke:ep-serve": "tsx packages/core/smoke/endpoint-serve.smoke.ts",
     "smoke:broker-teardown": "tsx packages/core/smoke/broker-teardown.smoke.ts",
     "smoke:bind-fence": "tsx packages/core/smoke/bind-fence.smoke.ts",

--- a/packages/core/smoke/endpoint-invoke.smoke.ts
+++ b/packages/core/smoke/endpoint-invoke.smoke.ts
@@ -106,6 +106,26 @@ function fakeInvokeNc(onPublish: () => void) {
         data: enc.encode(JSON.stringify({ v: 1, id: body.id, ok: true, data: { ran: true } })),
       }));
     },
+    // epCall watches nc.status() for a broker-refused publish. A double without it
+    // is not a NatsConnection for that path.
+    status() {
+      let release: (() => void) | undefined;
+      const stopped = new Promise<void>((r) => { release = r; });
+      return {
+        stop() { release?.(); },
+        [Symbol.asyncIterator]() {
+          return {
+            async next(): Promise<IteratorResult<{ type: string; error?: unknown }>> {
+              await stopped;
+              return { done: true, value: undefined };
+            },
+            async return(): Promise<IteratorResult<{ type: string; error?: unknown }>> {
+              return { done: true, value: undefined };
+            },
+          };
+        },
+      };
+    },
   } as unknown as Parameters<typeof invokeCommand>[0];
 }
 

--- a/packages/core/smoke/endpoint-publish-denial.mutations.json
+++ b/packages/core/smoke/endpoint-publish-denial.mutations.json
@@ -20,8 +20,8 @@
       "file": "packages/core/src/endpoint-publish-denial.ts",
       "find": "        if (s.error instanceof PermissionViolationError && s.error.subject === subject) {",
       "replace": "        if (s.error instanceof PermissionViolationError && s.error.subject === \"\") {",
-      "expectRed": "invoke is permission-denied, NOT a deadline",
-      "cell": "invoke is permission-denied, NOT a deadline"
+      "expectRed": "describe is permission-denied, not a deadline",
+      "cell": "describe is permission-denied, not a deadline"
     },
     {
       "name": "the refusal message omits the refused subject, so the grant to mint is unreadable",

--- a/packages/core/smoke/endpoint-publish-denial.mutations.json
+++ b/packages/core/smoke/endpoint-publish-denial.mutations.json
@@ -1,0 +1,43 @@
+{
+  "suite": [
+    "packages/core/smoke/endpoint-publish-denial.smoke.ts"
+  ],
+  "guard": "a broker-refused instance-rail invoke is permission-denied naming the subject, not an unanswered deadline, and the status watch is released",
+  "command": "pnpm smoke:ep-publish-denial:auth",
+  "completionMarker": "ENDPOINT PUBLISH DENIAL SMOKE",
+  "proveWith": "pnpm mutation-proof --config packages/core/smoke/endpoint-publish-denial.mutations.json",
+  "mutations": [
+    {
+      "name": "epCall never races the publish-denial watch, so a refused publish waits out the budget",
+      "file": "packages/core/src/endpoint-verbs.ts",
+      "find": "    const msg = await Promise.race([outcome, timeout, denialWatch.denied]);",
+      "replace": "    denialWatch.denied.catch(() => {});\n    const msg = await Promise.race([outcome, timeout]);",
+      "expectRed": "invoke is permission-denied, NOT a deadline",
+      "cell": "invoke is permission-denied, NOT a deadline"
+    },
+    {
+      "name": "the watch never matches the refused subject, so the call waits out the budget",
+      "file": "packages/core/src/endpoint-publish-denial.ts",
+      "find": "        if (s.error instanceof PermissionViolationError && s.error.subject === subject) {",
+      "replace": "        if (s.error instanceof PermissionViolationError && s.error.subject === \"\") {",
+      "expectRed": "invoke is permission-denied, NOT a deadline",
+      "cell": "invoke is permission-denied, NOT a deadline"
+    },
+    {
+      "name": "the refusal message omits the refused subject, so the grant to mint is unreadable",
+      "file": "packages/core/src/endpoint-verbs.ts",
+      "find": "      `the call for ${op.endpoint}.${op.command} was REFUSED BY THE BROKER, not unanswered: this caller's credential does not authorize publishing to \"${req.subject}\"${route.mode === \"inst\" ? ` (the instance rail for ${route.instanceId}: an instance-addressed call needs a credential minted with that instance, not a class-rail one)` : \"\"}. The responder may be perfectly healthy; the grant is what is missing (SPEC 13.2)`), \"call\");",
+      "replace": "      `the call for ${op.endpoint}.${op.command} was REFUSED BY THE BROKER, not unanswered. The responder may be perfectly healthy; the grant is what is missing (SPEC 13.2)`), \"call\");",
+      "expectRed": "invoke names the refused instance-rail subject",
+      "cell": "invoke names the refused instance-rail subject"
+    },
+    {
+      "name": "the status watch is never released, leaking one listener per call",
+      "file": "packages/core/src/endpoint-verbs.ts",
+      "find": "    denialWatch?.release();",
+      "replace": "    void denialWatch;",
+      "expectRed": "12 denied invokes leave the listener count where they found it",
+      "cell": "12 denied invokes leave the listener count where they found it"
+    }
+  ]
+}

--- a/packages/core/smoke/endpoint-publish-denial.smoke.ts
+++ b/packages/core/smoke/endpoint-publish-denial.smoke.ts
@@ -1,0 +1,130 @@
+/**
+ * A broker publish violation on an instance-pinned rail must surface as
+ * `permission-denied` naming the refused subject, not as an unanswered deadline.
+ * Covers describe AND invoke/`epCall`. Does not mint `ep.inst.*` grants.
+ *
+ * Run: pnpm smoke:ep-publish-denial:auth
+ */
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { connect } from "@nats-io/transport-node";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+import {
+  compileContract, createSpaceAuth, describeEndpoint, DEV_OWNER, EpEnvelopeError, epCall,
+  invokeCommand, isReachable, mintCreds, mintLifecycleUid, newIdentity, serverConfig,
+  standaloneConnectOpts, unansweredRequest, type EpCaller, type ResolvedService,
+} from "../src/index.js";
+import { pickFreePort } from "./_free-port.js";
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+let pass = 0, fail = 0;
+const check = (name: string, cond: boolean, extra?: unknown) => {
+  if (cond) { pass++; console.log(`  ✓ ${name}`); }
+  else { fail++; console.log(`  ✗ FAIL: ${name}`, extra ?? ""); }
+};
+
+const PORT = await pickFreePort();
+const SERVERS = `nats://127.0.0.1:${PORT}`;
+const space = "eppubdenial";
+const auth = await createSpaceAuth(space);
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
+writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
+const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(srv, dir);
+const IID = "i".repeat(26);
+const empty = compileContract({ root: { type: "null" } });
+const DEADLINE_MS = 800;
+
+const caught = async (fn: () => Promise<unknown>): Promise<{ code: string; message: string; elapsed: number; err: unknown }> => {
+  const started = Date.now();
+  try {
+    await fn();
+    return { code: "ok", message: "", elapsed: Date.now() - started, err: undefined };
+  } catch (e) {
+    return {
+      code: e instanceof EpEnvelopeError ? e.code : (e as Error).name,
+      message: e instanceof Error ? e.message : String(e),
+      elapsed: Date.now() - started,
+      err: e,
+    };
+  }
+};
+
+try {
+  let up = false;
+  for (let i = 0; i < 50 && !up; i++) { up = await isReachable(SERVERS); if (!up) await wait(100); }
+  if (!up) throw new Error("broker did not come up");
+
+  const id = newIdentity();
+  const uid = mintLifecycleUid();
+  const caller: EpCaller = { owner: DEV_OWNER, actor: id.id, uid };
+  // Class-rail instrument only. Pinning `ep.inst.*` is out of scope for this cell.
+  const creds = await mintCreds(auth, id, "control-caller-privileged", { lifecycleUid: uid });
+  const nc = await connect({ servers: SERVERS, ...standaloneConnectOpts({ creds, tls: false }), maxReconnectAttempts: 0 });
+
+  console.log("1. a class-rail credential's instance-addressed describe is a refused publish, not silence");
+  const describe = await caught(() => describeEndpoint(nc, space, "manager", caller, { deadlineMs: DEADLINE_MS, instanceId: IID }));
+  check("describe is permission-denied, not a deadline", describe.code === "permission-denied", describe);
+  check("describe names the refused instance-rail subject", describe.message.includes(`.ep.inst.manager.${IID}.describe.`), describe.message.slice(0, 280));
+  check("describe settles well inside the deadline (a timeout masquerade waits it out)", describe.elapsed < DEADLINE_MS / 2, describe.elapsed);
+  check("describe is not marked unanswered", !unansweredRequest(describe.err), describe.err);
+
+  console.log("2. the same hole on invoke/epCall: a pinned command publish must not wait out the budget");
+  const service: ResolvedService = {
+    endpoint: "manager",
+    owner: DEV_OWNER,
+    caller,
+    responder: { instanceId: IID, epoch: 1 },
+    pinnedInstanceId: IID,
+    commands: new Map([["status", {
+      command: "status",
+      contract: { input: empty, output: empty },
+      class: "ephemeral",
+      targeted: false,
+      modes: [],
+      capability: "status",
+    }]]),
+  };
+  const invoke = await caught(() => invokeCommand(nc, space, service, "status", undefined, { deadlineMs: DEADLINE_MS }));
+  check("invoke is permission-denied, NOT a deadline", invoke.code === "permission-denied", invoke);
+  check("invoke names the refused instance-rail subject", invoke.message.includes(`.ep.inst.manager.${IID}.status.`), invoke.message.slice(0, 280));
+  check("invoke settles well inside the deadline", invoke.elapsed < DEADLINE_MS / 2, invoke.elapsed);
+  check("invoke is not marked unanswered", !unansweredRequest(invoke.err), invoke.err);
+  check("invoke says the responder may be healthy (the wrong conclusion is the expensive one)",
+    /REFUSED BY THE BROKER/.test(invoke.message) && /grant is what is missing/.test(invoke.message),
+    invoke.message.slice(0, 280));
+
+  const direct = await caught(() => epCall(nc, space, { mode: "inst", instanceId: IID, epoch: 1 }, {
+    endpoint: "manager", command: "status", contract: { input: empty, output: empty }, caller,
+  }, { deadlineMs: DEADLINE_MS }));
+  check("epCall on the inst rail is the same permission-denied, not a second clock",
+    direct.code === "permission-denied" && direct.message.includes(`.ep.inst.manager.${IID}.status.`) && direct.elapsed < DEADLINE_MS / 2,
+    direct);
+
+  console.log("3. the call's permission watch does not leak a status listener per invoke");
+  const listeners = (): number =>
+    ((nc as unknown as { protocol?: { listeners?: unknown[] } }).protocol?.listeners ?? []).length;
+  check("the internal listener registry is reachable (else this cell proves nothing)",
+    Array.isArray((nc as unknown as { protocol?: { listeners?: unknown[] } }).protocol?.listeners), listeners());
+  const before = listeners();
+  const ROUNDS = 12;
+  for (let i = 0; i < ROUNDS; i++)
+    await invokeCommand(nc, space, service, "status", undefined, { deadlineMs: DEADLINE_MS }).catch(() => {});
+  const after = listeners();
+  console.log(`   listeners before=${before} after ${ROUNDS} denied invokes=${after}`);
+  check(`${ROUNDS} denied invokes leave the listener count where they found it`, after === before, { before, after });
+
+  await nc.drain().catch(() => nc.close());
+} catch (e) {
+  fail++;
+  console.error("  ✗ scenario threw:", (e as Error).stack ?? (e as Error).message);
+} finally {
+  srv.kill("SIGKILL");
+  rmSync(dir, { recursive: true, force: true });
+  releaseBroker();
+}
+
+console.log(`\nENDPOINT PUBLISH DENIAL SMOKE ${fail === 0 ? "OK ✅" : "FAILED"}  (${pass} passed, ${fail} failed)`);
+process.exit(fail === 0 ? 0 : 1);

--- a/packages/core/src/endpoint-invoke.ts
+++ b/packages/core/src/endpoint-invoke.ts
@@ -18,6 +18,7 @@
  */
 import { randomBytes } from "node:crypto";
 import { PermissionViolationError, type NatsConnection, type Subscription } from "@nats-io/transport-node";
+import { openPublishDenialWatch } from "./endpoint-publish-denial.js";
 import { jetstreamManager } from "@nats-io/jetstream";
 import { EpEnvelopeError, EP_UNBOUND_RESPONDER, EP_UNANSWERED, renderLifecycleBlocked, lifecycleBlockedFrom } from "./endpoint-envelope.js";
 import { compileContract, type CompiledContract } from "./schema-profile.js";
@@ -118,24 +119,13 @@ export async function describeEndpoint(
   let sub: Subscription | undefined;
   let timer: ReturnType<typeof setTimeout> | undefined;
   let retryTimer: ReturnType<typeof setInterval> | undefined;
-  /** The status stream itself, kept because `stop()`, not `return()`, is what releases it. */
-  let statusStream: { [Symbol.asyncIterator](): AsyncIterator<{ type: string; error?: unknown }>; stop(err?: Error): void } | undefined;
-  let statusIter: AsyncIterator<{ type: string; error?: unknown }> | undefined;
+  let denialWatch: { denied: Promise<never>; release(): void } | undefined;
   try {
-    // REGISTER THE PERMISSION WATCH BEFORE THE PUBLISH IT IS WATCHING: `nc.status()` registers its
-    // listener at CALL time, so one created after `nc.publish` cannot see a violation dispatched in
-    // between, and that dropped event is indistinguishable from the silence this watch exists to
-    // eliminate.
-    //
-    // RELEASE IS `stop()`, NOT `return()`. The stream is a `QueuedIterator` parked on an internal
-    // signal await, so a queued `return()` does not run until the NEXT status event — which on a
-    // healthy connection may never come, leaking one listener per resolve. `status()` is typed as a
-    // bare `AsyncIterable`, so `stop` is reached structurally and its absence fails loud HERE rather
-    // than leaking quietly.
-    statusStream = nc.status() as typeof statusStream;
-    if (typeof statusStream?.stop !== "function")
-      throw new EpEnvelopeError("unavailable", "the NATS connection's status() stream does not expose stop(); the describe's permission watch cannot be released and would leak a listener per resolve");
-    statusIter = statusStream[Symbol.asyncIterator]();
+    // REGISTER THE PERMISSION WATCH BEFORE THE PUBLISH IT IS WATCHING. See
+    // {@link openPublishDenialWatch}: a refused publish is otherwise indistinguishable
+    // from an unanswered describe.
+    denialWatch = openPublishDenialWatch(nc, subject, () => new EpEnvelopeError("permission-denied",
+      `the describe for ${endpoint} was REFUSED BY THE BROKER, not unanswered: this caller's credential does not authorize publishing to "${subject}"${opts.instanceId !== undefined ? ` (the instance rail for ${opts.instanceId}: an instance-addressed call needs a credential minted with that instance, not a class-rail one)` : ""}. The responder may be perfectly healthy; the grant is what is missing (SPEC 13.2)`), "describe");
     const got = new Promise<{ body: Record<string, unknown>; responder: { instanceId: string; epoch: number } }>((resolve, reject) => {
       sub = nc.subscribe(epCallerReplyFilter(space, caller), {
         callback: (err, msg) => {
@@ -171,32 +161,7 @@ export async function describeEndpoint(
       }, DESCRIBE_RETRY_MS);
     });
     const timeout = new Promise<never>((_, reject) => { timer = setTimeout(() => reject(new EpEnvelopeError("deadline-exceeded", `no describe reply from ${endpoint} within ${deadlineMs}ms`, [{ kind: EP_UNANSWERED, endpoint, command: "describe" }])), deadlineMs); });
-    // A REFUSED PUBLISH MUST NOT MASQUERADE AS AN ABSENT RESPONDER. `nc.publish` is fire-and-forget:
-    // when the credential lacks the subject the broker answers the CONNECTION asynchronously and the
-    // publish returns normally, so the only observable is a deadline that reads as "that endpoint
-    // isn't there". The two need opposite responses — mint the grant vs. find the responder.
-    //
-    // Watch only for OUR subject, and do not race the whole status stream: the connection is shared,
-    // and another component's denial or an unrelated transport error must not fail this describe.
-    const denied = new Promise<never>((_, reject) => {
-      void (async () => {
-        // Driven by hand rather than `for await` so the `finally` below can CLOSE it: `nc.status()`
-        // is connection-lived, and a `for await` parks on the next event and outlives the describe,
-        // leaking one listener per resolve.
-        const it = statusIter!;
-        for (;;) {
-          const { value: s, done } = await it.next();
-          if (done === true || s === undefined) return;
-          if (s.type !== "error") continue;
-          if (s.error instanceof PermissionViolationError && s.error.subject === subject) {
-            reject(new EpEnvelopeError("permission-denied",
-              `the describe for ${endpoint} was REFUSED BY THE BROKER, not unanswered: this caller's credential does not authorize publishing to "${subject}"${opts.instanceId !== undefined ? ` (the instance rail for ${opts.instanceId}: an instance-addressed call needs a credential minted with that instance, not a class-rail one)` : ""}. The responder may be perfectly healthy; the grant is what is missing (SPEC 13.2)`));
-            return;
-          }
-        }
-      })().catch(() => { /* the status stream ending is not a describe failure; the deadline still governs */ });
-    });
-    const { body: reply, responder } = await Promise.race([got, timeout, denied]);
+    const { body: reply, responder } = await Promise.race([got, timeout, denialWatch.denied]);
     if (reply.ok !== true) {
       // A responder ANSWERED with a refusal: it is rethrown under the responder's own code (which
       // may be `unavailable`) and deliberately without the EP_UNANSWERED marker the deadline above
@@ -209,11 +174,8 @@ export async function describeEndpoint(
     sub?.unsubscribe();
     if (timer !== undefined) clearTimeout(timer);
     if (retryTimer !== undefined) clearInterval(retryTimer);
-    // Release on EVERY exit, success included. `stop()` resolves the generator's signal and its
-    // `iterClosed`, which is what the transport splices the listener on; `return()` is kept only to
-    // settle the parked `next()` it wakes.
-    statusStream?.stop();
-    void statusIter?.return?.(undefined);
+    // Release on EVERY exit, success included. See {@link openPublishDenialWatch}.
+    denialWatch?.release();
   }
 }
 

--- a/packages/core/src/endpoint-publish-denial.ts
+++ b/packages/core/src/endpoint-publish-denial.ts
@@ -1,0 +1,64 @@
+/**
+ * A broker publish violation arrives on the CONNECTION, asynchronously, while
+ * `nc.publish` itself returns normally. Watching `nc.status()` for OUR subject
+ * is how a caller tells a missing GRANT from a missing RESPONDER: the two need
+ * opposite responses, and a deadline that reads as "that endpoint isn't there"
+ * is the wrong one.
+ *
+ * REGISTER THE WATCH BEFORE THE PUBLISH IT IS WATCHING. `nc.status()` registers
+ * its listener at CALL time, so one created after `nc.publish` cannot see a
+ * violation dispatched in between, and that dropped event is indistinguishable
+ * from the silence this watch exists to eliminate.
+ *
+ * RELEASE IS `stop()`, NOT `return()`. The stream is a `QueuedIterator` parked
+ * on an internal signal await, so a queued `return()` does not run until the
+ * NEXT status event — which on a healthy connection may never come, leaking one
+ * listener per call. `status()` is typed as a bare `AsyncIterable`, so `stop`
+ * is reached structurally and its absence fails loud HERE rather than leaking
+ * quietly.
+ *
+ * Watch only for OUR subject. The connection is shared, and another component's
+ * denial or an unrelated transport error must not fail this call.
+ */
+import { PermissionViolationError, type NatsConnection } from "@nats-io/transport-node";
+import { EpEnvelopeError } from "./endpoint-envelope.js";
+
+export type StatusStream = {
+  [Symbol.asyncIterator](): AsyncIterator<{ type: string; error?: unknown }>;
+  stop(err?: Error): void;
+};
+
+export function openPublishDenialWatch(
+  nc: NatsConnection,
+  subject: string,
+  refusal: (err: PermissionViolationError) => Error,
+  what: string,
+): { denied: Promise<never>; release(): void } {
+  const statusStream = nc.status() as StatusStream;
+  if (typeof statusStream?.stop !== "function")
+    throw new EpEnvelopeError("unavailable", `the NATS connection's status() stream does not expose stop(); the ${what} permission watch cannot be released and would leak a listener per call`);
+  const statusIter = statusStream[Symbol.asyncIterator]();
+  const denied = new Promise<never>((_, reject) => {
+    void (async () => {
+      // Driven by hand rather than `for await` so `release` can CLOSE it: `nc.status()`
+      // is connection-lived, and a `for await` parks on the next event and outlives the
+      // call, leaking one listener per request.
+      for (;;) {
+        const { value: s, done } = await statusIter.next();
+        if (done === true || s === undefined) return;
+        if (s.type !== "error") continue;
+        if (s.error instanceof PermissionViolationError && s.error.subject === subject) {
+          reject(refusal(s.error));
+          return;
+        }
+      }
+    })().catch(() => { /* the status stream ending is not this call's failure; the deadline still governs */ });
+  });
+  return {
+    denied,
+    release() {
+      statusStream.stop();
+      void statusIter.return?.(undefined);
+    },
+  };
+}

--- a/packages/core/src/endpoint-verbs.ts
+++ b/packages/core/src/endpoint-verbs.ts
@@ -14,6 +14,7 @@
  */
 import { randomBytes } from "node:crypto";
 import type { Msg, NatsConnection, Subscription } from "@nats-io/transport-node";
+import { openPublishDenialWatch } from "./endpoint-publish-denial.js";
 import { spacePrefix } from "./subjects.js";
 import {
   epRequestSubject, parseEpSubject, callerTokens, assertIdToken, assertLifecycleToken, assertBoundedOwner,
@@ -362,8 +363,10 @@ function parseAttributedReply(space: string, subject: string, data: Uint8Array, 
  * value `failed-precondition` (the read's own failure, never mislabeled staleness); a stale reply `expired`;
  * NO responder `unavailable` (SPEC 13.5, the broker no-responders answer — the broker's no-responders 503 lands on a reply-to that
  * sits on THIS caller's own rail, so a manual, fully-disposed probe distinguishes it from a slow
- * responder without leaving a lingering request); a failed reply subscription `unavailable`; the
- * elapsed budget `deadline-exceeded`. Every subscription and timer is released in the `finally`.
+ * responder without leaving a lingering request); a failed reply subscription `unavailable`; a
+ * broker publish violation `permission-denied` naming the refused subject (the connection-status
+ * watch that keeps a missing GRANT from reading as an unanswered deadline); the elapsed budget
+ * `deadline-exceeded`. Every subscription, timer, and status watch is released in the `finally`.
  */
 export async function epCall(
   nc: NatsConnection,
@@ -385,6 +388,7 @@ export async function epCall(
   const started = Date.now();
   let sub: Subscription | undefined;
   let timer: ReturnType<typeof setTimeout> | undefined;
+  let denialWatch: { denied: Promise<never>; release(): void } | undefined;
   try {
     const outcome = new Promise<{ subject: string; data: Uint8Array }>((resolve, reject) => {
       sub = nc.subscribe(replySubjectFor(space, op.caller, req.n), {
@@ -404,9 +408,14 @@ export async function epCall(
         },
       });
     });
+    // REGISTER THE PERMISSION WATCH BEFORE THE PUBLISH IT IS WATCHING. See
+    // {@link openPublishDenialWatch}: a refused publish is otherwise indistinguishable
+    // from an unanswered call.
+    denialWatch = openPublishDenialWatch(nc, req.subject, () => new EpEnvelopeError("permission-denied",
+      `the call for ${op.endpoint}.${op.command} was REFUSED BY THE BROKER, not unanswered: this caller's credential does not authorize publishing to "${req.subject}"${route.mode === "inst" ? ` (the instance rail for ${route.instanceId}: an instance-addressed call needs a credential minted with that instance, not a class-rail one)` : ""}. The responder may be perfectly healthy; the grant is what is missing (SPEC 13.2)`), "call");
     nc.publish(req.subject, req.body, { reply: noRespReplyTo });
     const timeout = new Promise<never>((_, reject) => { timer = setTimeout(() => reject(new EpEnvelopeError("deadline-exceeded", `no reply to ${op.endpoint}.${op.command} within the ${deadlineMs}ms budget (SPEC 13.5)`, [unansweredDetail(op)])), deadlineMs); });
-    const msg = await Promise.race([outcome, timeout]);
+    const msg = await Promise.race([outcome, timeout, denialWatch.denied]);
     const attributed = parseAttributedReply(space, msg.subject, msg.data, req.requestId, op, expect);
     // Taken BEFORE the currency check below, because a responder that fenced on the bind settled
     // the same question better: it knows it did not run the command, where the check can only
@@ -473,6 +482,7 @@ export async function epCall(
   } finally {
     sub?.unsubscribe();
     if (timer !== undefined) clearTimeout(timer);
+    denialWatch?.release();
   }
 }
 


### PR DESCRIPTION
## Scope

Related to #397 (defect 2 only). Does not mint `ep.inst.*` grants and does not close the issue.

A broker publish violation arrives on the connection asynchronously while `nc.publish` returns normally. `describeEndpoint` already watched for that and named the refused subject. `epCall` / `invokeCommand` still waited out the deadline and read as an unanswered responder.

This shares that status watch and races it on the call path so a missing grant is `permission-denied` naming the refused subject, not silence.

## Validation

- live JWT-auth smoke `pnpm smoke:ep-publish-denial:auth` (class-rail instrument, no `ep.inst.*` mint)
- hermetic `pnpm smoke:ep-invoke`
- `pnpm --filter @cotal-ai/core typecheck`
- `pnpm mutation-proof --config packages/core/smoke/endpoint-publish-denial.mutations.json` (4/4 KILLED)