### PR TITLE
ci: run Linux x64 jobs on Tenki runners

### DIFF
--- a/.changeset/tenki-linux-runners.md
+++ b/.changeset/tenki-linux-runners.md
@@ -1,0 +1,5 @@
+---
+---
+
+Run the Linux x64 jobs of CI, Mutation reproof, Docs and the Windows gate on Tenki runners
+(`tenki-standard-medium-4c-8g`). Windows and arm64 jobs stay on GitHub-hosted runners.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ concurrency:
   # above: a PR keeps the default single slot and supersedes, main queues instead of evicting.
   queue: ${{ github.event_name == 'pull_request' && 'single' || 'max' }}
 
+# Linux x64 jobs run on Tenki (the org's runner provider; the Tenki GitHub App is installed on
+# Cotal-AI). `tenki-standard-medium-4c-8g` matches GitHub's ubuntu-latest core count at half the RAM;
+# if a smoke or reproof shard starts failing on memory, step that job to `tenki-standard-large-8c-16g`.
+# Windows and arm64 stay on GitHub-hosted runners: Tenki offers neither. Before this, every Linux job
+# shared the org's 20-concurrent-job cap with Windows and arm64, and on 2026-09-10 the queue reached
+# 151 jobs with ubuntu jobs waiting up to 29 minutes to start.
 # Same coverage as before, fanned across parallel jobs so wall-clock is the slowest job, not the sum:
 #   • unit  — typecheck + build + unit tests + the broker-free view/pack checks (fast).
 #   • smoke — the protocol/security suite (smoke:ci), round-robin sharded across runners by
@@ -35,7 +41,7 @@ concurrency:
 jobs:
   unit:
     timeout-minutes: 20
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     steps:
       - uses: actions/checkout@v6
         with:
@@ -100,7 +106,7 @@ jobs:
     # cancelled healthy runs (#1220 died at 40m18s). Sized at ~1.5x the slowest observed
     # success, which absorbs runner variance and lets the corpus grow before this binds again.
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     strategy:
       fail-fast: false
       matrix:
@@ -154,7 +160,7 @@ jobs:
 
   live:
     timeout-minutes: 25
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6.0.8
@@ -232,7 +238,7 @@ jobs:
   seat-native-linux-x64:
     name: seat native (linux-x64)
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6.0.8
@@ -275,7 +281,7 @@ jobs:
     name: seat pack (assembled)
     timeout-minutes: 20
     needs: [seat-native-linux-x64, seat-native-linux-arm64]
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6.0.8
@@ -391,7 +397,7 @@ jobs:
     name: ci-ok (live outcome classified)
     if: always()
     needs: [unit, smoke, live, seat-pack, seat-linux-arm64]
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   docs:
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/mutation-reproof.yml
+++ b/.github/workflows/mutation-reproof.yml
@@ -15,7 +15,7 @@ jobs:
     # checkouts because mutation-proof temporarily changes source and compiled artifacts.
     if: github.event_name != 'schedule'
     timeout-minutes: 150
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     strategy:
       fail-fast: false
       matrix:
@@ -77,7 +77,7 @@ jobs:
   changed:
     if: github.event_name != 'schedule' && always()
     needs: [changed_shard]
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     steps:
       - name: Gate
         env:
@@ -91,7 +91,7 @@ jobs:
     # request pay for all 1,714 mutations. It is manually runnable after an infrastructure repair.
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 360
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -189,7 +189,7 @@ jobs:
     # dependency here — listing it would keep gating on it even while it is continue-on-error.
     if: always()
     needs: [required]
-    runs-on: ubuntu-latest
+    runs-on: tenki-standard-medium-4c-8g
     steps:
       - name: Gate
         run: |

--- a/bin/smoke/shard-stability.ts
+++ b/bin/smoke/shard-stability.ts
@@ -297,7 +297,7 @@ const verifierMatches = (sha: string): boolean => {
       stdio: ["ignore", "pipe", "pipe"],
     });
     const actual = createHash("sha256").update(source).digest("hex");
-    return actual === "117791a37fdaf0e0bb453546621ae3a2051fc85114ace53c3f28f7384ec5292f";
+    return actual === "e6f6302f1a432b2eebe170fecc7dbf712c2c7545d1893ba01524318df9213bc6";
   } catch {
     return false;
   }

--- a/bin/smoke/verify-shard-inputs.sh
+++ b/bin/smoke/verify-shard-inputs.sh
@@ -60,6 +60,7 @@ if [ "$#" -eq 10 ]; then
 else
   node_bin="$(command -v node || true)"
   pnpm_bin="$(command -v pnpm || true)"
+  runner_home="${HOME:-/home/runner}"
 fi
 
 if [ ! -x "$node_bin" ] || [ ! -x "$pnpm_bin" ]; then
@@ -72,9 +73,18 @@ if [ "$#" -eq 10 ]; then
     /opt/hostedtoolcache/node/22.*/*/bin/node) ;;
     *) echo "unexpected CI node path: $node_bin" >&2; exit 2 ;;
   esac
+  # pnpm/action-setup installs under the runner user's home. GitHub-hosted runners run as `runner`,
+  # Tenki runners as `tenki`; the shape below is what both produce, and the home is read back out of
+  # the matched path rather than assumed, so the clean environment further down names the home the
+  # toolchain actually lives in.
   case "$pnpm_bin" in
-    /home/runner/setup-pnpm/node_modules/.bin*/pnpm) ;;
+    /home/*/setup-pnpm/node_modules/.bin*/pnpm) ;;
     *) echo "unexpected CI pnpm path: $pnpm_bin" >&2; exit 2 ;;
+  esac
+  runner_home="${pnpm_bin%/setup-pnpm/*}"
+  case "$runner_home" in
+    /home/runner|/home/tenki) ;;
+    *) echo "unexpected CI runner home: $runner_home" >&2; exit 2 ;;
   esac
   actual_node_target="$(/usr/bin/readlink -f "$node_bin")"
   actual_pnpm_target="$(/usr/bin/readlink -f "$pnpm_bin")"
@@ -93,13 +103,14 @@ fi
 node_dir="${node_bin%/*}"
 pnpm_dir="${pnpm_bin%/*}"
 workspace="$(/bin/pwd -P)"
-clean_path="$pnpm_dir:$node_dir:/home/runner/nats-bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+runner_user="${runner_home##*/}"
+clean_path="$pnpm_dir:$node_dir:$runner_home/nats-bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
 exec /usr/bin/env -i \
   PATH="$clean_path" \
-  HOME=/home/runner \
-  USER=runner \
-  LOGNAME=runner \
+  HOME="$runner_home" \
+  USER="$runner_user" \
+  LOGNAME="$runner_user" \
   SHELL=/usr/bin/bash \
   TMPDIR=/tmp \
   TMP=/tmp \


### PR DESCRIPTION
## Problem

The org is on GitHub's 20-concurrent-job cap, shared by Cotal and foreman and by every OS. Measured 2026-09-10 12:19Z: 20 jobs running, 151 queued; ubuntu jobs waited 9 minutes on average and 29 at most over the preceding two hours. Each PR push costs about 30 jobs, 28 of them Linux x64.

## Change

The Tenki GitHub App is installed on Cotal-AI. Every `runs-on: ubuntu-latest` in `ci.yml`, `mutation-reproof.yml`, `docs.yml` and `windows.yml` becomes `tenki-standard-medium-4c-8g`: the same core count as GitHub's `ubuntu-latest`, half the RAM (8 GB vs 16 GB). Tenki runs the official `actions/runner-images` Ubuntu 24.04 image, so toolchains, `sudo apt-get` and `actions/cache` are unchanged.

Left on GitHub, deliberately:

- `windows-latest` and `ubuntu-24.04-arm` jobs: Tenki has no Windows or arm64 runners.
- `installer.yml`: its lint job runs Docker, which Tenki's docs do not mention.
- `changesets.yml` and `github-releases-to-discord.yml`: publishing paths, rare, not the bottleneck.

Empty changeset (CI-only).

## Proof

This PR's own `pull_request` runs execute the workflow files at its head, so the CI, Mutation reproof, Docs and Windows runs on this PR are the first jobs to target the Tenki labels. A job that stays `queued` with no runner is, per Tenki's troubleshooting page, a label or a plan-capacity problem; a job that starts is the proof.

## Not verified here

- Memory: the heaviest smoke and reproof shards have not been run on 8 GB before this PR's own run. If a shard fails on memory, the job steps to `tenki-standard-large-8c-16g`.
- Plan concurrency: the Tenki workspace's concurrent-session limit is not visible from the repo. If it is below 20, this change would make the queue worse, and the PR's own fan-out (12 reproof shards + 6 CI jobs) will show it.