### PR TITLE
test(ci): classify live suites from source declarations

### DIFF
--- a/.changeset/live-suite-source-guard.md
+++ b/.changeset/live-suite-source-guard.md
@@ -1,0 +1,4 @@
+---
+---
+
+Classify live smoke suites from their source-level REAL Manager / REAL agent processes / REAL pty children declarations, not from a `-live` script-name suffix.

--- a/bin/smoke/ci-suites.d/7b781a8bb5fa66ef0c50cf695e3edff6b6582d370f5eb9b71f8e942a991ba870.txt
+++ b/bin/smoke/ci-suites.d/7b781a8bb5fa66ef0c50cf695e3edff6b6582d370f5eb9b71f8e942a991ba870.txt
@@ -1,0 +1,1 @@
+smoke:live-suite

--- a/bin/smoke/gen-ci-suites-dts.mts
+++ b/bin/smoke/gen-ci-suites-dts.mts
@@ -16,6 +16,10 @@ export const DECLARATIONS = [
     module: fileURLToPath(new URL("../../scripts/live-job-conclusion.mjs", import.meta.url)),
     declaration: fileURLToPath(new URL("../../scripts/live-job-conclusion.d.mts", import.meta.url)),
   },
+  {
+    module: fileURLToPath(new URL("./live-suite.mjs", import.meta.url)),
+    declaration: fileURLToPath(new URL("./live-suite.d.mts", import.meta.url)),
+  },
 ] as const;
 
 function options(): ts.CompilerOptions {

--- a/bin/smoke/live-suite.d.mts
+++ b/bin/smoke/live-suite.d.mts
@@ -1,0 +1,64 @@
+// Generated from live-suite.mjs by gen-ci-suites-dts.mts. Do not edit: run `pnpm gen:ci-suites-dts`.
+// The .mjs module is the only source of truth; `pnpm smoke:ci-declarations` fails if this drifts.
+
+/**
+ * The leading header of a suite: shebang, then block and line comments and blank lines until
+ * the first non-comment token. That is the suite's own declaration of what it drives. Later
+ * comments in the body are not consulted, so a cell that mentions "REAL Manager" cannot
+ * reclassify a non-infrastructure suite.
+ *
+ * @param {string} source
+ * @returns {string}
+ */
+export function leadingSuiteHeader(source: string): string;
+/**
+ * @typedef {{ live: boolean, declarations: string[], brokerDeclarations: string[] }} LiveClassification
+ */
+/**
+ * Classify a suite from its source text. The script name is not an argument, so a rename
+ * cannot change the answer while the source still declares the same property.
+ *
+ * @param {string} source
+ * @returns {LiveClassification}
+ */
+export function classifyLiveSuiteSource(source: string): LiveClassification;
+/**
+ * Last `tsx`/`node` path in a package script body. Composite wrappers (`pnpm --filter … build
+ * && tsx path`) still resolve to the suite they execute. A body with no such path is not a
+ * classifiable suite source.
+ *
+ * @param {string} command
+ * @returns {string | null}
+ */
+export function suiteSourceFromScript(command: string): string | null;
+/**
+ * Classify a repository-relative suite file. Path hygiene matches mutation-suite-metadata:
+ * a source that is not a normalised POSIX path inside the root is refused, not classified.
+ *
+ * @param {string} root
+ * @param {string} sourcePath
+ * @returns {LiveClassification}
+ */
+export function classifyLiveSuiteFile(root: string, sourcePath: string): LiveClassification;
+/**
+ * Classify a public `smoke:*` script by resolving its package.json body to a source file
+ * and reading that file's leading header. The script NAME is used only as a key into the
+ * scripts map; it is never tested for a `-live` / `:live` suffix.
+ *
+ * @param {string} root
+ * @param {string} scriptName
+ * @param {Record<string, string>} scripts
+ * @returns {LiveClassification & { source: string | null }}
+ */
+export function classifyLiveSmokeScript(root: string, scriptName: string, scripts: Record<string, string>): LiveClassification & {
+    source: string | null;
+};
+/** Declarations that make a suite live. Exact phrases, not a prose heuristic. */
+export const LIVE_INFRASTRUCTURE_DECLARATIONS: readonly string[];
+/** Recorded on the classification, never sufficient on their own. */
+export const LIVE_BROKER_DECLARATIONS: readonly string[];
+export type LiveClassification = {
+    live: boolean;
+    declarations: string[];
+    brokerDeclarations: string[];
+};

--- a/bin/smoke/live-suite.mjs
+++ b/bin/smoke/live-suite.mjs
@@ -1,0 +1,179 @@
+// @ts-check
+/**
+ * Classify whether a smoke suite drives real infrastructure.
+ *
+ * The standing host rule is "never run a -live suite". A name is not a description of
+ * behaviour: `smoke:seat-input` targets `seat-input-live.smoke.ts`, whose header declares a
+ * REAL Manager, REAL JWT broker and REAL pty children, and a suffix matcher classifies it
+ * non-live. The inverse is also true: a `:live` script whose source does not declare those
+ * properties is not live by this guard.
+ *
+ * Live is a source-level property. The runner answers it by reading the suite's own leading
+ * header for the exact declarations `REAL Manager`, `REAL agent processes`, or `REAL pty
+ * children`. `REAL broker` / `REAL JWT broker` are recorded (a sandboxed nats-server is
+ * ordinary and not the hazard) but they are not sufficient. Script names and file names are
+ * never consulted.
+ *
+ * The six unsuffixed scripts whose headers already declare the property:
+ *   smoke:manager-service
+ *   smoke:manager-service-ops
+ *   smoke:manager-service-invoke
+ *   smoke:manager-spawn-action
+ *   smoke:persona-announce
+ *   smoke:seat-input
+ */
+import { readFileSync } from "node:fs";
+import { isAbsolute, posix, relative, resolve } from "node:path";
+
+/** Declarations that make a suite live. Exact phrases, not a prose heuristic. */
+export const LIVE_INFRASTRUCTURE_DECLARATIONS = Object.freeze([
+  "REAL Manager",
+  "REAL agent processes",
+  "REAL pty children",
+]);
+
+/** Recorded on the classification, never sufficient on their own. */
+export const LIVE_BROKER_DECLARATIONS = Object.freeze(["REAL JWT broker", "REAL broker"]);
+
+/**
+ * The leading header of a suite: shebang, then block and line comments and blank lines until
+ * the first non-comment token. That is the suite's own declaration of what it drives. Later
+ * comments in the body are not consulted, so a cell that mentions "REAL Manager" cannot
+ * reclassify a non-infrastructure suite.
+ *
+ * @param {string} source
+ * @returns {string}
+ */
+export function leadingSuiteHeader(source) {
+  if (typeof source !== "string") throw new Error("leadingSuiteHeader: source must be a string");
+  let i = 0;
+  if (source.startsWith("#!")) {
+    const nl = source.indexOf("\n");
+    i = nl === -1 ? source.length : nl + 1;
+  }
+  let out = "";
+  while (i < source.length) {
+    if (source.startsWith("/*", i)) {
+      const end = source.indexOf("*/", i + 2);
+      if (end === -1) return out + source.slice(i);
+      out += source.slice(i, end + 2);
+      i = end + 2;
+      continue;
+    }
+    if (source.startsWith("//", i)) {
+      const nl = source.indexOf("\n", i);
+      const end = nl === -1 ? source.length : nl + 1;
+      out += source.slice(i, end);
+      i = end;
+      continue;
+    }
+    const ch = source[i];
+    if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") {
+      out += ch;
+      i++;
+      continue;
+    }
+    break;
+  }
+  return out;
+}
+
+/**
+ * @typedef {{ live: boolean, declarations: string[], brokerDeclarations: string[] }} LiveClassification
+ */
+
+/**
+ * Classify a suite from its source text. The script name is not an argument, so a rename
+ * cannot change the answer while the source still declares the same property.
+ *
+ * @param {string} source
+ * @returns {LiveClassification}
+ */
+export function classifyLiveSuiteSource(source) {
+  const header = leadingSuiteHeader(source);
+  const declarations = LIVE_INFRASTRUCTURE_DECLARATIONS.filter((d) => header.includes(d));
+  const brokerDeclarations = LIVE_BROKER_DECLARATIONS.filter((d) => header.includes(d));
+  return { live: declarations.length > 0, declarations, brokerDeclarations };
+}
+
+/**
+ * Last `tsx`/`node` path in a package script body. Composite wrappers (`pnpm --filter … build
+ * && tsx path`) still resolve to the suite they execute. A body with no such path is not a
+ * classifiable suite source.
+ *
+ * @param {string} command
+ * @returns {string | null}
+ */
+export function suiteSourceFromScript(command) {
+  if (typeof command !== "string") throw new Error("suiteSourceFromScript: command must be a string");
+  const matches = [...command.matchAll(/(?:^|[\s&;])(?:tsx|node)\s+([^\s]+\.(?:ts|mjs|js|mts|cjs))/g)];
+  if (matches.length === 0) return null;
+  return matches[matches.length - 1][1];
+}
+
+/**
+ * @param {string} root
+ * @param {string} source
+ */
+function inside(root, source) {
+  const rel = relative(root, source);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+/**
+ * Classify a repository-relative suite file. Path hygiene matches mutation-suite-metadata:
+ * a source that is not a normalised POSIX path inside the root is refused, not classified.
+ *
+ * @param {string} root
+ * @param {string} sourcePath
+ * @returns {LiveClassification}
+ */
+export function classifyLiveSuiteFile(root, sourcePath) {
+  if (typeof root !== "string" || root.length === 0) throw new Error("classifyLiveSuiteFile: root is required");
+  if (typeof sourcePath !== "string" || sourcePath.length === 0) {
+    throw new Error("classifyLiveSuiteFile: sourcePath is required");
+  }
+  const segments = sourcePath.split("/");
+  if (
+    sourcePath.startsWith("/") ||
+    sourcePath.endsWith("/") ||
+    segments.some((segment) => segment === "" || segment === "." || segment === "..") ||
+    /[\s:\\]/u.test(sourcePath) ||
+    posix.normalize(sourcePath) !== sourcePath
+  ) {
+    throw new Error(`classifyLiveSuiteFile: not a normalised repository-relative POSIX path: ${JSON.stringify(sourcePath)}`);
+  }
+  const absolute = resolve(root, sourcePath);
+  if (!inside(root, absolute)) {
+    throw new Error(`classifyLiveSuiteFile: source escapes the repository root: ${JSON.stringify(sourcePath)}`);
+  }
+  return classifyLiveSuiteSource(readFileSync(absolute, "utf8"));
+}
+
+/**
+ * Classify a public `smoke:*` script by resolving its package.json body to a source file
+ * and reading that file's leading header. The script NAME is used only as a key into the
+ * scripts map; it is never tested for a `-live` / `:live` suffix.
+ *
+ * @param {string} root
+ * @param {string} scriptName
+ * @param {Record<string, string>} scripts
+ * @returns {LiveClassification & { source: string | null }}
+ */
+export function classifyLiveSmokeScript(root, scriptName, scripts) {
+  if (typeof scriptName !== "string" || scriptName.length === 0) {
+    throw new Error("classifyLiveSmokeScript: scriptName is required");
+  }
+  if (scripts === null || typeof scripts !== "object" || Array.isArray(scripts)) {
+    throw new Error("classifyLiveSmokeScript: scripts must be a map of script names to bodies");
+  }
+  const command = scripts[scriptName];
+  if (typeof command !== "string") {
+    throw new Error(`classifyLiveSmokeScript: missing script ${JSON.stringify(scriptName)}`);
+  }
+  const source = suiteSourceFromScript(command);
+  if (source === null) {
+    return { live: false, declarations: [], brokerDeclarations: [], source: null };
+  }
+  return { ...classifyLiveSuiteFile(root, source), source };
+}

--- a/bin/smoke/live-suite.smoke.ts
+++ b/bin/smoke/live-suite.smoke.ts
@@ -1,0 +1,183 @@
+/**
+ * Issue #1430: the live-suite guard must classify by source-level declarations, not by a
+ * `-live` / `:live` script-name suffix. A rename of the public script must not change the
+ * answer while the source still declares the three infrastructure properties, and a
+ * non-infrastructure suite must not become live just because it is named `:live`.
+ *
+ * Broker-free. The production classifier is imported and graded on fixtures plus the six
+ * unsuffixed scripts whose headers already declare the property.
+ *
+ * Run: pnpm smoke:live-suite
+ */
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  classifyLiveSmokeScript,
+  classifyLiveSuiteFile,
+  classifyLiveSuiteSource,
+  leadingSuiteHeader,
+  suiteSourceFromScript,
+} from "./live-suite.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const pkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8")) as {
+  scripts?: Record<string, string>;
+};
+const scripts = pkg.scripts ?? {};
+
+let pass = 0;
+let fail = 0;
+const check = (name: string, cond: boolean, extra?: unknown) => {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    fail++;
+    console.log(`  ✗ FAIL: ${name}`, extra ?? "");
+  }
+};
+
+const headerOf = (source: string) => leadingSuiteHeader(source);
+
+console.log("live-suite: source-level infrastructure classification");
+
+check(
+  "a leading block comment is the header and later body comments are not",
+  headerOf("/** REAL Manager */\nimport x from 'y';\n// REAL pty children\n") === "/** REAL Manager */\n" &&
+    !headerOf("/** REAL Manager */\nimport x from 'y';\n// REAL pty children\n").includes("REAL pty children"),
+);
+
+check(
+  "a REAL Manager header is live",
+  classifyLiveSuiteSource("/** a REAL Manager on a real JWT broker */\nexport {}\n").live === true,
+);
+
+check(
+  "REAL agent processes without a live suffix is live",
+  classifyLiveSuiteSource("/** REAL agent processes (e2e-stub.mjs) */\nexport {}\n").live === true,
+);
+
+check(
+  "REAL pty children without a live suffix is live",
+  classifyLiveSuiteSource("/** REAL pty children, graded on the child */\nexport {}\n").live === true,
+);
+
+check(
+  "a REAL broker header alone is not live",
+  classifyLiveSuiteSource("/** against a REAL JWT broker */\nexport {}\n").live === false &&
+    classifyLiveSuiteSource("/** against a REAL broker */\nexport {}\n").live === false,
+);
+
+check(
+  "a non-infrastructure suite is not live regardless of name",
+  classifyLiveSuiteSource("/** shard stability: frozen indices */\nexport {}\n").live === false,
+);
+
+check(
+  "a body mention of REAL Manager after the first statement is not a declaration",
+  classifyLiveSuiteSource("export {}\n/** later: REAL Manager */\n").live === false,
+);
+
+const fixtureRoot = mkdtempSync(join(tmpdir(), "cotal-live-suite-"));
+try {
+  mkdirSync(join(fixtureRoot, "smoke"), { recursive: true });
+  writeFileSync(
+    join(fixtureRoot, "smoke", "seat-input-live.smoke.ts"),
+    "/** over a REAL Manager, a REAL JWT broker and REAL pty children */\nexport {}\n",
+  );
+  writeFileSync(join(fixtureRoot, "smoke", "ordinary.smoke.ts"), "/** frozen list parser */\nexport {}\n");
+  const liveFile = classifyLiveSuiteFile(fixtureRoot, "smoke/seat-input-live.smoke.ts");
+  const ordinaryFile = classifyLiveSuiteFile(fixtureRoot, "smoke/ordinary.smoke.ts");
+  check(
+    "a file named *-live whose header declares REAL Manager and REAL pty children is live",
+    liveFile.live === true &&
+      liveFile.declarations.includes("REAL Manager") &&
+      liveFile.declarations.includes("REAL pty children"),
+    liveFile,
+  );
+  check("an ordinary suite file is not live", ordinaryFile.live === false, ordinaryFile);
+
+  const liveByHonestName = classifyLiveSmokeScript(fixtureRoot, "smoke:seat-input", {
+    "smoke:seat-input": "tsx smoke/seat-input-live.smoke.ts",
+  });
+  const liveByRenamedScript = classifyLiveSmokeScript(fixtureRoot, "smoke:renamed-harmless", {
+    "smoke:renamed-harmless": "tsx smoke/seat-input-live.smoke.ts",
+  });
+  check(
+    "renaming a script does not change classification when the source still declares real infrastructure",
+    liveByHonestName.live === true &&
+      liveByRenamedScript.live === true &&
+      JSON.stringify(liveByHonestName.declarations) === JSON.stringify(liveByRenamedScript.declarations),
+    { liveByHonestName, liveByRenamedScript },
+  );
+
+  const namedLiveOrdinary = classifyLiveSmokeScript(fixtureRoot, "smoke:ordinary:live", {
+    "smoke:ordinary:live": "tsx smoke/ordinary.smoke.ts",
+  });
+  const namedLiveDash = classifyLiveSmokeScript(fixtureRoot, "smoke:ordinary-live", {
+    "smoke:ordinary-live": "tsx smoke/ordinary.smoke.ts",
+  });
+  check(
+    "a :live script name does not classify a non-infrastructure suite as live",
+    namedLiveOrdinary.live === false && namedLiveOrdinary.source === "smoke/ordinary.smoke.ts",
+    namedLiveOrdinary,
+  );
+  check(
+    "a -live script name does not classify a non-infrastructure suite as live",
+    namedLiveDash.live === false,
+    namedLiveDash,
+  );
+
+  check(
+    "tsx path resolution ignores a live suffix on the public script name",
+    suiteSourceFromScript("pnpm --filter cotal-ai... build && tsx smoke/seat-input-live.smoke.ts") ===
+      "smoke/seat-input-live.smoke.ts",
+  );
+} finally {
+  rmSync(fixtureRoot, { recursive: true, force: true });
+}
+
+const expectedLive = [
+  "smoke:manager-service",
+  "smoke:manager-service-ops",
+  "smoke:manager-service-invoke",
+  "smoke:manager-spawn-action",
+  "smoke:persona-announce",
+  "smoke:seat-input",
+] as const;
+
+for (const name of expectedLive) {
+  const classified = classifyLiveSmokeScript(ROOT, name, scripts);
+  check(
+    `${name} is live from its source declarations, not from a -live suffix`,
+    classified.live === true && !/:(?:live)$/.test(name) && !/-live$/.test(name),
+    classified,
+  );
+}
+
+check(
+  "smoke:seat-input stays live even though the public script drops the file's -live suffix",
+  classifyLiveSmokeScript(ROOT, "smoke:seat-input", scripts).source ===
+    "implementations/manager/smoke/seat-input-live.smoke.ts" &&
+    classifyLiveSmokeScript(ROOT, "smoke:seat-input", scripts).live === true,
+);
+
+check(
+  "this classifier's own suite is not live",
+  classifyLiveSmokeScript(ROOT, "smoke:live-suite", {
+    ...scripts,
+    "smoke:live-suite": "tsx bin/smoke/live-suite.smoke.ts",
+  }).live === false,
+);
+
+const EXPECTED = 21;
+check(
+  `every cell ran - ${EXPECTED} expected, so a cell that stops existing is not mistaken for one that passed`,
+  pass + fail === EXPECTED,
+  `${pass + fail} cells reported`,
+);
+
+console.log(`LIVE SUITE SMOKE ${fail === 0 ? "OK" : "FAILED"} (${pass} passed, ${fail} failed)`);
+if (fail) process.exitCode = 1;

--- a/bin/smoke/mutations/ci-declarations.json
+++ b/bin/smoke/mutations/ci-declarations.json
@@ -28,6 +28,14 @@
       "replace": "export function changedSuiteIndices(base, head, strict = true) {\n  void strict;",
       "expectRed": "shard-stability.d.mts matches compiler output from its .mjs module",
       "cell": "shard-stability.d.mts matches compiler output from its .mjs module"
+    },
+    {
+      "name": "live-suite export changes without regenerating its declaration",
+      "file": "bin/smoke/live-suite.mjs",
+      "find": "export function classifyLiveSuiteSource(source) {",
+      "replace": "export function classifyLiveSuiteSource(source, unused = false) {\n  void unused;",
+      "expectRed": "live-suite.d.mts matches compiler output from its .mjs module",
+      "cell": "live-suite.d.mts matches compiler output from its .mjs module"
     }
   ]
 }

--- a/bin/smoke/mutations/live-suite.json
+++ b/bin/smoke/mutations/live-suite.json
@@ -1,0 +1,35 @@
+{
+  "suite": [
+    "bin/smoke/live-suite.smoke.ts"
+  ],
+  "guard": "live-suite classification is a source-level declaration, so a rename of the public script cannot hide a REAL Manager / REAL agent / REAL pty suite and a :live name cannot invent one",
+  "command": "pnpm smoke:live-suite",
+  "completionMarker": "LIVE SUITE SMOKE",
+  "grades": "tool",
+  "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/live-suite.json",
+  "why": [
+    "Issue #1430: the standing host rule matched -live / :live on the script name. Six suites that",
+    "drive a REAL Manager, REAL agent processes, or REAL pty children carry no such suffix, and",
+    "smoke:seat-input is the sharp case — the file is seat-input-live.smoke.ts and the script drops",
+    "the suffix. A suffix matcher on the public name is the defect, so the mutations restore that",
+    "matcher and must redden the rename and non-infrastructure-name cells by name."
+  ],
+  "mutations": [
+    {
+      "name": "classification keys on the public script suffix again",
+      "file": "bin/smoke/live-suite.mjs",
+      "find": "  const declarations = LIVE_INFRASTRUCTURE_DECLARATIONS.filter((d) => header.includes(d));\n  const brokerDeclarations = LIVE_BROKER_DECLARATIONS.filter((d) => header.includes(d));\n  return { live: declarations.length > 0, declarations, brokerDeclarations };",
+      "replace": "  const declarations = LIVE_INFRASTRUCTURE_DECLARATIONS.filter((d) => header.includes(d));\n  const brokerDeclarations = LIVE_BROKER_DECLARATIONS.filter((d) => header.includes(d));\n  return { live: false, declarations, brokerDeclarations };",
+      "expectRed": "renaming a script does not change classification when the source still declares real infrastructure",
+      "cell": "renaming a script does not change classification when the source still declares real infrastructure"
+    },
+    {
+      "name": "a :live script name is treated as live regardless of source",
+      "file": "bin/smoke/live-suite.mjs",
+      "find": "  const source = suiteSourceFromScript(command);\n  if (source === null) {\n    return { live: false, declarations: [], brokerDeclarations: [], source: null };\n  }\n  return { ...classifyLiveSuiteFile(root, source), source };",
+      "replace": "  const source = suiteSourceFromScript(command);\n  if (source === null) {\n    return { live: /(?:-live|:live)$/.test(scriptName), declarations: [], brokerDeclarations: [], source: null };\n  }\n  const classified = classifyLiveSuiteFile(root, source);\n  return { ...classified, live: classified.live || /(?:-live|:live)$/.test(scriptName), source };",
+      "expectRed": "a :live script name does not classify a non-infrastructure suite as live",
+      "cell": "a :live script name does not classify a non-infrastructure suite as live"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -594,6 +594,7 @@
     "smoke:shard-never-ran": "tsx bin/smoke/shard-never-ran.smoke.ts",
     "smoke:workflow-concurrency": "tsx bin/smoke/workflow-concurrency.smoke.ts",
     "smoke:live-job-conclusion": "tsx bin/smoke/live-job-conclusion.smoke.ts",
+    "smoke:live-suite": "tsx bin/smoke/live-suite.smoke.ts",
     "smoke:pr-head-gate": "tsx bin/smoke/pr-head-gate.smoke.ts",
     "smoke:verify-publish-closure": "tsx bin/smoke/verify-publish-closure.smoke.ts",
     "smoke:mutation-fixtures": "tsx bin/smoke/mutation-fixtures.smoke.ts",


### PR DESCRIPTION
The standing host rule never to run a `-live` suite was a name match. A name is not a description of behaviour.

Six current `smoke:*` scripts declare in their leading headers that they drive a REAL Manager, REAL agent processes, or REAL pty children, while their public script names do not end in `:live`:

- `smoke:manager-service`
- `smoke:manager-service-ops`
- `smoke:manager-service-invoke`
- `smoke:manager-spawn-action`
- `smoke:persona-announce`
- `smoke:seat-input`

`smoke:seat-input` is the sharp case: the file is `seat-input-live.smoke.ts` and the script drops the suffix. A guard keyed on the script name is defeated by exactly the rename that matters.

This change classifies live from the suite source instead. The runner reads the leading header for those three declarations. `REAL broker` / `REAL JWT broker` are recorded (a sandboxed nats-server is ordinary) but are not sufficient. Script names and file names are never consulted.

A smoke proves:

- renaming a public script does not change classification while the source still declares real infrastructure
- a non-infrastructure suite is not live under a `:live` or `-live` name
- the six unsuffixed scripts above are live

A mutation fixture restores suffix matching and must redden those cells by name. Independent of #1446, which owns the mutation-tool execution boundary rather than this classifier.

Refs #1430
