### PR TITLE
fix(ci): resolve YAML merge keys in pr-head-gate

### DIFF
--- a/bin/smoke/fixtures/pr-head-gate-fetch.mjs
+++ b/bin/smoke/fixtures/pr-head-gate-fetch.mjs
@@ -1,6 +1,14 @@
 const sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-const workflow = "name: Hidden\non: [push, pull_request] # ordinary YAML comment\n";
-const run = {
+const hidden = "name: Hidden\non: [push, pull_request] # ordinary YAML comment\n";
+const ci = "name: CI\non: [pull_request]\n";
+const mergeKey = `name: Merge
+defaults: &d
+  pull_request:
+on:
+  <<: *d
+  push:
+`;
+const hiddenRun = {
   id: 1,
   name: "Hidden",
   event: "pull_request",
@@ -10,6 +18,17 @@ const run = {
   created_at: "2026-08-30T00:00:00Z",
   pull_requests: [{ number: 1098 }],
 };
+const ciRun = {
+  id: 2,
+  name: "CI",
+  event: "pull_request",
+  head_sha: sha,
+  status: "completed",
+  conclusion: "success",
+  created_at: "2026-09-10T00:00:00Z",
+  pull_requests: [{ number: 1098 }],
+};
+const mergeKeyMode = process.env.PR_HEAD_GATE_FIXTURE === "merge-key";
 
 const json = (value) => new Response(JSON.stringify(value), {
   status: 200,
@@ -20,15 +39,29 @@ globalThis.fetch = async (input, init = {}) => {
   const url = new URL(String(input));
   const accept = new Headers(init.headers).get("accept") ?? "";
   if (url.pathname === "/repos/Cotal-AI/Cotal/pulls/1098") return json({ head: { sha } });
-  if (url.pathname === "/repos/Cotal-AI/Cotal/pulls/1098/files") return json([]);
+  if (url.pathname === "/repos/Cotal-AI/Cotal/pulls/1098/files") {
+    return json(mergeKeyMode ? [{ filename: "package.json" }] : []);
+  }
   if (url.pathname === "/repos/Cotal-AI/Cotal/contents/.github/workflows") {
-    return json([{ type: "file", name: "hidden.yml", path: ".github/workflows/hidden.yml" }]);
+    return json(mergeKeyMode
+      ? [
+        { type: "file", name: "ci.yml", path: ".github/workflows/ci.yml" },
+        { type: "file", name: "merge.yml", path: ".github/workflows/merge.yml" },
+      ]
+      : [{ type: "file", name: "hidden.yml", path: ".github/workflows/hidden.yml" }]);
   }
   if (url.pathname === "/repos/Cotal-AI/Cotal/contents/.github/workflows/hidden.yml" && accept.includes("raw")) {
-    return new Response(workflow, { status: 200 });
+    return new Response(hidden, { status: 200 });
+  }
+  if (url.pathname === "/repos/Cotal-AI/Cotal/contents/.github/workflows/ci.yml" && accept.includes("raw")) {
+    return new Response(ci, { status: 200 });
+  }
+  if (url.pathname === "/repos/Cotal-AI/Cotal/contents/.github/workflows/merge.yml" && accept.includes("raw")) {
+    return new Response(mergeKey, { status: 200 });
   }
   if (url.pathname === "/repos/Cotal-AI/Cotal/actions/runs") {
-    return json({ workflow_runs: process.env.PR_HEAD_GATE_FIXTURE === "missing" ? [] : [run] });
+    if (mergeKeyMode) return json({ workflow_runs: [ciRun] });
+    return json({ workflow_runs: process.env.PR_HEAD_GATE_FIXTURE === "missing" ? [] : [hiddenRun] });
   }
   return new Response(`unexpected fixture request: ${url}`, { status: 500 });
 };

--- a/bin/smoke/mutations/pr-head-gate.json
+++ b/bin/smoke/mutations/pr-head-gate.json
@@ -9,8 +9,9 @@
   "proveWith": "pnpm mutation-proof --config bin/smoke/mutations/pr-head-gate.json",
   "why": [
     "The guard and its smoke are repository tools rather than a published package boundary, so this",
-    "config grades them as a tool. The smoke imports scripts/pr-head-gate.mjs directly, and two cells",
-    "also execute the shipped pnpm pr-head-gate command against deterministic GitHub API responses."
+    "config grades them as a tool. The smoke imports scripts/pr-head-gate.mjs directly, and three cells",
+    "also execute the shipped pnpm pr-head-gate command against deterministic GitHub API responses,",
+    "including a merge-key pull_request declared via YAML <<."
   ],
   "mutations": [
     {
@@ -108,6 +109,14 @@
       "replace": "  const expected = [];",
       "expectRed": "the shipped pr-head-gate command reports the YAML-derived Hidden workflow green",
       "cell": "the shipped pr-head-gate command reports the YAML-derived Hidden workflow green"
+    },
+    {
+      "name": "YAML merge keys hide pull_request again",
+      "file": "scripts/pr-head-gate.mjs",
+      "find": "    uniqueKeys: true,\n    merge: true,",
+      "replace": "    uniqueKeys: true,",
+      "expectRed": "a merge-key on mapping includes pull_request in the expected set and is not green without that run",
+      "cell": "a merge-key on mapping includes pull_request in the expected set and is not green without that run"
     }
   ]
 }

--- a/bin/smoke/mutations/pr-head-gate.json
+++ b/bin/smoke/mutations/pr-head-gate.json
@@ -115,8 +115,8 @@
       "file": "scripts/pr-head-gate.mjs",
       "find": "    uniqueKeys: true,\n    merge: true,",
       "replace": "    uniqueKeys: true,",
-      "expectRed": "a merge-key on mapping includes pull_request in the expected set and is not green without that run",
-      "cell": "a merge-key on mapping includes pull_request in the expected set and is not green without that run"
+      "expectRed": "the shipped pr-head-gate command includes a merge-key pull_request workflow and is not green without its run",
+      "cell": "the shipped pr-head-gate command includes a merge-key pull_request workflow and is not green without its run"
     }
   ]
 }

--- a/bin/smoke/pr-head-gate.smoke.ts
+++ b/bin/smoke/pr-head-gate.smoke.ts
@@ -199,7 +199,7 @@ for (const conclusion of ["neutral", "skipped"]) {
   check(`a ${conclusion} expected workflow is failing, never green`, JSON.stringify(verdict.failing) === '["CI"]' && !verdict.green, verdict);
 }
 
-function shippedCommand(mode: "success" | "missing") {
+function shippedCommand(mode: "success" | "missing" | "merge-key") {
   // The shipped gate reads GitHub credentials (GH_TOKEN/GITHUB_TOKEN/GITHUB_REPOSITORY) and no
   // COTAL_ name at all, so an ambient copy would hand a live credential and broker URL to a child
   // that has no use for either. Strip the prefix.
@@ -229,8 +229,47 @@ check(
   shippedMissing.status === 1 && shippedMissing.stdout.includes("missing: Hidden") && shippedMissing.stdout.includes("verdict: NOT GREEN"),
   `${shippedMissing.stdout}${shippedMissing.stderr}`,
 );
+const shippedMergeKey = shippedCommand("merge-key");
+check(
+  "the shipped pr-head-gate command includes a merge-key pull_request workflow and is not green without its run",
+  shippedMergeKey.status === 1 &&
+    shippedMergeKey.stdout.includes("expected: CI, Merge") &&
+    shippedMergeKey.stdout.includes("missing: Merge") &&
+    shippedMergeKey.stdout.includes("verdict: NOT GREEN"),
+  `${shippedMergeKey.stdout}${shippedMergeKey.stderr}`,
+);
+const mergeKeyWorkflows = {
+  "ci.yml": "name: CI\non: [pull_request]\n",
+  "merge.yml": "name: Merge\ndefaults: &d\n  pull_request:\non:\n  <<: *d\n  push:\n",
+};
+const mergeKeyExpected = expectedPullRequestWorkflows(mergeKeyWorkflows, ["package.json"]);
+check(
+  "a YAML merge-key pull_request is included in the expected set",
+  JSON.stringify(mergeKeyExpected) === '["CI","Merge"]',
+  mergeKeyExpected,
+);
+const mergeKeyHead = classifyPullRequestHead({
+  pr: 1396,
+  headSha: "a".repeat(40),
+  expected: mergeKeyExpected,
+  runs: [{
+    id: 1,
+    name: "CI",
+    event: "pull_request",
+    head_sha: "a".repeat(40),
+    status: "completed",
+    conclusion: "success",
+    created_at: "2026-09-10T00:00:00Z",
+    pull_requests: [{ number: 1396 }],
+  }],
+});
+check(
+  "a missing merge-key pull_request workflow keeps the exact head not green",
+  JSON.stringify(mergeKeyHead.missing) === '["Merge"]' && !mergeKeyHead.green,
+  mergeKeyHead,
+);
 
-const EXPECTED = 34;
+const EXPECTED = 37;
 check(`every cell ran (${EXPECTED} before sentinel)`, passed + failed === EXPECTED);
 console.log(`PR HEAD GATE SMOKE ${failed === 0 ? "OK" : "FAILED"} (${passed} passed, ${failed} failed)`);
 console.log("SUITE COMPLETE");

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,9 +14,10 @@ pnpm pr-head-gate <pull-request-number>
 
 It parses `.github/workflows/*.yml` at the exact head with the repository's YAML parser and derives
 the expected named set, including `pull_request` path filters. Valid YAML forms such as flow event
-lists with trailing comments are handled by the parser rather than a line reader. Invalid YAML and
-invalid path-filter values stop the guard. Empty trigger collections also stop it. A non-empty
-scalar or mapping that names no `pull_request` event is explicitly treated as a non-PR workflow.
+lists with trailing comments and merge keys (`<<`) are handled by the parser rather than a line
+reader. Invalid YAML and invalid path-filter values stop the guard. Empty trigger collections also
+stop it. A non-empty scalar or mapping that names no `pull_request` event is explicitly treated as a
+non-PR workflow.
 It then grades only runs attached to that pull request and head. Its non-green categories are
 distinct:
 

--- a/scripts/pr-head-gate.mjs
+++ b/scripts/pr-head-gate.mjs
@@ -40,6 +40,7 @@ function pullRequestDeclaration(file, text) {
     strict: true,
     stringKeys: true,
     uniqueKeys: true,
+    merge: true,
   });
   const problem = document.errors[0] ?? document.warnings[0];
   if (problem) throw new Error(`${file}: invalid YAML: ${problem.message}`);


### PR DESCRIPTION
## What

`scripts/pr-head-gate.mjs` parsed workflow YAML without the `yaml` package's `merge` option, so a
`pull_request` event composed through a YAML merge key (`<<: *anchor`) was left as a literal `<<`
key. `Object.hasOwn(on, "pull_request")` was then false, the workflow was dropped from the expected
set, and the head could be reported green against a set the gate had quietly shrunk. Parsing
produced zero errors and zero warnings, so the fail-closed guard never fired.

## Evidence

Two workflow documents that mean the same thing to GitHub, given the same runs (only CI ran):

| `on` spelling | expected set | missing | green |
| --- | --- | --- | --- |
| plain mapping | `["CI","Merge"]` | `["Merge"]` | false |
| via merge key (before) | `["CI"]` | `[]` | **true** |
| via merge key (after) | `["CI","Merge"]` | `["Merge"]` | false |

## Scope

`merge: true` on the parse options only. A merge-key `on` now behaves exactly as the equivalent
plain mapping does, in every case.

Deliberately unchanged: `pull_request` still accepts only `paths` and `paths-ignore`, so a
`branches` filter still throws. That throw is pre-existing — plain YAML carrying the same filter
throws identically before and after this change — and is not part of this defect.

Refs #1396
