### PR TITLE
fix(smoke): pin reproof spawn timeouts by function body, not character window

### DIFF
--- a/.changeset/reproof-smoke-function-body.md
+++ b/.changeset/reproof-smoke-function-body.md
@@ -1,0 +1,4 @@
+---
+---
+
+The mutation-reproof smoke pins each spawn timeout inside its function body instead of a character window, so a prologue added to runCommand no longer reds main.

--- a/bin/smoke/mutation-reproof.smoke.ts
+++ b/bin/smoke/mutation-reproof.smoke.ts
@@ -1901,14 +1901,36 @@ try {
 }
 
 const source = readFileSync(SCAN, "utf8");
+// A function body, not a character window: a prologue added to runCommand (the live-shaped refusal
+// from #1492) or to runProof must not red this cell, and a timeout that migrated to a neighbouring
+// function must not green it. Each body is cut from its `function name(` header to the first line
+// that is exactly `}`.
+const functionBody = (name: string): string => {
+  const at = source.indexOf(`function ${name}(`);
+  if (at === -1) return "";
+  const end = source.indexOf("\n}\n", at);
+  return end === -1 ? source.slice(at) : source.slice(at, end + 2);
+};
+const runProofBody = functionBody("runProof");
+const runCommandBody = functionBody("runCommand");
+const rootProofSpawn = (() => {
+  const at = source.indexOf('spawnSync(process.execPath, [PROOF, "--config", path], {');
+  if (at === -1) return "";
+  const end = source.indexOf("});", at);
+  return end === -1 ? source.slice(at) : source.slice(at, end + 3);
+})();
+const spawnsWith = (body: string, timeoutName: string): boolean =>
+  body.includes("spawnSync(")
+  && new RegExp(`timeout: ${timeoutName},`).test(body)
+  && /killSignal: "SIGKILL"/.test(body);
 check(
   "root and snapshot mutation-proof children share a SIGKILL budget under the 145-minute job step (a missing timeout hung shard 10/12 for 145m after WRONG-RED; 900s on the child killed mutation-reproof.json at 901s)",
   /const COMMAND_TIMEOUT_MS = 900_000;/.test(source)
     && /const PROOF_TIMEOUT_MS = 140 \* 60 \* 1000;/.test(source)
-    && /function runProof\([\s\S]{0,700}?timeout: PROOF_TIMEOUT_MS,[\s\S]{0,160}?killSignal: "SIGKILL"/.test(source)
-    && /spawnSync\(process\.execPath, \[PROOF, "--config", path\], \{[\s\S]{0,180}?timeout: PROOF_TIMEOUT_MS,[\s\S]{0,80}?killSignal: "SIGKILL"/.test(source)
-    && /function runCommand\([\s\S]{0,240}?timeout: COMMAND_TIMEOUT_MS,[\s\S]{0,80}?killSignal: "SIGKILL"/.test(source),
-  "runProof and the root PROOF spawn must pass timeout: PROOF_TIMEOUT_MS; runCommand keeps COMMAND_TIMEOUT_MS",
+    && spawnsWith(runProofBody, "PROOF_TIMEOUT_MS")
+    && spawnsWith(rootProofSpawn, "PROOF_TIMEOUT_MS")
+    && spawnsWith(runCommandBody, "COMMAND_TIMEOUT_MS"),
+  `runProof and the root PROOF spawn must pass timeout: PROOF_TIMEOUT_MS; runCommand keeps COMMAND_TIMEOUT_MS (runProof body ${runProofBody.length} chars, runCommand body ${runCommandBody.length} chars, root spawn ${rootProofSpawn.length} chars)`,
 );
 
 console.log(`mutation-reproof smoke: ${passed} passed, ${failed} failed`);

--- a/bin/smoke/mutations/mutation-reproof.json
+++ b/bin/smoke/mutations/mutation-reproof.json
@@ -222,6 +222,22 @@
       "replace": "      return { kind: \"origin\", value: separator === -1 ? \"<TMP>\" : `<TMP>/${remainder.slice(separator + 1)}` };",
       "expectRed": "different depth-zero temp-root filenames remain different root and clean-head failure origins",
       "cell": "different depth-zero temp-root filenames remain different root and clean-head failure origins"
+    },
+    {
+      "name": "runCommand drops its SIGKILL timeout while the constant survives elsewhere",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "    cwd, shell: true, encoding: \"utf8\", timeout: COMMAND_TIMEOUT_MS,\n    maxBuffer: 64 * 1024 * 1024, killSignal: \"SIGKILL\",",
+      "replace": "    cwd, shell: true, encoding: \"utf8\",\n    maxBuffer: 64 * 1024 * 1024,",
+      "expectRed": "root and snapshot mutation-proof children share a SIGKILL budget under the 145-minute job step (a missing timeout hung shard 10/12 for 145m after WRONG-RED; 900s on the child killed mutation-reproof.json at 901s)",
+      "cell": "root and snapshot mutation-proof children share a SIGKILL budget under the 145-minute job step (a missing timeout hung shard 10/12 for 145m after WRONG-RED; 900s on the child killed mutation-reproof.json at 901s)"
+    },
+    {
+      "name": "runProof loses its SIGKILL timeout",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "    cwd, encoding: \"utf8\", timeout: PROOF_TIMEOUT_MS, maxBuffer: 64 * 1024 * 1024,\n    killSignal: \"SIGKILL\", env,",
+      "replace": "    cwd, encoding: \"utf8\", maxBuffer: 64 * 1024 * 1024,\n    env,",
+      "expectRed": "root and snapshot mutation-proof children share a SIGKILL budget under the 145-minute job step (a missing timeout hung shard 10/12 for 145m after WRONG-RED; 900s on the child killed mutation-reproof.json at 901s)",
+      "cell": "root and snapshot mutation-proof children share a SIGKILL budget under the 145-minute job step (a missing timeout hung shard 10/12 for 145m after WRONG-RED; 900s on the child killed mutation-reproof.json at 901s)"
     }
   ]
 }


### PR DESCRIPTION
The mutation-reproof smoke asserts that runCommand, runProof, and the root proof spawn pass a SIGKILL timeout. The cell found runCommand's timeout by requiring the option within 240 characters of the function header. The live-shaped refusal prologue merged in #1492 moved runCommand's spawnSync 429 characters in, so main at e3f2d21af fails the cell while #1445 and #1492 each passed at their own heads.

The cell now cuts each function body from its header to the closing brace and asserts the spawnSync options inside that body. A prologue, comment, or extra argument added to a function no longer reds the cell, and a timeout that migrates to a neighbouring function no longer greens it. Two mutants that drop the timeout from runCommand and from runProof are added to the fixture so the cell reds on the property it names.

Empty changeset: CI-only change.

Refs #1495
