### PR TITLE
fix(ci): fail closed on YAML merge keys in pr-head-gate

### DIFF
--- a/bin/smoke/fixtures/pr-head-gate-fetch.mjs
+++ b/bin/smoke/fixtures/pr-head-gate-fetch.mjs
@@ -1,6 +1,19 @@
 const sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-const workflow = "name: Hidden\non: [push, pull_request] # ordinary YAML comment\n";
-const run = {
+const hidden = "name: Hidden\non: [push, pull_request] # ordinary YAML comment\n";
+const mergeKey = `name: Merge
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - anchor: &events { pull_request: null }
+    steps: [{run: echo hi}]
+on:
+  <<: *events
+  push:
+`;
+const hiddenRun = {
   id: 1,
   name: "Hidden",
   event: "pull_request",
@@ -10,6 +23,7 @@ const run = {
   created_at: "2026-08-30T00:00:00Z",
   pull_requests: [{ number: 1098 }],
 };
+const mergeKeyMode = process.env.PR_HEAD_GATE_FIXTURE === "merge-key";
 
 const json = (value) => new Response(JSON.stringify(value), {
   status: 200,
@@ -20,15 +34,23 @@ globalThis.fetch = async (input, init = {}) => {
   const url = new URL(String(input));
   const accept = new Headers(init.headers).get("accept") ?? "";
   if (url.pathname === "/repos/Cotal-AI/Cotal/pulls/1098") return json({ head: { sha } });
-  if (url.pathname === "/repos/Cotal-AI/Cotal/pulls/1098/files") return json([]);
+  if (url.pathname === "/repos/Cotal-AI/Cotal/pulls/1098/files") {
+    return json(mergeKeyMode ? [{ filename: "package.json" }] : []);
+  }
   if (url.pathname === "/repos/Cotal-AI/Cotal/contents/.github/workflows") {
-    return json([{ type: "file", name: "hidden.yml", path: ".github/workflows/hidden.yml" }]);
+    return json(mergeKeyMode
+      ? [{ type: "file", name: "merge.yml", path: ".github/workflows/merge.yml" }]
+      : [{ type: "file", name: "hidden.yml", path: ".github/workflows/hidden.yml" }]);
   }
   if (url.pathname === "/repos/Cotal-AI/Cotal/contents/.github/workflows/hidden.yml" && accept.includes("raw")) {
-    return new Response(workflow, { status: 200 });
+    return new Response(hidden, { status: 200 });
+  }
+  if (url.pathname === "/repos/Cotal-AI/Cotal/contents/.github/workflows/merge.yml" && accept.includes("raw")) {
+    return new Response(mergeKey, { status: 200 });
   }
   if (url.pathname === "/repos/Cotal-AI/Cotal/actions/runs") {
-    return json({ workflow_runs: process.env.PR_HEAD_GATE_FIXTURE === "missing" ? [] : [run] });
+    if (mergeKeyMode) return json({ workflow_runs: [] });
+    return json({ workflow_runs: process.env.PR_HEAD_GATE_FIXTURE === "missing" ? [] : [hiddenRun] });
   }
   return new Response(`unexpected fixture request: ${url}`, { status: 500 });
 };

--- a/bin/smoke/mutations/pr-head-gate.json
+++ b/bin/smoke/mutations/pr-head-gate.json
@@ -132,6 +132,14 @@
       "replace": "    if (false) throw new Error(`${file}: unknown pull_request activity type: ${unknown.join(\", \")}`);",
       "expectRed": "an unknown pull_request activity type fails closed",
       "cell": "an unknown pull_request activity type fails closed"
+    },
+    {
+      "name": "YAML merge keys in on are silently ignored",
+      "file": "scripts/pr-head-gate.mjs",
+      "find": "  if (hasMergeKey(on)) throw new Error(`${file}: unsupported YAML merge key in the on mapping`);",
+      "replace": "  if (false) throw new Error(`${file}: unsupported YAML merge key in the on mapping`);",
+      "expectRed": "a merge key supplying the on event name fails closed",
+      "cell": "a merge key supplying the on event name fails closed"
     }
   ]
 }

--- a/bin/smoke/pr-head-gate.smoke.ts
+++ b/bin/smoke/pr-head-gate.smoke.ts
@@ -61,6 +61,47 @@ check(
     "hidden.yml": "name: Hidden\non: [push, pull_request] # ordinary YAML comment\n",
   }, ["package.json"])) === '["Hidden"]',
 );
+check(
+  "YAML anchors without a merge key still declare pull_request",
+  JSON.stringify(expectedPullRequestWorkflows({
+    "alias.yml": "name: Alias\njobs:\n  j:\n    runs-on: ubuntu-latest\n    strategy:\n      matrix:\n        include:\n          - anchor: &events { pull_request: null, push: null }\n    steps: [{run: echo hi}]\non: *events\n",
+  }, ["package.json"])) === '["Alias"]',
+);
+check(
+  "a schema-valid on mapping without a merge key still declares pull_request",
+  JSON.stringify(expectedPullRequestWorkflows({
+    "literal.yml": "name: Literal\njobs:\n  j:\n    runs-on: ubuntu-latest\n    steps: [{run: echo hi}]\non:\n  pull_request:\n  push:\n",
+  }, ["package.json"])) === '["Literal"]',
+);
+for (const [label, source] of [
+  [
+    "a merge key supplying the on event name fails closed",
+    "name: Merge\njobs:\n  j:\n    runs-on: ubuntu-latest\n    strategy:\n      matrix:\n        include:\n          - anchor: &events { pull_request: null }\n    steps: [{run: echo hi}]\non:\n  <<: *events\n  push:\n",
+  ],
+  [
+    "a merge key nested inside an on event config fails closed",
+    "name: Nested\njobs:\n  j:\n    runs-on: ubuntu-latest\n    strategy:\n      matrix:\n        include:\n          - anchor: &paths { paths: [\"src/**\"] }\n    steps: [{run: echo hi}]\non:\n  pull_request:\n    branches: [main]\n    <<: *paths\n",
+  ],
+] as const) {
+  let refused = false;
+  try { expectedPullRequestWorkflows({ "merge.yml": source }, ["package.json"]); }
+  catch (error) { refused = /unsupported YAML merge key in the on mapping/.test(String(error)); }
+  check(label, refused);
+}
+{
+  let refused = false;
+  let message = "";
+  try {
+    expectedPullRequestWorkflows({
+      "both.yml": "name: Both\njobs:\n  j:\n    runs-on: ubuntu-latest\n    strategy:\n      matrix:\n        include:\n          - anchor: &events { pull_request: { types: [opened] } }\n    steps: [{run: echo hi}]\non:\n  <<: *events\n  push:\n",
+    }, ["package.json"]);
+  } catch (error) {
+    message = String(error);
+    refused = /unsupported YAML merge key in the on mapping/.test(message) &&
+      !/types must keep opened and synchronize/.test(message);
+  }
+  check("a merge key and a types filter that drops synchronize report only the merge-key refusal", refused, message);
+}
 let invalidYamlRefused = false;
 try {
   expectedPullRequestWorkflows({
@@ -221,7 +262,7 @@ for (const conclusion of ["neutral", "skipped"]) {
   check(`a ${conclusion} expected workflow is failing, never green`, JSON.stringify(verdict.failing) === '["CI"]' && !verdict.green, verdict);
 }
 
-function shippedCommand(mode: "success" | "missing") {
+function shippedCommand(mode: "success" | "missing" | "merge-key") {
   // The shipped gate reads GitHub credentials (GH_TOKEN/GITHUB_TOKEN/GITHUB_REPOSITORY) and no
   // COTAL_ name at all, so an ambient copy would hand a live credential and broker URL to a child
   // that has no use for either. Strip the prefix.
@@ -251,8 +292,14 @@ check(
   shippedMissing.status === 1 && shippedMissing.stdout.includes("missing: Hidden") && shippedMissing.stdout.includes("verdict: NOT GREEN"),
   `${shippedMissing.stdout}${shippedMissing.stderr}`,
 );
+const shippedMergeKey = shippedCommand("merge-key");
+check(
+  "the shipped pr-head-gate command refuses a YAML merge key in on instead of shrinking the expected set",
+  shippedMergeKey.status === 2 && /unsupported YAML merge key in the on mapping/.test(`${shippedMergeKey.stdout}${shippedMergeKey.stderr}`),
+  `${shippedMergeKey.stdout}${shippedMergeKey.stderr}`,
+);
 
-const EXPECTED = 39;
+const EXPECTED = 45;
 check(`every cell ran (${EXPECTED} before sentinel)`, passed + failed === EXPECTED);
 console.log(`PR HEAD GATE SMOKE ${failed === 0 ? "OK" : "FAILED"} (${passed} passed, ${failed} failed)`);
 console.log("SUITE COMPLETE");

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,9 +14,10 @@ pnpm pr-head-gate <pull-request-number>
 
 It parses `.github/workflows/*.yml` at the exact head with the repository's YAML parser and derives
 the expected named set, including `pull_request` path filters. Valid YAML forms such as flow event
-lists with trailing comments are handled by the parser rather than a line reader. Invalid YAML and
-invalid path-filter values stop the guard. Empty trigger collections also stop it. A non-empty
-scalar or mapping that names no `pull_request` event is explicitly treated as a non-PR workflow.
+lists with trailing comments are handled by the parser rather than a line reader. Invalid YAML,
+invalid path-filter values, and a YAML merge key (`<<`) in `on` stop the guard. Empty trigger
+collections also stop it. A non-empty scalar or mapping that names no `pull_request` event is
+explicitly treated as a non-PR workflow.
 It then grades only runs attached to that pull request and head. Its non-green categories are
 distinct:
 

--- a/scripts/pr-head-gate.mjs
+++ b/scripts/pr-head-gate.mjs
@@ -27,6 +27,13 @@ const PULL_REQUEST_ACTIVITY_TYPES = new Set([
   "milestoned", "demilestoned",
 ]);
 
+function hasMergeKey(value) {
+  if (Array.isArray(value)) return value.some(hasMergeKey);
+  if (!plainObject(value)) return false;
+  if (Object.hasOwn(value, "<<")) return true;
+  return Object.values(value).some(hasMergeKey);
+}
+
 function pullRequestConfig(file, on) {
   if (typeof on === "string") {
     if (on.length === 0) throw new Error(`${file}: top-level on event must not be empty`);
@@ -38,6 +45,9 @@ function pullRequestConfig(file, on) {
     return on.includes("pull_request") ? null : undefined;
   }
   if (!plainObject(on)) throw new Error(`${file}: top-level on declaration must name one or more events`);
+  // GitHub never expands <<, so the rest of on is unevaluable. Refuse the merge key
+  // first and skip later checks such as types, rather than reporting both.
+  if (hasMergeKey(on)) throw new Error(`${file}: unsupported YAML merge key in the on mapping`);
   const events = Object.keys(on);
   if (events.length === 0) throw new Error(`${file}: top-level on mapping must not be empty`);
   return Object.hasOwn(on, "pull_request") ? on.pull_request : undefined;


### PR DESCRIPTION
## What

`scripts/pr-head-gate.mjs` now refuses a workflow whose top-level `on` mapping carries a literal
YAML merge key (`<<`), instead of silently dropping the event it could not evaluate.

GitHub Actions does not support YAML merge keys. Anchors (`&`) and aliases (`*`) shipped in
September 2025; merge keys are a YAML 1.1 type absent from YAML 1.2 and were deliberately excluded,
confirmed by a repository collaborator in `actions/runner#1182` on 2025-08-04. A workflow using one
is therefore never registered and never runs.

So the guard must not resolve the merge key either — doing so would make it expect a workflow that
can never produce a run, leaving the head permanently not-green. The failure this closes is the
narrower and real one: the guard could silently shrink its expected event set on a workflow it
could not evaluate. A form the guard cannot judge is now refused rather than dropped.

This joins an existing class in the same file, which already fails closed on invalid workflow YAML,
an empty `on` sequence, an unevaluable `pull_request` filter, and unsupported glob syntax.

## The real delta — please grade this, not the headline

Only the **top-level** form is a new refusal. The **nested** form (`<<` inside an event config)
**already threw before this change**, via the unsupported-filter path:

| input | before | after |
| --- | --- | --- |
| `on: { <<: *events, push: }` | silently dropped the event | **throws** (new) |
| `on: { pull_request: { <<: *f } }` | `unsupported pull_request filter: <<` | `unsupported YAML merge key in the on mapping` (clearer message only) |

No new coverage is claimed for the nested form. It is a message improvement on an existing refusal.

## Regression controls

Anchors and aliases *are* supported by GitHub and must keep working. Two cells guard that:
`on: *events` still declares `pull_request`, and a schema-valid literal `on` mapping still does.

## Verification

`pnpm smoke:pr-head-gate` — 40 passed, 0 failed (35 before). `pnpm mutation-proof --config
bin/smoke/mutations/pr-head-gate.json` — 13/13 killed; the mutation disabling the throw reddens
`a merge key supplying the on event name fails closed` first, at 37 marks against a 40 baseline.
One cell drives the shipped `pnpm pr-head-gate` command so a real entry point reaches the change.

Test fixtures use a schema-valid anchor carrier. An earlier draft used a `defaults:` block holding
`pull_request:`, which is independently invalid workflow syntax and would have made the cells
unable to attribute their result to the merge key.

## Known limits

**Coverage of the replaced behaviour was audited in this repository only.** A search for cells
asserting the old silent-shrink behaviour returned zero, and the surface is bounded: only
`bin/smoke/pr-head-gate.smoke.ts` imports `expectedPullRequestWorkflows` or
`classifyPullRequestHead`, so no other in-repo suite can assert it. That bound does not extend
outside this repository — a consumer elsewhere that relies on the guard silently omitting a
workflow it cannot evaluate would not be visible here, and this has not been searched for. Stated
as a limit, not as a risk that has been retired.

The repository's own workflows were checked separately: none of the seven files under
`.github/workflows/` carries a YAML merge key, so this change refuses none of them. (The
`<<'EOF'` in `ci.yml` is a heredoc inside a `run:` block, not a merge key.)

Supersedes the approach in #1438, which resolved the merge key rather than refusing it.

Refs #1396



## CI note

`live` was red on this head at run 34491677562 (job 102919724124) and green on re-run (attempt 2, job 103020582894). The two attempts were verified to grade the same work: identical suite roster and the same 57-cell opencode cooperative-stop total, with the single failing cell as the entire differential between them.

The failure is recorded in comment 5624409231 and the re-run outcome in comment 5624538586. It is deliberately not characterised as a flake — one event, no identified mechanism, no off-branch instance. Nothing in this PR addresses that cell, and nothing here is claimed to.


## This change is an instance of its own subject

The gate exists to stop a workflow declaring a check that will never be minted. This branch is currently blocked by exactly that failure in the live repository: it conflicts with main, so no merge ref regenerates; the workflow that would mint a now-required check is therefore absent from every ref this head is graded against; and the check can never appear, so the gate can never be satisfied. A gate that expects a run which cannot exist does not fail loudly — it waits forever.
