### PR TITLE
Grade smoke shards from cell-count sentinels

### DIFF
--- a/.changeset/shard-cell-sentinel.md
+++ b/.changeset/shard-cell-sentinel.md
@@ -1,0 +1,4 @@
+---
+---
+
+Smoke shards now read a cell-count sentinel from each suite's own output. A suite that exits 0 with no sentinel, or with zero cells run, fails the shard by name instead of counting as a covered pass, and the shard banner reports cells graded, not only suites.

--- a/bin/smoke/ci-suites.d/eb23a0bb414934ac6b02fa7dce225e30789212bbe0a0168be41de8aceb772d89.txt
+++ b/bin/smoke/ci-suites.d/eb23a0bb414934ac6b02fa7dce225e30789212bbe0a0168be41de8aceb772d89.txt
@@ -1,0 +1,3 @@
+# #1297: shard.mjs grades coverage from a cell-count sentinel, not exit status alone.
+# Mutation-proofed - bin/smoke/mutations/shard-sentinel.json.
+smoke:shard-sentinel

--- a/bin/smoke/flag-inventory.smoke.ts
+++ b/bin/smoke/flag-inventory.smoke.ts
@@ -14,7 +14,8 @@
  *
  * Run: pnpm smoke:flag-inventory
  */
-import assert from "node:assert/strict";
+import nodeAssert from "node:assert/strict";
+import { countedAssert, emitSentinel } from "./sentinel.mjs";
 import { registry, type Command } from "@cotal-ai/core";
 import "@cotal-ai/cli"; // registers the base CLI commands
 import "@cotal-ai/manager"; // registers supervise/start/stop/ps/attach
@@ -24,6 +25,7 @@ import "@cotal-ai/runtime"; // registers run
 
 /** flag spec inventory as "name:type" (+ ":short" when aliased), sorted. */
 const TARGET = ["creds:string", "server:string", "space:string"];
+const { assert, cells } = countedAssert(nodeAssert);
 const GOLDEN: Record<string, { flags: string[]; positionals: boolean; rawArgs?: boolean }> = {
   // Stage 2b: setup is configure-only — --open's home is `cotal up` (where it already lived);
   // --auth simply died with the launch behavior. `go` (a pure alias of setup) is deleted outright.
@@ -253,3 +255,4 @@ for (const cmd of commands) {
 }
 
 console.log(`✓ flag-inventory smoke passed (${commands.length} commands)`);
+emitSentinel({ passed: cells(), failed: 0 });

--- a/bin/smoke/flag-inventory.smoke.ts
+++ b/bin/smoke/flag-inventory.smoke.ts
@@ -25,7 +25,9 @@ import "@cotal-ai/runtime"; // registers run
 
 /** flag spec inventory as "name:type" (+ ":short" when aliased), sorted. */
 const TARGET = ["creds:string", "server:string", "space:string"];
-const { assert, cells } = countedAssert(nodeAssert);
+const counted = countedAssert(nodeAssert);
+const assert: typeof nodeAssert = counted.assert;
+const cells = counted.cells;
 const GOLDEN: Record<string, { flags: string[]; positionals: boolean; rawArgs?: boolean }> = {
   // Stage 2b: setup is configure-only — --open's home is `cotal up` (where it already lived);
   // --auth simply died with the launch behavior. `go` (a pure alias of setup) is deleted outright.

--- a/bin/smoke/flag-inventory.smoke.ts
+++ b/bin/smoke/flag-inventory.smoke.ts
@@ -15,7 +15,7 @@
  * Run: pnpm smoke:flag-inventory
  */
 import nodeAssert from "node:assert/strict";
-import { countedAssert, emitSentinel } from "./sentinel.mjs";
+import { countedAssert, emitSentinel } from "@cotal-ai/smoke-kit";
 import { registry, type Command } from "@cotal-ai/core";
 import "@cotal-ai/cli"; // registers the base CLI commands
 import "@cotal-ai/manager"; // registers supervise/start/stop/ps/attach

--- a/bin/smoke/launch-parity.smoke.ts
+++ b/bin/smoke/launch-parity.smoke.ts
@@ -19,7 +19,9 @@ import { spawnFlags, launchAgent, START_TIMEOUT_MS } from "@cotal-ai/cli";
 import { configFromEnv, cotalToolSpecs, SPAWN_TIMEOUT_MS } from "@cotal-ai/connector-core";
 import { READINESS_TIMEOUT_MS } from "@cotal-ai/manager";
 import type { CotalEndpoint } from "@cotal-ai/core";
-const { assert, cells } = countedAssert(nodeAssert);
+const counted = countedAssert(nodeAssert);
+const assert: typeof nodeAssert = counted.assert;
+const cells = counted.cells;
 
 // cotalToolSpecs is capability-gated: cotal_spawn only renders for a spawn-capable agent.
 process.env.COTAL_SPACE ||= "parity";

--- a/bin/smoke/launch-parity.smoke.ts
+++ b/bin/smoke/launch-parity.smoke.ts
@@ -12,12 +12,14 @@
  *      under that window kills real spawns while the launch proceeds.
  * Run: pnpm smoke:launch-parity
  */
-import assert from "node:assert/strict";
+import nodeAssert from "node:assert/strict";
+import { countedAssert, emitSentinel } from "./sentinel.mjs";
 import { launchFlags } from "@cotal-ai/workspace";
 import { spawnFlags, launchAgent, START_TIMEOUT_MS } from "@cotal-ai/cli";
 import { configFromEnv, cotalToolSpecs, SPAWN_TIMEOUT_MS } from "@cotal-ai/connector-core";
 import { READINESS_TIMEOUT_MS } from "@cotal-ai/manager";
 import type { CotalEndpoint } from "@cotal-ai/core";
+const { assert, cells } = countedAssert(nodeAssert);
 
 // cotalToolSpecs is capability-gated: cotal_spawn only renders for a spawn-capable agent.
 process.env.COTAL_SPACE ||= "parity";
@@ -123,3 +125,4 @@ assert.equal(launchCommand, "launch", "launchAgent must invoke the manager's lau
 assert.equal(launchTimeout, START_TIMEOUT_MS, "launchAgent must send the launch op with START_TIMEOUT_MS");
 
 console.log(`✓ launch-parity smoke passed (${launchFlags.length} grammar flags · ${toolParams.length} MCP params · readiness window ${READINESS_TIMEOUT_MS}ms < clients ${START_TIMEOUT_MS}/${SPAWN_TIMEOUT_MS}ms)`);
+emitSentinel({ passed: cells(), failed: 0 });

--- a/bin/smoke/launch-parity.smoke.ts
+++ b/bin/smoke/launch-parity.smoke.ts
@@ -13,7 +13,7 @@
  * Run: pnpm smoke:launch-parity
  */
 import nodeAssert from "node:assert/strict";
-import { countedAssert, emitSentinel } from "./sentinel.mjs";
+import { countedAssert, emitSentinel } from "@cotal-ai/smoke-kit";
 import { launchFlags } from "@cotal-ai/workspace";
 import { spawnFlags, launchAgent, START_TIMEOUT_MS } from "@cotal-ai/cli";
 import { configFromEnv, cotalToolSpecs, SPAWN_TIMEOUT_MS } from "@cotal-ai/connector-core";

--- a/bin/smoke/mutations/shard-never-ran.json
+++ b/bin/smoke/mutations/shard-never-ran.json
@@ -15,8 +15,8 @@
     {
       "name": "the break path no-ops never-ran emission",
       "file": "bin/smoke/shard.mjs",
-      "find": "    if (never) console.error(never);",
-      "replace": "    void never;",
+      "find": "  if (never) console.error(never);",
+      "replace": "  void never;",
       "expectRed": "a mid-partition break through shard.mjs reports NEVER RAN — 2 of 4",
       "cell": "a mid-partition break through shard.mjs reports NEVER RAN — 2 of 4"
     }

--- a/bin/smoke/mutations/shard-sentinel.json
+++ b/bin/smoke/mutations/shard-sentinel.json
@@ -1,0 +1,41 @@
+{
+  "suite": [
+    "bin/smoke/shard-sentinel.smoke.ts"
+  ],
+  "guard": "shard.mjs refuses a suite that exits 0 with no sentinel or zero cells, and reports cells graded",
+  "command": "pnpm smoke:shard-sentinel",
+  "completionMarker": "COTAL_SMOKE_SENTINEL",
+  "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/shard-sentinel.json",
+  "why": [
+    "Issue #1297 is a runner that grades on exit status alone. Isolating parseSentinel stays green if",
+    "shard.mjs never consults it. Each mutation targets a unique shipped-runner line so a revert to",
+    "status-only grading, a swallowed missing sentinel, a swallowed zero-cell run, or a suites-only",
+    "banner reddens the named cell through the shipped shard, not a helper."
+  ],
+  "mutations": [
+    {
+      "name": "the shard no longer requires a sentinel after exit 0",
+      "file": "bin/smoke/shard.mjs",
+      "find": "    const sentinel = parseSentinel(r.out);\n    if (!sentinel) {\n      failAt(cmd, i, \"no sentinel\", 1);",
+      "replace": "    const sentinel = parseSentinel(r.out) ?? { cells: 1, passed: 1, failed: 0, kind: \"canonical\" };\n    if (false && !sentinel) {\n      failAt(cmd, i, \"no sentinel\", 1);",
+      "expectRed": "a no-op suite that exits 0 is named FAILED with no sentinel",
+      "cell": "a no-op suite that exits 0 is named FAILED with no sentinel"
+    },
+    {
+      "name": "the shard accepts a zero-cell sentinel as a pass",
+      "file": "bin/smoke/shard.mjs",
+      "find": "    if (sentinel.cells === 0) {\n      failAt(cmd, i, \"zero cells\", 1);",
+      "replace": "    if (false && sentinel.cells === 0) {\n      failAt(cmd, i, \"zero cells\", 1);",
+      "expectRed": "a suite that prints a sentinel with zero cells is named FAILED with zero cells",
+      "cell": "a suite that prints a sentinel with zero cells is named FAILED with zero cells"
+    },
+    {
+      "name": "the green banner reports suites only",
+      "file": "bin/smoke/shard.mjs",
+      "find": "  console.log(`\\n✓ smoke:ci shard ${shard}/${count} passed (${mine.length} smokes, ${totalCells} cells)`);",
+      "replace": "  console.log(`\\n✓ smoke:ci shard ${shard}/${count} passed (${mine.length} smokes)`);",
+      "expectRed": "a sentinel-emitting suite greens the shard with the cell count",
+      "cell": "a sentinel-emitting suite greens the shard with the cell count"
+    }
+  ]
+}

--- a/bin/smoke/sentinel.d.mts
+++ b/bin/smoke/sentinel.d.mts
@@ -1,0 +1,21 @@
+/** Typed surface of `sentinel.mjs` for `tsc -p tsconfig.smoke.json`. */
+export const SENTINEL_PREFIX: "COTAL_SMOKE_SENTINEL";
+
+export function formatSentinel(counts: { passed: number; failed: number; cells?: number }): string;
+export function emitSentinel(counts: { passed: number; failed: number; cells?: number }): void;
+
+export type ParsedSentinel = {
+  cells: number;
+  passed: number;
+  failed: number;
+  kind: "canonical" | "legacy";
+};
+
+export function parseSentinel(text: string): ParsedSentinel | null;
+export function countedAssert<T extends object>(ns: T): { assert: T; cells: () => number };
+export function createSuite(): {
+  check: (name: string, cond: boolean, extra?: unknown) => void;
+  finish: () => void;
+  passed: () => number;
+  failed: () => number;
+};

--- a/bin/smoke/sentinel.mjs
+++ b/bin/smoke/sentinel.mjs
@@ -49,17 +49,17 @@ export function parseSentinel(text) {
       last = { cells, passed, failed, kind: "canonical" };
       continue;
     }
-    // Suites already name counts as `(N passed, M failed)` or `N passed, M failed; extra`.
-    // Require the close-paren / semicolon / end so a no-op cannot mint a tally from prose.
-    const pair = line.match(/\((\d+) passed, (\d+) failed(?:\)|;)/);
+    // A legacy banner must own the whole line. Trailing `;…` or a double-space
+    // annotation is extra, not a new clause. A single space then words is prose
+    // and must not mint a tally. Optional `label:` is the suite name, not English
+    // wrapping the number.
+    const pair = line.match(/^.*\((\d+) passed, (\d+) failed(?:;[^)]*)?\)(?:(?:;|\s{2}).*)?$/);
     if (pair) {
       const passed = Number(pair[1]);
       const failed = Number(pair[2]);
       last = { cells: passed + failed, passed, failed, kind: "legacy" };
       continue;
     }
-    // Trailing `;…` or a double-space annotation (`  [session: …]`) is extra, not a new clause.
-    // A single space then words is refused so prose cannot mint a tally.
     const suiteComplete = line.match(/^(?:SUITE COMPLETE:\s*)?(?:.*?:\s*)?(\d+) passed, (\d+) failed(?:(?:;|\s{2}).*)?$/);
     if (suiteComplete) {
       const passed = Number(suiteComplete[1]);
@@ -73,19 +73,19 @@ export function parseSentinel(text) {
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
-    const cellsOk = line.match(/:\s*(\d+) cells OK$/);
+    const cellsOk = line.match(/^(?:.*?:\s*)?(\d+) cells OK(?:, \d+ failed)?(?:(?:;|\s{2}).*)?$/);
     if (cellsOk) {
       const cells = Number(cellsOk[1]);
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
-    const testsExecuted = line.match(/:\s*(\d+) tests executed$/);
+    const testsExecuted = line.match(/^(?:.*?:\s*)?(\d+) tests executed(?:(?:;|\s{2}).*)?$/);
     if (testsExecuted) {
       const cells = Number(testsExecuted[1]);
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
-    const parenTests = line.match(/\((\d+) tests\)/);
+    const parenTests = line.match(/^.*\((\d+) tests\)(?:(?:;|\s{2}).*)?$/);
     if (parenTests) {
       const cells = Number(parenTests[1]);
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
@@ -98,7 +98,7 @@ export function parseSentinel(text) {
       last = { cells, passed, failed: cells - passed, kind: "legacy" };
       continue;
     }
-    const checksOnly = line.match(/\((\d+) checks(?: passed)?\)/);
+    const checksOnly = line.match(/^.*\((\d+) checks(?: passed)?\)(?:(?:;|\s{2}).*)?$/);
     if (checksOnly) {
       const cells = Number(checksOnly[1]);
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
@@ -110,49 +110,49 @@ export function parseSentinel(text) {
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
-    const scanned = line.match(/(\d+) (?:documents checked|source files scanned|files scanned)/);
+    const scanned = line.match(/^(?:.*?:\s*)?(\d+) (?:documents checked|source files scanned|files scanned)(?:, .*)?$/);
     if (scanned) {
       const cells = Number(scanned[1]);
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
-    const names = line.match(/(\d+) names across (\d+) imports/);
+    const names = line.match(/^(?:.*?:\s*)?(\d+) names across (\d+) imports(?:(?:;|\s{2}).*)?$/);
     if (names) {
       const cells = Number(names[1]);
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
-    const named = line.match(/: (\d+) named registrations/);
+    const named = line.match(/^(?:.*?:\s*)?(\d+) named registrations(?: across \d+.*)?$/);
     if (named) {
       const cells = Number(named[1]);
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
-    const filesDecls = line.match(/(\d+) files, (\d+) declarations/);
+    const filesDecls = line.match(/^(?:.*?:\s*)?(\d+) files, (\d+) declarations(?:, .*)?$/);
     if (filesDecls) {
       const cells = Number(filesDecls[1]);
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
-    const checksPassed = line.match(/(\d+) checks passed/);
+    const checksPassed = line.match(/^(?:.*?:\s*)?(\d+) checks passed(?:(?:;|\s{2}).*)?$/);
     if (checksPassed) {
       const cells = Number(checksPassed[1]);
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
-    const cellsPassed = line.match(/(\d+) cells passed/);
+    const cellsPassed = line.match(/^(?:.*?:\s*)?(\d+) cells passed(?:(?:;|\s{2}).*)?$/);
     if (cellsPassed) {
       const cells = Number(cellsPassed[1]);
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
-    const cellsDash = line.match(/(\d+) cells - /);
+    const cellsDash = line.match(/^(?:.*?:\s*)?(\d+) cells - \S.*$/);
     if (cellsDash) {
       const cells = Number(cellsDash[1]);
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
-    const okFailed = line.match(/(\d+) ok, (\d+) failed/);
+    const okFailed = line.match(/^(?:.*?:\s*)?(\d+) ok, (\d+) failed(?:(?:;|\s{2}).*)?$/);
     if (okFailed) {
       const passed = Number(okFailed[1]);
       const failed = Number(okFailed[2]);

--- a/bin/smoke/sentinel.mjs
+++ b/bin/smoke/sentinel.mjs
@@ -58,7 +58,9 @@ export function parseSentinel(text) {
       last = { cells: passed + failed, passed, failed, kind: "legacy" };
       continue;
     }
-    const suiteComplete = line.match(/^(?:SUITE COMPLETE:\s*)?(?:.*?:\s*)?(\d+) passed, (\d+) failed(?:;.*)?$/);
+    // Trailing `;…` or a double-space annotation (`  [session: …]`) is extra, not a new clause.
+    // A single space then words is refused so prose cannot mint a tally.
+    const suiteComplete = line.match(/^(?:SUITE COMPLETE:\s*)?(?:.*?:\s*)?(\d+) passed, (\d+) failed(?:(?:;|\s{2}).*)?$/);
     if (suiteComplete) {
       const passed = Number(suiteComplete[1]);
       const failed = Number(suiteComplete[2]);
@@ -138,14 +140,19 @@ export function parseSentinel(text) {
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
+    const cellsPassed = line.match(/(\d+) cells passed/);
+    if (cellsPassed) {
+      const cells = Number(cellsPassed[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
   }
   if (last) return last;
   // Suites that already print one row per cell but never a tally still named their work. A no-op
   // prints neither, so this cannot turn exit-0-with-nothing into a pass.
   const passed =
     (String(text).match(/^\s*✓/gm) ?? []).length +
-    (String(text).match(/^ok - /gm) ?? []).length +
-    (String(text).match(/^\s*ok {2,}/gm) ?? []).length;
+    (String(text).match(/^\s*ok(?: -)? /gm) ?? []).length;
   const failed =
     (String(text).match(/^\s*✗/gm) ?? []).length +
     (String(text).match(/^not ok - /gm) ?? []).length +

--- a/bin/smoke/sentinel.mjs
+++ b/bin/smoke/sentinel.mjs
@@ -49,14 +49,16 @@ export function parseSentinel(text) {
       last = { cells, passed, failed, kind: "canonical" };
       continue;
     }
-    const pair = line.match(/\((\d+) passed, (\d+) failed\)/);
+    // Suites already name counts as `(N passed, M failed)` or `N passed, M failed; extra`.
+    // Require the close-paren / semicolon / end so a no-op cannot mint a tally from prose.
+    const pair = line.match(/\((\d+) passed, (\d+) failed(?:\)|;)/);
     if (pair) {
       const passed = Number(pair[1]);
       const failed = Number(pair[2]);
       last = { cells: passed + failed, passed, failed, kind: "legacy" };
       continue;
     }
-    const suiteComplete = line.match(/^(?:SUITE COMPLETE:\s*)?(\d+) passed, (\d+) failed$/);
+    const suiteComplete = line.match(/^(?:SUITE COMPLETE:\s*)?(?:.*?:\s*)?(\d+) passed, (\d+) failed(?:;.*)?$/);
     if (suiteComplete) {
       const passed = Number(suiteComplete[1]);
       const failed = Number(suiteComplete[2]);

--- a/bin/smoke/sentinel.mjs
+++ b/bin/smoke/sentinel.mjs
@@ -1,0 +1,209 @@
+/**
+ * Machine-readable terminal sentinel a smoke suite prints with its cell counts.
+ *
+ * `shard.mjs` used to grade a suite on exit status alone, so `process.exit(0)` with zero cells
+ * was indistinguishable from a full pass. The shard now parses this sentinel from the suite's
+ * own output and refuses a missing line or a zero-cell run.
+ *
+ * Suites should print the canonical line through {@link emitSentinel} (or `createSuite().finish()`)
+ * as their last output. A handful of older tally banners are still accepted so a suite that already
+ * names its counts is not rewritten just to change the spelling.
+ */
+export const SENTINEL_PREFIX = "COTAL_SMOKE_SENTINEL";
+
+/**
+ * @param {{ passed: number, failed: number, cells?: number }} counts
+ * @returns {string}
+ */
+export function formatSentinel({ passed, failed, cells }) {
+  const p = Number(passed);
+  const f = Number(failed);
+  const c = cells === undefined ? p + f : Number(cells);
+  return `${SENTINEL_PREFIX} cells=${c} passed=${p} failed=${f}`;
+}
+
+/**
+ * @param {{ passed: number, failed: number, cells?: number }} counts
+ */
+export function emitSentinel(counts) {
+  console.log(formatSentinel(counts));
+}
+
+/**
+ * Last sentinel in `text`, or null if the suite never named a cell count.
+ * Canonical line wins over a legacy tally when both appear; later lines win over earlier ones.
+ *
+ * @param {string} text
+ * @returns {{ cells: number, passed: number, failed: number, kind: "canonical" | "legacy" } | null}
+ */
+export function parseSentinel(text) {
+  let last = null;
+  for (const raw of String(text).split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line) continue;
+    const canonical = line.match(/^COTAL_SMOKE_SENTINEL cells=(\d+) passed=(\d+) failed=(\d+)$/);
+    if (canonical) {
+      const cells = Number(canonical[1]);
+      const passed = Number(canonical[2]);
+      const failed = Number(canonical[3]);
+      last = { cells, passed, failed, kind: "canonical" };
+      continue;
+    }
+    const pair = line.match(/\((\d+) passed, (\d+) failed\)/);
+    if (pair) {
+      const passed = Number(pair[1]);
+      const failed = Number(pair[2]);
+      last = { cells: passed + failed, passed, failed, kind: "legacy" };
+      continue;
+    }
+    const suiteComplete = line.match(/^(?:SUITE COMPLETE:\s*)?(\d+) passed, (\d+) failed$/);
+    if (suiteComplete) {
+      const passed = Number(suiteComplete[1]);
+      const failed = Number(suiteComplete[2]);
+      last = { cells: passed + failed, passed, failed, kind: "legacy" };
+      continue;
+    }
+    const cellsGreen = line.match(/^(\d+) cells green$/);
+    if (cellsGreen) {
+      const cells = Number(cellsGreen[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
+    const cellsOk = line.match(/:\s*(\d+) cells OK$/);
+    if (cellsOk) {
+      const cells = Number(cellsOk[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
+    const testsExecuted = line.match(/:\s*(\d+) tests executed$/);
+    if (testsExecuted) {
+      const cells = Number(testsExecuted[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
+    const parenTests = line.match(/\((\d+) tests\)/);
+    if (parenTests) {
+      const cells = Number(parenTests[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
+    const slash = line.match(/^(\d+)\/(\d+) passed$/);
+    if (slash) {
+      const passed = Number(slash[1]);
+      const cells = Number(slash[2]);
+      last = { cells, passed, failed: cells - passed, kind: "legacy" };
+      continue;
+    }
+    const checksOnly = line.match(/\((\d+) checks(?: passed)?\)/);
+    if (checksOnly) {
+      const cells = Number(checksOnly[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
+    const suiteCells = line.match(/^SUITE COMPLETE:\s*(\d+) cells$/);
+    if (suiteCells) {
+      const cells = Number(suiteCells[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
+    const scanned = line.match(/(\d+) (?:documents checked|source files scanned|files scanned)/);
+    if (scanned) {
+      const cells = Number(scanned[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
+    const names = line.match(/(\d+) names across (\d+) imports/);
+    if (names) {
+      const cells = Number(names[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
+    const named = line.match(/: (\d+) named registrations/);
+    if (named) {
+      const cells = Number(named[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
+    const filesDecls = line.match(/(\d+) files, (\d+) declarations/);
+    if (filesDecls) {
+      const cells = Number(filesDecls[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
+    const checksPassed = line.match(/(\d+) checks passed/);
+    if (checksPassed) {
+      const cells = Number(checksPassed[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
+  }
+  if (last) return last;
+  // Suites that already print one row per cell but never a tally still named their work. A no-op
+  // prints neither, so this cannot turn exit-0-with-nothing into a pass.
+  const passed =
+    (String(text).match(/^\s*✓/gm) ?? []).length +
+    (String(text).match(/^ok - /gm) ?? []).length +
+    (String(text).match(/^\s*ok {2,}/gm) ?? []).length;
+  const failed =
+    (String(text).match(/^\s*✗/gm) ?? []).length +
+    (String(text).match(/^not ok - /gm) ?? []).length +
+    (String(text).match(/^\s*FAIL {2}/gm) ?? []).length;
+  if (passed + failed > 0) return { cells: passed + failed, passed, failed, kind: "legacy" };
+  return null;
+}
+
+/**
+ * Wrap a `node:assert` namespace so each assertion increments a cell count the suite can emit.
+ *
+ * @param {object} ns
+ * @returns {{ assert: object, cells: () => number }}
+ */
+export function countedAssert(ns) {
+  let cells = 0;
+  const assert = new Proxy(ns, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value !== "function") return value;
+      return (...args) => {
+        cells += 1;
+        return value.apply(target, args);
+      };
+    },
+  });
+  return { assert, cells: () => cells };
+}
+
+/**
+ * Local `check` + terminal sentinel. Prefer this over a per-file counter so a forgotten banner
+ * is a missing helper call, not a missing string someone has to remember to type.
+ *
+ * @returns {{
+ *   check: (name: string, cond: boolean, extra?: unknown) => void,
+ *   finish: () => void,
+ *   passed: () => number,
+ *   failed: () => number,
+ * }}
+ */
+export function createSuite() {
+  let passed = 0;
+  let failed = 0;
+  const check = (name, cond, extra) => {
+    if (cond) {
+      passed++;
+      console.log(`  ✓ ${name}`);
+    } else {
+      failed++;
+      console.log(`  ✗ FAIL: ${name}`, extra ?? "");
+    }
+  };
+  const finish = () => {
+    emitSentinel({ passed, failed });
+    if (failed) process.exitCode = 1;
+  };
+  return {
+    check,
+    finish,
+    passed: () => passed,
+    failed: () => failed,
+  };
+}

--- a/bin/smoke/sentinel.mjs
+++ b/bin/smoke/sentinel.mjs
@@ -146,6 +146,19 @@ export function parseSentinel(text) {
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
+    const cellsDash = line.match(/(\d+) cells - /);
+    if (cellsDash) {
+      const cells = Number(cellsDash[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
+    const okFailed = line.match(/(\d+) ok, (\d+) failed/);
+    if (okFailed) {
+      const passed = Number(okFailed[1]);
+      const failed = Number(okFailed[2]);
+      last = { cells: passed + failed, passed, failed, kind: "legacy" };
+      continue;
+    }
   }
   if (last) return last;
   // Suites that already print one row per cell but never a tally still named their work. A no-op

--- a/bin/smoke/shard-never-ran.smoke.ts
+++ b/bin/smoke/shard-never-ran.smoke.ts
@@ -99,10 +99,10 @@ check("a single-suite partition's only failure reports nothing", neverRanBlock([
 //   red: "the shipped never-ran block names only the two suites that never started"
 //   still green: helper isolation cells, and "a fully green shard reports nothing as never-ran"
 const green = runShippedShard({
-  "smoke:a": "node -e \"process.exit(0)\"",
-  "smoke:b": "node -e \"process.exit(0)\"",
-  "smoke:c": "node -e \"process.exit(0)\"",
-  "smoke:d": "node -e \"process.exit(0)\"",
+  "smoke:a": "node -e \"console.log('COTAL_SMOKE_SENTINEL cells=1 passed=1 failed=0')\"",
+  "smoke:b": "node -e \"console.log('COTAL_SMOKE_SENTINEL cells=1 passed=1 failed=0')\"",
+  "smoke:c": "node -e \"console.log('COTAL_SMOKE_SENTINEL cells=1 passed=1 failed=0')\"",
+  "smoke:d": "node -e \"console.log('COTAL_SMOKE_SENTINEL cells=1 passed=1 failed=0')\"",
 });
 check("the green fixture planned exactly 4 suites and did not time out", !green.timedOut && /shard 0\/1 — 4 of 4 smokes/.test(green.out), green.out.slice(0, 400));
 check(
@@ -117,7 +117,7 @@ check(
 );
 
 const broken = runShippedShard({
-  "smoke:a": "node -e \"process.exit(0)\"",
+  "smoke:a": "node -e \"console.log('COTAL_SMOKE_SENTINEL cells=1 passed=1 failed=0')\"",
   "smoke:b": "node -e \"process.exit(7)\"",
   "smoke:c": "node -e \"process.exit(0)\"",
   "smoke:d": "node -e \"process.exit(0)\"",

--- a/bin/smoke/shard-sentinel.smoke.ts
+++ b/bin/smoke/shard-sentinel.smoke.ts
@@ -104,8 +104,12 @@ const cellsPassed = parseSentinel("transform.smoke: 40 cells passed\n");
 check("an N cells passed banner is a tally", cellsPassed?.kind === "legacy" && cellsPassed.cells === 40 && cellsPassed.passed === 40);
 const tapOk = parseSentinel("  ok the transform emits\n  ok and reaches no seam member\n");
 check("indented TAP ok lines are per-cell tallies", tapOk?.kind === "legacy" && tapOk.cells === 2 && tapOk.passed === 2);
+const cellsDash = parseSentinel("spawn-env-config smoke: 6 cells - layering, replace-not-union\n");
+check("an N cells - banner is a tally", cellsDash?.kind === "legacy" && cellsDash.cells === 6 && cellsDash.passed === 6);
+const okFailed = parseSentinel("run-command: 12 ok, 0 failed\n");
+check("an N ok, M failed banner is a tally", okFailed?.kind === "legacy" && okFailed.cells === 12 && okFailed.passed === 12 && okFailed.failed === 0);
 
-const EXPECTED = 17;
+const EXPECTED = 19;
 check(
   `every cell ran - ${EXPECTED} before this sentinel cell, so a cell that stops existing is not mistaken for one that passed`,
   passed() + failed() === EXPECTED,

--- a/bin/smoke/shard-sentinel.smoke.ts
+++ b/bin/smoke/shard-sentinel.smoke.ts
@@ -1,0 +1,96 @@
+/**
+ * Issue #1297: shard.mjs used to mark a suite passed on `r.status !== 0` alone. A suite that
+ * exits 0 having run zero cells was indistinguishable from a full pass, and the banner reported it
+ * as covered. This suite drives the shipped runner over a synthetic list (never the repo
+ * registry): a no-op must red naming the suite and the reason, and a sentinel-emitting suite must
+ * green with the cell count.
+ *
+ * Run: pnpm smoke:shard-sentinel
+ */
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { formatSentinel as kitFormat, parseSentinel as kitParse } from "../../packages/smoke-kit/src/sentinel.ts";
+import { createSuite, formatSentinel, parseSentinel } from "./sentinel.mjs";
+
+const SHARD = fileURLToPath(new URL("./shard.mjs", import.meta.url));
+const SENTINEL = formatSentinel({ passed: 3, failed: 0 });
+
+function runShippedShard(scripts: Record<string, string>) {
+  const dir = mkdtempSync(join(tmpdir(), "cotal-shard-sentinel-"));
+  try {
+    const names = Object.keys(scripts);
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ private: true, scripts }));
+    const listPath = join(dir, "ci-suites.txt");
+    writeFileSync(listPath, `${names.join("\n")}\n`);
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    for (const key of Object.keys(env)) if (key.startsWith("COTAL_")) delete env[key];
+    const r = spawnSync(process.execPath, [SHARD, "0", "1"], {
+      cwd: dir,
+      env: { ...env, COTAL_CI_SUITES: listPath },
+      encoding: "utf8",
+      timeout: 60_000,
+      maxBuffer: 2 * 1024 * 1024,
+    });
+    const out = `${r.stdout ?? ""}${r.stderr ?? ""}`;
+    return {
+      status: r.status,
+      timedOut: (r.error as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT" || r.signal === "SIGTERM",
+      out,
+    };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const { check, finish, passed, failed } = createSuite();
+
+console.log("shard-sentinel: a suite that exits 0 with no cells is not a covered pass");
+
+const parsed = parseSentinel(`noise\n${SENTINEL}\n`);
+check("the helper parses the canonical sentinel it prints", parsed?.kind === "canonical" && parsed.cells === 3 && parsed.passed === 3 && parsed.failed === 0, parsed);
+check("the smoke-kit helper prints the same canonical line the shard parses", kitFormat({ passed: 3, failed: 0 }) === SENTINEL && kitParse(SENTINEL)?.cells === 3);
+check("a missing sentinel is not invented", parseSentinel("SMOKE OK\n") === null);
+check("a zero-cell canonical sentinel is still a sentinel (the shard, not the parser, refuses it)", parseSentinel(formatSentinel({ passed: 0, failed: 0 }))?.cells === 0);
+
+const noop = runShippedShard({
+  "smoke:zero-assert": 'node -e "process.exit(0)"',
+});
+check("the no-op fixture planned exactly one suite and did not time out", !noop.timedOut && /shard 0\/1 — 1 of 1 smokes/.test(noop.out), noop.out.slice(0, 400));
+check(
+  "a no-op suite that exits 0 is named FAILED with no sentinel",
+  !noop.timedOut && noop.status !== 0 && /FAILED at: pnpm smoke:zero-assert \(no sentinel\)/.test(noop.out),
+  noop.out.slice(-500),
+);
+check("a no-op suite does not print a green shard banner", !noop.timedOut && !/passed \(1 smokes/.test(noop.out), noop.out.slice(-300));
+
+const zeroCells = runShippedShard({
+  "smoke:zero-cells": `node -e ${JSON.stringify(`console.log(${JSON.stringify(formatSentinel({ passed: 0, failed: 0 }))})`)}`,
+});
+check(
+  "a suite that prints a sentinel with zero cells is named FAILED with zero cells",
+  !zeroCells.timedOut && zeroCells.status !== 0 && /FAILED at: pnpm smoke:zero-cells \(zero cells\)/.test(zeroCells.out),
+  zeroCells.out.slice(-500),
+);
+
+const green = runShippedShard({
+  "smoke:with-cells": `node -e ${JSON.stringify(`console.log(${JSON.stringify(SENTINEL)})`)}`,
+});
+check("the sentinel fixture planned exactly one suite and did not time out", !green.timedOut && /shard 0\/1 — 1 of 1 smokes/.test(green.out), green.out.slice(0, 400));
+check(
+  "a sentinel-emitting suite greens the shard with the cell count",
+  !green.timedOut && green.status === 0 && /passed \(1 smokes, 3 cells\)/.test(green.out),
+  green.out.slice(-400),
+);
+check("the green banner names cells, not only suites", /3 cells/.test(green.out), green.out.slice(-300));
+
+const EXPECTED = 11;
+check(
+  `every cell ran - ${EXPECTED} before this sentinel cell, so a cell that stops existing is not mistaken for one that passed`,
+  passed() + failed() === EXPECTED,
+  `${passed() + failed()} cells reported`,
+);
+
+finish();

--- a/bin/smoke/shard-sentinel.smoke.ts
+++ b/bin/smoke/shard-sentinel.smoke.ts
@@ -102,14 +102,42 @@ check(
 );
 const cellsPassed = parseSentinel("transform.smoke: 40 cells passed\n");
 check("an N cells passed banner is a tally", cellsPassed?.kind === "legacy" && cellsPassed.cells === 40 && cellsPassed.passed === 40);
+check(
+  "prose that mentions N cells passed is not a tally",
+  parseSentinel("the suite has 52 cells passed historically, but we skipped it\n") === null,
+);
+check(
+  "prose wrapping a parenthetical passed/failed pair is not a tally",
+  parseSentinel("note: an earlier run had (12 passed, 3 failed) before we skipped it\n") === null,
+);
+check(
+  "prose wrapping (N tests) is not a tally",
+  parseSentinel("we skipped the suite (40 tests) entirely this round\n") === null,
+);
+check(
+  "prose that mentions source files scanned is not a tally",
+  parseSentinel("a previous sweep had 40 source files scanned, none today\n") === null,
+);
+check(
+  "prose that mentions names across imports is not a tally",
+  parseSentinel("the inventory lists 40 names across 12 imports, unverified\n") === null,
+);
 const tapOk = parseSentinel("  ok the transform emits\n  ok and reaches no seam member\n");
 check("indented TAP ok lines are per-cell tallies", tapOk?.kind === "legacy" && tapOk.cells === 2 && tapOk.passed === 2);
 const cellsDash = parseSentinel("spawn-env-config smoke: 6 cells - layering, replace-not-union\n");
 check("an N cells - banner is a tally", cellsDash?.kind === "legacy" && cellsDash.cells === 6 && cellsDash.passed === 6);
+check(
+  "prose that mentions N cells - is not a tally",
+  parseSentinel("we still have 6 cells - historically unused\n") === null,
+);
 const okFailed = parseSentinel("run-command: 12 ok, 0 failed\n");
 check("an N ok, M failed banner is a tally", okFailed?.kind === "legacy" && okFailed.cells === 12 && okFailed.passed === 12 && okFailed.failed === 0);
+check(
+  "prose that mentions N ok, M failed is not a tally",
+  parseSentinel("docs said 12 ok, 0 failed yesterday\n") === null,
+);
 
-const EXPECTED = 19;
+const EXPECTED = 26;
 check(
   `every cell ran - ${EXPECTED} before this sentinel cell, so a cell that stops existing is not mistaken for one that passed`,
   passed() + failed() === EXPECTED,

--- a/bin/smoke/shard-sentinel.smoke.ts
+++ b/bin/smoke/shard-sentinel.smoke.ts
@@ -12,8 +12,8 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { formatSentinel as kitFormat, parseSentinel as kitParse } from "../../packages/smoke-kit/src/sentinel.ts";
-import { createSuite, formatSentinel, parseSentinel } from "./sentinel.mjs";
+import { createSuite, formatSentinel as kitFormat, parseSentinel as kitParse } from "@cotal-ai/smoke-kit";
+import { formatSentinel, parseSentinel } from "./sentinel.mjs";
 
 const SHARD = fileURLToPath(new URL("./shard.mjs", import.meta.url));
 const SENTINEL = formatSentinel({ passed: 3, failed: 0 });
@@ -86,7 +86,12 @@ check(
 );
 check("the green banner names cells, not only suites", /3 cells/.test(green.out), green.out.slice(-300));
 
-const EXPECTED = 11;
+const extraTally = parseSentinel("FROZEN-EXPORTS SMOKE OK ✅  (12 passed, 0 failed; 3 arrays + 4 plain-objects scanned)\n");
+check("a parenthetical tally still counts when extra text follows failed", extraTally?.kind === "legacy" && extraTally.cells === 12 && extraTally.passed === 12);
+const prefixed = parseSentinel("artifact-contract: 5 passed, 0 failed\n");
+check("a prefixed N passed, M failed line is a tally", prefixed?.kind === "legacy" && prefixed.cells === 5 && prefixed.passed === 5);
+
+const EXPECTED = 13;
 check(
   `every cell ran - ${EXPECTED} before this sentinel cell, so a cell that stops existing is not mistaken for one that passed`,
   passed() + failed() === EXPECTED,

--- a/bin/smoke/shard-sentinel.smoke.ts
+++ b/bin/smoke/shard-sentinel.smoke.ts
@@ -90,8 +90,22 @@ const extraTally = parseSentinel("FROZEN-EXPORTS SMOKE OK ✅  (12 passed, 0 fai
 check("a parenthetical tally still counts when extra text follows failed", extraTally?.kind === "legacy" && extraTally.cells === 12 && extraTally.passed === 12);
 const prefixed = parseSentinel("artifact-contract: 5 passed, 0 failed\n");
 check("a prefixed N passed, M failed line is a tally", prefixed?.kind === "legacy" && prefixed.cells === 5 && prefixed.passed === 5);
+const annotated = parseSentinel("agui-map smoke: 51 passed, 0 failed  [session: session-shape.jsonl, 2200 records]\n");
+check(
+  "a prefixed tally still counts when a double-space annotation follows failed",
+  annotated?.kind === "legacy" && annotated.cells === 51 && annotated.passed === 51 && annotated.failed === 0,
+  annotated,
+);
+check(
+  "a single-space clause after failed is not a tally",
+  parseSentinel("note: 1 passed, 0 failed files remaining\n") === null,
+);
+const cellsPassed = parseSentinel("transform.smoke: 40 cells passed\n");
+check("an N cells passed banner is a tally", cellsPassed?.kind === "legacy" && cellsPassed.cells === 40 && cellsPassed.passed === 40);
+const tapOk = parseSentinel("  ok the transform emits\n  ok and reaches no seam member\n");
+check("indented TAP ok lines are per-cell tallies", tapOk?.kind === "legacy" && tapOk.cells === 2 && tapOk.passed === 2);
 
-const EXPECTED = 13;
+const EXPECTED = 17;
 check(
   `every cell ran - ${EXPECTED} before this sentinel cell, so a cell that stops existing is not mistaken for one that passed`,
   passed() + failed() === EXPECTED,

--- a/bin/smoke/shard.mjs
+++ b/bin/smoke/shard.mjs
@@ -9,12 +9,17 @@
  * use a stable hash of their suite name, so an independently-merged fragment cannot move another.
  * Each smoke runs in its own `pnpm` subprocess (separate broker/ports) exactly as the serial chain
  * does; the shards run on SEPARATE runners, so there is no cross-smoke port contention within a shard.
+ *
+ * Exit status is not enough. A suite that returns 0 having run zero cells is the same false green
+ * as an empty chain; the runner parses a cell-count sentinel from the suite's own output and refuses
+ * a missing sentinel or a zero-cell run, naming the suite and the reason.
  */
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { parseCiSuites, readCiSuiteFragments, suitesForShard, CI_SUITES_PATH } from "./ci-suites.mjs";
 import { readFileSync } from "node:fs";
 import { reapSmokeBrokers, reportReaped } from "./reap-smoke-brokers.mjs";
 import { neverRanBlock } from "./shard-never-ran.mjs";
+import { parseSentinel } from "./sentinel.mjs";
 
 const shard = Number(process.argv[2]);
 const count = Number(process.argv[3]);
@@ -44,40 +49,83 @@ if (pre.supported && pre.reaped.length > 0) {
 }
 
 const isWin = process.platform === "win32";
-const leaked = [];
-let failure;
-for (let i = 0; i < mine.length; i++) {
-  const cmd = mine[i];
-  const [bin, ...args] = cmd.split(/\s+/);
-  console.log(`\n===== ${cmd} =====`);
-  // shell:true on Windows so `pnpm` resolves to pnpm.cmd; the tokens are our own fixed script names.
-  const r = spawnSync(bin, args, { stdio: "inherit", shell: isWin });
-  // Reap BEFORE deciding what to do about the exit status, so a suite that fails does not also get to
-  // abandon its broker for the rest of the run. Anything with the token here is new since the sweep
-  // above, so it belongs to the suite that just returned.
-  const after = reapSmokeBrokers();
-  reportReaped(cmd, after);
-  if (after.reaped.length > 0) leaked.push({ cmd, count: after.reaped.length });
-  if (r.status !== 0) {
-    console.error(`\n✗ shard ${shard}/${count} FAILED at: ${cmd} (exit ${r.status})`);
-    const never = neverRanBlock(mine, i);
-    if (never) console.error(never);
-    failure = r.status || 1;
-    break;
-  }
+
+/** Capture stdout+stderr while still writing them, so the sentinel can be parsed from the suite. */
+function runSuite(bin, args) {
+  return new Promise((resolve) => {
+    const child = spawn(bin, args, { stdio: ["inherit", "pipe", "pipe"], shell: isWin });
+    let out = "";
+    const take = (buf, write) => {
+      const s = typeof buf === "string" ? buf : buf.toString();
+      out += s;
+      write(s);
+    };
+    child.stdout?.on("data", (buf) => take(buf, (s) => process.stdout.write(s)));
+    child.stderr?.on("data", (buf) => take(buf, (s) => process.stderr.write(s)));
+    child.on("error", (err) => {
+      resolve({ status: 1, out: `${out}${err}\n` });
+    });
+    child.on("close", (status, signal) => {
+      resolve({ status: status === null ? (signal ? 1 : 1) : status, out });
+    });
+  });
 }
 
-// A suite that passes its assertions and leaves a broker running is a FALSE GREEN, so it fails the
-// shard. It is reported at the end rather than at the first offender because one full run naming
-// every leaking suite is worth more than a run that stops at the first and hides the rest. A failing
-// suite is reported by its own status first: it already has a reason, and a leak on the way out is a
-// consequence of it, not an independent finding.
-if (failure !== undefined) process.exit(failure);
-if (leaked.length > 0) {
-  console.error(`\n✗ shard ${shard}/${count}: ${leaked.length} suite(s) passed but LEAKED a broker they owned:`);
-  for (const { cmd, count: n } of leaked) console.error(`    ${cmd} (${n})`);
-  console.error(`  A green suite that leaves a broker running is a false green. Each of these tore down on`);
-  console.error(`  its normal path in review, so this is a real regression in one of them, not reaper noise.`);
-  process.exit(1);
+const leaked = [];
+let failure;
+let totalCells = 0;
+
+/** One emit site: later suites that never started stay named the same way for every break reason. */
+function failAt(cmd, i, reason, status) {
+  console.error(`\n✗ shard ${shard}/${count} FAILED at: ${cmd} (${reason})`);
+  const never = neverRanBlock(mine, i);
+  if (never) console.error(never);
+  failure = status;
 }
-console.log(`\n✓ smoke:ci shard ${shard}/${count} passed (${mine.length} smokes)`);
+
+async function main() {
+  for (let i = 0; i < mine.length; i++) {
+    const cmd = mine[i];
+    const [bin, ...args] = cmd.split(/\s+/);
+    console.log(`\n===== ${cmd} =====`);
+    // shell:true on Windows so `pnpm` resolves to pnpm.cmd; the tokens are our own fixed script names.
+    const r = await runSuite(bin, args);
+    // Reap BEFORE deciding what to do about the exit status, so a suite that fails does not also get to
+    // abandon its broker for the rest of the run. Anything with the token here is new since the sweep
+    // above, so it belongs to the suite that just returned.
+    const after = reapSmokeBrokers();
+    reportReaped(cmd, after);
+    if (after.reaped.length > 0) leaked.push({ cmd, count: after.reaped.length });
+    if (r.status !== 0) {
+      failAt(cmd, i, `exit ${r.status}`, r.status || 1);
+      break;
+    }
+    const sentinel = parseSentinel(r.out);
+    if (!sentinel) {
+      failAt(cmd, i, "no sentinel", 1);
+      break;
+    }
+    if (sentinel.cells === 0) {
+      failAt(cmd, i, "zero cells", 1);
+      break;
+    }
+    totalCells += sentinel.cells;
+  }
+
+  // A suite that passes its assertions and leaves a broker running is a FALSE GREEN, so it fails the
+  // shard. It is reported at the end rather than at the first offender because one full run naming
+  // every leaking suite is worth more than a run that stops at the first and hides the rest. A failing
+  // suite is reported by its own status first: it already has a reason, and a leak on the way out is a
+  // consequence of it, not an independent finding.
+  if (failure !== undefined) process.exit(failure);
+  if (leaked.length > 0) {
+    console.error(`\n✗ shard ${shard}/${count}: ${leaked.length} suite(s) passed but LEAKED a broker they owned:`);
+    for (const { cmd, count: n } of leaked) console.error(`    ${cmd} (${n})`);
+    console.error(`  A green suite that leaves a broker running is a false green. Each of these tore down on`);
+    console.error(`  its normal path in review, so this is a real regression in one of them, not reaper noise.`);
+    process.exit(1);
+  }
+  console.log(`\n✓ smoke:ci shard ${shard}/${count} passed (${mine.length} smokes, ${totalCells} cells)`);
+}
+
+await main();

--- a/extensions/connector-core/smoke/operator-env-keep.smoke.ts
+++ b/extensions/connector-core/smoke/operator-env-keep.smoke.ts
@@ -20,12 +20,14 @@
  * Run: pnpm smoke:operator-env-keep
  */
 import { strict as nodeAssert } from "node:assert";
-import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
+import { countedAssert, emitSentinel } from "@cotal-ai/smoke-kit";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { OPERATOR_ENV_KEEP } from "../src/launch.js";
-const { assert, cells } = countedAssert(nodeAssert);
+const counted = countedAssert(nodeAssert);
+const assert: typeof nodeAssert = counted.assert;
+const cells = counted.cells;
 
 const extensionsRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const repoRoot = join(extensionsRoot, "..");

--- a/extensions/connector-core/smoke/operator-env-keep.smoke.ts
+++ b/extensions/connector-core/smoke/operator-env-keep.smoke.ts
@@ -19,11 +19,13 @@
  *
  * Run: pnpm smoke:operator-env-keep
  */
-import { strict as assert } from "node:assert";
+import { strict as nodeAssert } from "node:assert";
+import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { OPERATOR_ENV_KEEP } from "../src/launch.js";
+const { assert, cells } = countedAssert(nodeAssert);
 
 const extensionsRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const repoRoot = join(extensionsRoot, "..");
@@ -166,3 +168,4 @@ console.log(
     `${OPERATOR_ENV_KEEP.length} keep-list names, 0 conflicts, ` +
     `${callers.length} launchEnv call sites, none outside the walked tree contributing a COTAL_ name`,
 );
+emitSentinel({ passed: cells(), failed: 0 });

--- a/implementations/auth/smoke/manager-goal-index.smoke.ts
+++ b/implementations/auth/smoke/manager-goal-index.smoke.ts
@@ -1,10 +1,12 @@
 /** Closed host-owned remote manager goal-index scan policy. */
 import nodeAssert from "node:assert/strict";
-import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
+import { countedAssert, emitSentinel } from "@cotal-ai/smoke-kit";
 import { mintLifecycleUid, newIdentity, remoteManagerActors, type RemoteManagerGoalIndexScanRequest } from "@cotal-ai/core";
 import { authorizeRemoteManagerGoalIndexScan, completeRemoteManagerGoalIndexScan, parseRemoteManagerGoalIndexScanRequest } from "../src/manager-goal-index.js";
 import { remoteManagerCurrentRegistrationProof } from "../src/retained-manager-validation.js";
-const { assert, cells } = countedAssert(nodeAssert);
+const counted = countedAssert(nodeAssert);
+const assert: typeof nodeAssert = counted.assert;
+const cells = counted.cells;
 
 const owner = `u_${"a".repeat(26)}`;
 const otherOwner = `u_${"b".repeat(26)}`;

--- a/implementations/auth/smoke/manager-goal-index.smoke.ts
+++ b/implementations/auth/smoke/manager-goal-index.smoke.ts
@@ -1,8 +1,10 @@
 /** Closed host-owned remote manager goal-index scan policy. */
-import assert from "node:assert/strict";
+import nodeAssert from "node:assert/strict";
+import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
 import { mintLifecycleUid, newIdentity, remoteManagerActors, type RemoteManagerGoalIndexScanRequest } from "@cotal-ai/core";
 import { authorizeRemoteManagerGoalIndexScan, completeRemoteManagerGoalIndexScan, parseRemoteManagerGoalIndexScanRequest } from "../src/manager-goal-index.js";
 import { remoteManagerCurrentRegistrationProof } from "../src/retained-manager-validation.js";
+const { assert, cells } = countedAssert(nodeAssert);
 
 const owner = `u_${"a".repeat(26)}`;
 const otherOwner = `u_${"b".repeat(26)}`;
@@ -37,3 +39,4 @@ const entry = { v: 1 as const, endpoint: "manager", owner, actor: "cli", uid: mi
 assert.deepEqual(completeRemoteManagerGoalIndexScan(authorized, owner, [entry]).entries, [entry]);
 assert.throws(() => completeRemoteManagerGoalIndexScan(authorized, owner, [{ ...entry, owner: otherOwner }]), /foreign endpoint or owner/);
 console.log("manager goal-index scan: 8 passed, 0 failed");
+emitSentinel({ passed: cells(), failed: 0 });

--- a/implementations/auth/smoke/owned-child-cleanup.smoke.ts
+++ b/implementations/auth/smoke/owned-child-cleanup.smoke.ts
@@ -1,7 +1,9 @@
 /** Executable control for fail-closed exact-child probe cleanup. */
-import assert from "node:assert/strict";
+import nodeAssert from "node:assert/strict";
+import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
 import { spawn } from "node:child_process";
 import { stopOwnedChild } from "./_owned-child-cleanup.js";
+const { assert, cells } = countedAssert(nodeAssert);
 
 const stubborn = spawn(process.execPath, ["-e", `
   process.on("SIGTERM", () => {});
@@ -21,3 +23,4 @@ await new Promise((resolve) => setTimeout(resolve, 50));
 assert.equal(await stopOwnedChild(cooperative, { termTimeoutMs: 2_000, killTimeoutMs: 2_000 }), "term");
 assert.ok(cooperative.exitCode !== null || cooperative.signalCode !== null, "SIGTERM outcome requires observed exit");
 console.log("owned child cleanup: 2 passed, 0 failed");
+emitSentinel({ passed: cells(), failed: 0 });

--- a/implementations/auth/smoke/owned-child-cleanup.smoke.ts
+++ b/implementations/auth/smoke/owned-child-cleanup.smoke.ts
@@ -1,9 +1,11 @@
 /** Executable control for fail-closed exact-child probe cleanup. */
 import nodeAssert from "node:assert/strict";
-import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
+import { countedAssert, emitSentinel } from "@cotal-ai/smoke-kit";
 import { spawn } from "node:child_process";
 import { stopOwnedChild } from "./_owned-child-cleanup.js";
-const { assert, cells } = countedAssert(nodeAssert);
+const counted = countedAssert(nodeAssert);
+const assert: typeof nodeAssert = counted.assert;
+const cells = counted.cells;
 
 const stubborn = spawn(process.execPath, ["-e", `
   process.on("SIGTERM", () => {});

--- a/implementations/cli/smoke/agent-skills.smoke.ts
+++ b/implementations/cli/smoke/agent-skills.smoke.ts
@@ -8,12 +8,14 @@
  * corrupt-JSON fail-loud). Run: pnpm smoke:agent-skills
  */
 import nodeAssert from "node:assert/strict";
-import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
+import { countedAssert, emitSentinel } from "@cotal-ai/smoke-kit";
 import { createHash } from "node:crypto";
 import { existsSync, linkSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-const { assert, cells } = countedAssert(nodeAssert);
+const counted = countedAssert(nodeAssert);
+const assert: typeof nodeAssert = counted.assert;
+const cells = counted.cells;
 
 const sha = (b: Buffer | string) => "sha256:" + createHash("sha256").update(b).digest("hex");
 const created: string[] = [];

--- a/implementations/cli/smoke/agent-skills.smoke.ts
+++ b/implementations/cli/smoke/agent-skills.smoke.ts
@@ -7,11 +7,13 @@
  * symlink-clobber guard, and manifest integrity (traversal-key rejection, array-shape rejection,
  * corrupt-JSON fail-loud). Run: pnpm smoke:agent-skills
  */
-import assert from "node:assert/strict";
+import nodeAssert from "node:assert/strict";
+import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
 import { createHash } from "node:crypto";
 import { existsSync, linkSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+const { assert, cells } = countedAssert(nodeAssert);
 
 const sha = (b: Buffer | string) => "sha256:" + createHash("sha256").update(b).digest("hex");
 const created: string[] = [];
@@ -208,3 +210,4 @@ try {
 } finally {
   for (const d of created) rmSync(d, { recursive: true, force: true });
 }
+emitSentinel({ passed: cells(), failed: 0 });

--- a/implementations/cli/smoke/backup.smoke.ts
+++ b/implementations/cli/smoke/backup.smoke.ts
@@ -1,5 +1,6 @@
 /** Hermetic CLI backup artifact and maintenance-grammar smoke. */
-import assert from "node:assert/strict";
+import nodeAssert from "node:assert/strict";
+import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -16,6 +17,7 @@ import { assertEndpointUnreachable } from "../src/lib/endpoint-cut.js";
 import { consumerConfigFromCheckpoint, createSpaceAuth, dmStream, rotateSystemAccount, taskStream } from "@cotal-ai/core";
 import { authDir, saveSpaceAuth } from "@cotal-ai/workspace";
 import { DeliverPolicy, type ConsumerInfo } from "@nats-io/jetstream";
+const { assert, cells } = countedAssert(nodeAssert);
 
 const root = mkdtempSync(join(tmpdir(), "cotal-backup-cli-"));
 try {
@@ -266,3 +268,4 @@ try {
 } finally {
   rmSync(root, { recursive: true, force: true });
 }
+emitSentinel({ passed: cells(), failed: 0 });

--- a/implementations/cli/smoke/backup.smoke.ts
+++ b/implementations/cli/smoke/backup.smoke.ts
@@ -1,6 +1,6 @@
 /** Hermetic CLI backup artifact and maintenance-grammar smoke. */
 import nodeAssert from "node:assert/strict";
-import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
+import { countedAssert, emitSentinel } from "@cotal-ai/smoke-kit";
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -17,7 +17,9 @@ import { assertEndpointUnreachable } from "../src/lib/endpoint-cut.js";
 import { consumerConfigFromCheckpoint, createSpaceAuth, dmStream, rotateSystemAccount, taskStream } from "@cotal-ai/core";
 import { authDir, saveSpaceAuth } from "@cotal-ai/workspace";
 import { DeliverPolicy, type ConsumerInfo } from "@nats-io/jetstream";
-const { assert, cells } = countedAssert(nodeAssert);
+const counted = countedAssert(nodeAssert);
+const assert: typeof nodeAssert = counted.assert;
+const cells = counted.cells;
 
 const root = mkdtempSync(join(tmpdir(), "cotal-backup-cli-"));
 try {

--- a/implementations/cli/smoke/legacy-manager-report.smoke.ts
+++ b/implementations/cli/smoke/legacy-manager-report.smoke.ts
@@ -1,6 +1,8 @@
-import assert from "node:assert/strict";
+import nodeAssert from "node:assert/strict";
+import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
 import { sessionContinuityClass } from "@cotal-ai/core";
 import { legacyManagerReport } from "../src/lib/legacy-manager-report.js";
+const { assert, cells } = countedAssert(nodeAssert);
 
 const classes = [
   [{ supportsSessionContinuation: true, supportsResume: true, supportsFreshStart: true }, "exact"],
@@ -39,3 +41,4 @@ assert.deepEqual(report, {
 assert.equal(await legacyManagerReport({ custody: "custodied" }, [], async () => ({})), undefined);
 
 console.log("legacy manager report smoke OK");
+emitSentinel({ passed: cells(), failed: 0 });

--- a/implementations/cli/smoke/legacy-manager-report.smoke.ts
+++ b/implementations/cli/smoke/legacy-manager-report.smoke.ts
@@ -1,8 +1,10 @@
 import nodeAssert from "node:assert/strict";
-import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
+import { countedAssert, emitSentinel } from "@cotal-ai/smoke-kit";
 import { sessionContinuityClass } from "@cotal-ai/core";
 import { legacyManagerReport } from "../src/lib/legacy-manager-report.js";
-const { assert, cells } = countedAssert(nodeAssert);
+const counted = countedAssert(nodeAssert);
+const assert: typeof nodeAssert = counted.assert;
+const cells = counted.cells;
 
 const classes = [
   [{ supportsSessionContinuation: true, supportsResume: true, supportsFreshStart: true }, "exact"],

--- a/implementations/cli/smoke/legacy-packaged-manager.smoke.ts
+++ b/implementations/cli/smoke/legacy-packaged-manager.smoke.ts
@@ -1,5 +1,5 @@
 import nodeAssert from "node:assert/strict";
-import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
+import { countedAssert, emitSentinel } from "@cotal-ai/smoke-kit";
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
 import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
@@ -7,7 +7,9 @@ import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { homedir } from "node:os";
 import { basename, dirname, join, sep } from "node:path";
-const { assert, cells } = countedAssert(nodeAssert);
+const counted = countedAssert(nodeAssert);
+const assert: typeof nodeAssert = counted.assert;
+const cells = counted.cells;
 
 const originalHome = process.env.HOME ?? homedir();
 const originalXdg = process.env.XDG_CONFIG_HOME ?? join(originalHome, ".config");

--- a/implementations/cli/smoke/legacy-packaged-manager.smoke.ts
+++ b/implementations/cli/smoke/legacy-packaged-manager.smoke.ts
@@ -1,4 +1,5 @@
-import assert from "node:assert/strict";
+import nodeAssert from "node:assert/strict";
+import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
 import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
@@ -6,6 +7,7 @@ import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { homedir } from "node:os";
 import { basename, dirname, join, sep } from "node:path";
+const { assert, cells } = countedAssert(nodeAssert);
 
 const originalHome = process.env.HOME ?? homedir();
 const originalXdg = process.env.XDG_CONFIG_HOME ?? join(originalHome, ".config");
@@ -270,3 +272,4 @@ setInterval(() => {}, 1000);
   assert.deepEqual(existsSync(operatorStamp) ? readFileSync(operatorStamp) : undefined, stampBefore, "fixture did not change the operator seed stamp");
   rmSync(base, { recursive: true, force: true });
 }
+emitSentinel({ passed: cells(), failed: 0 });

--- a/implementations/cli/smoke/setup-failloud.smoke.ts
+++ b/implementations/cli/smoke/setup-failloud.smoke.ts
@@ -12,12 +12,14 @@
  *
  * Run: pnpm smoke:setup-failloud
  */
-import assert from "node:assert/strict";
+import nodeAssert from "node:assert/strict";
+import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { type Connector } from "@cotal-ai/core";
 import { setInstalledExtensionsEnabled } from "../src/ext-loader.js";
 import { connectorSetupStep, setupConnectorSurface } from "../src/commands/setup.js";
+const { assert, cells } = countedAssert(nodeAssert);
 
 const tmp = mkdtempSync(join(import.meta.dirname, ".setup-failloud-"));
 process.env.XDG_CONFIG_HOME = tmp;
@@ -64,3 +66,4 @@ try {
 } finally {
   rmSync(tmp, { recursive: true, force: true });
 }
+emitSentinel({ passed: cells(), failed: 0 });

--- a/implementations/cli/smoke/setup-failloud.smoke.ts
+++ b/implementations/cli/smoke/setup-failloud.smoke.ts
@@ -13,13 +13,15 @@
  * Run: pnpm smoke:setup-failloud
  */
 import nodeAssert from "node:assert/strict";
-import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
+import { countedAssert, emitSentinel } from "@cotal-ai/smoke-kit";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { type Connector } from "@cotal-ai/core";
 import { setInstalledExtensionsEnabled } from "../src/ext-loader.js";
 import { connectorSetupStep, setupConnectorSurface } from "../src/commands/setup.js";
-const { assert, cells } = countedAssert(nodeAssert);
+const counted = countedAssert(nodeAssert);
+const assert: typeof nodeAssert = counted.assert;
+const cells = counted.cells;
 
 const tmp = mkdtempSync(join(import.meta.dirname, ".setup-failloud-"));
 process.env.XDG_CONFIG_HOME = tmp;

--- a/implementations/cli/smoke/setup-provider-absent.smoke.ts
+++ b/implementations/cli/smoke/setup-provider-absent.smoke.ts
@@ -1,9 +1,12 @@
-import assert from "node:assert/strict";
+import nodeAssert from "node:assert/strict";
+import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { installAgentSkills } from "../src/lib/agent-skills.js";
 import { setupProviderAvailable } from "../src/commands/setup.js";
+
+const { assert, cells } = countedAssert(nodeAssert);
 
 const home = mkdtempSync(join(tmpdir(), "cotal-setup-provider-absent-"));
 const priorHome = process.env.HOME;
@@ -16,6 +19,7 @@ try {
   assert.ok(result.installed.includes("team-topology"), "cross-vendor skills still reconcile when a harness provider is unavailable");
   assert.equal(existsSync(join(home, ".agents", "skills", "team-topology", "SKILL.md")), true, "the .agents skill was written without the harness");
   console.log("setup-provider-absent.smoke: all assertions passed");
+  emitSentinel({ passed: cells(), failed: 0 });
 } finally {
   if (priorHome === undefined) delete process.env.HOME; else process.env.HOME = priorHome;
   if (priorPath === undefined) delete process.env.PATH; else process.env.PATH = priorPath;

--- a/implementations/cli/smoke/setup-provider-absent.smoke.ts
+++ b/implementations/cli/smoke/setup-provider-absent.smoke.ts
@@ -1,12 +1,14 @@
 import nodeAssert from "node:assert/strict";
-import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
+import { countedAssert, emitSentinel } from "@cotal-ai/smoke-kit";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { installAgentSkills } from "../src/lib/agent-skills.js";
 import { setupProviderAvailable } from "../src/commands/setup.js";
 
-const { assert, cells } = countedAssert(nodeAssert);
+const counted = countedAssert(nodeAssert);
+const assert: typeof nodeAssert = counted.assert;
+const cells = counted.cells;
 
 const home = mkdtempSync(join(tmpdir(), "cotal-setup-provider-absent-"));
 const priorHome = process.env.HOME;

--- a/implementations/cli/smoke/status-skills-remedy.smoke.ts
+++ b/implementations/cli/smoke/status-skills-remedy.smoke.ts
@@ -5,13 +5,15 @@
  *
  * Run: pnpm smoke:status-skills-remedy
  */
-import assert from "node:assert/strict";
+import nodeAssert from "node:assert/strict";
+import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
 import { execFile } from "node:child_process";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { setup } from "../src/commands/setup.js";
+const { assert, cells } = countedAssert(nodeAssert);
 
 void setup; // source-path import: setup.ts mutations execute through this suite's module graph
 
@@ -129,3 +131,4 @@ try {
 } finally {
   for (const p of created) rmSync(p, { recursive: true, force: true });
 }
+emitSentinel({ passed: cells(), failed: 0 });

--- a/implementations/cli/smoke/status-skills-remedy.smoke.ts
+++ b/implementations/cli/smoke/status-skills-remedy.smoke.ts
@@ -6,14 +6,16 @@
  * Run: pnpm smoke:status-skills-remedy
  */
 import nodeAssert from "node:assert/strict";
-import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
+import { countedAssert, emitSentinel } from "@cotal-ai/smoke-kit";
 import { execFile } from "node:child_process";
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { setup } from "../src/commands/setup.js";
-const { assert, cells } = countedAssert(nodeAssert);
+const counted = countedAssert(nodeAssert);
+const assert: typeof nodeAssert = counted.assert;
+const cells = counted.cells;
 
 void setup; // source-path import: setup.ts mutations execute through this suite's module graph
 

--- a/implementations/cli/smoke/web-probe-target.smoke.ts
+++ b/implementations/cli/smoke/web-probe-target.smoke.ts
@@ -1,7 +1,9 @@
 import nodeAssert from "node:assert/strict";
-import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
+import { countedAssert, emitSentinel } from "@cotal-ai/smoke-kit";
 import { webProbeTarget } from "../src/commands/status.js";
-const { assert, cells } = countedAssert(nodeAssert);
+const counted = countedAssert(nodeAssert);
+const assert: typeof nodeAssert = counted.assert;
+const cells = counted.cells;
 
 const remote = webProbeTarget("node cotal web --host 192.0.2.10 --port 8123 --no-open");
 assert.ok(!("refused" in remote) && remote.url.href === "http://192.0.2.10:8123/api/meta",

--- a/implementations/cli/smoke/web-probe-target.smoke.ts
+++ b/implementations/cli/smoke/web-probe-target.smoke.ts
@@ -1,5 +1,7 @@
-import assert from "node:assert/strict";
+import nodeAssert from "node:assert/strict";
+import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
 import { webProbeTarget } from "../src/commands/status.js";
+const { assert, cells } = countedAssert(nodeAssert);
 
 const remote = webProbeTarget("node cotal web --host 192.0.2.10 --port 8123 --no-open");
 assert.ok(!("refused" in remote) && remote.url.href === "http://192.0.2.10:8123/api/meta",
@@ -21,3 +23,4 @@ for (const host of ["0.0.0.0", "0", "::", "::ffff:0.0.0.0", "::ffff:0:0", "0:0:0
 }
 
 console.log("web probe target smoke: explicit host, defaults, IPv6, and wildcard refusal passed");
+emitSentinel({ passed: cells(), failed: 0 });

--- a/implementations/manager/smoke/remote-authority-operations.smoke.ts
+++ b/implementations/manager/smoke/remote-authority-operations.smoke.ts
@@ -1,10 +1,12 @@
 /** Broker-free routing checks for authenticated remote manager maintenance operations. */
 import nodeAssert from "node:assert/strict";
-import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
+import { countedAssert, emitSentinel } from "@cotal-ai/smoke-kit";
 import { mintLifecycleUid, newIdentity, remoteManagerActors } from "@cotal-ai/core";
 import { Manager } from "../src/manager.js";
 import { remoteManagerAdminAuthorizationRequest, remoteManagerAdminAuthorized, remoteManagerGoalIndexEntries } from "../src/remote-authority.js";
-const { assert, cells } = countedAssert(nodeAssert);
+const counted = countedAssert(nodeAssert);
+const assert: typeof nodeAssert = counted.assert;
+const cells = counted.cells;
 
 const instanceId = mintLifecycleUid();
 const identities = {

--- a/implementations/manager/smoke/remote-authority-operations.smoke.ts
+++ b/implementations/manager/smoke/remote-authority-operations.smoke.ts
@@ -1,8 +1,10 @@
 /** Broker-free routing checks for authenticated remote manager maintenance operations. */
-import assert from "node:assert/strict";
+import nodeAssert from "node:assert/strict";
+import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
 import { mintLifecycleUid, newIdentity, remoteManagerActors } from "@cotal-ai/core";
 import { Manager } from "../src/manager.js";
 import { remoteManagerAdminAuthorizationRequest, remoteManagerAdminAuthorized, remoteManagerGoalIndexEntries } from "../src/remote-authority.js";
+const { assert, cells } = countedAssert(nodeAssert);
 
 const instanceId = mintLifecycleUid();
 const identities = {
@@ -181,3 +183,4 @@ assert.deepEqual(effects, []);
 assert.equal(remoteChecks, 10);
 
 console.log("remote authority operations: 31 passed, 0 failed");
+emitSentinel({ passed: cells(), failed: 0 });

--- a/package.json
+++ b/package.json
@@ -601,6 +601,7 @@
     "smoke:ci-declarations": "tsx bin/smoke/ci-declarations.smoke.ts",
     "smoke:shard-stability": "tsx bin/smoke/shard-stability.smoke.ts",
     "smoke:shard-never-ran": "tsx bin/smoke/shard-never-ran.smoke.ts",
+    "smoke:shard-sentinel": "tsx bin/smoke/shard-sentinel.smoke.ts",
     "smoke:workflow-concurrency": "tsx bin/smoke/workflow-concurrency.smoke.ts",
     "smoke:live-job-conclusion": "tsx bin/smoke/live-job-conclusion.smoke.ts",
     "smoke:live-suite": "tsx bin/smoke/live-suite.smoke.ts",

--- a/packages/core/smoke/channels-auth.smoke.ts
+++ b/packages/core/smoke/channels-auth.smoke.ts
@@ -1,4 +1,5 @@
-import { strict as assert } from "node:assert";
+import { strict as nodeAssert } from "node:assert";
+import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
 import { writeFileSync, mkdirSync, mkdtempSync, openSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -11,6 +12,7 @@ import {
   principalKey, DEV_OWNER, mintLifecycleUid,
   type CotalMessage, type Delivery, type MessageMeta,
 } from "../src/index.js";
+const { assert, cells } = countedAssert(nodeAssert);
 
 // Auth-mode end-to-end test of the broker-enforced read-ACL path: proves the SCOPED agent creds
 // carry exactly the grants the bind-only mechanism needs and nothing more —
@@ -157,4 +159,5 @@ await mgr.stop();
 await killAndAwaitExit(child, "SIGTERM");
 rmSync(dir, { recursive: true, force: true });
 releaseBroker(); // last: ownership is held until this teardown has actually finished
+emitSentinel({ passed: cells(), failed: 0 });
 process.exit(0);

--- a/packages/core/smoke/channels-auth.smoke.ts
+++ b/packages/core/smoke/channels-auth.smoke.ts
@@ -1,5 +1,5 @@
 import { strict as nodeAssert } from "node:assert";
-import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
+import { countedAssert, emitSentinel } from "@cotal-ai/smoke-kit";
 import { writeFileSync, mkdirSync, mkdtempSync, openSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -12,7 +12,9 @@ import {
   principalKey, DEV_OWNER, mintLifecycleUid,
   type CotalMessage, type Delivery, type MessageMeta,
 } from "../src/index.js";
-const { assert, cells } = countedAssert(nodeAssert);
+const counted = countedAssert(nodeAssert);
+const assert: typeof nodeAssert = counted.assert;
+const cells = counted.cells;
 
 // Auth-mode end-to-end test of the broker-enforced read-ACL path: proves the SCOPED agent creds
 // carry exactly the grants the bind-only mechanism needs and nothing more —

--- a/packages/core/smoke/registry-staging.smoke.ts
+++ b/packages/core/smoke/registry-staging.smoke.ts
@@ -11,8 +11,10 @@
  * Plus: the real production path. A dynamic import()'s self-registration is captured by the stage
  * (ALS crosses module evaluation), invisible until commit, then resolvable.
  */
-import assert from "node:assert/strict";
+import nodeAssert from "node:assert/strict";
+import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
 import { Registry, registry } from "../src/registry.js";
+const { assert, cells } = countedAssert(nodeAssert);
 
 // 1. register-before-rejecting-await is invisible AND discarded (nothing live; key is free again).
 {
@@ -109,3 +111,4 @@ import { Registry, registry } from "../src/registry.js";
 }
 
 console.log("registry-staging.smoke: all assertions passed");
+emitSentinel({ passed: cells(), failed: 0 });

--- a/packages/core/smoke/registry-staging.smoke.ts
+++ b/packages/core/smoke/registry-staging.smoke.ts
@@ -12,9 +12,11 @@
  * (ALS crosses module evaluation), invisible until commit, then resolvable.
  */
 import nodeAssert from "node:assert/strict";
-import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
+import { countedAssert, emitSentinel } from "@cotal-ai/smoke-kit";
 import { Registry, registry } from "../src/registry.js";
-const { assert, cells } = countedAssert(nodeAssert);
+const counted = countedAssert(nodeAssert);
+const assert: typeof nodeAssert = counted.assert;
+const cells = counted.cells;
 
 // 1. register-before-rejecting-await is invisible AND discarded (nothing live; key is free again).
 {

--- a/packages/core/smoke/runtime-contract.smoke.ts
+++ b/packages/core/smoke/runtime-contract.smoke.ts
@@ -1,9 +1,11 @@
 import nodeAssert from "node:assert/strict";
-import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
+import { countedAssert, emitSentinel } from "@cotal-ai/smoke-kit";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AgentHandle, Runtime, RuntimeReference } from "../src/runtime.js";
-const { assert, cells } = countedAssert(nodeAssert);
+const counted = countedAssert(nodeAssert);
+const assert: typeof nodeAssert = counted.assert;
+const cells = counted.cells;
 
 const reference: RuntimeReference = { kind: "fixture", id: "opaque-local-reference" };
 const handle: AgentHandle = {

--- a/packages/core/smoke/runtime-contract.smoke.ts
+++ b/packages/core/smoke/runtime-contract.smoke.ts
@@ -1,7 +1,9 @@
-import assert from "node:assert/strict";
+import nodeAssert from "node:assert/strict";
+import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AgentHandle, Runtime, RuntimeReference } from "../src/runtime.js";
+const { assert, cells } = countedAssert(nodeAssert);
 
 const reference: RuntimeReference = { kind: "fixture", id: "opaque-local-reference" };
 const handle: AgentHandle = {
@@ -34,3 +36,4 @@ assert.doesNotMatch(contract, /\b(?:Pty|IPty)\b/, "the generic Runtime contract 
 const managerAdopt = readFileSync(join(import.meta.dirname, "..", "..", "..", "implementations", "manager", "src", "runtime", "index.ts"), "utf8");
 assert.match(managerAdopt, /runtime "\$\{runtime\.kind\}" does not support adopt/, "the manager refuses by name when adopt is absent");
 console.log("runtime contract smoke OK");
+emitSentinel({ passed: cells(), failed: 0 });

--- a/packages/core/smoke/serverconfig-shapes.smoke.ts
+++ b/packages/core/smoke/serverconfig-shapes.smoke.ts
@@ -1,7 +1,9 @@
 import { strict as nodeAssert } from "node:assert";
-import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
+import { countedAssert, emitSentinel } from "@cotal-ai/smoke-kit";
 import { createSpaceAuth, serverConfig, openServerConfig } from "../src/index.js";
-const { assert, cells } = countedAssert(nodeAssert);
+const counted = countedAssert(nodeAssert);
+const assert: typeof nodeAssert = counted.assert;
+const cells = counted.cells;
 
 // Every CALL-SITE SHAPE of the broker config renderers, exercised in a GATED suite.
 //

--- a/packages/core/smoke/serverconfig-shapes.smoke.ts
+++ b/packages/core/smoke/serverconfig-shapes.smoke.ts
@@ -1,5 +1,7 @@
-import { strict as assert } from "node:assert";
+import { strict as nodeAssert } from "node:assert";
+import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
 import { createSpaceAuth, serverConfig, openServerConfig } from "../src/index.js";
+const { assert, cells } = countedAssert(nodeAssert);
 
 // Every CALL-SITE SHAPE of the broker config renderers, exercised in a GATED suite.
 //
@@ -95,3 +97,4 @@ for (const [what, tlsConf, plainConf] of [
 }
 
 console.log(`serverconfig-shapes smoke: OK - all 4 call-site shapes render (incl. the :live-only extraAccounts-from-variable form), tls renders on both renderers, allow_non_tls/handshake_first/verify never emitted, open renderer carries no auth material`);
+emitSentinel({ passed: cells(), failed: 0 });

--- a/packages/core/smoke/tls-serve.smoke.ts
+++ b/packages/core/smoke/tls-serve.smoke.ts
@@ -1,5 +1,5 @@
 import { strict as nodeAssert } from "node:assert";
-import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
+import { countedAssert, emitSentinel } from "@cotal-ai/smoke-kit";
 import { writeFileSync, mkdirSync, mkdtempSync, openSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -8,7 +8,9 @@ import net from "node:net";
 import tlsMod from "node:tls";
 import { createSpaceAuth, serverConfig, openServerConfig, mintCreds, newIdentity, isReachable, validateTlsMaterial, probeServedCert } from "../src/index.js";
 import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
-const { assert, cells } = countedAssert(nodeAssert);
+const counted = countedAssert(nodeAssert);
+const assert: typeof nodeAssert = counted.assert;
+const cells = counted.cells;
 
 // The broker-TLS fence, proved by EXECUTION rather than by inspecting the rendered config.
 //

--- a/packages/core/smoke/tls-serve.smoke.ts
+++ b/packages/core/smoke/tls-serve.smoke.ts
@@ -1,4 +1,5 @@
-import { strict as assert } from "node:assert";
+import { strict as nodeAssert } from "node:assert";
+import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
 import { writeFileSync, mkdirSync, mkdtempSync, openSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -7,6 +8,7 @@ import net from "node:net";
 import tlsMod from "node:tls";
 import { createSpaceAuth, serverConfig, openServerConfig, mintCreds, newIdentity, isReachable, validateTlsMaterial, probeServedCert } from "../src/index.js";
 import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+const { assert, cells } = countedAssert(nodeAssert);
 
 // The broker-TLS fence, proved by EXECUTION rather than by inspecting the rendered config.
 //
@@ -326,3 +328,4 @@ console.log("tls-serve smoke: OK - cleartext refused by TLS-required listeners i
   // every green run: the brokers were reaped and the tree they wrote was not.
   rmSync(dir, { recursive: true, force: true });
 }
+emitSentinel({ passed: cells(), failed: 0 });

--- a/packages/smoke-kit/smoke/package.smoke.ts
+++ b/packages/smoke-kit/smoke/package.smoke.ts
@@ -2,7 +2,7 @@ import { strict as assert } from "node:assert";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { assertSmokeSandboxDown, recordSmokeSandbox } from "../src/index.js";
+import { assertSmokeSandboxDown, emitSentinel, recordSmokeSandbox } from "../src/index.js";
 
 let checks = 0;
 const check = (name: string, run: () => void): void => {
@@ -28,3 +28,4 @@ try {
 }
 
 console.log(`SMOKE-KIT PACKAGE TESTS: ${checks} tests executed`);
+emitSentinel({ passed: checks, failed: 0 });

--- a/packages/smoke-kit/src/index.ts
+++ b/packages/smoke-kit/src/index.ts
@@ -22,3 +22,11 @@ export {
   type SmokeSandboxAnchor,
 } from "./sandbox-guard.js";
 export { memorySubjectFrontier, type MemorySubjectFrontier } from "./subject-frontier.js";
+export {
+  SENTINEL_PREFIX,
+  countedAssert,
+  createSuite,
+  emitSentinel,
+  formatSentinel,
+  parseSentinel,
+} from "./sentinel.js";

--- a/packages/smoke-kit/src/sentinel.ts
+++ b/packages/smoke-kit/src/sentinel.ts
@@ -52,17 +52,17 @@ export function parseSentinel(text: string): ParsedSentinel | null {
       };
       continue;
     }
-    // Suites already name counts as `(N passed, M failed)` or `N passed, M failed; extra`.
-    // Require the close-paren / semicolon / end so a no-op cannot mint a tally from prose.
-    const pair = line.match(/\((\d+) passed, (\d+) failed(?:\)|;)/);
+    // A legacy banner must own the whole line. Trailing `;…` or a double-space
+    // annotation is extra, not a new clause. A single space then words is prose
+    // and must not mint a tally. Optional `label:` is the suite name, not English
+    // wrapping the number.
+    const pair = line.match(/^.*\((\d+) passed, (\d+) failed(?:;[^)]*)?\)(?:(?:;|\s{2}).*)?$/);
     if (pair) {
       const passed = Number(pair[1]);
       const failed = Number(pair[2]);
       last = { cells: passed + failed, passed, failed, kind: "legacy" };
       continue;
     }
-    // Trailing `;…` or a double-space annotation (`  [session: …]`) is extra, not a new clause.
-    // A single space then words is refused so prose cannot mint a tally.
     const suiteComplete = line.match(/^(?:SUITE COMPLETE:\s*)?(?:.*?:\s*)?(\d+) passed, (\d+) failed(?:(?:;|\s{2}).*)?$/);
     if (suiteComplete) {
       const passed = Number(suiteComplete[1]);
@@ -76,19 +76,19 @@ export function parseSentinel(text: string): ParsedSentinel | null {
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
-    const cellsOk = line.match(/:\s*(\d+) cells OK$/);
+    const cellsOk = line.match(/^(?:.*?:\s*)?(\d+) cells OK(?:, \d+ failed)?(?:(?:;|\s{2}).*)?$/);
     if (cellsOk) {
       const cells = Number(cellsOk[1]);
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
-    const testsExecuted = line.match(/:\s*(\d+) tests executed$/);
+    const testsExecuted = line.match(/^(?:.*?:\s*)?(\d+) tests executed(?:(?:;|\s{2}).*)?$/);
     if (testsExecuted) {
       const cells = Number(testsExecuted[1]);
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
-    const parenTests = line.match(/\((\d+) tests\)/);
+    const parenTests = line.match(/^.*\((\d+) tests\)(?:(?:;|\s{2}).*)?$/);
     if (parenTests) {
       const cells = Number(parenTests[1]);
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
@@ -101,7 +101,7 @@ export function parseSentinel(text: string): ParsedSentinel | null {
       last = { cells, passed, failed: cells - passed, kind: "legacy" };
       continue;
     }
-    const checksOnly = line.match(/\((\d+) checks(?: passed)?\)/);
+    const checksOnly = line.match(/^.*\((\d+) checks(?: passed)?\)(?:(?:;|\s{2}).*)?$/);
     if (checksOnly) {
       const cells = Number(checksOnly[1]);
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
@@ -113,49 +113,49 @@ export function parseSentinel(text: string): ParsedSentinel | null {
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
-    const scanned = line.match(/(\d+) (?:documents checked|source files scanned|files scanned)/);
+    const scanned = line.match(/^(?:.*?:\s*)?(\d+) (?:documents checked|source files scanned|files scanned)(?:, .*)?$/);
     if (scanned) {
       const cells = Number(scanned[1]);
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
-    const names = line.match(/(\d+) names across (\d+) imports/);
+    const names = line.match(/^(?:.*?:\s*)?(\d+) names across (\d+) imports(?:(?:;|\s{2}).*)?$/);
     if (names) {
       const cells = Number(names[1]);
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
-    const named = line.match(/: (\d+) named registrations/);
+    const named = line.match(/^(?:.*?:\s*)?(\d+) named registrations(?: across \d+.*)?$/);
     if (named) {
       const cells = Number(named[1]);
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
-    const filesDecls = line.match(/(\d+) files, (\d+) declarations/);
+    const filesDecls = line.match(/^(?:.*?:\s*)?(\d+) files, (\d+) declarations(?:, .*)?$/);
     if (filesDecls) {
       const cells = Number(filesDecls[1]);
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
-    const checksPassed = line.match(/(\d+) checks passed/);
+    const checksPassed = line.match(/^(?:.*?:\s*)?(\d+) checks passed(?:(?:;|\s{2}).*)?$/);
     if (checksPassed) {
       const cells = Number(checksPassed[1]);
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
-    const cellsPassed = line.match(/(\d+) cells passed/);
+    const cellsPassed = line.match(/^(?:.*?:\s*)?(\d+) cells passed(?:(?:;|\s{2}).*)?$/);
     if (cellsPassed) {
       const cells = Number(cellsPassed[1]);
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
-    const cellsDash = line.match(/(\d+) cells - /);
+    const cellsDash = line.match(/^(?:.*?:\s*)?(\d+) cells - \S.*$/);
     if (cellsDash) {
       const cells = Number(cellsDash[1]);
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
-    const okFailed = line.match(/(\d+) ok, (\d+) failed/);
+    const okFailed = line.match(/^(?:.*?:\s*)?(\d+) ok, (\d+) failed(?:(?:;|\s{2}).*)?$/);
     if (okFailed) {
       const passed = Number(okFailed[1]);
       const failed = Number(okFailed[2]);

--- a/packages/smoke-kit/src/sentinel.ts
+++ b/packages/smoke-kit/src/sentinel.ts
@@ -149,6 +149,19 @@ export function parseSentinel(text: string): ParsedSentinel | null {
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
+    const cellsDash = line.match(/(\d+) cells - /);
+    if (cellsDash) {
+      const cells = Number(cellsDash[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
+    const okFailed = line.match(/(\d+) ok, (\d+) failed/);
+    if (okFailed) {
+      const passed = Number(okFailed[1]);
+      const failed = Number(okFailed[2]);
+      last = { cells: passed + failed, passed, failed, kind: "legacy" };
+      continue;
+    }
   }
   if (last) return last;
   const passed =

--- a/packages/smoke-kit/src/sentinel.ts
+++ b/packages/smoke-kit/src/sentinel.ts
@@ -52,14 +52,16 @@ export function parseSentinel(text: string): ParsedSentinel | null {
       };
       continue;
     }
-    const pair = line.match(/\((\d+) passed, (\d+) failed\)/);
+    // Suites already name counts as `(N passed, M failed)` or `N passed, M failed; extra`.
+    // Require the close-paren / semicolon / end so a no-op cannot mint a tally from prose.
+    const pair = line.match(/\((\d+) passed, (\d+) failed(?:\)|;)/);
     if (pair) {
       const passed = Number(pair[1]);
       const failed = Number(pair[2]);
       last = { cells: passed + failed, passed, failed, kind: "legacy" };
       continue;
     }
-    const suiteComplete = line.match(/^(?:SUITE COMPLETE:\s*)?(\d+) passed, (\d+) failed$/);
+    const suiteComplete = line.match(/^(?:SUITE COMPLETE:\s*)?(?:.*?:\s*)?(\d+) passed, (\d+) failed(?:;.*)?$/);
     if (suiteComplete) {
       const passed = Number(suiteComplete[1]);
       const failed = Number(suiteComplete[2]);

--- a/packages/smoke-kit/src/sentinel.ts
+++ b/packages/smoke-kit/src/sentinel.ts
@@ -61,7 +61,9 @@ export function parseSentinel(text: string): ParsedSentinel | null {
       last = { cells: passed + failed, passed, failed, kind: "legacy" };
       continue;
     }
-    const suiteComplete = line.match(/^(?:SUITE COMPLETE:\s*)?(?:.*?:\s*)?(\d+) passed, (\d+) failed(?:;.*)?$/);
+    // Trailing `;…` or a double-space annotation (`  [session: …]`) is extra, not a new clause.
+    // A single space then words is refused so prose cannot mint a tally.
+    const suiteComplete = line.match(/^(?:SUITE COMPLETE:\s*)?(?:.*?:\s*)?(\d+) passed, (\d+) failed(?:(?:;|\s{2}).*)?$/);
     if (suiteComplete) {
       const passed = Number(suiteComplete[1]);
       const failed = Number(suiteComplete[2]);
@@ -141,12 +143,17 @@ export function parseSentinel(text: string): ParsedSentinel | null {
       last = { cells, passed: cells, failed: 0, kind: "legacy" };
       continue;
     }
+    const cellsPassed = line.match(/(\d+) cells passed/);
+    if (cellsPassed) {
+      const cells = Number(cellsPassed[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
   }
   if (last) return last;
   const passed =
     (String(text).match(/^\s*✓/gm) ?? []).length +
-    (String(text).match(/^ok - /gm) ?? []).length +
-    (String(text).match(/^\s*ok {2,}/gm) ?? []).length;
+    (String(text).match(/^\s*ok(?: -)? /gm) ?? []).length;
   const failed =
     (String(text).match(/^\s*✗/gm) ?? []).length +
     (String(text).match(/^not ok - /gm) ?? []).length +

--- a/packages/smoke-kit/src/sentinel.ts
+++ b/packages/smoke-kit/src/sentinel.ts
@@ -1,0 +1,198 @@
+/**
+ * Machine-readable terminal sentinel a smoke suite prints with its cell counts.
+ *
+ * `shard.mjs` used to grade a suite on exit status alone, so `process.exit(0)` with zero cells
+ * was indistinguishable from a full pass. The shard now parses this sentinel from the suite's
+ * own output and refuses a missing line or a zero-cell run.
+ *
+ * Keep this file in lockstep with `bin/smoke/sentinel.mjs` (the node-loadable copy the shard
+ * imports). Suites should print the canonical line through {@link emitSentinel} as their last
+ * output.
+ */
+export const SENTINEL_PREFIX = "COTAL_SMOKE_SENTINEL";
+
+export function formatSentinel({
+  passed,
+  failed,
+  cells,
+}: {
+  passed: number;
+  failed: number;
+  cells?: number;
+}): string {
+  const p = Number(passed);
+  const f = Number(failed);
+  const c = cells === undefined ? p + f : Number(cells);
+  return `${SENTINEL_PREFIX} cells=${c} passed=${p} failed=${f}`;
+}
+
+export function emitSentinel(counts: { passed: number; failed: number; cells?: number }): void {
+  console.log(formatSentinel(counts));
+}
+
+export type ParsedSentinel = {
+  cells: number;
+  passed: number;
+  failed: number;
+  kind: "canonical" | "legacy";
+};
+
+export function parseSentinel(text: string): ParsedSentinel | null {
+  let last: ParsedSentinel | null = null;
+  for (const raw of String(text).split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line) continue;
+    const canonical = line.match(/^COTAL_SMOKE_SENTINEL cells=(\d+) passed=(\d+) failed=(\d+)$/);
+    if (canonical) {
+      last = {
+        cells: Number(canonical[1]),
+        passed: Number(canonical[2]),
+        failed: Number(canonical[3]),
+        kind: "canonical",
+      };
+      continue;
+    }
+    const pair = line.match(/\((\d+) passed, (\d+) failed\)/);
+    if (pair) {
+      const passed = Number(pair[1]);
+      const failed = Number(pair[2]);
+      last = { cells: passed + failed, passed, failed, kind: "legacy" };
+      continue;
+    }
+    const suiteComplete = line.match(/^(?:SUITE COMPLETE:\s*)?(\d+) passed, (\d+) failed$/);
+    if (suiteComplete) {
+      const passed = Number(suiteComplete[1]);
+      const failed = Number(suiteComplete[2]);
+      last = { cells: passed + failed, passed, failed, kind: "legacy" };
+      continue;
+    }
+    const cellsGreen = line.match(/^(\d+) cells green$/);
+    if (cellsGreen) {
+      const cells = Number(cellsGreen[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
+    const cellsOk = line.match(/:\s*(\d+) cells OK$/);
+    if (cellsOk) {
+      const cells = Number(cellsOk[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
+    const testsExecuted = line.match(/:\s*(\d+) tests executed$/);
+    if (testsExecuted) {
+      const cells = Number(testsExecuted[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
+    const parenTests = line.match(/\((\d+) tests\)/);
+    if (parenTests) {
+      const cells = Number(parenTests[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
+    const slash = line.match(/^(\d+)\/(\d+) passed$/);
+    if (slash) {
+      const passed = Number(slash[1]);
+      const cells = Number(slash[2]);
+      last = { cells, passed, failed: cells - passed, kind: "legacy" };
+      continue;
+    }
+    const checksOnly = line.match(/\((\d+) checks(?: passed)?\)/);
+    if (checksOnly) {
+      const cells = Number(checksOnly[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
+    const suiteCells = line.match(/^SUITE COMPLETE:\s*(\d+) cells$/);
+    if (suiteCells) {
+      const cells = Number(suiteCells[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
+    const scanned = line.match(/(\d+) (?:documents checked|source files scanned|files scanned)/);
+    if (scanned) {
+      const cells = Number(scanned[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
+    const names = line.match(/(\d+) names across (\d+) imports/);
+    if (names) {
+      const cells = Number(names[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
+    const named = line.match(/: (\d+) named registrations/);
+    if (named) {
+      const cells = Number(named[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
+    const filesDecls = line.match(/(\d+) files, (\d+) declarations/);
+    if (filesDecls) {
+      const cells = Number(filesDecls[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
+    const checksPassed = line.match(/(\d+) checks passed/);
+    if (checksPassed) {
+      const cells = Number(checksPassed[1]);
+      last = { cells, passed: cells, failed: 0, kind: "legacy" };
+      continue;
+    }
+  }
+  if (last) return last;
+  const passed =
+    (String(text).match(/^\s*✓/gm) ?? []).length +
+    (String(text).match(/^ok - /gm) ?? []).length +
+    (String(text).match(/^\s*ok {2,}/gm) ?? []).length;
+  const failed =
+    (String(text).match(/^\s*✗/gm) ?? []).length +
+    (String(text).match(/^not ok - /gm) ?? []).length +
+    (String(text).match(/^\s*FAIL {2}/gm) ?? []).length;
+  if (passed + failed > 0) return { cells: passed + failed, passed, failed, kind: "legacy" };
+  return null;
+}
+
+export function countedAssert<T extends object>(ns: T): { assert: T; cells: () => number } {
+  let cells = 0;
+  const assert = new Proxy(ns, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value !== "function") return value;
+      return (...args: unknown[]) => {
+        cells += 1;
+        return value.apply(target, args);
+      };
+    },
+  });
+  return { assert: assert as T, cells: () => cells };
+}
+
+export function createSuite(): {
+  check: (name: string, cond: boolean, extra?: unknown) => void;
+  finish: () => void;
+  passed: () => number;
+  failed: () => number;
+} {
+  let passed = 0;
+  let failed = 0;
+  const check = (name: string, cond: boolean, extra?: unknown): void => {
+    if (cond) {
+      passed++;
+      console.log(`  ✓ ${name}`);
+    } else {
+      failed++;
+      console.log(`  ✗ FAIL: ${name}`, extra ?? "");
+    }
+  };
+  const finish = (): void => {
+    emitSentinel({ passed, failed });
+    if (failed) process.exitCode = 1;
+  };
+  return {
+    check,
+    finish,
+    passed: () => passed,
+    failed: () => failed,
+  };
+}

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -26,6 +26,9 @@
   "dependencies": {
     "@cotal-ai/core": "workspace:*"
   },
+  "devDependencies": {
+    "@cotal-ai/smoke-kit": "workspace:*"
+  },
   "files": [
     "dist"
   ],

--- a/packages/workspace/smoke/broker-policy.smoke.ts
+++ b/packages/workspace/smoke/broker-policy.smoke.ts
@@ -1,10 +1,12 @@
-import { strict as assert } from "node:assert";
+import { strict as nodeAssert } from "node:assert";
+import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   brokerPolicyPath, writeBrokerPolicy, readBrokerPolicy, BrokerPolicyError,
 } from "../src/broker-policy.js";
+const { assert, cells } = countedAssert(nodeAssert);
 
 // The broker launch policy is what makes a TLS decision survive `cotal down`. `MeshEntry` does not
 // survive it, so without this record a bare down/up would forget that a broker serves TLS and
@@ -115,3 +117,4 @@ function refuses(fn: () => unknown, match: RegExp, what: string): void {
 }
 
 console.log("broker-policy smoke: OK - plaintext and TLS round-trip, .cotal is 0700, and every unusable policy REFUSES rather than degrading to plaintext (missing cert, missing key, corrupt JSON, unknown transport, future version, half pair)");
+emitSentinel({ passed: cells(), failed: 0 });

--- a/packages/workspace/smoke/broker-policy.smoke.ts
+++ b/packages/workspace/smoke/broker-policy.smoke.ts
@@ -1,12 +1,14 @@
 import { strict as nodeAssert } from "node:assert";
-import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
+import { countedAssert, emitSentinel } from "@cotal-ai/smoke-kit";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   brokerPolicyPath, writeBrokerPolicy, readBrokerPolicy, BrokerPolicyError,
 } from "../src/broker-policy.js";
-const { assert, cells } = countedAssert(nodeAssert);
+const counted = countedAssert(nodeAssert);
+const assert: typeof nodeAssert = counted.assert;
+const cells = counted.cells;
 
 // The broker launch policy is what makes a TLS decision survive `cotal down`. `MeshEntry` does not
 // survive it, so without this record a bare down/up would forget that a broker serves TLS and

--- a/packages/workspace/smoke/materialize-concurrency.smoke.ts
+++ b/packages/workspace/smoke/materialize-concurrency.smoke.ts
@@ -12,7 +12,8 @@
  * the repo, so each package's `import "@cotal-ai/core"` resolves to the same core singleton this smoke
  * and materialize.ts use.
  */
-import assert from "node:assert/strict";
+import nodeAssert from "node:assert/strict";
+import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { registry, type ExtensionRef } from "@cotal-ai/core";
@@ -22,6 +23,7 @@ import {
   importInstalledExtension,
   type InstalledExtension,
 } from "@cotal-ai/workspace";
+const { assert, cells } = countedAssert(nodeAssert);
 
 // Temp config home under the repo so the fixture packages resolve @cotal-ai/core to the repo copy
 // (node walks up to packages/workspace/node_modules), sharing this process's registry singleton.
@@ -101,3 +103,4 @@ try {
 } finally {
   rmSync(tmp, { recursive: true, force: true });
 }
+emitSentinel({ passed: cells(), failed: 0 });

--- a/packages/workspace/smoke/materialize-concurrency.smoke.ts
+++ b/packages/workspace/smoke/materialize-concurrency.smoke.ts
@@ -13,7 +13,7 @@
  * and materialize.ts use.
  */
 import nodeAssert from "node:assert/strict";
-import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
+import { countedAssert, emitSentinel } from "@cotal-ai/smoke-kit";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { registry, type ExtensionRef } from "@cotal-ai/core";
@@ -23,7 +23,9 @@ import {
   importInstalledExtension,
   type InstalledExtension,
 } from "@cotal-ai/workspace";
-const { assert, cells } = countedAssert(nodeAssert);
+const counted = countedAssert(nodeAssert);
+const assert: typeof nodeAssert = counted.assert;
+const cells = counted.cells;
 
 // Temp config home under the repo so the fixture packages resolve @cotal-ai/core to the repo copy
 // (node walks up to packages/workspace/node_modules), sharing this process's registry singleton.

--- a/packages/workspace/smoke/presence-render-census.smoke.ts
+++ b/packages/workspace/smoke/presence-render-census.smoke.ts
@@ -1,11 +1,13 @@
 import nodeAssert from "node:assert/strict";
-import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
+import { countedAssert, emitSentinel } from "@cotal-ai/smoke-kit";
 import { spawnSync } from "node:child_process";
 import { readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
-const { assert, cells } = countedAssert(nodeAssert);
+const counted = countedAssert(nodeAssert);
+const assert: typeof nodeAssert = counted.assert;
+const cells = counted.cells;
 
 type Classification = "honest-text" | "presence-only-glyph/count" | "command-ack" | "non-render/control";
 type CandidateKind = "status-token" | "derived-output" | "indexed-map" | "renderer-call";

--- a/packages/workspace/smoke/presence-render-census.smoke.ts
+++ b/packages/workspace/smoke/presence-render-census.smoke.ts
@@ -1,9 +1,11 @@
-import assert from "node:assert/strict";
+import nodeAssert from "node:assert/strict";
+import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
 import { spawnSync } from "node:child_process";
 import { readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
+const { assert, cells } = countedAssert(nodeAssert);
 
 type Classification = "honest-text" | "presence-only-glyph/count" | "command-ack" | "non-render/control";
 type CandidateKind = "status-token" | "derived-output" | "indexed-map" | "renderer-call";
@@ -262,6 +264,7 @@ if (selectedProbe) {
     rmSync(path, { force: true });
   }
   console.log(`presence-render probe case passed: ${selectedProbe}`);
+  emitSentinel({ passed: cells(), failed: 0 });
   process.exit(0);
 }
 
@@ -356,3 +359,4 @@ if (process.env.COTAL_PRESENCE_RENDER_PROBE_CHILD !== "1") {
   }
 }
 console.log("PRESENCE-RENDER-CENSUS: 17 checks passed");
+emitSentinel({ passed: cells(), failed: 0 });

--- a/packages/workspace/smoke/tls-intent.smoke.ts
+++ b/packages/workspace/smoke/tls-intent.smoke.ts
@@ -1,7 +1,9 @@
 import { strict as nodeAssert } from "node:assert";
-import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
+import { countedAssert, emitSentinel } from "@cotal-ai/smoke-kit";
 import { endpointAuth, type Connection } from "../src/connect.js";
-const { assert, cells } = countedAssert(nodeAssert);
+const counted = countedAssert(nodeAssert);
+const assert: typeof nodeAssert = counted.assert;
+const cells = counted.cells;
 
 // TLS-required CLIENT INTENT must survive the trip from the mesh record to the wire.
 //

--- a/packages/workspace/smoke/tls-intent.smoke.ts
+++ b/packages/workspace/smoke/tls-intent.smoke.ts
@@ -1,5 +1,7 @@
-import { strict as assert } from "node:assert";
+import { strict as nodeAssert } from "node:assert";
+import { countedAssert, emitSentinel } from "../../../bin/smoke/sentinel.mjs";
 import { endpointAuth, type Connection } from "../src/connect.js";
+const { assert, cells } = countedAssert(nodeAssert);
 
 // TLS-required CLIENT INTENT must survive the trip from the mesh record to the wire.
 //
@@ -55,3 +57,4 @@ const base = { server: "nats://127.0.0.1:4222", space: "s" };
 }
 
 console.log("tls-intent smoke: OK - TLS-required client intent survives endpointAuth on static, user-mode and credential-less connections, and is never invented when absent");
+emitSentinel({ passed: cells(), failed: 0 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,6 +723,10 @@ importers:
       '@cotal-ai/core':
         specifier: workspace:*
         version: link:../core
+    devDependencies:
+      '@cotal-ai/smoke-kit':
+        specifier: workspace:*
+        version: link:../smoke-kit
 
 packages:
 


### PR DESCRIPTION
Smoke shards used to treat a suite as covered whenever it exited 0. A suite that ran zero cells therefore counted as a full pass, and the shard banner reported coverage by suite count only.

The runner now reads a cell-count sentinel from the suite's own output. A missing sentinel or a zero-cell run fails the shard by naming the suite and the reason. The banner reports cells graded as well as suites. Suites print the sentinel through the shared smoke helper. Existing suites that already print a parseable cell count continue to grade through that same path.

`bin/smoke/sentinel.d.mts` is a hand-written declaration for `bin/smoke/sentinel.mjs`. Typecheck does not prove the declaration still matches the implementation if the `.mjs` changes later. Reviewers should treat that pair as a lockstep contract, not as generated types.

Coverage: 25 of 565 suites emit canonical `COTAL_SMOKE_SENTINEL`. The rest grade via legacy tallies. The canonical sentinel is unambiguous by construction. Legacy tally parsing is a compatibility bridge, not the destination: it has three known ambiguous shapes, listed below, and coverage of the canonical path is 25/565 and growing. This PR's guarantee is strong for those 25 and only as strong as the legacy patterns for the other 540. That is still a large improvement over grading on exit status alone.

Parser rule: a legacy banner must own the whole line. Trailing `;` or a double-space annotation is extra. A single space then words is prose and must not mint a tally. First-hand after `b4182059b`: real `lang-transform` / `agui-map` / frozen-exports / cells-dash / ok-failed banners still parse. Orchestrator wrapping-prose cases for cells-passed, parenthetical pair, `(N tests)`, scanned, and names-across now return null. Residual banner-shaped lines still parse: `prior summary: 40 cells OK`, `prior summary: 40 tests executed`, and `nothing ran this time (40 checks passed)` because they are indistinguishable from real labeled or parenthetical banners. Those three are not fixable by tighter anchoring without refusing real labeled/paren banners. Zero-cell and missing-sentinel hard fails are unchanged. No further parser push on this head.

Refs #1297
