### PR TITLE
fix(mutation): refuse live-shaped coverage commands

### DIFF
--- a/bin/smoke/ci-suites.d/fdd62ff229de09e4ac1b0f600f245fb18af8e1204aae733c6346fca862537f8e.txt
+++ b/bin/smoke/ci-suites.d/fdd62ff229de09e4ac1b0f600f245fb18af8e1204aae733c6346fca862537f8e.txt
@@ -1,0 +1,2 @@
+# Refuse live-shaped mutation commands before they execute.
+smoke:mutation-command-safety

--- a/bin/smoke/mutation-command-safety.smoke.ts
+++ b/bin/smoke/mutation-command-safety.smoke.ts
@@ -47,6 +47,7 @@ const files: Record<string, string> = {
       "smoke:user-spawn:live": "node suites/boom.mjs",
       "smoke:manager-service": "node suites/real.mjs",
       "smoke:safe": "node suites/safe.mjs",
+      "smoke:safe-options": "node --enable-source-maps suites/safe.mjs",
     },
   }),
   "suites/boom.mjs": "throw new Error('executed live-named suite');\n",
@@ -76,6 +77,22 @@ check(
   "a safe command is still executed",
   liveShapedCommandReason("pnpm smoke:safe", opts) === null,
   liveShapedCommandReason("pnpm smoke:safe", opts),
+);
+check(
+  "a node option before a marked suite path is refused",
+  liveShapedCommandReason("node --enable-source-maps suites/real.mjs", opts) ===
+    `suites/real.mjs declares ${MARKER}`,
+  liveShapedCommandReason("node --enable-source-maps suites/real.mjs", opts),
+);
+check(
+  "a package script with node options still executes a safe suite",
+  liveShapedCommandReason("pnpm smoke:safe-options", opts) === null,
+  liveShapedCommandReason("pnpm smoke:safe-options", opts),
+);
+check(
+  "inline node -e is not treated as a suite source",
+  liveShapedCommandReason(`${process.execPath} -e "console.log('ok')"`, opts) === null,
+  liveShapedCommandReason(`${process.execPath} -e "console.log('ok')"`, opts),
 );
 
 const git = (root: string, args: string[]) =>
@@ -129,6 +146,14 @@ function writeCoverageTree(root: string) {
     config("real", `${process.execPath} suites/real.mjs`, "suites/real.mjs"),
   );
   writeFileSync(
+    join(root, "smoke/mutations/options.json"),
+    config(
+      "options",
+      `${process.execPath} --enable-source-maps suites/real.mjs`,
+      "suites/real.mjs",
+    ),
+  );
+  writeFileSync(
     join(root, "smoke/mutations/safe.json"),
     JSON.stringify({
       suite: ["suites/safe.mjs"],
@@ -145,7 +170,13 @@ const coverageRoot = temp("mutation-command-safety-coverage-");
 writeCoverageTree(coverageRoot);
 const coverage = spawnSync(
   process.execPath,
-  [COVERAGE, "smoke/mutations/live.json", "smoke/mutations/real.json", "smoke/mutations/safe.json"],
+  [
+    COVERAGE,
+    "smoke/mutations/live.json",
+    "smoke/mutations/real.json",
+    "smoke/mutations/options.json",
+    "smoke/mutations/safe.json",
+  ],
   { cwd: coverageRoot, encoding: "utf8", timeout: 30_000 },
 );
 const coverageOut = `${coverage.stdout ?? ""}${coverage.stderr ?? ""}`;
@@ -154,7 +185,8 @@ check(
   coverage.status === 0
     && /smoke\/mutations\/live\.json\s+REFUSED `.*smoke:user-spawn:live`/.test(coverageOut)
     && /smoke\/mutations\/real\.json\s+REFUSED `.*suites\/real\.mjs`/.test(coverageOut)
-    && /2 live-shaped config\(s\) refused/.test(coverageOut),
+    && /smoke\/mutations\/options\.json\s+REFUSED `.*suites\/real\.mjs`/.test(coverageOut)
+    && /3 live-shaped config\(s\) refused/.test(coverageOut),
   coverageOut.slice(-800),
 );
 check(
@@ -190,6 +222,21 @@ writeFileSync(
     }],
   }),
 );
+writeFileSync(
+  join(reproofRoot, "smoke/mutations/options.json"),
+  JSON.stringify({
+    suite: ["suites/real.mjs"],
+    grades: "tool",
+    command: `${process.execPath} --enable-source-maps suites/real.mjs`,
+    mutations: [{
+      name: "the guard is removed",
+      file: "guard.mjs",
+      find: "export const n = 1;",
+      replace: "export const n = 2;",
+      expectRed: "the guard holds",
+    }],
+  }),
+);
 git(reproofRoot, ["add", "."]);
 git(reproofRoot, ["commit", "--quiet", "-m", "base"]);
 const base = git(reproofRoot, ["rev-parse", "HEAD"]);
@@ -206,8 +253,9 @@ const reproofOut = `${reproof.stdout ?? ""}${reproof.stderr ?? ""}`;
 check(
   "reproof names a refused live-shaped fixture and does not execute it",
   reproof.status === 0
-    && /live-shaped fixtures refused \(1\)/.test(reproofOut)
+    && /live-shaped fixtures refused \(2\)/.test(reproofOut)
     && /smoke\/mutations\/live\.json\s+REFUSED `.*smoke:user-spawn:live`/.test(reproofOut)
+    && /smoke\/mutations\/options\.json\s+REFUSED `.*suites\/real\.mjs`/.test(reproofOut)
     && !existsSync(join(reproofRoot, "SENTINEL")),
   reproofOut.slice(-800),
 );

--- a/bin/smoke/mutation-command-safety.smoke.ts
+++ b/bin/smoke/mutation-command-safety.smoke.ts
@@ -6,7 +6,7 @@
  * Run: pnpm smoke:mutation-command-safety
  */
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -94,6 +94,29 @@ check(
   liveShapedCommandReason(`${process.execPath} -e "console.log('ok')"`, opts) === null,
   liveShapedCommandReason(`${process.execPath} -e "console.log('ok')"`, opts),
 );
+check(
+  "a path-spelled tsx launcher of a marked suite is refused",
+  liveShapedCommandReason("./node_modules/.bin/tsx suites/real.mjs", opts) ===
+    `suites/real.mjs declares ${MARKER}`,
+  liveShapedCommandReason("./node_modules/.bin/tsx suites/real.mjs", opts),
+);
+check(
+  "an absolute tsx launcher of a marked suite is refused",
+  liveShapedCommandReason("/usr/local/bin/tsx suites/real.mjs", opts) ===
+    `suites/real.mjs declares ${MARKER}`,
+  liveShapedCommandReason("/usr/local/bin/tsx suites/real.mjs", opts),
+);
+check(
+  "a quoted path-spelled tsx launcher of a marked suite is refused",
+  liveShapedCommandReason(`"./node_modules/.bin/tsx" suites/real.mjs`, opts) ===
+    `suites/real.mjs declares ${MARKER}`,
+  liveShapedCommandReason(`"./node_modules/.bin/tsx" suites/real.mjs`, opts),
+);
+check(
+  "a path-spelled tsx launcher of a safe suite still executes",
+  liveShapedCommandReason("./node_modules/.bin/tsx suites/safe.mjs", opts) === null,
+  liveShapedCommandReason("./node_modules/.bin/tsx suites/safe.mjs", opts),
+);
 
 const git = (root: string, args: string[]) =>
   execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
@@ -153,6 +176,23 @@ function writeCoverageTree(root: string) {
       "suites/real.mjs",
     ),
   );
+  mkdirSync(join(root, "node_modules/.bin"), { recursive: true });
+  const stubTsx = join(root, "node_modules/.bin/tsx");
+  writeFileSync(
+    stubTsx,
+    [
+      "#!/usr/bin/env node",
+      "const { spawnSync } = require('node:child_process');",
+      "const run = spawnSync(process.execPath, process.argv.slice(2), { stdio: 'inherit' });",
+      "process.exit(run.status ?? 1);",
+      "",
+    ].join("\n"),
+  );
+  chmodSync(stubTsx, 0o755);
+  writeFileSync(
+    join(root, "smoke/mutations/tsx.json"),
+    config("tsx", "./node_modules/.bin/tsx suites/real.mjs", "suites/real.mjs"),
+  );
   writeFileSync(
     join(root, "smoke/mutations/safe.json"),
     JSON.stringify({
@@ -175,6 +215,7 @@ const coverage = spawnSync(
     "smoke/mutations/live.json",
     "smoke/mutations/real.json",
     "smoke/mutations/options.json",
+    "smoke/mutations/tsx.json",
     "smoke/mutations/safe.json",
   ],
   { cwd: coverageRoot, encoding: "utf8", timeout: 30_000 },
@@ -186,7 +227,8 @@ check(
     && /smoke\/mutations\/live\.json\s+REFUSED `.*smoke:user-spawn:live`/.test(coverageOut)
     && /smoke\/mutations\/real\.json\s+REFUSED `.*suites\/real\.mjs`/.test(coverageOut)
     && /smoke\/mutations\/options\.json\s+REFUSED `.*suites\/real\.mjs`/.test(coverageOut)
-    && /3 live-shaped config\(s\) refused/.test(coverageOut),
+    && /smoke\/mutations\/tsx\.json\s+REFUSED `.*suites\/real\.mjs`/.test(coverageOut)
+    && /4 live-shaped config\(s\) refused/.test(coverageOut),
   coverageOut.slice(-800),
 );
 check(
@@ -237,6 +279,21 @@ writeFileSync(
     }],
   }),
 );
+writeFileSync(
+  join(reproofRoot, "smoke/mutations/tsx.json"),
+  JSON.stringify({
+    suite: ["suites/real.mjs"],
+    grades: "tool",
+    command: "./node_modules/.bin/tsx suites/real.mjs",
+    mutations: [{
+      name: "the guard is removed",
+      file: "guard.mjs",
+      find: "export const n = 1;",
+      replace: "export const n = 2;",
+      expectRed: "the guard holds",
+    }],
+  }),
+);
 git(reproofRoot, ["add", "."]);
 git(reproofRoot, ["commit", "--quiet", "-m", "base"]);
 const base = git(reproofRoot, ["rev-parse", "HEAD"]);
@@ -253,9 +310,10 @@ const reproofOut = `${reproof.stdout ?? ""}${reproof.stderr ?? ""}`;
 check(
   "reproof names a refused live-shaped fixture and does not execute it",
   reproof.status === 0
-    && /live-shaped fixtures refused \(2\)/.test(reproofOut)
+    && /live-shaped fixtures refused \(3\)/.test(reproofOut)
     && /smoke\/mutations\/live\.json\s+REFUSED `.*smoke:user-spawn:live`/.test(reproofOut)
     && /smoke\/mutations\/options\.json\s+REFUSED `.*suites\/real\.mjs`/.test(reproofOut)
+    && /smoke\/mutations\/tsx\.json\s+REFUSED `.*suites\/real\.mjs`/.test(reproofOut)
     && !existsSync(join(reproofRoot, "SENTINEL")),
   reproofOut.slice(-800),
 );

--- a/bin/smoke/mutation-command-safety.smoke.ts
+++ b/bin/smoke/mutation-command-safety.smoke.ts
@@ -1,0 +1,217 @@
+/**
+ * Issue #1446: mutation-coverage and mutation-reproof execute whatever command a config names.
+ * A live-named suite, or a broker-starting suite that never used a :live suffix, must be refused
+ * before any child is spawned. A suffix-only guard is the defect this suite exists to catch.
+ *
+ * Run: pnpm smoke:mutation-command-safety
+ */
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  INFRASTRUCTURE_MARKERS,
+  liveShapedCommandReason,
+} from "../../scripts/mutation-command-safety.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const COVERAGE = join(ROOT, "scripts", "mutation-coverage.mjs");
+const REPROOF = join(ROOT, "scripts", "mutation-reproof.mjs");
+const MARKER = INFRASTRUCTURE_MARKERS[0];
+
+let pass = 0;
+let fail = 0;
+const check = (name: string, cond: boolean, extra?: unknown) => {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    fail++;
+    console.log(`  ✗ FAIL: ${name}`, extra ?? "");
+  }
+};
+
+const roots: string[] = [];
+const temp = (prefix: string) => {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+};
+
+console.log("A. the predicate refuses live-named and infrastructure-marked commands without a suffix");
+
+const files: Record<string, string> = {
+  "package.json": JSON.stringify({
+    scripts: {
+      "smoke:user-spawn:live": "node suites/boom.mjs",
+      "smoke:manager-service": "node suites/real.mjs",
+      "smoke:safe": "node suites/safe.mjs",
+    },
+  }),
+  "suites/boom.mjs": "throw new Error('executed live-named suite');\n",
+  "suites/real.mjs": `// ${MARKER} on a JWT broker\nthrow new Error('executed unsuffixed live suite');\n`,
+  "suites/safe.mjs": "console.log('safe');\n",
+};
+const readFile = (path: string) => {
+  const rel = path.replace(/\\/g, "/");
+  const key = Object.keys(files).find((name) => rel.endsWith(name));
+  if (!key) throw new Error(`unexpected read: ${path}`);
+  return files[key]!;
+};
+const exists = (path: string) => Object.keys(files).some((name) => path.replace(/\\/g, "/").endsWith(name));
+const opts = { cwd: "/repo", readFile, exists };
+
+check(
+  "a live-named command is refused without executing",
+  liveShapedCommandReason("pnpm smoke:user-spawn:live", opts) === "smoke:user-spawn:live is live-named",
+  liveShapedCommandReason("pnpm smoke:user-spawn:live", opts),
+);
+check(
+  "an unsuffixed broker-starting suite is refused without executing",
+  liveShapedCommandReason("pnpm smoke:manager-service", opts) === `suites/real.mjs declares ${MARKER}`,
+  liveShapedCommandReason("pnpm smoke:manager-service", opts),
+);
+check(
+  "a safe command is still executed",
+  liveShapedCommandReason("pnpm smoke:safe", opts) === null,
+  liveShapedCommandReason("pnpm smoke:safe", opts),
+);
+
+const git = (root: string, args: string[]) =>
+  execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
+
+const mutation = {
+  name: "cap",
+  file: "suites/safe.mjs",
+  find: "safe",
+  replace: "unsafe",
+  expectRed: "safe",
+};
+
+function writeCoverageTree(root: string) {
+  mkdirSync(join(root, "suites"), { recursive: true });
+  mkdirSync(join(root, "smoke", "mutations"), { recursive: true });
+  writeFileSync(join(root, "package.json"), files["package.json"]!);
+  writeFileSync(
+    join(root, "suites/boom.mjs"),
+    [
+      "import { writeFileSync } from 'node:fs';",
+      "writeFileSync('SENTINEL', 'ran');",
+      "console.log('FIXTURE: 1 passed, 0 failed');",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    join(root, "suites/real.mjs"),
+    [
+      `// ${MARKER} on a JWT broker`,
+      "import { writeFileSync } from 'node:fs';",
+      "writeFileSync('SENTINEL', 'ran');",
+      "console.log('FIXTURE: 1 passed, 0 failed');",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(join(root, "suites/safe.mjs"), "console.log('safe');\n");
+  const config = (name: string, command: string, suite: string) =>
+    JSON.stringify({
+      suite: [suite],
+      grades: "tool",
+      command,
+      mutations: [{ ...mutation, file: suite }],
+    });
+  writeFileSync(
+    join(root, "smoke/mutations/live.json"),
+    config("live", `${process.execPath} suites/boom.mjs # smoke:user-spawn:live`, "suites/boom.mjs"),
+  );
+  writeFileSync(
+    join(root, "smoke/mutations/real.json"),
+    config("real", `${process.execPath} suites/real.mjs`, "suites/real.mjs"),
+  );
+  writeFileSync(
+    join(root, "smoke/mutations/safe.json"),
+    JSON.stringify({
+      suite: ["suites/safe.mjs"],
+      grades: "tool",
+      command: `${process.execPath} -e "console.log('FIXTURE: 1 passed, 0 failed')"`,
+      mutations: [mutation],
+    }),
+  );
+}
+
+console.log("\nB. mutation-coverage refuses live-shaped configs and still runs a safe one");
+
+const coverageRoot = temp("mutation-command-safety-coverage-");
+writeCoverageTree(coverageRoot);
+const coverage = spawnSync(
+  process.execPath,
+  [COVERAGE, "smoke/mutations/live.json", "smoke/mutations/real.json", "smoke/mutations/safe.json"],
+  { cwd: coverageRoot, encoding: "utf8", timeout: 30_000 },
+);
+const coverageOut = `${coverage.stdout ?? ""}${coverage.stderr ?? ""}`;
+check(
+  "coverage names a refused live-shaped config",
+  coverage.status === 0
+    && /smoke\/mutations\/live\.json\s+REFUSED `.*smoke:user-spawn:live`/.test(coverageOut)
+    && /smoke\/mutations\/real\.json\s+REFUSED `.*suites\/real\.mjs`/.test(coverageOut)
+    && /2 live-shaped config\(s\) refused/.test(coverageOut),
+  coverageOut.slice(-800),
+);
+check(
+  "coverage does not execute a live-shaped command",
+  !existsSync(join(coverageRoot, "SENTINEL")),
+);
+check(
+  "coverage still executes a safe config",
+  coverage.status === 0 && /smoke\/mutations\/safe\.json\s+1 mutations against a self-test of 1 cells/.test(coverageOut),
+  coverageOut.slice(-400),
+);
+
+console.log("\nC. mutation-reproof names a live-shaped fixture and does not execute it");
+
+const reproofRoot = temp("mutation-command-safety-reproof-");
+git(reproofRoot, ["init", "--quiet"]);
+git(reproofRoot, ["config", "user.email", "smoke@example.test"]);
+git(reproofRoot, ["config", "user.name", "Smoke"]);
+writeCoverageTree(reproofRoot);
+writeFileSync(join(reproofRoot, "guard.mjs"), "export const n = 1;\n");
+writeFileSync(
+  join(reproofRoot, "smoke/mutations/live.json"),
+  JSON.stringify({
+    suite: ["suites/boom.mjs"],
+    grades: "tool",
+    command: `${process.execPath} suites/boom.mjs # smoke:user-spawn:live`,
+    mutations: [{
+      name: "the guard is removed",
+      file: "guard.mjs",
+      find: "export const n = 1;",
+      replace: "export const n = 2;",
+      expectRed: "the guard holds",
+    }],
+  }),
+);
+git(reproofRoot, ["add", "."]);
+git(reproofRoot, ["commit", "--quiet", "-m", "base"]);
+const base = git(reproofRoot, ["rev-parse", "HEAD"]);
+writeFileSync(join(reproofRoot, "guard.mjs"), "export const n = 3;\n");
+git(reproofRoot, ["add", "guard.mjs"]);
+git(reproofRoot, ["commit", "--quiet", "-m", "head"]);
+const head = git(reproofRoot, ["rev-parse", "HEAD"]);
+const reproof = spawnSync(
+  process.execPath,
+  [REPROOF, "--root", reproofRoot, "--base", base, "--head", head],
+  { cwd: reproofRoot, encoding: "utf8", timeout: 30_000 },
+);
+const reproofOut = `${reproof.stdout ?? ""}${reproof.stderr ?? ""}`;
+check(
+  "reproof names a refused live-shaped fixture and does not execute it",
+  reproof.status === 0
+    && /live-shaped fixtures refused \(1\)/.test(reproofOut)
+    && /smoke\/mutations\/live\.json\s+REFUSED `.*smoke:user-spawn:live`/.test(reproofOut)
+    && !existsSync(join(reproofRoot, "SENTINEL")),
+  reproofOut.slice(-800),
+);
+
+for (const root of roots) rmSync(root, { recursive: true, force: true });
+console.log(`\nMUTATION COMMAND SAFETY SMOKE ${fail === 0 ? "OK" : "FAILED"} (${pass} passed, ${fail} failed)`);
+if (fail) process.exitCode = 1;

--- a/bin/smoke/mutations/mutation-command-safety.json
+++ b/bin/smoke/mutations/mutation-command-safety.json
@@ -37,6 +37,14 @@
       "cell": "an unsuffixed broker-starting suite is refused without executing"
     },
     {
+      "name": "node options before a suite path skip source inspection",
+      "file": "scripts/mutation-command-safety.mjs",
+      "find": "      if (flag?.startsWith(\"-\")) {\n        if (EVAL_FLAGS.has(flag)) break;\n        if (takesValue(flag) && !token.includes(\"=\")) j++;\n        continue;\n      }\n",
+      "replace": "      if (flag?.startsWith(\"-\")) break;\n",
+      "expectRed": "a node option before a marked suite path is refused",
+      "cell": "a node option before a marked suite path is refused"
+    },
+    {
       "name": "reproof proves live-shaped fixtures instead of refusing them",
       "file": "scripts/mutation-reproof.mjs",
       "find": "const prove = selected.filter((fixture) => !liveRefusedPaths.has(fixture.path));\n",

--- a/bin/smoke/mutations/mutation-command-safety.json
+++ b/bin/smoke/mutations/mutation-command-safety.json
@@ -45,6 +45,14 @@
       "cell": "a node option before a marked suite path is refused"
     },
     {
+      "name": "path-spelled tsx launchers skip source inspection",
+      "file": "scripts/mutation-command-safety.mjs",
+      "find": "const LAUNCHER = /^(?:(?:.*[\\\\/])?(?:tsx|node))$/;\n",
+      "replace": "const LAUNCHER = /^(?:tsx|(?:.*\\/)?node)$/;\n",
+      "expectRed": "a path-spelled tsx launcher of a marked suite is refused",
+      "cell": "a path-spelled tsx launcher of a marked suite is refused"
+    },
+    {
       "name": "reproof proves live-shaped fixtures instead of refusing them",
       "file": "scripts/mutation-reproof.mjs",
       "find": "const prove = selected.filter((fixture) => !liveRefusedPaths.has(fixture.path));\n",

--- a/bin/smoke/mutations/mutation-command-safety.json
+++ b/bin/smoke/mutations/mutation-command-safety.json
@@ -1,0 +1,48 @@
+{
+  "suite": [
+    "bin/smoke/mutation-command-safety.smoke.ts"
+  ],
+  "grades": "tool",
+  "guard": "mutation-coverage and mutation-reproof refuse live-shaped commands before executing them, including unsuffixed broker-starting suites",
+  "command": "pnpm smoke:mutation-command-safety",
+  "completionMarker": "MUTATION COMMAND SAFETY SMOKE",
+  "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/mutation-command-safety.json",
+  "why": [
+    "A suffix-only live guard closes today's :live configs and leaves every broker-starting suite that never used that suffix reachable from a coverage audit or a changed-source reproof.",
+    "Each mutation removes one half of the execution-boundary refusal so the cell that would have gone silently missing is the one that reddens."
+  ],
+  "mutations": [
+    {
+      "name": "coverage executes a live-shaped command instead of refusing it",
+      "file": "scripts/mutation-coverage.mjs",
+      "find": "  if (liveReason) {\n    refused.push([path, cfg.command, liveReason]);\n    continue;\n  }\n",
+      "replace": "",
+      "expectRed": "coverage does not execute a live-shaped command",
+      "cell": "coverage does not execute a live-shaped command"
+    },
+    {
+      "name": "live-named tokens are no longer refused by the shared predicate",
+      "file": "scripts/mutation-command-safety.mjs",
+      "find": "  for (const token of tokens) {\n    if (isLiveNamedToken(token)) return `${token} is live-named`;\n  }\n",
+      "replace": "",
+      "expectRed": "a live-named command is refused without executing",
+      "cell": "a live-named command is refused without executing"
+    },
+    {
+      "name": "infrastructure markers in suite source are ignored",
+      "file": "scripts/mutation-command-safety.mjs",
+      "find": "    if (marker !== undefined) return `${file} declares ${marker}`;\n",
+      "replace": "    void marker;\n",
+      "expectRed": "an unsuffixed broker-starting suite is refused without executing",
+      "cell": "an unsuffixed broker-starting suite is refused without executing"
+    },
+    {
+      "name": "reproof proves live-shaped fixtures instead of refusing them",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "const prove = selected.filter((fixture) => !liveRefusedPaths.has(fixture.path));\n",
+      "replace": "const prove = selected;\n",
+      "expectRed": "reproof names a refused live-shaped fixture and does not execute it",
+      "cell": "reproof names a refused live-shaped fixture and does not execute it"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "smoke:mutation-proof": "node scripts/mutation-proof.selftest.mjs",
     "mutation-coverage:selftest": "node scripts/mutation-coverage.selftest.mjs",
     "smoke:mutation-coverage": "node scripts/mutation-coverage.selftest.mjs",
+    "smoke:mutation-command-safety": "tsx bin/smoke/mutation-command-safety.smoke.ts",
     "check:docsbundle": "pnpm check:docs-voice && pnpm gen:tooldocs && pnpm gen:docsbundle && git diff --exit-code -- docs/mcp-tools.md extensions/connector-core/src/docs-bundle.generated.ts",
     "check:shard-stability": "tsx bin/smoke/shard-stability.ts",
     "pr-head-gate": "node scripts/pr-head-gate.mjs",

--- a/scripts/mutation-command-safety.d.mts
+++ b/scripts/mutation-command-safety.d.mts
@@ -1,5 +1,3 @@
-import type { existsSync, readFileSync } from "node:fs";
-
 export const INFRASTRUCTURE_MARKERS: readonly [
   "REAL Manager",
   "REAL agent processes",
@@ -11,13 +9,15 @@ export function smokeTokens(command: string): string[];
 export function isLiveNamedToken(token: string): boolean;
 export function infrastructureMarkerIn(source: string): string | undefined;
 
+export interface LiveCommandSafetyOptions {
+  cwd?: string;
+  readFile?: (path: string, encoding?: string) => string;
+  exists?: (path: string) => boolean;
+}
+
 export function liveShapedCommandReason(
   command: string,
-  options?: {
-    cwd?: string;
-    readFile?: typeof readFileSync;
-    exists?: typeof existsSync;
-  },
+  options?: LiveCommandSafetyOptions,
 ): string | null;
 
 export function liveShapedFixtureReason(
@@ -25,9 +25,5 @@ export function liveShapedFixtureReason(
     command?: string;
     mutations?: { command?: string }[];
   },
-  options?: {
-    cwd?: string;
-    readFile?: typeof readFileSync;
-    exists?: typeof existsSync;
-  },
+  options?: LiveCommandSafetyOptions,
 ): string | null;

--- a/scripts/mutation-command-safety.d.mts
+++ b/scripts/mutation-command-safety.d.mts
@@ -1,0 +1,33 @@
+import type { existsSync, readFileSync } from "node:fs";
+
+export const INFRASTRUCTURE_MARKERS: readonly [
+  "REAL Manager",
+  "REAL agent processes",
+  "REAL pty children",
+  "REAL broker",
+];
+
+export function smokeTokens(command: string): string[];
+export function isLiveNamedToken(token: string): boolean;
+export function infrastructureMarkerIn(source: string): string | undefined;
+
+export function liveShapedCommandReason(
+  command: string,
+  options?: {
+    cwd?: string;
+    readFile?: typeof readFileSync;
+    exists?: typeof existsSync;
+  },
+): string | null;
+
+export function liveShapedFixtureReason(
+  fixture: {
+    command?: string;
+    mutations?: { command?: string }[];
+  },
+  options?: {
+    cwd?: string;
+    readFile?: typeof readFileSync;
+    exists?: typeof existsSync;
+  },
+): string | null;

--- a/scripts/mutation-command-safety.mjs
+++ b/scripts/mutation-command-safety.mjs
@@ -45,7 +45,7 @@ const VALUE_FLAGS = new Set([
   "--max-old-space-size",
   "--max-semi-space-size",
 ]);
-const LAUNCHER = /^(?:tsx|(?:.*\/)?node)$/;
+const LAUNCHER = /^(?:(?:.*[\\/])?(?:tsx|node))$/;
 const FLAG_NAME = /^([^=]+)(?:=.*)?$/;
 
 export function smokeTokens(command) {
@@ -96,9 +96,10 @@ function isSourcePath(token) {
 }
 
 /**
- * Collect suite files launched by `node` / `tsx`, skipping valid Node/tsx
- * options that sit between the launcher and the positional path. Inline
- * eval (`-e` / `--eval` / `-p`) is not a suite source.
+ * Collect suite files launched by `node` / `tsx` (bare or path-spelled, so
+ * `./node_modules/.bin/tsx` is inspected the same as `tsx`), skipping valid
+ * Node/tsx options that sit between the launcher and the positional path.
+ * Inline eval (`-e` / `--eval` / `-p`) is not a suite source.
  */
 function launchedFiles(command) {
   if (typeof command !== "string") return [];

--- a/scripts/mutation-command-safety.mjs
+++ b/scripts/mutation-command-safety.mjs
@@ -22,7 +22,31 @@ export const INFRASTRUCTURE_MARKERS = Object.freeze([
 
 const SMOKE_TOKEN = /\bsmoke:[A-Za-z0-9_-]+(?::[A-Za-z0-9_-]+)*/g;
 const LIVE_NAMED = /(?::live|-live)$/;
-const LAUNCHED_FILE = /(?:^|[\s;|&])(?:tsx|(?:\S*\/)?node)\s+([^\s;|&]+)/g;
+const TOKEN = /"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s;|&]+/g;
+const SOURCE_FILE = /[\\/]|\.(?:[cm]?[jt]s|tsx)$/;
+const EVAL_FLAGS = new Set(["-e", "--eval", "-p", "--print"]);
+const VALUE_FLAGS = new Set([
+  "-e",
+  "--eval",
+  "-p",
+  "--print",
+  "-r",
+  "--require",
+  "--import",
+  "--loader",
+  "--experimental-loader",
+  "-C",
+  "--conditions",
+  "--env-file",
+  "--title",
+  "--tsconfig",
+  "--input-type",
+  "--inspect-port",
+  "--max-old-space-size",
+  "--max-semi-space-size",
+]);
+const LAUNCHER = /^(?:tsx|(?:.*\/)?node)$/;
+const FLAG_NAME = /^([^=]+)(?:=.*)?$/;
 
 export function smokeTokens(command) {
   if (typeof command !== "string") return [];
@@ -48,11 +72,58 @@ function packageScripts(cwd, readFile) {
   }
 }
 
+function unquote(token) {
+  if (
+    (token.startsWith('"') && token.endsWith('"')) ||
+    (token.startsWith("'") && token.endsWith("'"))
+  ) {
+    return token.slice(1, -1);
+  }
+  return token;
+}
+
+function flagName(token) {
+  const match = FLAG_NAME.exec(token);
+  return match?.[1];
+}
+
+function takesValue(flag) {
+  return VALUE_FLAGS.has(flag);
+}
+
+function isSourcePath(token) {
+  return SOURCE_FILE.test(token);
+}
+
+/**
+ * Collect suite files launched by `node` / `tsx`, skipping valid Node/tsx
+ * options that sit between the launcher and the positional path. Inline
+ * eval (`-e` / `--eval` / `-p`) is not a suite source.
+ */
 function launchedFiles(command) {
   if (typeof command !== "string") return [];
-  return [...command.matchAll(LAUNCHED_FILE)]
-    .map((m) => m[1])
-    .filter((file) => file !== undefined && !file.startsWith("-"));
+  const tokens = [...command.matchAll(TOKEN)].map((m) => unquote(m[0]));
+  const files = [];
+  for (let i = 0; i < tokens.length; i++) {
+    if (!LAUNCHER.test(tokens[i])) continue;
+    for (let j = i + 1; j < tokens.length; j++) {
+      const token = tokens[j];
+      if (token === "--") {
+        const next = tokens[j + 1];
+        if (next !== undefined && isSourcePath(next)) files.push(next);
+        break;
+      }
+      const flag = flagName(token);
+      if (flag?.startsWith("-")) {
+        if (EVAL_FLAGS.has(flag)) break;
+        if (takesValue(flag) && !token.includes("=")) j++;
+        continue;
+      }
+      if (isSourcePath(token)) files.push(token);
+      break;
+    }
+  }
+  return files;
 }
 
 function resolveFile(cwd, file) {

--- a/scripts/mutation-command-safety.mjs
+++ b/scripts/mutation-command-safety.mjs
@@ -1,0 +1,143 @@
+/**
+ * Fail-closed live-shaped command policy for the mutation tools.
+ *
+ * Discovery can be broad; execution cannot. A config whose command resolves to a live-named
+ * suite, or to a suite whose source declares real infrastructure (REAL Manager, REAL agent
+ * processes, REAL pty children, REAL broker), is refused before any child is spawned. The
+ * `:live` / `-live` suffix is not enough on its own: several broker-starting suites carry no
+ * such marker in the script name.
+ *
+ * Unresolvable `smoke:*` tokens refuse rather than run. A command with no smoke token and no
+ * inspectable suite source is allowed only when it also lacks a live-shaped name.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
+
+export const INFRASTRUCTURE_MARKERS = Object.freeze([
+  "REAL Manager",
+  "REAL agent processes",
+  "REAL pty children",
+  "REAL broker",
+]);
+
+const SMOKE_TOKEN = /\bsmoke:[A-Za-z0-9_-]+(?::[A-Za-z0-9_-]+)*/g;
+const LIVE_NAMED = /(?::live|-live)$/;
+const LAUNCHED_FILE = /(?:^|[\s;|&])(?:tsx|(?:\S*\/)?node)\s+([^\s;|&]+)/g;
+
+export function smokeTokens(command) {
+  if (typeof command !== "string") return [];
+  return command.match(SMOKE_TOKEN) ?? [];
+}
+
+export function isLiveNamedToken(token) {
+  return typeof token === "string" && LIVE_NAMED.test(token);
+}
+
+export function infrastructureMarkerIn(source) {
+  if (typeof source !== "string") return undefined;
+  return INFRASTRUCTURE_MARKERS.find((marker) => source.includes(marker));
+}
+
+function packageScripts(cwd, readFile) {
+  try {
+    const pkg = JSON.parse(readFile(join(cwd, "package.json"), "utf8"));
+    if (!pkg || typeof pkg.scripts !== "object" || pkg.scripts === null) return {};
+    return pkg.scripts;
+  } catch {
+    return undefined;
+  }
+}
+
+function launchedFiles(command) {
+  if (typeof command !== "string") return [];
+  return [...command.matchAll(LAUNCHED_FILE)]
+    .map((m) => m[1])
+    .filter((file) => file !== undefined && !file.startsWith("-"));
+}
+
+function resolveFile(cwd, file) {
+  if (typeof file !== "string" || file === "") return undefined;
+  return isAbsolute(file) ? file : join(cwd, file);
+}
+
+/**
+ * @param {string} command
+ * @param {{ cwd?: string, readFile?: typeof readFileSync, exists?: typeof existsSync }} [options]
+ * @returns {string | null} refusal reason, or null when the command may run
+ */
+export function liveShapedCommandReason(command, options = {}) {
+  const cwd = options.cwd ?? process.cwd();
+  const readFile = options.readFile ?? readFileSync;
+  const exists = options.exists ?? existsSync;
+
+  if (typeof command !== "string" || command.trim() === "") {
+    return "command is missing";
+  }
+
+  const tokens = smokeTokens(command);
+  for (const token of tokens) {
+    if (isLiveNamedToken(token)) return `${token} is live-named`;
+  }
+
+  const scripts = tokens.length ? packageScripts(cwd, readFile) : {};
+  if (tokens.length && scripts === undefined) {
+    return "package.json scripts are unreadable; refusing to execute a smoke command";
+  }
+
+  const files = [];
+  for (const token of tokens) {
+    const body = scripts[token];
+    if (typeof body !== "string" || body.trim() === "") {
+      return `${token} does not resolve to a package script`;
+    }
+    if (smokeTokens(body).some(isLiveNamedToken)) {
+      return `${token} is live-named`;
+    }
+    files.push(...launchedFiles(body));
+  }
+  files.push(...launchedFiles(command));
+  if (tokens.length && files.length === 0) {
+    return `${tokens.join(", ")} does not resolve to a suite source`;
+  }
+
+  const seen = new Set();
+  for (const file of files) {
+    if (seen.has(file)) continue;
+    seen.add(file);
+    const absolute = resolveFile(cwd, file);
+    if (absolute === undefined) continue;
+    if (!exists(absolute)) {
+      return `${file} does not resolve to a suite source`;
+    }
+    let source;
+    try {
+      source = readFile(absolute, "utf8");
+    } catch {
+      return `${file} is unreadable; refusing to execute`;
+    }
+    const marker = infrastructureMarkerIn(source);
+    if (marker !== undefined) return `${file} declares ${marker}`;
+  }
+
+  return null;
+}
+
+/**
+ * @param {{ command?: string, mutations?: { command?: string }[] }} fixture
+ * @param {{ cwd?: string, readFile?: typeof readFileSync, exists?: typeof existsSync }} [options]
+ * @returns {string | null}
+ */
+export function liveShapedFixtureReason(fixture, options = {}) {
+  const commands = [
+    fixture?.command,
+    ...(Array.isArray(fixture?.mutations) ? fixture.mutations.map((m) => m?.command) : []),
+  ].filter((cmd) => typeof cmd === "string");
+  if (commands.length === 0) {
+    return liveShapedCommandReason("", options);
+  }
+  for (const command of commands) {
+    const reason = liveShapedCommandReason(command, options);
+    if (reason) return reason;
+  }
+  return null;
+}

--- a/scripts/mutation-coverage.mjs
+++ b/scripts/mutation-coverage.mjs
@@ -16,10 +16,15 @@
  *
  *   node scripts/mutation-coverage.mjs                     # every config in the tree
  *   node scripts/mutation-coverage.mjs <config.json> …     # just these
+ *
+ * A live-shaped command is refused before it runs, whether the config was discovered or named.
+ * Refused configs are counted and printed; they are never a silent hole in the denominator.
  */
 import { readFileSync } from "node:fs";
 import { execSync } from "node:child_process";
+import { liveShapedCommandReason } from "./mutation-command-safety.mjs";
 import { parseSuiteSources } from "./mutation-suite-metadata.mjs";
+
 
 /**
  * The config list is DISCOVERED from the tree, never a remembered list of directories: a config
@@ -60,6 +65,7 @@ const probes = [];
  * other repository fixture so corpus validation does not have a blind spot.
  */
 const tools = [];
+const refused = [];
 
 /**
  * Only the fields THIS script's report depends on are checked here. The set of keys the harness
@@ -182,6 +188,11 @@ for (const path of configs) {
     }
     if (!gradesTool) assertGradable(path, suites, m, cfg.assembles ?? []);
   }
+  const liveReason = liveShapedCommandReason(cfg.command, { cwd: process.cwd() });
+  if (liveReason) {
+    refused.push([path, cfg.command, liveReason]);
+    continue;
+  }
   const out = execSync(cfg.command, { encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] });
   // Two terminal shapes exist in this repo. "N passed, M failed" comes from a suite that records
   // failures and keeps going; "N checks passed" from a fail-fast one, where reaching the line at
@@ -214,11 +225,15 @@ for (const path of configs) {
   rows.push([suites.join(", "), executed, distinct.size]);
 }
 
-const w = Math.max(...rows.map((r) => r[0].length));
-for (const [suite, executed, distinct] of rows) {
-  console.log(`${suite.padEnd(w)}  ${String(distinct).padStart(3)} / ${String(executed).padStart(3)} cells observed failing`);
+if (rows.length) {
+  const w = Math.max(...rows.map((r) => r[0].length));
+  for (const [suite, executed, distinct] of rows) {
+    console.log(`${suite.padEnd(w)}  ${String(distinct).padStart(3)} / ${String(executed).padStart(3)} cells observed failing`);
+  }
+  console.log(`${"TOTAL".padEnd(w)}  ${named} / ${cells} = ${Math.round((named / cells) * 100)}%`);
+} else if (!tools.length && !probes.length) {
+  console.log("TOTAL  0 / 0 = n/a (no safe configs executed)");
 }
-console.log(`${"TOTAL".padEnd(w)}  ${named} / ${cells} = ${Math.round((named / cells) * 100)}%`);
 console.log(`${mutations} mutations run, ${unkillable} recorded unkillable by construction and not run.`);
 console.log("A lower bound: a mutation may redden more cells than the one it names, and those are not claimed here.");
 console.log(
@@ -241,4 +256,11 @@ if (tools.length) {
   for (const [path, n, executed] of tools) {
     console.log(`  ${path}  ${n} mutations against a self-test of ${executed} cells`);
   }
+}
+if (refused.length) {
+  console.log("\nLive-shaped configs — refused before execution, counted and named so the denominator stays honest.");
+  for (const [path, command, reason] of refused) {
+    console.log(`  ${path}  REFUSED \`${command}\` (${reason})`);
+  }
+  console.log(`${refused.length} live-shaped config(s) refused.`);
 }

--- a/scripts/mutation-reproof.mjs
+++ b/scripts/mutation-reproof.mjs
@@ -29,6 +29,7 @@ import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { isDeepStrictEqual } from "node:util";
 import { comparableFailure, failureSignatureHash, unmeasurableFailure } from "./mutation-failure-signature.mjs";
+import { liveShapedCommandReason, liveShapedFixtureReason } from "./mutation-command-safety.mjs";
 import { mutationShard } from "./mutation-shard.mjs";
 import { parseSuiteSources } from "./mutation-suite-metadata.mjs";
 
@@ -61,6 +62,11 @@ function git(root, argv) {
 }
 
 function runCommand(command, cwd, env) {
+  const liveReason = liveShapedCommandReason(command, { cwd });
+  if (liveReason) {
+    const output = `REFUSING live-shaped command \`${command}\` (${liveReason}) — mutation-reproof never executes a live suite\n`;
+    return { status: 2, signal: null, error: undefined, stdout: "", stderr: output, output };
+  }
   const run = spawnSync(command, {
     cwd, shell: true, encoding: "utf8", timeout: COMMAND_TIMEOUT_MS,
     maxBuffer: 64 * 1024 * 1024, killSignal: "SIGKILL",
@@ -227,6 +233,13 @@ let selected = fixtures.map((fixture) => ({
 })).filter(({ selectedBy }) => Object.values(selectedBy).some(Boolean));
 if (shard) selected = selected.filter(({ path }) => mutationShard(path, Number(shard[2])) === Number(shard[1]));
 
+const liveRefused = selected.flatMap((fixture) => {
+  const reason = liveShapedFixtureReason(fixture, { cwd: root });
+  return reason ? [{ path: fixture.path, command: fixture.command, reason }] : [];
+});
+const liveRefusedPaths = new Set(liveRefused.map(({ path }) => path));
+const prove = selected.filter((fixture) => !liveRefusedPaths.has(fixture.path));
+
 // Selection evidence precedes dangling validation. A deleted or renamed declared source is one of
 // the reasons a fixture is selected, so reporting the source error before the selected set would
 // hide the selector result the failure is meant to make observable.
@@ -237,6 +250,12 @@ console.log(`mutation reproof: ${selected.length} fixture(s) selected from ${fix
 if (metadataOnlyExclusions.size > 0)
   console.log(`metadata-only config-path exclusions (${metadataOnlyExclusions.size}):\n${[...metadataOnlyExclusions].map((path) => `  ${path}`).join("\n")}`);
 if (selected.length > 0) console.log(`selected fixture paths:\n${selected.map(({ path }) => `  ${path}`).join("\n")}`);
+if (liveRefused.length) {
+  console.log(`live-shaped fixtures refused (${liveRefused.length}):`);
+  for (const { path, command, reason } of liveRefused) {
+    console.log(`  ${path}  REFUSED \`${command}\` (${reason})`);
+  }
+}
 
 // UNMEASURED, exit 1: a selected fixture's guarded file does not exist at head — a dangling fixture.
 // Its guarded source was deleted or renamed away, so its anchor cannot resolve and its proof is
@@ -263,7 +282,7 @@ if (dangling.length) {
 // line is the JSON a workflow reads; an empty list is printed, not turned into exit 0 with no output,
 // so a caller that fans out on it can tell "nothing to prove" from "nothing was said".
 if (listShards !== undefined) {
-  const shards = [...new Set(selected.map(({ path }) => mutationShard(path, listShards)))].sort((x, y) => x - y);
+  const shards = [...new Set(prove.map(({ path }) => mutationShard(path, listShards)))].sort((x, y) => x - y);
   console.log(`shard plan: ${shards.length} of ${listShards} shard(s) hold a selected fixture${shards.length ? `: ${shards.join(", ")}` : ""}`);
   console.log(JSON.stringify({ shards }));
   process.exit(0);
@@ -271,12 +290,14 @@ if (listShards !== undefined) {
 
 // A zero after filtering means either no diff match or no assignment to this shard.
 // Keep the diff, corpus and selected counts visible in both cases.
-if (selected.length === 0) {
+if (prove.length === 0) {
   console.log(shard
     ? `No selected mutation fixtures are assigned to shard ${a.shard}.`
-    : metadataOnlyExclusions.size > 0
-      ? "No mutation fixtures to re-prove: the only intersections were metadata-only config-path exclusions."
-      : "No mutation fixtures to re-prove: no fixture config, suite, or guarded source intersects the diff.");
+    : liveRefused.length > 0
+      ? "No mutation fixtures to re-prove: every selected fixture was a named live-shaped refusal."
+      : metadataOnlyExclusions.size > 0
+        ? "No mutation fixtures to re-prove: the only intersections were metadata-only config-path exclusions."
+        : "No mutation fixtures to re-prove: no fixture config, suite, or guarded source intersects the diff.");
   process.exit(0);
 }
 
@@ -519,7 +540,7 @@ const preRed = [];      // exit 4 + base RED, or any exit 4 under --all — inhe
 const attributablePreRed = []; // exit 4 + the SAME command base GREEN -> head RED
 const unmeasuredPreRed = []; // exit 4 + absent/ambiguous/unrunnable base comparison — loud failure
 const inconclusive = []; // INCONCLUSIVE only — unmeasured, evidence in neither direction
-for (const { path, command, mutations } of selected) {
+for (const { path, command, mutations } of prove) {
   console.log(`\n===== ${path} =====`);
   const run = spawnSync(process.execPath, [PROOF, "--config", path], {
     cwd: root, encoding: "utf8", maxBuffer: 64 * 1024 * 1024, env: rootComparisonEnv(),
@@ -672,5 +693,5 @@ if (attributablePreRed.length || unmeasuredPreRed.length || fatal.length || unme
   process.exit(1);
 }
 console.log(a.all
-  ? `\nMUTATION REPROOF OK (${selected.length} fixture(s) selected; ${selected.length - preRed.length - inconclusive.length} discriminated, ${preRed.length} pre-red, ${inconclusive.length} inconclusive; base not compared under --all)`
-  : `\nMUTATION REPROOF OK (${selected.length} fixture(s) selected; ${selected.length - fixtureCount(preRed) - fixtureCount(inheritedFatal) - inconclusive.length} discriminated, ${fixtureCount(preRed)} inherited pre-red, 0 attributable pre-red, 0 unmeasured pre-red, ${inconclusive.length} inconclusive)`);
+  ? `\nMUTATION REPROOF OK (${selected.length} fixture(s) selected; ${prove.length - preRed.length - inconclusive.length} discriminated, ${preRed.length} pre-red, ${inconclusive.length} inconclusive; base not compared under --all)`
+  : `\nMUTATION REPROOF OK (${selected.length} fixture(s) selected; ${prove.length - fixtureCount(preRed) - fixtureCount(inheritedFatal) - inconclusive.length} discriminated, ${fixtureCount(preRed)} inherited pre-red, 0 attributable pre-red, 0 unmeasured pre-red, ${inconclusive.length} inconclusive)`);


### PR DESCRIPTION
## Summary

`mutation-coverage` and `mutation-reproof` execute whatever command a fixture names. A live-named suite, or a broker-starting suite that never used a `:live` suffix, could therefore be launched from a coverage audit or a changed-source reproof and take the host down.

Both tools now share one fail-closed predicate. Live-named smoke tokens and suite sources that declare REAL Manager, REAL agent processes, REAL pty children, or REAL broker are named and skipped before any child is spawned. Unresolvable smoke tokens refuse rather than run. Safe configs still execute.

This is a host-takedown predicate for the mutation tools, not a change to the CI live-suite classifier.

## Test plan

- [x] `pnpm smoke:mutation-command-safety` (predicate, coverage refusals, no SENTINEL, safe config still runs, reproof names the refusal)
- [x] `node scripts/mutation-coverage.selftest.mjs`
- [x] Census of existing mutation configs: live-named and infrastructure-marked commands refuse; safe commands remain runnable
- [ ] Do **not** run no-arg `mutation-coverage` on this host

Refs #1446