### PR TITLE
fix(seat): settle custodian after child exit

### DIFF
--- a/.changeset/seat-custodian-terminal-cleanup.md
+++ b/.changeset/seat-custodian-terminal-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/seat": patch
+---
+
+Close the custodian Unix server, socket, durable record, and process after the PTY child exits and the last client disconnects.

--- a/packages/seat/README.md
+++ b/packages/seat/README.md
@@ -36,7 +36,11 @@ The launcher owns no PTY and exits after writing a permissioned per-seat record.
 owns exactly one `node-pty` object, its child relationship, its screen mirror, and exit
 observation. A manager worker connects to that custodian over a 0600 filesystem Unix socket
 authenticated by `SO_PEERCRED` uid match plus a per-seat capability token. Path possession is
-not enough. Child exit is pushed to every authenticated controller socket.
+not enough. Child exit is pushed to every authenticated controller socket. After the child
+exits and the last client disconnects, the custodian closes the Unix server, unlinks the
+socket and record, and exits. An active child, or a still-connected observer of an exited
+child, keeps the process. A seat whose child has already exited at listen stays up briefly
+so the launcher can adopt it.
 
 Generation CAS, the crash journal, N/N-1 protocol compatibility, and manager-worker activation
 are later milestones. This package currently speaks a single implicit controller.

--- a/packages/seat/smoke/lifecycle.smoke.ts
+++ b/packages/seat/smoke/lifecycle.smoke.ts
@@ -2,7 +2,7 @@
  * Seat behavior cells plus worker-death survival and wait-exit close settlement.
  */
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -257,6 +257,20 @@ try {
     await h.waitForExit();
     check("natural exit: waitForExit resolves and status is exited", h.status() === "exited");
     h.close();
+    const recordGone = join(root, rec.id, "record.json");
+    check(
+      "natural exit: custodian process, socket, and record converge without fixture kill",
+      await until(() => {
+        const custodianGone = state(rec.custodianPid) === "gone" || state(rec.custodianPid) === "Z";
+        return custodianGone && !existsSync(rec.socket) && !existsSync(recordGone);
+      }, 5_000),
+      {
+        custodian: state(rec.custodianPid),
+        socket: existsSync(rec.socket),
+        record: existsSync(recordGone),
+      },
+    );
+    handles.push(h);
   }
 
   {
@@ -358,6 +372,9 @@ await h.waitForExit();
     } catch {
       /* gone */
     }
+    const childGone = state(h.record.childPid) === "gone" || state(h.record.childPid) === "Z";
+    const custodianGone = state(h.record.custodianPid) === "gone" || state(h.record.custodianPid) === "Z";
+    if (childGone && custodianGone) continue;
     try {
       process.kill(h.record.custodianPid, "SIGKILL");
     } catch {

--- a/packages/seat/smoke/mutations/lifecycle.json
+++ b/packages/seat/smoke/mutations/lifecycle.json
@@ -67,6 +67,16 @@
       "expectRed": "waitForExit drops the controller socket so the worker can exit",
       "cell": "waitForExit drops the controller socket so the worker can exit",
       "note": "A live Unix socket after waitForExit keeps the manager event loop alive through spawn-detach teardown."
+    },
+    {
+      "name": "M7 skip terminal custodian cleanup after child exit",
+      "file": "packages/seat/src/custodian.ts",
+      "find": "  const settleTerminal = (): void => {\n    if (alive || settling || !ready) return;",
+      "replace": "  const settleTerminal = (): void => {\n    return;\n    if (alive || settling || !ready) return;",
+      "afterRestore": "pnpm --filter @cotal-ai/seat build",
+      "expectRed": "natural exit: custodian process, socket, and record converge without fixture kill",
+      "cell": "natural exit: custodian process, socket, and record converge without fixture kill",
+      "note": "Deleting the owned terminal-settle transition leaves the Unix server, socket, record, and custodian process alive after waitForExit. The named cell must fail without fixture SIGKILL."
     }
   ]
 }

--- a/packages/seat/src/custodian.ts
+++ b/packages/seat/src/custodian.ts
@@ -70,15 +70,25 @@ export async function runCustodian(launch: CustodianLaunch): Promise<void> {
   term.loadAddon(serializer);
 
   let alive = true;
+  let ready = false;
+  let settling = false;
+  let seenClient = false;
   let cols = DEFAULT_COLS;
   let rows = DEFAULT_ROWS;
   let exit: { code?: number; signal?: number } | undefined;
   const dataSubs = new Map<number, Set<Socket>>();
   const waiters = new Map<Socket, Set<number>>();
   const controllers = new Set<Socket>();
+  const clients = new Set<Socket>();
   let nextSub = 1;
   let early = "";
   let confirmTimer: ReturnType<typeof setInterval> | undefined;
+  let killTimer: ReturnType<typeof setTimeout> | undefined;
+  let handoffTimer: ReturnType<typeof setTimeout> | undefined;
+  let reap: ReturnType<typeof setInterval> | undefined;
+  let server: ReturnType<typeof createServer> | undefined;
+  /** Wait for the first adopter when the child has already exited at listen. */
+  const LAUNCH_HANDOFF_MS = 5_000;
 
   if (launch.confirm) {
     let presses = 0;
@@ -111,9 +121,77 @@ export async function runCustodian(launch: CustodianLaunch): Promise<void> {
     }
   };
 
+  const settleTerminal = (): void => {
+    if (alive || settling || !ready) return;
+    if (clients.size > 0) return;
+    if (!seenClient) return;
+    settling = true;
+    if (confirmTimer) {
+      clearInterval(confirmTimer);
+      confirmTimer = undefined;
+    }
+    if (killTimer) {
+      clearTimeout(killTimer);
+      killTimer = undefined;
+    }
+    if (handoffTimer) {
+      clearTimeout(handoffTimer);
+      handoffTimer = undefined;
+    }
+    if (reap) {
+      clearInterval(reap);
+      reap = undefined;
+    }
+    try {
+      term.dispose();
+    } catch {
+      /* already gone */
+    }
+    try {
+      proc.kill("SIGKILL");
+    } catch {
+      /* already gone */
+    }
+    server?.close();
+    for (const sock of clients) {
+      try {
+        sock.destroy();
+      } catch {
+        /* already gone */
+      }
+    }
+    clients.clear();
+    controllers.clear();
+    waiters.clear();
+    dataSubs.clear();
+    try {
+      unlinkSync(launch.socket);
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+    }
+    try {
+      unlinkSync(launch.recordPath);
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+    }
+    process.exit(0);
+  };
+
+  const armUnobservedHandoff = (): void => {
+    if (alive || seenClient || settling || !ready || handoffTimer) return;
+    handoffTimer = setTimeout(() => {
+      handoffTimer = undefined;
+      seenClient = true;
+      settleTerminal();
+    }, LAUNCH_HANDOFF_MS);
+    handoffTimer.unref();
+  };
+
   const markExited = (info?: { code?: number; signal?: number }): void => {
     if (!alive) {
       resolveWaiters();
+      settleTerminal();
+      armUnobservedHandoff();
       return;
     }
     alive = false;
@@ -124,6 +202,8 @@ export async function runCustodian(launch: CustodianLaunch): Promise<void> {
     }
     for (const sock of controllers) send(sock, { event: "exit" });
     resolveWaiters();
+    settleTerminal();
+    armUnobservedHandoff();
   };
 
   proc.onData((d) => {
@@ -139,9 +219,10 @@ export async function runCustodian(launch: CustodianLaunch): Promise<void> {
   proc.onExit(({ exitCode, signal }) => {
     markExited({ code: exitCode, ...(signal === undefined ? {} : { signal }) });
   });
-  const reap = setInterval(() => {
+  reap = setInterval(() => {
     if (!alive) {
-      clearInterval(reap);
+      if (reap) clearInterval(reap);
+      reap = undefined;
       return;
     }
     if (childGone()) markExited({});
@@ -155,7 +236,8 @@ export async function runCustodian(launch: CustodianLaunch): Promise<void> {
       return;
     }
     proc.kill("SIGTERM");
-    setTimeout(() => alive && proc.kill("SIGKILL"), GRACE_MS);
+    if (killTimer) clearTimeout(killTimer);
+    killTimer = setTimeout(() => alive && proc.kill("SIGKILL"), GRACE_MS);
   };
 
   const record: SeatRecord = {
@@ -168,11 +250,13 @@ export async function runCustodian(launch: CustodianLaunch): Promise<void> {
     childPid: proc.pid,
   };
 
-  const server = createServer((sock) => {
+  server = createServer((sock) => {
     const reader = new FrameReader();
     let authed = false;
     const owned = new Set<number>();
+    clients.add(sock);
     const drop = (): void => {
+      clients.delete(sock);
       controllers.delete(sock);
       for (const sub of owned) {
         const socks = dataSubs.get(sub);
@@ -182,6 +266,7 @@ export async function runCustodian(launch: CustodianLaunch): Promise<void> {
       }
       owned.clear();
       waiters.delete(sock);
+      settleTerminal();
     };
     sock.on("data", (chunk) => {
       let messages: unknown[];
@@ -243,6 +328,11 @@ export async function runCustodian(launch: CustodianLaunch): Promise<void> {
           return;
         }
         session.setAuthed(true);
+        seenClient = true;
+        if (handoffTimer) {
+          clearTimeout(handoffTimer);
+          handoffTimer = undefined;
+        }
         if (alive && childGone()) markExited({});
         send(sock, {
           id: req.id,
@@ -340,14 +430,19 @@ export async function runCustodian(launch: CustodianLaunch): Promise<void> {
     }
   }
 
+  const listening = server;
+  if (!listening) throw new Error("custodian server missing");
   await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(launch.socket, () => {
+    listening.once("error", reject);
+    listening.listen(launch.socket, () => {
       chmodSync(launch.socket, 0o600);
       writeRecord(launch.recordPath, record);
-      const ready = `${JSON.stringify({ ready: true, childPid: proc.pid, custodianPid: process.pid })}\n`;
-      if (launch.logPath) appendFileSync(launch.logPath, ready, { mode: 0o600 });
-      else process.stdout.write(ready);
+      ready = true;
+      const announced = `${JSON.stringify({ ready: true, childPid: proc.pid, custodianPid: process.pid })}\n`;
+      if (launch.logPath) appendFileSync(launch.logPath, announced, { mode: 0o600 });
+      else process.stdout.write(announced);
+      armUnobservedHandoff();
+      settleTerminal();
       resolve();
     });
   });


### PR DESCRIPTION
## Summary

A seat whose PTY child has already exited used to leave its detached custodian listening. `markExited` recorded the child terminal state and resolved waiters, but the Unix server, socket, durable record, and custodian process stayed alive. Existing lifecycle smoke hid that by SIGKILLing every recorded custodian in final cleanup.

This makes terminal cleanup an owned custodian lifecycle transition. After the child exits and the last client disconnects, the custodian closes the Unix server, unlinks the socket and record, and exits. An active child stays up. A still-connected observer of an exited child stays up until it disconnects. An unobserved child that already exited at listen stays up briefly so `launchSeat` can still adopt, then converges on its own. Shutdown is idempotent.

## Proof

- `pnpm smoke:seat-lifecycle` 24/24, including `natural exit: custodian process, socket, and record converge without fixture kill`.
- `pnpm exec tsx packages/seat/smoke/isolation.smoke.ts` 5/5
- `pnpm exec tsx packages/seat/smoke/protocol.smoke.ts` 16/16
- `pnpm exec tsx packages/seat/smoke/platform.smoke.ts` 29/29
- `node scripts/mutation-proof.mjs --config packages/seat/smoke/mutations/lifecycle.json` 7/7 KILLED. M7 deletes `settleTerminal` and reds the named natural-exit converge cell.

Final cleanup no longer SIGKILLs a custodian whose child and process have already exited.

Refs #1450