### PR TITLE
test(core): grade the creds pre-dial guard on the cell that reds

### DIFF
--- a/packages/core/smoke/mutations/standing-renewal-expiry.json
+++ b/packages/core/smoke/mutations/standing-renewal-expiry.json
@@ -10,8 +10,12 @@
     "The endpoint's pre-connect refresh is deliberately best-effort after the first connection. If",
     "the source is down when the cached cred expires, removing this guard restores the reported",
     "behavior exactly: connectAndBind presents credential material it has already decoded as expired.",
-    "The live smoke captures the disposable broker's authentication-expired denial, so the named",
-    "cell proves the real dial path reached the broker rather than only exercising a local parser."
+    "The graded cell is the pre-dial refusal, because removing the guard removes the warning it emits.",
+    "The sibling cell counting the broker's expired-cred denials does NOT grade this mutation and must",
+    "not be named here: its detection window opens on the second failed renewal read, by which time the",
+    "dial has already happened, and whether the broker logs a fresh-dial rejection at all depends on",
+    "when the source returns. Measured green under this mutation across repeated runs. That cell's",
+    "non-discrimination is tracked separately; naming it here would report a red it never produces."
   ],
   "mutations": [
     {
@@ -19,9 +23,9 @@
       "file": "packages/core/src/endpoint.ts",
       "find": "    const credsExp = this.currentCreds && credsClaims(this.currentCreds).exp;\n    if (typeof credsExp === \"number\" && credsExp * 1000 <= Date.now())\n      throw new Error(\n        this.credsSource\n          ? \"this endpoint's creds have expired and renewal is failing - not presenting the expired credential to the broker; retrying with backoff\"\n          : \"this endpoint's creds have expired and it holds no creds source to renew them - replace the credential and rebuild the endpoint (pass a creds FUNCTION for standing renewal)\",\n      );\n",
       "replace": "",
-      "expectRed": "a rebuild presents cached expired creds to the broker ZERO times after renewal fails",
-      "cell": "a rebuild presents cached expired creds to the broker ZERO times after renewal fails",
-      "note": "Deleting the block is the issue's pre-fix behavior and leaves the tree compiling. The source fails twice, so the first reconnect dials the cached expired cred and the broker logs the denial before the source recovers."
+      "expectRed": "the pre-dial refusal is loud and names the failing renewal path",
+      "cell": "the pre-dial refusal is loud and names the failing renewal path",
+      "note": "expectRed names the pre-dial refusal, not the broker-denial cell. Under this mutation the broker-denial cell stays green, so a fixture naming it comes back WRONG-RED on every PR that touches endpoint.ts, which is how this was found."
     }
   ]
 }


### PR DESCRIPTION
Closes #1403.

`packages/core/smoke/mutations/standing-renewal-expiry.json` named `a rebuild presents cached expired creds to the broker ZERO times after renewal fails` as the expected red for the mutation that removes the pre-dial expiry guard. That cell does not go red when the guard is removed, so the fixture reports WRONG-RED: the suite exits 1, but on a different assertion than the one named.

Mutation reproof selects fixtures by changed guarded source, and this one guards `packages/core/src/endpoint.ts`. So every PR that touches `endpoint.ts` selects it and inherits a red it did not cause. #1397 is currently red on exactly this and nothing else.

## Why that cell stays green

Measured at `60f4ab82` by applying the fixture's own `find`/`replace` by hand and running the suite directly. Two independent reasons, and the second is why this is not a one-line repair of the cell:

- The detection window opens at `expiringReads === 3`, the second failed renewal read. The cached cred expires and the endpoint redials before that read, so the event the assertion is about falls outside the window it searches. Dumping the slice under the mutation gives 868 bytes containing only successful re-authentications and zero denials.
- Whether the broker logs a fresh-dial rejection at all is timing-dependent. `User JWT no longer valid: &{Issues:[claim is expired]}` appears in some mutated runs and not others, depending on when the fixture's source comes back. I confirmed this by widening the window and matching only that line: the mutation still came back WRONG-RED.

A third observation, recorded because it rules out the obvious repair: matching `User Authentication Expired` instead makes the cell fail on healthy code. That line is the broker terminating a live connection whose JWT expired underneath it, which is the documented outcome of renewal staying down — the suite's own warning says the connection dies at its current JWT's expiry if renewal keeps failing. It is not a presentation of an expired credential. With the window widened and that line matched, unmutated `main` went red.

## What this changes

`expectRed` and `cell` now name `the pre-dial refusal is loud and names the failing renewal path`, which is the assertion removing the guard actually silences, and which reds in every run measured. The fixture's `why` records that the broker-denial cell is deliberately not the graded one and why naming it produces a red it never emits.

This does not repair the broker-denial cell. That cell asserts something worth asserting and currently cannot discriminate this mutation; that is filed separately so it is not lost behind a green fixture.

## Verification

At `e8cd02a6c`, clean tree:

- `pnpm smoke:standing-renewal` twice unmutated: 0, 11 checks each.
- `node scripts/mutation-proof.mjs --config packages/core/smoke/mutations/standing-renewal-expiry.json`: 0. `KILLED`, `red, and named: the pre-dial refusal is loud and names the failing renewal path`, 9 marks against baseline 11. Tree verified clean after the run.

No changeset: the change is a smoke fixture and its rationale, with no first-party package behaviour altered.
