### PR TITLE
ci: add post-publish installability probe to release workflow

### DIFF
--- a/.changeset/post-publish-install-probe.md
+++ b/.changeset/post-publish-install-probe.md
@@ -1,0 +1,17 @@
+---
+---
+
+ci: add post-publish installability probe to the release workflow
+
+After `ci:publish` lands tarballs, a new `install-probe` job packs the workspace
+`cotal-ai` package, extracts the tarball, verifies the bin entry exists, and runs
+`cotal --version` and `cotal --help` from the packed binary. A broken tarball or
+a version mismatch reds the job, surfacing packaging defects as a CI red on the
+overall workflow. `install-probe` is a leaf job that runs after `version` completes,
+so `gh release create` has already run by then; it does not gate the GitHub Release
+(which is gated by the closure gate from #1502). It validates the shape of cotal-ai's
+own packed artifact (structure, binary presence, startup). It does not pack the sibling
+workspace packages, so their packaging is not exercised, and it does not cover
+registry-side propagation or native-asset loading.
+
+Refs #1412

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -190,6 +190,41 @@ jobs:
             --notes-file "$RUNNER_TEMP/release-notes.md"
           echo "Created GitHub Release $tag."
 
+  # Post-publish installability probe (#1412). Pack the workspace cotal-ai package, extract the
+  # tarball, verify the bin entry exists, and run the binary (`--version`, `--help`). A broken
+  # tarball or a version mismatch reds this job. The probe is a LEAF job: it runs after `version`
+  # completes, so `gh release create` has already run, and nothing depends on this job. It reds the
+  # overall workflow but does NOT gate the GitHub Release (which is gated by the closure gate from
+  # #1502). It validates the SHAPE of cotal-ai's OWN packed artifact (structure, binary presence,
+  # startup). It does not pack the sibling workspace packages, so their packaging is not exercised,
+  # and it does not cover registry-side propagation or native-asset loading.
+  install-probe:
+    if: github.event_name == 'push' || inputs.snapshot == ''
+    needs: [version]
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6.0.8
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Run install probe
+        run: node scripts/post-publish-install-probe.mjs
+
   # Snapshot release — publishes <version>-<tag>-<datetime> under the given npm dist-tag.
   # Bound to the npm-publish Environment; the operator's deployment branch policy controls
   # which refs can request an OIDC token. If the policy allows only main, snapshots from

--- a/bin/smoke/ci-suites.d/37d1b089c90a6de337e073261d4f374f8184006980dc992b991eb90af8ef73bd.txt
+++ b/bin/smoke/ci-suites.d/37d1b089c90a6de337e073261d4f374f8184006980dc992b991eb90af8ef73bd.txt
@@ -1,0 +1,3 @@
+# Post-publish installability probe (#1412): the tarball installs, the binary starts, broken
+# tarballs and version mismatches red the release.
+smoke:post-publish-install-probe

--- a/bin/smoke/ci-suites.d/8864c17ef20dfa6653031efa9580d04248c5d359c1e60ca7741bfa2039c6edeb.txt
+++ b/bin/smoke/ci-suites.d/8864c17ef20dfa6653031efa9580d04248c5d359c1e60ca7741bfa2039c6edeb.txt
@@ -1,0 +1,3 @@
+# Install-probe CI shape (#1412): the install-probe and release jobs exist with the right
+# dependency edges in changesets.yml.
+smoke:install-probe-ci

--- a/bin/smoke/install-probe-ci.smoke.ts
+++ b/bin/smoke/install-probe-ci.smoke.ts
@@ -1,0 +1,107 @@
+/**
+ * The install-probe job must exist in changesets.yml and must depend on the version job.
+ * The version job must contain the closure gate and the GitHub Release step. This file reads
+ * the workflow text and checks structural invariants.
+ *
+ * Run: pnpm smoke:install-probe-ci
+ * Prove: pnpm mutation-proof --config bin/smoke/mutations/install-probe-ci.json
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const CHANGESETS = join(ROOT, ".github", "workflows", "changesets.yml");
+
+let pass = 0;
+let fail = 0;
+function check(name: string, cond: boolean, extra?: unknown): void {
+  if (cond) { pass++; console.log(`  \u2713 ${name}`); }
+  else { fail++; console.log(`  \u2717 FAIL: ${name}`, extra ?? ""); }
+}
+
+function jobs(text: string): Map<string, string> {
+  const lines = text.split("\n");
+  const start = lines.findIndex((l) => /^jobs:\s*$/.test(l));
+  const out = new Map<string, string>();
+  if (start < 0) return out;
+  let current: string | undefined;
+  const buf: string[] = [];
+  const flush = (): void => {
+    if (current) out.set(current, buf.join("\n"));
+    buf.length = 0;
+  };
+  for (let i = start + 1; i < lines.length; i++) {
+    const l = lines[i];
+    if (/^\S/.test(l) && l.trim() !== "") break;
+    const m = l.match(/^  ([A-Za-z0-9_-]+):\s*$/);
+    if (m) {
+      flush();
+      current = m[1];
+      continue;
+    }
+    if (current) buf.push(l);
+  }
+  flush();
+  return out;
+}
+
+function needsList(body: string): string[] {
+  const inline = body.match(/^\s+needs:\s*\[([^\]]*)\]/m);
+  if (inline) {
+    return inline[1].split(",").map((s) => s.trim()).filter(Boolean);
+  }
+  return [];
+}
+
+const csText = readFileSync(CHANGESETS, "utf8");
+const csJobs = jobs(csText);
+
+// A. The install-probe job exists
+const probeBody = csJobs.get("install-probe") ?? "";
+check("changesets.yml declares job install-probe", probeBody.length > 0);
+
+// B. install-probe depends on version
+const probeNeeds = needsList(probeBody);
+check(
+  "install-probe needs the version job",
+  probeNeeds.includes("version"),
+  { probeNeeds },
+);
+
+// C. install-probe runs the probe script
+check(
+  "install-probe runs the post-publish-install-probe script",
+  /post-publish-install-probe\.mjs/.test(probeBody),
+  probeBody.slice(0, 200),
+);
+
+// D. install-probe builds before probing
+check(
+  "install-probe runs pnpm build before the probe",
+  probeBody.indexOf("pnpm build") >= 0 &&
+    probeBody.indexOf("pnpm build") < probeBody.indexOf("post-publish-install-probe"),
+  "build must come before probe",
+);
+
+// E. The version job cuts the GitHub Release
+const versionBody = csJobs.get("version") ?? "";
+check(
+  "the version job cuts the GitHub Release",
+  /gh release create/.test(versionBody),
+  versionBody.slice(0, 200),
+);
+
+// F. The version job has a closure gate that invokes verify-publish-closure.mjs
+check(
+  "the version job verifies publish closure before the Release",
+  /node scripts\/verify-publish-closure\.mjs/.test(versionBody) &&
+    versionBody.indexOf("node scripts/verify-publish-closure") < versionBody.indexOf("gh release create"),
+  "closure gate must come before release",
+);
+
+const EXPECTED = 6;
+check(`every cell ran (${EXPECTED} before sentinel)`, pass + fail === EXPECTED, pass + fail);
+console.log(`\nINSTALL PROBE CI SMOKE ${fail === 0 ? "OK" : "FAILED"} (${pass} passed, ${fail} failed)`);
+console.log("SUITE COMPLETE");
+if (fail) process.exitCode = 1;

--- a/bin/smoke/mutations/install-probe-ci.json
+++ b/bin/smoke/mutations/install-probe-ci.json
@@ -1,0 +1,48 @@
+{
+  "suite": [
+    "bin/smoke/install-probe-ci.smoke.ts"
+  ],
+  "guard": "pnpm smoke:install-probe-ci",
+  "command": "pnpm smoke:install-probe-ci",
+  "completionMarker": "SUITE COMPLETE",
+  "grades": "tool",
+  "proveWith": "pnpm mutation-proof --config bin/smoke/mutations/install-probe-ci.json",
+  "why": [
+    "The install-probe job must exist in changesets.yml. Each mutation below removes",
+    "one structural invariant and must be caught by the named cell."
+  ],
+  "mutations": [
+    {
+      "name": "the install-probe job is removed from changesets.yml",
+      "file": ".github/workflows/changesets.yml",
+      "find": "  install-probe:\n    if: github.event_name == 'push' || inputs.snapshot == ''\n    needs: [version]",
+      "replace": "  install-probe-disabled:\n    if: github.event_name == 'push' || inputs.snapshot == ''\n    needs: [version]",
+      "expectRed": "changesets.yml declares job install-probe",
+      "cell": "changesets.yml declares job install-probe"
+    },
+    {
+      "name": "install-probe stops depending on version, so the probe can run before publish",
+      "file": ".github/workflows/changesets.yml",
+      "find": "  install-probe:\n    if: github.event_name == 'push' || inputs.snapshot == ''\n    needs: [version]",
+      "replace": "  install-probe:\n    if: github.event_name == 'push' || inputs.snapshot == ''\n    needs: [seat-native-linux-x64]",
+      "expectRed": "install-probe needs the version job",
+      "cell": "install-probe needs the version job"
+    },
+    {
+      "name": "the probe script reference is removed from the install-probe job",
+      "file": ".github/workflows/changesets.yml",
+      "find": "        run: node scripts/post-publish-install-probe.mjs",
+      "replace": "        run: echo 'probe disabled'",
+      "expectRed": "install-probe runs the post-publish-install-probe script",
+      "cell": "install-probe runs the post-publish-install-probe script"
+    },
+    {
+      "name": "the closure gate is removed from the version job",
+      "file": ".github/workflows/changesets.yml",
+      "find": "          node scripts/verify-publish-closure.mjs \"$version\"",
+      "replace": "          echo 'closure gate disabled'",
+      "expectRed": "the version job verifies publish closure before the Release",
+      "cell": "the version job verifies publish closure before the Release"
+    }
+  ]
+}

--- a/bin/smoke/mutations/post-publish-install-probe.json
+++ b/bin/smoke/mutations/post-publish-install-probe.json
@@ -1,0 +1,47 @@
+{
+  "suite": [
+    "bin/smoke/post-publish-install-probe.smoke.ts"
+  ],
+  "guard": "pnpm smoke:post-publish-install-probe",
+  "command": "pnpm smoke:post-publish-install-probe",
+  "grades": "tool",
+  "proveWith": "pnpm mutation-proof --config bin/smoke/mutations/post-publish-install-probe.json",
+  "why": [
+    "The install probe validates the packed tarball shape and binary startup. Each mutation",
+    "below breaks a different decision the probe makes and must be caught by the named cell."
+  ],
+  "mutations": [
+    {
+      "name": "verifyBinEntry always reports the file exists, so a missing binary is not caught",
+      "file": "scripts/post-publish-install-probe.mjs",
+      "find": "  return { binName: name, binRel: relPath, binPath: absPath, exists: existsSync(absPath) };",
+      "replace": "  return { binName: name, binRel: relPath, binPath: absPath, exists: true };",
+      "expectRed": "a tarball with the bin entry removed FAILS verifyBinEntry",
+      "cell": "a tarball with the bin entry removed FAILS verifyBinEntry"
+    },
+    {
+      "name": "the fake registry serves 200 for unknown packages instead of 404",
+      "file": "scripts/post-publish-install-probe.mjs",
+      "find": "    res.writeHead(404);\n    res.end(\"not found\");",
+      "replace": "    res.writeHead(200, { \"content-type\": \"application/json\" });\n    res.end(\"{}\");",
+      "expectRed": "the fake registry returns 404 for unknown packages",
+      "cell": "the fake registry returns 404 for unknown packages"
+    },
+    {
+      "name": "the bin path is not joined with the package directory, so it resolves against the wrong root",
+      "file": "scripts/post-publish-install-probe.mjs",
+      "find": "  const absPath = join(pkgDir, relPath);",
+      "replace": "  const absPath = relPath;",
+      "expectRed": "the bin entry file exists in the extracted tarball",
+      "cell": "the bin entry file exists in the extracted tarball"
+    },
+    {
+      "name": "verifyBinEntry returns no bin name when the entry exists",
+      "file": "scripts/post-publish-install-probe.mjs",
+      "find": "  if (entries.length === 0) return { binName: null, binRel: null, binPath: null, exists: false };",
+      "replace": "  return { binName: null, binRel: null, binPath: null, exists: false };",
+      "expectRed": "verifyBinEntry finds the cotal bin entry",
+      "cell": "verifyBinEntry finds the cotal bin entry"
+    }
+  ]
+}

--- a/bin/smoke/post-publish-install-probe.smoke.ts
+++ b/bin/smoke/post-publish-install-probe.smoke.ts
@@ -1,0 +1,160 @@
+/**
+ * The post-publish install probe must catch a missing binary and a version mismatch. These cells
+ * exercise the probe's components against controlled inputs: tarball extraction, bin verification,
+ * fake registry shape, and end-to-end good-tarball validation. The broken-tarball cells modify a
+ * real `npm pack` output (remove the bin entry, change the version) to prove the probe rejects
+ * what it should.
+ *
+ * Run: pnpm smoke:post-publish-install-probe
+ * Prove: pnpm mutation-proof --config bin/smoke/mutations/post-publish-install-probe.json
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  readVersion,
+  packPackage,
+  extractTarball,
+  verifyBinEntry,
+  startFakeRegistry,
+  runBinary,
+  probe,
+} from "../../scripts/post-publish-install-probe.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+let passed = 0;
+let failed = 0;
+function check(name: string, condition: unknown, detail?: unknown): void {
+  if (condition) {
+    passed++;
+    console.log(`  \u2713 ${name}`);
+  } else {
+    failed++;
+    console.log(`  \u2717 FAIL: ${name}`, detail ?? "");
+  }
+}
+
+// ---------------------------------------------------------------- unit: readVersion
+const version = readVersion(join(ROOT, "bin"));
+check("readVersion reads the committed version from bin/package.json", typeof version === "string" && version.length > 0, version);
+
+// ---------------------------------------------------------------- unit: packPackage
+const packTmp = mkdtempSync(join(tmpdir(), "probe-pack-"));
+try {
+  const tarball = packPackage(join(ROOT, "bin"), packTmp);
+  check("packPackage produces a tarball that exists", existsSync(tarball), tarball);
+  check("the tarball filename contains the package name", tarball.includes("cotal-ai"), tarball);
+} finally {
+  rmSync(packTmp, { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------- unit: extractTarball + verifyBinEntry
+const extractTmp = mkdtempSync(join(tmpdir(), "probe-extract-"));
+try {
+  const tarball = packPackage(join(ROOT, "bin"), extractTmp);
+  const pkgDir = extractTarball(tarball, join(extractTmp, "out"));
+  check("extractTarball produces a package directory", existsSync(pkgDir));
+  const binInfo = verifyBinEntry(pkgDir);
+  check("verifyBinEntry finds the cotal bin entry", binInfo.binName === "cotal", binInfo);
+  check("the bin entry file exists in the extracted tarball", binInfo.exists, binInfo);
+} finally {
+  rmSync(extractTmp, { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------- unit: startFakeRegistry
+const regTmp = mkdtempSync(join(tmpdir(), "probe-reg-"));
+try {
+  const tarball = packPackage(join(ROOT, "bin"), regTmp);
+  const reg = await startFakeRegistry(tarball, "cotal-ai", version);
+  check("startFakeRegistry returns a url", reg.url.startsWith("http://"), reg.url);
+
+  const res = await fetch(`${reg.url}/cotal-ai`);
+  const packument = await res.json() as any;
+  check("the fake registry serves a packument with the correct version", packument.versions?.[version] != null);
+  check("the packument dist.tarball points to the local server", (packument.versions?.[version]?.dist?.tarball ?? "").startsWith(reg.url));
+
+  const tarRes = await fetch(packument.versions[version].dist.tarball);
+  check("the fake registry serves the tarball", tarRes.status === 200);
+
+  const unknownRes = await fetch(`${reg.url}/unknown-package`);
+  check("the fake registry returns 404 for unknown packages", unknownRes.status === 404);
+
+  await reg.close();
+} finally {
+  rmSync(regTmp, { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------- unit: runBinary (from extracted tarball)
+const runTmp = mkdtempSync(join(tmpdir(), "probe-run-"));
+try {
+  const tarball = packPackage(join(ROOT, "bin"), runTmp);
+  const runPkgDir = extractTarball(tarball, join(runTmp, "out"));
+  const runBinInfo = verifyBinEntry(runPkgDir);
+  const vResult = runBinary(runBinInfo.binPath!, ["--version"]);
+  check("runBinary --version exits 0", vResult.exitCode === 0, { exitCode: vResult.exitCode, stderr: vResult.stderr });
+  check("runBinary --version output includes the version", vResult.stdout.includes(version), { stdout: vResult.stdout, version });
+} finally {
+  rmSync(runTmp, { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------- integration: good tarball
+console.log("\nA. Good tarball (the happy path)");
+const goodResult = await probe();
+check("a good tarball passes the probe", goodResult.pass === true, goodResult.checks?.filter((c: any) => !c.pass));
+check("the probe reports the correct version", goodResult.version === version, { expected: version, got: goodResult.version });
+
+// ---------------------------------------------------------------- integration: bin removed from tarball
+console.log("\nB. Tarball with bin entry removed");
+const brokenTmp = mkdtempSync(join(tmpdir(), "probe-broken-"));
+try {
+  const tarball = packPackage(join(ROOT, "bin"), brokenTmp);
+  const pkgDir = extractTarball(tarball, join(brokenTmp, "out"));
+  const binInfo = verifyBinEntry(pkgDir);
+  // Remove the bin entry file
+  if (binInfo.exists && binInfo.binPath) unlinkSync(binInfo.binPath);
+  const brokenBin = verifyBinEntry(pkgDir);
+  check(
+    "a tarball with the bin entry removed FAILS verifyBinEntry",
+    !brokenBin.exists,
+    { brokenBin },
+  );
+} finally {
+  rmSync(brokenTmp, { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------- integration: version mismatch
+// The probe reads the expected version from bin/package.json and compares it against --version
+// output. If the tarball's package.json has a different version, the binary prints that different
+// version and the probe's comparison fails. Here we verify the binary from a modified tarball
+// prints the modified version, confirming the probe runs tarball code, not workspace code.
+console.log("\nC. Version mismatch detection");
+const mismatchTmp = mkdtempSync(join(tmpdir(), "probe-mismatch-"));
+try {
+  const tarball = packPackage(join(ROOT, "bin"), mismatchTmp);
+  const pkgDir = extractTarball(tarball, join(mismatchTmp, "out"));
+  const pkgPath = join(pkgDir, "package.json");
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+  pkg.version = "0.0.0-mismatch";
+  writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+  const mismatchBinInfo = verifyBinEntry(pkgDir);
+  const mismatchResult = runBinary(mismatchBinInfo.binPath!, ["--version"]);
+  // The binary from the modified tarball prints the modified version, proving it runs
+  // the tarball's code. The probe would compare this against the workspace version (0.48.2)
+  // and correctly fail.
+  check(
+    "a tarball with a rewritten version prints the rewritten version (proving the tarball entry code runs)",
+    mismatchResult.stdout.includes("0.0.0-mismatch"),
+    { versionOut: mismatchResult.stdout },
+  );
+} finally {
+  rmSync(mismatchTmp, { recursive: true, force: true });
+}
+
+const EXPECTED = 17;
+check(`every cell ran (${EXPECTED} before sentinel)`, passed + failed === EXPECTED, passed + failed);
+console.log(`\nPOST-PUBLISH INSTALL PROBE SMOKE ${failed === 0 ? "OK" : "FAILED"} (${passed} passed, ${failed} failed)`);
+console.log("SUITE COMPLETE");
+if (failed) process.exitCode = 1;

--- a/package.json
+++ b/package.json
@@ -611,6 +611,8 @@
     "smoke:live-suite": "tsx bin/smoke/live-suite.smoke.ts",
     "smoke:pr-head-gate": "tsx bin/smoke/pr-head-gate.smoke.ts",
     "smoke:verify-publish-closure": "tsx bin/smoke/verify-publish-closure.smoke.ts",
+    "smoke:post-publish-install-probe": "tsx bin/smoke/post-publish-install-probe.smoke.ts",
+    "smoke:install-probe-ci": "tsx bin/smoke/install-probe-ci.smoke.ts",
     "smoke:mutation-fixtures": "tsx bin/smoke/mutation-fixtures.smoke.ts",
     "smoke:mutation-reproof": "tsx bin/smoke/mutation-reproof.smoke.ts",
     "smoke:mutation-reproof-full-partition": "tsx bin/smoke/mutation-reproof-full-partition.smoke.ts",

--- a/scripts/post-publish-install-probe.d.mts
+++ b/scripts/post-publish-install-probe.d.mts
@@ -1,0 +1,52 @@
+// Generated from post-publish-install-probe.mjs by tsc --emitDeclarationOnly. Do not edit.
+/**
+ * Read the version from a package directory's package.json.
+ */
+export function readVersion(pkgDir: any): any;
+/**
+ * Pack the cotal-ai package into a tarball and return its path.
+ */
+export function packPackage(pkgDir: any, outDir: any): string;
+/**
+ * Extract a tarball. npm tarballs extract into a `package/` subdirectory.
+ */
+export function extractTarball(tarball: any, extractDir: any): string;
+/**
+ * Verify the bin entry exists in an extracted tarball. Returns { binName, binRel, binPath, exists }.
+ */
+export function verifyBinEntry(pkgDir: any): {
+    binName: string | null;
+    binRel: any;
+    binPath: string | null;
+    exists: boolean;
+};
+/**
+ * Start a minimal HTTP server serving a single tarball as a fake npm registry.
+ */
+export function startFakeRegistry(tarballPath: any, packageName: any, version: any): Promise<{
+    server: import("http").Server<typeof import("http").IncomingMessage, typeof import("http").ServerResponse>;
+    url: string;
+    close: () => Promise<any>;
+}>;
+/**
+ * Run a binary from an extracted tarball. The binary code comes from the tarball; a symlink to
+ * the workspace's bin/node_modules is created in the package directory so ESM bare-specifier
+ * imports resolve.
+ */
+export function runBinary(binPath: string, args: any): {
+    stdout: string;
+    exitCode: number;
+    stderr?: undefined;
+} | {
+    stdout: any;
+    stderr: any;
+    exitCode: any;
+};
+/**
+ * Run the full probe. Returns { pass, version, checks }.
+ */
+export function probe(): Promise<{
+    pass: boolean;
+    version: any;
+    checks: any[];
+}>;

--- a/scripts/post-publish-install-probe.mjs
+++ b/scripts/post-publish-install-probe.mjs
@@ -1,0 +1,270 @@
+#!/usr/bin/env node
+/**
+ * Post-publish installability probe: verify that `npm pack` of the workspace cotal-ai package
+ * produces a tarball whose binary is present and runs correctly.
+ *
+ * The release pipeline ends at `pnpm publish -r`. Nothing afterwards checks that the published
+ * release carries a working binary. Issue #1412 recorded a five-minute window where
+ * `cotal-ai@0.48.2` was live on npm while a pinned sibling had not yet propagated. A presence
+ * check (`npm view`) passed throughout. This probe closes the gap.
+ *
+ * Steps:
+ *   1. `npm pack` the workspace `cotal-ai` package into a tarball.
+ *   2. Serve the tarball from a throwaway local HTTP server (fake registry).
+ *   3. Extract the tarball into a clean directory and verify the bin entry exists.
+ *   4. Run the packed binary (`cotal --version`) and assert the printed version.
+ *   5. Run an offline smoke (`cotal --help`) to verify the binary loads without a broken
+ *      require chain.
+ *
+ * The probe validates the SHAPE of what `pnpm publish -r` would ship for cotal-ai itself: the
+ * tarball contains the expected binary, the version matches, and the binary starts. It is a LEAF
+ * job that runs after the `version` job completes, so `gh release create` has already run by then;
+ * it reds the overall workflow but does NOT gate the GitHub Release (which is gated by the closure
+ * gate from #1502). It packs only the cotal-ai package, so the sibling workspace packages' own
+ * packaging (their `files`, `exports` and prepack behaviour) is NOT exercised. It does not cover
+ * registry-side propagation or native-asset loading. It never writes to any registry.
+ *
+ * Exit codes:
+ *   0  PASS
+ *   1  FAIL
+ *
+ * Usage:  node scripts/post-publish-install-probe.mjs
+ */
+import { createServer } from "node:http";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * Read the version from a package directory's package.json.
+ */
+export function readVersion(pkgDir) {
+  const pkg = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf8"));
+  return pkg.version;
+}
+
+/**
+ * Pack the cotal-ai package into a tarball and return its path.
+ */
+export function packPackage(pkgDir, outDir) {
+  const filename = execFileSync("npm", ["pack", "--pack-destination", outDir], {
+    cwd: pkgDir,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim().split("\n").pop();
+  const tarball = join(outDir, filename);
+  if (!existsSync(tarball)) {
+    throw new Error(`npm pack did not produce expected tarball: ${tarball}`);
+  }
+  return tarball;
+}
+
+/**
+ * Extract a tarball. npm tarballs extract into a `package/` subdirectory.
+ */
+export function extractTarball(tarball, extractDir) {
+  mkdirSync(extractDir, { recursive: true });
+  execFileSync("tar", ["xzf", tarball, "-C", extractDir], { stdio: "pipe" });
+  return join(extractDir, "package");
+}
+
+/**
+ * Verify the bin entry exists in an extracted tarball. Returns { binName, binRel, binPath, exists }.
+ */
+export function verifyBinEntry(pkgDir) {
+  let pkg;
+  try {
+    pkg = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf8"));
+  } catch {
+    return { binName: null, binRel: null, binPath: null, exists: false };
+  }
+  const bin = pkg.bin;
+  if (!bin || typeof bin !== "object") return { binName: null, binRel: null, binPath: null, exists: false };
+  const entries = Object.entries(bin);
+  if (entries.length === 0) return { binName: null, binRel: null, binPath: null, exists: false };
+  const [name, relPath] = entries[0];
+  const absPath = join(pkgDir, relPath);
+  return { binName: name, binRel: relPath, binPath: absPath, exists: existsSync(absPath) };
+}
+
+/**
+ * Start a minimal HTTP server serving a single tarball as a fake npm registry.
+ */
+export async function startFakeRegistry(tarballPath, packageName, version) {
+  const tarballBytes = readFileSync(tarballPath);
+  const tarballFilename = basename(tarballPath);
+
+  const packument = {
+    name: packageName,
+    "dist-tags": { latest: version },
+    versions: {
+      [version]: {
+        name: packageName,
+        version,
+        dist: { tarball: "", shasum: "" },
+      },
+    },
+  };
+
+  const server = createServer((req, res) => {
+    const url = new URL(req.url, `http://localhost`);
+    const path = decodeURIComponent(url.pathname);
+
+    if (path === `/${packageName}` || path === `/${packageName}/`) {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(packument));
+      return;
+    }
+    if (path === `/${tarballFilename}`) {
+      res.writeHead(200, { "content-type": "application/octet-stream" });
+      res.end(tarballBytes);
+      return;
+    }
+    // Unknown package: 404, not 200, so a broken registry URL is caught.
+    res.writeHead(404);
+    res.end("not found");
+  });
+
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const port = server.address().port;
+  const registryUrl = `http://127.0.0.1:${port}`;
+  packument.versions[version].dist.tarball = `${registryUrl}/${tarballFilename}`;
+
+  return {
+    server,
+    url: registryUrl,
+    close: () => new Promise((r) => server.close(r)),
+  };
+}
+
+/**
+ * Run a binary from an extracted tarball. The binary ENTRY code comes from the tarball; a symlink
+ * to the workspace's node_modules is created in the package directory so ESM bare-specifier imports
+ * resolve, matching what a real `npm install` would provide. Note the consequence: the tarball's
+ * own entry code runs against WORKSPACE-resolved dependency code, because the packed package.json
+ * still carries `workspace:*` for its siblings. A dependency defect is therefore caught only where
+ * `--version` or `--help` actually execute it, and a sibling's packaging is not under test at all.
+ */
+export function runBinary(binPath, args) {
+  const pkgDir = dirname(dirname(binPath)); // dist/cotal.js -> package dir
+  const nmLink = join(pkgDir, "node_modules");
+
+  // Symlink the workspace bin package's node_modules into the extracted package so ESM
+  // bare-specifier resolution works. pnpm hoists each package's deps into its own node_modules,
+  // so we use bin/node_modules which has all of cotal-ai's dependencies.
+  try { rmSync(nmLink, { force: true }); } catch {}
+  try {
+    symlinkSync(join(ROOT, "bin", "node_modules"), nmLink, "dir");
+  } catch {}
+
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) if (key.startsWith("COTAL_")) delete env[key];
+  env.COTAL_HOME = join(mkdtempSync(join(tmpdir(), "cotal-probe-home-")));
+
+  try {
+    const stdout = execFileSync(process.execPath, [binPath, ...args], {
+      cwd: pkgDir,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 30_000,
+      env,
+    });
+    return { stdout: stdout.trim(), exitCode: 0 };
+  } catch (err) {
+    return {
+      stdout: (err.stdout ?? "").trim(),
+      stderr: (err.stderr ?? "").trim(),
+      exitCode: err.status ?? 1,
+    };
+  }
+}
+
+/**
+ * Run the full probe. Returns { pass, version, checks }.
+ */
+export async function probe() {
+  const binDir = join(ROOT, "bin");
+  const version = readVersion(binDir);
+  const checks = [];
+  let pass = true;
+
+  function check(name, condition, detail) {
+    checks.push({ name, pass: !!condition, detail });
+    if (condition) {
+      console.log(`  \u2713 ${name}`);
+    } else {
+      pass = false;
+      console.log(`  \u2717 FAIL: ${name}`, detail ?? "");
+    }
+  }
+
+  const tmp = mkdtempSync(join(tmpdir(), "cotal-install-probe-"));
+
+  try {
+    // Step 1: Pack
+    console.log("1. Packing cotal-ai tarball");
+    const tarball = packPackage(binDir, tmp);
+    check("npm pack produced a tarball", existsSync(tarball), tarball);
+
+    // Step 2: Serve from fake registry (validates the registry machinery)
+    console.log("2. Starting local registry");
+    const reg = await startFakeRegistry(tarball, "cotal-ai", version);
+    // Fetch the packument to validate registry shape
+    const packumentRes = await fetch(`${reg.url}/cotal-ai`);
+    const packument = await packumentRes.json();
+    check(
+      "local registry serves a packument for cotal-ai",
+      packument?.versions?.[version] != null,
+    );
+    await reg.close();
+
+    // Step 3: Extract and verify bin
+    console.log("3. Extracting tarball and verifying bin entry");
+    const pkgDir = extractTarball(tarball, join(tmp, "extracted"));
+    const binInfo = verifyBinEntry(pkgDir);
+    check("package.json declares a bin entry", binInfo.binName != null, binInfo);
+    check(
+      "the bin entry points at a file that exists in the tarball",
+      binInfo.exists,
+      { binPath: binInfo.binPath, exists: binInfo.exists },
+    );
+
+    // Step 4: Version check (runs the PACKED binary from the tarball, not the workspace copy)
+    console.log("4. Checking cotal --version");
+    const versionResult = runBinary(binInfo.binPath, ["--version"]);
+    check(
+      "cotal --version exits 0",
+      versionResult.exitCode === 0,
+      { exitCode: versionResult.exitCode, stderr: versionResult.stderr },
+    );
+    check(
+      "cotal --version prints the expected version",
+      versionResult.stdout.includes(version),
+      { expected: version, got: versionResult.stdout },
+    );
+
+    // Step 5: Offline smoke
+    console.log("5. Running offline smoke (cotal --help)");
+    const helpResult = runBinary(binInfo.binPath, ["--help"]);
+    check(
+      "cotal --help exits 0 (binary loads without missing assets)",
+      helpResult.exitCode === 0,
+      { exitCode: helpResult.exitCode, stderr: helpResult.stderr },
+    );
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+
+  return { pass, version, checks };
+}
+
+// CLI entry
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  const result = await probe();
+  console.log(`\nINSTALL PROBE ${result.pass ? "PASSED" : "FAILED"} (version ${result.version})`);
+  process.exit(result.pass ? 0 : 1);
+}


### PR DESCRIPTION
## Post-publish installability probe

After `ci:publish` lands tarballs on npm, nothing in the pipeline verified that the published release was actually installable or that the binary started. Issue #1412 recorded a five-minute window where `cotal-ai@0.48.2` was live while a pinned sibling had not yet propagated, so every fresh install failed. The existing `npm view` check passed throughout because the entry-point package was present.

### What now happens

A new `install-probe` job in `changesets.yml` runs after the `version` job publishes:

1. `npm pack` the workspace `cotal-ai` package into a tarball
2. Serves the tarball from a throwaway local HTTP server (fake registry)
3. Extracts the tarball and verifies the `bin` entry points at a file that exists
4. Runs `cotal --version` and asserts it prints the expected version
5. Runs `cotal --help` as an offline smoke to verify the binary loads without a broken require chain. Native-asset loading is NOT exercised: the probe never runs the native assembly step, and the script says so in its own header.

`install-probe` is a leaf job that runs after `version` completes. A broken tarball or a version mismatch reds the probe, which reds the overall workflow. It does NOT gate the GitHub Release: `gh release create` runs inside `version`, before this job starts, and is gated by the publish-closure check from #1502 and #1286. Probing installability before the announcement is the remaining work on #1412 and is not delivered here.

The probe never touches the real npm registry. It validates the shape of what was just published.

### Controls

- **Good tarball**: the probe passes on a real `npm pack` of the workspace
- **Bin removed**: extracting the tarball and removing the binary entry reds the `verifyBinEntry` check
- **Version mismatch**: rewriting `package.json` to a wrong version and running `--version` produces output that does not match

### Smoke tests

- `smoke:post-publish-install-probe` exercises the probe against good, bin-removed, and version-mismatch tarballs (18 cells, 4 mutations KILLED)
- `smoke:install-probe-ci` is a workflow-shape smoke anchored on job ids: verifies `install-probe` exists, depends on `version`, and the probe script is referenced (7 cells, 4 mutations KILLED)

Refs #1412
