### PR TITLE
ci(reproof): fan out only the shards that hold a selected fixture

### DIFF
--- a/.changeset/reproof-plan-shards.md
+++ b/.changeset/reproof-plan-shards.md
@@ -1,0 +1,8 @@
+---
+---
+
+The Mutation reproof workflow now plans its fan-out: one small job runs the selector and names the
+shards that hold a selected fixture, and only those shards are fanned. On 2026-09-10, 107 of 228
+shard jobs installed and built the tree and then reported no fixtures assigned to them, 173
+job-minutes of setup against a 20-job concurrency cap. An empty plan skips the fan-out and the gate
+passes only when the plan itself succeeded; a failed plan is unmeasured and fails the gate.

--- a/.github/workflows/mutation-reproof.yml
+++ b/.github/workflows/mutation-reproof.yml
@@ -9,17 +9,58 @@ on:
   workflow_dispatch:
 
 jobs:
+  plan:
+    # One checkout runs the selector and names the shards that hold a selected fixture. Before this
+    # job every push fanned all 12 shards; on 2026-09-10, 107 of 228 shard jobs installed and built
+    # the tree and then printed "No selected mutation fixtures are assigned to shard N", 173
+    # job-minutes of setup against the org's 20 concurrent jobs. The plan uses the same selector,
+    # the same UNMEASURED refusals and the same dangling check as a shard run, so a shard that is
+    # not fanned is one the selector would have emptied. No install and no build: selection reads
+    # git and fixture JSON only.
+    if: github.event_name != 'schedule'
+    timeout-minutes: 10
+    runs-on: tenki-standard-small-2c-4g
+    outputs:
+      shards: ${{ steps.plan.outputs.shards }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - name: Plan the fan-out
+        id: plan
+        env:
+          BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          set -euo pipefail
+          base="$BASE"
+          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+            base="$(git rev-parse HEAD~1)" || { echo "no base commit or first parent"; exit 2; }
+            echo "no base commit on this event; using first parent $base"
+          fi
+          out="$(node scripts/mutation-reproof.mjs --base "$base" --head "$(git rev-parse HEAD)" --list-shards 12)"
+          printf '%s\n' "$out"
+          # The plan's last line is the JSON. A selector refusal exits non-zero above and fails this
+          # job, which fails the gate: an unmeasured selection must not read as an empty fan-out.
+          shards="$(printf '%s\n' "$out" | tail -n 1 | node -e 'const p=JSON.parse(require("fs").readFileSync(0,"utf8"));if(!Array.isArray(p.shards))process.exit(3);console.log(JSON.stringify(p.shards))')"
+          echo "shards=$shards" >> "$GITHUB_OUTPUT"
+
   changed_shard:
     # At dfbb4550f, PR #1350 selected 32 fixtures and exhausted the 145-minute serial step.
     # Each path is assigned to one shard by the runner's existing hash. Shards use separate
     # checkouts because mutation-proof temporarily changes source and compiled artifacts.
-    if: github.event_name != 'schedule'
+    # Only the shards the plan named are fanned; the shard run re-selects for itself, so a shard
+    # that disagrees with the plan prints its own selection rather than trusting the plan's.
+    if: github.event_name != 'schedule' && needs.plan.outputs.shards != '[]'
+    needs: [plan]
     timeout-minutes: 150
     runs-on: tenki-standard-medium-4c-8g
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+        shard: ${{ fromJSON(needs.plan.outputs.shards) }}
     name: changed shard ${{ matrix.shard }}/12
     steps:
       - uses: actions/checkout@v6
@@ -76,15 +117,23 @@ jobs:
 
   changed:
     if: github.event_name != 'schedule' && always()
-    needs: [changed_shard]
+    needs: [plan, changed_shard]
     runs-on: tenki-standard-medium-4c-8g
     steps:
       - name: Gate
         env:
+          PLAN_RESULT: ${{ needs.plan.result }}
+          PLAN_SHARDS: ${{ needs.plan.outputs.shards }}
           SHARD_RESULT: ${{ needs.changed_shard.result }}
         run: |
-          echo "changed_shard=$SHARD_RESULT"
-          test "$SHARD_RESULT" = success
+          set -euo pipefail
+          echo "plan=$PLAN_RESULT shards=$PLAN_SHARDS changed_shard=$SHARD_RESULT"
+          # A failed plan is UNMEASURED and fails the gate. An empty plan skips the fan-out, and the
+          # skipped matrix reads `skipped`, which passes only when the plan itself succeeded and
+          # said `[]`; a skipped fan-out for any other reason is a failure. `set -e` is explicit so
+          # the first test is a gate under any shell, not only under the runner's default `-e`.
+          test "$PLAN_RESULT" = success
+          if [ "$PLAN_SHARDS" = "[]" ]; then test "$SHARD_RESULT" = skipped; else test "$SHARD_RESULT" = success; fi
 
   full:
     # A daily sweep keeps the remaining ambient-drift window bounded without making every pull

--- a/bin/smoke/mutation-reproof.smoke.ts
+++ b/bin/smoke/mutation-reproof.smoke.ts
@@ -190,38 +190,70 @@ try {
   process.env.COTAL_REPROOF_SENTINEL = "synthetic-session-secret";
   const shards = Array.from({ length: 12 }, (_, i) => i);
   const workflow = parse(readFileSync(join(ROOT, ".github/workflows/mutation-reproof.yml"), "utf8"));
+  const plan = workflow.jobs.plan;
   const job = workflow.jobs.changed_shard;
   const aggregate = workflow.jobs.changed;
+  const planStep = plan?.steps.find((step: { id?: string }) => step.id === "plan");
   const reprove = job?.steps.find((step: { name?: string }) => step.name === "Re-prove fixtures for changed guarded sources");
+  // The plan job runs the selector once and names the shards to fan; the matrix is its output, so a
+  // shard the selector would empty is never started. A plan that hardcodes the list, or a matrix
+  // that ignores the plan, silently restores the 12-way fan-out this job exists to avoid.
   check(
-    "the changed workload runs every configured shard without fail-fast cancellation",
-    JSON.stringify(job?.strategy?.matrix?.shard) === JSON.stringify(shards)
-      && job?.strategy?.["fail-fast"] === false
-      && job?.if === "github.event_name != 'schedule'"
-      && reprove?.["continue-on-error"] !== true
-      && job?.["continue-on-error"] !== true
-      && reprove?.run.includes('--shard "${{ matrix.shard }}/12"'),
+    "the plan job runs the selector over the same shard count and publishes the fan-out",
+    plan?.if === "github.event_name != 'schedule'"
+      && plan?.outputs?.shards === "${{ steps.plan.outputs.shards }}"
+      && typeof planStep?.run === "string"
+      && planStep.run.includes(`--list-shards ${shards.length}`)
+      && planStep.run.includes('echo "shards=$shards" >> "$GITHUB_OUTPUT"')
+      && !plan.steps.some((step: { run?: string }) => typeof step.run === "string" && /pnpm (install|build)/.test(step.run)),
   );
   check(
-    "the aggregate changed check waits for all shards even after a failed or cancelled shard",
+    "the changed workload fans exactly the planned shards without fail-fast cancellation",
+    job?.strategy?.matrix?.shard === "${{ fromJSON(needs.plan.outputs.shards) }}"
+      && job?.strategy?.["fail-fast"] === false
+      && job?.if === "github.event_name != 'schedule' && needs.plan.outputs.shards != '[]'"
+      && JSON.stringify(job?.needs) === JSON.stringify(["plan"])
+      && reprove?.["continue-on-error"] !== true
+      && job?.["continue-on-error"] !== true
+      && reprove?.run.includes(`--shard "\${{ matrix.shard }}/${shards.length}"`),
+  );
+  check(
+    "the aggregate changed check waits for the plan and every shard even after a failed or cancelled shard",
     aggregate?.if === "github.event_name != 'schedule' && always()"
-      && JSON.stringify(aggregate.needs) === JSON.stringify(["changed_shard"])
+      && JSON.stringify(aggregate.needs) === JSON.stringify(["plan", "changed_shard"])
       && aggregate["continue-on-error"] !== true,
   );
   const gate = aggregate?.steps.find((step: { name?: string }) => step.name === "Gate");
   let aggregateEnvClean = true;
-  for (const result of ["success", "failure", "cancelled", "skipped"]) {
+  // The gate reads three facts: whether the plan ran, what it planned, and what the matrix did.
+  // A skipped matrix passes only behind a successful, empty plan; every other skip, and every
+  // failed or cancelled matrix, and every failed plan, is a red gate.
+  const gateCases: Array<[string, string, string, boolean]> = [
+    ["success", "[0,3]", "success", true],
+    ["success", "[0,3]", "failure", false],
+    ["success", "[0,3]", "cancelled", false],
+    ["success", "[0,3]", "skipped", false],
+    ["success", "[]", "skipped", true],
+    ["success", "[]", "success", false],
+    ["failure", "[0,3]", "success", false],
+    ["failure", "[]", "skipped", false],
+    ["cancelled", "[0,3]", "skipped", false],
+    ["skipped", "", "skipped", false],
+  ];
+  for (const [planResult, planShards, result, accepts] of gateCases) {
     const command = `if [ "\${COTAL_REPROOF_SENTINEL+x}" ]; then echo SESSION_LEAK; fi\n${gate?.run}`;
     const run = typeof gate?.run === "string" ? spawnSync("bash", ["-c", command], {
-      encoding: "utf8", env: { ...childEnv(), SHARD_RESULT: result },
+      encoding: "utf8", env: { ...childEnv(), PLAN_RESULT: planResult, PLAN_SHARDS: planShards, SHARD_RESULT: result },
     }) : undefined;
     const status = run?.status ?? null;
     aggregateEnvClean &&= run !== undefined && !run.stdout.includes("SESSION_LEAK");
     check(
-      `the aggregate shell ${result === "success" ? "accepts" : "rejects"} shard result ${result}`,
-      gate?.env?.SHARD_RESULT === "${{ needs.changed_shard.result }}"
+      `the aggregate shell ${accepts ? "accepts" : "rejects"} plan=${planResult} shards=${planShards || "(unset)"} matrix=${result}`,
+      gate?.env?.PLAN_RESULT === "${{ needs.plan.result }}"
+        && gate?.env?.PLAN_SHARDS === "${{ needs.plan.outputs.shards }}"
+        && gate?.env?.SHARD_RESULT === "${{ needs.changed_shard.result }}"
         && gate?.["continue-on-error"] !== true
-        && status !== null && (result === "success" ? status === 0 : status !== 0),
+        && status !== null && (accepts ? status === 0 : status !== 0),
       `status=${status}`,
     );
   }

--- a/bin/smoke/mutations/mutation-reproof-shards.json
+++ b/bin/smoke/mutations/mutation-reproof-shards.json
@@ -28,64 +28,64 @@
       "file": ".github/workflows/mutation-reproof.yml",
       "find": " --shard \"${{ matrix.shard }}/12\"",
       "replace": "",
-      "expectRed": "the changed workload runs every configured shard without fail-fast cancellation",
-      "cell": "the changed workload runs every configured shard without fail-fast cancellation"
+      "expectRed": "the changed workload fans exactly the planned shards without fail-fast cancellation",
+      "cell": "the changed workload fans exactly the planned shards without fail-fast cancellation"
     },
     {
-      "name": "one configured shard is missing",
+      "name": "the matrix is hardcoded instead of read from the plan",
       "file": ".github/workflows/mutation-reproof.yml",
-      "find": "        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]",
-      "replace": "        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]",
-      "expectRed": "the changed workload runs every configured shard without fail-fast cancellation",
-      "cell": "the changed workload runs every configured shard without fail-fast cancellation"
+      "find": "        shard: ${{ fromJSON(needs.plan.outputs.shards) }}",
+      "replace": "        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]",
+      "expectRed": "the changed workload fans exactly the planned shards without fail-fast cancellation",
+      "cell": "the changed workload fans exactly the planned shards without fail-fast cancellation"
     },
     {
       "name": "a failed shard cancels its sibling work",
       "file": ".github/workflows/mutation-reproof.yml",
       "find": "      fail-fast: false",
       "replace": "      fail-fast: true",
-      "expectRed": "the changed workload runs every configured shard without fail-fast cancellation",
-      "cell": "the changed workload runs every configured shard without fail-fast cancellation"
+      "expectRed": "the changed workload fans exactly the planned shards without fail-fast cancellation",
+      "cell": "the changed workload fans exactly the planned shards without fail-fast cancellation"
     },
     {
       "name": "the aggregate is skipped after a shard fails",
       "file": ".github/workflows/mutation-reproof.yml",
       "find": "    if: github.event_name != 'schedule' && always()",
       "replace": "    if: github.event_name != 'schedule'",
-      "expectRed": "the aggregate changed check waits for all shards even after a failed or cancelled shard",
-      "cell": "the aggregate changed check waits for all shards even after a failed or cancelled shard"
+      "expectRed": "the aggregate changed check waits for the plan and every shard even after a failed or cancelled shard",
+      "cell": "the aggregate changed check waits for the plan and every shard even after a failed or cancelled shard"
     },
     {
       "name": "the aggregate no longer waits on the matrix",
       "file": ".github/workflows/mutation-reproof.yml",
-      "find": "    needs: [changed_shard]",
-      "replace": "    needs: []",
-      "expectRed": "the aggregate changed check waits for all shards even after a failed or cancelled shard",
-      "cell": "the aggregate changed check waits for all shards even after a failed or cancelled shard"
+      "find": "    needs: [plan, changed_shard]",
+      "replace": "    needs: [plan]",
+      "expectRed": "the aggregate changed check waits for the plan and every shard even after a failed or cancelled shard",
+      "cell": "the aggregate changed check waits for the plan and every shard even after a failed or cancelled shard"
     },
     {
       "name": "the aggregate accepts failed shards",
       "file": ".github/workflows/mutation-reproof.yml",
-      "find": "          test \"$SHARD_RESULT\" = success",
+      "find": "          if [ \"$PLAN_SHARDS\" = \"[]\" ]; then test \"$SHARD_RESULT\" = skipped; else test \"$SHARD_RESULT\" = success; fi",
       "replace": "          true",
-      "expectRed": "the aggregate shell rejects shard result failure",
-      "cell": "the aggregate shell rejects shard result failure"
+      "expectRed": "the aggregate shell rejects plan=success shards=[0,3] matrix=failure",
+      "cell": "the aggregate shell rejects plan=success shards=[0,3] matrix=failure"
     },
     {
       "name": "the aggregate accepts cancellation",
       "file": ".github/workflows/mutation-reproof.yml",
-      "find": "          test \"$SHARD_RESULT\" = success",
-      "replace": "          test \"$SHARD_RESULT\" != failure",
-      "expectRed": "the aggregate shell rejects shard result cancelled",
-      "cell": "the aggregate shell rejects shard result cancelled"
+      "find": "          if [ \"$PLAN_SHARDS\" = \"[]\" ]; then test \"$SHARD_RESULT\" = skipped; else test \"$SHARD_RESULT\" = success; fi",
+      "replace": "          if [ \"$PLAN_SHARDS\" = \"[]\" ]; then test \"$SHARD_RESULT\" = skipped; else test \"$SHARD_RESULT\" != failure; fi",
+      "expectRed": "the aggregate shell rejects plan=success shards=[0,3] matrix=cancelled",
+      "cell": "the aggregate shell rejects plan=success shards=[0,3] matrix=cancelled"
     },
     {
       "name": "the aggregate accepts a skipped shard set",
       "file": ".github/workflows/mutation-reproof.yml",
-      "find": "          test \"$SHARD_RESULT\" = success",
+      "find": "          if [ \"$PLAN_SHARDS\" = \"[]\" ]; then test \"$SHARD_RESULT\" = skipped; else test \"$SHARD_RESULT\" = success; fi",
       "replace": "          test \"$SHARD_RESULT\" = success || test \"$SHARD_RESULT\" = skipped",
-      "expectRed": "the aggregate shell rejects shard result skipped",
-      "cell": "the aggregate shell rejects shard result skipped"
+      "expectRed": "the aggregate shell rejects plan=success shards=[0,3] matrix=skipped",
+      "cell": "the aggregate shell rejects plan=success shards=[0,3] matrix=skipped"
     },
     {
       "name": "the common smoke child environment keeps Cotal session variables",
@@ -114,8 +114,8 @@
     {
       "name": "aggregate probes bypass the sanitized child environment",
       "file": "bin/smoke/mutation-reproof.smoke.ts",
-      "find": "env: { ...childEnv(), SHARD_RESULT: result }",
-      "replace": "env: { ...process.env, SHARD_RESULT: result }",
+      "find": "env: { ...childEnv(), PLAN_RESULT: planResult, PLAN_SHARDS: planShards, SHARD_RESULT: result }",
+      "replace": "env: { ...process.env, PLAN_RESULT: planResult, PLAN_SHARDS: planShards, SHARD_RESULT: result }",
       "expectRed": "aggregate probes do not inherit Cotal session credentials",
       "cell": "aggregate probes do not inherit Cotal session credentials"
     },
@@ -126,6 +126,54 @@
       "replace": "  console.log(false && shard\n",
       "expectRed": "an empty shard reports its own assignment without claiming a globally empty diff",
       "cell": "an empty shard reports its own assignment without claiming a globally empty diff"
+    },
+    {
+      "name": "the aggregate accepts a failed plan",
+      "file": ".github/workflows/mutation-reproof.yml",
+      "find": "          test \"$PLAN_RESULT\" = success\n",
+      "replace": "",
+      "cell": "the aggregate shell rejects plan=failure shards=[0,3] matrix=success",
+      "expectRed": "the aggregate shell rejects plan=failure shards=[0,3] matrix=success"
+    },
+    {
+      "name": "the aggregate accepts a successful fan-out behind an empty plan",
+      "file": ".github/workflows/mutation-reproof.yml",
+      "find": "          if [ \"$PLAN_SHARDS\" = \"[]\" ]; then test \"$SHARD_RESULT\" = skipped; else test \"$SHARD_RESULT\" = success; fi",
+      "replace": "          if [ \"$PLAN_SHARDS\" = \"[]\" ]; then true; else test \"$SHARD_RESULT\" = success; fi",
+      "cell": "the aggregate shell rejects plan=success shards=[] matrix=success",
+      "expectRed": "the aggregate shell rejects plan=success shards=[] matrix=success"
+    },
+    {
+      "name": "the fan-out no longer waits on the plan",
+      "file": ".github/workflows/mutation-reproof.yml",
+      "find": "    if: github.event_name != 'schedule' && needs.plan.outputs.shards != '[]'\n    needs: [plan]\n",
+      "replace": "    if: github.event_name != 'schedule'\n",
+      "cell": "the changed workload fans exactly the planned shards without fail-fast cancellation",
+      "expectRed": "the changed workload fans exactly the planned shards without fail-fast cancellation"
+    },
+    {
+      "name": "the plan installs before selecting",
+      "file": ".github/workflows/mutation-reproof.yml",
+      "find": "          out=\"$(node scripts/mutation-reproof.mjs --base \"$base\" --head \"$(git rev-parse HEAD)\" --list-shards 12)\"",
+      "replace": "          pnpm install --frozen-lockfile\n          out=\"$(node scripts/mutation-reproof.mjs --base \"$base\" --head \"$(git rev-parse HEAD)\" --list-shards 12)\"",
+      "cell": "the plan job runs the selector over the same shard count and publishes the fan-out",
+      "expectRed": "the plan job runs the selector over the same shard count and publishes the fan-out"
+    },
+    {
+      "name": "the plan asks for a different shard count than the fan-out uses",
+      "file": ".github/workflows/mutation-reproof.yml",
+      "find": "--list-shards 12)",
+      "replace": "--list-shards 6)",
+      "cell": "the plan job runs the selector over the same shard count and publishes the fan-out",
+      "expectRed": "the plan job runs the selector over the same shard count and publishes the fan-out"
+    },
+    {
+      "name": "the gate no longer stops at the first failed test",
+      "file": ".github/workflows/mutation-reproof.yml",
+      "find": "          set -euo pipefail\n          echo \"plan=$PLAN_RESULT",
+      "replace": "          echo \"plan=$PLAN_RESULT",
+      "cell": "the aggregate shell rejects plan=failure shards=[0,3] matrix=success",
+      "expectRed": "the aggregate shell rejects plan=failure shards=[0,3] matrix=success"
     }
   ]
 }

--- a/scripts/mutation-reproof.mjs
+++ b/scripts/mutation-reproof.mjs
@@ -37,13 +37,13 @@ const COMMAND_TIMEOUT_MS = 900_000;
 
 function usage(message) {
   if (message) console.error(message);
-  console.error("usage: node scripts/mutation-reproof.mjs --base <commit> [--head <commit>] [--root <dir>] [--all] [--shard <index>/<count>]");
+  console.error("usage: node scripts/mutation-reproof.mjs --base <commit> [--head <commit>] [--root <dir>] [--all] [--shard <index>/<count> | --list-shards <count>]");
   process.exit(2);
 }
 
 function args(argv) {
   const out = {};
-  const known = new Set(["base", "head", "root", "all", "shard"]);
+  const known = new Set(["base", "head", "root", "all", "shard", "list-shards"]);
   for (let i = 0; i < argv.length; i++) {
     if (!argv[i].startsWith("--")) usage(`unexpected argument: ${argv[i]}`);
     const key = argv[i].slice(2);
@@ -173,6 +173,10 @@ if (!a.all && !a.base) usage("--base is required unless --all is set");
 const shard = a.shard === undefined ? undefined : a.shard.match(/^(\d+)\/(\d+)$/);
 if (a.shard !== undefined && (!shard || Number(shard[2]) < 1 || Number(shard[1]) >= Number(shard[2])))
   usage(`invalid --shard ${a.shard}; use <index>/<count>`);
+const listShards = a["list-shards"] === undefined ? undefined : Number(a["list-shards"]);
+if (listShards !== undefined && (!Number.isInteger(listShards) || listShards < 1))
+  usage(`invalid --list-shards ${a["list-shards"]}; use a shard count of at least 1`);
+if (listShards !== undefined && shard) usage("--list-shards and --shard are exclusive: one plans the fan-out, the other runs one shard of it");
 
 if (!a.all) {
   try {
@@ -256,6 +260,18 @@ if (dangling.length) {
   console.error(`mutation reproof: UNMEASURED — ${dangling.length} dangling fixture(s); a guarded source was deleted or renamed away and the proof is unrunnable:`);
   for (const { path, missing } of dangling) console.error(`  ${path} -> missing: ${missing.join(", ")}`);
   process.exit(1);
+}
+
+// The plan: which shards of a fan-out would hold at least one selected fixture. Runs the same
+// selector, the same UNMEASURED refusals and the same dangling check as a shard run, so a plan that
+// prints is a plan whose selection a shard would also have made; only the proof is skipped. The last
+// line is the JSON a workflow reads; an empty list is printed, not turned into exit 0 with no output,
+// so a caller that fans out on it can tell "nothing to prove" from "nothing was said".
+if (listShards !== undefined) {
+  const shards = [...new Set(selected.map(({ path }) => shardOf(path, listShards)))].sort((x, y) => x - y);
+  console.log(`shard plan: ${shards.length} of ${listShards} shard(s) hold a selected fixture${shards.length ? `: ${shards.join(", ")}` : ""}`);
+  console.log(JSON.stringify({ shards }));
+  process.exit(0);
 }
 
 // A zero after filtering means either no diff match or no assignment to this shard.


### PR DESCRIPTION
## What

The Mutation reproof workflow plans its fan-out before it fans out. A new `plan` job (checkout and node only, no install, no build, small Tenki runner) runs the selector once via `scripts/mutation-reproof.mjs --list-shards 12` and emits the set of shards that hold at least one selected fixture. Only those shards are fanned; the matrix is `fromJSON` of the plan's output.

`--list-shards <count>` is exclusive with `--shard`. It runs the same selector, the same UNMEASURED refusals and the same dangling check as a shard run, then prints a human line and a JSON object as the last line. An empty set prints `[]`, never silence, so a caller can tell nothing-to-prove from nothing-was-said.

The `changed` gate requires the plan to have succeeded and accepts a skipped matrix only when the plan said `[]`. A failed plan is unmeasured and fails the gate. Each fanned shard still re-selects for itself, so a shard that disagrees with the plan prints its own selection.

## Why

Every push to a pull request fanned all 12 shards, and each shard checked out, installed and built before running the selector. On 2026-09-10, 107 of 228 shard jobs then reported that no selected fixture was assigned to them: 173 job-minutes of setup queued against the org's 20 concurrent-job cap, ahead of work with something to prove.

## Verification

- The workflow's own reproof fixture (`bin/smoke/mutations/mutation-reproof-shards.json`) caught this change on the first CI run: five mutations anchored on the matrix literal, the `needs` list and the `SHARD_RESULT` test that the plan job replaced. Re-anchored, plus six new mutations for the plan job (hardcoded matrix, fan-out that no longer waits on the plan, plan that installs before selecting, plan shard count diverging from the fan-out, gate accepting a failed plan, gate accepting a successful fan-out behind an empty plan, gate losing `set -e`). Full proof at 82fa8f11c: 21 of 21 KILLED, each red naming its cell.
- `bin/smoke/mutation-reproof.smoke.ts` now drives the gate shell over ten (plan result, planned shards, matrix result) cases instead of four matrix results; 95 of 95 cells green at this head.

- At 7c221ac71 on `ffa150174..7c221ac71`: the plan names shards 0, 1, 4 to 11 (10 of 12) for 20 selected fixtures. An independent replication of the shard hash over the same 20 paths gives the same set, with per-shard counts matching the shard runs checked (0=2, 1=3, 2=0, 3=0).
- A docs-only commit on top of main plans `[]`; a shard run on the same range selects 0 fixtures.
- Rebased onto 1c32566fc (Tenki runners): the plan job runs on the small Tenki runner, the shards on the medium one. The workflow-concurrency smoke passes on the rebased tree.
- Merges cleanly with the open concurrency-policy change to the same file.

## Not changed

The scheduled full sweep is untouched. The plan job is gated off the schedule event like the fan-out it replaces.

Empty changeset: CI only, no package change.
