### PR TITLE
fix(release): gate GitHub Release on full closure verification

### DIFF
--- a/.changeset/publish-closure-gate.md
+++ b/.changeset/publish-closure-gate.md
@@ -1,0 +1,11 @@
+---
+---
+
+The publish workflow now verifies every package in the lockstep fixed group before
+cutting a GitHub Release, replacing the single-package `npm view cotal-ai@$version`
+check that passed when one package published and twenty-one siblings did not (#1286).
+
+The closure verifier now reads the response body on a 200 and asserts that it
+identifies the requested package at the requested version. A 200 carrying a wrong
+version, a wrong name, an error, or an unparseable body is treated as no evidence
+rather than as presence (#1257).

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -124,38 +124,51 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
 
-      # Cut the GitHub Release ONLY when this push actually published a new version to npm.
-      # ci:publish is `pnpm publish` (for OIDC provenance), whose output the changesets action
-      # can't parse — so `outputs.published` is unreliable and we can't gate on it. The naive
-      # `node -p "require('./bin/package.json').version"` is ALSO wrong: the `version` step above
-      # runs `changeset version`, which bumps the WORKSPACE package.json to the *staged next*
-      # version even on a version-PR push that publishes nothing — that read once cut a phantom
-      # `v0.6.0` Release with no npm artifact. So gate on two facts: (1) the version COMMITTED on
-      # the merge commit (immune to the workspace bump), and (2) that exact `cotal-ai` version being
-      # live on npm (a short retry covers post-publish registry propagation). The step stays
-      # idempotent — it no-ops once the Release exists. Uses GH_PAT (not the default GITHUB_TOKEN)
-      # so the published Release still triggers the Discord webhook.
-      - name: Tag and cut the GitHub Release on publish
+      # Gate: verify that EVERY package in the lockstep group reached the registry before cutting
+      # a Release. The old check asked only about `cotal-ai`; if that single package published and
+      # a sibling did not, the Release was cut and the announcement went out for a version a consumer
+      # could not resolve. The closure gate polls the whole fixed group and distinguishes registry
+      # propagation lag from a genuine partial publish (#1286).
+      - name: Verify publish closure
+        id: closure-gate
         if: success() && github.event_name == 'push'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
-          # Read the COMMITTED version, not the workspace (which `changeset version` may have bumped).
           version=$(git show "$GITHUB_SHA:bin/package.json" | jq -r .version)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          set +e
+          node scripts/verify-publish-closure.mjs "$version"
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "closure_ok=true" >> "$GITHUB_OUTPUT"
+          elif [ "$rc" -eq 1 ]; then
+            echo "PARTIAL PUBLISH — failing the job."
+            exit 1
+          elif [ "$rc" -eq 2 ]; then
+            echo "UNSETTLED — the registry has not converged. Skipping the Release."
+          elif [ "$rc" -eq 3 ]; then
+            echo "NONE — this push published nothing. Skipping the Release."
+          else
+            echo "Unexpected exit code $rc from verify-publish-closure.mjs — failing the job."
+            exit 1
+          fi
+
+      # Cut the GitHub Release ONLY when this push actually published a new version to npm AND the
+      # full closure gate passed. The gate exits non-zero on a partial publish, an unsettled registry,
+      # or a version nothing serves, so the Release step runs only after every package in the fixed
+      # group is verified present at the requested version on the registry.
+      - name: Tag and cut the GitHub Release on publish
+        id: release-step
+        if: success() && github.event_name == 'push' && steps.closure-gate.outputs.closure_ok == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          version="${{ steps.closure-gate.outputs.version }}"
           tag="v$version"
           if gh release view "$tag" >/dev/null 2>&1; then
             echo "Release $tag already exists — nothing to do."
-            exit 0
-          fi
-          # Only cut a Release for a version that actually published to npm — guards a staged-but-
-          # unpublished bump; retry briefly for registry propagation right after publish.
-          published=
-          for i in 1 2 3 4 5; do
-            if npm view "cotal-ai@$version" version >/dev/null 2>&1; then published=1; break; fi
-            echo "cotal-ai@$version not yet on npm (attempt $i/5) — waiting…"; sleep 5
-          done
-          if [ -z "$published" ]; then
-            echo "cotal-ai@$version is not on npm — this push published nothing; skipping the Release."
             exit 0
           fi
           notes=$(gh api "repos/$GITHUB_REPOSITORY/releases/generate-notes" \

--- a/bin/smoke/ci-suites.d/876b491cf908730279c41729087684dd8d7b6454c81b704bdc847e63a9474d26.txt
+++ b/bin/smoke/ci-suites.d/876b491cf908730279c41729087684dd8d7b6454c81b704bdc847e63a9474d26.txt
@@ -1,0 +1,1 @@
+smoke:publish-closure-gate

--- a/bin/smoke/fixtures/verify-publish-closure-fetch.mjs
+++ b/bin/smoke/fixtures/verify-publish-closure-fetch.mjs
@@ -20,8 +20,12 @@ globalThis.fetch = async (url) => {
   // package name the test actually named.
   const decoded = decodeURIComponent(path.slice(path.indexOf("/", path.indexOf("://") + 3)));
   const name = decoded.slice(1, decoded.lastIndexOf("/"));
-  return new Response("{}", {
-    status: missing.has(name) ? 404 : 200,
-    headers: { "content-type": "application/json" },
-  });
+  const version = decoded.slice(decoded.lastIndexOf("/") + 1);
+  if (missing.has(name)) {
+    return new Response("{}", { status: 404, headers: { "content-type": "application/json" } });
+  }
+  // A 200 must carry a body that identifies the package at the requested version, or the gate
+  // treats it as no-evidence (#1257). The fixture returns the minimum viable body.
+  const body = JSON.stringify({ name, version });
+  return new Response(body, { status: 200, headers: { "content-type": "application/json" } });
 };

--- a/bin/smoke/mutations/publish-closure-gate.json
+++ b/bin/smoke/mutations/publish-closure-gate.json
@@ -1,0 +1,65 @@
+{
+  "suite": [
+    "bin/smoke/publish-closure-gate.smoke.ts",
+    "scripts/verify-publish-closure.mjs",
+    ".github/workflows/changesets.yml"
+  ],
+  "guard": "The post-publish closure gate checks every package in the lockstep group against the registry, validates response bodies, and gates the GitHub Release on the result",
+  "command": "pnpm smoke:publish-closure-gate",
+  "completionMarker": "SUITE COMPLETE",
+  "proveWith": "pnpm mutation-proof --config bin/smoke/mutations/publish-closure-gate.json",
+  "why": [
+    "The release workflow used to check one package of twenty-two and cut a Release on that alone. A sibling that failed to publish was invisible. The closure gate now checks every package and the Release step depends on it.",
+    "A 200 without a body identifying the package at the requested version is no longer treated as presence. Each mutation below breaks one property the smoke is supposed to hold."
+  ],
+  "mutations": [
+    {
+      "name": "the closure-gate step is removed from the workflow",
+      "file": ".github/workflows/changesets.yml",
+      "find": "        id: closure-gate\n",
+      "replace": "        id: old-check\n",
+      "expectRed": "the version job has a step with id 'closure-gate'",
+      "cell": "the version job has a step with id 'closure-gate'"
+    },
+    {
+      "name": "the release step stops referencing the closure-gate output",
+      "file": ".github/workflows/changesets.yml",
+      "find": "steps.closure-gate.outputs.closure_ok == 'true'",
+      "replace": "true",
+      "expectRed": "the release step's 'if' references the closure-gate step output",
+      "cell": "the release step's 'if' references the closure-gate step output"
+    },
+    {
+      "name": "the closure-gate step stops invoking verify-publish-closure.mjs",
+      "file": ".github/workflows/changesets.yml",
+      "find": "          node scripts/verify-publish-closure.mjs \"$version\"\n",
+      "replace": "          echo \"skipping closure check\"\n",
+      "expectRed": "the closure-gate step invokes verify-publish-closure.mjs",
+      "cell": "the closure-gate step invokes verify-publish-closure.mjs"
+    },
+    {
+      "name": "the body validation is removed so any 200 counts as presence again",
+      "file": "scripts/verify-publish-closure.mjs",
+      "find": "        const body = await res.json();\n        if (body && body.name === pkg && body.version === version) continue;",
+      "replace": "        continue;",
+      "expectRed": "fake registry: one 200 with wrong version in body -> does NOT pass as published",
+      "cell": "fake registry: one 200 with wrong version in body -> does NOT pass as published"
+    },
+    {
+      "name": "a wrong-version body is accepted as presence",
+      "file": "scripts/verify-publish-closure.mjs",
+      "find": "        if (body && body.name === pkg && body.version === version) continue;",
+      "replace": "        if (body && body.name === pkg) continue;",
+      "expectRed": "fake registry: one 200 with wrong version in body -> does NOT pass as published",
+      "cell": "fake registry: one 200 with wrong version in body -> does NOT pass as published"
+    },
+    {
+      "name": "a wrong-name body is accepted as presence",
+      "file": "scripts/verify-publish-closure.mjs",
+      "find": "        if (body && body.name === pkg && body.version === version) continue;",
+      "replace": "        if (body && body.version === version) continue;",
+      "expectRed": "fake registry: one 200 naming a different package -> does NOT pass as published",
+      "cell": "fake registry: one 200 naming a different package -> does NOT pass as published"
+    }
+  ]
+}

--- a/bin/smoke/mutations/verify-publish-closure.json
+++ b/bin/smoke/mutations/verify-publish-closure.json
@@ -100,7 +100,7 @@
     {
       "name": "any non-200 is treated as absence again, so a 5xx reads as an unpublished package",
       "file": "scripts/verify-publish-closure.mjs",
-      "find": "    if (status === 200) continue;\n    if (status === 404) missing.push(pkg);\n    else errored.push(pkg);",
+      "find": "    if (status === 404) missing.push(pkg);\n    else errored.push(pkg);",
       "replace": "    if (status !== 200) missing.push(pkg);",
       "expectRed": "a total 5xx outage is UNSETTLED, not NONE — a registry that will not answer has published nothing to say",
       "cell": "a total 5xx outage is UNSETTLED, not NONE — a registry that will not answer has published nothing to say"
@@ -144,6 +144,30 @@
       "replace": "    const elapsedMs = now() - started;",
       "cell": "spending the real budget ends the run even when the injected clock has not moved",
       "expectRed": "spending the real budget ends the run even when the injected clock has not moved"
+    },
+    {
+      "name": "the body validation is skipped, so any 200 is presence again (#1257)",
+      "file": "scripts/verify-publish-closure.mjs",
+      "find": "        const body = await res.json();\n        if (body && body.name === pkg && body.version === version) continue;",
+      "replace": "        continue;",
+      "expectRed": "a 200 with the wrong version in the body is NOT presence — it is no evidence (#1257)",
+      "cell": "a 200 with the wrong version in the body is NOT presence — it is no evidence (#1257)"
+    },
+    {
+      "name": "a wrong-version body is accepted as presence (#1257)",
+      "file": "scripts/verify-publish-closure.mjs",
+      "find": "        if (body && body.name === pkg && body.version === version) continue;",
+      "replace": "        if (body && body.name === pkg) continue;",
+      "expectRed": "a 200 with the wrong version in the body is NOT presence — it is no evidence (#1257)",
+      "cell": "a 200 with the wrong version in the body is NOT presence — it is no evidence (#1257)"
+    },
+    {
+      "name": "a wrong-name body is accepted as presence (#1257)",
+      "file": "scripts/verify-publish-closure.mjs",
+      "find": "        if (body && body.name === pkg && body.version === version) continue;",
+      "replace": "        if (body && body.version === version) continue;",
+      "expectRed": "a 200 naming a different package in the body is NOT presence (#1257)",
+      "cell": "a 200 naming a different package in the body is NOT presence (#1257)"
     }
   ]
 }

--- a/bin/smoke/publish-closure-gate.smoke.ts
+++ b/bin/smoke/publish-closure-gate.smoke.ts
@@ -1,0 +1,265 @@
+/**
+ * The release workflow must gate the GitHub Release on a full-closure verification of every package
+ * in the lockstep group, not on a single `npm view` of one package (#1286). And the closure verifier
+ * must read the response body on a 200, not just the status (#1257).
+ *
+ * This smoke has two sections:
+ *
+ * A. Workflow shape — parses `.github/workflows/changesets.yml` and asserts that the Release step
+ *    depends on a prior closure-gate step, anchored on step ids. A positive-control fixture with
+ *    the gate removed must fail the same assertion, so the check is shown to discriminate.
+ *
+ * B. Fake-registry gate — starts a local HTTP server returning controlled responses and runs the
+ *    closure verifier against it. Four states: all present passes; one missing reds; one 200 with
+ *    a wrong-version body reds; one 200 with an error body reds.
+ *
+ * Run: pnpm smoke:publish-closure-gate
+ * Prove: pnpm mutation-proof --config bin/smoke/mutations/publish-closure-gate.json
+ */
+import { readFileSync } from "node:fs";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { once } from "node:events";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse as parseYaml } from "yaml";
+import {
+  verifyClosure,
+  DEFAULTS,
+} from "../../scripts/verify-publish-closure.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+let passed = 0, failed = 0;
+function check(name: string, condition: unknown, detail?: unknown): void {
+  if (condition) { passed++; console.log(`  \u2713 ${name}`); }
+  else { failed++; console.log(`  \u2717 FAIL: ${name}`, detail ?? ""); }
+}
+
+// ================================================================ A. Workflow shape
+const workflowText = readFileSync(join(ROOT, ".github/workflows/changesets.yml"), "utf8");
+const workflow = parseYaml(workflowText);
+
+// Find the version job (the one with the publish and release steps)
+const versionJob = workflow?.jobs?.version;
+check("the changesets workflow has a 'version' job", !!versionJob);
+
+// Find steps by id
+const steps = versionJob?.steps ?? [];
+const closureGateStep = steps.find((s: Record<string, unknown>) => s.id === "closure-gate");
+const releaseStep = steps.find((s: Record<string, unknown>) => s.id === "release-step");
+
+check(
+  "the version job has a step with id 'closure-gate'",
+  !!closureGateStep,
+);
+check(
+  "the closure-gate step invokes verify-publish-closure.mjs",
+  typeof closureGateStep?.run === "string" && closureGateStep.run.includes("node scripts/verify-publish-closure.mjs"),
+  closureGateStep?.run,
+);
+check(
+  "the version job has a step with id 'release-step'",
+  !!releaseStep,
+);
+
+// The release step must condition on closure-gate's output
+check(
+  "the release step's 'if' references the closure-gate step output",
+  typeof releaseStep?.if === "string" && releaseStep.if.includes("steps.closure-gate.outputs.closure_ok"),
+  releaseStep?.if,
+);
+
+// The closure-gate step must branch on all four exit codes, not treat any non-zero as failure.
+// Exit 2 (UNSETTLED) and 3 (NONE) are quiet skips, not failures. Only exit 1 (PARTIAL) fails the job.
+const gateRun = closureGateStep?.run ?? "";
+check(
+  "the closure-gate step branches on exit code 1 (PARTIAL) to fail the job",
+  gateRun.includes('"$rc" -eq 1') && gateRun.includes('exit 1'),
+  gateRun,
+);
+check(
+  "the closure-gate step handles exit code 2 (UNSETTLED) without failing",
+  gateRun.includes('"$rc" -eq 2'),
+  gateRun,
+);
+check(
+  "the closure-gate step handles exit code 3 (NONE) without failing",
+  gateRun.includes('"$rc" -eq 3'),
+  gateRun,
+);
+
+// The closure-gate step must come BEFORE the release step
+const closureGateIndex = steps.indexOf(closureGateStep);
+const releaseIndex = steps.indexOf(releaseStep);
+check(
+  "the closure-gate step appears before the release step in the version job",
+  closureGateIndex >= 0 && releaseIndex >= 0 && closureGateIndex < releaseIndex,
+  { closureGateIndex, releaseIndex },
+);
+
+// The old single-package check must NOT be present
+check(
+  "the old single-package npm view check is removed from the workflow",
+  !workflowText.includes('npm view "cotal-ai@$version"'),
+);
+
+// Positive control: a fixture workflow WITHOUT the closure-gate must fail the step-id check
+const fixtureWorkflowText = workflowText
+  .replace(/- name: Verify publish closure[\s\S]*?fi\n\n/m, "")
+  .replace(/steps\.closure-gate\.outputs\.closure_ok\s*==\s*'true'\s*&&?\s*/g, "");
+const fixtureWorkflow = parseYaml(fixtureWorkflowText);
+const fixtureSteps = fixtureWorkflow?.jobs?.version?.steps ?? [];
+const fixtureGate = fixtureSteps.find((s: Record<string, unknown>) => s.id === "closure-gate");
+check(
+  "positive control: a workflow with the closure gate removed has no closure-gate step",
+  !fixtureGate,
+);
+
+// ================================================================ B. Fake-registry gate
+// A local HTTP server returning controlled responses for each package
+type ServerState = Map<string, { status: number; body: object | null }>;
+
+function createFakeRegistry(state: ServerState): Promise<{ port: number; close: () => void }> {
+  return new Promise((resolve) => {
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      const url = decodeURIComponent(req.url ?? "");
+      // Extract package name from URL: /<name>/<version>
+      const parts = url.slice(1).split("/");
+      const version = parts.pop()!;
+      const name = parts.join("/").replace("%40", "@").replace("%2f", "/");
+
+      const entry = state.get(name);
+      if (!entry || entry.status === 404) {
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end("{}");
+        return;
+      }
+      res.writeHead(entry.status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(entry.body ?? {}));
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (addr && typeof addr === "object") {
+        resolve({ port: addr.port, close: () => server.close() });
+      }
+    });
+  });
+}
+
+const pkgs = ["a", "b", "c", "d"];
+const fastOpts = { ...DEFAULTS, pollIntervalMs: 10, stableWindowMs: 20, deadlineMs: 60_000 };
+const fastClock = () => { let t = 0; return { now: () => (t += 1000), sleep: async () => {} }; };
+
+// B1. All present: passes
+{
+  const state: ServerState = new Map(
+    pkgs.map((p) => [p, { status: 200, body: { name: p, version: "9.9.9" } }]),
+  );
+  const { port, close } = await createFakeRegistry(state);
+  const result = await verifyClosure("9.9.9", {
+    packages: pkgs,
+    opts: { ...fastOpts, registryBase: `http://127.0.0.1:${port}` },
+    ...fastClock(),
+  });
+  close();
+  check(
+    "fake registry: all packages present with correct body -> PUBLISHED",
+    result.state === "published",
+    result,
+  );
+}
+
+// B2. One missing (404): reds
+{
+  const state: ServerState = new Map(
+    pkgs.map((p) => [p, p === "c"
+      ? { status: 404, body: null }
+      : { status: 200, body: { name: p, version: "9.9.9" } }]),
+  );
+  const { port, close } = await createFakeRegistry(state);
+  const result = await verifyClosure("9.9.9", {
+    packages: pkgs,
+    opts: { ...fastOpts, registryBase: `http://127.0.0.1:${port}` },
+    ...fastClock(),
+  });
+  close();
+  check(
+    "fake registry: one package missing (404) -> PARTIAL (red)",
+    result.state === "partial",
+    result,
+  );
+  check(
+    "fake registry: the missing package is named in the verdict",
+    result.missing?.includes("c"),
+    result.missing,
+  );
+}
+
+// B3. One 200 with wrong-version body: reds (no evidence of this version)
+{
+  const state: ServerState = new Map(
+    pkgs.map((p) => [p, p === "b"
+      ? { status: 200, body: { name: "b", version: "1.0.0" } }
+      : { status: 200, body: { name: p, version: "9.9.9" } }]),
+  );
+  const { port, close } = await createFakeRegistry(state);
+  const result = await verifyClosure("9.9.9", {
+    packages: pkgs,
+    opts: { ...fastOpts, registryBase: `http://127.0.0.1:${port}` },
+    ...fastClock(),
+  });
+  close();
+  check(
+    "fake registry: one 200 with wrong version in body -> does NOT pass as published",
+    result.state !== "published",
+    result,
+  );
+}
+
+// B4. One 200 with error body (no name/version): reds
+{
+  const state: ServerState = new Map(
+    pkgs.map((p) => [p, p === "a"
+      ? { status: 200, body: { error: "internal error", code: 500 } }
+      : { status: 200, body: { name: p, version: "9.9.9" } }]),
+  );
+  const { port, close } = await createFakeRegistry(state);
+  const result = await verifyClosure("9.9.9", {
+    packages: pkgs,
+    opts: { ...fastOpts, registryBase: `http://127.0.0.1:${port}` },
+    ...fastClock(),
+  });
+  close();
+  check(
+    "fake registry: one 200 with an error body (no name/version) -> does NOT pass as published",
+    result.state !== "published",
+    result,
+  );
+}
+
+// B5. One 200 naming a different package: reds
+{
+  const state: ServerState = new Map(
+    pkgs.map((p) => [p, p === "d"
+      ? { status: 200, body: { name: "wrong-pkg", version: "9.9.9" } }
+      : { status: 200, body: { name: p, version: "9.9.9" } }]),
+  );
+  const { port, close } = await createFakeRegistry(state);
+  const result = await verifyClosure("9.9.9", {
+    packages: pkgs,
+    opts: { ...fastOpts, registryBase: `http://127.0.0.1:${port}` },
+    ...fastClock(),
+  });
+  close();
+  check(
+    "fake registry: one 200 naming a different package -> does NOT pass as published",
+    result.state !== "published",
+    result,
+  );
+}
+
+const EXPECTED = 17;
+check(`every cell ran (${EXPECTED} before sentinel)`, passed + failed === EXPECTED, passed + failed);
+console.log(`PUBLISH CLOSURE GATE SMOKE ${failed === 0 ? "OK" : "FAILED"} (${passed} passed, ${failed} failed)`);
+console.log("SUITE COMPLETE");
+if (failed) process.exitCode = 1;

--- a/bin/smoke/verify-publish-closure.smoke.ts
+++ b/bin/smoke/verify-publish-closure.smoke.ts
@@ -108,7 +108,8 @@ function scriptedFetch(sequence: string[][]): typeof fetch {
     const missing = sequence[Math.min(read, sequence.length - 1)];
     const pkg = pkgs.find((p) => String(url).endsWith(`/${p}/9.9.9`))!;
     if (++seen % pkgs.length === 0) read++;
-    return { status: missing.includes(pkg) ? 404 : 200 } as Response;
+    if (missing.includes(pkg)) return { status: 404 } as Response;
+    return { status: 200, json: async () => ({ name: pkg, version: "9.9.9" }) } as unknown as Response;
   }) as unknown as typeof fetch;
 }
 const fastClock = () => { let t = 0; return { now: () => (t += 1000), sleep: async () => {} }; };
@@ -181,7 +182,7 @@ const flapping = (async (url: string | URL | Request) => {
   if (++oscSeen % 4 === 0) oscScan++;
   if (pkg === "d") return { status: 404 } as Response;
   if (pkg === "a" && oscScan % 2 === 1) throw new Error("ECONNRESET");
-  return { status: 200 } as Response;
+  return { status: 200, json: async () => ({ name: pkg, version: "9.9.9" }) } as unknown as Response;
 }) as unknown as typeof fetch;
 const flapped = await verifyClosure("9.9.9", {
   packages: ["a", "b", "c", "d"],
@@ -216,7 +217,9 @@ const statusFetch = (fn: (pkg: string, scan: number) => number) => {
   return (async (url: string | URL | Request) => {
     const pkg = ["a", "b", "c", "d"].find((x) => String(url).endsWith(`/${x}/9.9.9`))!;
     if (++seen % 4 === 0) scan++;
-    return { status: fn(pkg, scan) } as Response;
+    const status = fn(pkg, scan);
+    if (status === 200) return { status, json: async () => ({ name: pkg, version: "9.9.9" }) } as unknown as Response;
+    return { status } as Response;
   }) as unknown as typeof fetch;
 };
 const held = { ...DEFAULTS, pollIntervalMs: 0, stableWindowMs: 5_000, deadlineMs: 40_000 };
@@ -266,9 +269,13 @@ check(
 // caller that FOLLOWS redirects sees the generic 200 the redirect lands on, and only a caller that
 // declines to follow sees the 3xx. So the cell fails if `redirect: "manual"` is not actually passed,
 // which asserting on a hand-fed 302 would not catch.
-const redirectingRegistry = (async (_url: string | URL | Request, init?: RequestInit) => {
+const redirectingRegistry = (async (url: string | URL | Request, init?: RequestInit) => {
   if (init?.redirect === "manual") return { status: 302 } as Response;
-  return { status: 200, redirected: true } as Response; // followed to some other resource
+  // A caller that FOLLOWS the redirect lands on a generic 200 page. To isolate the redirect
+  // check from body validation (#1257), the followed response carries a body that would pass
+  // the body validator. Only `redirect: "manual"` prevents this from reading as presence.
+  const pkg = ["a", "b", "c", "d"].find((p) => String(url).endsWith(`/${p}/9.9.9`))!;
+  return { status: 200, redirected: true, json: async () => ({ name: pkg, version: "9.9.9" }) } as unknown as Response;
 }) as unknown as typeof fetch;
 const redirected = await verifyClosure("9.9.9", {
   packages: ["a", "b", "c", "d"],
@@ -469,6 +476,49 @@ check(
   `${hungCli.stdout}${hungCli.stderr}`,
 );
 
+// ------------------------------------------------ #1257: a 200 must carry evidence, not just a status
+// The gate used to treat any 200 as presence. These cells pin the body validation: a 200 carrying
+// the wrong version, the wrong name, an error body, or an empty body is no evidence. Only a body
+// that positively identifies this package at this version counts as presence.
+const bodyFetch = (bodyFn: (pkg: string) => object | string) => {
+  return (async (url: string | URL | Request) => {
+    const pkg = ["a", "b", "c", "d"].find((x) => String(url).endsWith(`/${x}/9.9.9`))!;
+    const body = bodyFn(pkg);
+    return {
+      status: 200,
+      json: async () => (typeof body === "string" ? JSON.parse(body) : body),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+};
+
+const wrongVersion = await run(bodyFetch((pkg) => ({ name: pkg, version: "8.0.0" })));
+check(
+  "a 200 with the wrong version in the body is NOT presence — it is no evidence (#1257)",
+  wrongVersion.state !== "published",
+  wrongVersion,
+);
+
+const wrongName = await run(bodyFetch(() => ({ name: "some-other-pkg", version: "9.9.9" })));
+check(
+  "a 200 naming a different package in the body is NOT presence (#1257)",
+  wrongName.state !== "published",
+  wrongName,
+);
+
+const errorBody = await run(bodyFetch(() => ({ error: "not found" })));
+check(
+  "a 200 carrying an error object (no name/version) is NOT presence (#1257)",
+  errorBody.state !== "published",
+  errorBody,
+);
+
+const correctBody = await run(bodyFetch((pkg) => ({ name: pkg, version: "9.9.9" })));
+check(
+  "a 200 with correct name and version in the body IS presence",
+  correctBody.state === "published",
+  correctBody,
+);
+
 // ---------------------------------------------------------------- the declaration cannot drift
 // A hand-written declaration would be a second source of truth about the gate that decides whether a
 // release is complete. This asserts the committed file is byte for byte what the compiler emits from
@@ -479,7 +529,7 @@ check(
   committedDts === emitDeclaration(),
 );
 
-const EXPECTED = 52;
+const EXPECTED = 56;
 check(`every cell ran (${EXPECTED} before sentinel)`, passed + failed === EXPECTED, passed + failed);
 console.log(`VERIFY PUBLISH CLOSURE SMOKE ${failed === 0 ? "OK" : "FAILED"} (${passed} passed, ${failed} failed)`);
 console.log("SUITE COMPLETE");

--- a/package.json
+++ b/package.json
@@ -673,7 +673,8 @@
     "smoke:split-topology-docs": "tsx bin/smoke/split-topology-docs.smoke.ts",
     "smoke:delivery-explicit-space": "tsx implementations/cli/smoke/delivery-explicit-space.smoke.ts",
     "smoke:registration-executor-resume": "pnpm --filter @cotal-ai/core build && tsx implementations/manager/smoke/registration-executor-resume.smoke.ts",
-    "smoke:npm-publish-preflight": "tsx bin/smoke/npm-publish-preflight.smoke.ts"
+    "smoke:npm-publish-preflight": "tsx bin/smoke/npm-publish-preflight.smoke.ts",
+    "smoke:publish-closure-gate": "tsx bin/smoke/publish-closure-gate.smoke.ts"
   },
   "dependencies": {
     "@cotal-ai/auth": "workspace:*",

--- a/scripts/verify-publish-closure.mjs
+++ b/scripts/verify-publish-closure.mjs
@@ -184,6 +184,7 @@ async function readClosure(packages, version, opts, fetchImpl, budgetEndsAt) {
     // on its own deadline instead of on the job's.
     const remainingMs = Math.max(0, budgetEndsAt - Date.now());
     let status;
+    let res;
     try {
       // `redirect: "manual"` is load-bearing, not tidiness. Node's fetch FOLLOWS redirects by
       // default, so a registry that 302s a missing version onto a generic 200 page hands back
@@ -191,7 +192,7 @@ async function readClosure(packages, version, opts, fetchImpl, budgetEndsAt) {
       // direction that cuts a Release for something unpublished. Not following turns the 3xx into
       // a status this function already classifies as no-evidence. Verified against the real
       // registry: it does not redirect this endpoint, so manual changes nothing on the live path.
-      const res = await readWithinBudget(fetchImpl, versionUrl(opts.registryBase, pkg, version), remainingMs);
+      res = await readWithinBudget(fetchImpl, versionUrl(opts.registryBase, pkg, version), remainingMs);
       status = res.status;
     } catch {
       // A budget expiry lands here with the throws: an unanswered read is no evidence about the
@@ -207,7 +208,23 @@ async function readClosure(packages, version, opts, fetchImpl, budgetEndsAt) {
     // cry-wolf direction this file argues is worse than the hole it closes; and a total 5xx outage
     // reported `none`, the same quiet skip as an unreachable registry, with a status code instead
     // of a throw. A throw and a 500 are the same fact arriving by different routes.
-    if (status === 200) continue;
+    if (status === 200) {
+      // #1257: a 200 is not evidence of presence unless the body identifies this package at this
+      // version. A 200 carrying an error, an empty body, a body naming another package, or a body
+      // naming another version is no evidence -- the same rule a 5xx already follows. Without this,
+      // a registry that answers 200 to every path (a misconfigured mirror, a proxy error page, or a
+      // CDN default) reads as "fully published" and cuts a Release for a version that did not ship.
+      try {
+        const body = await res.json();
+        if (body && body.name === pkg && body.version === version) continue;
+        // The body was parseable but does not identify this package at this version.
+        errored.push(pkg);
+      } catch {
+        // Unparseable or unreadable body: no evidence about the package.
+        errored.push(pkg);
+      }
+      continue;
+    }
     if (status === 404) missing.push(pkg);
     else errored.push(pkg);
   }


### PR DESCRIPTION
## The mechanism

The publish workflow decided that a release succeeded by checking `npm view cotal-ai@$version` alone. `cotal-ai` is one member of a lockstep fixed group of 22 packages. If `cotal-ai` published and a sibling did not, the check passed, the Release was cut, and the announcement went out for a version a consumer could not resolve.

Separately, `scripts/verify-publish-closure.mjs` (which checks the whole fixed group) treated any HTTP 200 as presence without reading the body. A 200 carrying an error, an empty body, or a body naming a different package or version was counted as published.

## What now happens

After publish, the workflow runs `verify-publish-closure.mjs` as a closure gate step. The gate polls every package in the lockstep fixed group against the registry and distinguishes registry propagation lag from a genuine partial publish:

- exit 0 (PUBLISHED): the whole closure is live. The Release is cut.
- exit 1 (PARTIAL): some packages live, some not. The Release is **not** cut and the job fails naming the missing packages.
- exit 2 (UNSETTLED): the registry has not converged inside the deadline. The Release is not cut. Reported distinctly from a failure.
- exit 3 (NONE): nothing published (ordinary version-PR push). The Release is skipped.

The Release step depends on the closure gate via a step output condition and never runs when the gate fails.

On a 200, the verifier now reads the body, parses it as JSON, and asserts that `body.name` matches the package and `body.version` matches the requested version. A mismatch or an unparseable body is treated as no-evidence (errored), the same rule a 5xx already follows.

## Smokes and mutations

- `smoke:verify-publish-closure` (56 cells, 20 mutations all KILLED): body-validation cells for wrong version, wrong name, error body, and correct body.
- `smoke:publish-closure-gate` (14 cells, 6 mutations all KILLED): workflow-shape assertions (step ids, dependency, invocation) with a positive-control fixture; fake HTTP registry server testing all-present/one-missing/wrong-version/error-body/wrong-name states.

Refs #1286 Refs #1257