### PR TITLE
ci-suites-freeze committed-list cell reds when BASE/HEAD are unset

### DIFF
--- a/.changeset/ci-suites-freeze-inventory.md
+++ b/.changeset/ci-suites-freeze-inventory.md
@@ -1,0 +1,4 @@
+---
+---
+
+The ci-suites-freeze committed-list cell always runs. Missing BASE/HEAD reds that cell by name instead of shrinking the inventory to a false green.

--- a/bin/smoke/ci-suites-freeze-drop.smoke.ts
+++ b/bin/smoke/ci-suites-freeze-drop.smoke.ts
@@ -1,0 +1,58 @@
+/**
+ * The freeze suite's committed-list cell must redden by name when BASE and HEAD are absent.
+ * A green inventory that adapted to that absence is the defect in #1422.
+ *
+ * Run: pnpm smoke:ci-suites-freeze-drop
+ */
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const CELL = "the committed frozen list added no suite names versus base";
+
+let pass = 0;
+let fail = 0;
+const check = (name: string, cond: boolean, extra?: unknown) => {
+  if (cond) {
+    pass++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    fail++;
+    console.log(`  ✗ FAIL: ${name}`, extra ?? "");
+  }
+};
+
+const env = { ...process.env };
+delete env.BASE;
+delete env.HEAD;
+
+const ran = spawnSync("pnpm", ["smoke:ci-suites-freeze"], {
+  cwd: ROOT,
+  encoding: "utf8",
+  env,
+  timeout: 60_000,
+  maxBuffer: 2 * 1024 * 1024,
+});
+const out = `${ran.stdout ?? ""}${ran.stderr ?? ""}`;
+const named = out.includes(`FAIL: ${CELL}`);
+
+check(
+  "ci-suites-freeze is red when BASE and HEAD are unset",
+  ran.status !== 0 && !ran.error,
+  ran.error ? String(ran.error) : `status=${ran.status}`,
+);
+check(
+  "the red names the committed frozen-list cell",
+  named,
+  named ? undefined : out.slice(-800),
+);
+
+const EXPECTED = 2;
+check(
+  `every cell ran - ${EXPECTED} expected, so a cell that stops existing is not mistaken for one that passed`,
+  pass + fail === EXPECTED,
+  `${pass + fail} cells reported`,
+);
+
+console.log(`CI SUITES FREEZE DROP SMOKE ${fail === 0 ? "OK" : "FAILED"} (${pass} passed, ${fail} failed)`);
+if (fail) process.exitCode = 1;

--- a/bin/smoke/ci-suites-freeze-drop.smoke.ts
+++ b/bin/smoke/ci-suites-freeze-drop.smoke.ts
@@ -23,6 +23,7 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 };
 
 const env = { ...process.env };
+for (const key of Object.keys(env)) if (key.startsWith("COTAL_")) delete env[key];
 delete env.BASE;
 delete env.HEAD;
 

--- a/bin/smoke/ci-suites-freeze.smoke.ts
+++ b/bin/smoke/ci-suites-freeze.smoke.ts
@@ -8,6 +8,10 @@
  * appends a suite line onto the real file and asserts the SET of names the scan returns.
  * The required unit job reaches the same scan through `pnpm check:shard-stability`.
  *
+ * The committed-list cell always runs. BASE and HEAD select the two revisions. When they are
+ * absent the cell is red by name; it is not omitted, and the inventory count does not shrink to
+ * match the omission.
+ *
  * Run: pnpm smoke:ci-suites-freeze
  */
 import { execFileSync } from "node:child_process";
@@ -95,9 +99,17 @@ check(
   fragmentFileName("smoke:other") !== expectedFragment,
 );
 
+const COMMITTED_LIST_CELL = "the committed frozen list added no suite names versus base";
+const zero = "0000000000000000000000000000000000000000";
 const base = process.env.BASE;
 const head = process.env.HEAD;
-if (base && head) {
+if (!base || !head || base === zero || head === zero) {
+  check(
+    COMMITTED_LIST_CELL,
+    false,
+    "BASE and HEAD were unset, so the committed frozen list was not compared",
+  );
+} else {
   const show = (sha: string): string =>
     execFileSync("git", ["--no-replace-objects", "show", `${sha}:bin/smoke/ci-suites.txt`], {
       encoding: "utf8",
@@ -111,7 +123,7 @@ if (base && head) {
   }
   const offenders = Array.isArray(live) ? live : [];
   check(
-    "the committed frozen list added no suite names versus base",
+    COMMITTED_LIST_CELL,
     Array.isArray(live) && offenders.length === 0,
     Array.isArray(live)
       ? offenders.map((suite) => `${suite} -> bin/smoke/ci-suites.d/${fragmentFileName(suite)}`).join(", ")
@@ -119,7 +131,7 @@ if (base && head) {
   );
 }
 
-const EXPECTED = base && head ? 9 : 8;
+const EXPECTED = 9;
 check(
   `every cell ran - ${EXPECTED} expected, so a cell that stops existing is not mistaken for one that passed`,
   pass + fail === EXPECTED,

--- a/bin/smoke/ci-suites.d/2589c74bf4870c9d9a3ffb321865869baad69d1c696550ced7539a99550b4254.txt
+++ b/bin/smoke/ci-suites.d/2589c74bf4870c9d9a3ffb321865869baad69d1c696550ced7539a99550b4254.txt
@@ -1,0 +1,2 @@
+# Red when ci-suites-freeze drops the committed-list cell under unset BASE/HEAD.
+smoke:ci-suites-freeze-drop

--- a/bin/smoke/mutations/ci-suites-freeze.json
+++ b/bin/smoke/mutations/ci-suites-freeze.json
@@ -1,16 +1,19 @@
 {
   "suite": [
-    "bin/smoke/ci-suites-freeze.smoke.ts"
+    "bin/smoke/ci-suites-freeze.smoke.ts",
+    "bin/smoke/ci-suites-freeze-drop.smoke.ts"
   ],
-  "guard": "a new suite line on ci-suites.txt is named as an offender; comment edits and deletions are not",
-  "command": "pnpm smoke:ci-suites-freeze",
+  "guard": "a new suite line on ci-suites.txt is named as an offender; comment edits and deletions are not; dropping the committed-list cell under unset BASE/HEAD reds that cell by name",
+  "command": "BASE=$(git rev-parse HEAD~1) HEAD=$(git rev-parse HEAD) pnpm smoke:ci-suites-freeze",
   "completionMarker": "CI SUITES FREEZE SMOKE",
   "proveWith": "pnpm mutation-proof --config bin/smoke/mutations/ci-suites-freeze.json",
   "grades": "tool",
   "why": [
     "Issue #1237: the freeze on ci-suites.txt is a comment. A tail append is shard-stable and inventory-green, then conflicts the next PR on a line neither cares about. GitHub will not build a CONFLICTING PR, so that branch also gets zero CI.",
     "",
-    "The scan is addedLegacySuites in ci-suites.mjs. The suite calls that function on a real file plus an appended line and asserts the SET of names it returns. Blinding the scan must redden the append cell; re-applying the rule in the test would stay green."
+    "The scan is addedLegacySuites in ci-suites.mjs. The suite calls that function on a real file plus an appended line and asserts the SET of names it returns. Blinding the scan must redden the append cell; re-applying the rule in the test would stay green.",
+    "",
+    "Issue #1422: the committed-list cell used to exist only inside if (base && head), and EXPECTED was derived from that same predicate, so a local run without BASE/HEAD printed every-cell-ran and exited 0. Restoring that omission must redden the drop control. Passing the unset-env cell without comparing two revisions must do the same."
   ],
   "mutations": [
     {
@@ -20,6 +23,26 @@
       "replace": "    if (!base.has(suite) && !added.includes(suite)) void suite;",
       "expectRed": "an appended suite is named as the set of offenders",
       "cell": "an appended suite is named as the set of offenders"
+    },
+    {
+      "name": "the committed-list cell is omitted when BASE and HEAD are unset and the inventory shrinks to match",
+      "file": "bin/smoke/ci-suites-freeze.smoke.ts",
+      "find": "if (!base || !head || base === zero || head === zero) {\n  check(\n    COMMITTED_LIST_CELL,\n    false,\n    \"BASE and HEAD were unset, so the committed frozen list was not compared\",\n  );\n} else {\n  const show = (sha: string): string =>\n    execFileSync(\"git\", [\"--no-replace-objects\", \"show\", `${sha}:bin/smoke/ci-suites.txt`], {\n      encoding: \"utf8\",\n      stdio: [\"ignore\", \"pipe\", \"pipe\"],\n    });\n  let live: string[] | string;\n  try {\n    live = addedLegacySuites(show(base), show(head), `ci-suites.txt@${base}`, `ci-suites.txt@${head}`);\n  } catch (error) {\n    live = `THREW: ${(error as Error).message}`;\n  }\n  const offenders = Array.isArray(live) ? live : [];\n  check(\n    COMMITTED_LIST_CELL,\n    Array.isArray(live) && offenders.length === 0,\n    Array.isArray(live)\n      ? offenders.map((suite) => `${suite} -> bin/smoke/ci-suites.d/${fragmentFileName(suite)}`).join(\", \")\n      : live,\n  );\n}\n\nconst EXPECTED = 9;",
+      "replace": "if (base && head) {\n  const show = (sha: string): string =>\n    execFileSync(\"git\", [\"--no-replace-objects\", \"show\", `${sha}:bin/smoke/ci-suites.txt`], {\n      encoding: \"utf8\",\n      stdio: [\"ignore\", \"pipe\", \"pipe\"],\n    });\n  let live: string[] | string;\n  try {\n    live = addedLegacySuites(show(base), show(head), `ci-suites.txt@${base}`, `ci-suites.txt@${head}`);\n  } catch (error) {\n    live = `THREW: ${(error as Error).message}`;\n  }\n  const offenders = Array.isArray(live) ? live : [];\n  check(\n    COMMITTED_LIST_CELL,\n    Array.isArray(live) && offenders.length === 0,\n    Array.isArray(live)\n      ? offenders.map((suite) => `${suite} -> bin/smoke/ci-suites.d/${fragmentFileName(suite)}`).join(\", \")\n      : live,\n  );\n}\n\nconst EXPECTED = base && head ? 9 : 8;",
+      "command": "pnpm smoke:ci-suites-freeze-drop",
+      "completionMarker": "CI SUITES FREEZE DROP SMOKE",
+      "expectRed": "ci-suites-freeze is red when BASE and HEAD are unset",
+      "cell": "ci-suites-freeze is red when BASE and HEAD are unset"
+    },
+    {
+      "name": "the committed-list cell passes when BASE and HEAD are unset",
+      "file": "bin/smoke/ci-suites-freeze.smoke.ts",
+      "find": "    COMMITTED_LIST_CELL,\n    false,\n    \"BASE and HEAD were unset, so the committed frozen list was not compared\",",
+      "replace": "    COMMITTED_LIST_CELL,\n    true,\n    \"BASE and HEAD were unset, so the committed frozen list was not compared\",",
+      "command": "pnpm smoke:ci-suites-freeze-drop",
+      "completionMarker": "CI SUITES FREEZE DROP SMOKE",
+      "expectRed": "ci-suites-freeze is red when BASE and HEAD are unset",
+      "cell": "ci-suites-freeze is red when BASE and HEAD are unset"
     }
   ]
 }

--- a/bin/smoke/shard-stability.ts
+++ b/bin/smoke/shard-stability.ts
@@ -297,7 +297,7 @@ const verifierMatches = (sha: string): boolean => {
       stdio: ["ignore", "pipe", "pipe"],
     });
     const actual = createHash("sha256").update(source).digest("hex");
-    return actual === "e6f6302f1a432b2eebe170fecc7dbf712c2c7545d1893ba01524318df9213bc6";
+    return actual === "4206ff926c9ff74e2d1990e77a786808930c429915c06a407262233f43b0264c";
   } catch {
     return false;
   }

--- a/bin/smoke/verify-shard-inputs.sh
+++ b/bin/smoke/verify-shard-inputs.sh
@@ -106,6 +106,27 @@ workspace="$(/bin/pwd -P)"
 runner_user="${runner_home##*/}"
 clean_path="$pnpm_dir:$node_dir:$runner_home/nats-bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
+# env -i drops the Actions environment, including BASE/HEAD. The freeze smoke's
+# committed-list cell reds by name when those are absent, so the shard has to
+# re-supply the two revisions or CI reports a local-shaped false red.
+zero="0000000000000000000000000000000000000000"
+head_rev="${HEAD:-${GITHUB_SHA:-}}"
+base_rev="${BASE:-}"
+if [ -z "$base_rev" ] && [ -n "${GITHUB_EVENT_PATH:-}" ] && [ -f "${GITHUB_EVENT_PATH}" ]; then
+  base_rev="$("$node_bin" -e 'const fs=require("fs"); const e=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); process.stdout.write((e.pull_request&&e.pull_request.base&&e.pull_request.base.sha)||e.before||"");' "${GITHUB_EVENT_PATH}")"
+fi
+if [ -z "$head_rev" ]; then
+  head_rev="$(/usr/bin/git --no-replace-objects rev-parse HEAD)"
+fi
+if [ -z "$base_rev" ] || [ "$base_rev" = "$zero" ]; then
+  base_rev="$(/usr/bin/git --no-replace-objects rev-parse HEAD^ 2>/dev/null || true)"
+fi
+if [ -n "$base_rev" ] && [ "$base_rev" != "$zero" ]; then
+  if ! /usr/bin/git --no-replace-objects cat-file -e "${base_rev}^{commit}" 2>/dev/null; then
+    /usr/bin/git --no-replace-objects fetch --no-tags --depth=1 origin "$base_rev" || true
+  fi
+fi
+
 exec /usr/bin/env -i \
   PATH="$clean_path" \
   HOME="$runner_home" \
@@ -123,4 +144,6 @@ exec /usr/bin/env -i \
   RUNNER_TEMP=/tmp \
   RUNNER_OS=Linux \
   RUNNER_ARCH=X64 \
+  BASE="$base_rev" \
+  HEAD="$head_rev" \
   "$node_bin" bin/smoke/shard.mjs "$2" "$3"

--- a/package.json
+++ b/package.json
@@ -601,6 +601,7 @@
     "smoke:package-test-contract": "tsx bin/smoke/package-test-contract.smoke.ts",
     "smoke:ci-fragments": "tsx bin/smoke/ci-fragments.smoke.ts",
     "smoke:ci-suites-freeze": "tsx bin/smoke/ci-suites-freeze.smoke.ts",
+    "smoke:ci-suites-freeze-drop": "tsx bin/smoke/ci-suites-freeze-drop.smoke.ts",
     "smoke:ci-declarations": "tsx bin/smoke/ci-declarations.smoke.ts",
     "smoke:shard-stability": "tsx bin/smoke/shard-stability.smoke.ts",
     "smoke:shard-never-ran": "tsx bin/smoke/shard-never-ran.smoke.ts",


### PR DESCRIPTION
## Summary

A local `pnpm smoke:ci-suites-freeze` run used to skip the only cell that compares two committed frozen lists whenever `BASE` and `HEAD` were unset, then shrink its inventory sentinel to match that omission, and exit green. A contributor could append a suite name to `bin/smoke/ci-suites.txt`, see `OK (9 passed, 0 failed)` plus `every cell ran`, and still be rejected later by the real scan.

The committed-list cell now always runs. Missing or zero `BASE`/`HEAD` reds that cell by name instead of deleting it. The inventory count is a constant of cells that actually executed. A new control suite drives freeze under that dropping condition and asserts the named red. The shard wrapper re-supplies `BASE` and `HEAD` after `env -i` so CI still compares two revisions.

Refs #1422

## Test plan

- [ ] `pnpm smoke:ci-suites-freeze` without `BASE`/`HEAD` is red and names `the committed frozen list added no suite names versus base`
- [ ] `BASE`/`HEAD` set on two revisions with no frozen-list append is green, 10 cells
- [ ] `pnpm smoke:ci-suites-freeze-drop` is green
- [ ] `pnpm mutation-proof --config bin/smoke/mutations/ci-suites-freeze.json` is 3/3 KILLED
- [ ] `pnpm check:shard-stability <main> <head>` is STABLE