### PR TITLE
fix(input): acknowledge PTY writes before receipts

### DIFF
--- a/.changeset/honest-seat-input-receipts.md
+++ b/.changeset/honest-seat-input-receipts.md
@@ -1,0 +1,8 @@
+---
+"@cotal-ai/core": patch
+"@cotal-ai/seat": patch
+"@cotal-ai/manager": patch
+"cotal-ai": patch
+---
+
+Make `cotal input` wait for the target runtime to acknowledge the PTY write before printing its byte receipt. Custodial and in-process PTY writes now return the accepted UTF-8 byte count or reject, and the manager refuses missing, partial, or failed acknowledgements with an error that names the seat. A dropped write therefore exits non-zero without a `sent` receipt instead of claiming delivery from the intended buffer.

--- a/.changeset/honest-seat-input-receipts.md
+++ b/.changeset/honest-seat-input-receipts.md
@@ -1,8 +1,8 @@
 ---
-"@cotal-ai/core": patch
-"@cotal-ai/seat": patch
-"@cotal-ai/manager": patch
-"cotal-ai": patch
+"@cotal-ai/core": minor
+"@cotal-ai/seat": minor
+"@cotal-ai/manager": minor
+"cotal-ai": minor
 ---
 
 Make `cotal input` wait for the target runtime to acknowledge the PTY write before printing its byte receipt. Custodial and in-process PTY writes now return the accepted UTF-8 byte count or reject, and the manager refuses missing, partial, or failed acknowledgements with an error that names the seat. A dropped write therefore exits non-zero without a `sent` receipt instead of claiming delivery from the intended buffer.

--- a/implementations/manager/smoke/fixtures/seat-input.mutations.json
+++ b/implementations/manager/smoke/fixtures/seat-input.mutations.json
@@ -2,7 +2,7 @@
   "suite": [
     "implementations/manager/smoke/seat-input-live.smoke.ts"
   ],
-  "guard": "the `input` op authorizes exactly as `attach` does before it writes, and `enter:false` really suppresses the carriage return",
+  "guard": "the `input` op authorizes exactly as `attach` does before it writes, `enter:false` suppresses the carriage return, and a sent receipt comes only from the runtime's acknowledged write",
   "command": "pnpm smoke:seat-input",
   "completionMarker": "SEAT INPUT SMOKE",
   "proveWith": "node scripts/mutation-proof.mjs --config implementations/manager/smoke/fixtures/seat-input.mutations.json",
@@ -48,6 +48,12 @@
     "with a FIXTURE FAILURE rather than letting a cell pass, and cell 1 asserts the marker exists, so",
     "a dead mechanism cannot be mistaken for a satisfied one.",
     "",
+    "THE ACKNOWLEDGED RECEIPT is the issue #1333 honesty boundary. The dropped-write cell replaces",
+    "the live handle write with a resolved no-op carrying no accepted-byte count. The real CLI must",
+    "exit non-zero, name the seat and the acknowledgement failure, print no `sent` receipt, and the",
+    "child must receive nothing. Its mutation restores the old intended-buffer arithmetic, which",
+    "turns that same cell back into the exact false success reported by triage.",
+    "",
     "NOT GRADED HERE, and named rather than implied: the refusal for a runtime with no `write` on",
     "its handle. That branch is reached by ABSENCE of an optional method, which no mutation of this",
     "source can produce and no fixture in this suite can spawn, so it is covered by the type and by",
@@ -70,7 +76,16 @@
       "replace": "    const data = `${String(args.text)}\\r`;",
       "expectRed": "THE CHILD RECEIVED EXACTLY `part` with NO trailing carriage return",
       "cell": "THE CHILD RECEIVED EXACTLY `part` with NO trailing carriage return",
-      "note": "The reply is not a witness to this and cannot be: a mutant that always appends still reports a byte count derived from what it wrote, so the count and the bytes agree with each other while disagreeing with what was asked for. Only the child's own transcript separates them, which is why the delivery cells read the sink and not the reply."
+      "note": "The reply is not a witness to this and cannot be: a mutant that always appends still reports a byte count acknowledged for what it wrote, so the count and the bytes agree with each other while disagreeing with what was asked for. Only the child's own transcript separates them, which is why the delivery cells read the sink and not the reply."
+    },
+    {
+      "name": "the manager restores an intended-buffer receipt and stops awaiting the runtime acknowledgement",
+      "file": "implementations/manager/src/manager.ts",
+      "find": "    const intendedBytes = Buffer.byteLength(data, \"utf8\");\n    let bytes: number;\n    try {\n      bytes = await write(data);\n    } catch (error) {\n      throw new EpEnvelopeError(\"unavailable\", `input for seat \"${a.name}\" failed: ${(error as Error).message}`);\n    }\n    if (!Number.isSafeInteger(bytes) || bytes !== intendedBytes)\n      throw new EpEnvelopeError(\"unavailable\", `input for seat \"${a.name}\" failed: runtime accepted ${String(bytes)} of ${intendedBytes} bytes`);\n    return { name: a.name, bytes };",
+      "replace": "    const intendedBytes = Buffer.byteLength(data, \"utf8\");\n    void write(data);\n    return { name: a.name, bytes: intendedBytes };",
+      "expectRed": "a dropped PTY write exits NON-ZERO, names the seat and the acknowledgement failure, and prints NO `sent` receipt",
+      "cell": "a dropped PTY write exits NON-ZERO, names the seat and the acknowledgement failure, and prints NO `sent` receipt",
+      "note": "This is the pre-fix mechanism in compact form: a fire-and-forget runtime call followed by a receipt calculated from the intended buffer. The dropped-write control then exits 0 and prints `sent 9 bytes` even though its child sink remains empty, so this exact regression cannot pass as a hedge or wording change."
     }
   ]
 }

--- a/implementations/manager/smoke/fixtures/seat-input.mutations.json
+++ b/implementations/manager/smoke/fixtures/seat-input.mutations.json
@@ -79,13 +79,13 @@
       "note": "The reply is not a witness to this and cannot be: a mutant that always appends still reports a byte count acknowledged for what it wrote, so the count and the bytes agree with each other while disagreeing with what was asked for. Only the child's own transcript separates them, which is why the delivery cells read the sink and not the reply."
     },
     {
-      "name": "the manager restores an intended-buffer receipt and stops awaiting the runtime acknowledgement",
+      "name": "the manager restores an intended-buffer receipt and ignores the runtime's accepted-byte count",
       "file": "implementations/manager/src/manager.ts",
       "find": "    const intendedBytes = Buffer.byteLength(data, \"utf8\");\n    let bytes: number;\n    try {\n      bytes = await write(data);\n    } catch (error) {\n      throw new EpEnvelopeError(\"unavailable\", `input for seat \"${a.name}\" failed: ${(error as Error).message}`);\n    }\n    if (!Number.isSafeInteger(bytes) || bytes !== intendedBytes)\n      throw new EpEnvelopeError(\"unavailable\", `input for seat \"${a.name}\" failed: runtime accepted ${String(bytes)} of ${intendedBytes} bytes`);\n    return { name: a.name, bytes };",
-      "replace": "    const intendedBytes = Buffer.byteLength(data, \"utf8\");\n    void write(data);\n    return { name: a.name, bytes: intendedBytes };",
+      "replace": "    const intendedBytes = Buffer.byteLength(data, \"utf8\");\n    try {\n      await write(data);\n    } catch (error) {\n      throw new EpEnvelopeError(\"unavailable\", `input for seat \"${a.name}\" failed: ${(error as Error).message}`);\n    }\n    return { name: a.name, bytes: intendedBytes };",
       "expectRed": "a dropped PTY write exits NON-ZERO, names the seat and the acknowledgement failure, and prints NO `sent` receipt",
       "cell": "a dropped PTY write exits NON-ZERO, names the seat and the acknowledgement failure, and prints NO `sent` receipt",
-      "note": "This is the pre-fix mechanism in compact form: a fire-and-forget runtime call followed by a receipt calculated from the intended buffer. The dropped-write control then exits 0 and prints `sent 9 bytes` even though its child sink remains empty, so this exact regression cannot pass as a hedge or wording change."
+      "note": "This restores the pre-fix receipt source while preserving the surrounding rejection path: the manager awaits the runtime call but ignores its accepted-byte result and reports the intended buffer length. The dropped-write control then exits 0 and prints `sent 9 bytes` even though its child sink remains empty, so this exact regression cannot pass as a hedge or wording change."
     }
   ]
 }

--- a/implementations/manager/smoke/seat-input-live.smoke.ts
+++ b/implementations/manager/smoke/seat-input-live.smoke.ts
@@ -28,8 +28,9 @@
  *      is operator-only on purpose; see the cell for what the one-word edit would cost.
  *   7. A seat that is not running refuses (see the cell for exactly what is forced and why).
  *   8. THE CLI PATH, end to end: the real binary as a subprocess runs
- *      `cotal input --name <seat> --text "/compact"`, exits 0, prints the byte count, and the child
- *      receives `/compact\r`. An external UI calls the CLI before it calls anything else, and a
+ *      `cotal input --name <seat> --text "/compact"`, exits 0, prints the acknowledged byte count,
+ *      and the child receives `/compact\r`. A dropped runtime write instead exits non-zero, names
+ *      the seat and prints no sent receipt. An external UI calls the CLI before anything else, and a
  *      defect anywhere in agents.ts -> control.ts -> the mint -> the subject leaves cells 2-7 green.
  *
  * COVERAGE BOUNDARY, stated so it is not over-read. This is a STATIC-auth mesh, so cell 4's refusal
@@ -45,6 +46,8 @@
  *      -> cell 4 "a caller that did NOT spawn the seat is refused" goes red.
  *   `input-enter`: flip `args.enter !== false ? "\r" : ""` in `inputAuthorized` to always append
  *      -> cell 3 "enter:false types the text with NO trailing carriage return" goes red.
+ *   `input-ack`: discard the runtime acknowledgement and restore intended-buffer arithmetic
+ *      -> cell 8 "a dropped PTY write exits NON-ZERO" goes red.
  *
  * Run: pnpm smoke:seat-input   (needs nats-server + node on PATH; boots its own broker; the CLI
  * cell drives bin/cotal.ts, which imports dist, so build first)
@@ -112,7 +115,7 @@ const sinkDir = join(dir, "sinks");
 mkdirSync(join(workspaceRoot, ".cotal", "agents"), { recursive: true });
 mkdirSync(sinkDir, { recursive: true });
 saveSpaceAuth(authDir(workspaceRoot), auth);
-for (const n of ["typist", "guarded", "opseat", "cliseat", "deadseat"])
+for (const n of ["typist", "guarded", "opseat", "cliseat", "dropseat", "deadseat"])
   writeFileSync(join(workspaceRoot, ".cotal", "agents", `${n}.md`), `---\nname: ${n}\nrole: worker\n---\n`);
 writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
 const srv = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
@@ -166,7 +169,7 @@ const echoCon: Connector = { kind: "connector", name: "input-echo", requires: ["
 registry.register(echoCon);
 
 const mgr = new Manager({ space, servers: SERVERS, runtime: "pty", workspaceRoot });
-type PrivHandle = { status: () => "running" | "exited"; kind: string };
+type PrivHandle = { status: () => "running" | "exited"; kind: string; write?: (data: string) => Promise<number> };
 const M = mgr as unknown as {
   managerInstanceId: string;
   agents: Map<string, { id: string; lifecycleUid: string; handle: PrivHandle }>;
@@ -419,6 +422,37 @@ try {
     const got = await sinkReaches(cliseat.name, 9);
     check("THE SEAT'S HARNESS RECEIVED EXACTLY `/compact\\r`: a slash command typed in a UI reaches the child verbatim",
       got.equals(Buffer.from("/compact\r", "utf8")), { hex: got.toString("hex"), want: Buffer.from("/compact\r", "utf8").toString("hex") });
+
+    // The receipt is derived from the runtime acknowledgement, not from `data`. A dropped write that
+    // resolves without an accepted-byte count is the mutation control from issue #1333: before the
+    // fix this exited 0 and printed `sent 9 bytes` while the child received nothing.
+    const dropseat = await spawnLive(A.call, { name: "dropseat", agent: "input-echo", cwd: repoRoot });
+    const dropped = M.agents.get(dropseat.name);
+    if (!dropped?.handle.write) throw new Error(`FIXTURE FAILURE: ${dropseat.name} has no writable managed handle`);
+    const realWrite = dropped.handle.write;
+    let rejectedRun: Run;
+    let droppedRun: Run;
+    try {
+      dropped.handle.write = async () => { throw new Error("custodian write rejected"); };
+      rejectedRun = await cotal(["input", "--name", dropseat.name, "--text", "/compact", "--space", space]);
+      dropped.handle.write = async () => undefined as unknown as number;
+      droppedRun = await cotal(["input", "--name", dropseat.name, "--text", "/compact", "--space", space]);
+    } finally {
+      dropped.handle.write = realWrite;
+    }
+    mustHaveRun(rejectedRun, "`cotal input` with a rejected PTY write");
+    const rejectedOut = strip(rejectedRun.out);
+    check("a rejected PTY write exits NON-ZERO, names the seat and the rejection, and prints NO `sent` receipt",
+      rejectedRun.status !== 0 && rejectedOut.includes(dropseat.name) && /failed: custodian write rejected/.test(rejectedOut)
+      && !/sent \d+ bytes/.test(rejectedOut), { status: rejectedRun.status, tail: rejectedOut.slice(-500) });
+    mustHaveRun(droppedRun, "`cotal input` with a dropped PTY write");
+    const droppedOut = strip(droppedRun.out);
+    check("a dropped PTY write exits NON-ZERO, names the seat and the acknowledgement failure, and prints NO `sent` receipt",
+      droppedRun.status !== 0 && droppedOut.includes(dropseat.name) && /failed: runtime accepted undefined of 9 bytes/.test(droppedOut)
+      && !/sent \d+ bytes/.test(droppedOut), { status: droppedRun.status, tail: droppedOut.slice(-500) });
+    await wait(750);
+    check("...and the dropped bytes never reached the child", sinkBytes(dropseat.name).length === 0,
+      { hex: sinkBytes(dropseat.name).toString("hex") });
 
     // `--no-enter` through the same real binary, carrying the HARDEST payload: text that is itself
     // a flag spelling. `--text=<value>` is the form node's `parseArgs` requires for a dash-leading

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -7577,7 +7577,7 @@ export class Manager {
    *
    *  `enter` defaults to true: a harness command typed but not submitted has not been delivered.
    *  Nothing is echoed back; the caller reads the resulting turns from the event plane. */
-  private inputAuthorized(a: ManagedAgent, args: Record<string, unknown>): { name: string; bytes: number } {
+  private async inputAuthorized(a: ManagedAgent, args: Record<string, unknown>): Promise<{ name: string; bytes: number }> {
     if (this.agents.get(a.name) !== a)
       throw new EpEnvelopeError("failed-precondition", `agent "${a.name}" was replaced during authorization - retry`);
     if (a.handle.status() !== "running")
@@ -7589,8 +7589,16 @@ export class Manager {
     // the only decision left is the carriage return. `!== false` and not `?? true`: an ABSENT enter
     // and an explicit `true` must behave identically, and only `false` may suppress the return.
     const data = `${String(args.text)}${args.enter !== false ? "\r" : ""}`;
-    write(data);
-    return { name: a.name, bytes: Buffer.byteLength(data, "utf8") };
+    const intendedBytes = Buffer.byteLength(data, "utf8");
+    let bytes: number;
+    try {
+      bytes = await write(data);
+    } catch (error) {
+      throw new EpEnvelopeError("unavailable", `input for seat "${a.name}" failed: ${(error as Error).message}`);
+    }
+    if (!Number.isSafeInteger(bytes) || bytes !== intendedBytes)
+      throw new EpEnvelopeError("unavailable", `input for seat "${a.name}" failed: runtime accepted ${String(bytes)} of ${intendedBytes} bytes`);
+    return { name: a.name, bytes };
   }
 
   /** The post-authorization attach effect (P2 item 6): mint the holder-bound §13.6 offer, redeem it

--- a/implementations/manager/src/runtime/pty.ts
+++ b/implementations/manager/src/runtime/pty.ts
@@ -160,8 +160,10 @@ export class LegacyPtyRuntime implements Runtime {
       // `interrupt` and the session's own `write` are: node-pty throws on a dead handle, and the
       // manager has already refused a non-running agent before it gets here, so this guard covers
       // only the narrow race where the child exits between that check and this call.
-      write: (data) => {
-        if (alive) proc.write(data);
+      write: async (data) => {
+        if (!alive) throw new Error(`seat ${name} is not running; the PTY rejected the write`);
+        proc.write(data);
+        return Buffer.byteLength(data, "utf8");
       },
       attach: (): AttachSession => ({
         get cols() {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -63,8 +63,12 @@ export interface AgentHandle {
    *  OPTIONAL, and absent means REFUSE, never degrade: a backend that does not own the child's
    *  input stream (tmux/cmux/orca/herdr attach to an externally-owned process) leaves it off, and
    *  the manager answers `input is not supported by runtime <kind>`. A silent no-op here would be
-   *  a dropped keystroke, which is worse than an error. */
-  write?(data: string): void;
+   *  a dropped keystroke, which is worse than an error.
+   *
+   *  Resolves only after the runtime has accepted the write, with the number of UTF-8 bytes it
+   *  accepted. Rejects when the runtime cannot accept it. A caller must derive any delivery receipt
+   *  from this acknowledgement, never from the buffer it intended to send. */
+  write?(data: string): Promise<number>;
   /** What the runtime OBSERVED when the child ended: the OS exit code, and/or the signal number
    *  that killed it. Meaningful only once {@link status} reports `exited`; before that a backend
    *  returns undefined.

--- a/packages/seat/src/client.ts
+++ b/packages/seat/src/client.ts
@@ -118,9 +118,10 @@ export class SeatClient {
     };
   }
 
-  async write(data: string): Promise<void> {
+  async write(data: string): Promise<number> {
     const reply = await this.request({ op: "write", data });
-    if (!reply.ok) throw new Error(reply.error);
+    if (!reply.ok || reply.op !== "write") throw new Error(reply.ok ? "unexpected write reply" : reply.error);
+    return reply.bytes;
   }
 
   async resize(cols: number, rows: number): Promise<void> {

--- a/packages/seat/src/custodian.ts
+++ b/packages/seat/src/custodian.ts
@@ -286,8 +286,9 @@ export async function runCustodian(launch: CustodianLaunch): Promise<void> {
         return;
       }
       case "write": {
-        if (alive) proc.write(req.data);
-        send(sock, { id: req.id, ok: true, op: "write" });
+        if (!alive) throw new Error(`seat ${launch.name} is not running; the PTY rejected the write`);
+        proc.write(req.data);
+        send(sock, { id: req.id, ok: true, op: "write", bytes: Buffer.byteLength(req.data, "utf8") });
         return;
       }
       case "resize": {

--- a/packages/seat/src/handle.ts
+++ b/packages/seat/src/handle.ts
@@ -22,7 +22,7 @@ export interface SeatHandle {
   stop(opts?: { graceful?: boolean }): void;
   waitForExit(): Promise<void>;
   interrupt(): void;
-  write(data: string): void;
+  write(data: string): Promise<number>;
   attach(): SeatAttachSession;
   close(): void;
 }
@@ -88,9 +88,7 @@ export function adoptSeatSync(record: SeatRecord): SeatHandle {
     interrupt: () => {
       later((c) => c.interrupt());
     },
-    write: (data) => {
-      later((c) => c.write(data));
-    },
+    write: async (data) => (await whenReady()).write(data),
     attach: () => {
       const sessionUnsubs = new Set<() => void>();
       // Fast-exit children print and die before hello. onData must replay the

--- a/packages/seat/src/protocol.ts
+++ b/packages/seat/src/protocol.ts
@@ -51,7 +51,7 @@ export type ServerReply =
   | { id: number; ok: true; op: "snapshot"; data: string; cols: number; rows: number }
   | { id: number; ok: true; op: "subscribe-output"; sub: number }
   | { id: number; ok: true; op: "unsubscribe-output" }
-  | { id: number; ok: true; op: "write" }
+  | { id: number; ok: true; op: "write"; bytes: number }
   | { id: number; ok: true; op: "resize" }
   | { id: number; ok: true; op: "interrupt" }
   | { id: number; ok: true; op: "stop" }


### PR DESCRIPTION
## What changed

`cotal input` previously printed a byte receipt calculated from the text it intended to write. The manager did not wait for the PTY runtime, and the custodial runtime discarded asynchronous write failures, so a dropped write could still exit successfully and claim delivery.

PTY runtimes now own an acknowledged write contract. They resolve with the UTF-8 byte count accepted by the PTY or reject. The manager waits for that acknowledgement and uses its count for the receipt. A rejected, missing, or partial acknowledgement now becomes a non-zero `cotal input` failure that names the target seat, with no `sent` receipt.

The seat-input smoke covers successful text-plus-carriage-return delivery, rejected writes, silently dropped writes, and the real CLI result. Its mutation matrix also restores the intended-length receipt and proves the dropped-write cell fails.

Fixes #1333.
