### PR TITLE
fix(ci): attribute mutation-reproof fatals by base-vs-head verdict

### DIFF
--- a/bin/smoke/mutation-reproof.smoke.ts
+++ b/bin/smoke/mutation-reproof.smoke.ts
@@ -460,28 +460,33 @@ try {
     );
   }
 
-  // 1d. Duplicate mutation names are valid. Identity is file+find, not the displayed label. A PR
-  //     that turns a later same-name KILLED into ERROR must fail even though an earlier same-name
-  //     ERROR is inherited.
+  // 1d. Duplicate mutation names are valid. Identity is file+find+replace, not the displayed
+  //     label. A later same-name mutant that newly becomes ERROR must still fail; matching by
+  //     label would inherit an earlier same-name ERROR from a different replacement.
   {
     const { root, base, head } = makeSingle(
       (r) => {
-        writeFileSync(join(r, "dup.mjs"), "export const dup = () => 1;\nexport const extra = () => 0;\n");
+        writeFileSync(join(r, "dup.mjs"), "export const dup = () => 1;\n");
         writeFileSync(join(r, "suites", "dup.suite.mjs"), "import { dup } from '../dup.mjs';\nif (dup() !== 1) { console.error('✗ FAIL: dup is one'); process.exit(1); }\nconsole.log('✓ dup is one');\n");
         writeFileSync(join(r, "smoke", "mutations", "dup.mutations.json"), JSON.stringify({
           suite: ["suites/dup.suite.mjs"],
           command: "node suites/dup.suite.mjs",
           mutations: [
-            { name: "same name", file: "dup.mjs", find: "export const extra = () => 0;", replace: "export const extra = () => 0;", expectRed: "dup is one" },
-            { name: "same name", file: "dup.mjs", find: "export const dup = () => 1;", replace: "export const dup = () => 2;", expectRed: "dup is one" },
+            { name: "same name", file: "dup.mjs", find: "export const dup = () => 1;", replace: "export const dup = () => 2;", expectRed: "dup is one", unknownKey: true },
+            { name: "same name", file: "dup.mjs", find: "export const dup = () => 1;", replace: "export const dup = () => 3;", expectRed: "dup is one" },
           ],
         }, null, 2));
       },
       (r) => {
         const path = join(r, "smoke", "mutations", "dup.mutations.json");
-        const config = JSON.parse(readFileSync(path, "utf8"));
-        config.mutations[1] = { name: "same name", file: "dup.mjs", find: "export const dup = () => 1;", replace: "export const dup = () => 2;", expectRed: "dup is one", unknownKey: true };
-        writeFileSync(path, JSON.stringify(config, null, 2));
+        writeFileSync(path, JSON.stringify({
+          suite: ["suites/dup.suite.mjs"],
+          command: "node suites/dup.suite.mjs",
+          mutations: [
+            { name: "same name", file: "dup.mjs", find: "export const dup = () => 1;", replace: "export const dup = () => 2;", expectRed: "dup is one" },
+            { name: "same name", file: "dup.mjs", find: "export const dup = () => 1;", replace: "export const dup = () => 3;", expectRed: "dup is one", unknownKey: true },
+          ],
+        }, null, 2));
       },
     );
     const { status, out } = scan(root, base, head);

--- a/bin/smoke/mutation-reproof.smoke.ts
+++ b/bin/smoke/mutation-reproof.smoke.ts
@@ -460,19 +460,19 @@ try {
     );
   }
 
-  // 1d. Duplicate mutation names are valid. Index, not displayed label, is the identity. A PR that
-  //     turns a later same-name KILLED into ERROR must fail even though an earlier same-name ERROR
-  //     is inherited.
+  // 1d. Duplicate mutation names are valid. Identity is file+find, not the displayed label. A PR
+  //     that turns a later same-name KILLED into ERROR must fail even though an earlier same-name
+  //     ERROR is inherited.
   {
     const { root, base, head } = makeSingle(
       (r) => {
-        writeFileSync(join(r, "dup.mjs"), "export const dup = () => 1;\n");
+        writeFileSync(join(r, "dup.mjs"), "export const dup = () => 1;\nexport const extra = () => 0;\n");
         writeFileSync(join(r, "suites", "dup.suite.mjs"), "import { dup } from '../dup.mjs';\nif (dup() !== 1) { console.error('✗ FAIL: dup is one'); process.exit(1); }\nconsole.log('✓ dup is one');\n");
         writeFileSync(join(r, "smoke", "mutations", "dup.mutations.json"), JSON.stringify({
           suite: ["suites/dup.suite.mjs"],
           command: "node suites/dup.suite.mjs",
           mutations: [
-            { name: "same name", file: "dup.mjs", find: "export const dup = () => 1;", replace: "export const dup = () => 1;", expectRed: "dup is one" },
+            { name: "same name", file: "dup.mjs", find: "export const extra = () => 0;", replace: "export const extra = () => 0;", expectRed: "dup is one" },
             { name: "same name", file: "dup.mjs", find: "export const dup = () => 1;", replace: "export const dup = () => 2;", expectRed: "dup is one" },
           ],
         }, null, 2));
@@ -491,6 +491,190 @@ try {
         && eq(offenderPaths(out), ["smoke/mutations/dup.mutations.json"])
         && /^MUTATION REPROOF FAILED /m.test(out),
       `status=${status} offenders=${JSON.stringify(offenderPaths(out))} inherited=${JSON.stringify(inheritedFatalPaths(out))}\n${out}`,
+    );
+  }
+
+  // 1e. Array position is not mutation identity. Reversing two unchanged objects must not attribute
+  //     the still-SURVIVED mutant just because it now sits at a later index.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "s.mjs"), "export const s = () => 1;\n");
+        writeFileSync(join(r, "suites", "s.suite.mjs"), "import { s } from '../s.mjs';\nif (s() !== 1) { console.error('✗ FAIL: s is one'); process.exit(1); }\nconsole.log('✓ s is one');\n");
+        writeFileSync(join(r, "smoke", "mutations", "s.mutations.json"), JSON.stringify({
+          suite: ["suites/s.suite.mjs"],
+          command: "node suites/s.suite.mjs",
+          mutations: [
+            { name: "equivalent survivor", file: "s.mjs", find: "export const s = () => 1;", replace: "export const s = () => 1 + 0;", expectRed: "s is one" },
+            { name: "positive control kill", file: "s.mjs", find: "export const s = () => 1;", replace: "export const s = () => 2;", expectRed: "s is one" },
+          ],
+        }, null, 2));
+      },
+      (r) => {
+        const path = join(r, "smoke", "mutations", "s.mutations.json");
+        const config = JSON.parse(readFileSync(path, "utf8"));
+        config.mutations = [...config.mutations].reverse();
+        writeFileSync(path, JSON.stringify(config, null, 2));
+        writeFileSync(join(r, "s.mjs"), "// select without moving the survivor\nexport const s = () => 1;\n");
+      },
+    );
+    const { status, out } = scan(root, base, head);
+    check(
+      "reordering unchanged mutations does not attribute a still-SURVIVED mutant by array position",
+      status === 0
+        && eq(selectedPaths(out), ["smoke/mutations/s.mutations.json"])
+        && eq(inheritedFatalPaths(out), ["smoke/mutations/s.mutations.json"])
+        && offenderPaths(out).length === 0
+        && out.includes("mutation: equivalent survivor; transition: base SURVIVED -> head SURVIVED"),
+      `status=${status} inherited=${JSON.stringify(inheritedFatalPaths(out))} offenders=${JSON.stringify(offenderPaths(out))}\n${out}`,
+    );
+  }
+
+  // 1f. Inserting a killed sibling before an unchanged survivor must not shift that survivor onto
+  //     another mutation's base verdict.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "s.mjs"), "export const s = () => 1;\n");
+        writeFileSync(join(r, "suites", "s.suite.mjs"), "import { s } from '../s.mjs';\nif (s() !== 1) { console.error('✗ FAIL: s is one'); process.exit(1); }\nconsole.log('✓ s is one');\n");
+        writeFileSync(join(r, "smoke", "mutations", "s.mutations.json"), JSON.stringify({
+          suite: ["suites/s.suite.mjs"],
+          command: "node suites/s.suite.mjs",
+          mutations: [
+            { name: "equivalent survivor", file: "s.mjs", find: "export const s = () => 1;", replace: "export const s = () => 1 + 0;", expectRed: "s is one" },
+            { name: "positive control kill", file: "s.mjs", find: "export const s = () => 1;", replace: "export const s = () => 2;", expectRed: "s is one" },
+          ],
+        }, null, 2));
+      },
+      (r) => {
+        const path = join(r, "smoke", "mutations", "s.mutations.json");
+        const config = JSON.parse(readFileSync(path, "utf8"));
+        config.mutations = [
+          { name: "inserted kill", file: "s.mjs", find: "export const s = () => 1;", replace: "export const s = () => 3;", expectRed: "s is one" },
+          ...config.mutations,
+        ];
+        writeFileSync(path, JSON.stringify(config, null, 2));
+        writeFileSync(join(r, "s.mjs"), "// select without moving the survivor\nexport const s = () => 1;\n");
+      },
+    );
+    const { status, out } = scan(root, base, head);
+    check(
+      "inserting a killed sibling before an unchanged SURVIVED mutant remains nonfatal",
+      status === 0
+        && eq(selectedPaths(out), ["smoke/mutations/s.mutations.json"])
+        && eq(inheritedFatalPaths(out), ["smoke/mutations/s.mutations.json"])
+        && offenderPaths(out).length === 0
+        && out.includes("mutation: equivalent survivor; transition: base SURVIVED -> head SURVIVED"),
+      `status=${status} inherited=${JSON.stringify(inheritedFatalPaths(out))} offenders=${JSON.stringify(offenderPaths(out))}\n${out}`,
+    );
+  }
+
+  // 1g. Deleting a killed sibling that sat before an unchanged survivor must not treat that
+  //     survivor as newly introduced.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "s.mjs"), "export const s = () => 1;\n");
+        writeFileSync(join(r, "suites", "s.suite.mjs"), "import { s } from '../s.mjs';\nif (s() !== 1) { console.error('✗ FAIL: s is one'); process.exit(1); }\nconsole.log('✓ s is one');\n");
+        writeFileSync(join(r, "smoke", "mutations", "s.mutations.json"), JSON.stringify({
+          suite: ["suites/s.suite.mjs"],
+          command: "node suites/s.suite.mjs",
+          mutations: [
+            { name: "leading kill", file: "s.mjs", find: "export const s = () => 1;", replace: "export const s = () => 2;", expectRed: "s is one" },
+            { name: "equivalent survivor", file: "s.mjs", find: "export const s = () => 1;", replace: "export const s = () => 1 + 0;", expectRed: "s is one" },
+            { name: "positive control kill", file: "s.mjs", find: "export const s = () => 1;", replace: "export const s = () => 3;", expectRed: "s is one" },
+          ],
+        }, null, 2));
+      },
+      (r) => {
+        const path = join(r, "smoke", "mutations", "s.mutations.json");
+        const config = JSON.parse(readFileSync(path, "utf8"));
+        config.mutations = config.mutations.slice(1);
+        writeFileSync(path, JSON.stringify(config, null, 2));
+        writeFileSync(join(r, "s.mjs"), "// select without moving the survivor\nexport const s = () => 1;\n");
+      },
+    );
+    const { status, out } = scan(root, base, head);
+    check(
+      "deleting a killed sibling before an unchanged SURVIVED mutant remains nonfatal",
+      status === 0
+        && eq(selectedPaths(out), ["smoke/mutations/s.mutations.json"])
+        && eq(inheritedFatalPaths(out), ["smoke/mutations/s.mutations.json"])
+        && offenderPaths(out).length === 0
+        && out.includes("mutation: equivalent survivor; transition: base SURVIVED -> head SURVIVED"),
+      `status=${status} inherited=${JSON.stringify(inheritedFatalPaths(out))} offenders=${JSON.stringify(offenderPaths(out))}\n${out}`,
+    );
+  }
+
+  // 1h. A 3-way rotation of unchanged objects must still inherit the same SURVIVED mutant.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "s.mjs"), "export const s = () => 1;\n");
+        writeFileSync(join(r, "suites", "s.suite.mjs"), "import { s } from '../s.mjs';\nif (s() !== 1) { console.error('✗ FAIL: s is one'); process.exit(1); }\nconsole.log('✓ s is one');\n");
+        writeFileSync(join(r, "smoke", "mutations", "s.mutations.json"), JSON.stringify({
+          suite: ["suites/s.suite.mjs"],
+          command: "node suites/s.suite.mjs",
+          mutations: [
+            { name: "equivalent survivor", file: "s.mjs", find: "export const s = () => 1;", replace: "export const s = () => 1 + 0;", expectRed: "s is one" },
+            { name: "positive control kill", file: "s.mjs", find: "export const s = () => 1;", replace: "export const s = () => 2;", expectRed: "s is one" },
+            { name: "second kill", file: "s.mjs", find: "export const s = () => 1;", replace: "export const s = () => 3;", expectRed: "s is one" },
+          ],
+        }, null, 2));
+      },
+      (r) => {
+        const path = join(r, "smoke", "mutations", "s.mutations.json");
+        const config = JSON.parse(readFileSync(path, "utf8"));
+        const [a, b, c] = config.mutations;
+        config.mutations = [c, a, b];
+        writeFileSync(path, JSON.stringify(config, null, 2));
+        writeFileSync(join(r, "s.mjs"), "// select without moving the survivor\nexport const s = () => 1;\n");
+      },
+    );
+    const { status, out } = scan(root, base, head);
+    check(
+      "rotating unchanged mutations does not attribute a still-SURVIVED mutant",
+      status === 0
+        && eq(selectedPaths(out), ["smoke/mutations/s.mutations.json"])
+        && eq(inheritedFatalPaths(out), ["smoke/mutations/s.mutations.json"])
+        && offenderPaths(out).length === 0
+        && out.includes("mutation: equivalent survivor; transition: base SURVIVED -> head SURVIVED"),
+      `status=${status} inherited=${JSON.stringify(inheritedFatalPaths(out))} offenders=${JSON.stringify(offenderPaths(out))}\n${out}`,
+    );
+  }
+
+  // 1i. Distinct labels reordered is the same identity defect as same-name reorder.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "s.mjs"), "export const s = () => 1;\n");
+        writeFileSync(join(r, "suites", "s.suite.mjs"), "import { s } from '../s.mjs';\nif (s() !== 1) { console.error('✗ FAIL: s is one'); process.exit(1); }\nconsole.log('✓ s is one');\n");
+        writeFileSync(join(r, "smoke", "mutations", "s.mutations.json"), JSON.stringify({
+          suite: ["suites/s.suite.mjs"],
+          command: "node suites/s.suite.mjs",
+          mutations: [
+            { name: "alpha survivor", file: "s.mjs", find: "export const s = () => 1;", replace: "export const s = () => 1 + 0;", expectRed: "s is one" },
+            { name: "beta kill", file: "s.mjs", find: "export const s = () => 1;", replace: "export const s = () => 2;", expectRed: "s is one" },
+          ],
+        }, null, 2));
+      },
+      (r) => {
+        const path = join(r, "smoke", "mutations", "s.mutations.json");
+        const config = JSON.parse(readFileSync(path, "utf8"));
+        config.mutations = [...config.mutations].reverse();
+        writeFileSync(path, JSON.stringify(config, null, 2));
+        writeFileSync(join(r, "s.mjs"), "// select without moving the survivor\nexport const s = () => 1;\n");
+      },
+    );
+    const { status, out } = scan(root, base, head);
+    check(
+      "reordering distinct-label unchanged mutations remains nonfatal",
+      status === 0
+        && eq(selectedPaths(out), ["smoke/mutations/s.mutations.json"])
+        && eq(inheritedFatalPaths(out), ["smoke/mutations/s.mutations.json"])
+        && offenderPaths(out).length === 0
+        && out.includes("mutation: alpha survivor; transition: base SURVIVED -> head SURVIVED"),
+      `status=${status} inherited=${JSON.stringify(inheritedFatalPaths(out))} offenders=${JSON.stringify(offenderPaths(out))}\n${out}`,
     );
   }
 

--- a/bin/smoke/mutation-reproof.smoke.ts
+++ b/bin/smoke/mutation-reproof.smoke.ts
@@ -460,6 +460,40 @@ try {
     );
   }
 
+  // 1d. Duplicate mutation names are valid. Index, not displayed label, is the identity. A PR that
+  //     turns a later same-name KILLED into ERROR must fail even though an earlier same-name ERROR
+  //     is inherited.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "dup.mjs"), "export const dup = () => 1;\n");
+        writeFileSync(join(r, "suites", "dup.suite.mjs"), "import { dup } from '../dup.mjs';\nif (dup() !== 1) { console.error('✗ FAIL: dup is one'); process.exit(1); }\nconsole.log('✓ dup is one');\n");
+        writeFileSync(join(r, "smoke", "mutations", "dup.mutations.json"), JSON.stringify({
+          suite: ["suites/dup.suite.mjs"],
+          command: "node suites/dup.suite.mjs",
+          mutations: [
+            { name: "same name", file: "dup.mjs", find: "export const dup = () => 1;", replace: "export const dup = () => 1;", expectRed: "dup is one" },
+            { name: "same name", file: "dup.mjs", find: "export const dup = () => 1;", replace: "export const dup = () => 2;", expectRed: "dup is one" },
+          ],
+        }, null, 2));
+      },
+      (r) => {
+        const path = join(r, "smoke", "mutations", "dup.mutations.json");
+        const config = JSON.parse(readFileSync(path, "utf8"));
+        config.mutations[1] = { name: "same name", file: "dup.mjs", find: "export const dup = () => 1;", replace: "export const dup = () => 2;", expectRed: "dup is one", unknownKey: true };
+        writeFileSync(path, JSON.stringify(config, null, 2));
+      },
+    );
+    const { status, out } = scan(root, base, head);
+    check(
+      "a later same-name mutation that newly becomes ERROR still fails and is not cleared by an earlier inherited ERROR",
+      status === 1
+        && eq(offenderPaths(out), ["smoke/mutations/dup.mutations.json"])
+        && /^MUTATION REPROOF FAILED /m.test(out),
+      `status=${status} offenders=${JSON.stringify(offenderPaths(out))} inherited=${JSON.stringify(inheritedFatalPaths(out))}\n${out}`,
+    );
+  }
+
   // Every member of a multi-source declaration participates in selection. The first source is the
   // suite command and remains unchanged; only the second metadata member moves.
   {

--- a/bin/smoke/mutation-reproof.smoke.ts
+++ b/bin/smoke/mutation-reproof.smoke.ts
@@ -66,12 +66,23 @@ const unmeasuredPreRedPaths = (out: string): string[] => {
   const block = out.match(/^PRE-RED TRANSITION UNMEASURED \(\d+ fixture\(s\)\)[^\n]*\n((?:  .+\n?)+)/m);
   return block ? [...block[1].matchAll(/^ {2}(\S+\.json) -> command:/gm)].map((m) => m[1]) : [];
 };
+/** Parse inherited fatal mutation verdicts: the same named verdict was already fatal at base. */
+const inheritedFatalPaths = (out: string): string[] => {
+  const block = out.match(/^FATAL INHERITED \(\d+ fixture\(s\)\)[^\n]*\n((?:  .+\n?)+)/m);
+  return block ? [...block[1].matchAll(/^ {2}(\S+\.json) -> mutation:/gm)].map((m) => m[1]) : [];
+};
+/** Parse fatal verdicts whose base comparison could not run. */
+const unmeasuredFatalPaths = (out: string): string[] => {
+  const block = out.match(/^FATAL TRANSITION UNMEASURED \(\d+ fixture\(s\)\)[^\n]*\n((?:  .+\n?)+)/m);
+  return block ? [...block[1].matchAll(/^ {2}(\S+\.json) -> transition:/gm)].map((m) => m[1]) : [];
+};
 /** Parse every fatal offender, retaining PRE-RED transition states as distinct output categories. */
 const offenderPaths = (out: string): string[] => [
   ...[...out.matchAll(/^MUTATION REPROOF FAILED \(\d+ fixture\(s\)\): (.+)$/gm)]
     .flatMap((m) => m[1].split(", ")),
   ...attributablePreRedPaths(out),
   ...unmeasuredPreRedPaths(out),
+  ...unmeasuredFatalPaths(out),
 ];
 /** Parse the inconclusive set: a selected fixture whose proof produced no evidence either way. */
 const inconclusivePaths = (out: string): string[] => {
@@ -388,6 +399,67 @@ try {
     );
   }
 
+  // 1b. Wrong-red control: a registered survivor already SURVIVED at base. A comment-only edit of
+  //     its guarded source selects the fixture without moving any mutation verdict. Before base-vs-head
+  //     attribution this is a red against the PR. After, it is inherited and nonfatal.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "s.mjs"), "export const s = () => 1;\n");
+        writeFileSync(join(r, "suites", "s.suite.mjs"), "import { s } from '../s.mjs';\nif (s() !== 1) { console.error('✗ FAIL: s is one'); process.exit(1); }\nconsole.log('✓ s is one');\n");
+        writeFileSync(join(r, "smoke", "mutations", "s.mutations.json"), JSON.stringify({
+          suite: ["suites/s.suite.mjs"],
+          command: "node suites/s.suite.mjs",
+          mutations: [
+            { name: "equivalent survivor", file: "s.mjs", find: "export const s = () => 1;", replace: "export const s = () => 1 + 0;", expectRed: "s is one" },
+            { name: "positive control kill", file: "s.mjs", find: "export const s = () => 1;", replace: "export const s = () => 2;", expectRed: "s is one" },
+          ],
+        }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "s.mjs"), "// select without moving the survivor\nexport const s = () => 1;\n"),
+    );
+    const { status, out } = scan(root, base, head);
+    check(
+      "an inherited SURVIVED selected only by a comment-only guarded-source change remains nonfatal",
+      status === 0
+        && eq(selectedPaths(out), ["smoke/mutations/s.mutations.json"])
+        && eq(inheritedFatalPaths(out), ["smoke/mutations/s.mutations.json"])
+        && offenderPaths(out).length === 0
+        && /SURVIVED /.test(out.replace(/\x1b\[[0-9;]*m/g, ""))
+        && out.includes("mutation: equivalent survivor; transition: base SURVIVED -> head SURVIVED"),
+      `status=${status} inherited=${JSON.stringify(inheritedFatalPaths(out))} offenders=${JSON.stringify(offenderPaths(out))}\n${out}`,
+    );
+  }
+
+  // 1c. Opposite control: the same two-mutation shape, but the PR actually moves a KILLED mutant
+  //     to SURVIVED by dropping the suite assertion. Attribution must still fail the gate.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "m.mjs"), "export const m = () => 1;\n");
+        writeFileSync(join(r, "suites", "m.suite.mjs"), "import { m } from '../m.mjs';\nif (m() !== 1) { console.error('✗ FAIL: m is one'); process.exit(1); }\nconsole.log('✓ m is one');\n");
+        writeFileSync(join(r, "smoke", "mutations", "m.mutations.json"), JSON.stringify({
+          suite: ["suites/m.suite.mjs"],
+          command: "node suites/m.suite.mjs",
+          mutations: [
+            { name: "equivalent survivor", file: "m.mjs", find: "export const m = () => 1;", replace: "export const m = () => 1 + 0;", expectRed: "m is one" },
+            { name: "positive control kill", file: "m.mjs", find: "export const m = () => 1;", replace: "export const m = () => 2;", expectRed: "m is one" },
+          ],
+        }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "suites", "m.suite.mjs"), "console.log('✓ m is one');\n"),
+    );
+    const { status, out } = scan(root, base, head);
+    check(
+      "a PR that moves a mutation from KILLED to SURVIVED still fails naming that fixture",
+      status === 1
+        && eq(offenderPaths(out), ["smoke/mutations/m.mutations.json"])
+        && /^MUTATION REPROOF FAILED /m.test(out)
+        && !inheritedFatalPaths(out).includes("smoke/mutations/m.mutations.json"),
+      `status=${status} offenders=${JSON.stringify(offenderPaths(out))} inherited=${JSON.stringify(inheritedFatalPaths(out))}\n${out}`,
+    );
+  }
+
   // Every member of a multi-source declaration participates in selection. The first source is the
   // suite command and remains unchanged; only the second metadata member moves.
   {
@@ -516,7 +588,7 @@ try {
     );
     const { status, out } = scan(root, base, head);
     check("canonical array to different array remains a selecting config change",
-      status !== 0 && eq(selectedPaths(out), ["smoke/mutations/a.mutations.json"])
+      eq(selectedPaths(out), ["smoke/mutations/a.mutations.json"])
         && metadataOnlyPaths(out).length === 0 && existsSync(join(root, "executed")),
       `status=${status}\n${out}`);
   }
@@ -1260,8 +1332,8 @@ try {
         writeFileSync(join(r, "suites", "red.suite.mjs"), "import { red } from '../red.mjs';\nif (red() !== 1) process.exit(1);\nconsole.log('✓ red is one');\n");
         writeFileSync(join(r, "smoke", "mutations", "fatal.mutations.json"), JSON.stringify({
           suite: ["suites/fatal.suite.mjs"], command: "node suites/fatal.suite.mjs", mutations: [{
-            name: "equivalent fatal mutant", file: "fatal.mjs", find: "export const fatal = () => 1;",
-            replace: "export const fatal = () => 1 + 0;", expectRed: "fatal is one",
+            name: "fatal returns two", file: "fatal.mjs", find: "export const fatal = () => 1;",
+            replace: "export const fatal = () => 2;", expectRed: "fatal is one",
           }],
         }, null, 2));
         writeFileSync(join(r, "smoke", "mutations", "red.mutations.json"), JSON.stringify({
@@ -1273,6 +1345,7 @@ try {
       },
       (r) => {
         writeFileSync(join(r, "fatal.mjs"), "// select fatal fixture\nexport const fatal = () => 1;\n");
+        writeFileSync(join(r, "suites", "fatal.suite.mjs"), "console.log('✓ fatal is one');\n");
         writeFileSync(join(r, "suites", "red.suite.mjs"), "console.error('red suite now fails');\nprocess.exit(1);\n");
       },
     );

--- a/bin/smoke/mutations/mutation-reproof.json
+++ b/bin/smoke/mutations/mutation-reproof.json
@@ -202,10 +202,18 @@
     {
       "name": "fatal attribution keys same-name mutations by displayed label",
       "file": "scripts/mutation-reproof.mjs",
-      "find": "    const baseRec = baseRecords.find((candidate) => candidate.index === rec.index);",
-      "replace": "    const baseRec = baseRecords.find((candidate) => candidate.label === rec.label);",
+      "find": "    const same = take((candidate) => candidate.identity === rec.identity && candidate.verdict === rec.verdict);\n    if (same) { inherited.push({ ...rec, baseVerdict: same.verdict }); continue; }\n    const other = take((candidate) => candidate.identity === rec.identity);",
+      "replace": "    const same = baseRecords.find((candidate) => candidate.label === rec.label);\n    if (same && same.verdict === rec.verdict) { inherited.push({ ...rec, baseVerdict: same.verdict }); continue; }\n    const other = same;",
       "expectRed": "a later same-name mutation that newly becomes ERROR still fails and is not cleared by an earlier inherited ERROR",
       "cell": "a later same-name mutation that newly becomes ERROR still fails and is not cleared by an earlier inherited ERROR"
+    },
+    {
+      "name": "fatal attribution keys mutations by array position",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "    const same = take((candidate) => candidate.identity === rec.identity && candidate.verdict === rec.verdict);\n    if (same) { inherited.push({ ...rec, baseVerdict: same.verdict }); continue; }\n    const other = take((candidate) => candidate.identity === rec.identity);\n    attributable.push({ ...rec, baseVerdict: other?.verdict ?? \"ABSENT\" });",
+      "replace": "    const same = take((candidate) => candidate.index === rec.index && candidate.verdict === rec.verdict);\n    if (same) { inherited.push({ ...rec, baseVerdict: same.verdict }); continue; }\n    const other = take((candidate) => candidate.index === rec.index);\n    attributable.push({ ...rec, baseVerdict: other?.verdict ?? \"ABSENT\" });",
+      "expectRed": "reordering unchanged mutations does not attribute a still-SURVIVED mutant by array position",
+      "cell": "reordering unchanged mutations does not attribute a still-SURVIVED mutant by array position"
     },
     {
       "name": "a depth-zero temp-root filename is erased as though it were a randomized directory",

--- a/bin/smoke/mutations/mutation-reproof.json
+++ b/bin/smoke/mutations/mutation-reproof.json
@@ -130,8 +130,8 @@
     {
       "name": "verdict lines are matched without stripping ANSI colour, so every verdict reads as absent",
       "file": "scripts/mutation-reproof.mjs",
-      "find": "[...output.replace(ANSI, \"\").matchAll(verdictRe)]",
-      "replace": "[...output.matchAll(verdictRe)]",
+      "find": "  for (const line of output.replace(ANSI, \"\").split(\"\\n\")) {",
+      "replace": "  for (const line of output.split(\"\\n\")) {",
       "expectRed": "an INCONCLUSIVE proof is reported as INCONCLUSIVE, does NOT fail the gate, and is not treated as SURVIVED",
       "cell": "an INCONCLUSIVE proof is reported as INCONCLUSIVE, does NOT fail the gate, and is not treated as SURVIVED"
     },

--- a/bin/smoke/mutations/mutation-reproof.json
+++ b/bin/smoke/mutations/mutation-reproof.json
@@ -192,6 +192,14 @@
       "cell": "different line-initial semantic [WARN] failures remain different when stable sibling assertion lines match"
     },
     {
+      "name": "fatal attribution ignores the same mutation's base-to-head transition",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "    const transition = compareFatalVerdicts(headRecordsClean, baseRecords);",
+      "replace": "    const transition = { inherited: [], attributable: headRecordsClean.filter((rec) => FATAL_VERDICTS.has(rec.verdict)) };",
+      "expectRed": "an inherited SURVIVED selected only by a comment-only guarded-source change remains nonfatal",
+      "cell": "an inherited SURVIVED selected only by a comment-only guarded-source change remains nonfatal"
+    },
+    {
       "name": "a depth-zero temp-root filename is erased as though it were a randomized directory",
       "file": "scripts/mutation-failure-signature.mjs",
       "find": "      return { kind: \"origin\", value: separator === -1 ? `<TMP>/${remainder}` : `<TMP>/${remainder.slice(separator + 1)}` };",

--- a/bin/smoke/mutations/mutation-reproof.json
+++ b/bin/smoke/mutations/mutation-reproof.json
@@ -200,6 +200,14 @@
       "cell": "an inherited SURVIVED selected only by a comment-only guarded-source change remains nonfatal"
     },
     {
+      "name": "fatal attribution keys same-name mutations by displayed label",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "    const baseRec = baseRecords.find((candidate) => candidate.index === rec.index);",
+      "replace": "    const baseRec = baseRecords.find((candidate) => candidate.label === rec.label);",
+      "expectRed": "a later same-name mutation that newly becomes ERROR still fails and is not cleared by an earlier inherited ERROR",
+      "cell": "a later same-name mutation that newly becomes ERROR still fails and is not cleared by an earlier inherited ERROR"
+    },
+    {
       "name": "a depth-zero temp-root filename is erased as though it were a randomized directory",
       "file": "scripts/mutation-failure-signature.mjs",
       "find": "      return { kind: \"origin\", value: separator === -1 ? `<TMP>/${remainder}` : `<TMP>/${remainder.slice(separator + 1)}` };",

--- a/scripts/mutation-reproof.mjs
+++ b/scripts/mutation-reproof.mjs
@@ -295,8 +295,12 @@ if (selected.length === 0) {
 //             inherited and non-fatal. An absent or unmeasurable base comparison fails loud. Under
 //             --all there is deliberately no base comparison, so PRE-RED remains non-fatal.
 //   exit 1  — at least one mutation did not produce a clean, named red. That splits again:
-//               SURVIVED / UNGRADABLE — the guard does not discriminate. A real finding. FAIL.
-//               ERROR                 — a dead or ambiguous anchor: the fixture is broken. FAIL.
+//               SURVIVED / UNGRADABLE / WRONG-RED / ERROR — fatal at head. In diff mode, re-run the
+//                                       same fixture proof against clean head and base snapshots.
+//                                       An unchanged fatal verdict is inherited and non-fatal; a
+//                                       verdict the PR actually moves still fails. An absent or
+//                                       unmeasurable base comparison fails loud. Under --all there
+//                                       is no base comparison, so these remain absolute findings.
 //               INCONCLUSIVE (only)   — a timeout or a teardown hang left no evidence either way.
 //                                       Collapsing it into SURVIVED is a false blocker and into
 //                                       KILLED a false clearance, so it is its own reported state
@@ -315,6 +319,32 @@ const FATAL_VERDICTS = new Set(["SURVIVED", "UNGRADABLE", "WRONG-RED", "ERROR"])
 const verdictRe = new RegExp(`^(${VERDICTS.join("|")}) `, "gm");
 const verdictsIn = (output) =>
   [...output.replace(ANSI, "").matchAll(verdictRe)].map((m) => m[1]);
+const labeledVerdictsIn = (output) =>
+  [...output.replace(ANSI, "").matchAll(new RegExp(`^(${VERDICTS.join("|")}) +(.*)$`, "gm"))]
+    .map((m) => ({ verdict: m[1], label: m[2].trim() }));
+
+function runProof(cwd, configPath, env) {
+  const run = spawnSync(process.execPath, [PROOF, "--config", configPath], {
+    cwd, encoding: "utf8", maxBuffer: 64 * 1024 * 1024, env,
+  });
+  return { ...run, output: `${run.stdout ?? ""}${run.stderr ?? ""}` };
+}
+
+function compareFatalVerdicts(headRecords, baseRecords) {
+  const baseByLabel = new Map();
+  for (const rec of baseRecords) {
+    if (!baseByLabel.has(rec.label)) baseByLabel.set(rec.label, rec.verdict);
+  }
+  const inherited = [];
+  const attributable = [];
+  for (const rec of headRecords) {
+    if (!FATAL_VERDICTS.has(rec.verdict)) continue;
+    const baseVerdict = baseByLabel.get(rec.label);
+    if (baseVerdict === rec.verdict) inherited.push({ ...rec, baseVerdict });
+    else attributable.push({ ...rec, baseVerdict: baseVerdict ?? "ABSENT" });
+  }
+  return { inherited, attributable };
+}
 
 /** mutation-proof aborts at its first red distinct command, so exactly one refusal is its contract.
  *  The all-command matrix below comes from fixture config without changing that contract. */
@@ -450,7 +480,9 @@ function rootContaminationReason(provenance, cleanHeadRun) {
   return undefined;
 }
 
-const fatal = [];       // SURVIVED / UNGRADABLE / WRONG-RED / ERROR — the gate's real findings
+const fatal = [];       // SURVIVED / UNGRADABLE / WRONG-RED / ERROR the PR actually moved
+const inheritedFatal = []; // same fatal verdict already present at base
+const unmeasuredFatal = []; // fatal at head but base comparison absent or unrunnable
 const preRed = [];      // exit 4 + base RED, or any exit 4 under --all — inherited/non-attributed
 const attributablePreRed = []; // exit 4 + the SAME command base GREEN -> head RED
 const unmeasuredPreRed = []; // exit 4 + absent/ambiguous/unrunnable base comparison — loud failure
@@ -523,7 +555,42 @@ for (const { path, command, mutations } of selected) {
   // no verdict is adverse and at least one is INCONCLUSIVE, i.e. the run produced no evidence against
   // the guard. Anything else — an empty parse, an exit-1 with only KILLED lines, a token this gate
   // does not know — is an unexplained non-zero and is treated as a finding, never as a pass.
-  if (verdicts.some((v) => FATAL_VERDICTS.has(v))) fatal.push(path);
+  if (verdicts.some((v) => FATAL_VERDICTS.has(v))) {
+    if (a.all) { fatal.push(path); continue; }
+    ensureSnapshotPrepared(snapshots.head, "head");
+    ensureSnapshotPrepared(snapshots.base, "base");
+    const preparationError = snapshots.head.error ?? snapshots.head.preparationError
+      ?? snapshots.base.error ?? snapshots.base.preparationError;
+    if (preparationError) { unmeasuredFatal.push({ path, reason: preparationError }); continue; }
+    if (!existsSync(join(snapshots.head.path, path)) || !existsSync(join(snapshots.base.path, path))) {
+      unmeasuredFatal.push({ path, reason: "fixture is absent from a comparison snapshot" });
+      continue;
+    }
+    const headProof = runProof(snapshots.head.path, path, snapshotComparisonEnv());
+    const baseProof = runProof(snapshots.base.path, path, snapshotComparisonEnv());
+    const headRecordsClean = labeledVerdictsIn(headProof.output);
+    const rootFatals = labeledVerdictsIn(output).filter((rec) => FATAL_VERDICTS.has(rec.verdict));
+    const cleanFatals = headRecordsClean.filter((rec) => FATAL_VERDICTS.has(rec.verdict));
+    if (JSON.stringify(rootFatals) !== JSON.stringify(cleanFatals)) {
+      unmeasuredFatal.push({ path, reason: "root fatal verdicts were not reproduced in the clean head snapshot" });
+      continue;
+    }
+    const baseReason = unmeasurableFailure(baseProof);
+    if (baseProof.error || baseProof.status === null || baseProof.signal) {
+      unmeasuredFatal.push({ path, reason: `base proof ${baseReason ?? "could not run"}` });
+      continue;
+    }
+    const baseRecords = labeledVerdictsIn(baseProof.output);
+    if (!baseRecords.length && baseProof.status !== 0) {
+      unmeasuredFatal.push({ path, reason: "base proof produced no comparable mutation verdicts" });
+      continue;
+    }
+    const transition = compareFatalVerdicts(headRecordsClean, baseRecords);
+    if (transition.attributable.length) fatal.push(path);
+    else if (transition.inherited.length) inheritedFatal.push({ path, mutations: transition.inherited });
+    else fatal.push(path);
+    continue;
+  }
   else if (verdicts.includes("INCONCLUSIVE") && verdicts.every((v) => v === "KILLED" || v === "INCONCLUSIVE")) inconclusive.push(path);
   else fatal.push(path);
 }
@@ -539,6 +606,13 @@ if (preRed.length) {
       : `  ${path} -> command: ${command}; transition: base RED (exit ${baseStatus}) -> head RED (exit ${headStatus})`);
   }
 }
+if (inheritedFatal.length) {
+  console.log(`\nFATAL INHERITED (${fixtureCount(inheritedFatal)} fixture(s)) — the same mutation verdict was already fatal at base; not caused by this diff:`);
+  for (const { path, mutations } of inheritedFatal) {
+    for (const rec of mutations)
+      console.log(`  ${path} -> mutation: ${rec.label}; transition: base ${rec.baseVerdict} -> head ${rec.verdict}`);
+  }
+}
 if (inconclusive.length) {
   console.log(`\nINCONCLUSIVE (${inconclusive.length} fixture(s)) — a timeout, a teardown hang, or a swallowed exit code left no evidence either way; not treated as SURVIVED and not treated as KILLED: ${inconclusive.join(", ")}`);
 }
@@ -552,12 +626,17 @@ if (unmeasuredPreRed.length) {
   for (const { path, command, reason } of unmeasuredPreRed)
     console.error(`  ${path} -> command: ${command}; transition: UNMEASURED (${reason}) -> head RED`);
 }
+if (unmeasuredFatal.length) {
+  console.error(`\nFATAL TRANSITION UNMEASURED (${fixtureCount(unmeasuredFatal)} fixture(s)) — base comparison was absent or could not run; refusing to clear:`);
+  for (const { path, reason } of unmeasuredFatal)
+    console.error(`  ${path} -> transition: UNMEASURED (${reason})`);
+}
 if (fatal.length) {
   console.error(`\nMUTATION REPROOF FAILED (${fatal.length} fixture(s)): ${fatal.join(", ")}`);
 }
-if (attributablePreRed.length || unmeasuredPreRed.length || fatal.length) {
+if (attributablePreRed.length || unmeasuredPreRed.length || fatal.length || unmeasuredFatal.length) {
   process.exit(1);
 }
 console.log(a.all
   ? `\nMUTATION REPROOF OK (${selected.length} fixture(s) selected; ${selected.length - preRed.length - inconclusive.length} discriminated, ${preRed.length} pre-red, ${inconclusive.length} inconclusive; base not compared under --all)`
-  : `\nMUTATION REPROOF OK (${selected.length} fixture(s) selected; ${selected.length - fixtureCount(preRed) - inconclusive.length} discriminated, ${fixtureCount(preRed)} inherited pre-red, 0 attributable pre-red, 0 unmeasured pre-red, ${inconclusive.length} inconclusive)`);
+  : `\nMUTATION REPROOF OK (${selected.length} fixture(s) selected; ${selected.length - fixtureCount(preRed) - fixtureCount(inheritedFatal) - inconclusive.length} discriminated, ${fixtureCount(preRed)} inherited pre-red, 0 attributable pre-red, 0 unmeasured pre-red, ${inconclusive.length} inconclusive)`);

--- a/scripts/mutation-reproof.mjs
+++ b/scripts/mutation-reproof.mjs
@@ -316,15 +316,38 @@ if (selected.length === 0) {
 const ANSI = /\x1b\[[0-9;]*m/g;
 const VERDICTS = ["KILLED", "SURVIVED", "INCONCLUSIVE", "UNGRADABLE", "WRONG-RED", "ERROR"];
 const FATAL_VERDICTS = new Set(["SURVIVED", "UNGRADABLE", "WRONG-RED", "ERROR"]);
-// mutation-proof prints `${verdict.padEnd(12)} ${label}`. That 12-wide field is the identity of a
-// report line: ERROR why-text can name KILLED, and duplicate mutation names are valid, so neither a
-// loose `^VERDICT ` match nor a label-keyed map is a mutation identity.
-const labeledVerdictsIn = (output) => {
+// mutation-proof prints `${verdict.padEnd(12)} ${label}`. That 12-wide field is the parse of a
+// report line: ERROR why-text can name KILLED, so a loose `^VERDICT ` match is not a parse.
+// Duplicate names are valid, and array position is not identity: reordering or inserting
+// unchanged objects must not attribute a still-SURVIVED mutant. Identity is the mutation's
+// `file` plus `find` from the snapshot fixture — the code the mutation edits. Same key more
+// than once compares the multiset of verdicts under that key.
+const mutationIdentity = (mutation, index) => {
+  if (!mutation || typeof mutation !== "object") return `\0unbound:${index}`;
+  return JSON.stringify([
+    typeof mutation.file === "string" ? mutation.file : null,
+    mutation.find ?? null,
+  ]);
+};
+const readFixtureMutations = (snapshotRoot, configPath) => {
+  try {
+    const config = JSON.parse(readFileSync(join(snapshotRoot, configPath), "utf8"));
+    return Array.isArray(config.mutations) ? config.mutations : [];
+  } catch {
+    return [];
+  }
+};
+const labeledVerdictsIn = (output, mutations = []) => {
   const records = [];
   for (const line of output.replace(ANSI, "").split("\n")) {
     const verdict = VERDICTS.find((token) => line.startsWith(`${token.padEnd(12)} `));
     if (!verdict) continue;
-    records.push({ index: records.length, verdict, label: line.slice(13).trim() });
+    records.push({
+      index: records.length,
+      verdict,
+      label: line.slice(13).trim(),
+      identity: mutationIdentity(mutations[records.length], records.length),
+    });
   }
   return records;
 };
@@ -338,14 +361,22 @@ function runProof(cwd, configPath, env) {
 }
 
 function compareFatalVerdicts(headRecords, baseRecords) {
+  const unused = baseRecords.map((_, i) => i);
   const inherited = [];
   const attributable = [];
+  const take = (pred) => {
+    const at = unused.findIndex((i) => pred(baseRecords[i]));
+    if (at === -1) return undefined;
+    const rec = baseRecords[unused[at]];
+    unused.splice(at, 1);
+    return rec;
+  };
   for (const rec of headRecords) {
     if (!FATAL_VERDICTS.has(rec.verdict)) continue;
-    const baseRec = baseRecords.find((candidate) => candidate.index === rec.index);
-    const baseVerdict = baseRec?.verdict;
-    if (baseVerdict === rec.verdict) inherited.push({ ...rec, baseVerdict });
-    else attributable.push({ ...rec, baseVerdict: baseVerdict ?? "ABSENT" });
+    const same = take((candidate) => candidate.identity === rec.identity && candidate.verdict === rec.verdict);
+    if (same) { inherited.push({ ...rec, baseVerdict: same.verdict }); continue; }
+    const other = take((candidate) => candidate.identity === rec.identity);
+    attributable.push({ ...rec, baseVerdict: other?.verdict ?? "ABSENT" });
   }
   return { inherited, attributable };
 }
@@ -572,8 +603,10 @@ for (const { path, command, mutations } of selected) {
     }
     const headProof = runProof(snapshots.head.path, path, snapshotComparisonEnv());
     const baseProof = runProof(snapshots.base.path, path, snapshotComparisonEnv());
-    const headRecordsClean = labeledVerdictsIn(headProof.output);
-    const rootFatals = labeledVerdictsIn(output).filter((rec) => FATAL_VERDICTS.has(rec.verdict));
+    const headMutations = readFixtureMutations(snapshots.head.path, path);
+    const baseMutations = readFixtureMutations(snapshots.base.path, path);
+    const headRecordsClean = labeledVerdictsIn(headProof.output, headMutations);
+    const rootFatals = labeledVerdictsIn(output, mutations).filter((rec) => FATAL_VERDICTS.has(rec.verdict));
     const cleanFatals = headRecordsClean.filter((rec) => FATAL_VERDICTS.has(rec.verdict));
     if (JSON.stringify(rootFatals) !== JSON.stringify(cleanFatals)) {
       unmeasuredFatal.push({ path, reason: "root fatal verdicts were not reproduced in the clean head snapshot" });
@@ -584,7 +617,7 @@ for (const { path, command, mutations } of selected) {
       unmeasuredFatal.push({ path, reason: `base proof ${baseReason ?? "could not run"}` });
       continue;
     }
-    const baseRecords = labeledVerdictsIn(baseProof.output);
+    const baseRecords = labeledVerdictsIn(baseProof.output, baseMutations);
     if (!baseRecords.length && baseProof.status !== 0) {
       unmeasuredFatal.push({ path, reason: "base proof produced no comparable mutation verdicts" });
       continue;

--- a/scripts/mutation-reproof.mjs
+++ b/scripts/mutation-reproof.mjs
@@ -320,13 +320,15 @@ const FATAL_VERDICTS = new Set(["SURVIVED", "UNGRADABLE", "WRONG-RED", "ERROR"])
 // report line: ERROR why-text can name KILLED, so a loose `^VERDICT ` match is not a parse.
 // Duplicate names are valid, and array position is not identity: reordering or inserting
 // unchanged objects must not attribute a still-SURVIVED mutant. Identity is the mutation's
-// `file` plus `find` from the snapshot fixture — the code the mutation edits. Same key more
-// than once compares the multiset of verdicts under that key.
+// `file`, `find`, and `replace` from the snapshot fixture — the code the mutation edits.
+// `find` alone is not enough when two mutants in the same file share an anchor and differ
+// only in the replacement. Same key more than once compares the multiset of verdicts.
 const mutationIdentity = (mutation, index) => {
   if (!mutation || typeof mutation !== "object") return `\0unbound:${index}`;
   return JSON.stringify([
     typeof mutation.file === "string" ? mutation.file : null,
     mutation.find ?? null,
+    mutation.replace ?? null,
   ]);
 };
 const readFixtureMutations = (snapshotRoot, configPath) => {

--- a/scripts/mutation-reproof.mjs
+++ b/scripts/mutation-reproof.mjs
@@ -316,12 +316,19 @@ if (selected.length === 0) {
 const ANSI = /\x1b\[[0-9;]*m/g;
 const VERDICTS = ["KILLED", "SURVIVED", "INCONCLUSIVE", "UNGRADABLE", "WRONG-RED", "ERROR"];
 const FATAL_VERDICTS = new Set(["SURVIVED", "UNGRADABLE", "WRONG-RED", "ERROR"]);
-const verdictRe = new RegExp(`^(${VERDICTS.join("|")}) `, "gm");
-const verdictsIn = (output) =>
-  [...output.replace(ANSI, "").matchAll(verdictRe)].map((m) => m[1]);
-const labeledVerdictsIn = (output) =>
-  [...output.replace(ANSI, "").matchAll(new RegExp(`^(${VERDICTS.join("|")}) +(.*)$`, "gm"))]
-    .map((m) => ({ verdict: m[1], label: m[2].trim() }));
+// mutation-proof prints `${verdict.padEnd(12)} ${label}`. That 12-wide field is the identity of a
+// report line: ERROR why-text can name KILLED, and duplicate mutation names are valid, so neither a
+// loose `^VERDICT ` match nor a label-keyed map is a mutation identity.
+const labeledVerdictsIn = (output) => {
+  const records = [];
+  for (const line of output.replace(ANSI, "").split("\n")) {
+    const verdict = VERDICTS.find((token) => line.startsWith(`${token.padEnd(12)} `));
+    if (!verdict) continue;
+    records.push({ index: records.length, verdict, label: line.slice(13).trim() });
+  }
+  return records;
+};
+const verdictsIn = (output) => labeledVerdictsIn(output).map((rec) => rec.verdict);
 
 function runProof(cwd, configPath, env) {
   const run = spawnSync(process.execPath, [PROOF, "--config", configPath], {
@@ -331,15 +338,12 @@ function runProof(cwd, configPath, env) {
 }
 
 function compareFatalVerdicts(headRecords, baseRecords) {
-  const baseByLabel = new Map();
-  for (const rec of baseRecords) {
-    if (!baseByLabel.has(rec.label)) baseByLabel.set(rec.label, rec.verdict);
-  }
   const inherited = [];
   const attributable = [];
   for (const rec of headRecords) {
     if (!FATAL_VERDICTS.has(rec.verdict)) continue;
-    const baseVerdict = baseByLabel.get(rec.label);
+    const baseRec = baseRecords.find((candidate) => candidate.index === rec.index);
+    const baseVerdict = baseRec?.verdict;
     if (baseVerdict === rec.verdict) inherited.push({ ...rec, baseVerdict });
     else attributable.push({ ...rec, baseVerdict: baseVerdict ?? "ABSENT" });
   }


### PR DESCRIPTION
## Summary
- Mutation reproof treated SURVIVED, UNGRADABLE, WRONG-RED, and ERROR as absolute findings with no base-vs-head comparison.
- A fixture whose named fatal verdict is unchanged from the base commit is inherited and does not fail the PR. A verdict the PR actually moves still fails. Unmeasurable base comparison still fails closed.
- Controls: inherited SURVIVED on a comment-only select is green; a PR that moves KILLED to SURVIVED stays red. A mutation that deletes the comparison reds the inherited-SURVIVED cell.

Refs #1473

## Test plan
- [ ] `pnpm smoke:mutation-reproof` green
- [ ] Mutation reproof at this exact head
- [ ] Tenki CI including ci-ok
- [ ] Confirm #1383 / #1435 / #1445 would no longer inherit the registered survivor as a PR red