### PR TITLE
fix(connector-core): enforce closed schema on AG-UI egress fence

### DIFF
--- a/.changeset/agui-egress-closed-schema.md
+++ b/.changeset/agui-egress-closed-schema.md
@@ -1,0 +1,4 @@
+---
+---
+
+AG-UI egress fence now validates the whole frame envelope against a closed schema, refusing any unknown or extra property at the frame level or inside individual events and naming the path. Previously, the fence only checked `.events[].type`, so tool bytes on a sibling property of the event, on an unknown top-level property, or nested inside an allowed event's unknown field passed untouched.

--- a/bin/smoke/ci-suites.d/7747ede8c90e1bc42e5b9d92fd23fba29b92376f584b4c878bb73825813b1c98.txt
+++ b/bin/smoke/ci-suites.d/7747ede8c90e1bc42e5b9d92fd23fba29b92376f584b4c878bb73825813b1c98.txt
@@ -1,0 +1,2 @@
+# The egress fence validates the whole frame envelope against a closed schema (#1432).
+smoke:agui-egress-closed-schema

--- a/extensions/connector-core/smoke/agui-egress-closed-schema.smoke.ts
+++ b/extensions/connector-core/smoke/agui-egress-closed-schema.smoke.ts
@@ -1,0 +1,364 @@
+/**
+ * THE EGRESS FENCE MUST REFUSE UNKNOWN PROPERTIES ON A FRAME ENVELOPE.
+ *
+ * Issue #1432: the AG-UI egress fence checked only `.events[].type`, so tool bytes on a sibling
+ * property of the event, on an unknown top-level property, or nested inside an allowed event's
+ * unknown field all published untouched. The fence now validates the whole envelope against a
+ * closed schema (known frame-level keys, known per-event keys per type) and refuses any envelope
+ * with an unknown or extra property, naming the path.
+ *
+ * THREE ATTACK VECTORS, THREE CELLS:
+ * 1. Sibling property at frame level (`recovery: { type: "TOOL_CALL_RESULT", content: "<bytes>" }`)
+ * 2. Unknown top-level property (`smuggled: "secret"`)
+ * 3. Unknown field nested inside an allowed event (`events[0].leaked: "<bytes>"`)
+ *
+ * POSITIVE CONTROLS:
+ * - A well-formed frame with only known keys passes.
+ * - A well-formed frame with `cotal` metadata on events passes.
+ * - A JSON-round-tripped frame passes (simulating WAL recovery).
+ * - `frozenBodyEgressVerdict` returns `"forbidden-kind"` for in-events TOOL_CALL_RESULT (existing
+ *   behaviour preserved).
+ *
+ * THE COORDINATE IS `frozenBodyEgressVerdict` AND `extraPropertyPath`. The verdict is what
+ * `AguiEmitter.attempt()` uses to decide whether to publish. `extraPropertyPath` is the function
+ * that identifies the first unknown property and returns its dotted path.
+ *
+ * RECOVERY CELL: an `AguiEmitter.start()` against a WAL with a `sent_unacked` body carrying a
+ * sibling property must halt with `egress-extra-property`, not republish.
+ *
+ * Run: pnpm smoke:agui-egress-closed-schema
+ */
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { eventChannel, type Part } from "@cotal-ai/core";
+import { memorySubjectFrontier } from "@cotal-ai/smoke-kit";
+import {
+  AguiEmitter,
+  AguiEmitterHalted,
+  aguiFrame,
+  extraPropertyPath,
+  frozenBodyEgressVerdict,
+  type FrozenBodyEgressVerdict,
+  isAguiFramePart,
+  parseAguiFrame,
+  runStarted,
+  runFinished,
+  textMessageContent,
+  textMessageEnd,
+  textMessageStart,
+  toolCallEnd,
+  toolCallStart,
+  type AguiEvent,
+  type RecordMapper,
+} from "../src/agui.js";
+import { JsonlFileSource } from "../src/durable-source.js";
+import { EventWal } from "../src/event-wal.js";
+import { createClaudeMapper, type ClaudeEntry } from "../../connector-claude-code/src/agui-map.js";
+
+let pass = 0;
+let fail = 0;
+const c = (n: string, v: boolean, extra?: unknown): void => {
+  if (v) {
+    pass += 1;
+    return;
+  }
+  fail += 1;
+  console.error(`  x FAIL: ${n}${extra === undefined ? "" : ` ${JSON.stringify(extra)}`}`);
+};
+
+const PRINCIPAL = { owner: "local", actor: "aaa" };
+const PRINCIPAL_KEY = "local.aaa";
+const SPACE = "main";
+const THREAD = "thread-1";
+const CHANNEL = eventChannel(PRINCIPAL);
+
+const SIBLING_TOOL_BYTES = "SYNTHETIC-PLACEHOLDER-1432-SIBLING-TOOL-BYTES-NOT-A-SECRET";
+const SMUGGLED_SECRET = "SYNTHETIC-PLACEHOLDER-1432-SMUGGLED-SECRET-NOT-A-SECRET";
+const NESTED_TOOL_BYTES = "SYNTHETIC-PLACEHOLDER-1432-NESTED-TOOL-BYTES-NOT-A-SECRET";
+
+interface Call {
+  id: string;
+  expectedLastSubjectSeq: number;
+  parts: Part[];
+  channel: string;
+}
+
+class FakeEndpoint {
+  readonly principal = PRINCIPAL;
+  readonly actorIsEphemeral = false;
+  maxPayload = 65536;
+  preflightCalls = 0;
+  publishes: Call[] = [];
+  answers: ({ seq: number; duplicate: boolean } | Error)[] = [];
+  async assertExpectationSemantics(): Promise<void> {
+    this.preflightCalls += 1;
+  }
+  encodedSize(o: { channel: string; parts: Part[]; id: string; expectedLastSubjectSeq: number }): number {
+    return Buffer.byteLength(JSON.stringify(o), "utf8") + 64;
+  }
+  async multicastExpecting(o: {
+    channel: string;
+    parts: Part[];
+    id: string;
+    expectedLastSubjectSeq: number;
+  }): Promise<{ ack: { seq: number; duplicate: boolean } }> {
+    this.publishes.push({
+      id: o.id,
+      expectedLastSubjectSeq: o.expectedLastSubjectSeq,
+      parts: o.parts,
+      channel: o.channel,
+    });
+    const a = this.answers.shift() ?? { seq: this.publishes.length, duplicate: false };
+    if (a instanceof Error) throw a;
+    return { ack: a };
+  }
+}
+
+const dir = mkdtempSync(join(tmpdir(), "agui-egress-closed-schema-"));
+let n = 0;
+
+const attempt = async <T>(fn: () => Promise<T>): Promise<{ value?: T; err?: Error }> => {
+  try {
+    return { value: await fn() };
+  } catch (e) {
+    return { err: e as Error };
+  }
+};
+
+const fresh = async (name: string) => {
+  const d = join(dir, `${++n}-${name}`);
+  const src = join(d, "session.jsonl");
+  const walPath = join(d, "wal.json");
+  mkdirSync(d, { recursive: true });
+  writeFileSync(src, "");
+  const wal = await EventWal.open(walPath, {
+    space: SPACE,
+    threadId: THREAD,
+    principal: PRINCIPAL_KEY,
+    subjectMayExist: false,
+  });
+  return { d, src, walPath, wal, source: new JsonlFileSource<unknown>(src) };
+};
+
+const append = (path: string, ...recs: unknown[]) => {
+  writeFileSync(path, recs.map((r) => JSON.stringify(r)).join("\n") + "\n", { flag: "a" });
+};
+
+const publishedWire = (ep: FakeEndpoint): string => JSON.stringify(ep.publishes);
+
+try {
+  // ── DIRECT VERDICT CELLS ────────────────────────────────────────────────────
+
+  // 1. Sibling property at frame level carrying tool bytes
+  {
+    const frame = {
+      kind: "ag-ui.frame" as const,
+      protocol: "ag-ui/0.0.57",
+      threadId: "t1",
+      runId: "r1",
+      epoch: "e1",
+      seq: 0,
+      events: [{ type: "RUN_STARTED", threadId: "t1", runId: "r1", timestamp: 1 }],
+      recovery: { type: "TOOL_CALL_RESULT", content: SIBLING_TOOL_BYTES },
+    };
+    const verdict = frozenBodyEgressVerdict([frame]);
+    c("closed-schema:sibling-property frame-level tool bytes are refused", verdict === "extra-property", { verdict });
+    const path = extraPropertyPath(frame as Record<string, unknown>);
+    c("closed-schema:sibling-property path names 'recovery'", path === "recovery", { path });
+  }
+
+  // 2. Unknown top-level property
+  {
+    const frame = {
+      kind: "ag-ui.frame" as const,
+      protocol: "ag-ui/0.0.57",
+      threadId: "t1",
+      runId: "r1",
+      epoch: "e1",
+      seq: 0,
+      events: [{ type: "RUN_STARTED", threadId: "t1", runId: "r1", timestamp: 1 }],
+      smuggled: SMUGGLED_SECRET,
+    };
+    const verdict = frozenBodyEgressVerdict([frame]);
+    c("closed-schema:unknown-top-level property is refused", verdict === "extra-property", { verdict });
+    const path = extraPropertyPath(frame as Record<string, unknown>);
+    c("closed-schema:unknown-top-level path names 'smuggled'", path === "smuggled", { path });
+  }
+
+  // 3. Unknown field nested inside an allowed event
+  {
+    const frame = {
+      kind: "ag-ui.frame" as const,
+      protocol: "ag-ui/0.0.57",
+      threadId: "t1",
+      runId: "r1",
+      epoch: "e1",
+      seq: 0,
+      events: [{
+        type: "RUN_STARTED",
+        threadId: "t1",
+        runId: "r1",
+        timestamp: 1,
+        leaked: { type: "TOOL_CALL_RESULT", content: NESTED_TOOL_BYTES },
+      }],
+    };
+    const verdict = frozenBodyEgressVerdict([frame]);
+    c("closed-schema:nested-event-field tool bytes are refused", verdict === "extra-property", { verdict });
+    const path = extraPropertyPath(frame as Record<string, unknown>);
+    c("closed-schema:nested-event-field path names 'events[0].leaked'", path === "events[0].leaked", { path });
+  }
+
+  // ── POSITIVE CONTROLS ──────────────────────────────────────────────────────
+
+  // Well-formed frame with only known keys
+  {
+    const frame = aguiFrame({
+      threadId: "t1", runId: "r1", epoch: "e1", seq: 0,
+      events: [runStarted({ threadId: "t1", runId: "r1", timestamp: 1 })],
+    });
+    c("control:well-formed-lifecycle frame passes", frozenBodyEgressVerdict([frame]) === "clean");
+  }
+
+  // Well-formed frame with text events
+  {
+    const frame = aguiFrame({
+      threadId: "t1", runId: "r1", epoch: "e1", seq: 1,
+      events: [
+        textMessageStart({ messageId: "m1", timestamp: 2 }),
+        textMessageContent({ messageId: "m1", delta: "hello", timestamp: 3 }),
+        textMessageEnd({ messageId: "m1", timestamp: 4 }),
+      ],
+    });
+    c("control:well-formed-text frame passes", frozenBodyEgressVerdict([frame]) === "clean");
+  }
+
+  // Well-formed frame with cotal metadata
+  {
+    const frame = aguiFrame({
+      threadId: "t1", runId: "r1", epoch: "e1", seq: 2,
+      events: [runStarted({ threadId: "t1", runId: "r1", timestamp: 5, cotal: { tsSource: "arrival" } })],
+    });
+    c("control:frame-with-cotal-metadata passes", frozenBodyEgressVerdict([frame]) === "clean");
+  }
+
+  // JSON-round-tripped frame (WAL recovery simulation)
+  {
+    const live = aguiFrame({
+      threadId: "t1", runId: "r1", epoch: "e1", seq: 3,
+      events: [runStarted({ threadId: "t1", runId: "r1", timestamp: 6 })],
+    });
+    const rtFrame = JSON.parse(JSON.stringify(live));
+    c("control:json-round-tripped frame passes", frozenBodyEgressVerdict([rtFrame]) === "clean");
+  }
+
+  // Existing behaviour: in-events forbidden kind still returns "forbidden-kind"
+  {
+    const frame = {
+      kind: "ag-ui.frame" as const,
+      protocol: "ag-ui/0.0.57",
+      threadId: "t1",
+      runId: "r1",
+      epoch: "e1",
+      seq: 0,
+      events: [{ type: "TOOL_CALL_RESULT", messageId: "m", toolCallId: "t", content: "x", timestamp: 1 }],
+    };
+    c("control:in-events-forbidden-kind still returns forbidden-kind", frozenBodyEgressVerdict([frame]) === "forbidden-kind");
+  }
+
+  // Well-formed frame with tool call (start/end, no args/result)
+  {
+    const frame = aguiFrame({
+      threadId: "t1", runId: "r1", epoch: "e1", seq: 4,
+      events: [
+        toolCallStart({ toolCallId: "tc1", toolCallName: "read", timestamp: 7 }),
+        toolCallEnd({ toolCallId: "tc1", timestamp: 8 }),
+      ],
+    });
+    c("control:tool-call-start-end (no args/result) passes", frozenBodyEgressVerdict([frame]) === "clean");
+  }
+
+  // Well-formed frame with rawEvent field (AG-UI schema key)
+  {
+    const frame = {
+      kind: "ag-ui.frame" as const,
+      protocol: "ag-ui/0.0.57",
+      threadId: "t1",
+      runId: "r1",
+      epoch: "e1",
+      seq: 0,
+      events: [{ type: "RUN_STARTED", threadId: "t1", runId: "r1", timestamp: 1, rawEvent: { foo: "bar" } }],
+    };
+    c("control:event-with-rawEvent (AG-UI schema key) passes", frozenBodyEgressVerdict([frame]) === "clean");
+  }
+
+  // Well-formed frame with runFinished outcome
+  {
+    const frame = aguiFrame({
+      threadId: "t1", runId: "r1", epoch: "e1", seq: 5,
+      events: [runFinished({ threadId: "t1", runId: "r1", timestamp: 9, outcome: { type: "success" } })],
+    });
+    c("control:runFinished-with-outcome passes", frozenBodyEgressVerdict([frame]) === "clean");
+  }
+
+  // ── RECOVERY CELL ──────────────────────────────────────────────────────────
+  // An AguiEmitter.start() against a WAL with a sent_unacked body carrying a
+  // sibling property must halt with egress-extra-property, not republish.
+  {
+    const { wal, walPath, source, src } = await fresh("recover-extra-prop");
+    const sf = memorySubjectFrontier();
+    await wal.bindSubjectFrontier(sf);
+
+    // Write a WAL entry with a sent_unacked body carrying an extra property.
+    const body: Part[] = [
+      {
+        kind: "ag-ui.frame",
+        protocol: "ag-ui/0.0.57",
+        threadId: THREAD,
+        runId: "run-recover",
+        epoch: wal.epoch,
+        seq: 0,
+        events: [{ type: "RUN_STARTED", threadId: THREAD, runId: "run-recover", timestamp: 1 }],
+        recovery: { type: "TOOL_CALL_RESULT", content: SIBLING_TOOL_BYTES },
+      } as unknown as Part,
+    ];
+    await wal.beginSend({
+      id: "recover-extra-1",
+      E: 0,
+      seq: 1,
+      sourceCursor: "1:2:0:0000000000000000",
+      body,
+      brackets: { run: "run-recover", text: [], reasoning: [], tools: [] },
+    });
+    // Close and reopen the WAL to simulate restart.
+    const wal2 = await EventWal.open(walPath, {
+      space: SPACE,
+      threadId: THREAD,
+      principal: PRINCIPAL_KEY,
+      subjectMayExist: true,
+    });
+    c("recover:pending.state is sent_unacked before start", wal2.pending?.state === "sent_unacked", wal2.pending?.state);
+    const ep = new FakeEndpoint();
+    const map: RecordMapper<unknown> = () => null;
+    const started = await attempt(() =>
+      AguiEmitter.start({ endpoint: ep, wal: wal2, subjectFrontier: sf, source, map }),
+    );
+    c(
+      "recover:AguiEmitter.start halts with egress-extra-property for frozen sibling-property body",
+      started.err instanceof AguiEmitterHalted && started.err.reason === "egress-extra-property",
+      { err: started.err?.message, reason: started.err instanceof AguiEmitterHalted ? started.err.reason : undefined },
+    );
+    c(
+      "recover:sibling tool bytes do NOT reach the wire",
+      !publishedWire(ep).includes(SIBLING_TOOL_BYTES),
+    );
+  }
+
+  console.log(`agui-egress-closed-schema smoke: ${pass} passed, ${fail} failed`);
+  if (fail > 0) process.exit(1);
+} catch (e) {
+  console.error("FATAL:", e);
+  process.exit(1);
+} finally {
+  try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+}

--- a/extensions/connector-core/smoke/egress-guard-differential.smoke.ts
+++ b/extensions/connector-core/smoke/egress-guard-differential.smoke.ts
@@ -757,7 +757,14 @@ const PAIRS: Pair[] = [
     baseRef: PREDECESSOR,
     headRef: "HEAD",
     expectWeakerMin: 0,
-    expectStricterMax: 0,
+    // #1432: the closed-schema check intentionally refuses frames whose events carry
+    // keys outside the per-type allowlist. The corpus row "allowed: well-formed CUSTOM"
+    // builds a CUSTOM event by spreading TextMessageContent (adding `messageId` and
+    // `delta`), which the predecessor never checked. BaseEventSchema is `.passthrough()`
+    // for ALL event types (not just CUSTOM), so the upstream schema would accept the
+    // extra keys, but the egress fence enforces the closed shape Cotal publishes:
+    // CUSTOM's extension point is `value: z.any()`, not arbitrary sibling keys.
+    expectStricterMax: 1,
   },
 ];
 

--- a/extensions/connector-core/smoke/egress-guard-differential.smoke.ts
+++ b/extensions/connector-core/smoke/egress-guard-differential.smoke.ts
@@ -513,6 +513,9 @@ for (const type of forbiddenTypes) {
   push("forbidden-kind", `forbidden: well-formed ${type}`, [frameOf([eventOf(type)], 1)]);
 }
 for (const type of allowedTypes) {
+  // CUSTOM is in DIVERGENT: predecessor ALLOW, HEAD THROW (extra-property from spread
+  // TextMessageContent siblings). Pinned by identity, not counted in expectStricterMax.
+  if (type === "CUSTOM") continue;
   push("allowed-kind", `allowed: well-formed ${type}`, [frameOf([eventOf(type)])]);
 }
 
@@ -650,6 +653,19 @@ interface DivergentRow {
 
 const unreadablePart = () => over({ seq: -1 });
 const DIVERGENT: DivergentRow[] = [
+  // #1432: the closed-schema check intentionally refuses frames whose events carry
+  // keys outside the per-type allowlist. The corpus builder (eventOf) constructs CUSTOM
+  // by spreading TextMessageContent (adding `messageId` and `delta`), which the
+  // predecessor never checked. BaseEventSchema is `.passthrough()` for ALL event types,
+  // so the upstream schema would accept the extra keys, but the egress fence enforces
+  // the closed shape Cotal publishes: CUSTOM's extension point is `value: z.any()`,
+  // not arbitrary sibling keys.
+  {
+    name: "allowed: well-formed CUSTOM",
+    axis: "allowed-kind",
+    body: [frameOf([eventOf("CUSTOM")])],
+    expected: { [PREDECESSOR]: "ALLOW", HEAD: "THROW", [ADAPTER_FREE]: "ALLOW" },
+  },
   {
     name: "across parts: unreadable then TOOL_CALL_RESULT",
     axis: "body-composition",
@@ -757,14 +773,9 @@ const PAIRS: Pair[] = [
     baseRef: PREDECESSOR,
     headRef: "HEAD",
     expectWeakerMin: 0,
-    // #1432: the closed-schema check intentionally refuses frames whose events carry
-    // keys outside the per-type allowlist. The corpus row "allowed: well-formed CUSTOM"
-    // builds a CUSTOM event by spreading TextMessageContent (adding `messageId` and
-    // `delta`), which the predecessor never checked. BaseEventSchema is `.passthrough()`
-    // for ALL event types (not just CUSTOM), so the upstream schema would accept the
-    // extra keys, but the egress fence enforces the closed shape Cotal publishes:
-    // CUSTOM's extension point is `value: z.any()`, not arbitrary sibling keys.
-    expectStricterMax: 1,
+    // Zero: every known divergence is pinned by identity in DIVERGENT, not counted here.
+    // A new STRICTER row fails loudly rather than slotting into a numeric budget.
+    expectStricterMax: 0,
   },
 ];
 
@@ -882,18 +893,18 @@ try {
   );
   ok(
     "PREDICT across-unreadable-then-forbidden matches the predecessor/HEAD pins",
-    DIVERGENT[0]!.expected[PREDECESSOR] === PREDICT.acrossUnreadableThenForbidden.boolean &&
-      DIVERGENT[0]!.expected.HEAD === PREDICT.acrossUnreadableThenForbidden.threeWay,
+    DIVERGENT[1]!.expected[PREDECESSOR] === PREDICT.acrossUnreadableThenForbidden.boolean &&
+      DIVERGENT[1]!.expected.HEAD === PREDICT.acrossUnreadableThenForbidden.threeWay,
   );
   ok(
     "PREDICT across-forbidden-then-unreadable matches the predecessor/HEAD pins",
-    DIVERGENT[1]!.expected[PREDECESSOR] === PREDICT.acrossForbiddenThenUnreadable.boolean &&
-      DIVERGENT[1]!.expected.HEAD === PREDICT.acrossForbiddenThenUnreadable.threeWay,
+    DIVERGENT[2]!.expected[PREDECESSOR] === PREDICT.acrossForbiddenThenUnreadable.boolean &&
+      DIVERGENT[2]!.expected.HEAD === PREDICT.acrossForbiddenThenUnreadable.threeWay,
   );
   ok(
     "PREDICT same-part unreadable-beats-forbidden matches the predecessor/HEAD pins",
-    DIVERGENT[4]!.expected[PREDECESSOR] === PREDICT.samePartUnreadableAndForbidden.boolean &&
-      DIVERGENT[4]!.expected.HEAD === PREDICT.samePartUnreadableAndForbidden.threeWay,
+    DIVERGENT[5]!.expected[PREDECESSOR] === PREDICT.samePartUnreadableAndForbidden.boolean &&
+      DIVERGENT[5]!.expected.HEAD === PREDICT.samePartUnreadableAndForbidden.threeWay,
   );
 
   let missingHistory = "";

--- a/extensions/connector-core/smoke/mutations/agui-egress-closed-schema.json
+++ b/extensions/connector-core/smoke/mutations/agui-egress-closed-schema.json
@@ -1,0 +1,58 @@
+{
+  "suite": [
+    "extensions/connector-core/smoke/agui-egress-closed-schema.smoke.ts"
+  ],
+  "guard": "the egress fence validates the whole frame envelope against a closed schema: known top-level frame keys and known per-event keys per type; an envelope with an unknown or extra property at any level is refused naming the path; a frozen body carrying an extra property halts AguiEmitter.start recovery rather than republishing",
+  "command": "pnpm --filter @cotal-ai/connector-core... build && pnpm smoke:agui-egress-closed-schema",
+  "completionMarker": "agui-egress-closed-schema smoke:",
+  "proveWith": "node scripts/mutation-proof.mjs --config extensions/connector-core/smoke/mutations/agui-egress-closed-schema.json",
+  "why": [
+    "THE FIX IS A CLOSED SCHEMA, NOT AN EVENT-TYPE ALLOWLIST. The fence already had event-kind control",
+    "on .events[].type; extending that list is the enumerated-bad-input shape the fence already has.",
+    "The closed-schema approach validates the WHOLE envelope: known frame keys, known per-event keys",
+    "per type, and refuses any unknown property naming its path. This is a structural fix, not a",
+    "band-aid.",
+    "",
+    "T-SCHEMA-BYPASS removes the extraPropertyPath call from frozenBodyEgressVerdict, reopening the",
+    "sibling-property gap. T-ATTEMPT-EXTRA removes the extra-property halt from attempt(), so the",
+    "recovery path publishes the sibling bytes. T-LIVENESS adds a fake key to KNOWN_FRAME_KEYS,",
+    "proving the fence actually checks frame keys and is not vacuously passing.",
+    "",
+    "T-EVENT-LIVENESS adds a fake key to the RUN_STARTED event type's known keys, proving per-event",
+    "key checking is not vacuous."
+  ],
+  "mutations": [
+    {
+      "name": "T-SCHEMA-BYPASS the extraPropertyPath check is removed from frozenBodyEgressVerdict so the fence reverts to event-kind-only control",
+      "file": "extensions/connector-core/src/agui.ts",
+      "find": "        const extra = extraPropertyPath(part as Record<string, unknown>);\n        if (extra !== undefined) return \"extra-property\";\n      } catch {",
+      "replace": "      } catch {",
+      "expectRed": "closed-schema:sibling-property frame-level tool bytes are refused",
+      "afterRestore": "pnpm --filter @cotal-ai/connector-core... build"
+    },
+    {
+      "name": "T-ATTEMPT-EXTRA the extra-property verdict is silently swallowed in attempt() so AguiEmitter.start republishes a frozen body with extra properties",
+      "file": "extensions/connector-core/src/agui.ts",
+      "find": "      throw this.halt(\n        \"egress-extra-property\",",
+      "replace": "      void this.halt(\n        \"egress-extra-property\",",
+      "expectRed": "recover:AguiEmitter.start halts with egress-extra-property for frozen sibling-property body",
+      "afterRestore": "pnpm --filter @cotal-ai/connector-core... build"
+    },
+    {
+      "name": "T-LIVENESS KNOWN_FRAME_KEYS is widened with a fake key, proving the fence does not vacuously pass frame-level checks",
+      "file": "extensions/connector-core/src/agui.ts",
+      "find": "const KNOWN_FRAME_KEYS: ReadonlySet<string> = new Set([\n  \"kind\", \"protocol\", \"threadId\", \"runId\", \"epoch\", \"seq\", \"events\",\n]);",
+      "replace": "const KNOWN_FRAME_KEYS: ReadonlySet<string> = new Set([\n  \"kind\", \"protocol\", \"threadId\", \"runId\", \"epoch\", \"seq\", \"events\",\n  \"recovery\", \"smuggled\",\n]);",
+      "expectRed": "closed-schema:sibling-property frame-level tool bytes are refused",
+      "afterRestore": "pnpm --filter @cotal-ai/connector-core... build"
+    },
+    {
+      "name": "T-EVENT-LIVENESS KNOWN_EVENT_KEYS_BY_TYPE for RUN_STARTED is widened with a fake key, proving per-event key checking is not vacuous",
+      "file": "extensions/connector-core/src/agui.ts",
+      "find": "[AGUI_EVENT_TYPE.RUN_STARTED, new Set([\"type\", \"timestamp\", \"rawEvent\", \"threadId\", \"runId\", \"parentRunId\", \"input\", \"cotal\"])],",
+      "replace": "[AGUI_EVENT_TYPE.RUN_STARTED, new Set([\"type\", \"timestamp\", \"rawEvent\", \"threadId\", \"runId\", \"parentRunId\", \"input\", \"cotal\", \"leaked\"])],",
+      "expectRed": "closed-schema:nested-event-field tool bytes are refused",
+      "afterRestore": "pnpm --filter @cotal-ai/connector-core... build"
+    }
+  ]
+}

--- a/extensions/connector-core/src/agui.ts
+++ b/extensions/connector-core/src/agui.ts
@@ -1134,7 +1134,7 @@ export class AguiBracketStateLost extends AguiVocabularyError {
 
 export class AguiEmitterHalted extends Error {
   constructor(
-    readonly reason: "duplicate-ack" | "cas-loss" | "egress-policy" | "egress-unreadable",
+    readonly reason: "duplicate-ack" | "cas-loss" | "egress-policy" | "egress-unreadable" | "egress-extra-property",
     message: string,
   ) {
     super(message);
@@ -1271,6 +1271,84 @@ const EGRESS_FORBIDDEN_TYPES: ReadonlySet<string> = new Set([
 /** Every `type` the vocabulary defines. An element outside it cannot be classified, only refused. */
 const KNOWN_AGUI_EVENT_TYPES: ReadonlySet<string> = new Set(Object.values(AGUI_EVENT_TYPE));
 
+// ---------------------------------------------------------------------------
+// Closed-schema tables.
+//
+// The egress fence must validate the WHOLE envelope, not just `.events[].type`.
+// A frame with extra properties at any level passes the event-kind check and
+// publishes its payload untouched. These tables define the closed shape so the
+// fence can refuse an envelope carrying unknown properties and name the path.
+//
+// `cotal` is an allowed extension key on every event (WithCotal<E>). AG-UI
+// schemas are `.passthrough()`, so the upstream schema would not refuse it;
+// this fence enforces the closed shape Cotal publishes.
+// ---------------------------------------------------------------------------
+
+/** The ONLY keys a frame part may carry at the top level. */
+const KNOWN_FRAME_KEYS: ReadonlySet<string> = new Set([
+  "kind", "protocol", "threadId", "runId", "epoch", "seq", "events",
+]);
+
+/**
+ * The allowed keys per event type. Each set includes the AG-UI schema keys for
+ * that type PLUS `cotal` (the Cotal extension key carried via `WithCotal<E>`).
+ *
+ * The source of truth is the AG-UI 0.0.57 schema shapes, measured at build time
+ * by the conformance smoke. `rawEvent` is an AG-UI schema key on every type.
+ */
+const KNOWN_EVENT_KEYS_BY_TYPE: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+  [AGUI_EVENT_TYPE.RUN_STARTED, new Set(["type", "timestamp", "rawEvent", "threadId", "runId", "parentRunId", "input", "cotal"])],
+  [AGUI_EVENT_TYPE.RUN_FINISHED, new Set(["type", "timestamp", "rawEvent", "threadId", "runId", "result", "outcome", "cotal"])],
+  [AGUI_EVENT_TYPE.RUN_ERROR, new Set(["type", "timestamp", "rawEvent", "message", "code", "cotal"])],
+  [AGUI_EVENT_TYPE.TEXT_MESSAGE_START, new Set(["type", "timestamp", "rawEvent", "messageId", "role", "name", "cotal"])],
+  [AGUI_EVENT_TYPE.TEXT_MESSAGE_CONTENT, new Set(["type", "timestamp", "rawEvent", "messageId", "delta", "cotal"])],
+  [AGUI_EVENT_TYPE.TEXT_MESSAGE_END, new Set(["type", "timestamp", "rawEvent", "messageId", "cotal"])],
+  [AGUI_EVENT_TYPE.TOOL_CALL_START, new Set(["type", "timestamp", "rawEvent", "toolCallId", "toolCallName", "parentMessageId", "cotal"])],
+  [AGUI_EVENT_TYPE.TOOL_CALL_ARGS, new Set(["type", "timestamp", "rawEvent", "toolCallId", "delta", "cotal"])],
+  [AGUI_EVENT_TYPE.TOOL_CALL_END, new Set(["type", "timestamp", "rawEvent", "toolCallId", "cotal"])],
+  [AGUI_EVENT_TYPE.TOOL_CALL_RESULT, new Set(["type", "timestamp", "rawEvent", "messageId", "toolCallId", "content", "role", "cotal"])],
+  [AGUI_EVENT_TYPE.REASONING_MESSAGE_START, new Set(["type", "timestamp", "rawEvent", "messageId", "role", "cotal"])],
+  [AGUI_EVENT_TYPE.REASONING_MESSAGE_CONTENT, new Set(["type", "timestamp", "rawEvent", "messageId", "delta", "cotal"])],
+  [AGUI_EVENT_TYPE.REASONING_MESSAGE_END, new Set(["type", "timestamp", "rawEvent", "messageId", "cotal"])],
+  [AGUI_EVENT_TYPE.CUSTOM, new Set(["type", "timestamp", "rawEvent", "name", "value", "cotal"])],
+]);
+
+/**
+ * Find the first extra property on a parsed frame, returning its JSON-path
+ * string, or `undefined` when the envelope is closed.
+ *
+ * Checks two levels:
+ * 1. Frame-level keys against {@link KNOWN_FRAME_KEYS}.
+ * 2. Per-event keys against {@link KNOWN_EVENT_KEYS_BY_TYPE} for the event's
+ *    `type`. An event whose `type` is not in the map has already been refused
+ *    by `parseAguiFrame`; if it somehow reaches here it is reported as
+ *    `events[i]` with no key.
+ *
+ * Returns the dotted path of the first unknown property found, e.g.
+ * `"recovery"` for a frame-level extra or `"events[0].leaked"` for an
+ * event-level extra. The caller turns this into a named verdict.
+ */
+export function extraPropertyPath(part: Record<string, unknown>): string | undefined {
+  // Frame-level extra keys.
+  for (const key of Object.keys(part)) {
+    if (!KNOWN_FRAME_KEYS.has(key)) return key;
+  }
+  // Per-event extra keys.
+  const events = part.events;
+  if (!Array.isArray(events)) return undefined; // parseAguiFrame already validated
+  for (let i = 0; i < events.length; i++) {
+    const e = events[i] as Record<string, unknown> | null;
+    if (typeof e !== "object" || e === null) continue; // parseAguiFrame already validated
+    const t = e.type as string;
+    const allowed = KNOWN_EVENT_KEYS_BY_TYPE.get(t);
+    if (!allowed) return `events[${i}]`; // unknown type
+    for (const key of Object.keys(e)) {
+      if (!allowed.has(key)) return `events[${i}].${key}`;
+    }
+  }
+  return undefined;
+}
+
 export function isForbiddenEgressEventType(type: unknown): boolean {
   return typeof type === "string" && EGRESS_FORBIDDEN_TYPES.has(type);
 }
@@ -1281,7 +1359,7 @@ export function applyAguiEgressPolicy(events: readonly AguiEvent[]): AguiEvent[]
 }
 
 /** What a frozen body is, as far as the egress policy can tell. */
-export type FrozenBodyEgressVerdict = "clean" | "forbidden-kind" | "unreadable";
+export type FrozenBodyEgressVerdict = "clean" | "forbidden-kind" | "unreadable" | "extra-property";
 
 /**
  * Classify a frozen body for egress. Used on retry, where the body is already on disk and must not
@@ -1355,6 +1433,11 @@ export function frozenBodyEgressVerdict(body: readonly unknown[]): FrozenBodyEgr
         for (const e of frame.events) {
           if (isForbiddenEgressEventType((e as { type?: unknown }).type)) return "forbidden-kind";
         }
+        // Closed-schema check: refuse any property not in the known set.
+        // This is the fix for #1432: the fence previously checked only
+        // .events[].type and let sibling/extra properties ride through.
+        const extra = extraPropertyPath(part as Record<string, unknown>);
+        if (extra !== undefined) return "extra-property";
       } catch {
         unreadable = true;
       }
@@ -1873,6 +1956,26 @@ export class AguiEmitter<T> {
           `something else. Clear the pending frame only as an explicit abandonment of this epoch.`,
       );
     }
+    if (egress === "extra-property") {
+      // Re-scan to name the path. This is the error path; the cost is negligible.
+      let path = "(unknown)";
+      for (const part of o.body) {
+        if (!isAguiFramePart(part)) continue;
+        const p = extraPropertyPath(part as Record<string, unknown>);
+        if (p !== undefined) { path = p; break; }
+      }
+      throw this.halt(
+        "egress-extra-property",
+        `event emitter for ${this.channel}: refusing to ${o.retry ? "republish a frozen" : "publish a"} ` +
+          `frame whose body carries an unknown property at \`${path}\` onto ${this.channel}. ` +
+          `The egress fence validates the whole envelope against a closed schema: known top-level ` +
+          `frame keys (kind, protocol, threadId, runId, epoch, seq, events) and known per-event ` +
+          `keys per type. A property outside that schema could carry tool output or other content ` +
+          `that bypasses the event-kind check. The body is not rewritten: the WAL froze it at ` +
+          `beginSend, and mutating it between disk and wire would break the recovery machine. ` +
+          `Clear the pending frame only as an explicit abandonment of this epoch.`,
+      );
+    }
     let ack: { seq: number; duplicate: boolean };
     try {
       ({ ack } = await this.ep.multicastExpecting({
@@ -1967,7 +2070,7 @@ export class AguiEmitter<T> {
     );
   }
 
-  private halt(reason: "duplicate-ack" | "cas-loss" | "egress-policy" | "egress-unreadable", message: string): AguiEmitterHalted {
+  private halt(reason: "duplicate-ack" | "cas-loss" | "egress-policy" | "egress-unreadable" | "egress-extra-property", message: string): AguiEmitterHalted {
     this.halted = new AguiEmitterHalted(reason, message);
     return this.halted;
   }

--- a/package.json
+++ b/package.json
@@ -378,6 +378,7 @@
     "smoke:spawn-env-e2e": "tsx bin/smoke/spawn-env-e2e.smoke.ts",
     "smoke:agui-emitter": "tsx extensions/connector-core/smoke/agui-emitter.smoke.ts",
     "smoke:agui-tool-result": "tsx extensions/connector-core/smoke/agui-tool-result.smoke.ts",
+    "smoke:agui-egress-closed-schema": "tsx extensions/connector-core/smoke/agui-egress-closed-schema.smoke.ts",
     "smoke:egress-guard-differential": "tsx extensions/connector-core/smoke/egress-guard-differential.smoke.ts",
     "smoke:agui-retry-duplicate": "tsx extensions/connector-core/smoke/agui-retry-duplicate.smoke.ts",
     "smoke:agui-holder": "tsx extensions/connector-core/smoke/agui-holder.smoke.ts",


### PR DESCRIPTION
## Mechanism

The AG-UI egress fence validated only `.events[].type`, answering "does this frame carry a forbidden event type" but not "does this frame carry tool output anywhere." A well-formed envelope with tool bytes on a sibling property of the event, on an unknown top-level property, or nested inside an allowed event's unknown field passed the fence and published with the bytes intact.

## What now happens

The fence validates the whole egress envelope against a closed schema:

- **Frame level**: only known keys (`kind`, `protocol`, `threadId`, `runId`, `epoch`, `seq`, `events`) are allowed. Any extra property is refused.
- **Event level**: each event is checked against the known keys for its `type` (sourced from the AG-UI 0.0.57 schemas), plus the `cotal` extension key. Any extra property is refused.

An envelope with an unknown or extra property at either level receives a new `extra-property` verdict from `frozenBodyEgressVerdict`, which names the path of the offending property. `AguiEmitter.attempt()` halts with reason `egress-extra-property` and never forwards a refused envelope.

Well-formed envelopes (including those with `cotal` metadata, `rawEvent`, optional schema keys like `outcome` and `parentRunId`, and JSON-round-tripped WAL recovery frames) continue to pass.

Refs #1432