### PR TITLE
test(manager,auth,bin): read a broker-refused publish as permission-denied

### DIFF
--- a/bin/smoke/required-arg-seam.smoke.ts
+++ b/bin/smoke/required-arg-seam.smoke.ts
@@ -306,7 +306,10 @@ const SEAMS: Seam[] = [
   // 128/94 -> 133/98: #774 adds one typechecked provisioner re-read before each static reconcile
   // retry, plus four smoke-side connections for the isolated broker acceptance fixture (orphan write,
   // observer, caller, and exact terminal gate inspection). Every site states tls: false.
-  { fn: "standaloneConnectOpts", key: "tls", sites: 133, untypecheckedSites: 98 },
+  // 133/98 -> 134/99: the publish-denial smoke dials a static-auth broker under a class-rail
+  // instrument to prove a refused instance-rail invoke is permission-denied (one smoke-side call,
+  // tls: false).
+  { fn: "standaloneConnectOpts", key: "tls", sites: 134, untypecheckedSites: 99 },
 ];
 
 /**

--- a/implementations/auth/smoke/user-spawn.smoke.ts
+++ b/implementations/auth/smoke/user-spawn.smoke.ts
@@ -743,14 +743,20 @@ try {
       check("user bearer invokes `inspect` over ep (a spawn-set row; describe-bound currency, no epoch stub)",
         ri.reply.ok === true && (ri.reply.data as { name: string }).name === "alpha", ri.reply);
       let refused: string | undefined;
+      let detail = "";
       try {
         const rp = await invokeCommand(epNc, SPACE, svc, "ps", undefined, { deadlineMs: 2500 });
         refused = rp.reply.ok === false ? rp.reply.error?.code : "SERVED-OK";
+        detail = rp.reply.ok === false ? rp.reply.error?.message ?? "" : "";
       } catch (e) {
         refused = e instanceof EpEnvelopeError ? e.code : String(e);
+        detail = e instanceof Error ? e.message : String(e);
       }
-      check("a spawn-scope bearer's `ps` is broker-dropped (manager.read is not in the spawn set - the ep tier boundary holds on a user mesh)",
-        refused === "deadline-exceeded" || refused === "unavailable", refused);
+      // The broker refuses the publish and the caller's connection-status watch names the refused
+      // subject, so the refusal is permission-denied in the broker's words (a handler refusal
+      // would carry the same code without them).
+      check("a spawn-scope bearer's `ps` is refused by the broker (manager.read is not in the spawn set - the ep tier boundary holds on a user mesh)",
+        refused === "permission-denied" && /REFUSED BY THE BROKER/.test(detail), { refused, detail: detail.slice(0, 200) });
     } finally {
       await epNc.drain().catch(() => epNc.close());
     }
@@ -781,10 +787,10 @@ try {
     !missing.timedOut && missing.status !== 0 && /could not resolve "missing"|no agent/i.test(missing.plain), missing);
   const deniedRead = await cliResult(["invoke", "manager", "ps", "--space", SPACE, "--timeout", "1000"]);
   check("the shipped CLI leaves manager.read denied to a spawn-scoped user bearer",
-    !deniedRead.timedOut && deniedRead.status !== 0 && /deadline-exceeded|unavailable/i.test(deniedRead.plain), deniedRead);
+    !deniedRead.timedOut && deniedRead.status !== 0 && /permission-denied: .*REFUSED BY THE BROKER/.test(deniedRead.plain), deniedRead);
   const deniedAdmin = await cliResult(["invoke", "manager", "purge", "--args", "{}", "--space", SPACE, "--timeout", "1000"]);
   check("the shipped CLI leaves manager.admin denied to a spawn-scoped user bearer",
-    !deniedAdmin.timedOut && deniedAdmin.status !== 0 && /deadline-exceeded|unavailable/i.test(deniedAdmin.plain), deniedAdmin);
+    !deniedAdmin.timedOut && deniedAdmin.status !== 0 && /permission-denied: .*REFUSED BY THE BROKER/.test(deniedAdmin.plain), deniedAdmin);
 
   // The mutation proof runs this same fixture with only the native endpoint setup and B1g. It is
   // not a substitute: the full smoke still runs every section below. It keeps the old-guard red
@@ -1077,13 +1083,15 @@ try {
   // bearer is minted no `input` row in either mode, so the publish is broker-denied before the
   // manager sees it. `alpha` rather than `delta` because the sibling stop above took delta.
   // The refusal is asserted BY SHAPE, not just by `ok === false`, because an absence assertion is
-  // the kind that passes for the wrong reason. A broker drop surfaces as `unavailable` or
-  // `deadline-exceeded`: the publish never reached a manager, so nothing answered. Restoring the
-  // grant would not merely change that string, it would make the owner-mode call SUCCEED, since the
-  // own-domain arm admits the sibling. A `permission-denied` would mean the publish was ADMITTED
-  // and the handler refused, which is a weaker property than the one these cells are for.
+  // the kind that passes for the wrong reason. A broker refusal surfaces as `permission-denied`
+  // in the BROKER's words: the caller's connection-status watch sees the publish violation and
+  // names the refused subject, so the publish never reached a manager. Restoring the grant would
+  // not merely change that string, it would make the owner-mode call SUCCEED, since the own-domain
+  // arm admits the sibling. A handler `permission-denied` carries the same code without the
+  // broker's words, and would mean the publish was ADMITTED, which is the weaker property these
+  // cells are not for; the words are what tell the two apart.
   const brokerDropped = (r: EpReply): boolean =>
-    r.ok === false && /unavailable|deadline-exceeded/.test(r.error ?? "");
+    r.ok === false && /^permission-denied: .*REFUSED BY THE BROKER/.test(r.error ?? "");
   // BOTH modes, and the second one has to be forced. The helper derives `owner` for a same-owner
   // target, so without the override the any-mode subject is never published and a claim about it
   // would be untested text sitting next to a green cell.

--- a/implementations/manager/smoke/manager-service-ops.smoke.ts
+++ b/implementations/manager/smoke/manager-service-ops.smoke.ts
@@ -718,17 +718,24 @@ try {
   console.log("9. escalation negative: a spawn-cap-only agent cred is broker-refused on admin-class ep commands");
   {
     const S = await instrument([{ command: "spawn" }]); // spawn only - NO manager.admin capability
+    // A missing publish grant is refused BY THE BROKER: epCall watches the connection for the
+    // violation and names the refused subject, so the refusal is permission-denied carrying the
+    // broker's words. A handler refusal would carry the same code without them, and a dead
+    // responder would be unavailable or the deadline, so the words are what pin the tier.
     let refused: string | undefined;
+    let detail = "";
     try {
       const r = await epCall(S.nc, space, { mode: "one" }, {
         endpoint: MANAGER_ENDPOINT, command: "purge", contract: MANAGER_CONTRACTS.purge, caller: S.caller, args: {},
       }, { deadlineMs: 2500, currentEpoch: async () => 0 });
       refused = r.reply.ok === false ? r.reply.error?.code : "SERVED-OK";
+      detail = r.reply.ok === false ? r.reply.error?.message ?? "" : "";
     } catch (e) {
       refused = e instanceof EpEnvelopeError ? e.code : (e as Error).message;
+      detail = (e as Error).message;
     }
-    check("purge from a spawn-cap-only cred NEVER reaches the handler (no publish grant: dropped by the broker, no reply)",
-      refused === "unavailable" || refused === "deadline-exceeded", refused);
+    check("purge from a spawn-cap-only cred NEVER reaches the handler (no publish grant: refused by the broker, naming the subject)",
+      refused === "permission-denied" && /REFUSED BY THE BROKER/.test(detail), { refused, detail: detail.slice(0, 200) });
     await S.nc.drain().catch(() => S.nc.close());
   }
 
@@ -767,20 +774,23 @@ try {
   console.log("12. any-mode is operator-policy-mintable ONLY: an agent cred's any-mode request never reaches the handler");
   {
     // B holds the spawn set's OWNER-mode despawn row. The ANY-mode form of the SAME command is a
-    // different subject its credential does not carry — the broker drops the publish (default
-    // deny), so the admin path is structurally unreachable from every agent-grade credential.
+    // different subject its credential does not carry, so the broker refuses the publish (default
+    // deny) and the admin path is structurally unreachable from every agent-grade credential.
     let refused: string | undefined;
+    let detail = "";
     try {
       const r = await epCall(B.nc, space, { mode: "one" }, {
         endpoint: MANAGER_ENDPOINT, command: "despawn", contract: MANAGER_CONTRACTS.despawn, caller: B.caller,
         args: { graceful: false }, target: { mode: "any", owner: DEV_OWNER, actor: B.caller.actor, lifecycleUid: B.caller.uid },
       }, { deadlineMs: 2500, currentEpoch: async () => 0 });
       refused = r.reply.ok === false ? r.reply.error?.code : "SERVED-OK";
+      detail = r.reply.ok === false ? r.reply.error?.message ?? "" : "";
     } catch (e) {
       refused = e instanceof EpEnvelopeError ? e.code : (e as Error).message;
+      detail = (e as Error).message;
     }
-    check("a spawn-capable agent publishing the any-mode despawn subject is broker-dropped (no reply, never served)",
-      refused === "unavailable" || refused === "deadline-exceeded", refused);
+    check("a spawn-capable agent publishing the any-mode despawn subject is refused by the broker (permission-denied naming the subject, never served)",
+      refused === "permission-denied" && /REFUSED BY THE BROKER/.test(detail), { refused, detail: detail.slice(0, 200) });
   }
 
   }

--- a/implementations/manager/smoke/seat-input-live.smoke.ts
+++ b/implementations/manager/smoke/seat-input-live.smoke.ts
@@ -352,10 +352,13 @@ try {
   console.log("\n6. the tier boundary is the GRANT: an agent cred's any-mode input never reaches the handler");
   {
     // B holds the OWNER-mode input row. The any-mode form of the same command is a different
-    // subject its credential does not carry, so the broker drops the publish (default deny) and the
-    // admin path is structurally unreachable from every agent-grade credential: exactly the
+    // subject its credential does not carry, so the broker refuses the publish (default deny) and
+    // the admin path is structurally unreachable from every agent-grade credential: exactly the
     // property that lets `input` share `attach`'s row shape without inventing a second tier.
+    // epCall watches the connection for the violation, so the refusal is permission-denied in the
+    // broker's own words naming the subject; a handler refusal carries the code without them.
     let refused: string | undefined;
+    let detail = "";
     try {
       const r = await epCall(B.nc, space, { mode: "one" }, {
         endpoint: MANAGER_ENDPOINT, command: "input", contract: MANAGER_CONTRACTS.input, caller: B.caller,
@@ -363,11 +366,13 @@ try {
         target: { mode: "any", owner: DEV_OWNER, actor: typist.id, lifecycleUid: typist.lifecycleUid },
       }, { deadlineMs: 3_000, currentEpoch: async () => 0 });
       refused = r.reply.ok === false ? r.reply.error?.code : "SERVED-OK";
+      detail = r.reply.ok === false ? r.reply.error?.message ?? "" : "";
     } catch (e) {
       refused = e instanceof EpEnvelopeError ? e.code : (e as Error).message;
+      detail = (e as Error).message;
     }
-    check("a spawn-capable agent publishing the ANY-mode input subject is broker-dropped (no reply, never served)",
-      refused === "unavailable" || refused === "deadline-exceeded", refused);
+    check("a spawn-capable agent publishing the ANY-mode input subject is refused by the broker (permission-denied naming the subject, never served)",
+      refused === "permission-denied" && /REFUSED BY THE BROKER/.test(detail), { refused, detail: detail.slice(0, 200) });
   }
 
   console.log("\n7. a seat that is not running refuses");
@@ -462,6 +467,7 @@ try {
     const S = await instrument([{ command: "inspect" }]); // capabilities: ["spawn"], NO input row
     for (const mode of ["owner", "any"] as const) {
       let refused: string | undefined;
+      let detail = "";
       try {
         const r = await epCall(S.nc, space, { mode: "one" }, {
           endpoint: MANAGER_ENDPOINT, command: "input", contract: MANAGER_CONTRACTS.input, caller: S.caller,
@@ -469,11 +475,13 @@ try {
           target: { mode, owner: DEV_OWNER, actor: typist.id, lifecycleUid: typist.lifecycleUid },
         }, { deadlineMs: 3_000, currentEpoch: async () => 0 });
         refused = r.reply.ok === false ? r.reply.error?.code : "SERVED-OK";
+        detail = r.reply.ok === false ? r.reply.error?.message ?? "" : "";
       } catch (e) {
         refused = e instanceof EpEnvelopeError ? e.code : (e as Error).message;
+        detail = (e as Error).message;
       }
-      check(`a credential holding ONLY the spawn capability is broker-dropped on the ${mode}-mode input subject`,
-        refused === "unavailable" || refused === "deadline-exceeded", { mode, refused });
+      check(`a credential holding ONLY the spawn capability is refused by the broker on the ${mode}-mode input subject (permission-denied naming the subject)`,
+        refused === "permission-denied" && /REFUSED BY THE BROKER/.test(detail), { mode, refused, detail: detail.slice(0, 200) });
     }
     // The control that stops the cell above passing vacuously: the SAME credential class reaches
     // the manager fine on a row it does hold, so the refusals are about the missing input row and


### PR DESCRIPTION
## Scope

Main is red on smoke shards 0, 1 and 2 since #1402 (`ffa150174`). That change makes `epCall` race the connection's publish-violation watch, so a missing publish grant is now `permission-denied` naming the refused subject rather than a deadline or a no-responders answer.

Nine cells still asserted the old silence and went red:

- `manager-service-ops`: the spawn-cap-only purge and the any-mode despawn
- `seat-input-live`: the any-mode input from an agent credential and the owner/any-mode input from a spawn-only instrument
- `user-spawn`: the spawn-scope bearer's `ps`, the two shipped-CLI denials, and the two sibling input cells

They now assert `permission-denied` carrying the broker's own words (`REFUSED BY THE BROKER`), which a handler refusal never carries, so the cells still distinguish a broker drop from an admitted-then-refused call.

The new publish-denial smoke also added one `standaloneConnectOpts` call site under `smoke/`; the required-arg seam golden counts it (133/98 to 134/99) with its ledger line.

## Validation

Reproduced on clean `origin/main` (`ffa150174`) under nats-server 2.12.12: `smoke:seat-input` 23/3, `smoke:user-spawn:live` 111/5, `smoke:required-arg-seam` 251/2, matching the CI shard logs. With this change, on the same broker: `smoke:seat-input` 26/0, `smoke:manager-service-ops` 84/0, `smoke:user-spawn:live` 116/0, `smoke:required-arg-seam` 253/0.

No mutation fixture names any of the renamed cells. Test-only change, no changeset.