### PR TITLE
ci: give Mutation reproof and Docs the CI concurrency policy

### DIFF
--- a/.changeset/reproof-docs-concurrency.md
+++ b/.changeset/reproof-docs-concurrency.md
@@ -1,0 +1,6 @@
+---
+---
+
+Give the Mutation reproof and Docs workflows the same concurrency policy as CI: a new push to a pull
+request supersedes the run already going for it, a merge to main queues instead of evicting. Without
+a group every pushed head kept its own 12-shard reproof matrix queued against the org's 20-job cap.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,13 @@ on:
   release:
     types: [published]
 
+# A new push to a PR supersedes the preview build already running for it; main and release builds
+# queue behind each other, because a deploy result is the record for that commit.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  queue: ${{ github.event_name == 'pull_request' && 'single' || 'max' }}
+
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/mutation-reproof.yml
+++ b/.github/workflows/mutation-reproof.yml
@@ -8,6 +8,17 @@ on:
     - cron: '17 5 * * *'
   workflow_dispatch:
 
+# Same policy as ci.yml: a new push to a PR supersedes the reproof already running for that PR; a
+# merge to main queues behind the previous main run instead of evicting it. Without this block every
+# PR head kept its own 12-shard matrix queued, so a PR pushed three times held 36 shard jobs of the
+# org's 20-job concurrency cap, and on 2026-09-10 the queue reached 151 jobs with 24 of them for heads
+# their PRs no longer had.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # `queue: max` with `cancel-in-progress: true` is a validation error, so this tracks the line above.
+  queue: ${{ github.event_name == 'pull_request' && 'single' || 'max' }}
+
 jobs:
   changed_shard:
     # At dfbb4550f, PR #1350 selected 32 fixtures and exhausted the 145-minute serial step.

--- a/bin/smoke/workflow-concurrency.smoke.ts
+++ b/bin/smoke/workflow-concurrency.smoke.ts
@@ -68,19 +68,15 @@ function check(name: string, cond: boolean, extra?: unknown): void {
  *  group was considered and deliberately not added here. */
 const EXPECTED_WORKFLOWS = 7;
 const EXPECTED_PUSH_TO_MAIN = 6;
-/** Of those, the ones that declare a concurrency group and therefore CAN evict. `docs.yml` pushes
- *  to main with no group at all, so its runs are independent and there is nothing to queue. That is
- *  a valid answer to this problem, not an omission, and counting it separately keeps the difference
- *  visible instead of letting a future removal of a group look like compliance.
- *
- *  `mutation-reproof.yml` is also groupless, on purpose: its scheduled full sweep runs daily (cron
- *  `17 5 * * *`) under a 360-minute cap, so a scheduled run cannot overlap the next one, and its
- *  lightweight push/PR `changed` job wants ordinary per-ref eviction, not queueing. The one residual
- *  overlap — a manual `workflow_dispatch` sweep alongside a scheduled one — is rare and intentional.
- *  A job-scoped `full` group (queue, not evict) would be the tidy belt-and-braces answer, but adding
- *  it edits a file under `.github/workflows/` and is folded into #1292 with the triage step, which
- *  needs a credential with the `workflow` OAuth scope this lane lacks. */
-const EXPECTED_GROUPED = 4;
+/** Of those, the ones that declare a concurrency group and therefore CAN evict. Every push-to-main
+ *  workflow carries one now: `docs.yml` and `mutation-reproof.yml` were groupless until 2026-09-10,
+ *  when every pushed pull-request head kept its own 12-shard reproof matrix and its own docs build
+ *  queued against the org's 20 concurrent-job cap. Both now use the CI policy: a pull-request push
+ *  supersedes the run already going for that ref, a merge to main queues (`queue: max`) instead of
+ *  evicting, which the checks below hold them to. The scheduled reproof sweep keys its group on
+ *  `refs/heads/main` like a merge, so a sweep and a merge queue behind each other rather than
+ *  running side by side; a manual `workflow_dispatch` sweep joins the same queue. */
+const EXPECTED_GROUPED = 6;
 
 /** What a concurrency key can be: absent, a literal, or one of the expressions this repo uses.
  *  `unknown` is deliberately terminal. */


### PR DESCRIPTION
## Problem

`mutation-reproof.yml` and `docs.yml` have no `concurrency` block. Every push to a pull request therefore leaves the previous head's run queued: a 12-shard reproof matrix per head, plus a docs build. `ci.yml` and `windows.yml` already supersede on pull_request and queue on main.

Measured 2026-09-10 12:19Z with the org on the 20-concurrent-job plan: 20 jobs running, 151 queued, of which 24 belonged to heads their PRs no longer carried. Ubuntu jobs waited 9 minutes on average and up to 29 minutes to start over the preceding two hours.

## Change

Both workflows get the block `ci.yml` carries, verbatim in policy: group by workflow and ref, `cancel-in-progress` only on `pull_request`, `queue: max` on main so a merge keeps its own verdict instead of being evicted.

Empty changeset (CI-only).

## Not verified here

A workflow file change takes effect on the next run that reads it from the target ref, so this PR's own reproof run does not exercise the new block. The first PR pushed twice after merge is the proof: its first reproof run should read `cancelled` with the second one running.