### PR TITLE
fix(cli): resume interrupted connector upgrades

### DIFF
--- a/.changeset/warm-tigers-resume.md
+++ b/.changeset/warm-tigers-resume.md
@@ -1,0 +1,9 @@
+---
+"cotal-ai": patch
+---
+
+Resume an interrupted built-in connector refresh automatically when the durable seed stamp proves
+that the running CLI is advancing the store to a newer generation and no reconcile or seed child is
+still live. The manager now reaches readiness after that safe upgrade repair, while same-generation
+and unattributable interruption markers still fail closed and report the recorded package, phase,
+store generation, running generation, and absence of a live writer.

--- a/bin/smoke/ci-suites.d/63114f51beb69f3273b26373437e0f8ca1cb5a968a5c366a1cbeb0f3d7f701c8.txt
+++ b/bin/smoke/ci-suites.d/63114f51beb69f3273b26373437e0f8ca1cb5a968a5c366a1cbeb0f3d7f701c8.txt
@@ -1,0 +1,2 @@
+# A current manager resumes an interrupted refresh over a v0.33.1-shaped seed store.
+smoke:seed-upgrade-resume

--- a/implementations/cli/smoke/fixtures/seed-upgrade-resume.mutations.json
+++ b/implementations/cli/smoke/fixtures/seed-upgrade-resume.mutations.json
@@ -1,0 +1,26 @@
+{
+  "suite": [
+    "implementations/cli/smoke/seed-upgrade-resume.smoke.ts"
+  ],
+  "guard": "a manager resumes an interrupted connector generation upgrade automatically, while a same-generation interrupted seed still fails loud",
+  "command": "pnpm smoke:seed-upgrade-resume",
+  "completionMarker": "seed-upgrade-resume smoke:",
+  "proveWith": "node scripts/mutation-proof.mjs --config implementations/cli/smoke/fixtures/seed-upgrade-resume.mutations.json",
+  "why": [
+    "A completed 0.33.1-shaped store has no reconcile marker. The marker is a cursor written by the newer seeder before its copy/add mutation and cleared only after authority, witness, and the new generation stamp commit.",
+    "The smoke builds the 0.33.1 state through the released package, leaves the old stamp in place with a compatible cursor as an interrupted newer-generation refresh would, and boots the current public manager against an isolated broker. That manager must repair and reach readiness without a hand-run maintenance command.",
+    "The bidirectional control changes only the stamp to the current generation. That state cannot be attributed to an upgrade, so the manager must still refuse and retain the cursor.",
+    "The mutation deletes the unattended repair call. The manager then returns from the seed gate with the cursor still present, and the matching marker-retirement assertion turns red."
+  ],
+  "mutations": [
+    {
+      "name": "the manager recognizes an interrupted generation upgrade but skips the verified repair",
+      "file": "implementations/cli/src/seed/reconcile.ts",
+      "find": "          await reconcile(\"repair\");\n          return NOOP;",
+      "replace": "          return NOOP;",
+      "afterRestore": "pnpm --filter @cotal-ai/cli build && pnpm --filter cotal-ai build",
+      "expectRed": "upgrade interruption: manager repairs the newer-generation cursor before reaching ready",
+      "cell": "upgrade interruption: manager repairs the newer-generation cursor before reaching ready"
+    }
+  ]
+}

--- a/implementations/cli/smoke/seed-upgrade-resume.smoke.ts
+++ b/implementations/cli/smoke/seed-upgrade-resume.smoke.ts
@@ -1,0 +1,190 @@
+/**
+ * Issue #1336: a completed v0.33.1 seed store has no interruption marker, but a newer generation can
+ * leave the shared reconcile cursor if its upgrade refresh is interrupted before the final stamp
+ * commit. The current manager must resume that exact upgrade safely and reach readiness. A cursor
+ * whose stamp already names the current generation is not upgrade-attributable and must still stop.
+ *
+ * Broker-only fixture. It never runs `cotal up` or `cotal down`, and every home/config/root is isolated.
+ * Run: pnpm smoke:seed-upgrade-resume
+ */
+import assert from "node:assert/strict";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+const repo = join(import.meta.dirname, "..", "..", "..");
+const cli = join(repo, "bin", "dist", "cotal.js");
+if (!existsSync(cli)) throw new Error(`built CLI missing at ${cli}`);
+
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+const originalXdg = process.env.XDG_CONFIG_HOME;
+const originalCotalHome = process.env.COTAL_HOME;
+const originalAllowCheckoutSeed = process.env.COTAL_ALLOW_CHECKOUT_SEED;
+const originalNoColor = process.env.NO_COLOR;
+const originalCotal = new Map(
+  Object.entries(process.env).filter(([key]) => key.startsWith("COTAL_")),
+);
+const ambient: NodeJS.ProcessEnv = { ...process.env };
+for (const key of Object.keys(ambient)) if (key.startsWith("COTAL_")) delete ambient[key];
+
+const base = mkdtempSync(join(tmpdir(), "cotal-seed-upgrade-resume-"));
+const home = join(base, "home");
+const xdg = join(base, "xdg");
+const cotalHome = join(base, "cotal-home");
+const root = join(base, "workspace");
+const npmPrefix = join(base, "old-prefix");
+const brokerStore = join(base, "jetstream");
+for (const path of [home, xdg, cotalHome, root, npmPrefix, brokerStore]) mkdirSync(path, { recursive: true });
+mkdirSync(join(root, ".cotal"), { recursive: true });
+
+process.env.HOME = home;
+process.env.USERPROFILE = home;
+process.env.XDG_CONFIG_HOME = xdg;
+process.env.COTAL_HOME = cotalHome;
+process.env.COTAL_ALLOW_CHECKOUT_SEED = "1";
+process.env.NO_COLOR = "1";
+for (const key of Object.keys(process.env)) if (key.startsWith("COTAL_") && !["COTAL_HOME", "COTAL_ALLOW_CHECKOUT_SEED"].includes(key)) delete process.env[key];
+
+const { probeConnect, setupSpaceStreams } = await import("@cotal-ai/core");
+const { recordMesh } = await import("@cotal-ai/workspace");
+
+const freePort = (): Promise<number> => new Promise((resolve, reject) => {
+  const socket = createServer();
+  socket.on("error", reject);
+  socket.listen(0, "127.0.0.1", () => {
+    const port = (socket.address() as AddressInfo).port;
+    socket.close(() => resolve(port));
+  });
+});
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const alive = (pid: number | undefined): boolean => {
+  if (!pid) return false;
+  try { process.kill(pid, 0); return true; } catch { return false; }
+};
+const stop = async (child: ChildProcess | undefined): Promise<void> => {
+  if (!child || child.exitCode !== null || child.signalCode !== null) return;
+  child.kill("SIGTERM");
+  await Promise.race([
+    new Promise<void>((resolve) => child.once("exit", () => resolve())),
+    wait(5_000).then(() => { if (alive(child.pid)) child.kill("SIGKILL"); }),
+  ]);
+};
+const childEnv = (extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv => ({
+  ...ambient,
+  HOME: home,
+  USERPROFILE: home,
+  XDG_CONFIG_HOME: xdg,
+  COTAL_HOME: cotalHome,
+  COTAL_ALLOW_CHECKOUT_SEED: "1",
+  NO_COLOR: "1",
+  ...extra,
+});
+const seedDir = join(xdg, "cotal", "seed");
+const cursorPath = join(seedDir, "reconcile.cursor.json");
+const stampPath = join(seedDir, "stamp.json");
+const oldCli = join(npmPrefix, "node_modules", "cotal-ai", "dist", "cotal.js");
+const currentGeneration = (JSON.parse(readFileSync(join(repo, "bin", "package.json"), "utf8")) as { version: string }).version;
+const cursor = { nonce: "issue-1336-upgrade", package: "claude", phase: "add" } as const;
+
+let broker: ChildProcess | undefined;
+let manager: ChildProcess | undefined;
+let pass = 0;
+function check(name: string, condition: boolean, extra?: unknown): void {
+  if (!condition) throw new Error(`FAIL: ${name}${extra === undefined ? "" : `\n${String(extra)}`}`);
+  pass += 1;
+  console.log(`  ✓ ${name}`);
+}
+
+try {
+  const installed = spawnSync("npm", ["install", "--ignore-scripts", "--no-audit", "--no-fund", "--prefix", npmPrefix, "cotal-ai@0.33.1"], {
+    env: childEnv({ COTAL_ALLOW_CHECKOUT_SEED: undefined }),
+    encoding: "utf8",
+    timeout: 180_000,
+  });
+  assert.equal(installed.status, 0, `install v0.33.1 failed:\n${installed.stdout}\n${installed.stderr}`);
+  const oldSeed = spawnSync(process.execPath, [oldCli, "ext", "list"], {
+    cwd: root,
+    env: childEnv({ COTAL_ALLOW_CHECKOUT_SEED: undefined }),
+    encoding: "utf8",
+    timeout: 180_000,
+  });
+  assert.equal(oldSeed.status, 0, `v0.33.1 seed failed:\n${oldSeed.stdout}\n${oldSeed.stderr}`);
+  check("v0.33.1 layout: a completed seed store has no reconcile cursor", !existsSync(cursorPath));
+  check(
+    "v0.33.1 layout: the committed legacy stamp names generation 0.33.1",
+    (JSON.parse(readFileSync(stampPath, "utf8")) as { generation?: string }).generation === "0.33.1",
+  );
+
+  writeFileSync(cursorPath, `${JSON.stringify(cursor)}\n`);
+  const port = await freePort();
+  const server = `nats://127.0.0.1:${port}`;
+  const space = "seed-upgrade-resume";
+  broker = spawn("nats-server", ["-a", "127.0.0.1", "-p", String(port), "-js", "-sd", brokerStore], { stdio: "ignore" });
+  let serving = false;
+  for (let tries = 0; tries < 80 && !serving; tries++) {
+    serving = (await probeConnect(server, { timeoutMs: 400 })).ok;
+    if (!serving) await wait(100);
+  }
+  assert.ok(serving, "isolated broker did not become reachable");
+  await setupSpaceStreams({ servers: server, space });
+  recordMesh({ space, server, root, mode: "open", ts: new Date().toISOString(), origin: "manual" });
+
+  let managerOutput = "";
+  manager = spawn(process.execPath, [cli, "supervise", "--space", space, "--server", server, "--runtime", "pty"], {
+    cwd: root,
+    env: childEnv(),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  manager.stdout?.on("data", (chunk: Buffer | string) => { managerOutput += chunk.toString(); });
+  manager.stderr?.on("data", (chunk: Buffer | string) => { managerOutput += chunk.toString(); });
+  for (let tries = 0; tries < 900 && !managerOutput.includes("manager up"); tries++) {
+    if (manager.exitCode !== null || manager.signalCode !== null) break;
+    await wait(100);
+  }
+  check(
+    "upgrade interruption: manager repairs the newer-generation cursor before reaching ready",
+    managerOutput.includes("manager up") && !existsSync(cursorPath) && manager.exitCode === null,
+    managerOutput.slice(-2_000),
+  );
+  check(
+    "upgrade interruption: the repaired store commits the current generation",
+    (JSON.parse(readFileSync(stampPath, "utf8")) as { generation?: string }).generation === currentGeneration,
+  );
+  await stop(manager);
+  manager = undefined;
+
+  writeFileSync(stampPath, `${JSON.stringify({ generation: currentGeneration })}\n`);
+  writeFileSync(cursorPath, `${JSON.stringify({ ...cursor, nonce: "issue-1336-control" })}\n`);
+  const interrupted = spawnSync(process.execPath, [cli, "supervise", "--space", space, "--server", server, "--runtime", "pty"], {
+    cwd: root,
+    env: childEnv(),
+    encoding: "utf8",
+    timeout: 30_000,
+  });
+  const interruptedOutput = `${interrupted.stdout ?? ""}${interrupted.stderr ?? ""}`;
+  check(
+    "actual interruption: a same-generation cursor still hard-stops the manager with exact state",
+    interrupted.status !== 0 &&
+      interruptedOutput.includes(`package \"claude\", phase add`) &&
+      interruptedOutput.includes(`seed store generation ${currentGeneration}, running generation ${currentGeneration}`) &&
+      existsSync(cursorPath),
+    interruptedOutput,
+  );
+} finally {
+  await stop(manager);
+  await stop(broker);
+  if (originalHome === undefined) delete process.env.HOME; else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = originalUserProfile;
+  if (originalXdg === undefined) delete process.env.XDG_CONFIG_HOME; else process.env.XDG_CONFIG_HOME = originalXdg;
+  if (originalCotalHome === undefined) delete process.env.COTAL_HOME; else process.env.COTAL_HOME = originalCotalHome;
+  if (originalAllowCheckoutSeed === undefined) delete process.env.COTAL_ALLOW_CHECKOUT_SEED; else process.env.COTAL_ALLOW_CHECKOUT_SEED = originalAllowCheckoutSeed;
+  if (originalNoColor === undefined) delete process.env.NO_COLOR; else process.env.NO_COLOR = originalNoColor;
+  for (const key of Object.keys(process.env)) if (key.startsWith("COTAL_")) delete process.env[key];
+  for (const [key, value] of originalCotal) process.env[key] = value;
+  rmSync(base, { recursive: true, force: true });
+}
+
+console.log(`seed-upgrade-resume smoke: ${pass} passed, 0 failed`);

--- a/implementations/cli/smoke/seed-upgrade-resume.smoke.ts
+++ b/implementations/cli/smoke/seed-upgrade-resume.smoke.ts
@@ -92,10 +92,15 @@ const cursor = { nonce: "issue-1336-upgrade", package: "claude", phase: "add" } 
 let broker: ChildProcess | undefined;
 let manager: ChildProcess | undefined;
 let pass = 0;
+let fail = 0;
 function check(name: string, condition: boolean, extra?: unknown): void {
-  if (!condition) throw new Error(`FAIL: ${name}${extra === undefined ? "" : `\n${String(extra)}`}`);
-  pass += 1;
-  console.log(`  ✓ ${name}`);
+  if (condition) {
+    pass += 1;
+    console.log(`  ✓ ${name}`);
+  } else {
+    fail += 1;
+    console.log(`  ✗ FAIL: ${name}`, extra ?? "");
+  }
 }
 
 try {
@@ -187,4 +192,5 @@ try {
   rmSync(base, { recursive: true, force: true });
 }
 
-console.log(`seed-upgrade-resume smoke: ${pass} passed, 0 failed`);
+console.log(`seed-upgrade-resume smoke: ${pass} passed, ${fail} failed`);
+process.exitCode = fail ? 1 : 0;

--- a/implementations/cli/src/seed/reconcile.ts
+++ b/implementations/cli/src/seed/reconcile.ts
@@ -25,6 +25,7 @@ import {
   recoveryPending,
   sanitizeCorruptCrashState,
   seedChildStatus,
+  type ReconcileCursor,
   writeCursor,
   writePendingChildMarker,
   writeRecovery,
@@ -119,7 +120,29 @@ async function reconcile(mode: Mode): Promise<ReconcileResult> {
           throw new Error(`a connector seed child (pid ${child.pid}) is still installing - retry once it finishes`);
         if (child.kind === "ambiguous")
           throw new Error(`a connector seed may be mid-flight (marker ${child.path}) - if no cotal process is running, remove it, then run \`cotal ext seed --repair\``);
-        throw new Error("a previous connector seed or repair was interrupted - run `cotal ext seed --repair`");
+        const migration = cursor ? interruptedUpgrade(cursor, generation) : undefined;
+        if (migration && cursor) {
+          console.error(
+            c.dim(
+              `resuming an interrupted connector upgrade (seed store ${migration.from} -> ${generation}; ` +
+                `package "${cursor.package}", phase ${cursor.phase}) …`,
+            ),
+          );
+          await reconcile("repair");
+          return NOOP;
+        }
+        if (cursor) {
+          const storeGeneration = readStamp()?.generation ?? "absent";
+          throw new Error(
+            `a previous connector seed was interrupted (package "${cursor.package}", phase ${cursor.phase}; ` +
+              `seed store generation ${storeGeneration}, running generation ${generation}; ` +
+              "no live reconcile or seed child found) - run `cotal ext seed --repair`",
+          );
+        }
+        throw new Error(
+          "a previous connector repair was interrupted (recovery journal present; no live reconcile or seed child found) - " +
+            "run `cotal ext seed --repair`",
+        );
       }
     } else if (readWitness() && authorityIntact() && builtinsAccounted() && builtinsMetadataCurrent() && readStamp()?.generation === generation && !reconcileLockActive()) {
       // Steady state AND no reconcile in flight. The lock check is LAST (immediately before NOOP) so
@@ -145,6 +168,18 @@ async function reconcile(mode: Mode): Promise<ReconcileResult> {
   } finally {
     lock.release();
   }
+}
+
+/** A cursor left while the durable stamp still names an older generation is evidence that this
+ * running generation began the ordinary upgrade refresh and did not reach its final commit. The
+ * cursor identifies the exact package to reinstall, the child marker proves no installer remains,
+ * and the reconcile/extension locks serialize the recovery, so the same verified repair used by the
+ * maintenance command is safe to resume unattended. A same-generation (or unstamped/corrupt-stamp)
+ * cursor is not attributed to an upgrade and remains fail-loud. */
+function interruptedUpgrade(cursor: ReconcileCursor, generation: string): { readonly from: string } | undefined {
+  const stamp = readStamp();
+  if (!stamp || !isValidSemver(stamp.generation) || !isStrictlyNewer(generation, stamp.generation)) return undefined;
+  return { from: stamp.generation };
 }
 
 /** Authority present, readable, and structurally valid (a corrupt one is NOT intact — it routes to

--- a/package.json
+++ b/package.json
@@ -553,6 +553,7 @@
     "smoke:setup-provider-pack": "pnpm --filter @cotal-ai/workspace... build && pnpm --filter @cotal-ai/connector-core build && pnpm --filter @cotal-ai/connector-claude-code build && pnpm --filter @cotal-ai/cli build && tsx implementations/cli/smoke/setup-provider-pack.smoke.ts && tsx implementations/cli/smoke/setup-provider-absent.smoke.ts",
     "smoke:ext-seed-help": "pnpm --filter cotal-ai... build && tsx implementations/cli/smoke/ext-seed-help.smoke.ts",
     "smoke:seed": "pnpm --filter cotal-ai... build && tsx implementations/cli/smoke/seed.smoke.ts",
+    "smoke:seed-upgrade-resume": "pnpm --filter cotal-ai... build && tsx implementations/cli/smoke/seed-upgrade-resume.smoke.ts",
     "smoke:seed-checkout-store": "tsx implementations/cli/smoke/seed-checkout-store.smoke.ts",
     "smoke:seed-migration-provenance": "pnpm --filter cotal-ai... build && pnpm --dir bin seeded-connectors && tsx implementations/cli/smoke/seed-migration-provenance.smoke.ts",
     "smoke:seed-tarball:live": "pnpm --filter cotal-ai... build && tsx bin/smoke/seed-tarball-live.smoke.ts",


### PR DESCRIPTION
Fixes #1336.

## What the marker was

The manager's boot gate reads `seed/reconcile.cursor.json`. The newer seeder writes that cursor before each built-in connector payload copy and `ext add`, then deliberately retains it until the final transaction commit has written the ever-seeded authority, initialization witness, and new generation stamp.

The seed parent writes the cursor. The final successful reconcile clears it. A seed child has a separate liveness marker, which is checked before any recovery so an orphan installer is never raced.

## Why the upgrade left it

A completed 0.33.1 seed store has no reconcile marker at all. I built one with the released 0.33.1 package and confirmed that both 0.45.0 and current main refresh it normally. The absence is not misread.

The reported marker therefore means the newer-generation connector refresh started but did not reach its final commit. That can happen while an installation is otherwise being upgraded normally if a connector refresh is in flight when its owning process exits. The old stamp remains durable, and the cursor identifies the exact package and phase that did not commit.

## What now happens

When the cursor is present, no reconcile lock or seed child is live, and the durable stamp names a strictly older generation than the running CLI, manager boot treats that state as an interrupted generation upgrade. It runs the existing verified repair path itself, retires the cursor only after the repaired transaction commits, and continues to manager readiness.

A same-generation, unstamped, or otherwise unattributable cursor still fails closed. Its message now states the package, phase, store generation, running generation, and that no live writer was found. Recovery-journal failures likewise say which marker remains.

## Controls

- New broker-backed smoke builds the seed layout through the released `cotal-ai@0.33.1`, boots the current public `cotal supervise`, and asserts the manager reaches `manager up` after automatic repair.
- The same smoke proves the opposite direction: a same-generation cursor still stops manager boot and remains on disk.
- Matching mutation deletes the unattended repair call and is killed by the manager-ready/marker-retirement cell.
- Existing interrupted-seed smoke remains green.
- `pnpm typecheck` is green.
