### PR TITLE
fix(connector-claude-code): list marketplace plugins as objects with a source

### DIFF
--- a/.changeset/claude-marketplace-plugin-entries.md
+++ b/.changeset/claude-marketplace-plugin-entries.md
@@ -1,0 +1,15 @@
+---
+"@cotal-ai/connector-claude-code": patch
+---
+
+Generate the Claude Code marketplace manifest with object plugin entries
+
+`cotal setup` wrote `.claude-plugin/marketplace.json` with `plugins` as bare names. Claude Code
+validates that form, so `plugin marketplace add` and `plugin marketplace update` both report
+success, and the install then fails with `Plugin "cotal" not found in marketplace "cotal-mesh"`.
+The message points at a stale local copy rather than at the manifest, so the suggested
+`marketplace update` changes nothing, and re-running setup regenerates the same file over a hand
+repair. Setup pauses at that step, so later steps including persona seeding never run.
+
+Each present plugin is now listed as an object carrying `name`, `source` and the `description`
+read from that plugin's own `plugin.json`.

--- a/bin/smoke/ci-suites.d/91b19ac8585a7d1c0a92100baf9c2f6b86136b240be91b702feedd8d78929e7d.txt
+++ b/bin/smoke/ci-suites.d/91b19ac8585a7d1c0a92100baf9c2f6b86136b240be91b702feedd8d78929e7d.txt
@@ -1,0 +1,3 @@
+# The generated Claude Code marketplace must list plugins as objects carrying a resolvable source.
+# Bare names validate and then fail to resolve, which pauses `cotal setup` for every new install.
+smoke:claude-marketplace

--- a/extensions/connector-claude-code/smoke/marketplace-manifest.smoke.ts
+++ b/extensions/connector-claude-code/smoke/marketplace-manifest.smoke.ts
@@ -5,16 +5,18 @@
  * "cotal-mesh"`. The message names a stale local copy, so the obvious remedy changes nothing, and
  * re-running setup regenerates the same broken file over a hand repair.
  *
- * The suite grades `marketplaceManifest`, which is the value `writeMarketplace` serializes — not a
- * restatement of it. It does not spawn `claude`: the `plugin marketplace add` call in
- * `writeMarketplace` is the shipped side effect and is out of scope here, so this proves the
- * manifest's SHAPE and not that Claude Code accepts it. The acceptance evidence is on the issue.
+ * The suite grades `marketplaceManifest`, which is the value the writer serializes, and separately
+ * reads back the file `writeMarketplaceManifest` puts on disk. Both halves are needed: the builder
+ * cells cannot see a writer that serializes a different array, and the writer cell cannot say which
+ * field was wrong. It does not spawn `claude` — the `plugin marketplace add` that follows the write
+ * is the shipped side effect and stays out of scope — so this proves the manifest's SHAPE and the
+ * bytes written, not that Claude Code accepts them. The acceptance evidence is on the issue.
  */
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { marketplaceManifest } from "../src/setup.js";
+import { marketplaceManifest, writeMarketplaceManifest } from "../src/setup.js";
 
 let passed = 0;
 let failed = 0;
@@ -45,8 +47,11 @@ try {
   plant(market, "cotal-skills", "Cotal-authored skills.");
   const manifest = marketplaceManifest(market);
 
-  // LIVENESS. Kept first and kept separate so that a builder emitting nothing reddens HERE, and the
-  // shape cells below stay honest about what they grade rather than doubling as a count check.
+  // LIVENESS. Kept first and kept separate so a builder emitting nothing reddens HERE, on a cell
+  // that says so, rather than somewhere downstream that reads as a shape failure. Only the
+  // objectness loop below is genuinely vacuous on an empty array; the source, description and
+  // omission cells all compare against expected entries and would redden too. This cell earns its
+  // place by being the FIRST red and by naming the actual fault, not by being the only one.
   ok("LIVENESS — the manifest lists every planted plugin", () => {
     assert.equal(manifest.plugins.length, 2, "both planted plugins are listed");
   });
@@ -76,6 +81,24 @@ try {
     assert.equal(entry.name, "cotal");
     assert.equal(entry.source, "./cotal");
     assert.equal(entry.description, undefined, "absent rather than an empty string");
+  });
+
+  // WRITER BOUNDARY. Everything above grades the builder's return value. `writeMarketplace` is what
+  // setup actually calls, and it serializes that value itself, so a regression between the builder
+  // and the bytes on disk is invisible to every cell above. Read the file back rather than the
+  // object that produced it.
+  ok("the file the writer puts on disk carries the entries the builder produced", () => {
+    const written = join(root, "written");
+    plant(written, "cotal", "Join the Cotal mesh over NATS.");
+    plant(written, "cotal-skills", "Cotal-authored skills.");
+    const path = writeMarketplaceManifest(written);
+    assert.equal(path, join(written, ".claude-plugin", "marketplace.json"), "the path Claude is pointed at");
+    const onDisk = JSON.parse(readFileSync(path, "utf8")) as { plugins: { name: string; source: string }[] };
+    assert.deepEqual(onDisk.plugins, marketplaceManifest(written).plugins, "the bytes match the builder");
+    for (const entry of onDisk.plugins) {
+      assert.equal(typeof entry, "object", `written entry is an object, got ${typeof entry}`);
+      assert.equal(entry.source, `./${entry.name}`, "written entry carries its resolvable source");
+    }
   });
 
   ok("an absent plugin directory is omitted rather than listed unresolvably", () => {

--- a/extensions/connector-claude-code/smoke/marketplace-manifest.smoke.ts
+++ b/extensions/connector-claude-code/smoke/marketplace-manifest.smoke.ts
@@ -1,0 +1,92 @@
+/**
+ * #1392: `cotal setup` generated `.claude-plugin/marketplace.json` with `plugins` as bare names.
+ * Claude Code validates that form and then cannot RESOLVE it, so `plugin marketplace add` and
+ * `update` both report success and the install fails with `Plugin "cotal" not found in marketplace
+ * "cotal-mesh"`. The message names a stale local copy, so the obvious remedy changes nothing, and
+ * re-running setup regenerates the same broken file over a hand repair.
+ *
+ * The suite grades `marketplaceManifest`, which is the value `writeMarketplace` serializes — not a
+ * restatement of it. It does not spawn `claude`: the `plugin marketplace add` call in
+ * `writeMarketplace` is the shipped side effect and is out of scope here, so this proves the
+ * manifest's SHAPE and not that Claude Code accepts it. The acceptance evidence is on the issue.
+ */
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { marketplaceManifest } from "../src/setup.js";
+
+let passed = 0;
+let failed = 0;
+const ok = (label: string, fn: () => void): void => {
+  try {
+    fn();
+    passed += 1;
+    console.log(`  ✓ ${label}`);
+  } catch (error) {
+    failed += 1;
+    console.log(`  ✗ FAIL: ${label} ${(error as Error).message}`);
+  }
+};
+
+const root = mkdtempSync(join(tmpdir(), "cotal-1392-"));
+
+function plant(market: string, name: string, description?: string): void {
+  mkdirSync(join(market, name, ".claude-plugin"), { recursive: true });
+  writeFileSync(
+    join(market, name, ".claude-plugin", "plugin.json"),
+    JSON.stringify({ name, version: "0.0.0", ...(description ? { description } : {}) }, null, 2),
+  );
+}
+
+try {
+  const market = join(root, "claude-plugin");
+  plant(market, "cotal", "Join the Cotal mesh over NATS.");
+  plant(market, "cotal-skills", "Cotal-authored skills.");
+  const manifest = marketplaceManifest(market);
+
+  // LIVENESS. Kept first and kept separate so that a builder emitting nothing reddens HERE, and the
+  // shape cells below stay honest about what they grade rather than doubling as a count check.
+  ok("LIVENESS — the manifest lists every planted plugin", () => {
+    assert.equal(manifest.plugins.length, 2, "both planted plugins are listed");
+  });
+
+  ok("every plugin entry is an object, never a bare name", () => {
+    for (const entry of manifest.plugins) {
+      assert.equal(typeof entry, "object", `entry is an object, got ${typeof entry}`);
+      assert.notEqual(entry, null, "entry is not null");
+    }
+  });
+
+  ok("every entry carries the source Claude Code resolves against", () => {
+    const sources = manifest.plugins.map((entry) => entry.source);
+    assert.deepEqual(sources, ["./cotal", "./cotal-skills"], "source is the plugin's own directory");
+  });
+
+  ok("the description is taken from the plugin's own manifest, not restated here", () => {
+    const byName = Object.fromEntries(manifest.plugins.map((entry) => [entry.name, entry.description]));
+    assert.equal(byName["cotal"], "Join the Cotal mesh over NATS.");
+    assert.equal(byName["cotal-skills"], "Cotal-authored skills.");
+  });
+
+  ok("a plugin whose manifest states no description still gets a resolvable entry", () => {
+    const bare = join(root, "bare");
+    plant(bare, "cotal");
+    const [entry] = marketplaceManifest(bare).plugins;
+    assert.equal(entry.name, "cotal");
+    assert.equal(entry.source, "./cotal");
+    assert.equal(entry.description, undefined, "absent rather than an empty string");
+  });
+
+  ok("an absent plugin directory is omitted rather than listed unresolvably", () => {
+    const partial = join(root, "partial");
+    plant(partial, "cotal", "only this one exists");
+    const names = marketplaceManifest(partial).plugins.map((entry) => entry.name);
+    assert.deepEqual(names, ["cotal"], "lists the planted plugin and omits the absent one");
+  });
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}
+
+console.log(`marketplace-manifest smoke: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/extensions/connector-claude-code/smoke/mutations/marketplace-manifest.json
+++ b/extensions/connector-claude-code/smoke/mutations/marketplace-manifest.json
@@ -9,17 +9,24 @@
   "why": [
     "#1392: the manifest listed plugins as bare names. Claude Code VALIDATES that form, so",
     "`plugin marketplace add` and `update` both report success, and resolution then fails with",
-    "`Plugin \"cotal\" not found in marketplace \"cotal-mesh\"` — a message about a stale local copy.",
+    "`Plugin \"cotal\" not found in marketplace \"cotal-mesh\"` \u2014 a message about a stale local copy.",
     "So the failure never names the manifest, and re-running setup regenerates it over a hand fix.",
     "",
     "The guard is joined, so it gets a mutation per fact. T1 is the reported defect. T2 is the",
     "near-miss it invites: an object entry is not sufficient, it must carry `source`. T3 is the",
-    "liveness arm — every shape assertion is vacuously satisfied by a builder that emits no",
-    "entries at all, so without it a mutation that lists nothing would come back SURVIVED.",
+    "liveness arm. T4 is the writer boundary.",
     "",
-    "BOUNDARY. The suite grades `marketplaceManifest`, the value `writeMarketplace` serializes, and",
-    "does not spawn `claude`. So a kill shows the manifest's shape is guarded, NOT that Claude Code",
-    "accepts it; that evidence is the reproduction recorded on the issue."
+    "CORRECTED. An earlier revision of this block said every shape assertion is vacuously satisfied",
+    "by a builder emitting no entries. That is wrong, and two reviewers caught it independently.",
+    "Only the objectness loop is vacuous on an empty array; the source, description and omission",
+    "cells compare against expected entries and redden too. T3's real claim is the narrower one that",
+    "the dedicated count cell is the FIRST red, so a builder that lists nothing is reported as a",
+    "count failure rather than as a shape failure somewhere downstream.",
+    "",
+    "BOUNDARY. T1-T3 mutate the builder; T4 mutates the write that follows it, because the builder",
+    "cells read a return value and cannot see a writer that serializes something else. None of the",
+    "four spawns `claude`. So a kill shows the manifest's shape and its bytes are guarded, NOT that",
+    "Claude Code accepts them; that evidence is the reproduction recorded on the issue."
   ],
   "mutations": [
     {
@@ -45,9 +52,18 @@
       "file": "extensions/connector-claude-code/src/setup.ts",
       "find": "    .filter((name) => existsSync(join(market, name, \".claude-plugin\", \"plugin.json\")))",
       "replace": "    .filter(() => false)",
-      "expectRed": "LIVENESS — the manifest lists every planted plugin",
-      "cell": "LIVENESS — the manifest lists every planted plugin",
-      "note": "The vacuous-pass mutant. Every shape assertion iterates an empty array and passes; only the count cell reds, and it reds first."
+      "expectRed": "LIVENESS \u2014 the manifest lists every planted plugin",
+      "cell": "LIVENESS \u2014 the manifest lists every planted plugin",
+      "note": "The vacuous-pass mutant. Several cells redden on an empty array, so this fixture's claim is specifically that the dedicated count cell is FIRST \u2014 the failure is reported as 'nothing was listed' rather than as a malformed entry."
+    },
+    {
+      "name": "T4 the writer serializes bare names while the builder stays correct",
+      "file": "extensions/connector-claude-code/src/setup.ts",
+      "find": "  writeFileSync(path, JSON.stringify(marketplaceManifest(market), null, 2) + \"\\n\");",
+      "replace": "  writeFileSync(path, JSON.stringify({ ...marketplaceManifest(market), plugins: marketplaceManifest(market).plugins.map((entry) => entry.name) }, null, 2) + \"\\n\");",
+      "expectRed": "the file the writer puts on disk carries the entries the builder produced",
+      "cell": "the file the writer puts on disk carries the entries the builder produced",
+      "note": "The regression the builder cells are blind to by construction: marketplaceManifest keeps returning correct objects, so T1-T3's cells all stay green, and only the cell that reads the file back can see it. This is the gap the review panel named on PR #1416."
     }
   ]
 }

--- a/extensions/connector-claude-code/smoke/mutations/marketplace-manifest.json
+++ b/extensions/connector-claude-code/smoke/mutations/marketplace-manifest.json
@@ -1,0 +1,53 @@
+{
+  "suite": [
+    "extensions/connector-claude-code/smoke/marketplace-manifest.smoke.ts"
+  ],
+  "guard": "the generated marketplace lists every present plugin as an object carrying the source Claude Code resolves against",
+  "command": "pnpm smoke:claude-marketplace",
+  "completionMarker": "marketplace-manifest smoke:",
+  "proveWith": "node scripts/mutation-proof.mjs --config extensions/connector-claude-code/smoke/mutations/marketplace-manifest.json",
+  "why": [
+    "#1392: the manifest listed plugins as bare names. Claude Code VALIDATES that form, so",
+    "`plugin marketplace add` and `update` both report success, and resolution then fails with",
+    "`Plugin \"cotal\" not found in marketplace \"cotal-mesh\"` — a message about a stale local copy.",
+    "So the failure never names the manifest, and re-running setup regenerates it over a hand fix.",
+    "",
+    "The guard is joined, so it gets a mutation per fact. T1 is the reported defect. T2 is the",
+    "near-miss it invites: an object entry is not sufficient, it must carry `source`. T3 is the",
+    "liveness arm — every shape assertion is vacuously satisfied by a builder that emits no",
+    "entries at all, so without it a mutation that lists nothing would come back SURVIVED.",
+    "",
+    "BOUNDARY. The suite grades `marketplaceManifest`, the value `writeMarketplace` serializes, and",
+    "does not spawn `claude`. So a kill shows the manifest's shape is guarded, NOT that Claude Code",
+    "accepts it; that evidence is the reproduction recorded on the issue."
+  ],
+  "mutations": [
+    {
+      "name": "T1 restore the bare-name plugin entries",
+      "file": "extensions/connector-claude-code/src/setup.ts",
+      "find": "  return { name, source: `./${name}`, ...(description ? { description } : {}) };",
+      "replace": "  return name as unknown as { name: string; source: string; description?: string };",
+      "expectRed": "every plugin entry is an object, never a bare name",
+      "cell": "every plugin entry is an object, never a bare name",
+      "note": "Exactly the pre-fix output. The liveness cell above still passes because the count is unchanged, so this cell is the first red."
+    },
+    {
+      "name": "T2 emit an object entry with no source",
+      "file": "extensions/connector-claude-code/src/setup.ts",
+      "find": "  return { name, source: `./${name}`, ...(description ? { description } : {}) };",
+      "replace": "  return { name, ...(description ? { description } : {}) } as { name: string; source: string; description?: string };",
+      "expectRed": "every entry carries the source Claude Code resolves against",
+      "cell": "every entry carries the source Claude Code resolves against",
+      "note": "The near-miss fix. Count and objectness both still pass, so the source cell is the first red."
+    },
+    {
+      "name": "T3 list no plugins at all",
+      "file": "extensions/connector-claude-code/src/setup.ts",
+      "find": "    .filter((name) => existsSync(join(market, name, \".claude-plugin\", \"plugin.json\")))",
+      "replace": "    .filter(() => false)",
+      "expectRed": "LIVENESS — the manifest lists every planted plugin",
+      "cell": "LIVENESS — the manifest lists every planted plugin",
+      "note": "The vacuous-pass mutant. Every shape assertion iterates an empty array and passes; only the count cell reds, and it reds first."
+    }
+  ]
+}

--- a/extensions/connector-claude-code/src/setup.ts
+++ b/extensions/connector-claude-code/src/setup.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { registry, type ConnectorSetupProvider } from "@cotal-ai/core";
 
@@ -100,13 +100,21 @@ export function marketplaceManifest(market: string): {
   return { name: MARKETPLACE, description: "Cotal for Claude Code", owner: { name: "Cotal" }, plugins };
 }
 
+/**
+ * The write half of `writeMarketplace`, split out from the `plugin marketplace add` that follows it
+ * so a suite can grade the bytes that reach disk without spawning `claude`. Returns the path so a
+ * caller reads back the file this wrote rather than one it rebuilt from the same inputs.
+ */
+export function writeMarketplaceManifest(market: string): string {
+  const path = join(market, ".claude-plugin", "marketplace.json");
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(marketplaceManifest(market), null, 2) + "\n");
+  return path;
+}
+
 function writeMarketplace(): void {
   const market = marketplaceDir();
-  mkdirSync(join(market, ".claude-plugin"), { recursive: true });
-  writeFileSync(
-    join(market, ".claude-plugin", "marketplace.json"),
-    JSON.stringify(marketplaceManifest(market), null, 2) + "\n",
-  );
+  writeMarketplaceManifest(market);
   const add = command("plugin", "marketplace", "add", market);
   if (add.status !== 0 && !/already (?:exists|added)/i.test(add.output)) throw new Error(`plugin marketplace add failed:\n${add.output}`);
   if (/already (?:exists|added)/i.test(add.output)) {

--- a/extensions/connector-claude-code/src/setup.ts
+++ b/extensions/connector-claude-code/src/setup.ts
@@ -69,13 +69,43 @@ function command(...args: string[]): { status: number | null; output: string } {
   return { status: result.status, output: `${result.stdout ?? ""}${result.stderr ?? ""}`.trim() };
 }
 
+/**
+ * A marketplace entry is an OBJECT carrying `source`, never a bare name. Claude Code validates the
+ * manifest either way, so the string form passes `plugin marketplace add`/`update` and then fails
+ * at resolution with `Plugin "cotal" not found in marketplace "cotal-mesh"` — a message that points
+ * at a stale local copy rather than at the manifest, so `marketplace update` looks like the remedy
+ * and changes nothing.
+ *
+ * `description` is read from each plugin's own `plugin.json` rather than written here, so the two
+ * files cannot drift into disagreeing about the same plugin.
+ */
+function marketplaceEntry(market: string, name: string): { name: string; source: string; description?: string } {
+  const manifest = JSON.parse(readFileSync(join(market, name, ".claude-plugin", "plugin.json"), "utf8")) as {
+    description?: unknown;
+  };
+  const description = typeof manifest.description === "string" ? manifest.description : undefined;
+  return { name, source: `./${name}`, ...(description ? { description } : {}) };
+}
+
+/** Exported so a suite can grade the manifest that is actually written, not a second copy of it. */
+export function marketplaceManifest(market: string): {
+  name: string;
+  description: string;
+  owner: { name: string };
+  plugins: { name: string; source: string; description?: string }[];
+} {
+  const plugins = ["cotal", "cotal-skills"]
+    .filter((name) => existsSync(join(market, name, ".claude-plugin", "plugin.json")))
+    .map((name) => marketplaceEntry(market, name));
+  return { name: MARKETPLACE, description: "Cotal for Claude Code", owner: { name: "Cotal" }, plugins };
+}
+
 function writeMarketplace(): void {
   const market = marketplaceDir();
-  const plugins = ["cotal", "cotal-skills"].filter((name) => existsSync(join(market, name, ".claude-plugin", "plugin.json")));
   mkdirSync(join(market, ".claude-plugin"), { recursive: true });
   writeFileSync(
     join(market, ".claude-plugin", "marketplace.json"),
-    JSON.stringify({ name: MARKETPLACE, description: "Cotal for Claude Code", owner: { name: "Cotal" }, plugins }, null, 2) + "\n",
+    JSON.stringify(marketplaceManifest(market), null, 2) + "\n",
   );
   const add = command("plugin", "marketplace", "add", market);
   if (add.status !== 0 && !/already (?:exists|added)/i.test(add.output)) throw new Error(`plugin marketplace add failed:\n${add.output}`);

--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
     "smoke:claude-launch-env": "tsx extensions/connector-claude-code/smoke/launch-env.smoke.ts",
     "smoke:claude-persona-file": "pnpm --filter @cotal-ai/connector-claude-code... build && tsx extensions/connector-claude-code/smoke/persona-file.smoke.ts",
     "smoke:claude-events-arm": "tsx extensions/connector-claude-code/smoke/events-arm.smoke.ts",
+    "smoke:claude-marketplace": "pnpm --filter @cotal-ai/connector-claude-code... build && tsx extensions/connector-claude-code/smoke/marketplace-manifest.smoke.ts",
     "smoke:claude-run-error": "tsx extensions/connector-claude-code/smoke/agui-run-error.smoke.ts",
     "smoke:claude-start-source": "tsx extensions/connector-claude-code/smoke/agui-start-source.smoke.ts",
     "smoke:agui-authorship": "tsx extensions/connector-claude-code/smoke/agui-authorship.smoke.ts",


### PR DESCRIPTION
Fixes #1392.

`cotal setup` generated `~/.cotal/claude-plugin/.claude-plugin/marketplace.json` with `plugins` as
an array of bare names. Claude Code validates that form, so `plugin marketplace add` and
`plugin marketplace update` both report success — and resolution then fails with
`Plugin "cotal" not found in marketplace "cotal-mesh"`. The message names a stale local copy, so
the suggested `marketplace update` reads as the remedy and changes nothing. Setup pauses at that
step, so everything after it, persona seeding included, never runs; and because each run
regenerates the manifest, a hand repair does not survive the next `cotal setup`.

Every present plugin is now listed as an object carrying `name`, `source` (the plugin's own
directory, which is where the generated tree already puts it) and the `description` read from that
plugin's `plugin.json`. Taking the description from the plugin's own manifest rather than restating
it here means the two files cannot drift into disagreeing about the same plugin.

`marketplaceManifest` is exported and `writeMarketplace` serializes its return value, so the new
suite grades the manifest that is actually written rather than a second copy of the same shape.

## Reproduced before fixing

Independently confirmed on this machine against the generated manifest, read-only, on Claude Code
**2.1.267** — newer than the 2.1.265 in the report, so the defect is not confined to that version.
`claude plugin list --json` shows both plugins enabled and unresolvable:

```
"cotal@cotal-mesh"         errors: ["Plugin cotal not found in marketplace cotal-mesh"]
"cotal-skills@cotal-mesh"  errors: ["Plugin cotal-skills not found in marketplace cotal-mesh"]
```

Worth noting the report describes one plugin; both entries are affected, and `verify()` fails on a
non-empty `errors` array, which is what pauses setup.

## Coverage

`pnpm smoke:claude-marketplace` — 6 cells. Mutation proof `marketplace-manifest.json`, **3/3
KILLED**, each on its named cell, tree clean after restore:

| mutation | first red |
| --- | --- |
| T1 restore the bare-name entries (the reported defect) | `every plugin entry is an object, never a bare name` |
| T2 emit an object entry with no `source` (the near-miss) | `every entry carries the source Claude Code resolves against` |
| T3 list no plugins at all (vacuous pass) | `LIVENESS — the manifest lists every planted plugin` |
| T4 the writer serializes bare names while the builder stays correct | `the file the writer puts on disk carries the entries the builder produced` |

T4 is the one that earns its place: `marketplaceManifest` keeps returning correct objects under it,
so every builder cell stays green (6 marks of 7) and only the cell that reads the file back reddens.
`writeMarketplace` shells out to `plugin marketplace add` straight after writing, so the write half
is split into `writeMarketplaceManifest(market)` to make it gradable without spawning `claude`.

T3's claim is narrower than an earlier revision of this body said. Only the objectness loop is
vacuous on an empty array; the source, description and omission cells all compare against expected
entries and redden too. What T3 establishes is that the dedicated count cell is the FIRST red, so a
builder listing nothing is reported as a count failure rather than as a malformed entry.

Also green: `smoke:setup-provider-pack` (8 checks) and `setup-provider-absent`,
`smoke:claude-persona-file` (6 cells), `tsc --noEmit` for the connector, and
`extensions/connector-claude-code/smoke/setup-provider.smoke.ts` (2 checks) invoked directly —
there is no `smoke:setup-provider` root script, and an earlier revision of this body implied there
was.

The suite is registered for CI as `bin/smoke/ci-suites.d/91b19ac8585a7d1c0a92100baf9c2f6b86136b240be91b702feedd8d78929e7d.txt`.
`pnpm smoke:gate-inventory`, `pnpm smoke:ci-fragments` and `pnpm check:shard-stability` are green;
the suite count goes 533 to 534 with no pre-existing suite changing shard.

## What this does not prove

The suite grades the manifest's shape and does not spawn `claude`, so it shows the generated
manifest is well-formed, not that Claude Code accepts it. The acceptance evidence is the
reproduction above and the reporter's confirmation that the object form installs immediately.
