### PR TITLE
fix(manager): declare MAX_AGENTS once and share it with the resume schema

### DIFF
--- a/.changeset/manager-max-agents-single-source.md
+++ b/.changeset/manager-max-agents-single-source.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/manager": patch
+---
+
+`MAX_AGENTS` is declared once, exported from `resume.ts`, and imported by `manager.ts`. The two private copies (spawn/resume capacity checks and the resume inventory schema's array cap) could drift apart silently: raising the ceiling in `manager.ts` left resume inventories refused above 50 with a zod length error that never mentioned capacity.

--- a/.changeset/manager-max-agents-single-source.md
+++ b/.changeset/manager-max-agents-single-source.md
@@ -2,4 +2,4 @@
 "@cotal-ai/manager": patch
 ---
 
-`MAX_AGENTS` is declared once, exported from `resume.ts`, and imported by `manager.ts`. The two private copies (spawn/resume capacity checks and the resume inventory schema's array cap) could drift apart silently: raising the ceiling in `manager.ts` left resume inventories refused above 50 with a zod length error that never mentioned capacity.
+`MAX_AGENTS` is declared once, exported from `resume.ts`, and imported by `manager.ts`. The two private copies (spawn/resume capacity checks and the resume inventory schema's array cap) could drift apart silently: raising the ceiling in `manager.ts` left resume inventories refused above 50 with a zod length error that never mentioned capacity. A derived smoke walks the production manager source tree and proves there is exactly one definition and that both consumers acquire it.

--- a/bin/smoke/ci-suites.d/fda9beda8a9901333aa2837f9698e1632ce7eea3d3534cd9dcea128c5f8068b1.txt
+++ b/bin/smoke/ci-suites.d/fda9beda8a9901333aa2837f9698e1632ce7eea3d3534cd9dcea128c5f8068b1.txt
@@ -1,0 +1,2 @@
+# One production MAX_AGENTS definition, acquired by manager capacity and the resume schema.
+smoke:max-agents-single-source

--- a/implementations/manager/smoke/max-agents-single-source.smoke.ts
+++ b/implementations/manager/smoke/max-agents-single-source.smoke.ts
@@ -1,0 +1,202 @@
+/**
+ * MAX_AGENTS has one production meaning: the manager's live+in-flight+cooling ceiling
+ * and the resume inventory schema's array cap. Those used to be two private copies that
+ * failed with different error classes (#1462). This suite proves the shipped source still
+ * has one definition and that both consumers acquire that definition.
+ *
+ * WHAT THIS DISCOVERS, rather than names. It walks `implementations/manager/src` and
+ * parses every `.ts` file with the TypeScript compiler API. Definitions are
+ * `VariableDeclaration`s whose binding is `MAX_AGENTS`. Acquisition is a value-level
+ * named import of that binding whose specifier resolves to the defining file, or a use
+ * of the binding in the defining file. A hand-enumerated pair of filenames is not the
+ * universe: a third `const MAX_AGENTS` in any other production file in that tree is a
+ * finding, and a consumer that stops importing the definition is a finding even if the
+ * two well-known files still exist.
+ *
+ * WHAT IT CANNOT SEE, said first:
+ *   - Runtime copies (a number written into a message, a rebuilt dist). This is a
+ *     source-acquisition proof.
+ *   - A namespace import (`import * as resume` then `resume.MAX_AGENTS`). Named import
+ *     is the acquisition this tree uses; a shift to namespace import fails the import
+ *     cell rather than being silently accepted.
+ *   - Comments, strings, and type-only imports. Those are not value acquisition.
+ *
+ * Run: pnpm smoke:max-agents-single-source
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const repo = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const srcRoot = join(repo, "implementations", "manager", "src");
+const skipDirs = new Set(["dist", "smoke", "test", "tests", "fixtures", "node_modules"]);
+
+let ok = 0;
+let fail = 0;
+const check = (label: string, cond: boolean, detail?: unknown): void => {
+  if (cond) {
+    ok++;
+    console.log(`  ✓ ${label}`);
+  } else {
+    fail++;
+    console.log(`  ✗ FAIL: ${label}`, detail ?? "");
+  }
+};
+
+function* walk(path: string): Generator<string> {
+  const stat = statSync(path);
+  if (stat.isFile()) {
+    if (path.endsWith(".ts") && !path.endsWith(".d.ts")) yield path;
+    return;
+  }
+  for (const entry of readdirSync(path, { withFileTypes: true })) {
+    if (entry.name.startsWith(".") || skipDirs.has(entry.name)) continue;
+    const child = join(path, entry.name);
+    if (entry.isDirectory()) yield* walk(child);
+    else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts")) yield child;
+  }
+}
+
+type Definition = { file: string; exported: boolean; numeric: boolean };
+type NamedImport = { file: string; from: string; typeOnly: boolean };
+
+const definitions: Definition[] = [];
+const namedImports: NamedImport[] = [];
+const schemaCapFiles: string[] = [];
+const importedUseFiles: string[] = [];
+const localUseFiles: string[] = [];
+const unboundUses: Array<{ file: string; text: string }> = [];
+
+function isMaxAgentsIdentifier(node: ts.Node): node is ts.Identifier {
+  return ts.isIdentifier(node) && node.text === "MAX_AGENTS";
+}
+
+function exportedVariable(node: ts.VariableDeclaration): boolean {
+  const statement = node.parent?.parent;
+  return !!statement && ts.isVariableStatement(statement)
+    && statement.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword) === true;
+}
+
+function resolveSpecifier(fromFile: string, spec: string): string | null {
+  if (!spec.startsWith(".")) return null;
+  const resolved = resolve(dirname(fromFile), spec);
+  return resolved.endsWith(".js") ? `${resolved.slice(0, -3)}.ts`
+    : resolved.endsWith(".ts") ? resolved
+    : `${resolved}.ts`;
+}
+
+function isBindingSite(node: ts.Identifier): boolean {
+  const parent = node.parent;
+  if (!parent) return false;
+  if (ts.isVariableDeclaration(parent) && parent.name === node) return true;
+  if (ts.isImportSpecifier(parent) && (parent.name === node || parent.propertyName === node)) return true;
+  return false;
+}
+
+function isSchemaCapArgument(node: ts.Identifier): boolean {
+  const parent = node.parent;
+  if (!parent || !ts.isCallExpression(parent) || parent.arguments[0] !== node) return false;
+  return ts.isPropertyAccessExpression(parent.expression) && parent.expression.name.text === "max";
+}
+
+const files = [...walk(srcRoot)];
+for (const file of files) {
+  const text = readFileSync(file, "utf8");
+  const source = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  let defines = false;
+  let valueImport = false;
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isVariableDeclaration(node) && isMaxAgentsIdentifier(node.name)) {
+      defines = true;
+      definitions.push({
+        file,
+        exported: exportedVariable(node),
+        numeric: !!node.initializer && ts.isNumericLiteral(node.initializer),
+      });
+    }
+    if (ts.isImportDeclaration(node) && node.importClause && ts.isStringLiteral(node.moduleSpecifier)) {
+      const named = node.importClause.namedBindings;
+      if (named && ts.isNamedImports(named)) {
+        for (const el of named.elements) {
+          const imported = el.propertyName ?? el.name;
+          if (isMaxAgentsIdentifier(imported) || isMaxAgentsIdentifier(el.name)) {
+            const typeOnly = node.importClause.isTypeOnly || el.isTypeOnly;
+            if (!typeOnly) valueImport = true;
+            namedImports.push({ file, from: node.moduleSpecifier.text, typeOnly });
+          }
+        }
+      }
+    }
+    if (isMaxAgentsIdentifier(node) && !isBindingSite(node)) {
+      if (isSchemaCapArgument(node)) schemaCapFiles.push(file);
+      if (defines) localUseFiles.push(file);
+      else if (valueImport) importedUseFiles.push(file);
+      else unboundUses.push({ file, text: node.parent?.getText().slice(0, 80) ?? node.getText() });
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+}
+
+const rel = (file: string): string => relative(repo, file);
+const unique = (xs: string[]): string[] => [...new Set(xs)];
+const definition = definitions[0];
+const valueImports = namedImports.filter((row) => !row.typeOnly);
+const importsOfDefinition = valueImports.filter((row) => definition !== undefined && resolveSpecifier(row.file, row.from) === definition.file);
+const schemaCaps = unique(schemaCapFiles);
+const acquiringSchemaCaps = schemaCaps.filter((file) =>
+  (definition !== undefined && file === definition.file) || importsOfDefinition.some((row) => row.file === file),
+);
+
+console.log("\n── discovery ──");
+check(
+  `production manager src walk found files (floor 20, found ${files.length})`,
+  files.length >= 20,
+  { files: files.length, root: rel(srcRoot) },
+);
+
+console.log("\n── one definition ──");
+check(
+  "exactly one production MAX_AGENTS VariableDeclaration",
+  definitions.length === 1,
+  definitions.map((d) => ({ file: rel(d.file), exported: d.exported, numeric: d.numeric })),
+);
+check("the single MAX_AGENTS definition is exported", !!definition && definition.exported, definition && rel(definition.file));
+check("the single MAX_AGENTS definition is a numeric literal", !!definition && definition.numeric, definition);
+
+console.log("\n── both consumers acquire it ──");
+check(
+  "a value import of MAX_AGENTS resolves to the definition",
+  importsOfDefinition.length >= 1,
+  { imports: valueImports.map((row) => ({ file: rel(row.file), from: row.from, resolved: resolveSpecifier(row.file, row.from) })) },
+);
+check(
+  "every value import of MAX_AGENTS resolves to that same definition",
+  valueImports.length > 0 && importsOfDefinition.length === valueImports.length,
+  { extra: valueImports.filter((row) => !importsOfDefinition.includes(row)).map((row) => rel(row.file)) },
+);
+check(
+  "the imported binding is used (manager capacity path)",
+  unique(importedUseFiles).length >= 1,
+  unique(importedUseFiles).map(rel),
+);
+check(
+  "the defining file uses its local MAX_AGENTS binding",
+  !!definition && unique(localUseFiles).includes(definition.file),
+  unique(localUseFiles).map(rel),
+);
+check(
+  "an acquiring file caps the resume inventory array with MAX_AGENTS",
+  acquiringSchemaCaps.length >= 1,
+  { schemaCaps: schemaCaps.map(rel), acquiring: acquiringSchemaCaps.map(rel) },
+);
+check(
+  "no production file uses MAX_AGENTS without defining or importing it",
+  unboundUses.length === 0,
+  unboundUses.map((row) => ({ file: rel(row.file), text: row.text })),
+);
+
+console.log(`\nMAX-AGENTS SINGLE-SOURCE SMOKE ${fail === 0 ? "OK ✅" : "FAILED ❌"}  (${ok} passed, ${fail} failed; scanned ${files.length} files)`);
+if (fail > 0) process.exitCode = 1;

--- a/implementations/manager/smoke/mutations/max-agents-single-source.json
+++ b/implementations/manager/smoke/mutations/max-agents-single-source.json
@@ -1,0 +1,52 @@
+{
+  "suite": [
+    "implementations/manager/smoke/max-agents-single-source.smoke.ts"
+  ],
+  "guard": "production MAX_AGENTS is one exported numeric definition; manager imports that binding and the resume schema caps agents with it",
+  "command": "pnpm smoke:max-agents-single-source",
+  "completionMarker": "MAX-AGENTS SINGLE-SOURCE SMOKE",
+  "proveWith": "pnpm mutation-proof -- --config implementations/manager/smoke/mutations/max-agents-single-source.json",
+  "why": [
+    "The defect is a second private copy, not a wrong number. The suite therefore walks the",
+    "production manager src tree and counts VariableDeclarations named MAX_AGENTS, then",
+    "checks that both consumers acquire that one binding. A filename list would stay green",
+    "if a third file grew its own copy."
+  ],
+  "mutations": [
+    {
+      "name": "a second production MAX_AGENTS definition appears outside the known pair",
+      "file": "implementations/manager/src/launch.ts",
+      "find": "const TOKEN = /^[A-Za-z0-9_-]+$/;\n",
+      "replace": "const TOKEN = /^[A-Za-z0-9_-]+$/;\nconst MAX_AGENTS = 50;\n",
+      "expectRed": "exactly one production MAX_AGENTS VariableDeclaration",
+      "cell": "exactly one production MAX_AGENTS VariableDeclaration",
+      "note": "A third file is the case a two-name detector cannot see."
+    },
+    {
+      "name": "manager stops importing MAX_AGENTS from the defining module",
+      "file": "implementations/manager/src/manager.ts",
+      "find": "import { MAX_AGENTS, parseResumeCommitArgs, parseResumeControlArgs, parseResumeFinalizeArgs } from \"./resume.js\";\n",
+      "replace": "import { parseResumeCommitArgs, parseResumeControlArgs, parseResumeFinalizeArgs } from \"./resume.js\";\n",
+      "expectRed": "a value import of MAX_AGENTS resolves to the definition",
+      "cell": "a value import of MAX_AGENTS resolves to the definition",
+      "note": "Capacity checks can keep using the identifier; without the import they no longer acquire the definition."
+    },
+    {
+      "name": "resume schema recaps the array with a literal instead of the shared binding",
+      "file": "implementations/manager/src/resume.ts",
+      "find": "  agents: z.array(agent).max(MAX_AGENTS),\n",
+      "replace": "  agents: z.array(agent).max(50),\n",
+      "expectRed": "an acquiring file caps the resume inventory array with MAX_AGENTS",
+      "cell": "an acquiring file caps the resume inventory array with MAX_AGENTS",
+      "note": "The definition can remain exported while the schema consumer silently forks."
+    },
+    {
+      "name": "the single definition is no longer exported",
+      "file": "implementations/manager/src/resume.ts",
+      "find": "export const MAX_AGENTS = 50;\n",
+      "replace": "const MAX_AGENTS = 50;\n",
+      "expectRed": "the single MAX_AGENTS definition is exported",
+      "cell": "the single MAX_AGENTS definition is exported"
+    }
+  ]
+}

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -73,7 +73,7 @@ import { authorizeLaunch, authorizeNamedControl } from "./authorize.js";
 import { controlShutdown } from "./control-shutdown.js";
 import { RunHosting } from "./run-hosting.js";
 import { controlSession } from "./control-session.js";
-import { parseResumeCommitArgs, parseResumeControlArgs, parseResumeFinalizeArgs } from "./resume.js";
+import { MAX_AGENTS, parseResumeCommitArgs, parseResumeControlArgs, parseResumeFinalizeArgs } from "./resume.js";
 // Unit B (the static §13.1 lifecycle executor): the shared grammar/stores from core plus the
 // manager-side adapter (transport + slot orchestration + the F1 terminal) — see static-lifecycle.ts.
 import { jetstream, jetstreamManager } from "@nats-io/jetstream";
@@ -179,9 +179,6 @@ import {
   STATIC_SLOT_READ_FAILED_DETAIL,
 } from "./static-lifecycle.js";
 
-/** Concurrency ceiling — the manager refuses to hold more than this many live + in-flight +
- *  cooling slots at once (P4a). Bounds a fork-bomb: spawn is a full agent process per call. */
-const MAX_AGENTS = 50;
 /** Minimum slot lifetime for rate-flooring (P4c). A slot freed (by despawn OR natural exit/reap)
  *  before living this long leaves a cooling stamp that still counts toward the ceiling until it
  *  expires — so churn (spawn↔despawn or spawn↔fast-exit) can't outrun the concurrency bound. */

--- a/implementations/manager/src/resume.ts
+++ b/implementations/manager/src/resume.ts
@@ -3,7 +3,11 @@ import type { ManagerResumeInventory } from "./manager.js";
 
 export const MAX_RESUME_CONTROL_BYTES = 512 * 1024;
 export const MAX_RESUME_COMMIT_BYTES = 1024;
-const MAX_AGENTS = 50;
+/** Concurrency ceiling — the manager refuses to hold more than this many live + in-flight +
+ *  cooling slots at once (P4a). Bounds a fork-bomb: spawn is a full agent process per call.
+ *  Declared here (not in manager.ts) so the resume inventory schema and the spawn/resume
+ *  capacity checks share one value; manager.ts imports it. */
+export const MAX_AGENTS = 50;
 const TOKEN = /^[A-Za-z0-9_]+$/;
 const SHA256 = /^[a-f0-9]{64}$/;
 

--- a/package.json
+++ b/package.json
@@ -394,6 +394,7 @@
     "smoke:manager-service-invoke": "tsx implementations/manager/smoke/manager-service-invoke.smoke.ts",
     "smoke:journal-model-b": "tsx implementations/manager/smoke/journal-model-b.smoke.ts",
     "smoke:journal-declaration": "tsx implementations/manager/smoke/journal-declaration.smoke.ts",
+    "smoke:max-agents-single-source": "tsx implementations/manager/smoke/max-agents-single-source.smoke.ts",
     "smoke:contract-vocabulary": "tsx implementations/manager/smoke/contract-vocabulary.smoke.ts",
     "smoke:manager-spawn-action": "tsx implementations/manager/smoke/spawn-action.smoke.ts",
     "smoke:manager-supervise-restart": "tsx implementations/manager/smoke/supervise-restart.smoke.ts",


### PR DESCRIPTION
Refs #1462.

`implementations/manager/src/manager.ts` and `implementations/manager/src/resume.ts` each declared a private `const MAX_AGENTS = 50`, with no value-level link between them (`resume.ts` only imports a type from `manager.js`). The two copies gate different paths and fail with different error classes: the spawn/resume capacity checks in `manager.ts` report `at capacity (50 agents incl. in-flight + cooling)`, while the resume inventory schema caps `agents` with `z.array(agent).max(MAX_AGENTS)` and fails with a zod array-length error that never mentions capacity. Raising the ceiling in `manager.ts` therefore left resume inventories refused above 50 with a message that gives the reader no reason to look at the other constant.

**Change**

- `MAX_AGENTS` is declared once in `resume.ts`, exported, with the doc comment moved there and extended to say why it lives in that module.
- `manager.ts` drops its copy and imports the constant alongside the resume parsers it already imports from `./resume.js`. `resume.ts` keeps importing only a type from `manager.js`, so no new import cycle.
- Changeset: `@cotal-ai/manager` patch.
- Derived regression: `pnpm smoke:max-agents-single-source` walks `implementations/manager/src` with the TypeScript compiler API, counts `MAX_AGENTS` VariableDeclarations, and requires a value import plus the resume inventory `.max(MAX_AGENTS)` cap to acquire that one definition. A third production const, a dropped import, or a schema recap with a literal each fail a named cell.

**Validation**

```
pnpm smoke:max-agents-single-source
pnpm mutation-proof -- --config implementations/manager/smoke/mutations/max-agents-single-source.json
```

Local mutation-proof: 4/4 killed. Behaviour is unchanged today (both copies were 50); the change removes the way they could drift.
