### PR TITLE
fix(workspace): pin Windows teardowns to process creation time

### DIFF
--- a/.changeset/win32-identity-pin.md
+++ b/.changeset/win32-identity-pin.md
@@ -1,0 +1,6 @@
+---
+"@cotal-ai/workspace": patch
+"cotal-ai": patch
+---
+
+Pin Windows teardowns to process creation time. A launch writes a sibling identity file from the UTC FILETIME of `Get-Process StartTime`, and a stop refuses when that pin no longer matches. Records with no sibling pin stay on the upgrade-only legacy path.

--- a/bin/smoke/mutations/pid-identity.json
+++ b/bin/smoke/mutations/pid-identity.json
@@ -68,8 +68,8 @@
     {
       "name": "M4 writeIdentityPin never writes a sibling (the #1437 pin-absent defect)",
       "file": "packages/workspace/src/pid.ts",
-      "find": "  if (!(\"token\" in rec)) return; // no start could be established: leave the legacy bare-pid shape, loud\n  writeFileSync(identityPinPath(pidfilePath), formatRecord(rec));",
-      "replace": "  if (!(\"token\" in rec)) return; // no start could be established: leave the legacy bare-pid shape, loud\n  return;",
+      "find": "  writeFileSync(identityPinPath(pidfilePath), formatRecord(rec));",
+      "replace": "  return;",
       "expectRed": "F2 a win32 launch WRITES the sibling pin (the #1437 defect is writing none)",
       "cell": "F2 a win32 launch WRITES the sibling pin (the #1437 defect is writing none)",
       "note": "Restores the write skip that made every Windows record unpinned. F2 reds when the sibling is absent after a win32-capable launch.",

--- a/bin/smoke/mutations/pid-identity.json
+++ b/bin/smoke/mutations/pid-identity.json
@@ -2,7 +2,7 @@
   "suite": [
     "packages/workspace/smoke/pid-identity.smoke.ts"
   ],
-  "guard": "pinned teardown refuses reused pids and torn pins, while a legacy live record warns and remains signalable for upgrade compatibility",
+  "guard": "pinned teardown refuses reused pids and torn pins; win32 launches write a creation-time pin; a legacy live record warns and remains signalable only when no sibling pin exists",
   "command": "pnpm build > /dev/null && pnpm smoke:pid-identity",
   "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/pid-identity.json",
   "why": [
@@ -22,7 +22,13 @@
     "delivery teardown actually routes through the seam rather than the cells merely depending on",
     "the shared module in some other way.",
     "",
-    "BOTH RUN THE CLI-LIB-BACKED SUITE, so they build first (implementations/cli resolves to dist/)",
+    "M3 RESTORES THE #1437 WIN32 DEFECT: identityStartToken returns undefined on win32, so a launch",
+    "never has a token to pin. F1 is the off-Windows executable of that branch.",
+    "",
+    "M4 RESTORES THE WRITE SKIP: writeIdentityPin returns without creating a sibling even when a",
+    "token exists. That is the Windows steady state the issue named. F2 must red.",
+    "",
+    "ALL FOUR RUN THE CLI-LIB-BACKED SUITE, so they build first (implementations/cli resolves to dist/)",
     "and rebuild in afterRestore - git cannot recover a gitignored dist compiled from the mutant."
   ],
   "mutations": [
@@ -45,6 +51,28 @@
       "expectRed": "A1 a REUSED pid (pin mismatch) is REFUSED by stopDelivery, never signalled",
       "cell": "A1 a REUSED pid (pin mismatch) is REFUSED by stopDelivery, never signalled",
       "note": "Removes the gate entirely at one real call site. A1 reddens when the mismatch record is signalled; M2's distinct value over M1 proves the call site routes through the seam, not only that the shared verdict compares tokens.",
+      "command": "pnpm build > /dev/null && pnpm smoke:pid-identity",
+      "afterRestore": "pnpm build > /dev/null"
+    },
+    {
+      "name": "M3 win32 identity token is undefined again (the #1437 reader defect)",
+      "file": "packages/workspace/src/pid.ts",
+      "find": "  if (platform === \"win32\") return win32(pid);",
+      "replace": "  if (platform === \"win32\") return undefined;",
+      "expectRed": "F1 win32 identity uses the creation-time reader, not undefined",
+      "cell": "F1 win32 identity uses the creation-time reader, not undefined",
+      "note": "The Windows reader branch must not fold to undefined. F1 injects a FILETIME reader and names win32; returning undefined is the pre-fix processStartToken behaviour.",
+      "command": "pnpm build > /dev/null && pnpm smoke:pid-identity",
+      "afterRestore": "pnpm build > /dev/null"
+    },
+    {
+      "name": "M4 writeIdentityPin never writes a sibling (the #1437 pin-absent defect)",
+      "file": "packages/workspace/src/pid.ts",
+      "find": "  if (!(\"token\" in rec)) return; // no start could be established: leave the legacy bare-pid shape, loud\n  writeFileSync(identityPinPath(pidfilePath), formatRecord(rec));",
+      "replace": "  if (!(\"token\" in rec)) return; // no start could be established: leave the legacy bare-pid shape, loud\n  return;",
+      "expectRed": "F2 a win32 launch WRITES the sibling pin (the #1437 defect is writing none)",
+      "cell": "F2 a win32 launch WRITES the sibling pin (the #1437 defect is writing none)",
+      "note": "Restores the write skip that made every Windows record unpinned. F2 reds when the sibling is absent after a win32-capable launch.",
       "command": "pnpm build > /dev/null && pnpm smoke:pid-identity",
       "afterRestore": "pnpm build > /dev/null"
     }

--- a/packages/workspace/smoke/pid-identity.smoke.ts
+++ b/packages/workspace/smoke/pid-identity.smoke.ts
@@ -10,18 +10,18 @@
  * pid) will meet in production.
  *
  * THE DESIGN: the launch writes a sibling identity pin `<pidfile>.identity` holding `pid token`
- * (the process-start token the advisory lock already uses on Linux/macOS), and every teardown runs
- * ONE shared open-verify-terminate rule: mismatch (pid reuse) refuses and preserves; legacy (no
- * pin) live records warn and proceed for upgrade compatibility; torn pins refuse; only an
- * ESRCH-proven death clears a record.
+ * (the process-start token the advisory lock already uses on Linux/macOS, and on Windows the
+ * process creation FILETIME), and every teardown runs ONE shared open-verify-terminate rule:
+ * mismatch (pid reuse) refuses and preserves; legacy (no pin) live records warn and proceed for
+ * upgrade compatibility; torn pins refuse; only an ESRCH-proven death clears a record.
  *
  * WHAT IS AND IS NOT PROVEN HERE. Every cell drives the REAL stop entry points with REAL child
  * processes and REAL pins; the pid-reuse state itself is built by pinning a start token that
  * differs from the live process's actual start (the truthful post-reuse state: the recorded start
- * belongs to the dead process, the live process started later). The NATIVE WINDOWS surface
- * (CreateProcess handle lifetime, DETACHED_PROCESS parent exit, the absence of a stable start
- * token on win32) is NOT exercised here and is named as the gap in the PR: this suite runs the
- * cross-platform seam, not the Windows-native launcher.
+ * belongs to the dead process, the live process started later). The NATIVE WINDOWS launcher
+ * (CreateProcess handle lifetime, DETACHED_PROCESS parent exit) is not exercised here. The win32
+ * identity token IS: cell F drives the Windows reader/writer seam, including a mutation that
+ * restores "write no pin on win32" and must red.
  *
  * Run: pnpm smoke:pid-identity
  */
@@ -32,7 +32,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
-  defaultStartToken, formatRecord, identityPinPath, parseRecord,
+  defaultStartToken, formatRecord, identityPinPath, identityStartToken, parseRecord,
+  parseWin32CreationToken, verifyIdentityPin, writeIdentityPin,
 } from "@cotal-ai/workspace";
 
 const prevCwd = process.cwd();
@@ -216,6 +217,38 @@ try {
     check("E4 the torn pair is preserved", existsSync(join(root, ".cotal", "delivery.pid")) && existsSync(join(root, ".cotal", "delivery.pid.identity")));
     reap(torn.child);
   }
+
+  // ── F. WIN32 LAUNCHES WRITE A PIN (#1437). The pre-fix defect: processStartToken was undefined
+  // on win32, writeIdentityPin skipped, every teardown took the legacy path. Cell F1 is the
+  // mutation target: restoring "never write a pin" must red here, on this host, without Windows.
+  {
+    check("F0 a FILETIME integer is a win32 pin token; a MSYS ps date is not",
+      parseWin32CreationToken("  133000000000000000\r\n") === "133000000000000000"
+      && parseWin32CreationToken("Wed Sep 11 23:05:21 2026") === undefined
+      && parseWin32CreationToken("") === undefined);
+    const win32Token = "133000000000000000";
+    check("F1 win32 identity uses the creation-time reader, not undefined",
+      identityStartToken(4242, "win32", () => win32Token) === win32Token);
+    const pidPath = join(root, ".cotal", "win32.pid");
+    writeFileSync(pidPath, "4242");
+    writeIdentityPin(pidPath, 4242, (pid) => identityStartToken(pid, "win32", () => win32Token));
+    check("F2 a win32 launch WRITES the sibling pin (the #1437 defect is writing none)",
+      existsSync(identityPinPath(pidPath)), { pin: identityPinPath(pidPath) });
+    check("F3 the written pin is a two-field record, not a bare pid",
+      parseRecord(readFileSync(identityPinPath(pidPath), "utf8")).kind === "record");
+    check("F4 a matching win32 pin verifies as match",
+      verifyIdentityPin(pidPath, () => win32Token).kind === "match");
+    check("F5 a win32 pin mismatch is mismatch, never the legacy proceed-and-signal path",
+      verifyIdentityPin(pidPath, () => "133000000000000001").kind === "mismatch");
+    const liveLegacy = spawnTarget();
+    strays.push(liveLegacy.child);
+    await wait(150);
+    const legacyPath = join(root, ".cotal", "win32-legacy.pid");
+    writeFileSync(legacyPath, String(liveLegacy.pid));
+    check("F6 a live record with no sibling pin is still legacy (upgrade path only)",
+      verifyIdentityPin(legacyPath, () => win32Token).kind === "legacy");
+    reap(liveLegacy.child);
+  }
 } finally {
   for (const s of strays) reap(s);
   process.chdir(prevCwd);
@@ -225,9 +258,8 @@ try {
 console.log(`\nPID IDENTITY TESTS PASSED ✅  (${pass} checks)`);
 console.log(
   "  COVERAGE, precisely: every cell drives a REAL stop entry point against REAL child processes.\n" +
-  "  What this suite does NOT prove: the native Windows surface - CreateProcess handle lifetime,\n" +
-  "  DETACHED_PROCESS parent exit, and the fact that win32 has no stable start token (a pin cannot\n" +
-  "  be written there, so every record is the reduced-guarantee legacy shape and warns). That is named as the\n" +
-  "  gap in the PR; the Windows-native launcher (PR #880) must integrate with this seam there.",
+  "  Cell F proves the win32 identity seam: a creation-time token is a pin, a launch writes the\n" +
+  "  sibling, mismatch refuses, and a missing sibling remains the legacy upgrade path. What this\n" +
+  "  suite does NOT prove: CreateProcess handle lifetime and DETACHED_PROCESS parent exit.",
 );
 process.exit(0);

--- a/packages/workspace/src/advisory-lock.ts
+++ b/packages/workspace/src/advisory-lock.ts
@@ -66,10 +66,12 @@ export interface AcquireOptions {
 /** A best-effort, OS-cheap process-start token used ONLY to detect PID reuse. Undefined ⇒ the check
  *  is skipped for that platform and the bounded wait is the sole backstop (never a hard dependency). */
 export function processStartToken(pid: number): string | undefined {
-  // Windows has no cheap, STABLE start token here: `/proc` is absent and a `ps` on PATH (MSYS/Git)
-  // returns inconsistent output between calls, which would make the SAME live lock read differently
-  // from the acquirer vs a reader and be misjudged stale. Per the no-token rule, return undefined so a
-  // live PID keeps the lock active/unknown (bounded-wait is the backstop) rather than a false reclaim.
+  // This reader is polled by the advisory lock, so it must stay cheap. Windows has no cheap STABLE
+  // token here: `/proc` is absent and a `ps` on PATH (MSYS/Git) returns inconsistent output between
+  // calls, which would make the SAME live lock read differently from the acquirer vs a reader and be
+  // misjudged stale. Return undefined so a live PID keeps the lock active/unknown (bounded-wait is the
+  // backstop) rather than a false reclaim. Teardown identity pinning does NOT use this function on
+  // win32; see `win32ProcessCreationToken` in pid.ts (#1437).
   if (process.platform === "win32") return undefined;
   try {
     // Linux: /proc/<pid>/stat field 22 (starttime). comm (field 2) may hold spaces/parens, so parse

--- a/packages/workspace/src/pid.ts
+++ b/packages/workspace/src/pid.ts
@@ -18,8 +18,9 @@
  * module they may depend on, never a core export.
  */
 
-import { spawnSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { readFileSync, rmSync, writeFileSync } from "node:fs";
+import { processStartToken as posixStartToken } from "./advisory-lock.js";
 
 /** A Node/POSIX-signalable pid: a positive INTEGER within the signed 32-bit range `process.kill`
  *  accepts (it throws `ERR_INVALID_ARG_TYPE`/`ERR_OUT_OF_RANGE` outside it). Anything else -
@@ -185,28 +186,74 @@ export function formatRecord(record: ProcessIdentityRecord): string {
 /**
  * The creation-identity token of a live pid: on Linux `/proc/<pid>/stat` field 22 (starttime —
  * ticks since boot, fixed for the life of the pid); on macOS/BSD `ps -o lstart=`; on Windows
- * `undefined`, because no cheap STABLE token exists there (see the Windows note in
- * `advisory-lock.ts`'s `processStartToken` for why a `ps` on PATH is worse than none). A pid whose
- * token is `undefined` can still be recorded — the record then carries no start pin, and teardown
- * warns that it is proceeding without the identity check.
+ * the process creation FILETIME (PowerShell `Get-Process StartTime`, #1437). A pid whose token is
+ * `undefined` can still be recorded — the record then carries no start pin, and teardown warns that
+ * it is proceeding without the identity check. That pid-only shape is for a record that predates
+ * pinning, or a host that could not read a start at all. It is not the Windows steady state.
  */
 export type ProcessStartTokenReader = (pid: number) => string | undefined;
 
+/**
+ * Parse the stdout of the Windows creation-time reader into a pin token. Accepts only a bare
+ * unsigned FILETIME integer so a MSYS `ps` date string cannot become a "token" that drifts
+ * between launch and teardown (the original reason the lock reader refuses win32 `ps`).
+ */
+export function parseWin32CreationToken(raw: string): string | undefined {
+  const token = raw.trim();
+  return /^\d{1,20}$/.test(token) ? token : undefined;
+}
+
+/**
+ * Windows process-creation identity (#1437). A stop runs once, so unlike the advisory lock this
+ * may spend a PowerShell spawn: the token must be STABLE, not cheap. `Get-Process StartTime`
+ * converted to UTC FILETIME is fixed for the life of that pid and changes when the number is
+ * reused. `undefined` means the process is gone or PowerShell could not answer.
+ */
+export function win32ProcessCreationToken(pid: number): string | undefined {
+  if (!Number.isInteger(pid) || pid <= 0) return undefined;
+  try {
+    const out = execFileSync(
+      "powershell.exe",
+      [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `(Get-Process -Id ${pid} -ErrorAction Stop).StartTime.ToUniversalTime().ToFileTimeUtc()`,
+      ],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 5000 },
+    );
+    return parseWin32CreationToken(out);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Identity's start-token reader: POSIX uses the same `/proc`/`ps` implementation as the advisory
+ *  lock so launch and teardown cannot drift; win32 uses {@link win32ProcessCreationToken} instead
+ *  of the lock's `undefined`. `platform` is a parameter so the win32 branch is executable off
+ *  Windows: a mutation that returns `undefined` on win32 must redden without a Windows kernel. */
+export function identityStartToken(
+  pid: number,
+  platform: string = process.platform,
+  win32: ProcessStartTokenReader = win32ProcessCreationToken,
+  posix: ProcessStartTokenReader = posixStartToken,
+): string | undefined {
+  if (platform === "win32") return win32(pid);
+  return posix(pid);
+}
+
+export function defaultStartToken(pid: number): string | undefined {
+  return identityStartToken(pid);
+}
+
 /** The start token for a pid THIS PROCESS is about to record. Prefer the reader passed by the
- *  caller (tests inject divergence), fall back to the same `/proc`/`ps` read the advisory lock
- *  uses, so the token written at launch and the token compared at teardown come from ONE
- *  implementation. `undefined` (Windows, or a ps-less host) records a pid-only LEGACY record —
+ *  caller (tests inject divergence), fall back to {@link defaultStartToken}. `undefined` (a
+ *  ps-less host, or a Windows pid PowerShell could not read) records a pid-only LEGACY record —
  *  visible as such to every reader, never silently. */
 export function identityRecord(pid: number, tokenAt: ProcessStartTokenReader = defaultStartToken): ProcessIdentityRecord | { pid: number } {
   const token = tokenAt(pid);
   return token === undefined ? { pid } : { pid, token };
 }
-
-/** The start-token reader shared with the advisory lock, so launch and teardown agree on the token
- *  for the same live pid. Imported here rather than reimplemented: two token readers that drift
- *  would make the SAME process look like a stranger at teardown. */
-import { processStartToken as defaultStartToken } from "./advisory-lock.js";
-export { defaultStartToken };
 
 /** The verdict of {@link assertRecordIdentity}: does the live process behind `pid` still carry the
  *  start this record pinned? `unreadable` is deliberately NOT a variant: the reader signature
@@ -276,18 +323,18 @@ export function identityPinPath(pidfilePath: string): string {
 
 /** Write the sibling pin for a pid this launch just spawned. Called AFTER the pidfile write, with
  *  the same pid, so a reader that sees a pidfile with no pin yet is reading either a legacy record
- *  or a launch mid-pairing - both are visible below, never silent. `undefined` token (Windows,
- *  ps-less host) writes NO pin, which is the honest legacy shape for that platform rather than a
- *  pin that cannot be checked. */
+ *  or a launch mid-pairing - both are visible below, never silent. `undefined` token (ps-less host,
+ *  or a pid whose creation time could not be read) writes NO pin. Windows writes a pin whenever
+ *  {@link win32ProcessCreationToken} returns a FILETIME (#1437). */
 export function writeIdentityPin(pidfilePath: string, pid: number, tokenAt: ProcessStartTokenReader = defaultStartToken): void {
   const rec = identityRecord(pid, tokenAt);
-  if (!("token" in rec)) return; // platform cannot pin: leave the legacy bare-pid shape, loud
+  if (!("token" in rec)) return; // no start could be established: leave the legacy bare-pid shape, loud
   writeFileSync(identityPinPath(pidfilePath), formatRecord(rec));
 }
 
 /** What {@link verifyIdentityPin} found for one pidfile. */
 export type PinVerdict =
-  | { kind: "legacy" }        // no sibling: a pre-identity record (or a platform that cannot pin)
+  | { kind: "legacy" }        // no sibling: a pre-identity record. Windows launches write a sibling (#1437)
   | { kind: "match" }         // pinned, and the live process carries the recorded start
   | { kind: "gone" }          // pinned, and the pid is ESRCH-dead: the recorded process is gone
   | { kind: "mismatch"; record: ProcessIdentityRecord; liveToken: string } // PID REUSE: refuse


### PR DESCRIPTION
## Summary
- Windows launches now write a sibling identity pin from the UTC FILETIME of `Get-Process StartTime`, so teardown can refuse a reused pid.
- Records with no sibling pin stay on the upgrade-only legacy path. A mutation that restores the pin-absent skip reddens F1/F2.
- Advisory-lock polling still skips a Windows start token because that path must stay cheap.

## Test plan
- [x] `pnpm smoke:pid-identity` (29 checks, including cell F)
- [x] `node scripts/mutation-proof.mjs --config bin/smoke/mutations/pid-identity.json` (M1-M4 KILLED)
- [ ] Linux x64 CI on `tenki-standard-medium-4c-8g`

Refs #1437