### PR TITLE
fix(core): fence reconnect before credential expiry

### DIFF
--- a/.changeset/quiet-dodos-close.md
+++ b/.changeset/quiet-dodos-close.md
@@ -1,0 +1,5 @@
+---
+"@cotal-ai/core": patch
+---
+
+Disable the NATS client's reconnect loop before an endpoint credential expires or its connection is deliberately closed. Credential-expiry closes now resolve through the connection's documented `closed()` result without an unhandled rejection.

--- a/.changeset/quiet-dodos-close.md
+++ b/.changeset/quiet-dodos-close.md
@@ -2,4 +2,4 @@
 "@cotal-ai/core": patch
 ---
 
-Disable the NATS client's reconnect loop before an endpoint credential expires or its connection is deliberately closed. Credential-expiry closes now resolve through the connection's documented `closed()` result without an unhandled rejection.
+Disable the NATS client's reconnect loop before an endpoint credential expires or its connection is deliberately closed, then close that connection instead of draining it. Credential-expiry closes resolve through `closed()` without an unhandled rejection, and a half-open socket cannot leave teardown waiting for a drain PONG.

--- a/bin/smoke/ci-suites.d/3bb23c552b41aaf622c9763554aa09e25fdf5ae6c1427da88a9590677092b26a.txt
+++ b/bin/smoke/ci-suites.d/3bb23c552b41aaf622c9763554aa09e25fdf5ae6c1427da88a9590677092b26a.txt
@@ -1,0 +1,1 @@
+smoke:reconnect-fence-close

--- a/extensions/connector-core/smoke/fixtures/transport-liveness.mutations.json
+++ b/extensions/connector-core/smoke/fixtures/transport-liveness.mutations.json
@@ -176,6 +176,16 @@
       "expectRed": "MeshAgent.stop clears both readiness and transport locally",
       "cell": "MeshAgent.stop clears both readiness and transport locally",
       "afterRestore": "pnpm --filter @cotal-ai/core build"
+    },
+    {
+      "name": "a reconnect-disabled teardown drains instead of closing",
+      "file": "packages/core/src/endpoint.ts",
+      "find": "    this.disableLibraryReconnect(nc);\n    try {\n      await nc.close();\n",
+      "replace": "    this.disableLibraryReconnect(nc);\n    try {\n      await nc.drain();\n",
+      "expectRed": "#975: stop racing the INITIAL bind leaves no nc, heartbeat, or armed supervisor",
+      "cell": "#975: stop racing the INITIAL bind leaves no nc, heartbeat, or armed supervisor",
+      "afterRestore": "pnpm --filter @cotal-ai/core build",
+      "note": "The FakeNc #975 witness counts close() and drain() separately. Restoring drain() increments drains and reds the named cell."
     }
   ]
 }

--- a/extensions/connector-core/smoke/transport-liveness.smoke.ts
+++ b/extensions/connector-core/smoke/transport-liveness.smoke.ts
@@ -111,6 +111,17 @@
  * and reaches the behavior it is meant to break. The other five mutations killed their predicted
  * named cells on that first run.
  *
+ * Harness correction after close-after-disable (#1480/#1486): FakeNc previously implemented only
+ * drain(). Product teardown after a reconnect fence now calls close(), so the missing method threw
+ * inside closeWithoutLibraryReconnect, the catch swallowed it, and #975 went red at HEAD
+ * (mutation-reproof PRE-RED: base GREEN -> head RED). FakeNc.close() is the product path;
+ * drain() delegates to close() for older teardown. DrainWitnessNc counts them separately so a
+ * drain() restore still reds #975.
+ *
+ * M17 restores drain() inside closeWithoutLibraryReconnect.
+ *   IN  #975: the witness requires close() and zero drain().
+ *   OUT every other cell: they do not count teardown method.
+ *
  * Run: pnpm smoke:transport-liveness
  */
 import type { Status } from "@nats-io/nats-core";
@@ -169,7 +180,9 @@ class FakeNc {
   status(): AsyncIterable<Status> { return this.queue; }
   getServer(): string { return this.server; }
   isClosed(): boolean { return this.closedFlag; }
-  async drain(): Promise<void> { this.closedFlag = true; this.queue.push({ type: "close" }); this.queue.close(); }
+  /** Product teardown after a reconnect fence uses close(), not drain(). */
+  async close(): Promise<void> { this.closedFlag = true; this.queue.push({ type: "close" }); this.queue.close(); }
+  async drain(): Promise<void> { await this.close(); }
   async closed(): Promise<void> { return new Promise(() => {}); }
 }
 
@@ -182,7 +195,9 @@ class ClosingNc extends FakeNc {
 
 class DrainWitnessNc extends FakeNc {
   drains = 0;
+  closes = 0;
   override async drain(): Promise<void> { this.drains++; await super.drain(); }
+  override async close(): Promise<void> { this.closes++; await super.close(); }
 }
 
 const cfg: AgentConfig = {
@@ -414,9 +429,10 @@ releaseBind();
 await startingPromise;
 check(
   "#975: stop racing the INITIAL bind leaves no nc, heartbeat, or armed supervisor",
-  freshNc.drains === 1 && freshNc.closedFlag === true && startingEp.nc === undefined &&
+  freshNc.closes === 1 && freshNc.drains === 0 && freshNc.closedFlag === true && startingEp.nc === undefined &&
     startingEp.heartbeatTimer === undefined && supervised === 0,
   {
+    closes: freshNc.closes,
     drains: freshNc.drains,
     closed: freshNc.closedFlag,
     hasNc: startingEp.nc !== undefined,
@@ -428,7 +444,7 @@ check(
 // nc live, which is the named failure above. Clear/close them after observing so the suite reaches its
 // terminal marker and mutation-proof can grade the red instead of timing out on the leaked resource.
 if (startingEp.heartbeatTimer) clearInterval(startingEp.heartbeatTimer);
-if (!freshNc.closedFlag) await freshNc.drain();
+if (!freshNc.closedFlag) await freshNc.close();
 
 const failing = new MeshAgent({ ...cfg, name: "failing-start-agent" });
 let rejectStart!: (error: Error) => void;

--- a/implementations/delivery/smoke/delivery-cred-renewal.smoke.ts
+++ b/implementations/delivery/smoke/delivery-cred-renewal.smoke.ts
@@ -19,7 +19,7 @@
  */
 import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, realpathSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { connect, credsAuthenticator } from "@nats-io/transport-node";
@@ -38,6 +38,7 @@ import {
   setupSpaceStreams,
   waitForDeliveryLease,
 } from "@cotal-ai/core";
+import { spaceMaterialDir } from "@cotal-ai/workspace";
 import { SMOKE_BROKER_TOKEN, killAndAwaitExit, teardownOnSignal } from "@cotal-ai/smoke-kit";
 import { pickFreePort } from "./_free-port.js";
 
@@ -92,10 +93,13 @@ const releaseBroker = teardownOnSignal(srv, dir);
 
 // The daemon's ISOLATED workspace root — findCotalRoot(cwd) lands here, so the membership feed's
 // creds/config come from THIS staging, never the developer's real .cotal.
-const root = mkdtempSync(join(tmpdir(), "cotal-dlv-renew-root-"));
-mkdirSync(join(root, ".cotal"), { recursive: true });
-const credsPath = join(root, ".cotal", "delivery.creds");
-const rwPath = join(root, ".cotal", "membership-rw.creds");
+// Resolve once before deriving cwd or credential paths. Sandboxed runners may expose tmpdir through
+// an alias, and reloadStoreIdentity intentionally compares canonical filesystem roots.
+const root = realpathSync(mkdtempSync(join(tmpdir(), "cotal-dlv-renew-root-")));
+const spaceDir = spaceMaterialDir(root, space);
+mkdirSync(spaceDir, { recursive: true });
+const credsPath = join(spaceDir, "delivery.creds");
+const rwPath = join(spaceDir, "membership-rw.creds");
 
 let daemon: ReturnType<typeof spawn> | undefined;
 let daemonExited = false;
@@ -113,9 +117,9 @@ try {
   const credA = await mintCreds(auth, dlvId, "delivery", { expiresInSeconds: TTL });
   writeFileSync(credsPath, credA, { mode: 0o600 });
   writeFileSync(rwPath, await mintCreds(auth, rwId, "membership-rw", { expiresInSeconds: 120 }), { mode: 0o600 });
-  writeFileSync(join(root, ".cotal", "membership-observer.creds"), obsCreds, { mode: 0o600 });
-  writeFileSync(join(root, ".cotal", "connection-evictor.creds"), evictorCreds, { mode: 0o600 });
-  writeFileSync(join(root, ".cotal", "membership.json"), JSON.stringify({ accountId: auth.account.pub }), { mode: 0o600 });
+  writeFileSync(join(spaceDir, "membership-observer.creds"), obsCreds, { mode: 0o600 });
+  writeFileSync(join(spaceDir, "connection-evictor.creds"), evictorCreds, { mode: 0o600 });
+  writeFileSync(join(spaceDir, "membership.json"), JSON.stringify({ accountId: auth.account.pub }), { mode: 0o600 });
   const bornAt = Date.now();
 
   daemon = spawn(process.execPath, [cotalJs, "deliver", "--space", space, "--server", SERVERS, "--creds", credsPath], {

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "smoke:control-auth": "tsx packages/core/smoke/control-auth.smoke.ts",
     "smoke:manager-split": "tsx packages/core/smoke/manager-split-auth.smoke.ts",
     "smoke:cred-lifetime": "tsx packages/core/smoke/cred-lifetime-auth.smoke.ts",
+    "smoke:reconnect-fence-close": "tsx packages/core/smoke/reconnect-fence-close.smoke.ts",
     "smoke:standing-renewal": "tsx packages/core/smoke/standing-renewal-auth.smoke.ts",
     "smoke:seat-creds-renewal": "tsx extensions/connector-core/smoke/seat-creds-renewal.smoke.ts",
     "smoke:doctor-auth": "tsx implementations/cli/smoke/doctor-auth.smoke.ts",

--- a/packages/core/smoke/cred-lifetime-auth.smoke.ts
+++ b/packages/core/smoke/cred-lifetime-auth.smoke.ts
@@ -7,15 +7,16 @@
  */
 import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { parseCreds } from "@nats-io/jwt";
-import { connect, credsAuthenticator } from "@nats-io/transport-node";
+import { connect, credsAuthenticator, type NatsConnection } from "@nats-io/transport-node";
 import {
+  CotalEndpoint,
   createSpaceAuth,
   credentialLifetime,
-  chatSubject,
   isReachable,
   probeConnect,
   mintConnectionEvictorCreds,
@@ -23,7 +24,6 @@ import {
   mintCreds,
   newIdentity,
   serverConfig,
-  DEV_OWNER,
   ROTATION_RENEWED_TTL_SEC,
   STANDING_RENEWABLE_TTL_SEC,
 } from "../src/index.js";
@@ -40,6 +40,49 @@ const awaitExit = (proc: ReturnType<typeof spawn>, timeoutMs = 3000): Promise<vo
     proc.once("exit", () => resolve());
     setTimeout(resolve, timeoutMs);
   });
+
+const SELF = fileURLToPath(import.meta.url);
+
+if (process.argv[2] === "expiry-child") {
+  const [, , , servers, childSpace, credsPath, id] = process.argv;
+  if (!servers || !childSpace || !credsPath || !id) throw new Error("expiry child requires servers, space, creds path, and id");
+  const liveCreds = readFileSync(credsPath, "utf8");
+  const liveClaims = await parseCreds(enc(liveCreds));
+  if (typeof liveClaims.uc.exp !== "number") throw new Error("expiry child credential has no exp");
+  const ep = new CotalEndpoint({
+    space: childSpace,
+    servers,
+    creds: liveCreds,
+    card: { name: "expiry-child", kind: "endpoint", id },
+    consume: false,
+    registerPresence: false,
+    watchPresence: false,
+    watchChannels: false,
+  });
+  const endpointErrors: string[] = [];
+  ep.on("error", (err: Error) => endpointErrors.push(err.message));
+  await ep.start();
+  const nc = (ep as unknown as { nc?: NatsConnection }).nc;
+  if (!nc) throw new Error("expiry child started without a NATS connection");
+  const closed = nc.closed();
+  // Observe the policy after Cotal's pre-expiry timer has fired but before the broker's expiry close.
+  // This makes the root mechanism itself a deterministic mutation control while the same child keeps
+  // running to grade the real nc.closed() value and process survival below.
+  await wait(Math.max(0, liveClaims.uc.exp * 1000 - Date.now() - 250));
+  const reconnectDisabled = (nc as unknown as { protocol?: { options?: { reconnect?: boolean } } }).protocol?.options?.reconnect === false;
+  const reason = await Promise.race([
+    closed,
+    wait(10_000).then(() => "timeout" as const),
+  ]);
+  if (reason === "timeout") throw new Error("the broker did not close the expired connection");
+  console.log(`EXPIRY_CHILD_CLOSED ${JSON.stringify({ name: reason?.name, message: reason?.message, reconnectDisabled, endpointErrors })}`);
+  await ep.stop();
+  // Let the transport-close continuation and its microtasks settle before the explicit exit. With the
+  // reconnect fence removed, nats-core's discarded continuation rejects during this window and Node
+  // exits nonzero. No process-level rejection handler is installed.
+  await wait(100);
+  process.exit(0);
+}
 
 let pass = 0;
 let fail = 0;
@@ -59,6 +102,7 @@ async function tryConnect(creds: string, id: string): Promise<"ok" | "rejected">
       servers: SERVERS,
       authenticator: credsAuthenticator(enc(creds)),
       inboxPrefix: `_INBOX_${id}`,
+      reconnect: false,
       maxReconnectAttempts: 0,
     });
     await nc.close();
@@ -136,24 +180,24 @@ try {
   check("fresh bounded cred connects", await tryConnect(freshCreds, fresh.id) === "ok");
 
   const live = newIdentity();
-  const liveCreds = await mintCreds(auth, live, "operator", { expiresInSeconds: 1 });
-  const nc = await connect({
-    servers: SERVERS,
-    authenticator: credsAuthenticator(enc(liveCreds)),
-    inboxPrefix: `_INBOX_${live.id}`,
-    maxReconnectAttempts: 0,
+  const liveCreds = await mintCreds(auth, live, "operator", { expiresInSeconds: 6 });
+  const liveCredsPath = join(dir, "live.creds");
+  writeFileSync(liveCredsPath, liveCreds, { mode: 0o600 });
+  const expiryChild = spawn(process.execPath, ["--import", "tsx", SELF, "expiry-child", SERVERS, space, liveCredsPath, live.id], {
+    stdio: ["ignore", "pipe", "pipe"],
   });
-  await wait(1600);
-  let liveAfterExp: "allowed" | "closed" = "allowed";
-  try {
-    nc.publish(chatSubject(space, DEV_OWNER, live.id, "general"), enc("after-exp"));
-    await nc.flush();
-  } catch {
-    liveAfterExp = "closed";
-  } finally {
-    await nc.close().catch(() => {});
-  }
-  check("live connection behavior after exp is empirically pinned (nats-server closes/rejects after expiry)", liveAfterExp === "closed", liveAfterExp);
+  let expiryOutput = "";
+  expiryChild.stdout?.on("data", (chunk) => { expiryOutput += String(chunk); });
+  expiryChild.stderr?.on("data", (chunk) => { expiryOutput += String(chunk); });
+  await awaitExit(expiryChild, 12_000);
+  if (expiryChild.exitCode === null && expiryChild.signalCode === null) expiryChild.kill("SIGKILL");
+  const closeLine = expiryOutput.split("\n").find((line) => line.startsWith("EXPIRY_CHILD_CLOSED "));
+  const closeReason = closeLine ? JSON.parse(closeLine.slice("EXPIRY_CHILD_CLOSED ".length)) as { name?: string; message?: string; reconnectDisabled?: boolean; endpointErrors?: string[] } : undefined;
+  check(
+    "CotalEndpoint disables library reconnect before credential expiry, nc.closed() resolves with the expiry error, and the process stays alive",
+    expiryChild.exitCode === 0 && closeReason?.reconnectDisabled === true && closeReason.name === "UserAuthenticationExpiredError" && closeReason.message === "User Authentication Expired",
+    { exitCode: expiryChild.exitCode, signal: expiryChild.signalCode, closeReason, output: expiryOutput },
+  );
 } finally {
   srv.kill();
   await awaitExit(srv);

--- a/packages/core/smoke/mutations/credential-expiry-reconnect.json
+++ b/packages/core/smoke/mutations/credential-expiry-reconnect.json
@@ -1,0 +1,24 @@
+{
+  "suite": [
+    "packages/core/smoke/cred-lifetime-auth.smoke.ts"
+  ],
+  "guard": "an endpoint disables nats-core reconnect before its authenticated JWT expires, so the close error stays on nc.closed() instead of rejecting a discarded transport-close continuation",
+  "command": "pnpm smoke:cred-lifetime",
+  "proveWith": "node scripts/mutation-proof.mjs --config packages/core/smoke/mutations/credential-expiry-reconnect.json",
+  "why": [
+    "nats-core 3.4.0 discards the promise returned by ProtocolHandler.prepare()'s async transport.closed() continuation.",
+    "If the library reconnect remains enabled when the broker expires a JWT, that continuation enters dialLoop with the dead credential and its terminal UserAuthenticationExpiredError is unhandled.",
+    "The child process makes process survival observable without installing a process-level unhandledRejection handler. The parent grades both the child's zero exit and the public nc.closed() resolution value."
+  ],
+  "mutations": [
+    {
+      "name": "the credential-expiry timer leaves nats-core reconnect enabled",
+      "file": "packages/core/src/endpoint.ts",
+      "find": "      if (this.nc === nc) this.disableLibraryReconnect(nc);\n",
+      "replace": "",
+      "expectRed": "CotalEndpoint disables library reconnect before credential expiry, nc.closed() resolves with the expiry error, and the process stays alive",
+      "cell": "CotalEndpoint disables library reconnect before credential expiry, nc.closed() resolves with the expiry error, and the process stays alive",
+      "note": "With the fence removed, the expiry child reaches nats-core's reconnect dial loop with the expired credential and exits nonzero on the discarded continuation's unhandled rejection. The parent remains alive and reds this named cell."
+    }
+  ]
+}

--- a/packages/core/smoke/mutations/reconnect-fence-close.json
+++ b/packages/core/smoke/mutations/reconnect-fence-close.json
@@ -1,0 +1,24 @@
+{
+  "suite": [
+    "packages/core/smoke/reconnect-fence-close.smoke.ts"
+  ],
+  "guard": "after Cotal disables nats-core reconnect, teardown closes the connection instead of draining it, so a half-open socket cannot leave stop() waiting for a PONG",
+  "command": "pnpm smoke:reconnect-fence-close",
+  "proveWith": "node scripts/mutation-proof.mjs --config packages/core/smoke/mutations/reconnect-fence-close.json",
+  "why": [
+    "nats-core 3.4.0 drain() flushes with a PING and waits for the matching PONG.",
+    "That waiter is only rejected inside reconnect prepare(). With reconnect=false, a half-open socket leaves drain pending until the 2-minute ping interval.",
+    "The child grades stop() returning inside an 8s budget. Restoring drain() in the helper means the child never prints STOPPED and the parent reds the named cell."
+  ],
+  "mutations": [
+    {
+      "name": "a reconnect-disabled teardown drains instead of closing",
+      "file": "packages/core/src/endpoint.ts",
+      "find": "    this.disableLibraryReconnect(nc);\n    try {\n      await nc.close();\n",
+      "replace": "    this.disableLibraryReconnect(nc);\n    try {\n      await nc.drain();\n",
+      "expectRed": "stop() after a reconnect-disable on a half-open socket returns without waiting for a drain PONG",
+      "cell": "stop() after a reconnect-disable on a half-open socket returns without waiting for a drain PONG",
+      "note": "With drain restored, nats-core waits for a PONG that the cut relay never delivers. The child is killed at the 8s budget without printing STOPPED, and the parent reds this named cell."
+    }
+  ]
+}

--- a/packages/core/smoke/mutations/standing-renewal-expiry.json
+++ b/packages/core/smoke/mutations/standing-renewal-expiry.json
@@ -19,6 +19,15 @@
   ],
   "mutations": [
     {
+      "name": "the reconnect-denial observation window starts before the original expiry log settles",
+      "file": "packages/core/smoke/standing-renewal-auth.smoke.ts",
+      "find": "        originalExpiryObservedBeforeReconnectWindow = await until(\n          () => /cotal:expired-creds.*User Authentication Expired/.test(brokerLog),\n          2_000,\n          10,\n        );\n        failedRebuildLogStart = brokerLog.length;\n",
+      "replace": "        failedRebuildLogStart = brokerLog.length;\n",
+      "expectRed": "the original wire's expiry log lands before the reconnect-denial observation window opens",
+      "cell": "the original wire's expiry log lands before the reconnect-denial observation window opens",
+      "note": "The control records the original connection's expiry diagnostic before opening the reconnect-denial window. Removing that wait leaves the control false and deterministically reds the named cell, instead of relying on pipe scheduling to make a later substring count flaky."
+    },
+    {
       "name": "the creds pre-dial expiry guard is removed",
       "file": "packages/core/src/endpoint.ts",
       "find": "    const credsExp = this.currentCreds && credsClaims(this.currentCreds).exp;\n    if (typeof credsExp === \"number\" && credsExp * 1000 <= Date.now())\n      throw new Error(\n        this.credsSource\n          ? \"this endpoint's creds have expired and renewal is failing - not presenting the expired credential to the broker; retrying with backoff\"\n          : \"this endpoint's creds have expired and it holds no creds source to renew them - replace the credential and rebuild the endpoint (pass a creds FUNCTION for standing renewal)\",\n      );\n",

--- a/packages/core/smoke/reconnect-fence-close.smoke.ts
+++ b/packages/core/smoke/reconnect-fence-close.smoke.ts
@@ -1,0 +1,152 @@
+/**
+ * After Cotal disables nats-core reconnect, teardown must CLOSE the connection, not drain it.
+ *
+ * nats-core 3.4.0 `drain()` flushes with a PING and waits for the matching PONG. It only rejects
+ * that waiter inside reconnect `prepare()`. With reconnect=false, a half-open socket therefore
+ * leaves drain pending until the 2-minute ping interval times out. That is the hang that cancelled
+ * `smoke:opencode-events-release` in CI: the suite cut a TCP relay, the emitter logged
+ * `stream CHAT_* info unavailable (timeout)`, and `stop()` then waited on drain forever.
+ *
+ * This suite is the named cell for that ordering. It starts a live endpoint, disables library
+ * reconnect, cuts the socket without a TCP close, and asserts `stop()` returns well inside the
+ * ping interval. Mutation-proved: restoring `drain()` in `closeWithoutLibraryReconnect` reds the
+ * cell because the child never prints STOPPED.
+ *
+ * Run: pnpm smoke:reconnect-fence-close
+ */
+import { spawn } from "node:child_process";
+import { createServer as createNetServer, connect as netConnect, type Socket } from "node:net";
+import { once } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { CotalEndpoint, isReachable } from "../src/index.js";
+import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const SELF = fileURLToPath(import.meta.url);
+const STOP_BUDGET_MS = 8_000;
+
+if (process.argv[2] === "stop-child") {
+  const [, , , servers] = process.argv;
+  if (!servers) throw new Error("stop child requires servers");
+  const ep = new CotalEndpoint({
+    space: "fenceclose",
+    servers,
+    channels: [],
+    consume: false,
+    registerPresence: false,
+    watchPresence: false,
+    watchChannels: false,
+    card: { name: "fence-close-child", kind: "endpoint" },
+  });
+  await ep.start();
+  const nc = (ep as unknown as { nc?: { protocol?: { options?: { reconnect?: boolean } } } }).nc;
+  if (!nc) throw new Error("stop child started without a NATS connection");
+  (ep as unknown as { disableLibraryReconnect: (c: unknown) => void }).disableLibraryReconnect(nc);
+  if (nc.protocol?.options?.reconnect !== false) throw new Error("stop child failed to disable library reconnect");
+  process.stdout.write("FENCED\n");
+  process.stdin.resume();
+  const cut = await Promise.race([
+    new Promise<boolean>((resolve) => {
+      process.stdin.on("data", (chunk) => {
+        if (String(chunk).includes("CUT")) resolve(true);
+      });
+    }),
+    wait(10_000).then(() => false),
+  ]);
+  if (!cut) throw new Error("stop child never received CUT");
+  const started = Date.now();
+  await ep.stop();
+  process.stdout.write(`STOPPED ${Date.now() - started}\n`);
+  process.exit(0);
+}
+
+let pass = 0;
+let fail = 0;
+const check = (name: string, cond: boolean, extra?: unknown) => {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+    return;
+  }
+  fail++;
+  console.error(`  ✗ ${name}${extra !== undefined ? `: ${JSON.stringify(extra)}` : ""}`);
+};
+
+const PORT = await pickFreePort();
+if (PORT === 4222) throw new Error("refusing to bind :4222 (shared with the workstation broker)");
+const dir = mkdtempSync(join("/var/tmp", SMOKE_BROKER_TOKEN));
+const broker = spawn("nats-server", ["-a", "127.0.0.1", "-p", String(PORT), "-js", "-sd", join(dir, "js")], { stdio: "ignore" });
+const releaseBroker = teardownOnSignal(broker, dir);
+const servers = `nats://127.0.0.1:${PORT}`;
+let up = false;
+for (let i = 0; i < 50; i++) { if (await isReachable(servers)) { up = true; break; } await wait(100); }
+if (!up) throw new Error(`nats-server did not come up on ${PORT}`);
+
+const relayPort = await pickFreePort();
+let cut = false;
+const relaySockets: Socket[] = [];
+const relay = createNetServer((client) => {
+  const upSock = netConnect(PORT, "127.0.0.1");
+  relaySockets.push(client, upSock);
+  client.on("data", (d) => { if (!cut) upSock.write(d); });
+  upSock.on("data", (d) => { if (!cut) client.write(d); });
+  const bye = (): void => { client.destroy(); upSock.destroy(); };
+  for (const sock of [client, upSock]) { sock.on("error", () => {}); }
+  client.on("close", bye);
+  upSock.on("close", bye);
+});
+relay.listen(relayPort, "127.0.0.1");
+await once(relay, "listening");
+
+let child: ReturnType<typeof spawn> | undefined;
+try {
+  child = spawn(process.execPath, ["--import", "tsx", SELF, "stop-child", `nats://127.0.0.1:${relayPort}`], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  let output = "";
+  child.stdout?.on("data", (chunk) => { output += String(chunk); });
+  child.stderr?.on("data", (chunk) => { output += String(chunk); });
+  const fenced = await Promise.race([
+    new Promise<boolean>((resolve) => {
+      const tick = (): void => {
+        if (output.includes("FENCED")) resolve(true);
+        else setTimeout(tick, 50);
+      };
+      tick();
+    }),
+    wait(10_000).then(() => false),
+  ]);
+  check("the child armed the reconnect fence on a live connection", fenced, output.slice(-400));
+  cut = true;
+  child.stdin?.write("CUT\n");
+  const done = await Promise.race([
+    new Promise<number | null>((resolve) => child!.once("exit", (code) => resolve(code))),
+    wait(STOP_BUDGET_MS).then(() => "timeout" as const),
+  ]);
+  if (done === "timeout") child.kill("SIGKILL");
+  const stopped = output.split("\n").find((line) => line.startsWith("STOPPED "));
+  const stopMs = stopped ? Number(stopped.slice("STOPPED ".length)) : NaN;
+  check(
+    "stop() after a reconnect-disable on a half-open socket returns without waiting for a drain PONG",
+    done === 0 && Number.isFinite(stopMs) && stopMs < STOP_BUDGET_MS,
+    { done, stopMs, output: output.slice(-400) },
+  );
+} finally {
+  child?.kill("SIGKILL");
+  relay.close();
+  for (const sock of relaySockets) sock.destroy();
+  broker.kill("SIGKILL");
+  await wait(200);
+  rmSync(dir, { recursive: true, force: true });
+  releaseBroker();
+}
+
+console.log(
+  fail === 0
+    ? `\nRECONNECT-FENCE-CLOSE SMOKE PASSED ✅  (${pass} checks)`
+    : `\nRECONNECT-FENCE-CLOSE SMOKE FAILED ❌  (${pass} passed, ${fail} failed)`,
+);
+process.exit(fail === 0 ? 0 : 1);

--- a/packages/core/smoke/standing-renewal-auth.smoke.ts
+++ b/packages/core/smoke/standing-renewal-auth.smoke.ts
@@ -119,17 +119,30 @@ try {
   const expiring = newIdentity();
   let expiringReads = 0;
   let failedRebuildLogStart = -1;
+  let originalExpiryObservedBeforeReconnectWindow = false;
   const expiringErrors: string[] = [];
   // Recoverable notices — the failed renewal and the pre-dial refusal below — ride `warning`,
   // not `error`: Node rethrows an unhandled `error` and would kill a host the endpoint is still
   // surviving (#891). The subject here is that the refusal is LOUD and names the renewal path.
   const expiringWarnings: string[] = [];
-  const expiringSource = () => {
+  const expiringSource = async () => {
     expiringReads++;
     if (expiringReads <= 3) {
       if (expiringReads === 1)
         return mintCreds(auth, expiring, "supervisor", { expiresInSeconds: 3 });
-      if (expiringReads === 3) failedRebuildLogStart = brokerLog.length;
+      if (expiringReads === 3) {
+        // The rebuild is triggered by the original connection's broker-auth-expiry close. Its log
+        // line and the socket close are separate asynchronous deliveries, so the source read can run
+        // before the log pipe appends that already-authenticated connection's expiry. That line is not
+        // a reconnect presenting cached credentials. Wait for that specific original-wire line before
+        // opening the reconnect-denial observation window; a real post-guard dial still logs after it.
+        originalExpiryObservedBeforeReconnectWindow = await until(
+          () => /cotal:expired-creds.*User Authentication Expired/.test(brokerLog),
+          2_000,
+          10,
+        );
+        failedRebuildLogStart = brokerLog.length;
+      }
       throw new Error("fixture renewal source offline");
     }
     return mintCreds(auth, expiring, "supervisor", { expiresInSeconds: 60 });
@@ -164,6 +177,10 @@ try {
   );
   const expiredCredDenials = brokerLog.slice(failedRebuildLogStart).split("\n").filter((l) =>
     /User JWT no longer valid.*claim is expired|cotal:expired-creds.*User Authentication Expired/.test(l),
+  );
+  check(
+    "the original wire's expiry log lands before the reconnect-denial observation window opens",
+    originalExpiryObservedBeforeReconnectWindow,
   );
   check(
     "a rebuild presents cached expired creds to the broker ZERO times after renewal fails",

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -390,6 +390,12 @@ export class CotalEndpoint extends EventEmitter {
   /** The freshest bearer — what every (re)connect attempt presents. */
   private currentBearer?: string;
   private bearerTimer?: NodeJS.Timeout;
+  /** Arms against the credential authenticated on the current wire. nats-core 3.4.0 discards the
+   *  promise returned by its async transport-close continuation; if that continuation enters the
+   *  reconnect dial loop with an expired JWT, its terminal auth error becomes an unhandled rejection.
+   *  Cotal knows the JWT expiry, so it disables the library reconnect before the broker closes the
+   *  transport. The endpoint's observed `closed()` supervisor remains responsible for rebuilding. */
+  private authExpiryReconnectTimer?: NodeJS.Timeout;
   private readonly sentinelCreds?: string;
   private readonly tls: boolean;
   private readonly heartbeatMs: number;
@@ -834,12 +840,43 @@ export class CotalEndpoint extends EventEmitter {
   /** Swap the live connection onto the freshest cached cred with a controlled `nc.reconnect()`
    *  (nats.js re-evaluates the creds getter per attempt). Swapping now, instead of waiting for the
    *  broker to close the connection at `exp`, means the wire never carries a near-dead JWT and the
-   *  operator never sees a spurious "authentication expired" — the broker's expiry-close remains the
-   *  BACKSTOP if a swap is missed, not the mechanism. Already-closed/draining rejections are the
-   *  supervise loop's to own (its rebuild re-fetches); an already-disconnected client is a no-op
-   *  (its own reconnect loop presents the fresh cred). */
+   *  operator never sees a spurious "authentication expired". After the reconnect succeeds, re-arm
+   *  the expiry fence for the credential now authenticated on the wire. */
   private async swapConnectionOntoFreshCreds(): Promise<void> {
-    if (this.nc && !this.stopped) await this.nc.reconnect().catch(() => {});
+    const nc = this.nc;
+    if (nc && !this.stopped) {
+      await nc.reconnect().catch(() => {});
+      if (this.nc === nc && !this.stopped) this.armAuthExpiryReconnectFence(nc);
+    }
+  }
+
+  /** nats-core keeps its reconnect switch on the protocol handler. This pinned internal shape is the
+   *  same last-resort surface used by {@link closeFailedBind}; there is no public API for changing the
+   *  reconnect policy of an existing connection. Disabling it does not disable Cotal self-heal: the
+   *  `nc.closed()` supervisor below rebuilds the endpoint with freshly checked auth material. */
+  private disableLibraryReconnect(nc: NatsConnection): void {
+    const protocol = (nc as unknown as { protocol?: { options?: { reconnect?: boolean } } }).protocol;
+    if (protocol?.options) protocol.options.reconnect = false;
+  }
+
+  /** Disable nats-core reconnect shortly before the JWT authenticated on this wire expires. The small
+   *  lead makes the policy change precede the broker's expiry close even when both timers wake in the
+   *  same event-loop turn. A credential adoption does not move this fence until the resident reconnect
+   *  is requested, so the old wire remains protected during the prove-then-adopt window. */
+  private armAuthExpiryReconnectFence(nc: NatsConnection): void {
+    clearTimeout(this.authExpiryReconnectTimer);
+    this.authExpiryReconnectTimer = undefined;
+    const credsExp = this.currentCreds && credsClaims(this.currentCreds).exp;
+    const expiryMs = this.userMode && this.currentBearer
+      ? bearerExpiryMs(this.currentBearer)
+      : typeof credsExp === "number"
+        ? credsExp * 1000
+        : undefined;
+    if (expiryMs === undefined || this.stopped) return;
+    this.authExpiryReconnectTimer = setTimeout(() => {
+      if (this.nc === nc) this.disableLibraryReconnect(nc);
+    }, Math.max(0, expiryMs - Date.now() - 500));
+    this.authExpiryReconnectTimer.unref?.();
   }
 
   /** The connectAndBind PRE-CONNECT fetch: pull the freshest source cred and pin it into
@@ -1055,6 +1092,7 @@ export class CotalEndpoint extends EventEmitter {
       // one the broker forces at JWT `exp`) present whatever refreshCreds last fetched.
       ...authOpts({ token: this.token, user: this.user, pass: this.pass, creds: this.credsSource ? () => this.currentCreds! : this.currentCreds, bearer: this.userMode ? () => this.currentBearer! : undefined, sentinelCreds: this.sentinelCreds, tls: this.tls }),
     });
+    this.armAuthExpiryReconnectFence(this.nc);
     this.watchStatus();
     this.js = jetstream(this.nc);
 
@@ -1193,6 +1231,10 @@ export class CotalEndpoint extends EventEmitter {
    *  second heartbeat, double-pump a consumer, or keep stale roster ghosts. Caller-owned
    *  subs (tap/serve) are left alone — they aren't rebuilt here. */
   private clearConnectionScoped(): void {
+    if (this.authExpiryReconnectTimer) {
+      clearTimeout(this.authExpiryReconnectTimer);
+      this.authExpiryReconnectTimer = undefined;
+    }
     if (this.heartbeatTimer) {
       clearInterval(this.heartbeatTimer);
       this.heartbeatTimer = undefined;
@@ -1277,6 +1319,7 @@ export class CotalEndpoint extends EventEmitter {
    * retry starts with the same empty state as a first attempt. */
   private async closeFailedBind(): Promise<void> {
     const failedNc = this.nc;
+    if (failedNc) this.disableLibraryReconnect(failedNc);
     this.clearConnectionScoped();
     this.nc = undefined;
     this.js = undefined;
@@ -1351,6 +1394,7 @@ export class CotalEndpoint extends EventEmitter {
   private async tearDownIfStopped(): Promise<boolean> {
     if (!this.stopped) return false;
     const nc = this.nc;
+    if (nc) this.disableLibraryReconnect(nc);
     this.clearConnectionScoped();
     try {
       await nc?.drain();
@@ -1404,6 +1448,7 @@ export class CotalEndpoint extends EventEmitter {
    *  idempotent, so connectAndBind's own call here is a noop. */
   private async doRebuild(): Promise<void> {
     const oldNc = this.nc;
+    if (oldNc) this.disableLibraryReconnect(oldNc);
     this.reconnecting = true;
     try {
       this.clearConnectionScoped();
@@ -1522,6 +1567,7 @@ export class CotalEndpoint extends EventEmitter {
    *  (see {@link startPresenceWatch}). */
   async stop(): Promise<void> {
     if (this.stopped) return;
+    if (this.nc) this.disableLibraryReconnect(this.nc);
     this.stopped = true;
     this.presenceEpoch++;
     this.presenceRebind = undefined;
@@ -1532,6 +1578,7 @@ export class CotalEndpoint extends EventEmitter {
     if (this.sweepTimer) clearInterval(this.sweepTimer);
     if (this.bearerTimer) clearTimeout(this.bearerTimer);
     if (this.credsTimer) clearTimeout(this.credsTimer);
+    if (this.authExpiryReconnectTimer) clearTimeout(this.authExpiryReconnectTimer);
     for (const watch of this.membershipFeedWatches) {
       watch.stopped = true;
       watch.arm = watch.arm.catch(() => {}).then(async () => {
@@ -3169,6 +3216,7 @@ export class CotalEndpoint extends EventEmitter {
           continue;
         }
         if (s.type === "reconnect") {
+          this.armAuthExpiryReconnectFence(nc);
           this.emit("transport", { connected: true, server: s.server } satisfies TransportState);
           continue;
         }

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -859,6 +859,22 @@ export class CotalEndpoint extends EventEmitter {
     if (protocol?.options) protocol.options.reconnect = false;
   }
 
+  /** Close a connection whose library reconnect has already been disabled. `drain()` flushes with a
+   *  PING and waits for the matching PONG; nats-core only rejects that waiter inside reconnect
+   *  `prepare()`, so a half-open socket with reconnect=false leaves drain pending until the 2-minute
+   *  ping interval times out. `close()` tears the transport down without that round-trip, which is
+   *  the same public path {@link closeFailedBind} already uses when there is no graceful delivery
+   *  contract left. */
+  private async closeWithoutLibraryReconnect(nc: NatsConnection | undefined): Promise<void> {
+    if (!nc) return;
+    this.disableLibraryReconnect(nc);
+    try {
+      await nc.close();
+    } catch {
+      /* already closing */
+    }
+  }
+
   /** Disable nats-core reconnect shortly before the JWT authenticated on this wire expires. The small
    *  lead makes the policy change precede the broker's expiry close even when both timers wake in the
    *  same event-loop turn. A credential adoption does not move this fence until the resident reconnect
@@ -1396,11 +1412,7 @@ export class CotalEndpoint extends EventEmitter {
     const nc = this.nc;
     if (nc) this.disableLibraryReconnect(nc);
     this.clearConnectionScoped();
-    try {
-      await nc?.drain();
-    } catch {
-      /* already closing */
-    }
+    await this.closeWithoutLibraryReconnect(nc);
     this.nc = undefined;
     return true;
   }
@@ -1443,7 +1455,7 @@ export class CotalEndpoint extends EventEmitter {
   }
 
   /** The transition: stop the connection-scoped timers FIRST (so nothing live touches
-   *  this.nc during the null window), drop the connection refs, drain the old nc, then
+   *  this.nc during the null window), drop the connection refs, close the old nc, then
    *  rebind + re-arm the supervisor on the fresh connection. clearConnectionScoped is
    *  idempotent, so connectAndBind's own call here is a noop. */
   private async doRebuild(): Promise<void> {
@@ -1452,7 +1464,7 @@ export class CotalEndpoint extends EventEmitter {
     this.reconnecting = true;
     try {
       this.clearConnectionScoped();
-      // Manual reconnect still has a live old epoch: complete broker-consumer cleanup before drain.
+      // Manual reconnect still has a live old epoch: complete broker-consumer cleanup before close.
       // Terminal self-heal has an already-closed epoch: disarm retains stream/name for fresh cleanup.
       if (oldNc && !oldNc.isClosed())
         await Promise.all([...this.membershipFeedWatches].map((watch) => watch.arm));
@@ -1476,11 +1488,7 @@ export class CotalEndpoint extends EventEmitter {
       // the authoritative raw-liveness edge for the no-nc window until the new watcher seeds true.
       this.emit("transport", { connected: false } satisfies TransportState);
       this.emit("connection", { connected: false });
-      try {
-        await oldNc?.drain();
-      } catch {
-        /* already closing */
-      }
+      await this.closeWithoutLibraryReconnect(oldNc);
       await this.connectAndBind();
       // stop() may have run during the await — don't leave a live connection + heartbeat +
       // supervisor on a stopped endpoint. (Reads this.nc in its own scope — a bare `this.nc`
@@ -1625,7 +1633,7 @@ export class CotalEndpoint extends EventEmitter {
       /* best-effort graceful leave */
     }
     try {
-      await this.nc?.drain();
+      await this.closeWithoutLibraryReconnect(this.nc);
     } catch {
       /* ignore */
     }


### PR DESCRIPTION
## What changed

Cotal endpoints now disable the NATS client's reconnect loop before the credential authenticated on the current connection expires and before deliberate endpoint teardown. Cotal's existing connection supervisor still rebuilds the endpoint after the documented `closed()` result resolves, but nats-core no longer enters its reconnect dial loop with credential material Cotal already knows is dead.

The credential lifetime smoke now registers `nc.closed()` before expiry in a child process, grades the returned expiry error, and proves the process stays alive. Its mutation removes the reconnect-disable at the expiry boundary and reds that exact cell.

## Why

In nats-core 3.4.0, `ProtocolHandler.prepare()` discards the promise returned by an async `transport.closed().then(...)` continuation. When credential expiry sends that continuation through `dialLoop()`, the terminal authentication error can reject the discarded promise and terminate the process. Public `nc.closed()` resolves with the close error and is not the rejecting emitter.

Cotal knows credential expiry before the broker closes the transport, so preventing that dead-credential reconnect is the root fix within Cotal's control. No process-level rejection handler, skipped cell, retry, or nats-core patch is used.

## Validation

- `pnpm typecheck`
- `pnpm smoke:cred-lifetime`
- `pnpm smoke:mutation-fixtures`
- `node scripts/mutation-proof.mjs --config packages/core/smoke/mutations/credential-expiry-reconnect.json`
- 20/20 `pnpm smoke:cred-lifetime` repetitions with Node v22.23.2 and nats-server v2.12.12

Refs #1480
