### PR TITLE
fix(connector-claude-code)!: withhold tool-result bodies on the events plane

### DIFF
--- a/.changeset/claude-tool-result-acl.md
+++ b/.changeset/claude-tool-result-acl.md
@@ -1,0 +1,10 @@
+---
+"@cotal-ai/connector-claude-code": minor
+---
+
+The Claude Code event plane no longer republishes tool-result bodies. A `tool_result` block has no
+trusted provenance at the mapper, and `events.<owner>.<actor>` carries a different read ACL from
+wherever the tool read, so `TOOL_CALL_RESULT` is suppressed rather than emitted with the body, an
+empty string, or a placeholder. Call lifecycle (`TOOL_CALL_START` / `TOOL_CALL_ARGS` /
+`TOOL_CALL_END`) is unchanged. Observers lose tool output they saw before; that is the intended
+boundary, not a regression.

--- a/bin/smoke/ci-suites.d/3e72e02679e616db96d35f56218c0ae8277472183c0f82cc940579fab4ba88cb.txt
+++ b/bin/smoke/ci-suites.d/3e72e02679e616db96d35f56218c0ae8277472183c0f82cc940579fab4ba88cb.txt
@@ -1,0 +1,2 @@
+# Claude Code mapper: withhold tool-result bodies on the events plane.
+smoke:agui-tool-result

--- a/docs/connect-claude.md
+++ b/docs/connect-claude.md
@@ -243,10 +243,10 @@ with the adapter:
 ## Event plane
 
 A session launched with `cotal spawn --events` publishes a **structured** account of what it
-did: run boundaries per turn, assistant text, reasoning, and each tool call with its arguments,
-its end, and its result. Not prose about the work, the work itself, in a vocabulary a program can
-read. Arming is `COTAL_EVENTS`, which the launcher sets for `--events` spawns; a personal session
-with the plugin installed publishes nothing.
+did: run boundaries per turn, assistant text, reasoning, and each tool call with its arguments
+and its end. Tool **results are not published**. Not prose about the work, the work itself, in a
+vocabulary a program can read, minus the result body. Arming is `COTAL_EVENTS`, which the launcher
+sets for `--events` spawns; a personal session with the plugin installed publishes nothing.
 
 A new session includes its first run even when Claude writes a positional startup prompt before the
 connector receives `SessionStart`. That from-zero read is keyed only to Claude's explicit
@@ -268,9 +268,13 @@ new startup waits up to five seconds for that file with capped backoff, and the 
 one stalled file read; expiry fails loud instead of silently losing the first run. Retained-history
 starts and recovered cursors still require their existing source at once.
 
-Tool arguments and results go on this channel verbatim, so withholding user-authored text does not
-make the stream safe to widen: anything a tool reads or prints, including a secret in a command line
-or in the contents of a file, reaches every reader of the channel.
+Tool arguments still go on this channel, so withholding user-authored text and tool results does
+not make the stream safe to widen: anything a tool is *asked* to do, including a secret in a
+command line, reaches every reader of the channel. Tool **results** do not. A `tool_result` block
+has no trusted provenance at the mapper, and `TOOL_CALL_RESULT.content` is mandatory, so the
+result event is suppressed rather than emitted empty or with a placeholder. Observers lose that
+output on purpose: republishing it onto `events.<owner>.<actor>` would move text from a narrower
+reader set onto a broader one.
 
 The channel is **`events.<owner>.<actor>`**, named after the session's principal. What the actor
 half is depends on the mesh, and the difference matters when you go looking for it: on a static mesh
@@ -279,7 +283,7 @@ do not share a stream; on a user-auth mesh it is the agent's own name, because t
 ledger row is keyed on. Spelled out again with both halves below. The launch grants publish rights
 on that channel alone. A spawn
 that asks for a *different* agent's event channel is refused at the door rather than granted, since
-that channel carries the session's tool inputs and outputs. The same rule runs on restart: a manager
+that channel carries the session's tool arguments and assistant text. The same rule runs on restart: a manager
 resume document that names another agent's event channel is refused rather than adopted, because the
 managed row is re-armed from that document and the credential is re-minted from the row.
 

--- a/extensions/connector-claude-code/smoke/agui-authorship.smoke.ts
+++ b/extensions/connector-claude-code/smoke/agui-authorship.smoke.ts
@@ -131,10 +131,9 @@ const mapAll = (entries: ClaudeEntry[]) => {
     events.filter((e) => e.type === "RUN_STARTED").length);
 }
 
-// ── ARM D: A TOOL RESULT CARRYING ANOTHER PRINCIPAL'S TEXT ────────────────────────────────────
-// Named separately because it arrives by a different route: not an `origin.kind`, but a peer's
-// words quoted inside this session's own tool output. Recorded as a KNOWN LIMIT rather than
-// asserted as safe — see the cell name.
+// ── ARM D: A TOOL RESULT, WHICH HAS NO PROVENANCE AT THIS LAYER ──────────────
+// Named separately because it arrives by a different route: not an `origin.kind`.
+// Fail-closed: TOOL_CALL_RESULT.content is mandatory, so the event is suppressed.
 {
   const toolResult = mk({
     uuid: "u8",
@@ -144,11 +143,8 @@ const mapAll = (entries: ClaudeEntry[]) => {
   } as never);
   const { events } = mapAll([human("u9", MINE), toolResult]);
   const wire = JSON.stringify(events);
-  // This is NOT a safety claim. A tool result is this session's own output and IS republished by
-  // design; if it quotes a peer, that text rides along. Stating it as a measured limit so nobody
-  // reads arm A as "no peer text can ever reach the wire".
-  c("KNOWN LIMIT: a tool result IS emitted, so peer text quoted inside one is not covered by this filter",
-    wire.includes(TOOL_SECRET));
+  c("FAIL-CLOSED: a tool_result body is withheld (no TOOL_CALL_RESULT, no placeholder bytes)",
+    !wire.includes(TOOL_SECRET) && !events.some((e) => e.type === "TOOL_CALL_RESULT"));
 }
 
 // A COUNT, because several cells above build their own inputs and a regression that DELETES one

--- a/extensions/connector-claude-code/smoke/agui-map.smoke.ts
+++ b/extensions/connector-claude-code/smoke/agui-map.smoke.ts
@@ -98,6 +98,8 @@
  *       to be doing work -> KILLED `real:every-tool_use-block-became-a-START-ARGS-END-triple`
  *   M7  [B] make the RESULT name an id no START opened
  *       -> KILLED `real:every-RESULT-names-a-toolCallId-that-a-START-opened`
+ *       **STALE: that cell no longer exists.** Tool-result bodies are withheld, so there is no
+ *       RESULT to join. Replaced by `real:no-RESULT-is-emitted-and-every-START-still-has-an-id`.
  *
  *   ⚠️ M8/M9 — **BOTH PREDICTIONS WERE WRONG, AND THE PAIR IS THE MOST INSTRUCTIVE ROW HERE.**
  *       M8 (drop the `promptSource` run-opening test) was predicted to KILL and **SURVIVED**. M9
@@ -952,9 +954,9 @@ c("real:every-tool_use-block-INSIDE-a-run-became-a-START-ARGS-END-triple", (() =
   return toolUse > 0 && typesOf("TOOL_CALL_START") === toolUse && typesOf("TOOL_CALL_ARGS") === toolUse && typesOf("TOOL_CALL_END") === toolUse;
 })(), { firstRunAt: FIRST_RUN_AT, start: typesOf("TOOL_CALL_START"), args: typesOf("TOOL_CALL_ARGS"), end: typesOf("TOOL_CALL_END") });
 
-c("real:every-tool_result-block-INSIDE-a-run-became-a-RESULT", (() => {
+c("real:every-tool_result-block-INSIDE-a-run-is-WITHHELD", (() => {
   const results = FIRST_RUN_AT < 0 ? 0 : blocksIn(FIRST_RUN_AT, "tool_result");
-  return results > 0 && typesOf("TOOL_CALL_RESULT") === results;
+  return results > 0 && typesOf("TOOL_CALL_RESULT") === 0;
 })(), { firstRunAt: FIRST_RUN_AT, results: typesOf("TOOL_CALL_RESULT") });
 
 // THE OTHER HALF OF THE PARTITION, asserted rather than absorbed. The cells above would also pass
@@ -987,10 +989,10 @@ if (HEAD.tool_use + HEAD.tool_result + HEAD.thinking > 0) {
   });
 }
 
-c("real:every-RESULT-names-a-toolCallId-that-a-START-opened", (() => {
-  const opened = new Set(events.filter((e) => e.type === "TOOL_CALL_START").map((e) => (e as { toolCallId: string }).toolCallId));
-  const results = events.filter((e) => e.type === "TOOL_CALL_RESULT") as { toolCallId: string }[];
-  return results.length > 0 && results.every((r) => opened.has(r.toolCallId));
+c("real:no-RESULT-is-emitted-and-every-START-still-has-an-id", (() => {
+  const opened = events.filter((e) => e.type === "TOOL_CALL_START") as { toolCallId: string }[];
+  const results = events.filter((e) => e.type === "TOOL_CALL_RESULT");
+  return results.length === 0 && opened.length > 0 && opened.every((s) => typeof s.toolCallId === "string" && s.toolCallId.length > 0);
 })());
 
 // IDENTITY. This is the `message.id` defect: a provider request id repeats across entries and

--- a/extensions/connector-claude-code/smoke/agui-tool-result.smoke.ts
+++ b/extensions/connector-claude-code/smoke/agui-tool-result.smoke.ts
@@ -1,0 +1,151 @@
+/**
+ * FAIL CLOSED ON TOOL-RESULT BODIES.
+ *
+ * `events.<owner>.<actor>` carries a DIFFERENT read ACL from wherever a tool read. A
+ * `tool_result` block at this mapper has no trusted provenance and no evidence the destination
+ * audience may read it, so the body is not republished. `TOOL_CALL_RESULT.content` is mandatory,
+ * so the event is suppressed rather than emitted empty or with a placeholder.
+ *
+ * Observers lose the tool output they see today. That is the point, not a regression.
+ *
+ * THE CLAIM IS JOINED, SO IT GETS A DECOY PER FACT. "No tool-result body is emitted" is
+ * satisfied completely by a mapper that emits nothing at all, so a one-armed suite would go green
+ * against a filter that had broken everything. The two arms are therefore:
+ *
+ *   A. SAFETY  — a tool_result record emits NO TOOL_CALL_RESULT and the placeholder never appears.
+ *   B. LIVENESS — the matching tool_use still emits START/ARGS/END, and a human prompt still
+ *                 opens a run with its body.
+ *
+ * A mutation that restores verbatim result content reddens A while B stays green; a mutation that
+ * drops tool_use lifecycle as well reddens B while A stays green.
+ *
+ * THE SAFETY CELL ASSERTS ABSENCE OF THE BYTES, NOT ABSENCE OF AN EVENT TYPE. Checking only that
+ * no TOOL_CALL_RESULT appears would pass a mapper that moved the body into a delta on some other
+ * event, or into cotal metadata. So the corpus is searched for the placeholder itself.
+ *
+ * Placeholders only. No live ACL crossing, no real tool output, no secrets.
+ *
+ * Run: npx tsx extensions/connector-claude-code/smoke/agui-tool-result.smoke.ts
+ */
+import { createClaudeMapper, type ClaudeEntry } from "../src/agui-map.js";
+
+let pass = 0;
+let fail = 0;
+const c = (n: string, v: boolean, extra?: unknown): void => {
+  if (v) {
+    pass += 1;
+    return;
+  }
+  fail += 1;
+  console.error(`  x FAIL: ${n}${extra === undefined ? "" : ` ${JSON.stringify(extra)}`}`);
+};
+
+const RESULT_PLACEHOLDER = "SYNTHETIC-TOOL-RESULT-PLACEHOLDER-695-NOT-A-SECRET";
+const ARGS_PLACEHOLDER = "SYNTHETIC-TOOL-ARGS-PLACEHOLDER-695-NOT-A-SECRET";
+const PROMPT = "synthetic human prompt for 695 liveness";
+
+const mk = (o: Partial<ClaudeEntry> & { uuid: string }): ClaudeEntry => o as ClaudeEntry;
+
+const human = (uuid: string, text: string): ClaudeEntry =>
+  mk({
+    uuid,
+    type: "user",
+    timestamp: "2026-08-15T00:00:00.000Z",
+    origin: { kind: "human" },
+    message: { role: "user", content: text },
+  } as never);
+
+const toolUse = (uuid: string, id: string, name: string, input: unknown): ClaudeEntry =>
+  mk({
+    uuid,
+    type: "assistant",
+    timestamp: "2026-08-15T00:00:01.000Z",
+    message: {
+      role: "assistant",
+      content: [{ type: "tool_use", id, name, input }],
+    },
+  } as never);
+
+const toolResult = (uuid: string, toolUseId: string, content: unknown, isError = false): ClaudeEntry =>
+  mk({
+    uuid,
+    type: "user",
+    timestamp: "2026-08-15T00:00:02.000Z",
+    message: {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: toolUseId, content, is_error: isError }],
+    },
+  } as never);
+
+const mapAll = (entries: ClaudeEntry[]) => {
+  let n = 0;
+  const m = createClaudeMapper({ threadId: "thread-695", mintRunId: () => `run-${++n}` });
+  const events: Record<string, unknown>[] = [];
+  for (const e of entries) {
+    const out = m.map(e);
+    if (out) events.push(...(out.events as unknown as Record<string, unknown>[]));
+  }
+  return { events, mapper: m };
+};
+
+{
+  const { events } = mapAll([
+    human("u0", PROMPT),
+    toolUse("a1", "t1", "Read", { path: ARGS_PLACEHOLDER }),
+    toolResult("u1", "t1", RESULT_PLACEHOLDER, true),
+  ]);
+  const wire = JSON.stringify(events);
+  const types = events.map((e) => e.type);
+
+  c("a tool_result placeholder does NOT appear anywhere on the wire", !wire.includes(RESULT_PLACEHOLDER));
+  c("NO TOOL_CALL_RESULT is emitted for a tool_result record",
+    !types.includes("TOOL_CALL_RESULT"), types);
+  c("an is_error flag is not a loophole that restores the body",
+    !events.some((e) => (e.cotal as Record<string, unknown> | undefined)?.isError === true)
+      && !wire.includes(RESULT_PLACEHOLDER));
+}
+
+{
+  const { events } = mapAll([
+    human("u0", PROMPT),
+    toolUse("a1", "t1", "Read", { path: ARGS_PLACEHOLDER }),
+    toolResult("u1", "t1", RESULT_PLACEHOLDER),
+  ]);
+  const wire = JSON.stringify(events);
+  const types = events.map((e) => e.type);
+  const start = events.find((e) => e.type === "TOOL_CALL_START") as
+    | { toolCallId?: string; toolCallName?: string; parentMessageId?: string }
+    | undefined;
+  const args = events.find((e) => e.type === "TOOL_CALL_ARGS") as { toolCallId?: string } | undefined;
+  const end = events.find((e) => e.type === "TOOL_CALL_END") as { toolCallId?: string } | undefined;
+
+  c("DECOY/LIVENESS — a human prompt still emits its body", wire.includes(PROMPT));
+  c("DECOY/LIVENESS — tool_use still emits START/ARGS/END",
+    types.includes("TOOL_CALL_START") && types.includes("TOOL_CALL_ARGS") && types.includes("TOOL_CALL_END"),
+    types);
+  c("DECOY/LIVENESS — the START keeps toolCallId, name, and parentMessageId",
+    start?.toolCallId === "t1" && start?.toolCallName === "Read" && start?.parentMessageId === "a1#0",
+    start);
+  c("DECOY/LIVENESS — ARGS and END keep the same toolCallId",
+    args?.toolCallId === "t1" && end?.toolCallId === "t1",
+    { args, end });
+  c("DECOY/LIVENESS — ARGS still carry the synthetic input, which is not the result body",
+    wire.includes(ARGS_PLACEHOLDER) && !wire.includes(RESULT_PLACEHOLDER));
+}
+
+{
+  const { events } = mapAll([
+    human("u0", PROMPT),
+    toolUse("a1", "t1", "Read", { path: ARGS_PLACEHOLDER }),
+    toolResult("u1", "t1", [{ type: "text", text: RESULT_PLACEHOLDER }]),
+  ]);
+  const wire = JSON.stringify(events);
+  c("an array-shaped tool_result is suppressed the same way as a string",
+    !wire.includes(RESULT_PLACEHOLDER) && !events.some((e) => e.type === "TOOL_CALL_RESULT"));
+}
+
+const EXPECTED = 9;
+c(`every cell ran - ${EXPECTED} expected`, pass + fail === EXPECTED, `${pass + fail} cells reported`);
+
+console.log(`agui-tool-result smoke: ${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/extensions/connector-claude-code/smoke/mutations/agui-tool-result.json
+++ b/extensions/connector-claude-code/smoke/mutations/agui-tool-result.json
@@ -1,0 +1,42 @@
+{
+  "suite": [
+    "extensions/connector-claude-code/smoke/agui-tool-result.smoke.ts"
+  ],
+  "guard": "a tool_result record is not republished onto the events plane; the matching tool_use still emits START/ARGS/END",
+  "command": "pnpm smoke:agui-tool-result",
+  "completionMarker": "agui-tool-result smoke:",
+  "proveWith": "node scripts/mutation-proof.mjs --config extensions/connector-claude-code/smoke/mutations/agui-tool-result.json",
+  "why": [
+    "events.<owner>.<actor> carries a different read ACL from wherever a tool read. A tool_result",
+    "block at this mapper has no trusted provenance, so TOOL_CALL_RESULT is suppressed rather than",
+    "emitted with the body, an empty string, or a placeholder.",
+    "",
+    "The claim is joined, so it gets a mutation per fact. 'No tool-result body is emitted' is",
+    "satisfied completely by a mapper that emits nothing at all, which is why T2 exists: it drops",
+    "tool_use lifecycle and must redden the liveness arm while leaving the safety arm green.",
+    "",
+    "SPECIFIER BOUNDARY. The suite imports the mapper by relative source path (../src/agui-map.js)",
+    "and calls it directly. Its only other import is connector-core's event constructors, which no",
+    "mutation below touches, so a kill comes from the mapper and not from the vocabulary."
+  ],
+  "mutations": [
+    {
+      "name": "T1 restore verbatim TOOL_CALL_RESULT content",
+      "file": "extensions/connector-claude-code/src/agui-map.ts",
+      "find": "        return null; // fail-closed: no TOOL_CALL_RESULT without trusted provenance",
+      "replace": "        for (const b of content as { type?: string; tool_use_id?: string; content?: unknown; is_error?: boolean }[]) {\n          if (b.type !== \"tool_result\" || !b.tool_use_id) continue;\n          events.push({\n            type: \"TOOL_CALL_RESULT\",\n            messageId: `${uuid}#0`,\n            toolCallId: b.tool_use_id,\n            content: typeof b.content === \"string\" ? b.content : JSON.stringify(b.content ?? null),\n            timestamp: ts,\n          } as never);\n        }\n        return events.length > 0 && open !== null ? { runId: open, events } : null;",
+      "expectRed": "a tool_result placeholder does NOT appear anywhere on the wire",
+      "cell": "a tool_result placeholder does NOT appear anywhere on the wire",
+      "note": "This is the defect: the previous mapper published result content verbatim onto events.<owner>.<actor>. The named cell searches for the placeholder bytes, so an empty-string or placeholder-string mutant would also fail it."
+    },
+    {
+      "name": "T2 drop tool_use lifecycle as well as the result",
+      "file": "extensions/connector-claude-code/src/agui-map.ts",
+      "find": "      if (b.type === \"tool_use\" && b.id) {",
+      "replace": "      if (false && b.type === \"tool_use\" && b.id) {",
+      "expectRed": "DECOY/LIVENESS — tool_use still emits START/ARGS/END",
+      "cell": "DECOY/LIVENESS — tool_use still emits START/ARGS/END",
+      "note": "The over-broad filter, which passes every safety cell in the file. Without a liveness arm this mutant survives and the suite goes green against a mapper that publishes no tool activity at all."
+    }
+  ]
+}

--- a/extensions/connector-claude-code/src/agui-map.ts
+++ b/extensions/connector-claude-code/src/agui-map.ts
@@ -86,10 +86,11 @@
  * because an enumeration over `origin.kind` cannot classify a record that has none. Every value
  * outside either table **fails loud** rather than being silently treated as not-a-turn.
  *
- * **(C) `TOOL_CALL_RESULT.messageId` is unstated in §3.1's table** (the row names only
- * `toolCallId`) while the real schema REQUIRES it. It is keyed the same way every other message
- * identity here is — entry `uuid` plus block index — so it is unique, stable, and derived rather
- * than invented at a call site. Raised as a gap in `connector-core`'s constructor doc as well.
+ * **(C) `TOOL_CALL_RESULT` is withheld.** The real schema REQUIRES `content` (and `messageId`,
+ * unstated in §3.1's table). A `tool_result` block at this layer has no trusted provenance and
+ * no evidence the destination audience may read it, so the event is suppressed rather than
+ * emitted empty or with a placeholder. Lifecycle for the call still arrives as
+ * `TOOL_CALL_START` / `TOOL_CALL_ARGS` / `TOOL_CALL_END` from the matching `tool_use` block.
  * ---------------------------------------------------------------------------------------------
  *
  * `messageId` is `${uuid}#${blockIndex}` and NOT `message.id`. `message.id` is a provider request
@@ -109,7 +110,6 @@ import {
   toolCallStart,
   toolCallArgs,
   toolCallEnd,
-  toolCallResult,
   reasoningMessageStart,
   reasoningMessageContent,
   reasoningMessageEnd,
@@ -350,15 +350,6 @@ function stampOf(entry: ClaudeEntry, now: () => number): { ts: number; arrival: 
   return Number.isFinite(parsed) ? { ts: parsed, arrival: false } : { ts: now(), arrival: true };
 }
 
-/**
- * `tool_result.content` is a string on some entries and an array of blocks on others. AG-UI's
- * `content` is a string, so the array form is JSON-encoded rather than joined: joining would
- * silently drop every non-text member, which is `salient()`'s defect in a smaller costume.
- */
-function resultContent(raw: unknown): string {
-  return typeof raw === "string" ? raw : JSON.stringify(raw ?? null);
-}
-
 export function createClaudeMapper(opts: ClaudeMapperOptions): ClaudeMapper {
   const now = opts.now ?? (() => Date.now());
   let open: string | null = null;
@@ -410,21 +401,25 @@ export function createClaudeMapper(opts: ClaudeMapperOptions): ClaudeMapper {
       // The discriminator is the presence of a `tool_result` block, not the array-ness.
       const toolResults = Array.isArray(content) ? content.filter((b) => b.type === "tool_result" && b.tool_use_id) : [];
       if (toolResults.length > 0) {
-        (content as ClaudeBlock[]).forEach((b, i) => {
-          if (b.type !== "tool_result" || !b.tool_use_id) return;
-          events.push(
-            toolCallResult({
-              messageId: `${uuid}#${i}`,
-              toolCallId: b.tool_use_id,
-              content: resultContent(b.content),
-              timestamp: ts,
-              ...(b.is_error || arrivalMeta
-                ? { cotal: { ...(b.is_error ? { isError: true } : {}), ...arrivalMeta } }
-                : {}),
-            }),
-          );
-        });
-        return events.length > 0 && open !== null ? { runId: open, events } : null;
+        /**
+         * FAIL CLOSED ON TOOL-RESULT BODIES. `events.<owner>.<actor>` carries a DIFFERENT read ACL
+         * from wherever the tool read. A `tool_result` block at this layer has no trusted provenance
+         * and no evidence the destination audience may read it, so the body is not republished.
+         *
+         * `TOOL_CALL_RESULT.content` is mandatory in the real schema. An empty string or a fixed
+         * placeholder would invent vocabulary §3.1 does not define, and a placeholder string is one
+         * edit away from being a real delta again. So the event is suppressed, not redacted.
+         *
+         * Observers lose the tool output they see today. That is the point: the previous mapping
+         * published the block's `content` verbatim (string as-is, array JSON-encoded), which is the
+         * ACL-crossing this branch existed to prevent and then had nothing enforcing.
+         *
+         * Not a tool-name allowlist. Not a tool-supplied "this output is safe" flag. Either would
+         * authorize release from the same untrusted record. Lifecycle for the call itself still
+         * arrives as `TOOL_CALL_START` / `TOOL_CALL_ARGS` / `TOOL_CALL_END` from the matching
+         * `tool_use` block; those events do not carry the result body.
+         */
+        return null; // fail-closed: no TOOL_CALL_RESULT without trusted provenance
       }
 
       // The prompt body. A string entry is its own body; an array entry with no tool results is a

--- a/package.json
+++ b/package.json
@@ -201,6 +201,7 @@
     "smoke:claude-run-error": "tsx extensions/connector-claude-code/smoke/agui-run-error.smoke.ts",
     "smoke:claude-start-source": "tsx extensions/connector-claude-code/smoke/agui-start-source.smoke.ts",
     "smoke:agui-authorship": "tsx extensions/connector-claude-code/smoke/agui-authorship.smoke.ts",
+    "smoke:agui-tool-result": "tsx extensions/connector-claude-code/smoke/agui-tool-result.smoke.ts",
     "smoke:agui-map": "COTAL_AGUI_SESSION=extensions/connector-claude-code/smoke/fixtures/session-shape.jsonl tsx extensions/connector-claude-code/smoke/agui-map.smoke.ts",
     "smoke:agui-map:real": "tsx extensions/connector-claude-code/smoke/agui-map.smoke.ts",
     "smoke:agui-opencode-map": "tsx extensions/connector-opencode/smoke/agui-map.smoke.ts",


### PR DESCRIPTION
## Summary

The Claude Code mapper used to copy every `tool_result` body onto `events.<owner>.<actor>` as `TOOL_CALL_RESULT.content`. That subject has a different read ACL from wherever the tool read, so a seat calling a mesh read tool moved text from a narrower reader set onto a broader one, unredacted.

The defect in #695 is repaired by failing closed in `createClaudeMapper`: without trusted provenance and evidence the destination audience may read the body, the mapper does not emit `TOOL_CALL_RESULT` at all. `content` is mandatory on that event, so there is no empty-string or placeholder form. Call lifecycle (`TOOL_CALL_START` / `TOOL_CALL_ARGS` / `TOOL_CALL_END`) is unchanged.

Observers lose tool output they see today. That is the intended boundary, not a regression.

## What this does not do

- No tool-name allowlist.
- No redaction marker or invented schema field.
- No new provenance protocol.
- Tool-supplied "this output is safe" is not treated as evidence.

## Follow-up (out of this PR)

The same unconditional republish exists in:

- `extensions/connector-codex/src/agui-map.ts` (`function_call_output` / `custom_tool_call_output` → `toolCallResult` with `outputText(payload)`).
- `extensions/connector-opencode/src/agui-map.ts` (`part.type === "tool"` → `toolCallResult` with `toolResultContent(part.state)`).

`@cotal-ai/connector-core` only constructs the event; it does not map harness records. Those adapters are separately scoped.

## Testing

Synthetic placeholders only. No live ACL crossing, no real tool output, no secrets.

- Reproduced from source before the change: a synthetic `tool_result` mapped to `TOOL_CALL_RESULT` with the placeholder on the serialized events.
- `pnpm smoke:agui-tool-result` (safety: placeholder absent, no `TOOL_CALL_RESULT`; liveness: START/ARGS/END and prompt body retained).
- `pnpm smoke:agui-authorship` (former known-limit arm is now fail-closed).
- `pnpm smoke:agui-map` against the committed session fixture.
- `pnpm --filter @cotal-ai/connector-claude-code typecheck`
- `pnpm check:docs-voice`
- `pnpm smoke:gate-inventory`
- `node scripts/mutation-proof.mjs --config extensions/connector-claude-code/smoke/mutations/agui-tool-result.json`
  - T1 restore verbatim content → KILLED `a tool_result placeholder does NOT appear anywhere on the wire`
  - T2 drop tool_use lifecycle → KILLED `DECOY/LIVENESS — tool_use still emits START/ARGS/END`