### PR TITLE
ci: shard the scheduled mutation reproof sweep

### DIFF
--- a/.changeset/twelve-reproof-shards.md
+++ b/.changeset/twelve-reproof-shards.md
@@ -1,0 +1,6 @@
+---
+---
+
+Split the scheduled full mutation reproof into twelve deterministic shards with bounded per-shard
+budgets, an aggregate gate, and CI controls for complete corpus assignment and shard failure
+propagation.

--- a/.github/workflows/mutation-reproof.yml
+++ b/.github/workflows/mutation-reproof.yml
@@ -146,12 +146,18 @@ jobs:
           test "$PLAN_RESULT" = success
           if [ "$PLAN_SHARDS" = "[]" ]; then test "$SHARD_RESULT" = skipped; else test "$SHARD_RESULT" = success; fi
 
-  full:
+  full_shard:
     # A daily sweep keeps the remaining ambient-drift window bounded without making every pull
-    # request pay for all 1,714 mutations. It is manually runnable after an infrastructure repair.
+    # request pay for the full corpus. The corpus takes roughly 20 hours as one serial process, so
+    # the runner's deterministic path hash partitions it across 12 independent mutation trees.
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    timeout-minutes: 360
+    timeout-minutes: 240
     runs-on: tenki-standard-medium-4c-8g
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+    name: full shard ${{ matrix.shard }}/12
     permissions:
       contents: read
     steps:
@@ -182,15 +188,42 @@ jobs:
         run: echo "$HOME/nats-bin" >> "$GITHUB_PATH"
       - name: Build
         run: pnpm build
-      - name: Re-prove every mutation fixture
-        run: node scripts/mutation-reproof.mjs --all
+      - name: Re-prove every mutation fixture assigned to this shard
+        # Leave 15 minutes after a step timeout for teardown and elapsed reporting.
+        timeout-minutes: 225
+        run: |
+          date +%s > "$RUNNER_TEMP/mutation-started"
+          node scripts/mutation-reproof.mjs --all --shard "${{ matrix.shard }}/12"
+      - name: Report elapsed
+        if: always()
+        run: |
+          marker="$RUNNER_TEMP/mutation-started"
+          if [ -s "$marker" ]; then
+            echo "mutation reproof: full shard ${{ matrix.shard }}/12 elapsed $(( $(date +%s) - $(cat "$marker") ))s (step budget 225m; job budget 240m)"
+          else
+            echo "mutation reproof: no start marker; the job ended before the full re-prove step began"
+          fi
+
+  full:
+    name: full sweep aggregate
+    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && always()
+    needs: [full_shard]
+    timeout-minutes: 10
+    runs-on: tenki-standard-small-2c-4g
+    steps:
+      - name: Gate
+        env:
+          SHARD_RESULT: ${{ needs.full_shard.result }}
+        run: |
+          set -euo pipefail
+          echo "full_shard=$SHARD_RESULT"
+          test "$SHARD_RESULT" = success
 
   full-alarm:
-    # The alarm lives outside the job it watches. A job-level timeout ends `full` as `cancelled`,
-    # which `failure()` never matches, and a step trailing the sweep inside the same job can be
-    # killed with it: every retained scheduled sweep ended cancelled and none filed an issue. A
-    # dependent job still runs after the sweep's timeout, so this one reads the sweep's result and
-    # turns a failed or cancelled sweep into one open, labelled tracking issue: a run that ends
+    # The alarm lives outside the aggregate gate it watches. A shard timeout makes the matrix result
+    # non-success, and the always-running aggregate turns that into a failure before this job reads
+    # it. The alarm therefore still turns a failed or cancelled full sweep into one open, labelled
+    # tracking issue: a run that ends
     # that way while the marker issue is still open comments on it instead of opening a second.
     # The key is the label, read through the Issues API, not title search (tokenised and
     # eventually consistent). A skipped sweep (any other event) leaves this job skipped too.
@@ -214,7 +247,7 @@ jobs:
           gh label create "$label" --description "Open while the scheduled mutation-reproof full sweep is failing" --color B60205 --force
           existing="$(gh issue list --state open --label "$label" --json number --jq '.[0].number // empty')"
           if [ "$SWEEP_RESULT" = cancelled ]; then
-            outcome="did not finish (job result: cancelled; the sweep's 360-minute timeout ends it this way)"
+            outcome="did not finish (aggregate job result: cancelled)"
           else
             outcome="failed (job result: $SWEEP_RESULT)"
           fi

--- a/bin/smoke/ci-suites.d/1d7410192b766e473aa3d689ad4d5274a28b0f1f39bb3eb3f05964f167b9e252.txt
+++ b/bin/smoke/ci-suites.d/1d7410192b766e473aa3d689ad4d5274a28b0f1f39bb3eb3f05964f167b9e252.txt
@@ -1,0 +1,2 @@
+# Issue #1482 full-sweep control.
+smoke:mutation-reproof-full-partition

--- a/bin/smoke/ci-suites.d/6dce6f5d7c0adb38114b530000749e1e5eb49d2f85d34115d38f554f48226898.txt
+++ b/bin/smoke/ci-suites.d/6dce6f5d7c0adb38114b530000749e1e5eb49d2f85d34115d38f554f48226898.txt
@@ -1,0 +1,2 @@
+# Issue #1482 full-sweep control.
+smoke:mutation-reproof-full-workflow

--- a/bin/smoke/gen-ci-suites-dts.mts
+++ b/bin/smoke/gen-ci-suites-dts.mts
@@ -20,6 +20,10 @@ export const DECLARATIONS = [
     module: fileURLToPath(new URL("./live-suite.mjs", import.meta.url)),
     declaration: fileURLToPath(new URL("./live-suite.d.mts", import.meta.url)),
   },
+  {
+    module: fileURLToPath(new URL("../../scripts/mutation-shard.mjs", import.meta.url)),
+    declaration: fileURLToPath(new URL("../../scripts/mutation-shard.d.mts", import.meta.url)),
+  },
 ] as const;
 
 function options(): ts.CompilerOptions {

--- a/bin/smoke/mutation-reproof-full-partition.smoke.ts
+++ b/bin/smoke/mutation-reproof-full-partition.smoke.ts
@@ -1,0 +1,57 @@
+/**
+ * Issue #1482: prove the committed mutation corpus is a complete, disjoint 12-way partition.
+ *
+ * This smoke is stack-free. It walks the same git-tracked corpus convention as the runner and calls
+ * the runner's exported shard function rather than copying the hash into a detector.
+ */
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mutationShard } from "../../scripts/mutation-shard.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const SHARD_COUNT = 12;
+let passed = 0;
+let failed = 0;
+
+function check(name: string, ok: unknown, detail = ""): void {
+  if (ok) { passed++; console.log(`  ✓ ${name}`); }
+  else { failed++; console.log(`  ✗ FAIL: ${name}${detail ? `\n      ${detail}` : ""}`); }
+}
+
+const paths = execFileSync("git", ["ls-files", "*/mutations/*.json", "*.mutations.json"], {
+  cwd: ROOT,
+  encoding: "utf8",
+}).split("\n").filter(Boolean);
+const malformed: string[] = [];
+for (const path of paths) {
+  try {
+    const config = JSON.parse(readFileSync(join(ROOT, path), "utf8"));
+    if (!Array.isArray(config.mutations)) malformed.push(`${path}: no top-level mutations array`);
+  } catch (error) {
+    malformed.push(`${path}: ${(error as Error).message}`);
+  }
+}
+
+const shards = Array.from({ length: SHARD_COUNT }, () => [] as string[]);
+for (const path of paths) shards[mutationShard(path, SHARD_COUNT)]!.push(path);
+const assigned = shards.flat();
+const counts = shards.map((entries) => entries.length);
+
+check("the tracked mutation corpus is non-empty and parseable", paths.length > 0 && malformed.length === 0,
+  malformed.join("\n"));
+check("every corpus fixture is assigned to exactly one of 12 shards",
+  assigned.length === paths.length && new Set(assigned).size === paths.length
+    && paths.every((path) => assigned.includes(path)),
+  JSON.stringify({ corpus: paths.length, assigned: assigned.length, unique: new Set(assigned).size }));
+check("the production shard function returns only configured shard indexes",
+  paths.every((path) => {
+    const shard = mutationShard(path, SHARD_COUNT);
+    return Number.isInteger(shard) && shard >= 0 && shard < SHARD_COUNT;
+  }));
+check("all 12 full-sweep shards receive at least one fixture", counts.every((count) => count > 0),
+  JSON.stringify(counts));
+
+console.log(`\nmutation corpus partition: ${passed} passed, ${failed} failed (${paths.length} fixtures; shard counts ${counts.join(",")})`);
+if (failed) process.exit(1);

--- a/bin/smoke/mutation-reproof-full-workflow.smoke.ts
+++ b/bin/smoke/mutation-reproof-full-workflow.smoke.ts
@@ -12,6 +12,11 @@ import { fileURLToPath } from "node:url";
 import { parse } from "yaml";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const childEnv = (): NodeJS.ProcessEnv => {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) if (key.startsWith("COTAL_")) delete env[key];
+  return env;
+};
 const workflow = parse(readFileSync(join(ROOT, ".github/workflows/mutation-reproof.yml"), "utf8"));
 const jobs = workflow?.jobs ?? {};
 const shardJob = jobs.full_shard;
@@ -47,18 +52,28 @@ check("full is the named always-running aggregate gate over full_shard",
     && JSON.stringify(aggregate?.needs) === JSON.stringify(["full_shard"])
     && aggregate?.["continue-on-error"] !== true);
 
+const previousSentinel = process.env.COTAL_REPROOF_SENTINEL;
+process.env.COTAL_REPROOF_SENTINEL = "synthetic-session-secret";
 const gate = aggregate?.steps?.find((step: { name?: string }) => step.name === "Gate");
+let aggregateEnvClean = true;
 for (const [result, accepts] of [["success", true], ["failure", false], ["cancelled", false], ["skipped", false]] as const) {
-  const run = typeof gate?.run === "string" ? spawnSync("bash", ["-c", gate.run], {
+  const command = typeof gate?.run === "string"
+    ? `if [ "\${COTAL_REPROOF_SENTINEL+x}" ]; then echo SESSION_LEAK; fi\n${gate.run}`
+    : undefined;
+  const run = command ? spawnSync("bash", ["-c", command], {
     encoding: "utf8",
-    env: { ...process.env, SHARD_RESULT: result },
+    env: { ...childEnv(), SHARD_RESULT: result },
   }) : undefined;
+  aggregateEnvClean &&= run !== undefined && !`${run.stdout ?? ""}${run.stderr ?? ""}`.includes("SESSION_LEAK");
   check(`the full aggregate ${accepts ? "accepts" : "rejects"} matrix=${result}`,
     gate?.env?.SHARD_RESULT === "${{ needs.full_shard.result }}"
       && run?.status !== null && run?.status !== undefined
       && (accepts ? run.status === 0 : run.status !== 0),
     `status=${run?.status ?? "not run"}`);
 }
+check("aggregate probes do not inherit Cotal session credentials", aggregateEnvClean);
+if (previousSentinel === undefined) delete process.env.COTAL_REPROOF_SENTINEL;
+else process.env.COTAL_REPROOF_SENTINEL = previousSentinel;
 check("full-alarm remains pointed at the full aggregate gate",
   alarm?.needs === "full"
     && alarm?.if === "always() && (needs.full.result == 'failure' || needs.full.result == 'cancelled')"

--- a/bin/smoke/mutation-reproof-full-workflow.smoke.ts
+++ b/bin/smoke/mutation-reproof-full-workflow.smoke.ts
@@ -1,0 +1,69 @@
+/**
+ * Issue #1482: workflow-shape control for the scheduled full mutation sweep.
+ *
+ * The checks are anchored on parsed job ids and exercise the aggregate gate's real shell. A matrix
+ * failure or cancellation must therefore make the named aggregate red rather than only looking right
+ * in YAML comments.
+ */
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse } from "yaml";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const workflow = parse(readFileSync(join(ROOT, ".github/workflows/mutation-reproof.yml"), "utf8"));
+const jobs = workflow?.jobs ?? {};
+const shardJob = jobs.full_shard;
+const aggregate = jobs.full;
+const alarm = jobs["full-alarm"];
+const shards = Array.from({ length: 12 }, (_, index) => index);
+let passed = 0;
+let failed = 0;
+
+function check(name: string, ok: unknown, detail = ""): void {
+  if (ok) { passed++; console.log(`  ✓ ${name}`); }
+  else { failed++; console.log(`  ✗ FAIL: ${name}${detail ? `\n      ${detail}` : ""}`); }
+}
+
+const reproof = shardJob?.steps?.find((step: { name?: string }) =>
+  step.name === "Re-prove every mutation fixture assigned to this shard");
+const report = shardJob?.steps?.find((step: { name?: string }) => step.name === "Report elapsed");
+check("full_shard is a 12-way fail-fast-disabled Tenki matrix",
+  shardJob?.["runs-on"] === "tenki-standard-medium-4c-8g"
+    && shardJob?.["timeout-minutes"] === 240
+    && shardJob?.strategy?.["fail-fast"] === false
+    && JSON.stringify(shardJob?.strategy?.matrix?.shard) === JSON.stringify(shards));
+check("every full shard uses the runner's --all --shard support with a 225-minute step ceiling",
+  reproof?.["timeout-minutes"] === 225
+    && typeof reproof?.run === "string"
+    && reproof.run.includes('node scripts/mutation-reproof.mjs --all --shard "${{ matrix.shard }}/12"'));
+check("every full shard preserves time for an always-running elapsed report",
+  report?.if === "always()" && typeof report?.run === "string"
+    && report.run.includes("step budget 225m; job budget 240m"));
+check("full is the named always-running aggregate gate over full_shard",
+  aggregate?.name === "full sweep aggregate"
+    && aggregate?.if === "(github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && always()"
+    && JSON.stringify(aggregate?.needs) === JSON.stringify(["full_shard"])
+    && aggregate?.["continue-on-error"] !== true);
+
+const gate = aggregate?.steps?.find((step: { name?: string }) => step.name === "Gate");
+for (const [result, accepts] of [["success", true], ["failure", false], ["cancelled", false], ["skipped", false]] as const) {
+  const run = typeof gate?.run === "string" ? spawnSync("bash", ["-c", gate.run], {
+    encoding: "utf8",
+    env: { ...process.env, SHARD_RESULT: result },
+  }) : undefined;
+  check(`the full aggregate ${accepts ? "accepts" : "rejects"} matrix=${result}`,
+    gate?.env?.SHARD_RESULT === "${{ needs.full_shard.result }}"
+      && run?.status !== null && run?.status !== undefined
+      && (accepts ? run.status === 0 : run.status !== 0),
+    `status=${run?.status ?? "not run"}`);
+}
+check("full-alarm remains pointed at the full aggregate gate",
+  alarm?.needs === "full"
+    && alarm?.if === "always() && (needs.full.result == 'failure' || needs.full.result == 'cancelled')"
+    && alarm?.steps?.some((step: { env?: { SWEEP_RESULT?: string } }) =>
+      step.env?.SWEEP_RESULT === "${{ needs.full.result }}"));
+
+console.log(`\nmutation full workflow: ${passed} passed, ${failed} failed`);
+if (failed) process.exit(1);

--- a/bin/smoke/mutations/mutation-reproof-full-partition.json
+++ b/bin/smoke/mutations/mutation-reproof-full-partition.json
@@ -1,0 +1,19 @@
+{
+  "suite": [
+    "bin/smoke/mutation-reproof-full-partition.smoke.ts"
+  ],
+  "guard": "Every git-tracked fixture in the mutation corpus is assigned exactly once by the production shard function for a 12-way full sweep.",
+  "command": "pnpm smoke:mutation-reproof-full-partition",
+  "grades": "tool",
+  "proveWith": "pnpm mutation-proof --config bin/smoke/mutations/mutation-reproof-full-partition.json",
+  "mutations": [
+    {
+      "name": "the production shard function collapses the corpus onto shard zero",
+      "file": "scripts/mutation-shard.mjs",
+      "find": "  return hash % count;",
+      "replace": "  return 0;",
+      "expectRed": "all 12 full-sweep shards receive at least one fixture",
+      "cell": "all 12 full-sweep shards receive at least one fixture"
+    }
+  ]
+}

--- a/bin/smoke/mutations/mutation-reproof-full-workflow.json
+++ b/bin/smoke/mutations/mutation-reproof-full-workflow.json
@@ -1,0 +1,43 @@
+{
+  "suite": [
+    "bin/smoke/mutation-reproof-full-workflow.smoke.ts"
+  ],
+  "guard": "The scheduled full sweep is a 12-way fail-fast-disabled Tenki matrix with bounded shard budgets, a named aggregate gate that rejects failed or cancelled shards, and the full alarm depending on that aggregate.",
+  "command": "pnpm smoke:mutation-reproof-full-workflow",
+  "grades": "tool",
+  "proveWith": "pnpm mutation-proof --config bin/smoke/mutations/mutation-reproof-full-workflow.json",
+  "mutations": [
+    {
+      "name": "the full matrix cancels siblings after one shard fails",
+      "file": ".github/workflows/mutation-reproof.yml",
+      "find": "  full_shard:\n    # A daily sweep keeps the remaining ambient-drift window bounded without making every pull\n    # request pay for the full corpus. The corpus takes roughly 20 hours as one serial process, so\n    # the runner's deterministic path hash partitions it across 12 independent mutation trees.\n    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'\n    timeout-minutes: 240\n    runs-on: tenki-standard-medium-4c-8g\n    strategy:\n      fail-fast: false",
+      "replace": "  full_shard:\n    # A daily sweep keeps the remaining ambient-drift window bounded without making every pull\n    # request pay for the full corpus. The corpus takes roughly 20 hours as one serial process, so\n    # the runner's deterministic path hash partitions it across 12 independent mutation trees.\n    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'\n    timeout-minutes: 240\n    runs-on: tenki-standard-medium-4c-8g\n    strategy:\n      fail-fast: true",
+      "expectRed": "full_shard is a 12-way fail-fast-disabled Tenki matrix",
+      "cell": "full_shard is a 12-way fail-fast-disabled Tenki matrix"
+    },
+    {
+      "name": "the full aggregate accepts a failed matrix",
+      "file": ".github/workflows/mutation-reproof.yml",
+      "find": "          test \"$SHARD_RESULT\" = success",
+      "replace": "          test \"$SHARD_RESULT\" != cancelled",
+      "expectRed": "the full aggregate rejects matrix=failure",
+      "cell": "the full aggregate rejects matrix=failure"
+    },
+    {
+      "name": "the full aggregate accepts a cancelled matrix",
+      "file": ".github/workflows/mutation-reproof.yml",
+      "find": "          test \"$SHARD_RESULT\" = success",
+      "replace": "          test \"$SHARD_RESULT\" != failure",
+      "expectRed": "the full aggregate rejects matrix=cancelled",
+      "cell": "the full aggregate rejects matrix=cancelled"
+    },
+    {
+      "name": "the full alarm watches shards instead of the aggregate gate",
+      "file": ".github/workflows/mutation-reproof.yml",
+      "find": "    needs: full\n    if: always() && (needs.full.result == 'failure' || needs.full.result == 'cancelled')",
+      "replace": "    needs: full_shard\n    if: always() && (needs.full_shard.result == 'failure' || needs.full_shard.result == 'cancelled')",
+      "expectRed": "full-alarm remains pointed at the full aggregate gate",
+      "cell": "full-alarm remains pointed at the full aggregate gate"
+    }
+  ]
+}

--- a/bin/smoke/mutations/mutation-reproof-full-workflow.json
+++ b/bin/smoke/mutations/mutation-reproof-full-workflow.json
@@ -32,6 +32,14 @@
       "cell": "the full aggregate rejects matrix=cancelled"
     },
     {
+      "name": "the aggregate probe keeps Cotal session variables",
+      "file": "bin/smoke/mutation-reproof-full-workflow.smoke.ts",
+      "find": "    env: { ...childEnv(), SHARD_RESULT: result },",
+      "replace": "    env: { ...process.env, SHARD_RESULT: result },",
+      "expectRed": "aggregate probes do not inherit Cotal session credentials",
+      "cell": "aggregate probes do not inherit Cotal session credentials"
+    },
+    {
       "name": "the full alarm watches shards instead of the aggregate gate",
       "file": ".github/workflows/mutation-reproof.yml",
       "find": "    needs: full\n    if: always() && (needs.full.result == 'failure' || needs.full.result == 'cancelled')",

--- a/bin/smoke/mutations/mutation-reproof-shards.json
+++ b/bin/smoke/mutations/mutation-reproof-shards.json
@@ -10,14 +10,14 @@
     {
       "name": "every shard executes the full selected set",
       "file": "scripts/mutation-reproof.mjs",
-      "find": "if (shard) selected = selected.filter(({ path }) => shardOf(path, Number(shard[2])) === Number(shard[1]));",
-      "replace": "if (false && shard) selected = selected.filter(({ path }) => shardOf(path, Number(shard[2])) === Number(shard[1]));",
+      "find": "if (shard) selected = selected.filter(({ path }) => mutationShard(path, Number(shard[2])) === Number(shard[1]));",
+      "replace": "if (false && shard) selected = selected.filter(({ path }) => mutationShard(path, Number(shard[2])) === Number(shard[1]));",
       "expectRed": "fixture shards partition the selected set without omission or overlap",
       "cell": "fixture shards partition the selected set without omission or overlap"
     },
     {
       "name": "all fixtures collapse onto shard zero",
-      "file": "scripts/mutation-reproof.mjs",
+      "file": "scripts/mutation-shard.mjs",
       "find": "  return hash % count;",
       "replace": "  return 0;",
       "expectRed": "the partition control exercises every configured shard with a discriminating fixture",
@@ -26,8 +26,8 @@
     {
       "name": "the workflow omits the runner shard argument",
       "file": ".github/workflows/mutation-reproof.yml",
-      "find": " --shard \"${{ matrix.shard }}/12\"",
-      "replace": "",
+      "find": "          node scripts/mutation-reproof.mjs --base \"$base\" --head \"$(git rev-parse HEAD)\" --shard \"${{ matrix.shard }}/12\"",
+      "replace": "          node scripts/mutation-reproof.mjs --base \"$base\" --head \"$(git rev-parse HEAD)\"",
       "expectRed": "the changed workload fans exactly the planned shards without fail-fast cancellation",
       "cell": "the changed workload fans exactly the planned shards without fail-fast cancellation"
     },
@@ -42,8 +42,8 @@
     {
       "name": "a failed shard cancels its sibling work",
       "file": ".github/workflows/mutation-reproof.yml",
-      "find": "      fail-fast: false",
-      "replace": "      fail-fast: true",
+      "find": "  changed_shard:\n    # At dfbb4550f, PR #1350 selected 32 fixtures and exhausted the 145-minute serial step.\n    # Each path is assigned to one shard by the runner's existing hash. Shards use separate\n    # checkouts because mutation-proof temporarily changes source and compiled artifacts.\n    # Only the shards the plan named are fanned; the shard run re-selects for itself, so a shard\n    # that disagrees with the plan prints its own selection rather than trusting the plan's.\n    if: github.event_name != 'schedule' && needs.plan.outputs.shards != '[]'\n    needs: [plan]\n    timeout-minutes: 150\n    runs-on: tenki-standard-medium-4c-8g\n    strategy:\n      fail-fast: false",
+      "replace": "  changed_shard:\n    # At dfbb4550f, PR #1350 selected 32 fixtures and exhausted the 145-minute serial step.\n    # Each path is assigned to one shard by the runner's existing hash. Shards use separate\n    # checkouts because mutation-proof temporarily changes source and compiled artifacts.\n    # Only the shards the plan named are fanned; the shard run re-selects for itself, so a shard\n    # that disagrees with the plan prints its own selection rather than trusting the plan's.\n    if: github.event_name != 'schedule' && needs.plan.outputs.shards != '[]'\n    needs: [plan]\n    timeout-minutes: 150\n    runs-on: tenki-standard-medium-4c-8g\n    strategy:\n      fail-fast: true",
       "expectRed": "the changed workload fans exactly the planned shards without fail-fast cancellation",
       "cell": "the changed workload fans exactly the planned shards without fail-fast cancellation"
     },

--- a/package.json
+++ b/package.json
@@ -601,6 +601,8 @@
     "smoke:verify-publish-closure": "tsx bin/smoke/verify-publish-closure.smoke.ts",
     "smoke:mutation-fixtures": "tsx bin/smoke/mutation-fixtures.smoke.ts",
     "smoke:mutation-reproof": "tsx bin/smoke/mutation-reproof.smoke.ts",
+    "smoke:mutation-reproof-full-partition": "tsx bin/smoke/mutation-reproof-full-partition.smoke.ts",
+    "smoke:mutation-reproof-full-workflow": "tsx bin/smoke/mutation-reproof-full-workflow.smoke.ts",
     "smoke:dep-pins": "tsx bin/smoke/dep-pins.smoke.ts",
     "smoke:manager-runtime-deps": "tsx bin/smoke/manager-runtime-deps.smoke.ts",
     "smoke:inst-route-enforce": "tsx packages/core/smoke/inst-route-enforce.smoke.ts",

--- a/scripts/mutation-reproof.mjs
+++ b/scripts/mutation-reproof.mjs
@@ -29,6 +29,7 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { isDeepStrictEqual } from "node:util";
 import { comparableFailure, failureSignatureHash, unmeasurableFailure } from "./mutation-failure-signature.mjs";
+import { mutationShard } from "./mutation-shard.mjs";
 import { parseSuiteSources } from "./mutation-suite-metadata.mjs";
 
 const SCRIPT = fileURLToPath(import.meta.url);
@@ -160,12 +161,6 @@ function isMetadataOnlySuiteCanonicalization(root, base, fixture) {
   return isDeepStrictEqual(baseRest, headRest);
 }
 
-function shardOf(path, count) {
-  let hash = 0;
-  for (const byte of Buffer.from(path)) hash = (hash * 31 + byte) >>> 0;
-  return hash % count;
-}
-
 const a = args(process.argv.slice(2));
 const root = resolve(a.root ?? process.cwd());
 const head = a.head ?? "HEAD";
@@ -230,7 +225,7 @@ let selected = fixtures.map((fixture) => ({
       typeof mutation?.file === "string" && changed.has(mutation.file)),
   },
 })).filter(({ selectedBy }) => Object.values(selectedBy).some(Boolean));
-if (shard) selected = selected.filter(({ path }) => shardOf(path, Number(shard[2])) === Number(shard[1]));
+if (shard) selected = selected.filter(({ path }) => mutationShard(path, Number(shard[2])) === Number(shard[1]));
 
 // Selection evidence precedes dangling validation. A deleted or renamed declared source is one of
 // the reasons a fixture is selected, so reporting the source error before the selected set would
@@ -268,7 +263,7 @@ if (dangling.length) {
 // line is the JSON a workflow reads; an empty list is printed, not turned into exit 0 with no output,
 // so a caller that fans out on it can tell "nothing to prove" from "nothing was said".
 if (listShards !== undefined) {
-  const shards = [...new Set(selected.map(({ path }) => shardOf(path, listShards)))].sort((x, y) => x - y);
+  const shards = [...new Set(selected.map(({ path }) => mutationShard(path, listShards)))].sort((x, y) => x - y);
   console.log(`shard plan: ${shards.length} of ${listShards} shard(s) hold a selected fixture${shards.length ? `: ${shards.join(", ")}` : ""}`);
   console.log(JSON.stringify({ shards }));
   process.exit(0);

--- a/scripts/mutation-shard.d.mts
+++ b/scripts/mutation-shard.d.mts
@@ -1,0 +1,12 @@
+// Generated from mutation-shard.mjs by gen-ci-suites-dts.mts. Do not edit: run `pnpm gen:ci-suites-dts`.
+// The .mjs module is the only source of truth; `pnpm smoke:ci-declarations` fails if this drifts.
+
+/**
+ * Deterministic fixture-path assignment shared by mutation reproof and its corpus partition control.
+ * Keep this independent of fixture contents so changing or adding one fixture cannot move another.
+ *
+ * @param {string} path
+ * @param {number} count
+ * @returns {number}
+ */
+export function mutationShard(path: string, count: number): number;

--- a/scripts/mutation-shard.mjs
+++ b/scripts/mutation-shard.mjs
@@ -1,0 +1,13 @@
+/**
+ * Deterministic fixture-path assignment shared by mutation reproof and its corpus partition control.
+ * Keep this independent of fixture contents so changing or adding one fixture cannot move another.
+ *
+ * @param {string} path
+ * @param {number} count
+ * @returns {number}
+ */
+export function mutationShard(path, count) {
+  let hash = 0;
+  for (const byte of Buffer.from(path)) hash = (hash * 31 + byte) >>> 0;
+  return hash % count;
+}


### PR DESCRIPTION
## Mechanism

The scheduled full mutation reproof was one serial `node scripts/mutation-reproof.mjs --all` process under a 360-minute job ceiling. The corpus is hundreds of fixtures and thousands of executions at a stable ~28-29 s mean, so the serial sweep needs roughly 20 hours and has been cancelled at six hours on every retained run with no final tally. That is aggregate serial budget, not a hang of a single mutation.

Raising the monolithic ceiling would need more than 20 hours today and would regress as the corpus grows. The runner already has a deterministic `--all --shard i/N` partition, so the full sweep now uses that.

## What now happens

- The scheduled (and dispatch) full sweep is a 12-way matrix, one `tenki-standard-medium-4c-8g` job per shard, fail-fast disabled.
- Each shard has a 240-minute job ceiling and a 225-minute reproof-step ceiling so teardown and elapsed reporting stay observable after a step timeout.
- The 15-minute per-command ceiling is unchanged.
- A named `full` aggregate gate waits on the matrix with `always()` and fails when any shard fails or is cancelled.
- The existing `full-alarm` job still watches that aggregate, so a failed or cancelled sweep still files (or comments on) the tracking issue.

## Controls

Stack-free CI smokes:

- Every git-tracked mutation fixture is assigned to exactly one of 12 shards by the production shard function.
- The parsed workflow is a 12-way fail-fast-disabled Tenki matrix with the named aggregate, and that aggregate's real shell rejects `failure` and `cancelled`.
- Mutations for both controls, every one KILLED.

Empty changeset: CI-only.

Refs #1482
