### PR TITLE
fix(mutation-coverage): grade aliased launchers and bound entry names

### DIFF
--- a/.changeset/mutation-coverage-executes-witness-forms.md
+++ b/.changeset/mutation-coverage-executes-witness-forms.md
@@ -1,0 +1,4 @@
+---
+---
+
+`mutation-coverage`'s executes witness now recognises a launcher imported under an alias (`import { spawnSync as run }`) and a target bound to a name before the call (`const ENTRY = join(ROOT, "scripts", "x.mjs"); execFileSync(process.execPath, [ENTRY])`), so a suite that really runs the mutated script is graded instead of refused as not reaching it. A bound name only counts inside the launcher's argument list; a name that is merely printed after an unrelated spawn stays refused. Self-test cells cover both directions plus `spawnSync("node", …)`.

--- a/scripts/mutation-coverage.mjs
+++ b/scripts/mutation-coverage.mjs
@@ -101,11 +101,40 @@ const quoted = (s) => `["'\`]${s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}["'\`]`;
  */
 const referencesRoot = (suiteSource, root) =>
   new RegExp([quoted(root), root.split("/").map(quoted).join("\\s*,\\s*")].join("|")).test(suiteSource);
+const LAUNCHERS = ["spawnSync", "spawn", "execFileSync", "execFile"];
+/**
+ * The names a suite calls the child_process launchers by: the canonical four plus whatever a
+ * `{ spawnSync as run }` import binds them to. A member call (`cp.spawnSync(`) already matches
+ * the bare name.
+ */
+const launcherNames = (suiteSource) => {
+  const names = new Set(LAUNCHERS);
+  for (const m of suiteSource.matchAll(/import\s*\{([^}]*)\}\s*from\s*["'](?:node:)?child_process["']/g)) {
+    for (const part of m[1].split(",")) {
+      const alias = part.match(/^\s*(\w+)\s+as\s+(\w+)\s*$/);
+      if (alias !== null && LAUNCHERS.includes(alias[1])) names.add(alias[2]);
+    }
+  }
+  return [...names];
+};
+/** Identifiers the suite binds to a quoted mention of the file (`const ENTRY = join(ROOT, "scripts",
+ *  "x.mjs")`), so a later `spawnSync(process.execPath, [ENTRY])` still names the target. */
+const boundNames = (suiteSource, basename) =>
+  [...suiteSource.matchAll(new RegExp(`(?:const|let|var)\\s+(\\w+)\\s*=[^;\\n]{0,300}${quoted(basename)}`, "g"))].map((m) => m[1]);
 const invokesFile = (suiteSource, file) => {
   const parts = file.split("/");
   const basename = parts.at(-1);
   if (basename === undefined || !referencesRoot(suiteSource, file)) return false;
-  return new RegExp(`(?:spawnSync|spawn|execFileSync|execFile)\\s*\\([\\s\\S]{0,500}${quoted(basename)}`).test(suiteSource);
+  const call = `(?:${launcherNames(suiteSource).join("|")})\\s*\\(`;
+  if (new RegExp(`${call}[\\s\\S]{0,500}${quoted(basename)}`).test(suiteSource)) return true;
+  // A bound name has to sit inside the launcher's argument list (one level of nesting allowed);
+  // merely appearing after the call is not an invocation.
+  const names = boundNames(suiteSource, basename);
+  if (names.length === 0) return false;
+  for (const m of suiteSource.matchAll(new RegExp(`${call}((?:[^()]|\\([^()]*\\))*)\\)`, "g"))) {
+    if (names.some((name) => new RegExp(`\\b${name}\\b`).test(m[1]))) return true;
+  }
+  return false;
 };
 
 /** Does THIS one suite run the bytes the mutation edits? The witnesses are tried in the order they

--- a/scripts/mutation-coverage.selftest.mjs
+++ b/scripts/mutation-coverage.selftest.mjs
@@ -80,14 +80,14 @@ writeFileSync(
   'spawnSync("node", [join(ROOT, "scripts", "direct.mjs")]);\n',
 );
 writeFileSync(
+  join(root, "bin/smoke/mentions-script.smoke.ts"),
+  'const note = "scripts/direct.mjs";\n',
+);
+writeFileSync(
   join(root, "bin/smoke/bound-entry-unused.smoke.ts"),
   'const ENTRY = join(ROOT, "scripts", "direct.mjs");\n' +
   'spawnSync(process.execPath, ["-e", "void 0"]);\n' +
   "console.log(ENTRY);\n",
-);
-writeFileSync(
-  join(root, "bin/smoke/mentions-script.smoke.ts"),
-  'const note = "scripts/direct.mjs";\n',
 );
 writeFileSync(
   join(root, "bin/smoke/unused-root.smoke.ts"),
@@ -175,20 +175,10 @@ for (const [name, label] of [
   check(label, r.status === 0 && r.stdout.includes("1 /   3 cells observed failing"), (r.stderr || r.stdout).slice(-300));
 }
 
-// 4e. A BOUND NAME OUTSIDE THE ARGUMENT LIST IS NOT AN INVOCATION: the launcher runs something
-// else and the name is only printed afterwards.
-writeConfig("bound-entry-unused.json", {
-  suite: ["bin/smoke/bound-entry-unused.smoke.ts"], command: TALLY,
-  mutations: [mutation("scripts/direct.mjs")],
-});
-r = runTool("bound-entry-unused.json");
-check(
-  "a name bound to the target but never passed to a launcher is still refused",
-  r.status !== 0 && /assembles/.test(r.stderr),
-  r.stderr.slice(-300),
-);
-
 // 5. A QUOTED PATH IS NOT AN INVOCATION: prose or a fixture string cannot license a mutation.
+// This cell is a contiguous quoted path with no launcher and no bound identifier, so a mutation
+// that treats any quoted mention as a witness reddens HERE rather than a later bound-name cell
+// that also happens to quote the basename.
 writeConfig("mentions-script.json", {
   suite: ["bin/smoke/mentions-script.smoke.ts"], command: TALLY,
   mutations: [mutation("scripts/direct.mjs")],
@@ -197,6 +187,21 @@ r = runTool("mentions-script.json");
 check(
   "a quoted script path without an invocation is refused",
   r.status !== 0 && /imports by source path or reaches through/.test(r.stderr),
+  r.stderr.slice(-300),
+);
+
+// 5b. A BOUND NAME OUTSIDE THE ARGUMENT LIST IS NOT AN INVOCATION: the launcher runs something
+// else and the name is only printed afterwards. Distinct from cell 5: the basename is quoted
+// inside a binding, so collapsing invokesFile to referencesRoot would also grade this one —
+// that is why cell 5 runs first, and a separate mutation drops the argument-list check.
+writeConfig("bound-entry-unused.json", {
+  suite: ["bin/smoke/bound-entry-unused.smoke.ts"], command: TALLY,
+  mutations: [mutation("scripts/direct.mjs")],
+});
+r = runTool("bound-entry-unused.json");
+check(
+  "a name bound to the target but never passed to a launcher is still refused",
+  r.status !== 0 && /assembles/.test(r.stderr),
   r.stderr.slice(-300),
 );
 

--- a/scripts/mutation-coverage.selftest.mjs
+++ b/scripts/mutation-coverage.selftest.mjs
@@ -66,6 +66,26 @@ writeFileSync(
   'spawnSync(process.execPath, [join(ROOT, "scripts", "direct.mjs")]);\n',
 );
 writeFileSync(
+  join(root, "bin/smoke/aliased-launcher.smoke.ts"),
+  'import { spawnSync as run } from "node:child_process";\n' +
+  'run(process.execPath, [join(ROOT, "scripts", "direct.mjs")]);\n',
+);
+writeFileSync(
+  join(root, "bin/smoke/bound-entry.smoke.ts"),
+  'const ENTRY = join(ROOT, "scripts", "direct.mjs");\n' +
+  "execFileSync(process.execPath, [ENTRY]);\n",
+);
+writeFileSync(
+  join(root, "bin/smoke/node-by-name.smoke.ts"),
+  'spawnSync("node", [join(ROOT, "scripts", "direct.mjs")]);\n',
+);
+writeFileSync(
+  join(root, "bin/smoke/bound-entry-unused.smoke.ts"),
+  'const ENTRY = join(ROOT, "scripts", "direct.mjs");\n' +
+  'spawnSync(process.execPath, ["-e", "void 0"]);\n' +
+  "console.log(ENTRY);\n",
+);
+writeFileSync(
   join(root, "bin/smoke/mentions-script.smoke.ts"),
   'const note = "scripts/direct.mjs";\n',
 );
@@ -138,6 +158,34 @@ check(
   "a suite is gradable when it launches the exact mutated script path",
   r.status === 0 && r.stdout.includes("1 /   3 cells observed failing"),
   (r.stderr || r.stdout).slice(-300),
+);
+
+// 4b-4d. THE SAME INVOCATION, SPELLED THE WAYS THE REPO SPELLS IT: an aliased launcher import,
+// a target bound to a name before the call, and "node" by name instead of process.execPath.
+for (const [name, label] of [
+  ["aliased-launcher", "a launcher imported under an alias still witnesses the script it runs"],
+  ["bound-entry", "a target bound to a const before the launcher call still witnesses it"],
+  ["node-by-name", "spawning \"node\" by name is the same witness as process.execPath"],
+]) {
+  writeConfig(`${name}.json`, {
+    suite: [`bin/smoke/${name}.smoke.ts`], command: TALLY,
+    mutations: [mutation("scripts/direct.mjs")],
+  });
+  r = runTool(`${name}.json`);
+  check(label, r.status === 0 && r.stdout.includes("1 /   3 cells observed failing"), (r.stderr || r.stdout).slice(-300));
+}
+
+// 4e. A BOUND NAME OUTSIDE THE ARGUMENT LIST IS NOT AN INVOCATION: the launcher runs something
+// else and the name is only printed afterwards.
+writeConfig("bound-entry-unused.json", {
+  suite: ["bin/smoke/bound-entry-unused.smoke.ts"], command: TALLY,
+  mutations: [mutation("scripts/direct.mjs")],
+});
+r = runTool("bound-entry-unused.json");
+check(
+  "a name bound to the target but never passed to a launcher is still refused",
+  r.status !== 0 && /assembles/.test(r.stderr),
+  r.stderr.slice(-300),
 );
 
 // 5. A QUOTED PATH IS NOT AN INVOCATION: prose or a fixture string cannot license a mutation.

--- a/scripts/mutations/mutation-coverage.json
+++ b/scripts/mutations/mutation-coverage.json
@@ -32,6 +32,27 @@
       "find": "  if (m.file === suite || invokesFile(suiteSource, m.file)) return true;",
       "replace": "  if (m.file === suite || referencesRoot(suiteSource, m.file)) return true;",
       "expectRed": "a quoted script path without an invocation is refused"
+    },
+    {
+      "name": "a launcher imported under an alias is no longer a witness",
+      "file": "scripts/mutation-coverage.mjs",
+      "find": "      if (alias !== null && LAUNCHERS.includes(alias[1])) names.add(alias[2]);",
+      "replace": "      if (alias !== null && LAUNCHERS.includes(alias[1])) { /* aliases ignored */ }",
+      "expectRed": "a launcher imported under an alias still witnesses the script it runs"
+    },
+    {
+      "name": "a target bound to a name before the call is no longer a witness",
+      "file": "scripts/mutation-coverage.mjs",
+      "find": "  for (const m of suiteSource.matchAll(new RegExp(`${call}((?:[^()]|\\\\([^()]*\\\\))*)\\\\)`, \"g\"))) {\n    if (names.some((name) => new RegExp(`\\\\b${name}\\\\b`).test(m[1]))) return true;\n  }",
+      "replace": "  void 0;",
+      "expectRed": "a target bound to a const before the launcher call still witnesses it"
+    },
+    {
+      "name": "a bound name printed after an unrelated spawn is treated as a witness",
+      "file": "scripts/mutation-coverage.mjs",
+      "find": "  if (names.length === 0) return false;",
+      "replace": "  if (names.length === 0) return false;\n  return true;",
+      "expectRed": "a name bound to the target but never passed to a launcher is still refused"
     }
   ]
 }

--- a/scripts/mutations/mutation-coverage.json
+++ b/scripts/mutations/mutation-coverage.json
@@ -34,24 +34,24 @@
       "expectRed": "a quoted script path without an invocation is refused"
     },
     {
-      "name": "a launcher imported under an alias is no longer a witness",
+      "name": "launcher aliases are ignored",
       "file": "scripts/mutation-coverage.mjs",
       "find": "      if (alias !== null && LAUNCHERS.includes(alias[1])) names.add(alias[2]);",
-      "replace": "      if (alias !== null && LAUNCHERS.includes(alias[1])) { /* aliases ignored */ }",
+      "replace": "      if (alias !== null && LAUNCHERS.includes(alias[1])) names.add(alias[1]);",
       "expectRed": "a launcher imported under an alias still witnesses the script it runs"
     },
     {
-      "name": "a target bound to a name before the call is no longer a witness",
+      "name": "bound entry names are ignored",
       "file": "scripts/mutation-coverage.mjs",
-      "find": "  for (const m of suiteSource.matchAll(new RegExp(`${call}((?:[^()]|\\\\([^()]*\\\\))*)\\\\)`, \"g\"))) {\n    if (names.some((name) => new RegExp(`\\\\b${name}\\\\b`).test(m[1]))) return true;\n  }",
-      "replace": "  void 0;",
+      "find": "  const names = boundNames(suiteSource, basename);",
+      "replace": "  const names = [];",
       "expectRed": "a target bound to a const before the launcher call still witnesses it"
     },
     {
-      "name": "a bound name printed after an unrelated spawn is treated as a witness",
+      "name": "a bound entry anywhere after a launcher is treated as its argument",
       "file": "scripts/mutation-coverage.mjs",
-      "find": "  if (names.length === 0) return false;",
-      "replace": "  if (names.length === 0) return false;\n  return true;",
+      "find": "  for (const m of suiteSource.matchAll(new RegExp(`${call}((?:[^()]|\\\\([^()]*\\\\))*)\\\\)`, \"g\"))) {",
+      "replace": "  for (const m of suiteSource.matchAll(new RegExp(`${call}([\\\\s\\\\S]{0,500})`, \"g\"))) {",
       "expectRed": "a name bound to the target but never passed to a launcher is still refused"
     }
   ]


### PR DESCRIPTION
Refs #1466.

**What the witness does at head.** I rebuilt the issue's fixture shapes with the self-test's own harness (throwaway root, tally-only command, one mutation on `scripts/direct.mjs`) and ran `scripts/mutation-coverage.mjs` from `main` against each suite form:

| suite form | main |
| --- | --- |
| `spawnSync(process.execPath, [join(ROOT, "scripts", "direct.mjs")])` (control) | graded |
| `execFileSync(process.execPath, [join(ROOT, "scripts", "direct.mjs")])` | graded |
| `spawnSync("node", [join(ROOT, "scripts", "direct.mjs")])` | graded |
| `cp.spawnSync(process.execPath, [join(ROOT, "scripts", "direct.mjs")])` | graded |
| `import { spawnSync as run }` + `run(process.execPath, [join(ROOT, "scripts", "direct.mjs")])` | **refused** |
| `const ENTRY = join(ROOT, "scripts", "direct.mjs"); execFileSync(process.execPath, [ENTRY]);` | **refused** |

So the two headline forms of #1466 already grade at head (the regex in `invokesFile` lists `execFileSync`, and `"node"` is never inspected), but two spellings from the same class in the issue's history still are refused: an aliased launcher import, and a target bound to a name before the call, which is exactly the `[ENTRY]` shape the issue's table uses whenever `ENTRY` is declared above the call rather than inline. The refusal message then says the suite does not reach the file.

**Change** (`scripts/mutation-coverage.mjs`)

- `launcherNames()` adds `x as y` aliases from the suite's `child_process` import to the four canonical launcher names.
- `boundNames()` collects identifiers bound to a quoted mention of the file; such a name counts only when it sits inside a launcher's argument list (one level of nesting), so `const ENTRY = …; spawnSync(process.execPath, ["-e", "void 0"]); console.log(ENTRY)` stays refused.
- The existing quoted-basename-within-500-characters rule is unchanged, including its known over-admission (#1434, self-test cells 9/10).

**Self-test** (`scripts/mutation-coverage.selftest.mjs`): three graded cells (aliased launcher, bound entry, `"node"` by name) and one refused cell (bound name outside the argument list). `node scripts/mutation-coverage.selftest.mjs` → 14 passed. Changeset added with no package bump (scripts only, same shape as `attribution-check.md`).
