### PR TITLE
fix(smoke): grade the creds expiry mutation on the cell that detects it

### DIFF
--- a/packages/core/smoke/mutations/standing-renewal-expiry.json
+++ b/packages/core/smoke/mutations/standing-renewal-expiry.json
@@ -10,8 +10,10 @@
     "The endpoint's pre-connect refresh is deliberately best-effort after the first connection. If",
     "the source is down when the cached cred expires, removing this guard restores the reported",
     "behavior exactly: connectAndBind presents credential material it has already decoded as expired.",
-    "The live smoke captures the disposable broker's authentication-expired denial, so the named",
-    "cell proves the real dial path reached the broker rather than only exercising a local parser."
+    "The named cell asserts the refusal is raised. The sibling cell counting broker denials cannot",
+    "grade this mutation: credsRenewalDelayMs reports creds stale at 75% of lifetime while the guard",
+    "refuses only at exp, so between those points the cached cred is still valid, the broker accepts",
+    "it, and no denial is logged whether or not the guard is present."
   ],
   "mutations": [
     {
@@ -19,8 +21,8 @@
       "file": "packages/core/src/endpoint.ts",
       "find": "    const credsExp = this.currentCreds && credsClaims(this.currentCreds).exp;\n    if (typeof credsExp === \"number\" && credsExp * 1000 <= Date.now())\n      throw new Error(\n        this.credsSource\n          ? \"this endpoint's creds have expired and renewal is failing - not presenting the expired credential to the broker; retrying with backoff\"\n          : \"this endpoint's creds have expired and it holds no creds source to renew them - replace the credential and rebuild the endpoint (pass a creds FUNCTION for standing renewal)\",\n      );\n",
       "replace": "",
-      "expectRed": "a rebuild presents cached expired creds to the broker ZERO times after renewal fails",
-      "cell": "a rebuild presents cached expired creds to the broker ZERO times after renewal fails",
+      "expectRed": "the pre-dial refusal is loud and names the failing renewal path",
+      "cell": "the pre-dial refusal is loud and names the failing renewal path",
       "note": "Deleting the block is the issue's pre-fix behavior and leaves the tree compiling. The source fails twice, so the first reconnect dials the cached expired cred and the broker logs the denial before the source recovers."
     }
   ]

--- a/packages/core/smoke/mutations/standing-renewal-expiry.json
+++ b/packages/core/smoke/mutations/standing-renewal-expiry.json
@@ -10,10 +10,12 @@
     "The endpoint's pre-connect refresh is deliberately best-effort after the first connection. If",
     "the source is down when the cached cred expires, removing this guard restores the reported",
     "behavior exactly: connectAndBind presents credential material it has already decoded as expired.",
-    "The named cell asserts the refusal is raised. The sibling cell counting broker denials cannot",
-    "grade this mutation: credsRenewalDelayMs reports creds stale at 75% of lifetime while the guard",
-    "refuses only at exp, so between those points the cached cred is still valid, the broker accepts",
-    "it, and no denial is logged whether or not the guard is present."
+    "The named cell asserts the refusal is raised, so it goes red on the deleted block itself.",
+    "The sibling cell counting broker denials cannot grade this mutation. It can read zero denials",
+    "while the guard is absent in two ways: a rebuild that dials before exp presents a cred the",
+    "broker still accepts, and a denial that does land can fall outside the slice the cell inspects,",
+    "because failedRebuildLogStart only records that the marker fired. Under the mutation that cell",
+    "was observed both red and green on the same machine, and green in CI."
   ],
   "mutations": [
     {
@@ -23,7 +25,7 @@
       "replace": "",
       "expectRed": "the pre-dial refusal is loud and names the failing renewal path",
       "cell": "the pre-dial refusal is loud and names the failing renewal path",
-      "note": "Deleting the block is the issue's pre-fix behavior and leaves the tree compiling. The source fails twice, so the first reconnect dials the cached expired cred and the broker logs the denial before the source recovers."
+      "note": "Deleting the block is the issue's pre-fix behavior and leaves the tree compiling. The refusal text the named cell matches exists only inside the deleted block, so removing it is what makes the cell red. The suite's own recovery path is unaffected: the source fails twice and then returns."
     }
   ]
 }


### PR DESCRIPTION
Closes #1403.

Addresses #1408 (the same fixture's intermittent discrimination); leaving that one's disposition to its owner rather than auto-closing it, since its lane carried measurement scope beyond this fixture.

The product defect in #1411 remains unresolved and is out of scope here: the pre-dial guard is absent from the getter nats.js uses for its own reconnects (`endpoint.ts:1017`), so an expired credential can still reach the broker. This PR changes fixture metadata only and fixes none of that. The zero-expired-presentation guarantee is explicitly **unproved** after this change: the old cell claimed it and never reliably delivered it, and the new cell asserts the local refusal is raised, which is a diagnostic, not the wire-level property.

`packages/core/smoke/mutations/standing-renewal-expiry.json` named a cell that cannot detect its own mutation, so mutation reproof returned `WRONG-RED` and reddened every change touching `packages/core/src/endpoint.ts`. This points the fixture at the adjacent cell that does detect it. No production code changes.

## The defect

The fixture graded `a rebuild presents cached expired creds to the broker ZERO times after renewal fails`, whose predicate is `failedRebuildLogStart >= 0 && expiredCredDenials.length === 0`. It asserts the **absence** of a broker denial.

`credsRenewalDelayMs` returns `iatMs + 0.75 * (expMs - iatMs) - Date.now()`, so the endpoint treats creds as stale at 75% of lifetime while the pre-dial guard refuses only at `exp`. Between those points the cached credential is still valid: the broker accepts it and logs no denial. Deleting the guard is unobservable to that cell in that window, which at the suite's `expiresInSeconds: 3` is 750ms wide.

The first conjunct compounds it. `failedRebuildLogStart >= 0` is satisfied by the marker having fired, not by the sliced window containing anything, so an empty capture satisfies the predicate vacuously.

The adjacent cell `the pre-dial refusal is loud and names the failing renewal path` asserts the **presence** of the thrown refusal. Removing the guard removes the refusal, so it goes red on the mutation rather than on a timing window.

## Evidence

Baseline, unmutated, at `origin/main`: 11 passed, 0 failed. The new named cell is green without the mutation.

`node scripts/mutation-proof.mjs --config packages/core/smoke/mutations/standing-renewal-expiry.json`, five consecutive runs on this head: **KILLED 5/5**, each `red, and named: the pre-dial refusal is loud and names the failing renewal path`, tree clean after every restore.

Direct runs with the guard removed by hand, three consecutive: both cells red locally. Contrast that with CI run [34355677896](https://github.com/Cotal-AI/Cotal/actions/runs/34355677896/job/102479616037) `changed shard 8/12`, where under the same mutation the old cell printed its GREEN text while the new one failed. Same mutation, opposite verdicts from the old cell on two machines, which is the intermittency stated as a measurement rather than a hypothesis. Mark counts across the five proof runs vary 9/10 against a baseline of 11 for the same reason: the old cell contributes a red only when the timing lands past `exp`.

## Scope

Test fixture only, so no changeset. The mutation, the suite and `endpoint.ts` are untouched; only `cell`, `expectRed` and the `why` rationale change. This does not alter what the guard does, only whether the suite can prove it.