### PR TITLE
Make first manager identity an exclusive create

### DIFF
--- a/.changeset/fresh-root-identity-exclusive.md
+++ b/.changeset/fresh-root-identity-exclusive.md
@@ -1,0 +1,8 @@
+---
+"@cotal-ai/core": patch
+"@cotal-ai/workspace": patch
+"@cotal-ai/manager": patch
+"cotal-ai": patch
+---
+
+Make the first manager identity on a fresh root an exclusive create. Of N concurrent starts, exactly one process mints the instance file and the others adopt that identity or refuse with a named error, so they cannot take two leases.

--- a/bin/smoke/ci-suites.d/76d19c3afb0eb70a532ece361f362591fd724c8239808f670f645ca78e650b1f.txt
+++ b/bin/smoke/ci-suites.d/76d19c3afb0eb70a532ece361f362591fd724c8239808f670f645ca78e650b1f.txt
@@ -1,0 +1,2 @@
+# Exclusive first-start identity mint: of N concurrent creators exactly one wins.
+smoke:manager-instance-exclusive

--- a/bin/smoke/ci-suites.d/82be78d9c68a87e914ad047dcdd83f0d9ed608ae47f91c6e3e23748e3721e7aa.txt
+++ b/bin/smoke/ci-suites.d/82be78d9c68a87e914ad047dcdd83f0d9ed608ae47f91c6e3e23748e3721e7aa.txt
@@ -1,0 +1,2 @@
+# Concurrent Manager.start on a fresh root mints one identity; losers refuse.
+smoke:manager-fresh-root-identity

--- a/bin/smoke/mutations/manager-instance-exclusive.json
+++ b/bin/smoke/mutations/manager-instance-exclusive.json
@@ -17,7 +17,13 @@
     "M3 RESTORES ATOMIC RENAME. linkSync becomes renameSync. Rename publishes one file but every",
     "caller still believes it won. The concurrent unique-identity cell must red, which is why",
     "atomic replace is not the fix. The command rebuilds @cotal-ai/core so the exclusive helper",
-    "is not graded against a stale dist."
+    "is not graded against a stale dist.",
+    "",
+    "M4 RESTORES THE PLAIN TEMP WRITE. The publish is exclusive but the temp write becomes a plain",
+    "overwrite, which is what the code did before review. Two creators that collide on the temp name",
+    "then swap each other's bytes, and the one whose link succeeds returns the candidate IT minted",
+    "while the published file holds the OTHER identity - the same split, one step earlier. A temp",
+    "name unique only by pid+clock+Math.random is a probability argument, not a concurrency one."
   ],
   "mutations": [
     {
@@ -50,6 +56,17 @@
       "cell": "N=8 concurrent first mints over 20 rounds share exactly one identity",
       "note": "Rename cannot interleave torn bytes, but every caller still returns its own candidate. That is why exclusive create, not rename, is the primitive.",
       "command": "pnpm --filter @cotal-ai/core build && pnpm smoke:manager-instance-exclusive",
+      "afterRestore": "pnpm --filter @cotal-ai/core build"
+    },
+    {
+      "name": "M4 the temp write is a plain overwrite again (colliding creators swap bytes)",
+      "file": "packages/core/src/secret-fs.ts",
+      "find": "  writeSecretFileCreateOnlyRaw(tmp, data);\n  try {\n    try {\n      linkSync(tmp, path);",
+      "replace": "  writeSecretFile(tmp, data);\n  try {\n    try {\n      linkSync(tmp, path);",
+      "expectRed": "REFUSE: a colliding temp-shaped name is EEXIST, not a silent overwrite",
+      "cell": "REFUSE: a colliding temp-shaped name is EEXIST, not a silent overwrite",
+      "note": "A probabilistically-unique temp name is not a concurrency argument; the collision must refuse, not overwrite.",
+      "command": "pnpm smoke:secret-fs",
       "afterRestore": "pnpm --filter @cotal-ai/core build"
     }
   ]

--- a/bin/smoke/mutations/manager-instance-exclusive.json
+++ b/bin/smoke/mutations/manager-instance-exclusive.json
@@ -1,0 +1,53 @@
+{
+  "suite": [
+    "packages/workspace/smoke/manager-instance-exclusive.smoke.ts",
+    "packages/core/smoke/secret-fs.smoke.ts"
+  ],
+  "guard": "first identity mint on a fresh root is exclusive create: of N concurrent starts exactly one identity exists and losers adopt or refuse; a second exclusive create of an existing file is EEXIST",
+  "command": "pnpm --filter @cotal-ai/core build && pnpm smoke:manager-instance-exclusive && pnpm smoke:secret-fs",
+  "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/manager-instance-exclusive.json",
+  "why": [
+    "M1 RESTORES THE IN-MEMORY LOSER. Exclusive create loses with EEXIST and the helper still",
+    "returns the candidate it minted. That is the defect the issue named: the file is single-valued",
+    "and the loser still serves under a different id. The concurrent unique-identity cell must red.",
+    "",
+    "M2 RESTORES THE PLAIN WRITE. writeSecretFileCreateOnly becomes writeSecretFile, so a second",
+    "writer overwrites instead of EEXIST. The refuse-existing cell must red.",
+    "",
+    "M3 RESTORES ATOMIC RENAME. linkSync becomes renameSync. Rename publishes one file but every",
+    "caller still believes it won. The concurrent unique-identity cell must red, which is why",
+    "atomic replace is not the fix. The command rebuilds @cotal-ai/core so the exclusive helper",
+    "is not graded against a stale dist."
+  ],
+  "mutations": [
+    {
+      "name": "M1 EEXIST still returns the minted candidate (in-memory loser)",
+      "file": "packages/workspace/src/auth-paths.ts",
+      "find": "    if ((e as NodeJS.ErrnoException).code !== \"EEXIST\") throw e;\n    const winner = loadManagerInstanceIdentity(root, space);\n    if (winner === undefined)\n      throw new Error(\n        `manager-instance-identity-create-lost: exclusive create for space \"${space}\" at ${path} lost and the existing file could not be adopted`,\n      );\n    return winner;",
+      "replace": "    if ((e as NodeJS.ErrnoException).code !== \"EEXIST\") throw e;\n    return candidate;",
+      "expectRed": "N=8 concurrent first mints over 20 rounds share exactly one identity",
+      "cell": "N=8 concurrent first mints over 20 rounds share exactly one identity",
+      "note": "The file is single-valued; the loser keeps a different in-memory id. That is the lease-CAS hole."
+    },
+    {
+      "name": "M2 exclusive create is a plain overwrite (no EEXIST)",
+      "file": "packages/core/src/secret-fs.ts",
+      "find": "  const tmp = `${path}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;\n  try {\n    writeSecretFile(tmp, data);\n    try {\n      linkSync(tmp, path);",
+      "replace": "  writeSecretFile(path, data);\n  return;\n  const tmp = `${path}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;\n  try {\n    writeSecretFile(tmp, data);\n    try {\n      linkSync(tmp, path);",
+      "expectRed": "writeSecretFileCreateOnly REFUSES an existing file (EEXIST), never overwrites",
+      "cell": "writeSecretFileCreateOnly REFUSES an existing file (EEXIST), never overwrites",
+      "note": "The second writer must not replace the first. Overwrite is the pre-fix persist.",
+      "afterRestore": "pnpm --filter @cotal-ai/core build"
+    },
+    {
+      "name": "M3 exclusive link becomes rename (atomic replace, still two in-memory ids)",
+      "file": "packages/core/src/secret-fs.ts",
+      "find": "      linkSync(tmp, path);",
+      "replace": "      renameSync(tmp, path);",
+      "expectRed": "N=8 concurrent first mints over 20 rounds share exactly one identity",
+      "cell": "N=8 concurrent first mints over 20 rounds share exactly one identity",
+      "note": "Rename cannot interleave torn bytes, but every caller still returns its own candidate. That is why exclusive create, not rename, is the primitive.",
+      "afterRestore": "pnpm --filter @cotal-ai/core build"
+    }
+  ]
+}

--- a/bin/smoke/mutations/manager-instance-exclusive.json
+++ b/bin/smoke/mutations/manager-instance-exclusive.json
@@ -74,9 +74,9 @@
       "file": "packages/core/src/secret-fs.ts",
       "find": "  writeFileSync(path, data, { flag: \"wx\", mode: 0o600 });\n  if (!isWin) return;",
       "replace": "  writeFileSync(path, data, { mode: 0o600 });\n  if (!isWin) return;",
-      "expectRed": "REFUSE: of 8 concurrent creators over 12 rounds exactly one ever creates the name",
-      "cell": "REFUSE: of 8 concurrent creators over 12 rounds exactly one ever creates the name",
-      "note": "Raised by review: refusing an existing file is not the same property as being atomic about it. With the lstat refusal in place only real concurrency separates O_EXCL from a check-then-write, so this cell is N real processes on a barrier.",
+      "expectRed": "REFUSE: a name taken AFTER the check but BEFORE the write does not get overwritten (O_EXCL decides at the write)",
+      "cell": "REFUSE: a name taken AFTER the check but BEFORE the write does not get overwritten (O_EXCL decides at the write)",
+      "note": "Raised by review: refusing an existing name is not the same property as deciding a concurrent create, since a userspace check-then-write refuses too. Graded deterministically by a name that is free when a pre-check would look and taken by the time the write runs. This replaced an N-process barrier race that was measured to fail toward green under a post-release stall.",
       "command": "pnpm smoke:secret-fs",
       "afterRestore": "pnpm --filter @cotal-ai/core build"
     },

--- a/bin/smoke/mutations/manager-instance-exclusive.json
+++ b/bin/smoke/mutations/manager-instance-exclusive.json
@@ -74,9 +74,9 @@
       "file": "packages/core/src/secret-fs.ts",
       "find": "  writeFileSync(path, data, { flag: \"wx\", mode: 0o600 });\n  if (!isWin) return;",
       "replace": "  writeFileSync(path, data, { mode: 0o600 });\n  if (!isWin) return;",
-      "expectRed": "REFUSE: a temp name that exists but resolves to nothing is EEXIST (kernel-atomic, not check-then-write)",
-      "cell": "REFUSE: a temp name that exists but resolves to nothing is EEXIST (kernel-atomic, not check-then-write)",
-      "note": "Raised by review: refusing an existing file is not the same property as being atomic about it. A check-then-write passes every other refusing cell and is still the defect, because the check and the write are two syscalls.",
+      "expectRed": "REFUSE: of 8 concurrent creators over 12 rounds exactly one ever creates the name",
+      "cell": "REFUSE: of 8 concurrent creators over 12 rounds exactly one ever creates the name",
+      "note": "Raised by review: refusing an existing file is not the same property as being atomic about it. With the lstat refusal in place only real concurrency separates O_EXCL from a check-then-write, so this cell is N real processes on a barrier.",
       "command": "pnpm smoke:secret-fs",
       "afterRestore": "pnpm --filter @cotal-ai/core build"
     },

--- a/bin/smoke/mutations/manager-instance-exclusive.json
+++ b/bin/smoke/mutations/manager-instance-exclusive.json
@@ -68,6 +68,17 @@
       "note": "A probabilistically-unique temp name is not a concurrency argument; the collision must refuse, not overwrite.",
       "command": "pnpm smoke:secret-fs",
       "afterRestore": "pnpm --filter @cotal-ai/core build"
+    },
+    {
+      "name": "M5 O_EXCL becomes a userspace check-then-write (refuses, but is not atomic)",
+      "file": "packages/core/src/secret-fs.ts",
+      "find": "function writeSecretFileCreateOnlyRaw(path: string, data: string | Buffer): void {\n  writeFileSync(path, data, { flag: \"wx\", mode: 0o600 });",
+      "replace": "function writeSecretFileCreateOnlyRaw(path: string, data: string | Buffer): void {\n  let present = true;\n  try { chmodSync(path, 0o600); } catch { present = false; }\n  if (present) { const err: NodeJS.ErrnoException = new Error(`EEXIST: file already exists, open '${path}'`); err.code = \"EEXIST\"; throw err; }\n  writeFileSync(path, data, { mode: 0o600 });",
+      "expectRed": "REFUSE: a name that exists but resolves to nothing is EEXIST (kernel-atomic, not check-then-write)",
+      "cell": "REFUSE: a name that exists but resolves to nothing is EEXIST (kernel-atomic, not check-then-write)",
+      "note": "Raised by review: refusing an existing file is not the same property as being atomic about it. A check-then-write passes every other refusing cell and is still the defect, because the check and the write are two syscalls.",
+      "command": "pnpm smoke:secret-fs",
+      "afterRestore": "pnpm --filter @cotal-ai/core build"
     }
   ]
 }

--- a/bin/smoke/mutations/manager-instance-exclusive.json
+++ b/bin/smoke/mutations/manager-instance-exclusive.json
@@ -90,6 +90,17 @@
       "note": "Raised by review as the last accepting branch with no refusing case. Where link is unavailable this IS the exclusive-create primitive; a plain write there makes every guarantee POSIX-only.",
       "command": "pnpm smoke:secret-fs",
       "afterRestore": "pnpm --filter @cotal-ai/core build"
+    },
+    {
+      "name": "M7 O_EXCL becomes a REFUSING userspace check-then-write (lstat then plain write)",
+      "file": "packages/core/src/secret-fs.ts",
+      "find": "  writeFileSync(path, data, { flag: \"wx\", mode: 0o600 });\n  if (!isWin) return;",
+      "replace": "  try { lstatSync(path); const t: NodeJS.ErrnoException = new Error(\"EEXIST\"); t.code = \"EEXIST\"; throw t; } catch (e) { if ((e as NodeJS.ErrnoException).code === \"EEXIST\") throw e; }\n  writeFileSync(path, data, { mode: 0o600 });\n  if (!isWin) return;",
+      "expectRed": "REFUSE: concurrent creators never both win a name \u2014 total wins equals names created",
+      "cell": "REFUSE: concurrent creators never both win a name \u2014 total wins equals names created",
+      "note": "The hardest mutant and the reason the contention cell is kept: this one REFUSES an existing name exactly as O_EXCL does, so every single-process cell passes against it. Only overlapping creators separate them, as excess wins.",
+      "command": "pnpm smoke:secret-fs",
+      "afterRestore": "pnpm --filter @cotal-ai/core build"
     }
   ]
 }

--- a/bin/smoke/mutations/manager-instance-exclusive.json
+++ b/bin/smoke/mutations/manager-instance-exclusive.json
@@ -96,8 +96,8 @@
       "file": "packages/core/src/secret-fs.ts",
       "find": "  writeFileSync(path, data, { flag: \"wx\", mode: 0o600 });\n  if (!isWin) return;",
       "replace": "  try { lstatSync(path); const t: NodeJS.ErrnoException = new Error(\"EEXIST\"); t.code = \"EEXIST\"; throw t; } catch (e) { if ((e as NodeJS.ErrnoException).code === \"EEXIST\") throw e; }\n  writeFileSync(path, data, { mode: 0o600 });\n  if (!isWin) return;",
-      "expectRed": "REFUSE: concurrent creators never both win a name \u2014 total wins equals names created",
-      "cell": "REFUSE: concurrent creators never both win a name \u2014 total wins equals names created",
+      "expectRed": "REFUSE: concurrent creators never both win a name: total wins equals names created",
+      "cell": "REFUSE: concurrent creators never both win a name: total wins equals names created",
       "note": "The hardest mutant and the reason the contention cell is kept: this one REFUSES an existing name exactly as O_EXCL does, so every single-process cell passes against it. Only overlapping creators separate them, as excess wins.",
       "command": "pnpm smoke:secret-fs",
       "afterRestore": "pnpm --filter @cotal-ai/core build"

--- a/bin/smoke/mutations/manager-instance-exclusive.json
+++ b/bin/smoke/mutations/manager-instance-exclusive.json
@@ -39,8 +39,8 @@
     {
       "name": "M2 exclusive create is a plain overwrite (no EEXIST)",
       "file": "packages/core/src/secret-fs.ts",
-      "find": "  const tmp = `${path}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;\n  try {\n    writeSecretFile(tmp, data);\n    try {\n      linkSync(tmp, path);",
-      "replace": "  writeSecretFile(path, data);\n  return;\n  const tmp = `${path}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;\n  try {\n    writeSecretFile(tmp, data);\n    try {\n      linkSync(tmp, path);",
+      "find": "  writeSecretFileCreateOnlyRaw(tmp, data);\n  try {\n    try {\n      linkSync(tmp, path);",
+      "replace": "  writeSecretFile(path, data);\n  return;\n  writeSecretFileCreateOnlyRaw(tmp, data);\n  try {\n    try {\n      linkSync(tmp, path);",
       "expectRed": "writeSecretFileCreateOnly REFUSES an existing file (EEXIST), never overwrites",
       "cell": "writeSecretFileCreateOnly REFUSES an existing file (EEXIST), never overwrites",
       "note": "The second writer must not replace the first. Overwrite is the pre-fix persist.",
@@ -61,10 +61,10 @@
     {
       "name": "M4 the temp write is a plain overwrite again (colliding creators swap bytes)",
       "file": "packages/core/src/secret-fs.ts",
-      "find": "  writeSecretFileCreateOnlyRaw(tmp, data);\n  try {\n    try {\n      linkSync(tmp, path);",
-      "replace": "  writeSecretFile(tmp, data);\n  try {\n    try {\n      linkSync(tmp, path);",
-      "expectRed": "REFUSE: a colliding temp-shaped name is EEXIST, not a silent overwrite",
-      "cell": "REFUSE: a colliding temp-shaped name is EEXIST, not a silent overwrite",
+      "find": "function writeSecretFileCreateOnlyRaw(path: string, data: string | Buffer): void {\n  writeFileSync(path, data, { flag: \"wx\", mode: 0o600 });",
+      "replace": "function writeSecretFileCreateOnlyRaw(path: string, data: string | Buffer): void {\n  writeFileSync(path, data, { mode: 0o600 });",
+      "expectRed": "REFUSE: a temp name already held by another creator is EEXIST, not a silent overwrite",
+      "cell": "REFUSE: a temp name already held by another creator is EEXIST, not a silent overwrite",
       "note": "A probabilistically-unique temp name is not a concurrency argument; the collision must refuse, not overwrite.",
       "command": "pnpm smoke:secret-fs",
       "afterRestore": "pnpm --filter @cotal-ai/core build"

--- a/bin/smoke/mutations/manager-instance-exclusive.json
+++ b/bin/smoke/mutations/manager-instance-exclusive.json
@@ -74,8 +74,8 @@
       "file": "packages/core/src/secret-fs.ts",
       "find": "function writeSecretFileCreateOnlyRaw(path: string, data: string | Buffer): void {\n  writeFileSync(path, data, { flag: \"wx\", mode: 0o600 });",
       "replace": "function writeSecretFileCreateOnlyRaw(path: string, data: string | Buffer): void {\n  let present = true;\n  try { chmodSync(path, 0o600); } catch { present = false; }\n  if (present) { const err: NodeJS.ErrnoException = new Error(`EEXIST: file already exists, open '${path}'`); err.code = \"EEXIST\"; throw err; }\n  writeFileSync(path, data, { mode: 0o600 });",
-      "expectRed": "REFUSE: a name that exists but resolves to nothing is EEXIST (kernel-atomic, not check-then-write)",
-      "cell": "REFUSE: a name that exists but resolves to nothing is EEXIST (kernel-atomic, not check-then-write)",
+      "expectRed": "REFUSE: a temp name that exists but resolves to nothing is EEXIST (kernel-atomic, not check-then-write)",
+      "cell": "REFUSE: a temp name that exists but resolves to nothing is EEXIST (kernel-atomic, not check-then-write)",
       "note": "Raised by review: refusing an existing file is not the same property as being atomic about it. A check-then-write passes every other refusing cell and is still the defect, because the check and the write are two syscalls.",
       "command": "pnpm smoke:secret-fs",
       "afterRestore": "pnpm --filter @cotal-ai/core build"

--- a/bin/smoke/mutations/manager-instance-exclusive.json
+++ b/bin/smoke/mutations/manager-instance-exclusive.json
@@ -79,6 +79,17 @@
       "note": "Raised by review: refusing an existing file is not the same property as being atomic about it. A check-then-write passes every other refusing cell and is still the defect, because the check and the write are two syscalls.",
       "command": "pnpm smoke:secret-fs",
       "afterRestore": "pnpm --filter @cotal-ai/core build"
+    },
+    {
+      "name": "M6 the link-unavailable fallback is a plain overwrite (the Windows primitive)",
+      "file": "packages/core/src/secret-fs.ts",
+      "find": "      if (code === \"ENOTSUP\" || code === \"EPERM\" || code === \"ENOSYS\") {\n        writeSecretFileCreateOnlyRaw(path, data);",
+      "replace": "      if (code === \"ENOTSUP\" || code === \"EPERM\" || code === \"ENOSYS\") {\n        writeSecretFile(path, data);",
+      "expectRed": "REFUSE: the ENOTSUP fallback is EEXIST on an existing path, never an overwrite",
+      "cell": "REFUSE: the ENOTSUP fallback is EEXIST on an existing path, never an overwrite",
+      "note": "Raised by review as the last accepting branch with no refusing case. Where link is unavailable this IS the exclusive-create primitive; a plain write there makes every guarantee POSIX-only.",
+      "command": "pnpm smoke:secret-fs",
+      "afterRestore": "pnpm --filter @cotal-ai/core build"
     }
   ]
 }

--- a/bin/smoke/mutations/manager-instance-exclusive.json
+++ b/bin/smoke/mutations/manager-instance-exclusive.json
@@ -27,7 +27,8 @@
       "replace": "    if ((e as NodeJS.ErrnoException).code !== \"EEXIST\") throw e;\n    return candidate;",
       "expectRed": "N=8 concurrent first mints over 20 rounds share exactly one identity",
       "cell": "N=8 concurrent first mints over 20 rounds share exactly one identity",
-      "note": "The file is single-valued; the loser keeps a different in-memory id. That is the lease-CAS hole."
+      "note": "The file is single-valued; the loser keeps a different in-memory id. That is the lease-CAS hole.",
+      "command": "pnpm smoke:manager-instance-exclusive"
     },
     {
       "name": "M2 exclusive create is a plain overwrite (no EEXIST)",
@@ -37,6 +38,7 @@
       "expectRed": "writeSecretFileCreateOnly REFUSES an existing file (EEXIST), never overwrites",
       "cell": "writeSecretFileCreateOnly REFUSES an existing file (EEXIST), never overwrites",
       "note": "The second writer must not replace the first. Overwrite is the pre-fix persist.",
+      "command": "pnpm smoke:secret-fs",
       "afterRestore": "pnpm --filter @cotal-ai/core build"
     },
     {
@@ -47,6 +49,7 @@
       "expectRed": "N=8 concurrent first mints over 20 rounds share exactly one identity",
       "cell": "N=8 concurrent first mints over 20 rounds share exactly one identity",
       "note": "Rename cannot interleave torn bytes, but every caller still returns its own candidate. That is why exclusive create, not rename, is the primitive.",
+      "command": "pnpm --filter @cotal-ai/core build && pnpm smoke:manager-instance-exclusive",
       "afterRestore": "pnpm --filter @cotal-ai/core build"
     }
   ]

--- a/bin/smoke/mutations/manager-instance-exclusive.json
+++ b/bin/smoke/mutations/manager-instance-exclusive.json
@@ -39,8 +39,8 @@
     {
       "name": "M2 exclusive create is a plain overwrite (no EEXIST)",
       "file": "packages/core/src/secret-fs.ts",
-      "find": "  writeSecretFileCreateOnlyRaw(tmp, data);\n  try {\n    try {\n      linkSync(tmp, path);",
-      "replace": "  writeSecretFile(path, data);\n  return;\n  writeSecretFileCreateOnlyRaw(tmp, data);\n  try {\n    try {\n      linkSync(tmp, path);",
+      "find": "  writeSecretFileCreateOnlyRaw(tmp, data);\n  try {\n    try {\n      publishLink(tmp, path);",
+      "replace": "  writeSecretFile(path, data);\n  return;\n  writeSecretFileCreateOnlyRaw(tmp, data);\n  try {\n    try {\n      publishLink(tmp, path);",
       "expectRed": "writeSecretFileCreateOnly REFUSES an existing file (EEXIST), never overwrites",
       "cell": "writeSecretFileCreateOnly REFUSES an existing file (EEXIST), never overwrites",
       "note": "The second writer must not replace the first. Overwrite is the pre-fix persist.",
@@ -50,7 +50,7 @@
     {
       "name": "M3 exclusive link becomes rename (atomic replace, still two in-memory ids)",
       "file": "packages/core/src/secret-fs.ts",
-      "find": "      linkSync(tmp, path);",
+      "find": "      publishLink(tmp, path);",
       "replace": "      renameSync(tmp, path);",
       "expectRed": "N=8 concurrent first mints over 20 rounds share exactly one identity",
       "cell": "N=8 concurrent first mints over 20 rounds share exactly one identity",
@@ -61,8 +61,8 @@
     {
       "name": "M4 the temp write is a plain overwrite again (colliding creators swap bytes)",
       "file": "packages/core/src/secret-fs.ts",
-      "find": "function writeSecretFileCreateOnlyRaw(path: string, data: string | Buffer): void {\n  writeFileSync(path, data, { flag: \"wx\", mode: 0o600 });",
-      "replace": "function writeSecretFileCreateOnlyRaw(path: string, data: string | Buffer): void {\n  writeFileSync(path, data, { mode: 0o600 });",
+      "find": "  writeSecretFileCreateOnlyRaw(tmp, data);\n  try {",
+      "replace": "  writeSecretFile(tmp, data);\n  try {",
       "expectRed": "REFUSE: a temp name already held by another creator is EEXIST, not a silent overwrite",
       "cell": "REFUSE: a temp name already held by another creator is EEXIST, not a silent overwrite",
       "note": "A probabilistically-unique temp name is not a concurrency argument; the collision must refuse, not overwrite.",
@@ -72,8 +72,8 @@
     {
       "name": "M5 O_EXCL becomes a userspace check-then-write (refuses, but is not atomic)",
       "file": "packages/core/src/secret-fs.ts",
-      "find": "function writeSecretFileCreateOnlyRaw(path: string, data: string | Buffer): void {\n  writeFileSync(path, data, { flag: \"wx\", mode: 0o600 });",
-      "replace": "function writeSecretFileCreateOnlyRaw(path: string, data: string | Buffer): void {\n  let present = true;\n  try { chmodSync(path, 0o600); } catch { present = false; }\n  if (present) { const err: NodeJS.ErrnoException = new Error(`EEXIST: file already exists, open '${path}'`); err.code = \"EEXIST\"; throw err; }\n  writeFileSync(path, data, { mode: 0o600 });",
+      "find": "  writeFileSync(path, data, { flag: \"wx\", mode: 0o600 });\n  if (!isWin) return;",
+      "replace": "  writeFileSync(path, data, { mode: 0o600 });\n  if (!isWin) return;",
       "expectRed": "REFUSE: a temp name that exists but resolves to nothing is EEXIST (kernel-atomic, not check-then-write)",
       "cell": "REFUSE: a temp name that exists but resolves to nothing is EEXIST (kernel-atomic, not check-then-write)",
       "note": "Raised by review: refusing an existing file is not the same property as being atomic about it. A check-then-write passes every other refusing cell and is still the defect, because the check and the write are two syscalls.",

--- a/bin/smoke/mutations/manager-instance-exclusive.json
+++ b/bin/smoke/mutations/manager-instance-exclusive.json
@@ -99,7 +99,7 @@
       "expectRed": "REFUSE: a name taken while the creator is past its check is still not overwritten (O_EXCL re-decides at the write)",
       "cell": "REFUSE: a name taken while the creator is past its check is still not overwritten (O_EXCL re-decides at the write)",
       "note": "The mutant no in-process cell can catch: it REFUSES an existing name exactly as O_EXCL does. They differ only for a creator already past its check when the name is taken. An N-process race reached that window only by luck and let this escape ~1 run in 6 while staying green when the implementation was correct, so the competitor is now placed in the window by an fs preload.",
-      "command": "pnpm smoke:secret-fs",
+      "command": "pnpm --filter @cotal-ai/core build && pnpm smoke:secret-fs",
       "afterRestore": "pnpm --filter @cotal-ai/core build"
     }
   ]

--- a/bin/smoke/mutations/manager-instance-exclusive.json
+++ b/bin/smoke/mutations/manager-instance-exclusive.json
@@ -96,9 +96,9 @@
       "file": "packages/core/src/secret-fs.ts",
       "find": "  writeFileSync(path, data, { flag: \"wx\", mode: 0o600 });\n  if (!isWin) return;",
       "replace": "  try { lstatSync(path); const t: NodeJS.ErrnoException = new Error(\"EEXIST\"); t.code = \"EEXIST\"; throw t; } catch (e) { if ((e as NodeJS.ErrnoException).code === \"EEXIST\") throw e; }\n  writeFileSync(path, data, { mode: 0o600 });\n  if (!isWin) return;",
-      "expectRed": "REFUSE: concurrent creators never both win a name: total wins equals names created",
-      "cell": "REFUSE: concurrent creators never both win a name: total wins equals names created",
-      "note": "The hardest mutant and the reason the contention cell is kept: this one REFUSES an existing name exactly as O_EXCL does, so every single-process cell passes against it. Only overlapping creators separate them, as excess wins.",
+      "expectRed": "REFUSE: a name taken while the creator is past its check is still not overwritten (O_EXCL re-decides at the write)",
+      "cell": "REFUSE: a name taken while the creator is past its check is still not overwritten (O_EXCL re-decides at the write)",
+      "note": "The mutant no in-process cell can catch: it REFUSES an existing name exactly as O_EXCL does. They differ only for a creator already past its check when the name is taken. An N-process race reached that window only by luck and let this escape ~1 run in 6 while staying green when the implementation was correct, so the competitor is now placed in the window by an fs preload.",
       "command": "pnpm smoke:secret-fs",
       "afterRestore": "pnpm --filter @cotal-ai/core build"
     }

--- a/implementations/manager/smoke/manager-fresh-root-identity.smoke.ts
+++ b/implementations/manager/smoke/manager-fresh-root-identity.smoke.ts
@@ -1,0 +1,154 @@
+/**
+ * Concurrent first-start on one fresh root (#1263).
+ *
+ * Two manager processes that both observe no identity file used to mint different instance ids
+ * and take different leases. This suite forks N real Manager.start() processes against one root
+ * after a shared barrier, then asserts exactly one identity exists and losers refuse with
+ * `already serves space`. Sequential start is the control that the established fence still holds.
+ *
+ * PRE-FIX CONTROL: the load-absent-then-write probe minted two in-memory ids in 2/40 rounds on
+ * origin/main. A Manager.start that still calls saveManagerInstanceIdentity must fail the unique-id
+ * cell the same way.
+ *
+ * Throwaway nats-server on a free loopback port. Never the live mesh.
+ *
+ * Run: pnpm smoke:manager-fresh-root-identity
+ */
+import { spawn as spawnProc, type ChildProcess } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createServer, type AddressInfo } from "node:net";
+import { probeConnect } from "@cotal-ai/core";
+import { loadManagerInstanceIdentity, recordMesh } from "@cotal-ai/workspace";
+import { Manager } from "../src/manager.js";
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const freePort = (): Promise<number> =>
+  new Promise((res, rej) => {
+    const s = createServer();
+    s.on("error", rej);
+    s.listen(0, "127.0.0.1", () => { const p = (s.address() as AddressInfo).port; s.close(() => res(p)); });
+  });
+
+const HERE = fileURLToPath(import.meta.url);
+const TSX = join(fileURLToPath(new URL("../../../", import.meta.url)), "node_modules", ".bin", "tsx");
+
+if (process.env.COTAL_I1263_WORKER === "1") {
+  const root = process.env.COTAL_I1263_ROOT!;
+  const space = process.env.COTAL_I1263_SPACE!;
+  const server = process.env.COTAL_I1263_SERVER!;
+  const barrier = process.env.COTAL_I1263_BARRIER!;
+  while (!existsSync(barrier)) await wait(5);
+  const m = new Manager({ space, servers: server, runtime: "pty", workspaceRoot: root });
+  try {
+    await m.start();
+    const id = (m as unknown as { managerInstanceId: string }).managerInstanceId;
+    process.stdout.write(JSON.stringify({ ok: true, pid: process.pid, instanceId: id }) + "\n");
+    await new Promise(() => {});
+  } catch (e) {
+    process.stdout.write(JSON.stringify({ ok: false, pid: process.pid, error: (e as Error).message }) + "\n");
+    process.exit(2);
+  }
+}
+
+const N = 4;
+const ROUNDS = 6;
+const SPACE = "issue-1263-start";
+
+let pass = 0, fail = 0;
+const check = (name: string, cond: boolean, extra?: unknown) => {
+  if (cond) { pass++; console.log(`  ✓ ${name}`); }
+  else { fail++; console.log(`  ✗ FAIL: ${name}`, extra !== undefined ? extra : ""); }
+};
+
+const PORT = await freePort();
+const SERVER = `nats://127.0.0.1:${PORT}`;
+const kids: ChildProcess[] = [];
+try {
+  const broker = spawnProc("nats-server", ["-a", "127.0.0.1", "-p", String(PORT), "-js", "-sd", mkdtempSync(join(tmpdir(), "cotal-i1263-js-"))], { stdio: "ignore" });
+  kids.push(broker);
+  for (let i = 0; i < 60; i++) { if ((await probeConnect(SERVER, { timeoutMs: 400 })).ok) break; await wait(120); }
+
+  const seqRoot = mkdtempSync(join(tmpdir(), "cotal-i1263-seq-"));
+  mkdirSync(join(seqRoot, ".cotal", "agents"), { recursive: true });
+  recordMesh({ space: SPACE, server: SERVER, root: seqRoot, mode: "open", ts: new Date().toISOString() });
+  const first = new Manager({ space: SPACE, servers: SERVER, runtime: "pty", workspaceRoot: seqRoot });
+  await first.start();
+  const firstId = (first as unknown as { managerInstanceId: string }).managerInstanceId;
+  let seqErr = "";
+  const second = new Manager({ space: SPACE, servers: SERVER, runtime: "pty", workspaceRoot: seqRoot });
+  try { await second.start(); } catch (e) { seqErr = (e as Error).message; }
+  check("sequential second start REFUSES with already-serves (fence after identity exists)",
+    /already serves space/.test(seqErr), seqErr);
+  check("sequential pair shares the persisted identity",
+    loadManagerInstanceIdentity(seqRoot, SPACE)?.instanceId === firstId);
+  await second.stop({ withAgents: true }).catch(() => {});
+  await first.stop({ withAgents: true }).catch(() => {});
+
+  let raced = 0;
+  let missingRefuse = 0;
+  for (let r = 0; r < ROUNDS; r++) {
+    const root = mkdtempSync(join(tmpdir(), "cotal-i1263-race-"));
+    mkdirSync(join(root, ".cotal", "agents"), { recursive: true });
+    recordMesh({ space: SPACE, server: SERVER, root, mode: "open", ts: new Date().toISOString() });
+    const barrier = join(root, "go");
+    const workers: ChildProcess[] = [];
+    const parsed: Array<{ ok: boolean; pid: number; instanceId?: string; error?: string }> = [];
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("workers did not report")), 25_000);
+      for (let i = 0; i < N; i++) {
+        const child = spawnProc(TSX, [HERE], {
+          env: {
+            ...process.env,
+            COTAL_I1263_WORKER: "1",
+            COTAL_I1263_ROOT: root,
+            COTAL_I1263_SPACE: SPACE,
+            COTAL_I1263_SERVER: SERVER,
+            COTAL_I1263_BARRIER: barrier,
+          },
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        workers.push(child);
+        kids.push(child);
+        let buf = "";
+        let reported = false;
+        child.stdout?.on("data", (c: Buffer) => {
+          if (reported) return;
+          buf += c.toString();
+          const line = buf.trim().split("\n").find((l) => l.startsWith("{"));
+          if (!line) return;
+          try { parsed.push(JSON.parse(line)); } catch { return; }
+          reported = true;
+          try { child.kill("SIGKILL"); } catch { /* already gone */ }
+          if (parsed.length >= N) { clearTimeout(timer); resolve(); }
+        });
+      }
+      writeFileSync(barrier, "go");
+    });
+    for (const w of workers) {
+      try { w.kill("SIGKILL"); } catch { /* done */ }
+    }
+    const started = parsed.filter((p) => p.ok);
+    const refused = parsed.filter((p) => !p.ok);
+    const unique = new Set(started.map((p) => p.instanceId).filter(Boolean));
+    const fileId = loadManagerInstanceIdentity(root, SPACE)?.instanceId;
+    if (unique.size !== 1 || fileId === undefined || !unique.has(fileId)) {
+      raced++;
+      console.log(`  ✗ FAIL: round ${r} started=${started.length} unique=${unique.size} file=${fileId}`, parsed);
+    }
+    if (started.length !== 1 || refused.length < 1 || refused.some((p) => !/already serves space/.test(p.error ?? ""))) {
+      missingRefuse++;
+      console.log(`  ✗ FAIL: round ${r} refusal path`, { started: started.length, refused: refused.map((p) => p.error) });
+    }
+  }
+  check(`N=${N} concurrent Manager.start over ${ROUNDS} rounds mint exactly one identity`, raced === 0, { raced });
+  check("losers refuse with already-serves (adopt then lease CAS)", missingRefuse === 0, { missingRefuse });
+} finally {
+  for (const k of kids) { try { k.kill("SIGKILL"); } catch { /* best effort */ } }
+}
+
+console.log(`COTAL_SMOKE_SENTINEL cells=${pass + fail} passed=${pass} failed=${fail}`);
+console.log(`\n${fail === 0 ? "MANAGER FRESH-ROOT IDENTITY SMOKE OK" : "MANAGER FRESH-ROOT IDENTITY SMOKE FAILED"}  (${pass} passed, ${fail} failed)`);
+process.exit(fail === 0 ? 0 : 1);

--- a/implementations/manager/smoke/manager-fresh-root-identity.smoke.ts
+++ b/implementations/manager/smoke/manager-fresh-root-identity.smoke.ts
@@ -96,12 +96,14 @@ try {
     const barrier = join(root, "go");
     const workers: ChildProcess[] = [];
     const parsed: Array<{ ok: boolean; pid: number; instanceId?: string; error?: string }> = [];
+    const ambientEnv: NodeJS.ProcessEnv = { ...process.env };
+    for (const key of Object.keys(ambientEnv)) if (key.startsWith("COTAL_")) delete ambientEnv[key];
     await new Promise<void>((resolve, reject) => {
       const timer = setTimeout(() => reject(new Error("workers did not report")), 25_000);
       for (let i = 0; i < N; i++) {
         const child = spawnProc(TSX, [HERE], {
           env: {
-            ...process.env,
+            ...ambientEnv,
             COTAL_I1263_WORKER: "1",
             COTAL_I1263_ROOT: root,
             COTAL_I1263_SPACE: SPACE,

--- a/implementations/manager/src/manager.ts
+++ b/implementations/manager/src/manager.ts
@@ -60,7 +60,7 @@ import {
   controlServiceSubject,
   eventChannelPrincipal,
 } from "@cotal-ai/core";
-import { agentAuthState, agentCredsDir, agentLifecycleSecretFilePaths, agentSecretFilePaths, agentSecretKeyForFile, authDir, connectorInstallHint, DEFAULT_CONNECTOR, defaultAgentType, DELIVERY_CREDS_KIND, extensionConnectors, findCotalRoot, getSpaceAuth, hasUserAuthState, loadExtensionsManifest, loadManagerInstanceIdentity, loadMeshes, manifestExtensionNames, materializeFromManifest, materializeSecretToFile, MEMBERSHIP_RW_CREDS_KIND, mergeLaunchOptions, remintDaemonCreds, resolveOnPath, saveManagerInstanceIdentity, spaceMaterialKey, SYSTEM_CREDS_FILES, userAuthStateDir, workspaceSecretStore, writeRenewalRecord, type RenewalRecord } from "@cotal-ai/workspace";
+import { agentAuthState, agentCredsDir, agentLifecycleSecretFilePaths, agentSecretFilePaths, agentSecretKeyForFile, authDir, connectorInstallHint, DEFAULT_CONNECTOR, defaultAgentType, DELIVERY_CREDS_KIND, extensionConnectors, findCotalRoot, getSpaceAuth, hasUserAuthState, loadExtensionsManifest, loadManagerInstanceIdentity, loadMeshes, manifestExtensionNames, materializeFromManifest, materializeSecretToFile, MEMBERSHIP_RW_CREDS_KIND, mergeLaunchOptions, remintDaemonCreds, resolveOnPath, createManagerInstanceIdentity, spaceMaterialKey, SYSTEM_CREDS_FILES, userAuthStateDir, workspaceSecretStore, writeRenewalRecord, type RenewalRecord } from "@cotal-ai/workspace";
 import type { ActionContext, AgentDef, AttachSession, Connector, ConnectorModelCatalog, ControlReply, CredHealth, EpCaller, LaunchOpts, LaunchSpec, ManagerLeaseInfo, MeshLaunchAgent, Presence, RuntimeReference, SecretStore, SecretStoreIdentity, SpaceAuth } from "@cotal-ai/core";
 import {
   createRuntime,
@@ -1305,6 +1305,12 @@ export class Manager {
     // refused loud (no-fallbacks - a restart never silently becomes a fresh instance). A second
     // manager in a DIFFERENT workspace root is a DIFFERENT logical id by construction (its own state
     // dir) - two managers in ONE space are two workspace roots.
+    //
+    // First mint on a fresh root is exclusive create (#1263). Two processes that both observe no
+    // file must not keep different in-memory ids: of N concurrent starts exactly one creates the
+    // file (`link` / O_EXCL) and the others adopt that identity before taking a lease, or refuse
+    // with manager-instance-identity-create-lost. Atomic rename is not enough, because the loser
+    // of a replace would still serve under the id it minted.
     {
       if (this.remoteAuthority) {
         this.managerInstanceId = this.remoteAuthority.instanceId;
@@ -1315,9 +1321,12 @@ export class Manager {
         this.managerInstanceId = persisted.instanceId;
         this.managerServeIdentity = persisted.serveIdentity;
       } else {
-        this.managerInstanceId = mintLifecycleUid();
-        this.managerServeIdentity = newIdentity();
-        saveManagerInstanceIdentity(this.workspaceRoot, this.space, { instanceId: this.managerInstanceId, serveIdentity: this.managerServeIdentity });
+        const claimed = createManagerInstanceIdentity(this.workspaceRoot, this.space, {
+          instanceId: mintLifecycleUid(),
+          serveIdentity: newIdentity(),
+        });
+        this.managerInstanceId = claimed.instanceId;
+        this.managerServeIdentity = claimed.serveIdentity;
       }
       }
     }

--- a/package.json
+++ b/package.json
@@ -425,6 +425,8 @@
     "smoke:manager-spawn-action-auth": "tsx implementations/manager/smoke/spawn-action-auth.smoke.ts",
     "smoke:manager-restart-fence": "tsx implementations/manager/smoke/manager-restart-fence.smoke.ts",
     "smoke:manager-coexist": "tsx implementations/manager/smoke/manager-coexist.smoke.ts",
+    "smoke:manager-instance-exclusive": "tsx packages/workspace/smoke/manager-instance-exclusive.smoke.ts",
+    "smoke:manager-fresh-root-identity": "tsx implementations/manager/smoke/manager-fresh-root-identity.smoke.ts",
     "smoke:goal-sibling-race": "tsx implementations/manager/smoke/goal-sibling-race.smoke.ts",
     "smoke:manager-reconcile-ownership": "tsx implementations/manager/smoke/manager-reconcile-ownership.smoke.ts",
     "smoke:manager-reconcile-startup": "tsx implementations/manager/smoke/manager-reconcile-startup.smoke.ts",

--- a/packages/core/smoke/_secret-fs-interleave-child.mjs
+++ b/packages/core/smoke/_secret-fs-interleave-child.mjs
@@ -1,0 +1,34 @@
+/**
+ * Child for the between-check-and-write interleave (see secret-fs.smoke.ts).
+ *
+ * Runs against the BUILT package rather than the source, because the interleave is installed by an
+ * `fs` preload and must reach the exact binding the shipped module uses. Prints one JSON line so
+ * the parent asserts on observations rather than on this child's opinion.
+ */
+import { readFileSync } from "node:fs";
+
+const target = process.env.COTAL_SECRETFS_INTERLEAVE_TARGET;
+const dist = process.env.COTAL_SECRETFS_INTERLEAVE_DIST;
+const mod = await import(dist);
+
+// `link` publishes the destination atomically by itself, so the fallback is forced: the raw write
+// then decides the destination, which is also the real Windows-side primitive.
+mod.__setPublishLinkForTest(() => {
+  const e = new Error("ENOTSUP: forced fallback");
+  e.code = "ENOTSUP";
+  throw e;
+});
+
+let code;
+try {
+  mod.writeSecretFileCreateOnly(target, "latecomer\n");
+} catch (e) {
+  code = e.code;
+}
+let bytes;
+try {
+  bytes = readFileSync(target, "utf8");
+} catch {
+  bytes = "\u0000ABSENT";
+}
+process.stdout.write(`${JSON.stringify({ code, bytes })}\n`);

--- a/packages/core/smoke/_secret-fs-interleave-preload.cjs
+++ b/packages/core/smoke/_secret-fs-interleave-preload.cjs
@@ -1,0 +1,29 @@
+/**
+ * Preload for the between-check-and-write interleave (see secret-fs.smoke.ts).
+ *
+ * A userspace `if (exists) throw; write()` REFUSES an already-taken name exactly as `O_EXCL` does,
+ * so no in-process cell can tell them apart: both raise EEXIST. The difference only shows when a
+ * competitor takes the name AFTER the check has passed and BEFORE the write runs. A race can reach
+ * that window only by luck (measured: the previous N-process cell let that mutant escape roughly 1
+ * run in 6, and it failed toward GREEN). This lands the competitor in the window deterministically.
+ *
+ * `--require` runs before the module graph loads, so patching `fs` here reaches the binding that
+ * `secret-fs.js` closes over. It fires exactly once, only for the one path under test, and then
+ * restores itself, so nothing else in the process is affected.
+ */
+const fs = require("node:fs");
+
+const target = process.env.COTAL_SECRETFS_INTERLEAVE_TARGET;
+if (target) {
+  const realWrite = fs.writeFileSync;
+  let armed = true;
+  fs.writeFileSync = function patched(path, data, options) {
+    if (armed && path === target) {
+      armed = false;
+      fs.writeFileSync = realWrite; // one shot: the rest of the process sees the real function
+      // The competitor wins the name in the window a check-then-write has already walked past.
+      realWrite(target, "incumbent\n", { mode: 0o600 });
+    }
+    return realWrite.call(this, path, data, options);
+  };
+}

--- a/packages/core/smoke/secret-fs.smoke.ts
+++ b/packages/core/smoke/secret-fs.smoke.ts
@@ -66,6 +66,11 @@ const TSX_CLI = join(
   "cli.mjs",
 );
 const statSafe = (p: string): boolean => { try { return statSync(p).isFile(); } catch { return false; } };
+// Read for an ASSERTION, never for control flow. A broken implementation can delete or never
+// create the file a cell is about to inspect, and a raw readFileSync would then throw and abort
+// the whole suite — every later cell silently unreported, which reads as a WRONG-RED rather than
+// as the kill it actually is. A missing file simply is not the expected bytes.
+const readSafe = (p: string): string => { try { return readFileSync(p, "utf8"); } catch { return "\u0000ABSENT"; } };
 let failures = 0;
 function check(label: string, cond: boolean): void {
   console.log(`${cond ? "✓" : "✗"} ${label}`);
@@ -89,7 +94,7 @@ try {
   exclusiveCode = (e as NodeJS.ErrnoException).code;
 }
 check("writeSecretFileCreateOnly REFUSES an existing file (EEXIST), never overwrites", exclusiveCode === "EEXIST");
-check("...and the first writer's bytes are unchanged", readFileSync(exclusive, "utf8") === "first-writer\n");
+check("...and the first writer's bytes are unchanged", readSafe(exclusive) === "first-writer\n");
 
 // The TEMP write is exclusive too. A temp-name collision that plain-overwrote would destroy the
 // other creator's bytes, and the caller whose link then succeeded would return the candidate IT
@@ -117,7 +122,7 @@ try {
 check("REFUSE: a temp name already held by another creator is EEXIST, not a silent overwrite",
   squatCode === "EEXIST");
 check("...and that other creator's bytes were NOT destroyed",
-  readFileSync(squattedTmp, "utf8") === "other-creator\n");
+  readSafe(squattedTmp) === "other-creator\n");
 check("...and nothing was published at the destination on that refusal", !statSafe(squatDest));
 
 // A loser must never destroy a live creator's temp. Publishing into an already-taken destination
@@ -133,7 +138,7 @@ try {
 check("REFUSE: publishing into a taken destination is EEXIST", secondPublish === "EEXIST");
 check("...and a failed create leaves no .tmp litter behind",
   readdirSync(dir).filter((n) => n.endsWith(".tmp") && n.startsWith("taken.secret")).length === 0);
-check("...and the incumbent's bytes are intact", readFileSync(takenDest, "utf8") === "incumbent\n");
+check("...and the incumbent's bytes are intact", readSafe(takenDest) === "incumbent\n");
 
 // REFUSING an existing file is NOT the same property as being ATOMIC about it. A userspace
 // check-then-write (`if (existsSync) throw; writeFileSync(...)`) passes every cell above: it
@@ -203,7 +208,7 @@ for (const code of ["ENOTSUP", "EPERM", "ENOSYS"] as const) {
     const fresh = join(fbDir, "fresh.secret");
     writeSecretFileCreateOnly(fresh, "first\n");
     check(`ACCEPT: the ${code} fallback still creates a missing path`,
-      readFileSync(fresh, "utf8") === "first\n");
+      readSafe(fresh) === "first\n");
     let fbCode: string | undefined;
     try {
       writeSecretFileCreateOnly(fresh, "second\n");
@@ -213,7 +218,7 @@ for (const code of ["ENOTSUP", "EPERM", "ENOSYS"] as const) {
     check(`REFUSE: the ${code} fallback is EEXIST on an existing path, never an overwrite`,
       fbCode === "EEXIST");
     check(`...and the ${code} fallback did not replace the first writer's bytes`,
-      readFileSync(fresh, "utf8") === "first\n");
+      readSafe(fresh) === "first\n");
     check(`...and the ${code} fallback left no .tmp litter`,
       readdirSync(fbDir).filter((n) => n.endsWith(".tmp")).length === 0);
   } finally {
@@ -279,7 +284,7 @@ check("...and that failure left no .tmp litter",
   // The bytes are the real assertion. An error code alone would also be satisfied by a write that
   // clobbered the incumbent and then failed for some other reason.
   check("REFUSE: a name taken AFTER the check but BEFORE the write does not get overwritten (O_EXCL decides at the write)",
-    readFileSync(contested, "utf8") === "incumbent\n");
+    readSafe(contested) === "incumbent\n");
   check("...and the losing creator sees EEXIST", raced === "EEXIST");
   check("...and that loss left no .tmp litter",
     readdirSync(atomicDir).filter((n) => n.endsWith(".tmp")).length === 0);
@@ -312,7 +317,7 @@ check("...and that failure left no .tmp litter",
     Math.random = realRandom;
   }
   check("REFUSE: a temp name taken before the write is not overwritten (the temp write is exclusive too)",
-    readFileSync(tmpName, "utf8") === "squatter\n");
+    readSafe(tmpName) === "squatter\n");
   check("...and the creator that lost the temp name sees EEXIST", tempRaced === "EEXIST");
   check("...and nothing was published at the destination on that refusal", !statSafe(dest));
 }

--- a/packages/core/smoke/secret-fs.smoke.ts
+++ b/packages/core/smoke/secret-fs.smoke.ts
@@ -7,10 +7,10 @@
  * point — broad inherited access is actually stripped) is win32-only; Windows CI is the oracle.
  */
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { hardenPrivate, mkSecretDir, writeSecretFile } from "../src/secret-fs.js";
+import { hardenPrivate, mkSecretDir, writeSecretFile, writeSecretFileCreateOnly } from "../src/secret-fs.js";
 
 const isWin = process.platform === "win32";
 let failures = 0;
@@ -25,6 +25,18 @@ const dir = mkdtempSync(join(tmpdir(), "cotal-secret-"));
 const file = join(dir, "creds.secret");
 writeSecretFile(file, "super-secret-token\n");
 check("writeSecretFile wrote the file", statSync(file).isFile());
+
+const exclusive = join(dir, "exclusive.secret");
+writeSecretFileCreateOnly(exclusive, "first-writer\n");
+check("writeSecretFileCreateOnly ACCEPTS a missing path", statSync(exclusive).isFile());
+let exclusiveCode: string | undefined;
+try {
+  writeSecretFileCreateOnly(exclusive, "second-writer\n");
+} catch (e) {
+  exclusiveCode = (e as NodeJS.ErrnoException).code;
+}
+check("writeSecretFileCreateOnly REFUSES an existing file (EEXIST), never overwrites", exclusiveCode === "EEXIST");
+check("...and the first writer's bytes are unchanged", readFileSync(exclusive, "utf8") === "first-writer\n");
 
 // mkSecretDir creates a private dir.
 const sub = join(dir, "auth");

--- a/packages/core/smoke/secret-fs.smoke.ts
+++ b/packages/core/smoke/secret-fs.smoke.ts
@@ -10,7 +10,7 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { hardenPrivate, mkSecretDir, writeSecretFile, writeSecretFileCreateOnly } from "../src/secret-fs.js";
+import { __setPublishLinkForTest, hardenPrivate, mkSecretDir, writeSecretFile, writeSecretFileCreateOnly } from "../src/secret-fs.js";
 
 const isWin = process.platform === "win32";
 const statSafe = (p: string): boolean => { try { return statSync(p).isFile(); } catch { return false; } };
@@ -99,52 +99,97 @@ check("...and the incumbent's bytes are intact", readFileSync(takenDest, "utf8")
 // actually grades it.
 const tmpVictim = join(dir, "tmp-symlink-victim");
 const danglingDest = join(dir, "dangling.secret");
-// This cell rests on a POSIX guarantee: O_EXCL does not follow a final symlink, so a DANGLING link
-// is EEXIST. Windows resolves the reparse point instead and reports the missing target, so the
-// same call is not EEXIST there and the discriminator does not exist on that platform.
-//
-// Gate on the BEHAVIOUR, measured here, not on `process.platform` and not on whether a symlink can
-// be created. Creating one succeeded on the Windows runner; it was the O_EXCL semantics that
-// differed, which is exactly the assumption a platform check would have hidden.
-let danglingIsExclusive = false;
-try {
-  const probeTarget = join(dir, "probe-target-missing");
-  const probeLink = join(dir, "probe-link");
-  symlinkSync(probeTarget, probeLink);
-  try {
-    // Exactly the primitive the cell depends on: O_EXCL against a dangling link. Not the whole
-    // helper, whose publish step answers for a different reason and would mispredict this.
-    writeFileSync(probeLink, "probe\n", { flag: "wx", mode: 0o600 });
-  } catch (e) {
-    danglingIsExclusive = (e as NodeJS.ErrnoException).code === "EEXIST";
-  }
-  rmSync(probeLink, { force: true });
-  rmSync(probeTarget, { force: true });
-} catch {
-  danglingIsExclusive = false; // no symlink privilege at all
-}
-if (danglingIsExclusive) {
+{
+  // No platform gate on the ASSERTION: `lstatSync` makes the refusal portable, so EEXIST must hold
+  // on every platform. Only the SETUP can be unavailable — creating a symlink needs a privilege on
+  // Windows — and that is reported as a named skip rather than a pass, so it can never read as a
+  // green that proves something it did not test.
+  let linkPlanted = true;
   const realRandom2 = Math.random;
   const realNow2 = Date.now;
   Math.random = () => 0.5;
   Date.now = () => 1;
   const danglingTmp = `${danglingDest}.${process.pid}.1.${(0.5).toString(36).slice(2)}.tmp`;
-  symlinkSync(tmpVictim, danglingTmp);
-  let danglingCode: string | undefined;
   try {
-    writeSecretFileCreateOnly(danglingDest, "attacker\n");
-  } catch (e) {
-    danglingCode = (e as NodeJS.ErrnoException).code;
-  } finally {
-    Math.random = realRandom2;
-    Date.now = realNow2;
+    symlinkSync(tmpVictim, danglingTmp);
+  } catch {
+    linkPlanted = false;
   }
-  check("REFUSE: a temp name that exists but resolves to nothing is EEXIST (kernel-atomic, not check-then-write)",
-    danglingCode === "EEXIST");
-  check("...and nothing was written through the dangling link", !statSafe(tmpVictim));
-} else {
-  console.log("· dangling-symlink atomicity cell needs POSIX O_EXCL-on-symlink semantics — skipped (POSIX CI is the oracle)");
+  let danglingCode: string | undefined;
+  if (linkPlanted) {
+    try {
+      writeSecretFileCreateOnly(danglingDest, "attacker\n");
+    } catch (e) {
+      danglingCode = (e as NodeJS.ErrnoException).code;
+    }
+  }
+  Math.random = realRandom2;
+  Date.now = realNow2;
+  if (linkPlanted) {
+    check("REFUSE: a temp name that exists but resolves to nothing is EEXIST (kernel-atomic, not check-then-write)",
+      danglingCode === "EEXIST");
+    check("...and nothing was written through the dangling link", !statSafe(tmpVictim));
+  } else {
+    console.log("· dangling-symlink atomicity cell could not PLANT a symlink (no privilege) — skipped, setup only");
+  }
 }
+
+// THE FALLBACK BRANCH, raised in review as the last accepting branch with no refusing case.
+// When `link` is unavailable (ENOTSUP/EPERM/ENOSYS on some Windows volumes and network mounts)
+// the helper writes O_EXCL directly to the destination. No POSIX CI host reaches that branch
+// naturally, so it is driven through the named platform seam. It is the WINDOWS primitive: if it
+// is not exclusive, every guarantee above is POSIX-only.
+for (const code of ["ENOTSUP", "EPERM", "ENOSYS"] as const) {
+  const fbDir = join(dir, `fallback-${code}`);
+  mkSecretDir(fbDir);
+  __setPublishLinkForTest(() => {
+    const e: NodeJS.ErrnoException = new Error(`${code}: link unavailable`);
+    e.code = code;
+    throw e;
+  });
+  try {
+    const fresh = join(fbDir, "fresh.secret");
+    writeSecretFileCreateOnly(fresh, "first\n");
+    check(`ACCEPT: the ${code} fallback still creates a missing path`,
+      readFileSync(fresh, "utf8") === "first\n");
+    let fbCode: string | undefined;
+    try {
+      writeSecretFileCreateOnly(fresh, "second\n");
+    } catch (e) {
+      fbCode = (e as NodeJS.ErrnoException).code;
+    }
+    check(`REFUSE: the ${code} fallback is EEXIST on an existing path, never an overwrite`,
+      fbCode === "EEXIST");
+    check(`...and the ${code} fallback did not replace the first writer's bytes`,
+      readFileSync(fresh, "utf8") === "first\n");
+    check(`...and the ${code} fallback left no .tmp litter`,
+      readdirSync(fbDir).filter((n) => n.endsWith(".tmp")).length === 0);
+  } finally {
+    __setPublishLinkForTest(undefined);
+  }
+}
+
+// A non-fallback link error must PROPAGATE, not silently take the fallback path. One refusing
+// case per accepting branch: EACCES is not in the allowed set and must surface as itself.
+const propagateDir = join(dir, "fallback-propagate");
+mkSecretDir(propagateDir);
+__setPublishLinkForTest(() => {
+  const e: NodeJS.ErrnoException = new Error("EACCES: permission denied");
+  e.code = "EACCES";
+  throw e;
+});
+let propagated: string | undefined;
+try {
+  writeSecretFileCreateOnly(join(propagateDir, "nope.secret"), "x\n");
+} catch (e) {
+  propagated = (e as NodeJS.ErrnoException).code;
+} finally {
+  __setPublishLinkForTest(undefined);
+}
+check("REFUSE: a link error outside ENOTSUP/EPERM/ENOSYS propagates instead of falling back",
+  propagated === "EACCES");
+check("...and that failure left no .tmp litter",
+  readdirSync(propagateDir).filter((n) => n.endsWith(".tmp")).length === 0);
 
 // mkSecretDir creates a private dir.
 const sub = join(dir, "auth");

--- a/packages/core/smoke/secret-fs.smoke.ts
+++ b/packages/core/smoke/secret-fs.smoke.ts
@@ -7,7 +7,7 @@
  * point — broad inherited access is actually stripped) is win32-only; Windows CI is the oracle.
  */
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { hardenPrivate, mkSecretDir, writeSecretFile, writeSecretFileCreateOnly } from "../src/secret-fs.js";
@@ -82,6 +82,29 @@ check("REFUSE: publishing into a taken destination is EEXIST", secondPublish ===
 check("...and a failed create leaves no .tmp litter behind",
   readdirSync(dir).filter((n) => n.endsWith(".tmp") && n.startsWith("taken.secret")).length === 0);
 check("...and the incumbent's bytes are intact", readFileSync(takenDest, "utf8") === "incumbent\n");
+
+// REFUSING an existing file is NOT the same property as being ATOMIC about it. A userspace
+// check-then-write (`if (existsSync) throw; writeFileSync(...)`) passes every cell above: it
+// refuses a file that is already there. It is still the defect, because the check and the write
+// are two syscalls and a creator arriving between them is overwritten.
+//
+// Discriminate the two WITHOUT monkeypatching, using a property only the kernel has. A dangling
+// symlink is a name that EXISTS while `existsSync` reports false, because `existsSync` follows the
+// link to a missing target. `O_EXCL` refuses it (the kernel checks the name, and O_EXCL explicitly
+// does not follow a final symlink); a userspace absence check is told "absent", writes through the
+// link, and creates the target. Same call, opposite outcomes, no test seam in src/.
+const linkTarget = join(dir, "symlink-victim");
+const danglingName = join(dir, "dangling.secret");
+symlinkSync(linkTarget, danglingName);
+let danglingCode: string | undefined;
+try {
+  writeSecretFileCreateOnly(danglingName, "attacker\n");
+} catch (e) {
+  danglingCode = (e as NodeJS.ErrnoException).code;
+}
+check("REFUSE: a name that exists but resolves to nothing is EEXIST (kernel-atomic, not check-then-write)",
+  danglingCode === "EEXIST");
+check("...and nothing was written through the dangling link", !statSafe(linkTarget));
 
 // mkSecretDir creates a private dir.
 const sub = join(dir, "auth");

--- a/packages/core/smoke/secret-fs.smoke.ts
+++ b/packages/core/smoke/secret-fs.smoke.ts
@@ -7,7 +7,7 @@
  * point — broad inherited access is actually stripped) is win32-only; Windows CI is the oracle.
  */
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync, symlinkSync } from "node:fs";
+import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { hardenPrivate, mkSecretDir, writeSecretFile, writeSecretFileCreateOnly } from "../src/secret-fs.js";
@@ -99,18 +99,31 @@ check("...and the incumbent's bytes are intact", readFileSync(takenDest, "utf8")
 // actually grades it.
 const tmpVictim = join(dir, "tmp-symlink-victim");
 const danglingDest = join(dir, "dangling.secret");
-// Creating a symlink needs SeCreateSymbolicLinkPrivilege on Windows, which an unprivileged CI
-// runner does not have. Probe the capability rather than assuming it from the platform: a
-// developer box with Developer Mode on DOES have it, and this cell is worth running there.
-let canSymlink = true;
+// This cell rests on a POSIX guarantee: O_EXCL does not follow a final symlink, so a DANGLING link
+// is EEXIST. Windows resolves the reparse point instead and reports the missing target, so the
+// same call is not EEXIST there and the discriminator does not exist on that platform.
+//
+// Gate on the BEHAVIOUR, measured here, not on `process.platform` and not on whether a symlink can
+// be created. Creating one succeeded on the Windows runner; it was the O_EXCL semantics that
+// differed, which is exactly the assumption a platform check would have hidden.
+let danglingIsExclusive = false;
 try {
-  const probeLink = join(dir, "symlink-capability-probe");
-  symlinkSync(join(dir, "no-such-target"), probeLink);
+  const probeTarget = join(dir, "probe-target-missing");
+  const probeLink = join(dir, "probe-link");
+  symlinkSync(probeTarget, probeLink);
+  try {
+    // Exactly the primitive the cell depends on: O_EXCL against a dangling link. Not the whole
+    // helper, whose publish step answers for a different reason and would mispredict this.
+    writeFileSync(probeLink, "probe\n", { flag: "wx", mode: 0o600 });
+  } catch (e) {
+    danglingIsExclusive = (e as NodeJS.ErrnoException).code === "EEXIST";
+  }
   rmSync(probeLink, { force: true });
+  rmSync(probeTarget, { force: true });
 } catch {
-  canSymlink = false;
+  danglingIsExclusive = false; // no symlink privilege at all
 }
-if (canSymlink) {
+if (danglingIsExclusive) {
   const realRandom2 = Math.random;
   const realNow2 = Date.now;
   Math.random = () => 0.5;
@@ -130,7 +143,7 @@ if (canSymlink) {
     danglingCode === "EEXIST");
   check("...and nothing was written through the dangling link", !statSafe(tmpVictim));
 } else {
-  console.log("· dangling-symlink atomicity cell needs symlink privilege — skipped (POSIX CI is the oracle)");
+  console.log("· dangling-symlink atomicity cell needs POSIX O_EXCL-on-symlink semantics — skipped (POSIX CI is the oracle)");
 }
 
 // mkSecretDir creates a private dir.

--- a/packages/core/smoke/secret-fs.smoke.ts
+++ b/packages/core/smoke/secret-fs.smoke.ts
@@ -7,7 +7,7 @@
  * point — broad inherited access is actually stripped) is win32-only; Windows CI is the oracle.
  */
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { hardenPrivate, mkSecretDir, writeSecretFile, writeSecretFileCreateOnly } from "../src/secret-fs.js";
@@ -37,6 +37,36 @@ try {
 }
 check("writeSecretFileCreateOnly REFUSES an existing file (EEXIST), never overwrites", exclusiveCode === "EEXIST");
 check("...and the first writer's bytes are unchanged", readFileSync(exclusive, "utf8") === "first-writer\n");
+
+// The TEMP write is exclusive too. A temp-name collision that plain-overwrote would let the caller
+// whose link succeeded return the candidate IT minted while the file held the OTHER one's bytes —
+// the identity split, one step earlier. Drive the collision directly on a temp-shaped name.
+const tmpShaped = join(dir, `collide.secret.${process.pid}.0.zzz.tmp`);
+writeSecretFileCreateOnly(tmpShaped, "creator-A\n");
+let tmpCollisionCode: string | undefined;
+try {
+  writeSecretFileCreateOnly(tmpShaped, "creator-B\n");
+} catch (e) {
+  tmpCollisionCode = (e as NodeJS.ErrnoException).code;
+}
+check("REFUSE: a colliding temp-shaped name is EEXIST, not a silent overwrite", tmpCollisionCode === "EEXIST");
+check("...and the colliding creator did NOT swap the first creator's bytes",
+  readFileSync(tmpShaped, "utf8") === "creator-A\n");
+
+// A loser must never destroy a live creator's temp. Publishing into an already-taken destination
+// fails, and the pre-existing temp-shaped sibling must survive that failure untouched.
+const takenDest = join(dir, "taken.secret");
+writeSecretFileCreateOnly(takenDest, "incumbent\n");
+let secondPublish: string | undefined;
+try {
+  writeSecretFileCreateOnly(takenDest, "challenger\n");
+} catch (e) {
+  secondPublish = (e as NodeJS.ErrnoException).code;
+}
+check("REFUSE: publishing into a taken destination is EEXIST", secondPublish === "EEXIST");
+check("...and a failed create leaves no .tmp litter behind",
+  readdirSync(dir).filter((n) => n.endsWith(".tmp") && n.startsWith("taken.secret")).length === 0);
+check("...and the incumbent's bytes are intact", readFileSync(takenDest, "utf8") === "incumbent\n");
 
 // mkSecretDir creates a private dir.
 const sub = join(dir, "auth");

--- a/packages/core/smoke/secret-fs.smoke.ts
+++ b/packages/core/smoke/secret-fs.smoke.ts
@@ -6,13 +6,34 @@
  * (the local regression guard — mode bits after write/harden). The win32 `icacls` readback (the real
  * point — broad inherited access is actually stripped) is win32-only; Windows CI is the oracle.
  */
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { __setPublishLinkForTest, hardenPrivate, mkSecretDir, writeSecretFile, writeSecretFileCreateOnly } from "../src/secret-fs.js";
 
+// THE RACE ITSELF, which no single-process cell can reach. `lstatSync` refuses a name that is
+// already there, but on its own that is a CHECK followed by a WRITE: two creators that both pass
+// the check would both write, and both would believe they created the name. Only `O_EXCL` makes
+// the decision one syscall, and only concurrency can tell the two apart.
+//
+// N real processes are released on a barrier against one fresh path. Exactly one may succeed.
+if (process.env.COTAL_SECRETFS_RACE_WORKER === "1") {
+  const target = process.env.COTAL_SECRETFS_RACE_PATH!;
+  const barrier = process.env.COTAL_SECRETFS_RACE_BARRIER!;
+  const there = (p: string): boolean => { try { return statSync(p).isFile(); } catch { return false; } };
+  while (!there(barrier)) { /* spin to the barrier: the tightest release available */ }
+  try {
+    writeSecretFileCreateOnly(target, `${process.pid}\n`);
+    process.stdout.write("WON\n");
+  } catch {
+    process.stdout.write("LOST\n");
+  }
+  process.exit(0);
+}
 const isWin = process.platform === "win32";
+const TSX = join(fileURLToPath(new URL("../../../", import.meta.url)), "node_modules", ".bin", "tsx");
 const statSafe = (p: string): boolean => { try { return statSync(p).isFile(); } catch { return false; } };
 let failures = 0;
 function check(label: string, cond: boolean): void {
@@ -191,6 +212,51 @@ check("REFUSE: a link error outside ENOTSUP/EPERM/ENOSYS propagates instead of f
 check("...and that failure left no .tmp litter",
   readdirSync(propagateDir).filter((n) => n.endsWith(".tmp")).length === 0);
 
+{
+  const RACERS = 8;
+  const ROUNDS = 12;
+  let multiWinner = 0;
+  let observed = 0;
+  for (let r = 0; r < ROUNDS; r++) {
+    const raceDir = join(dir, `race-${r}`);
+    mkSecretDir(raceDir);
+    const target = join(raceDir, "contested.secret");
+    const barrier = join(raceDir, "go");
+    const outcomes: string[] = [];
+    await new Promise<void>((resolve, reject) => {
+      let left = RACERS;
+      const timer = setTimeout(() => reject(new Error("race workers did not report")), 60_000);
+      for (let i = 0; i < RACERS; i++) {
+        // spawnSync would serialise the racers and could never observe a conflict; these run
+        // concurrently and are released together by the barrier below.
+        const child = spawn(TSX, [process.argv[1]!], {
+          env: {
+            ...process.env,
+            COTAL_SECRETFS_RACE_WORKER: "1",
+            COTAL_SECRETFS_RACE_PATH: target,
+            COTAL_SECRETFS_RACE_BARRIER: barrier,
+          },
+          stdio: ["ignore", "pipe", "ignore"],
+        });
+        let buf = "";
+        child.stdout.on("data", (c: Buffer) => { buf += c.toString(); });
+        child.on("error", (e) => { clearTimeout(timer); reject(e); });
+        child.on("exit", () => {
+          outcomes.push(buf.trim());
+          if (--left === 0) { clearTimeout(timer); resolve(); }
+        });
+      }
+      // Let every child reach its spin loop before releasing them.
+      setTimeout(() => writeFileSync(barrier, "go"), 300);
+    });
+    const winners = outcomes.filter((o) => o === "WON").length;
+    observed += outcomes.length;
+    if (winners !== 1) multiWinner++;
+  }
+  check(`REFUSE: of ${RACERS} concurrent creators over ${ROUNDS} rounds exactly one ever creates the name`,
+    multiWinner === 0 && observed === RACERS * ROUNDS);
+}
+
 // mkSecretDir creates a private dir.
 const sub = join(dir, "auth");
 mkSecretDir(sub);
@@ -231,3 +297,4 @@ if (!isWin) {
 rmSync(dir, { recursive: true, force: true, maxRetries: 10 });
 console.log(failures ? `\n${failures} check(s) failed` : "\nall checks passed");
 process.exit(failures ? 1 : 0);
+(failures ? 1 : 0);

--- a/packages/core/smoke/secret-fs.smoke.ts
+++ b/packages/core/smoke/secret-fs.smoke.ts
@@ -25,7 +25,7 @@ if (process.env.COTAL_SECRETFS_RACE_WORKER === "1") {
   const names = Number(process.env.COTAL_SECRETFS_RACE_NAMES);
   const barrier = process.env.COTAL_SECRETFS_RACE_BARRIER!;
   // `link` publishes the destination atomically on its own, so a race there says nothing about the
-  // raw write. Force the link-unavailable path and the raw write becomes the sole decider — which
+  // raw write. Force the link-unavailable path and the raw write becomes the sole decider, which
   // is also the real Windows-side primitive.
   __setPublishLinkForTest(() => {
     const e: NodeJS.ErrnoException = new Error("ENOTSUP: forced fallback");
@@ -68,7 +68,7 @@ const TSX_CLI = join(
 const statSafe = (p: string): boolean => { try { return statSync(p).isFile(); } catch { return false; } };
 // Read for an ASSERTION, never for control flow. A broken implementation can delete or never
 // create the file a cell is about to inspect, and a raw readFileSync would then throw and abort
-// the whole suite — every later cell silently unreported, which reads as a WRONG-RED rather than
+// the whole suite, every later cell silently unreported, which reads as a WRONG-RED rather than
 // as the kill it actually is. A missing file simply is not the expected bytes.
 const readSafe = (p: string): string => { try { return readFileSync(p, "utf8"); } catch { return "\u0000ABSENT"; } };
 let failures = 0;
@@ -266,7 +266,7 @@ check("...and that failure left no .tmp litter",
   // The competitor lands DURING the call, after any pre-check has seen a free name. The publish
   // seam is the seam that runs between the two, so it is where the interleave is injected; it also
   // forces the link-unavailable fallback, making the raw write the only thing deciding the
-  // destination — the Windows-side primitive, and the one place a check-then-write could hide.
+  // destination, the Windows-side primitive, and the one place a check-then-write could hide.
   __setPublishLinkForTest(() => {
     writeFileSync(contested, "incumbent\n", { mode: 0o600 }); // the competitor wins the name here
     const e: NodeJS.ErrnoException = new Error("ENOTSUP: forced fallback");
@@ -336,7 +336,7 @@ check("...and that failure left no .tmp litter",
 // merely queued.
 {
   // Sized by measurement, not taste. At 4 racers x 150 names a check-then-write mutant survived 2
-  // runs in 3; at 6 x 1200 it died 5 times out of 5. The cell above is the deterministic grader —
+  // runs in 3; at 6 x 1200 it died 5 times out of 5. The cell above is the deterministic grader.
   // this one exists for the mutant that also refuses, which only contention can catch.
   const RACERS = 6;
   const NAMES = 1200;
@@ -387,7 +387,7 @@ check("...and that failure left no .tmp litter",
   }).catch((e: Error) => { spawnFailure ??= e; });
   const total = wins.reduce((a, b) => a + b, 0);
   const created = readdirSync(raceDir).filter((n) => n.endsWith(".secret")).length;
-  check("REFUSE: concurrent creators never both win a name — total wins equals names created",
+  check("REFUSE: concurrent creators never both win a name: total wins equals names created",
     spawnFailure === undefined && total === created && created === NAMES);
   // The positive control. Every racer must have run AND won at least one name, which is only true
   // if the field genuinely overlapped. Without this, a queue passes the check above perfectly.
@@ -435,4 +435,3 @@ if (!isWin) {
 rmSync(dir, { recursive: true, force: true, maxRetries: 10 });
 console.log(failures ? `\n${failures} check(s) failed` : "\nall checks passed");
 process.exit(failures ? 1 : 0);
-(failures ? 1 : 0);

--- a/packages/core/smoke/secret-fs.smoke.ts
+++ b/packages/core/smoke/secret-fs.smoke.ts
@@ -13,42 +13,51 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { __setPublishLinkForTest, hardenPrivate, mkSecretDir, writeSecretFile, writeSecretFileCreateOnly } from "../src/secret-fs.js";
 
-// THE RACE ITSELF, which no single-process cell can reach. `lstatSync` refuses a name that is
-// already there, but on its own that is a CHECK followed by a WRITE: two creators that both pass
-// the check would both write, and both would believe they created the name. Only `O_EXCL` makes
-// the decision one syscall, and only concurrency can tell the two apart.
+// CONTENTION WORKER. A userspace `if (exists) throw; write()` REFUSES an existing name exactly like
+// `O_EXCL` does, so no single-process cell can tell them apart: the difference only exists while
+// two creators are inside the call at once. This worker races the real function over many names.
 //
-// N real processes are released on a barrier against one fresh path. Exactly one may succeed.
+// It reports how many names it WON. The parent grades two things, and both fail toward RED:
+// double-wins (two creators both believing they created one name) and a racer that won nothing
+// (which means the field never actually overlapped, so the measurement did not happen).
 if (process.env.COTAL_SECRETFS_RACE_WORKER === "1") {
-  const target = process.env.COTAL_SECRETFS_RACE_PATH!;
+  const raceDir = process.env.COTAL_SECRETFS_RACE_DIR!;
+  const names = Number(process.env.COTAL_SECRETFS_RACE_NAMES);
   const barrier = process.env.COTAL_SECRETFS_RACE_BARRIER!;
-  // The DESTINATION is normally published by `link`, which is atomic on its own, so a race there
-  // cannot say anything about the raw write. Force the link-unavailable path: the raw write is
-  // then the only thing deciding the destination, which is exactly the Windows-side primitive.
+  // `link` publishes the destination atomically on its own, so a race there says nothing about the
+  // raw write. Force the link-unavailable path and the raw write becomes the sole decider — which
+  // is also the real Windows-side primitive.
   __setPublishLinkForTest(() => {
     const e: NodeJS.ErrnoException = new Error("ENOTSUP: forced fallback");
     e.code = "ENOTSUP";
     throw e;
   });
   const there = (p: string): boolean => { try { return statSync(p).isFile(); } catch { return false; } };
-  // Announce arrival BEFORE spinning. The parent releases only once every racer has parked here,
-  // so a slow loader cannot make a racer show up after the winner has already finished: that is a
-  // staggered queue, not a race, and it passes against a check-then-write.
   writeFileSync(process.env.COTAL_SECRETFS_RACE_READY!, "");
-  while (!there(barrier)) { /* spin to the barrier: the tightest release available */ }
-  try {
-    writeSecretFileCreateOnly(target, `${process.pid}\n`);
-    process.stdout.write("WON\n");
-  } catch {
-    process.stdout.write("LOST\n");
+  while (!there(barrier)) { /* spin: the tightest release available */ }
+  // Walk the names in a per-racer random order. In lockstep order the racer that starts first
+  // simply sweeps the list and the others only ever arrive second, which looks like a queue even
+  // though the processes overlap. Shuffling spreads the collisions across the whole space.
+  const order = Array.from({ length: names }, (_, i) => i);
+  for (let i = order.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [order[i], order[j]] = [order[j]!, order[i]!];
   }
+  let won = 0;
+  for (const i of order) {
+    try {
+      writeSecretFileCreateOnly(join(raceDir, `n${i}.secret`), `${process.pid}\n`);
+      won++;
+    } catch { /* EEXIST: another creator got this name, which is the expected outcome */ }
+  }
+  process.stdout.write(`WON:${won}\n`);
   process.exit(0);
 }
+
 const isWin = process.platform === "win32";
-// Racers re-enter THIS file, so they need the same loader running it. Do NOT spawn
-// `node_modules/.bin/tsx`: on Windows that is an extensionless shell shim and spawns ENOENT, and
-// the `.CMD` beside it needs a shell. The package's own CLI entry is a plain .mjs that `node` can
-// run directly on every platform, which is what the tsx bin resolves to anyway.
+// Racers re-enter THIS file, so they need the same loader. Do NOT spawn `node_modules/.bin/tsx`:
+// on Windows that is an extensionless shell shim and spawns ENOENT, and the `.CMD` beside it needs
+// a shell. tsx's own CLI entry is a plain .mjs that `node` runs directly on every platform.
 const TSX_CLI = join(
   fileURLToPath(new URL("../../../", import.meta.url)),
   "node_modules",
@@ -234,73 +243,151 @@ check("REFUSE: a link error outside ENOTSUP/EPERM/ENOSYS propagates instead of f
 check("...and that failure left no .tmp litter",
   readdirSync(propagateDir).filter((n) => n.endsWith(".tmp")).length === 0);
 
+// ATOMICITY, graded deterministically. Refusing an existing name is NOT the same property as
+// deciding a concurrent create: a userspace `if (exists) throw; write()` refuses too, and is
+// exactly the defect. The discriminator is a name that is FREE when a pre-check would look and
+// TAKEN by the time the write runs. `O_EXCL` re-decides at the write and refuses; a check-then-
+// write has already passed its check and overwrites the incumbent.
+//
+// This replaces an N-process barrier race that was measured to FAIL TOWARD GREEN: with a stall
+// between the release and the write, racers arrive one at a time, each finds the name taken, and
+// the round records exactly one winner with `O_EXCL` removed. A cell that passes when the code is
+// correct AND (often) when it is broken launders a survived mutant into a green. This one is
+// deterministic: same verdict on every machine, every run, no N and no timing.
 {
-  const RACERS = 8;
-  const ROUNDS = 12;
-  let multiWinner = 0;
-  let silent = 0;
-  let observed = 0;
-  for (let r = 0; r < ROUNDS; r++) {
-    const raceDir = join(dir, `race-${r}`);
-    mkSecretDir(raceDir);
-    const target = join(raceDir, "contested.secret");
-    const barrier = join(raceDir, "go");
-    const outcomes: string[] = [];
-    // Whatever runs a suite may be a managed agent session, so a raw spread would hand each racer
-    // a live credential and broker URL. Strip every COTAL_ key from the copy first; the racers need
-    // only their own three variables.
-    const cleanEnv: NodeJS.ProcessEnv = { ...process.env };
-    for (const k of Object.keys(cleanEnv)) if (k.startsWith("COTAL_")) delete cleanEnv[k];
-    await new Promise<void>((resolve, reject) => {
-      let left = RACERS;
-      const timer = setTimeout(() => reject(new Error("race workers did not report")), 60_000);
-      for (let i = 0; i < RACERS; i++) {
-        // spawnSync would serialise the racers and could never observe a conflict; these run
-        // concurrently and are released together by the barrier below.
-        const child = spawn(process.execPath, [TSX_CLI, process.argv[1]!], {
-          env: {
-            ...cleanEnv,
-            COTAL_SECRETFS_RACE_WORKER: "1",
-            COTAL_SECRETFS_RACE_PATH: target,
-            COTAL_SECRETFS_RACE_BARRIER: barrier,
-            COTAL_SECRETFS_RACE_READY: join(raceDir, `ready-${i}`),
-          },
-          stdio: ["ignore", "pipe", "ignore"],
-        });
-        let buf = "";
-        child.stdout.on("data", (c: Buffer) => { buf += c.toString(); });
-        child.on("error", (e) => { clearTimeout(timer); reject(e); });
-        child.on("exit", () => {
-          outcomes.push(buf.trim());
-          if (--left === 0) { clearTimeout(timer); resolve(); }
-        });
-      }
-      // Release only when all RACERS are parked at the barrier. A fixed sleep is a guess about
-      // process startup, and on a loaded CI runner it expires early: the racers then arrive one at
-      // a time, each finding the name already taken, and the cell passes even against a
-      // check-then-write. That is exactly how this cell reported a false green in CI.
-      const ready = (): number =>
-        readdirSync(raceDir).filter((n) => n.startsWith("ready-")).length;
-      const releaseAt = Date.now() + 45_000;
-      const poll = setInterval(() => {
-        if (ready() === RACERS) { clearInterval(poll); writeFileSync(barrier, "go"); }
-        else if (Date.now() > releaseAt) {
-          clearInterval(poll);
-          clearTimeout(timer);
-          reject(new Error(`only ${ready()} of ${RACERS} racers parked at the barrier`));
-        }
-      }, 5);
-    });
-    const winners = outcomes.filter((o) => o === "WON").length;
-    const reported = outcomes.filter((o) => o === "WON" || o === "LOST").length;
-    // A racer that never started prints nothing and would otherwise be counted a loser, which
-    // makes "exactly one winner" true for the wrong reason. Every racer must have reported.
-    if (reported !== RACERS) silent++;
-    observed += reported;
-    if (winners !== 1) multiWinner++;
+  const atomicDir = join(dir, "atomic-decides");
+  mkSecretDir(atomicDir);
+  const contested = join(atomicDir, "contested.secret");
+  // The competitor lands DURING the call, after any pre-check has seen a free name. The publish
+  // seam is the seam that runs between the two, so it is where the interleave is injected; it also
+  // forces the link-unavailable fallback, making the raw write the only thing deciding the
+  // destination — the Windows-side primitive, and the one place a check-then-write could hide.
+  __setPublishLinkForTest(() => {
+    writeFileSync(contested, "incumbent\n", { mode: 0o600 }); // the competitor wins the name here
+    const e: NodeJS.ErrnoException = new Error("ENOTSUP: forced fallback");
+    e.code = "ENOTSUP";
+    throw e;
+  });
+  let raced: string | undefined;
+  try {
+    writeSecretFileCreateOnly(contested, "latecomer\n");
+  } catch (e) {
+    raced = (e as NodeJS.ErrnoException).code;
+  } finally {
+    __setPublishLinkForTest(undefined);
   }
-  check(`REFUSE: of ${RACERS} concurrent creators over ${ROUNDS} rounds exactly one ever creates the name`,
-    multiWinner === 0 && silent === 0 && observed === RACERS * ROUNDS);
+  // The bytes are the real assertion. An error code alone would also be satisfied by a write that
+  // clobbered the incumbent and then failed for some other reason.
+  check("REFUSE: a name taken AFTER the check but BEFORE the write does not get overwritten (O_EXCL decides at the write)",
+    readFileSync(contested, "utf8") === "incumbent\n");
+  check("...and the losing creator sees EEXIST", raced === "EEXIST");
+  check("...and that loss left no .tmp litter",
+    readdirSync(atomicDir).filter((n) => n.endsWith(".tmp")).length === 0);
+}
+
+// The SAME interleave, aimed at the TEMP write rather than the destination. The destination cell
+// above rides the fallback seam; this one proves the property holds on the primary path too, where
+// the temp inode is built before `link` publishes it. One refusing case per accepting branch: the
+// two branches write through the same raw helper but reach it by different routes.
+{
+  const tempRaceDir = join(dir, "atomic-temp");
+  mkSecretDir(tempRaceDir);
+  const dest = join(tempRaceDir, "primary.secret");
+  // Pin the clock and the RNG so the internal temp name is computable, then squat it between the
+  // moment a pre-check would look and the moment the write runs. The destination stays FREE, so
+  // only the temp write can refuse.
+  const realNow = Date.now;
+  const realRandom = Math.random;
+  Date.now = () => 1700000000000;
+  Math.random = () => 0.5;
+  const tmpName = `${dest}.${process.pid}.1700000000000.${(0.5).toString(36).slice(2)}.tmp`;
+  writeFileSync(tmpName, "squatter\n", { mode: 0o600 });
+  let tempRaced: string | undefined;
+  try {
+    writeSecretFileCreateOnly(dest, "latecomer\n");
+  } catch (e) {
+    tempRaced = (e as NodeJS.ErrnoException).code;
+  } finally {
+    Date.now = realNow;
+    Math.random = realRandom;
+  }
+  check("REFUSE: a temp name taken before the write is not overwritten (the temp write is exclusive too)",
+    readFileSync(tmpName, "utf8") === "squatter\n");
+  check("...and the creator that lost the temp name sees EEXIST", tempRaced === "EEXIST");
+  check("...and nothing was published at the destination on that refusal", !statSafe(dest));
+}
+
+// CONTENTION, and the one cell that can separate `O_EXCL` from a userspace check-then-write that
+// also refuses. Both produce EEXIST for a caller that arrives second, so only overlapping creators
+// can tell them apart: under a check-then-write, two creators that both pass the check both write,
+// and the TOTAL number of wins exceeds the number of names.
+//
+// Counting wins is what makes this fail toward RED. The earlier version of this cell asked "was
+// there exactly one winner per round", which a degraded field satisfies by accident: if the racers
+// arrive one at a time, each later one finds the name taken and the round looks perfect while the
+// implementation is broken. It false-greened 3 runs out of 3 under a post-release stall. Here a
+// field that fails to overlap shows up as a racer that won NOTHING, which is a red, and the excess
+// wins that a check-then-write produces are a red as well. Neither can be reached by racers that
+// merely queued.
+{
+  // Sized by measurement, not taste. At 4 racers x 150 names a check-then-write mutant survived 2
+  // runs in 3; at 6 x 1200 it died 5 times out of 5. The cell above is the deterministic grader —
+  // this one exists for the mutant that also refuses, which only contention can catch.
+  const RACERS = 6;
+  const NAMES = 1200;
+  const raceDir = join(dir, "contention");
+  mkSecretDir(raceDir);
+  const barrier = join(raceDir, "go");
+  // Whatever runs a suite may be a managed agent session, so a raw env spread would hand each child
+  // a live credential and broker URL. Strip every COTAL_ key; the racers need only their own.
+  const cleanEnv: NodeJS.ProcessEnv = { ...process.env };
+  for (const k of Object.keys(cleanEnv)) if (k.startsWith("COTAL_")) delete cleanEnv[k];
+  const wins: number[] = [];
+  let spawnFailure: Error | undefined;
+  await new Promise<void>((resolve, reject) => {
+    let left = RACERS;
+    const timer = setTimeout(() => reject(new Error("contention workers did not report")), 120_000);
+    for (let i = 0; i < RACERS; i++) {
+      const child = spawn(process.execPath, [TSX_CLI, process.argv[1]!], {
+        env: {
+          ...cleanEnv,
+          COTAL_SECRETFS_RACE_WORKER: "1",
+          COTAL_SECRETFS_RACE_DIR: raceDir,
+          COTAL_SECRETFS_RACE_NAMES: String(NAMES),
+          COTAL_SECRETFS_RACE_BARRIER: barrier,
+          COTAL_SECRETFS_RACE_READY: join(raceDir, `ready-${i}`),
+        },
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      let buf = "";
+      child.stdout.on("data", (c: Buffer) => { buf += c.toString(); });
+      child.on("error", (e) => { spawnFailure = e as Error; clearTimeout(timer); reject(e); });
+      child.on("exit", () => {
+        const m = /WON:(\d+)/.exec(buf);
+        // A racer that never ran prints nothing. Recording -1 rather than 0 keeps "did not run"
+        // distinguishable from "ran and won nothing"; both are red, for different reasons.
+        wins.push(m ? Number(m[1]) : -1);
+        if (--left === 0) { clearTimeout(timer); resolve(); }
+      });
+    }
+    const ready = (): number => readdirSync(raceDir).filter((n) => n.startsWith("ready-")).length;
+    const releaseAt = Date.now() + 60_000;
+    const poll = setInterval(() => {
+      if (ready() === RACERS) { clearInterval(poll); writeFileSync(barrier, "go"); }
+      else if (Date.now() > releaseAt) {
+        clearInterval(poll);
+        reject(new Error(`only ${ready()} of ${RACERS} racers parked at the barrier`));
+      }
+    }, 5);
+  }).catch((e: Error) => { spawnFailure ??= e; });
+  const total = wins.reduce((a, b) => a + b, 0);
+  const created = readdirSync(raceDir).filter((n) => n.endsWith(".secret")).length;
+  check("REFUSE: concurrent creators never both win a name — total wins equals names created",
+    spawnFailure === undefined && total === created && created === NAMES);
+  // The positive control. Every racer must have run AND won at least one name, which is only true
+  // if the field genuinely overlapped. Without this, a queue passes the check above perfectly.
+  check("...and every racer ran and won at least one name (the field really was contended)",
+    wins.length === RACERS && wins.every((w) => w > 0));
 }
 
 // mkSecretDir creates a private dir.

--- a/packages/core/smoke/secret-fs.smoke.ts
+++ b/packages/core/smoke/secret-fs.smoke.ts
@@ -99,24 +99,39 @@ check("...and the incumbent's bytes are intact", readFileSync(takenDest, "utf8")
 // actually grades it.
 const tmpVictim = join(dir, "tmp-symlink-victim");
 const danglingDest = join(dir, "dangling.secret");
-const realRandom2 = Math.random;
-const realNow2 = Date.now;
-Math.random = () => 0.5;
-Date.now = () => 1;
-const danglingTmp = `${danglingDest}.${process.pid}.1.${(0.5).toString(36).slice(2)}.tmp`;
-symlinkSync(tmpVictim, danglingTmp);
-let danglingCode: string | undefined;
+// Creating a symlink needs SeCreateSymbolicLinkPrivilege on Windows, which an unprivileged CI
+// runner does not have. Probe the capability rather than assuming it from the platform: a
+// developer box with Developer Mode on DOES have it, and this cell is worth running there.
+let canSymlink = true;
 try {
-  writeSecretFileCreateOnly(danglingDest, "attacker\n");
-} catch (e) {
-  danglingCode = (e as NodeJS.ErrnoException).code;
-} finally {
-  Math.random = realRandom2;
-  Date.now = realNow2;
+  const probeLink = join(dir, "symlink-capability-probe");
+  symlinkSync(join(dir, "no-such-target"), probeLink);
+  rmSync(probeLink, { force: true });
+} catch {
+  canSymlink = false;
 }
-check("REFUSE: a temp name that exists but resolves to nothing is EEXIST (kernel-atomic, not check-then-write)",
-  danglingCode === "EEXIST");
-check("...and nothing was written through the dangling link", !statSafe(tmpVictim));
+if (canSymlink) {
+  const realRandom2 = Math.random;
+  const realNow2 = Date.now;
+  Math.random = () => 0.5;
+  Date.now = () => 1;
+  const danglingTmp = `${danglingDest}.${process.pid}.1.${(0.5).toString(36).slice(2)}.tmp`;
+  symlinkSync(tmpVictim, danglingTmp);
+  let danglingCode: string | undefined;
+  try {
+    writeSecretFileCreateOnly(danglingDest, "attacker\n");
+  } catch (e) {
+    danglingCode = (e as NodeJS.ErrnoException).code;
+  } finally {
+    Math.random = realRandom2;
+    Date.now = realNow2;
+  }
+  check("REFUSE: a temp name that exists but resolves to nothing is EEXIST (kernel-atomic, not check-then-write)",
+    danglingCode === "EEXIST");
+  check("...and nothing was written through the dangling link", !statSafe(tmpVictim));
+} else {
+  console.log("· dangling-symlink atomicity cell needs symlink privilege — skipped (POSIX CI is the oracle)");
+}
 
 // mkSecretDir creates a private dir.
 const sub = join(dir, "auth");

--- a/packages/core/smoke/secret-fs.smoke.ts
+++ b/packages/core/smoke/secret-fs.smoke.ts
@@ -41,7 +41,17 @@ if (process.env.COTAL_SECRETFS_RACE_WORKER === "1") {
   process.exit(0);
 }
 const isWin = process.platform === "win32";
-const TSX = join(fileURLToPath(new URL("../../../", import.meta.url)), "node_modules", ".bin", "tsx");
+// Racers re-enter THIS file, so they need the same loader running it. Do NOT spawn
+// `node_modules/.bin/tsx`: on Windows that is an extensionless shell shim and spawns ENOENT, and
+// the `.CMD` beside it needs a shell. The package's own CLI entry is a plain .mjs that `node` can
+// run directly on every platform, which is what the tsx bin resolves to anyway.
+const TSX_CLI = join(
+  fileURLToPath(new URL("../../../", import.meta.url)),
+  "node_modules",
+  "tsx",
+  "dist",
+  "cli.mjs",
+);
 const statSafe = (p: string): boolean => { try { return statSync(p).isFile(); } catch { return false; } };
 let failures = 0;
 function check(label: string, cond: boolean): void {
@@ -224,6 +234,7 @@ check("...and that failure left no .tmp litter",
   const RACERS = 8;
   const ROUNDS = 12;
   let multiWinner = 0;
+  let silent = 0;
   let observed = 0;
   for (let r = 0; r < ROUNDS; r++) {
     const raceDir = join(dir, `race-${r}`);
@@ -231,15 +242,20 @@ check("...and that failure left no .tmp litter",
     const target = join(raceDir, "contested.secret");
     const barrier = join(raceDir, "go");
     const outcomes: string[] = [];
+    // Whatever runs a suite may be a managed agent session, so a raw spread would hand each racer
+    // a live credential and broker URL. Strip every COTAL_ key from the copy first; the racers need
+    // only their own three variables.
+    const cleanEnv: NodeJS.ProcessEnv = { ...process.env };
+    for (const k of Object.keys(cleanEnv)) if (k.startsWith("COTAL_")) delete cleanEnv[k];
     await new Promise<void>((resolve, reject) => {
       let left = RACERS;
       const timer = setTimeout(() => reject(new Error("race workers did not report")), 60_000);
       for (let i = 0; i < RACERS; i++) {
         // spawnSync would serialise the racers and could never observe a conflict; these run
         // concurrently and are released together by the barrier below.
-        const child = spawn(TSX, [process.argv[1]!], {
+        const child = spawn(process.execPath, [TSX_CLI, process.argv[1]!], {
           env: {
-            ...process.env,
+            ...cleanEnv,
             COTAL_SECRETFS_RACE_WORKER: "1",
             COTAL_SECRETFS_RACE_PATH: target,
             COTAL_SECRETFS_RACE_BARRIER: barrier,
@@ -258,11 +274,15 @@ check("...and that failure left no .tmp litter",
       setTimeout(() => writeFileSync(barrier, "go"), 300);
     });
     const winners = outcomes.filter((o) => o === "WON").length;
-    observed += outcomes.length;
+    const reported = outcomes.filter((o) => o === "WON" || o === "LOST").length;
+    // A racer that never started prints nothing and would otherwise be counted a loser, which
+    // makes "exactly one winner" true for the wrong reason. Every racer must have reported.
+    if (reported !== RACERS) silent++;
+    observed += reported;
     if (winners !== 1) multiWinner++;
   }
   check(`REFUSE: of ${RACERS} concurrent creators over ${ROUNDS} rounds exactly one ever creates the name`,
-    multiWinner === 0 && observed === RACERS * ROUNDS);
+    multiWinner === 0 && silent === 0 && observed === RACERS * ROUNDS);
 }
 
 // mkSecretDir creates a private dir.

--- a/packages/core/smoke/secret-fs.smoke.ts
+++ b/packages/core/smoke/secret-fs.smoke.ts
@@ -89,22 +89,34 @@ check("...and the incumbent's bytes are intact", readFileSync(takenDest, "utf8")
 // are two syscalls and a creator arriving between them is overwritten.
 //
 // Discriminate the two WITHOUT monkeypatching, using a property only the kernel has. A dangling
-// symlink is a name that EXISTS while `existsSync` reports false, because `existsSync` follows the
-// link to a missing target. `O_EXCL` refuses it (the kernel checks the name, and O_EXCL explicitly
-// does not follow a final symlink); a userspace absence check is told "absent", writes through the
-// link, and creates the target. Same call, opposite outcomes, no test seam in src/.
-const linkTarget = join(dir, "symlink-victim");
-const danglingName = join(dir, "dangling.secret");
-symlinkSync(linkTarget, danglingName);
+// symlink is a name that EXISTS while a follow-the-link presence check reports absent. `O_EXCL`
+// refuses it (the kernel checks the name and does not follow a final symlink); a userspace check
+// is told "absent", writes THROUGH the link, and creates the target.
+//
+// It has to be the TEMP name, not the destination: the destination is also guarded by `linkSync`,
+// which refuses a dangling link on its own, so a destination cell would pass even with the raw
+// write broken. On the temp path the raw write is the only guard, so this cell is the one that
+// actually grades it.
+const tmpVictim = join(dir, "tmp-symlink-victim");
+const danglingDest = join(dir, "dangling.secret");
+const realRandom2 = Math.random;
+const realNow2 = Date.now;
+Math.random = () => 0.5;
+Date.now = () => 1;
+const danglingTmp = `${danglingDest}.${process.pid}.1.${(0.5).toString(36).slice(2)}.tmp`;
+symlinkSync(tmpVictim, danglingTmp);
 let danglingCode: string | undefined;
 try {
-  writeSecretFileCreateOnly(danglingName, "attacker\n");
+  writeSecretFileCreateOnly(danglingDest, "attacker\n");
 } catch (e) {
   danglingCode = (e as NodeJS.ErrnoException).code;
+} finally {
+  Math.random = realRandom2;
+  Date.now = realNow2;
 }
-check("REFUSE: a name that exists but resolves to nothing is EEXIST (kernel-atomic, not check-then-write)",
+check("REFUSE: a temp name that exists but resolves to nothing is EEXIST (kernel-atomic, not check-then-write)",
   danglingCode === "EEXIST");
-check("...and nothing was written through the dangling link", !statSafe(linkTarget));
+check("...and nothing was written through the dangling link", !statSafe(tmpVictim));
 
 // mkSecretDir creates a private dir.
 const sub = join(dir, "auth");

--- a/packages/core/smoke/secret-fs.smoke.ts
+++ b/packages/core/smoke/secret-fs.smoke.ts
@@ -31,6 +31,10 @@ if (process.env.COTAL_SECRETFS_RACE_WORKER === "1") {
     throw e;
   });
   const there = (p: string): boolean => { try { return statSync(p).isFile(); } catch { return false; } };
+  // Announce arrival BEFORE spinning. The parent releases only once every racer has parked here,
+  // so a slow loader cannot make a racer show up after the winner has already finished: that is a
+  // staggered queue, not a race, and it passes against a check-then-write.
+  writeFileSync(process.env.COTAL_SECRETFS_RACE_READY!, "");
   while (!there(barrier)) { /* spin to the barrier: the tightest release available */ }
   try {
     writeSecretFileCreateOnly(target, `${process.pid}\n`);
@@ -259,6 +263,7 @@ check("...and that failure left no .tmp litter",
             COTAL_SECRETFS_RACE_WORKER: "1",
             COTAL_SECRETFS_RACE_PATH: target,
             COTAL_SECRETFS_RACE_BARRIER: barrier,
+            COTAL_SECRETFS_RACE_READY: join(raceDir, `ready-${i}`),
           },
           stdio: ["ignore", "pipe", "ignore"],
         });
@@ -270,8 +275,21 @@ check("...and that failure left no .tmp litter",
           if (--left === 0) { clearTimeout(timer); resolve(); }
         });
       }
-      // Let every child reach its spin loop before releasing them.
-      setTimeout(() => writeFileSync(barrier, "go"), 300);
+      // Release only when all RACERS are parked at the barrier. A fixed sleep is a guess about
+      // process startup, and on a loaded CI runner it expires early: the racers then arrive one at
+      // a time, each finding the name already taken, and the cell passes even against a
+      // check-then-write. That is exactly how this cell reported a false green in CI.
+      const ready = (): number =>
+        readdirSync(raceDir).filter((n) => n.startsWith("ready-")).length;
+      const releaseAt = Date.now() + 45_000;
+      const poll = setInterval(() => {
+        if (ready() === RACERS) { clearInterval(poll); writeFileSync(barrier, "go"); }
+        else if (Date.now() > releaseAt) {
+          clearInterval(poll);
+          clearTimeout(timer);
+          reject(new Error(`only ${ready()} of ${RACERS} racers parked at the barrier`));
+        }
+      }, 5);
     });
     const winners = outcomes.filter((o) => o === "WON").length;
     const reported = outcomes.filter((o) => o === "WON" || o === "LOST").length;

--- a/packages/core/smoke/secret-fs.smoke.ts
+++ b/packages/core/smoke/secret-fs.smoke.ts
@@ -13,6 +13,7 @@ import { join } from "node:path";
 import { hardenPrivate, mkSecretDir, writeSecretFile, writeSecretFileCreateOnly } from "../src/secret-fs.js";
 
 const isWin = process.platform === "win32";
+const statSafe = (p: string): boolean => { try { return statSync(p).isFile(); } catch { return false; } };
 let failures = 0;
 function check(label: string, cond: boolean): void {
   console.log(`${cond ? "✓" : "✗"} ${label}`);
@@ -38,23 +39,37 @@ try {
 check("writeSecretFileCreateOnly REFUSES an existing file (EEXIST), never overwrites", exclusiveCode === "EEXIST");
 check("...and the first writer's bytes are unchanged", readFileSync(exclusive, "utf8") === "first-writer\n");
 
-// The TEMP write is exclusive too. A temp-name collision that plain-overwrote would let the caller
-// whose link succeeded return the candidate IT minted while the file held the OTHER one's bytes —
-// the identity split, one step earlier. Drive the collision directly on a temp-shaped name.
-const tmpShaped = join(dir, `collide.secret.${process.pid}.0.zzz.tmp`);
-writeSecretFileCreateOnly(tmpShaped, "creator-A\n");
-let tmpCollisionCode: string | undefined;
+// The TEMP write is exclusive too. A temp-name collision that plain-overwrote would destroy the
+// other creator's bytes, and the caller whose link then succeeded would return the candidate IT
+// minted while the file held the OTHER identity — the split, one step earlier.
+//
+// The temp name is internal (pid + clock + Math.random), so pin the clock and the RNG, compute the
+// exact name this call will choose, and squat it with another creator's bytes. The destination is
+// FRESH, so the publish would succeed: the only thing under test is the temp write itself.
+const squatDest = join(dir, "squat.secret");
+const realRandom = Math.random;
+const realNow = Date.now;
+Math.random = () => 0.5;
+Date.now = () => 1;
+const squattedTmp = `${squatDest}.${process.pid}.1.${(0.5).toString(36).slice(2)}.tmp`;
+writeSecretFile(squattedTmp, "other-creator\n");
+let squatCode: string | undefined;
 try {
-  writeSecretFileCreateOnly(tmpShaped, "creator-B\n");
+  writeSecretFileCreateOnly(squatDest, "my-candidate\n");
 } catch (e) {
-  tmpCollisionCode = (e as NodeJS.ErrnoException).code;
+  squatCode = (e as NodeJS.ErrnoException).code;
+} finally {
+  Math.random = realRandom;
+  Date.now = realNow;
 }
-check("REFUSE: a colliding temp-shaped name is EEXIST, not a silent overwrite", tmpCollisionCode === "EEXIST");
-check("...and the colliding creator did NOT swap the first creator's bytes",
-  readFileSync(tmpShaped, "utf8") === "creator-A\n");
+check("REFUSE: a temp name already held by another creator is EEXIST, not a silent overwrite",
+  squatCode === "EEXIST");
+check("...and that other creator's bytes were NOT destroyed",
+  readFileSync(squattedTmp, "utf8") === "other-creator\n");
+check("...and nothing was published at the destination on that refusal", !statSafe(squatDest));
 
 // A loser must never destroy a live creator's temp. Publishing into an already-taken destination
-// fails, and the pre-existing temp-shaped sibling must survive that failure untouched.
+// fails, and leaves no litter of its own behind.
 const takenDest = join(dir, "taken.secret");
 writeSecretFileCreateOnly(takenDest, "incumbent\n");
 let secondPublish: string | undefined;

--- a/packages/core/smoke/secret-fs.smoke.ts
+++ b/packages/core/smoke/secret-fs.smoke.ts
@@ -289,7 +289,18 @@ check("...and that failure left no .tmp litter",
   const preload = fileURLToPath(new URL("./_secret-fs-interleave-preload.cjs", import.meta.url));
   const child = fileURLToPath(new URL("./_secret-fs-interleave-child.mjs", import.meta.url));
   // The BUILT module, because the preload patches the `fs` binding the shipped package closes over.
-  const dist = pathToFileURL(fileURLToPath(new URL("../dist/secret-fs.js", import.meta.url))).href;
+  // The BUILT module, because tsx re-execs into a child process and the `--require` preload does
+  // not survive that, while plain node running the compiled `.js` keeps it. That makes the cell
+  // dependent on `dist` being current, so staleness is checked rather than assumed: a stale build
+  // would grade the PREVIOUS implementation and pass while the current one is broken, which is the
+  // vacuous green this suite exists to make impossible.
+  const distPath = fileURLToPath(new URL("../dist/secret-fs.js", import.meta.url));
+  const srcPath = fileURLToPath(new URL("../src/secret-fs.ts", import.meta.url));
+  const distFresh = statSafe(distPath) &&
+    statSync(distPath).mtimeMs >= statSync(srcPath).mtimeMs;
+  check("the built module is current with its source (else this cell would grade stale code)",
+    distFresh);
+  const dist = pathToFileURL(distPath).href;
   // Whatever runs a suite may be a managed agent session, so a raw env spread would hand the child
   // a live credential and broker URL. Strip every COTAL_ key, then add only what it needs.
   const childEnv: NodeJS.ProcessEnv = { ...process.env };

--- a/packages/core/smoke/secret-fs.smoke.ts
+++ b/packages/core/smoke/secret-fs.smoke.ts
@@ -47,7 +47,7 @@ check("...and the first writer's bytes are unchanged", readSafe(exclusive) === "
 
 // The TEMP write is exclusive too. A temp-name collision that plain-overwrote would destroy the
 // other creator's bytes, and the caller whose link then succeeded would return the candidate IT
-// minted while the file held the OTHER identity — the split, one step earlier.
+// minted while the file held the OTHER identity: the split, one step earlier.
 //
 // The temp name is internal (pid + clock + Math.random), so pin the clock and the RNG, compute the
 // exact name this call will choose, and squat it with another creator's bytes. The destination is
@@ -107,8 +107,8 @@ const tmpVictim = join(dir, "tmp-symlink-victim");
 const danglingDest = join(dir, "dangling.secret");
 {
   // No platform gate on the ASSERTION: `lstatSync` makes the refusal portable, so EEXIST must hold
-  // on every platform. Only the SETUP can be unavailable — creating a symlink needs a privilege on
-  // Windows — and that is reported as a named skip rather than a pass, so it can never read as a
+  // on every platform. Only the SETUP can be unavailable, since creating a symlink needs a privilege
+  // on Windows, and that is reported as a named skip rather than a pass, so it can never read as a
   // green that proves something it did not test.
   let linkPlanted = true;
   const realRandom2 = Math.random;
@@ -136,7 +136,7 @@ const danglingDest = join(dir, "dangling.secret");
       danglingCode === "EEXIST");
     check("...and nothing was written through the dangling link", !statSafe(tmpVictim));
   } else {
-    console.log("· dangling-symlink atomicity cell could not PLANT a symlink (no privilege) — skipped, setup only");
+    console.log("· dangling-symlink atomicity cell could not PLANT a symlink (no privilege): skipped, setup only");
   }
 }
 

--- a/packages/core/smoke/secret-fs.smoke.ts
+++ b/packages/core/smoke/secret-fs.smoke.ts
@@ -22,6 +22,14 @@ import { __setPublishLinkForTest, hardenPrivate, mkSecretDir, writeSecretFile, w
 if (process.env.COTAL_SECRETFS_RACE_WORKER === "1") {
   const target = process.env.COTAL_SECRETFS_RACE_PATH!;
   const barrier = process.env.COTAL_SECRETFS_RACE_BARRIER!;
+  // The DESTINATION is normally published by `link`, which is atomic on its own, so a race there
+  // cannot say anything about the raw write. Force the link-unavailable path: the raw write is
+  // then the only thing deciding the destination, which is exactly the Windows-side primitive.
+  __setPublishLinkForTest(() => {
+    const e: NodeJS.ErrnoException = new Error("ENOTSUP: forced fallback");
+    e.code = "ENOTSUP";
+    throw e;
+  });
   const there = (p: string): boolean => { try { return statSync(p).isFile(); } catch { return false; } };
   while (!there(barrier)) { /* spin to the barrier: the tightest release available */ }
   try {

--- a/packages/core/smoke/secret-fs.smoke.ts
+++ b/packages/core/smoke/secret-fs.smoke.ts
@@ -6,65 +6,14 @@
  * (the local regression guard — mode bits after write/harden). The win32 `icacls` readback (the real
  * point — broad inherited access is actually stripped) is win32-only; Windows CI is the oracle.
  */
-import { execFileSync, spawn } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { __setPublishLinkForTest, hardenPrivate, mkSecretDir, writeSecretFile, writeSecretFileCreateOnly } from "../src/secret-fs.js";
 
-// CONTENTION WORKER. A userspace `if (exists) throw; write()` REFUSES an existing name exactly like
-// `O_EXCL` does, so no single-process cell can tell them apart: the difference only exists while
-// two creators are inside the call at once. This worker races the real function over many names.
-//
-// It reports how many names it WON. The parent grades two things, and both fail toward RED:
-// double-wins (two creators both believing they created one name) and a racer that won nothing
-// (which means the field never actually overlapped, so the measurement did not happen).
-if (process.env.COTAL_SECRETFS_RACE_WORKER === "1") {
-  const raceDir = process.env.COTAL_SECRETFS_RACE_DIR!;
-  const names = Number(process.env.COTAL_SECRETFS_RACE_NAMES);
-  const barrier = process.env.COTAL_SECRETFS_RACE_BARRIER!;
-  // `link` publishes the destination atomically on its own, so a race there says nothing about the
-  // raw write. Force the link-unavailable path and the raw write becomes the sole decider, which
-  // is also the real Windows-side primitive.
-  __setPublishLinkForTest(() => {
-    const e: NodeJS.ErrnoException = new Error("ENOTSUP: forced fallback");
-    e.code = "ENOTSUP";
-    throw e;
-  });
-  const there = (p: string): boolean => { try { return statSync(p).isFile(); } catch { return false; } };
-  writeFileSync(process.env.COTAL_SECRETFS_RACE_READY!, "");
-  while (!there(barrier)) { /* spin: the tightest release available */ }
-  // Walk the names in a per-racer random order. In lockstep order the racer that starts first
-  // simply sweeps the list and the others only ever arrive second, which looks like a queue even
-  // though the processes overlap. Shuffling spreads the collisions across the whole space.
-  const order = Array.from({ length: names }, (_, i) => i);
-  for (let i = order.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [order[i], order[j]] = [order[j]!, order[i]!];
-  }
-  let won = 0;
-  for (const i of order) {
-    try {
-      writeSecretFileCreateOnly(join(raceDir, `n${i}.secret`), `${process.pid}\n`);
-      won++;
-    } catch { /* EEXIST: another creator got this name, which is the expected outcome */ }
-  }
-  process.stdout.write(`WON:${won}\n`);
-  process.exit(0);
-}
-
 const isWin = process.platform === "win32";
-// Racers re-enter THIS file, so they need the same loader. Do NOT spawn `node_modules/.bin/tsx`:
-// on Windows that is an extensionless shell shim and spawns ENOENT, and the `.CMD` beside it needs
-// a shell. tsx's own CLI entry is a plain .mjs that `node` runs directly on every platform.
-const TSX_CLI = join(
-  fileURLToPath(new URL("../../../", import.meta.url)),
-  "node_modules",
-  "tsx",
-  "dist",
-  "cli.mjs",
-);
 const statSafe = (p: string): boolean => { try { return statSync(p).isFile(); } catch { return false; } };
 // Read for an ASSERTION, never for control flow. A broken implementation can delete or never
 // create the file a cell is about to inspect, and a raw readFileSync would then throw and abort
@@ -322,77 +271,52 @@ check("...and that failure left no .tmp litter",
   check("...and nothing was published at the destination on that refusal", !statSafe(dest));
 }
 
-// CONTENTION, and the one cell that can separate `O_EXCL` from a userspace check-then-write that
-// also refuses. Both produce EEXIST for a caller that arrives second, so only overlapping creators
-// can tell them apart: under a check-then-write, two creators that both pass the check both write,
-// and the TOTAL number of wins exceeds the number of names.
+// THE REFUSING CHECK-THEN-WRITE, graded deterministically. This is the mutant no in-process cell
+// can catch: `if (exists) throw; write()` raises EEXIST for a caller that arrives second, exactly
+// as `O_EXCL` does. They differ only for a creator that is ALREADY PAST the check when the name is
+// taken. `O_EXCL` re-decides at the write and refuses; the check-then-write has nothing left to
+// check and overwrites the incumbent.
 //
-// Counting wins is what makes this fail toward RED. The earlier version of this cell asked "was
-// there exactly one winner per round", which a degraded field satisfies by accident: if the racers
-// arrive one at a time, each later one finds the name taken and the round looks perfect while the
-// implementation is broken. It false-greened 3 runs out of 3 under a post-release stall. Here a
-// field that fails to overlap shows up as a racer that won NOTHING, which is a red, and the excess
-// wins that a check-then-write produces are a red as well. Neither can be reached by racers that
-// merely queued.
+// An earlier version of this cell raced N processes and hoped to land in that window. Measured, it
+// let this mutant escape roughly one run in six while staying green 12/12 when the implementation
+// was correct: a one-sided failure toward green, which is the direction that ships a live defect.
+// Here the competitor is placed IN the window by an `fs` preload instead of being hoped for, so
+// the verdict is the same on every machine, every run, with no N and no scheduler.
 {
-  // Sized by measurement, not taste. At 4 racers x 150 names a check-then-write mutant survived 2
-  // runs in 3; at 6 x 1200 it died 5 times out of 5. The cell above is the deterministic grader.
-  // this one exists for the mutant that also refuses, which only contention can catch.
-  const RACERS = 6;
-  const NAMES = 1200;
-  const raceDir = join(dir, "contention");
-  mkSecretDir(raceDir);
-  const barrier = join(raceDir, "go");
-  // Whatever runs a suite may be a managed agent session, so a raw env spread would hand each child
-  // a live credential and broker URL. Strip every COTAL_ key; the racers need only their own.
-  const cleanEnv: NodeJS.ProcessEnv = { ...process.env };
-  for (const k of Object.keys(cleanEnv)) if (k.startsWith("COTAL_")) delete cleanEnv[k];
-  const wins: number[] = [];
-  let spawnFailure: Error | undefined;
-  await new Promise<void>((resolve, reject) => {
-    let left = RACERS;
-    const timer = setTimeout(() => reject(new Error("contention workers did not report")), 120_000);
-    for (let i = 0; i < RACERS; i++) {
-      const child = spawn(process.execPath, [TSX_CLI, process.argv[1]!], {
-        env: {
-          ...cleanEnv,
-          COTAL_SECRETFS_RACE_WORKER: "1",
-          COTAL_SECRETFS_RACE_DIR: raceDir,
-          COTAL_SECRETFS_RACE_NAMES: String(NAMES),
-          COTAL_SECRETFS_RACE_BARRIER: barrier,
-          COTAL_SECRETFS_RACE_READY: join(raceDir, `ready-${i}`),
-        },
-        stdio: ["ignore", "pipe", "ignore"],
-      });
-      let buf = "";
-      child.stdout.on("data", (c: Buffer) => { buf += c.toString(); });
-      child.on("error", (e) => { spawnFailure = e as Error; clearTimeout(timer); reject(e); });
-      child.on("exit", () => {
-        const m = /WON:(\d+)/.exec(buf);
-        // A racer that never ran prints nothing. Recording -1 rather than 0 keeps "did not run"
-        // distinguishable from "ran and won nothing"; both are red, for different reasons.
-        wins.push(m ? Number(m[1]) : -1);
-        if (--left === 0) { clearTimeout(timer); resolve(); }
-      });
-    }
-    const ready = (): number => readdirSync(raceDir).filter((n) => n.startsWith("ready-")).length;
-    const releaseAt = Date.now() + 60_000;
-    const poll = setInterval(() => {
-      if (ready() === RACERS) { clearInterval(poll); writeFileSync(barrier, "go"); }
-      else if (Date.now() > releaseAt) {
-        clearInterval(poll);
-        reject(new Error(`only ${ready()} of ${RACERS} racers parked at the barrier`));
-      }
-    }, 5);
-  }).catch((e: Error) => { spawnFailure ??= e; });
-  const total = wins.reduce((a, b) => a + b, 0);
-  const created = readdirSync(raceDir).filter((n) => n.endsWith(".secret")).length;
-  check("REFUSE: concurrent creators never both win a name: total wins equals names created",
-    spawnFailure === undefined && total === created && created === NAMES);
-  // The positive control. Every racer must have run AND won at least one name, which is only true
-  // if the field genuinely overlapped. Without this, a queue passes the check above perfectly.
-  check("...and every racer ran and won at least one name (the field really was contended)",
-    wins.length === RACERS && wins.every((w) => w > 0));
+  const interleaveDir = join(dir, "interleave");
+  mkSecretDir(interleaveDir);
+  const target = join(interleaveDir, "contested.secret");
+  const preload = fileURLToPath(new URL("./_secret-fs-interleave-preload.cjs", import.meta.url));
+  const child = fileURLToPath(new URL("./_secret-fs-interleave-child.mjs", import.meta.url));
+  // The BUILT module, because the preload patches the `fs` binding the shipped package closes over.
+  const dist = pathToFileURL(fileURLToPath(new URL("../dist/secret-fs.js", import.meta.url))).href;
+  // Whatever runs a suite may be a managed agent session, so a raw env spread would hand the child
+  // a live credential and broker URL. Strip every COTAL_ key, then add only what it needs.
+  const childEnv: NodeJS.ProcessEnv = { ...process.env };
+  for (const k of Object.keys(childEnv)) if (k.startsWith("COTAL_")) delete childEnv[k];
+  const run = spawnSync(process.execPath, ["--require", preload, child], {
+    env: {
+      ...childEnv,
+      COTAL_SECRETFS_INTERLEAVE_TARGET: target,
+      COTAL_SECRETFS_INTERLEAVE_DIST: dist,
+    },
+    encoding: "utf8",
+  });
+  // A child that never ran would print nothing, and "no clobber observed" would then be true for
+  // the wrong reason. Parse explicitly and treat an unparseable result as a failure.
+  let observed: { code?: string; bytes?: string } | undefined;
+  try {
+    observed = JSON.parse(run.stdout.trim()) as { code?: string; bytes?: string };
+  } catch {
+    observed = undefined;
+  }
+  check("REFUSE: a name taken while the creator is past its check is still not overwritten (O_EXCL re-decides at the write)",
+    observed?.bytes === "incumbent\n");
+  check("...and that creator sees EEXIST rather than believing it created the name",
+    observed?.code === "EEXIST");
+  // The positive control: the interleave has to have actually happened, or the cell above is vacuous.
+  check("...and the interleaved child ran and reported (the window was really entered)",
+    run.status === 0 && observed !== undefined);
 }
 
 // mkSecretDir creates a private dir.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -50,7 +50,17 @@ export * from "./lease.js";
 export * from "./agent-file.js";
 export * from "./launch.js";
 export * from "./fs-safe.js";
-export * from "./secret-fs.js";
+// Explicit, NOT `export *`, and deliberately so: a star export would put the test-only seam
+// `__setPublishLinkForTest` on this package's public root, where any dependent could swap the
+// publish primitive of the code that writes secrets. Everything a consumer legitimately needs is
+// named here; the seam stays reachable from the suite via a deep import of the module itself.
+export {
+  hardenPrivate,
+  mkSecretDir,
+  writeSecretFile,
+  writeSecretFileAtomic,
+  writeSecretFileCreateOnly,
+} from "./secret-fs.js";
 export * from "./launch-material.js";
 export * from "./connector-config.js";
 export * from "./kv-scan.js";

--- a/packages/core/src/secret-fs.ts
+++ b/packages/core/src/secret-fs.ts
@@ -129,26 +129,43 @@ export function writeSecretFileAtomic(path: string, data: string | Buffer): void
  * were private. EEXIST propagates to the caller, which is the point: the name was already taken.
  *
  * `O_EXCL` alone does not carry that contract everywhere. On POSIX it refuses a final symlink
- * without following it, so a DANGLING link is EEXIST. On Windows the reparse point resolves, the
- * missing target is created, and the bytes land at a name this caller did NOT create — which is
- * precisely what the contract above forbids. `lstatSync` closes that: it reports the LINK rather
+ * without following it, so a DANGLING link is EEXIST (measured: file, directory and dangling link
+ * all refuse, and nothing is materialised). On Windows the reparse point resolves, the missing
+ * target is created, and the bytes land at a name this caller did NOT create — which is precisely
+ * what the contract above forbids. A win32-only `lstatSync` closes that: it reports the LINK rather
  * than its target, so a name that exists in any form is refused before anything is written.
  *
- * This is a refusal, never a fallback: it only ever converts a would-be silent write-through into
- * the EEXIST the caller already handles. The race that `O_EXCL` closes stays closed, because
- * `O_EXCL` still runs and is still what decides a concurrent create; the `lstat` only adds names
- * that `O_EXCL` would have followed rather than refused.
+ * That pre-check is deliberately NOT run on POSIX. It would be a check-then-act step guarding a
+ * case `O_EXCL` already refuses, and an unnecessary one weakens the very property this function
+ * exists to provide. Where it does run it is a refusal, never a fallback: it only converts a
+ * would-be silent write-through into the EEXIST the caller already handles, and it never decides a
+ * concurrent create — two creators that both find the name free still both reach `O_EXCL`, which is
+ * one syscall and is what picks the winner.
  */
 function writeSecretFileCreateOnlyRaw(path: string, data: string | Buffer): void {
-  try {
-    lstatSync(path); // the NAME exists (file, dir, or dangling link) — never write through it
-    const taken: NodeJS.ErrnoException = new Error(`EEXIST: file already exists, open '${path}'`);
-    taken.code = "EEXIST";
-    throw taken;
-  } catch (e) {
-    if ((e as NodeJS.ErrnoException).code === "EEXIST") throw e;
-    // ENOENT is the expected case: the name is free, so O_EXCL below decides the race.
-    if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+  // WIN32 ONLY, and deliberately so. Measured on POSIX: `O_EXCL` already refuses a plain file, a
+  // directory AND a dangling symlink with EEXIST, materialising nothing — so a pre-check there
+  // would add a check-then-act step that buys nothing and can only weaken the guarantee. Windows
+  // is the platform where `O_EXCL` RESOLVES a reparse point and creates its target, which would
+  // land bytes at a name the caller never asked for; `lstatSync` reports the link rather than its
+  // target, so the name is refused before anything is written.
+  //
+  // This never decides a concurrent create. Two creators that both see the name free still both
+  // reach `O_EXCL` below, and O_EXCL — one syscall — is what picks the winner. The check only ever
+  // converts a would-be write-through into the EEXIST the caller already handles.
+  if (isWin) {
+    let exists = true;
+    try {
+      lstatSync(path); // the NAME exists (file, dir, or dangling link) — never write through it
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+      exists = false;
+    }
+    if (exists) {
+      const taken: NodeJS.ErrnoException = new Error(`EEXIST: file already exists, open '${path}'`);
+      taken.code = "EEXIST";
+      throw taken;
+    }
   }
   writeFileSync(path, data, { flag: "wx", mode: 0o600 });
   if (!isWin) return; // POSIX mode set at create — nothing more to do

--- a/packages/core/src/secret-fs.ts
+++ b/packages/core/src/secret-fs.ts
@@ -86,14 +86,14 @@ export function hardenPrivate(path: string, kind: "file" | "dir"): void {
  */
 export function writeSecretFile(path: string, data: string | Buffer): void {
   writeFileSync(path, data, { mode: 0o600 });
-  if (!isWin) return; // POSIX mode set at create — nothing more to do
+  if (!isWin) return; // POSIX mode set at create, nothing more to do
   try {
     hardenPrivate(path, "file");
   } catch (e) {
     try {
       unlinkSync(path); // best-effort cleanup; the hardening error below is what the caller sees
     } catch {
-      /* ignore — surface the original hardening failure, not a secondary unlink error */
+      /* ignore: surface the original hardening failure, not a secondary unlink error */
     }
     throw e;
   }
@@ -124,7 +124,7 @@ export function writeSecretFileAtomic(path: string, data: string | Buffer): void
 
 /**
  * {@link writeSecretFile} with `O_EXCL`: the bytes land only if this caller created the name.
- * Same fail-closed hardening contract as {@link writeSecretFile} — a win32 ACL failure propagates
+ * Same fail-closed hardening contract as {@link writeSecretFile}: a win32 ACL failure propagates
  * and the just-written file is best-effort removed, so a caller never proceeds as if the secret
  * were private. EEXIST propagates to the caller, which is the point: the name was already taken.
  *
@@ -168,14 +168,14 @@ function writeSecretFileCreateOnlyRaw(path: string, data: string | Buffer): void
     }
   }
   writeFileSync(path, data, { flag: "wx", mode: 0o600 });
-  if (!isWin) return; // POSIX mode set at create — nothing more to do
+  if (!isWin) return; // POSIX mode set at create, nothing more to do
   try {
     hardenPrivate(path, "file");
   } catch (e) {
     try {
       unlinkSync(path); // best-effort cleanup; the hardening error below is what the caller sees
     } catch {
-      /* ignore — surface the original hardening failure, not a secondary unlink error */
+      /* ignore: surface the original hardening failure, not a secondary unlink error */
     }
     throw e;
   }
@@ -215,7 +215,7 @@ export function __setPublishLinkForTest(fn: ((from: string, to: string) => void)
  * probability (pid plus clock plus `Math.random`), and probability is not a concurrency argument:
  * two creators that collided on the name would plain-overwrite each other's bytes, and then the
  * one whose `link` succeeded would return the candidate IT minted while the published file held
- * the OTHER one's identity — the exact split this function exists to prevent, reintroduced one
+ * the OTHER one's identity: the exact split this function exists to prevent, reintroduced one
  * step earlier. `wx` on the temp makes a collision fail loudly instead of silently swapping bytes.
  */
 export function writeSecretFileCreateOnly(path: string, data: string | Buffer): void {
@@ -238,7 +238,7 @@ export function writeSecretFileCreateOnly(path: string, data: string | Buffer): 
     try {
       unlinkSync(tmp);
     } catch {
-      /* ignore — surface the original exclusive-create error */
+      /* ignore: surface the original exclusive-create error */
     }
     throw e;
   }

--- a/packages/core/src/secret-fs.ts
+++ b/packages/core/src/secret-fs.ts
@@ -7,7 +7,7 @@
  * world-readable (e.g. a `.cotal/auth` under a project on a permissive path). The fix is to harden
  * the NTFS ACL explicitly with the built-in `icacls` (no new dependency). See {@link hardenPrivate}.
  */
-import { chmodSync, linkSync, mkdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, linkSync, lstatSync, mkdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 
@@ -127,8 +127,29 @@ export function writeSecretFileAtomic(path: string, data: string | Buffer): void
  * Same fail-closed hardening contract as {@link writeSecretFile} — a win32 ACL failure propagates
  * and the just-written file is best-effort removed, so a caller never proceeds as if the secret
  * were private. EEXIST propagates to the caller, which is the point: the name was already taken.
+ *
+ * `O_EXCL` alone does not carry that contract everywhere. On POSIX it refuses a final symlink
+ * without following it, so a DANGLING link is EEXIST. On Windows the reparse point resolves, the
+ * missing target is created, and the bytes land at a name this caller did NOT create — which is
+ * precisely what the contract above forbids. `lstatSync` closes that: it reports the LINK rather
+ * than its target, so a name that exists in any form is refused before anything is written.
+ *
+ * This is a refusal, never a fallback: it only ever converts a would-be silent write-through into
+ * the EEXIST the caller already handles. The race that `O_EXCL` closes stays closed, because
+ * `O_EXCL` still runs and is still what decides a concurrent create; the `lstat` only adds names
+ * that `O_EXCL` would have followed rather than refused.
  */
 function writeSecretFileCreateOnlyRaw(path: string, data: string | Buffer): void {
+  try {
+    lstatSync(path); // the NAME exists (file, dir, or dangling link) — never write through it
+    const taken: NodeJS.ErrnoException = new Error(`EEXIST: file already exists, open '${path}'`);
+    taken.code = "EEXIST";
+    throw taken;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "EEXIST") throw e;
+    // ENOENT is the expected case: the name is free, so O_EXCL below decides the race.
+    if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+  }
   writeFileSync(path, data, { flag: "wx", mode: 0o600 });
   if (!isWin) return; // POSIX mode set at create — nothing more to do
   try {
@@ -141,6 +162,22 @@ function writeSecretFileCreateOnlyRaw(path: string, data: string | Buffer): void
     }
     throw e;
   }
+}
+
+/**
+ * Publish a completed temp inode at its final name. Separated from {@link writeSecretFileCreateOnly}
+ * because the hard-link primitive is the one part of exclusive create whose AVAILABILITY is
+ * platform-dependent: some Windows volumes and some network filesystems reject `link` outright, and
+ * the caller must then fall back to `O_EXCL` on the destination. Naming that seam also makes the
+ * fallback branch reachable from a suite, so the Windows-side primitive can carry a refusing case
+ * instead of being the one accepting branch nothing grades.
+ */
+let publishLink: (from: string, to: string) => void = linkSync;
+
+/** Test-only: drive the `link`-unavailable fallback, which no POSIX CI host can reach naturally.
+ *  Pass `undefined` to restore. Not exported from the package index. */
+export function __setPublishLinkForTest(fn: ((from: string, to: string) => void) | undefined): void {
+  publishLink = fn ?? linkSync;
 }
 
 /**
@@ -171,7 +208,7 @@ export function writeSecretFileCreateOnly(path: string, data: string | Buffer): 
   writeSecretFileCreateOnlyRaw(tmp, data);
   try {
     try {
-      linkSync(tmp, path);
+      publishLink(tmp, path);
     } catch (e) {
       const code = (e as NodeJS.ErrnoException).code;
       if (code === "ENOTSUP" || code === "EPERM" || code === "ENOSYS") {

--- a/packages/core/src/secret-fs.ts
+++ b/packages/core/src/secret-fs.ts
@@ -7,7 +7,7 @@
  * world-readable (e.g. a `.cotal/auth` under a project on a permissive path). The fix is to harden
  * the NTFS ACL explicitly with the built-in `icacls` (no new dependency). See {@link hardenPrivate}.
  */
-import { chmodSync, mkdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, linkSync, mkdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 
@@ -119,6 +119,50 @@ export function writeSecretFileAtomic(path: string, data: string | Buffer): void
       /* ignore — surface the original write/rename error */
     }
     throw e;
+  }
+}
+
+/**
+ * Create a private secret file that MUST NOT already exist. Bytes are written to a unique temp
+ * sibling first, then {@link linkSync} publishes that complete inode at `path`. `link` is an
+ * atomic filesystem primitive: it fails with EEXIST if the destination exists, so of N concurrent
+ * creators exactly one succeeds and the others observe EEXIST. A concurrent reader never sees a
+ * torn destination because the name appears only after the temp write finished.
+ *
+ * `renameSync` is NOT this function. Rename replaces a winner, which would let every caller keep
+ * the identity it minted in memory. Exclusive create is the mutual-exclusion primitive; atomic
+ * replace is not.
+ *
+ * When the filesystem cannot hard-link (some Windows volumes), the fallback is `wx`
+ * (`O_CREAT|O_EXCL`) on `path` itself, which is still exclusive create, not a replace.
+ */
+export function writeSecretFileCreateOnly(path: string, data: string | Buffer): void {
+  const tmp = `${path}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
+  try {
+    writeSecretFile(tmp, data);
+    try {
+      linkSync(tmp, path);
+    } catch (e) {
+      const code = (e as NodeJS.ErrnoException).code;
+      if (code === "ENOTSUP" || code === "EPERM" || code === "ENOSYS") {
+        writeFileSync(path, data, { flag: "wx", mode: 0o600 });
+        if (isWin) hardenPrivate(path, "file");
+      } else {
+        throw e;
+      }
+    }
+  } catch (e) {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* ignore — surface the original exclusive-create error */
+    }
+    throw e;
+  }
+  try {
+    unlinkSync(tmp);
+  } catch {
+    /* drop the extra nlink after a successful link, or a leftover temp */
   }
 }
 

--- a/packages/core/src/secret-fs.ts
+++ b/packages/core/src/secret-fs.ts
@@ -123,6 +123,27 @@ export function writeSecretFileAtomic(path: string, data: string | Buffer): void
 }
 
 /**
+ * {@link writeSecretFile} with `O_EXCL`: the bytes land only if this caller created the name.
+ * Same fail-closed hardening contract as {@link writeSecretFile} — a win32 ACL failure propagates
+ * and the just-written file is best-effort removed, so a caller never proceeds as if the secret
+ * were private. EEXIST propagates to the caller, which is the point: the name was already taken.
+ */
+function writeSecretFileCreateOnlyRaw(path: string, data: string | Buffer): void {
+  writeFileSync(path, data, { flag: "wx", mode: 0o600 });
+  if (!isWin) return; // POSIX mode set at create — nothing more to do
+  try {
+    hardenPrivate(path, "file");
+  } catch (e) {
+    try {
+      unlinkSync(path); // best-effort cleanup; the hardening error below is what the caller sees
+    } catch {
+      /* ignore — surface the original hardening failure, not a secondary unlink error */
+    }
+    throw e;
+  }
+}
+
+/**
  * Create a private secret file that MUST NOT already exist. Bytes are written to a unique temp
  * sibling first, then {@link linkSync} publishes that complete inode at `path`. `link` is an
  * atomic filesystem primitive: it fails with EEXIST if the destination exists, so of N concurrent
@@ -135,18 +156,26 @@ export function writeSecretFileAtomic(path: string, data: string | Buffer): void
  *
  * When the filesystem cannot hard-link (some Windows volumes), the fallback is `wx`
  * (`O_CREAT|O_EXCL`) on `path` itself, which is still exclusive create, not a replace.
+ *
+ * The TEMP write is exclusive for the same reason the publish is. A temp name is unique only by
+ * probability (pid plus clock plus `Math.random`), and probability is not a concurrency argument:
+ * two creators that collided on the name would plain-overwrite each other's bytes, and then the
+ * one whose `link` succeeded would return the candidate IT minted while the published file held
+ * the OTHER one's identity — the exact split this function exists to prevent, reintroduced one
+ * step earlier. `wx` on the temp makes a collision fail loudly instead of silently swapping bytes.
  */
 export function writeSecretFileCreateOnly(path: string, data: string | Buffer): void {
   const tmp = `${path}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
+  // Exclusive, so EEXIST here means the temp name belongs to ANOTHER creator. Cleanup below must
+  // never run in that case: unlinking it would delete a live creator's bytes out from under it.
+  writeSecretFileCreateOnlyRaw(tmp, data);
   try {
-    writeSecretFile(tmp, data);
     try {
       linkSync(tmp, path);
     } catch (e) {
       const code = (e as NodeJS.ErrnoException).code;
       if (code === "ENOTSUP" || code === "EPERM" || code === "ENOSYS") {
-        writeFileSync(path, data, { flag: "wx", mode: 0o600 });
-        if (isWin) hardenPrivate(path, "file");
+        writeSecretFileCreateOnlyRaw(path, data);
       } else {
         throw e;
       }

--- a/packages/core/src/secret-fs.ts
+++ b/packages/core/src/secret-fs.ts
@@ -131,7 +131,7 @@ export function writeSecretFileAtomic(path: string, data: string | Buffer): void
  * `O_EXCL` alone does not carry that contract everywhere. On POSIX it refuses a final symlink
  * without following it, so a DANGLING link is EEXIST (measured: file, directory and dangling link
  * all refuse, and nothing is materialised). On Windows the reparse point resolves, the missing
- * target is created, and the bytes land at a name this caller did NOT create — which is precisely
+ * target is created, and the bytes land at a name this caller did NOT create, which is precisely
  * what the contract above forbids. A win32-only `lstatSync` closes that: it reports the LINK rather
  * than its target, so a name that exists in any form is refused before anything is written.
  *
@@ -139,24 +139,24 @@ export function writeSecretFileAtomic(path: string, data: string | Buffer): void
  * case `O_EXCL` already refuses, and an unnecessary one weakens the very property this function
  * exists to provide. Where it does run it is a refusal, never a fallback: it only converts a
  * would-be silent write-through into the EEXIST the caller already handles, and it never decides a
- * concurrent create — two creators that both find the name free still both reach `O_EXCL`, which is
+ * concurrent create: two creators that both find the name free still both reach `O_EXCL`, which is
  * one syscall and is what picks the winner.
  */
 function writeSecretFileCreateOnlyRaw(path: string, data: string | Buffer): void {
   // WIN32 ONLY, and deliberately so. Measured on POSIX: `O_EXCL` already refuses a plain file, a
-  // directory AND a dangling symlink with EEXIST, materialising nothing — so a pre-check there
+  // directory AND a dangling symlink with EEXIST, materialising nothing, so a pre-check there
   // would add a check-then-act step that buys nothing and can only weaken the guarantee. Windows
   // is the platform where `O_EXCL` RESOLVES a reparse point and creates its target, which would
   // land bytes at a name the caller never asked for; `lstatSync` reports the link rather than its
   // target, so the name is refused before anything is written.
   //
   // This never decides a concurrent create. Two creators that both see the name free still both
-  // reach `O_EXCL` below, and O_EXCL — one syscall — is what picks the winner. The check only ever
+  // reach `O_EXCL` below, and O_EXCL, one syscall, is what picks the winner. The check only ever
   // converts a would-be write-through into the EEXIST the caller already handles.
   if (isWin) {
     let exists = true;
     try {
-      lstatSync(path); // the NAME exists (file, dir, or dangling link) — never write through it
+      lstatSync(path); // the NAME exists (file, dir, or dangling link), never write through it
     } catch (e) {
       if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
       exists = false;

--- a/packages/workspace/smoke/manager-instance-exclusive.smoke.ts
+++ b/packages/workspace/smoke/manager-instance-exclusive.smoke.ts
@@ -12,7 +12,7 @@
  *
  * Run: pnpm smoke:manager-instance-exclusive
  */
-import { Worker, isMainThread, parentPort, workerData } from "node:worker_threads";
+import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -26,6 +26,8 @@ import {
 const N = 8;
 const ROUNDS = 20;
 const SPACE = "issue-1263";
+const HERE = fileURLToPath(import.meta.url);
+const TSX = join(fileURLToPath(new URL("../../../", import.meta.url)), "node_modules", ".bin", "tsx");
 
 function candidate(tag: string) {
   return {
@@ -34,11 +36,13 @@ function candidate(tag: string) {
   };
 }
 
-if (!isMainThread) {
-  const { root, barrier } = workerData as { root: string; barrier: string };
+if (process.env.COTAL_I1263_EXCL_WORKER === "1") {
+  const root = process.env.COTAL_I1263_EXCL_ROOT!;
+  const barrier = process.env.COTAL_I1263_EXCL_BARRIER!;
   while (!existsSync(barrier)) {}
   const claimed = createManagerInstanceIdentity(root, SPACE, candidate(`w${process.pid}`));
-  parentPort!.postMessage(claimed.instanceId);
+  process.stdout.write(`${claimed.instanceId}\n`);
+  process.exit(0);
 } else {
   let pass = 0, fail = 0;
   const check = (name: string, cond: boolean, extra?: unknown) => {
@@ -82,25 +86,64 @@ if (!isMainThread) {
       adoptedAfterExclusive.instanceId.startsWith("winner-"));
     rmSync(lostRoot, { recursive: true, force: true });
 
+    const ambientEnv: NodeJS.ProcessEnv = { ...process.env };
+    for (const key of Object.keys(ambientEnv)) if (key.startsWith("COTAL_")) delete ambientEnv[key];
     let raced = 0;
     for (let r = 0; r < ROUNDS; r++) {
       const raceRoot = mkdtempSync(join(tmpdir(), "cotal-iid-race-"));
       mkdirSync(join(raceRoot, ".cotal"), { recursive: true });
       const barrier = join(raceRoot, "go");
       const ids: string[] = [];
+      const workers: ChildProcess[] = [];
       await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error("exclusive workers did not report")), 25_000);
         let left = N;
         for (let i = 0; i < N; i++) {
-          const w = new Worker(fileURLToPath(import.meta.url), { workerData: { root: raceRoot, barrier } });
-          w.on("message", (id: string) => ids.push(id));
-          w.on("error", reject);
-          w.on("exit", (code) => {
-            if (code !== 0) reject(new Error(`worker exit ${code}`));
-            if (--left === 0) resolve();
+          const child = spawn(TSX, [HERE], {
+            env: {
+              ...ambientEnv,
+              COTAL_I1263_EXCL_WORKER: "1",
+              COTAL_I1263_EXCL_ROOT: raceRoot,
+              COTAL_I1263_EXCL_BARRIER: barrier,
+            },
+            stdio: ["ignore", "pipe", "pipe"],
+          });
+          workers.push(child);
+          let buf = "";
+          let reported = false;
+          child.stdout?.on("data", (c: Buffer) => {
+            if (reported) return;
+            buf += c.toString();
+            const line = buf.trim().split("\n").find((l) => l.length > 0);
+            if (!line) return;
+            reported = true;
+            ids.push(line.trim());
+          });
+          child.on("error", (err) => {
+            clearTimeout(timer);
+            reject(err);
+          });
+          child.on("exit", (code) => {
+            if (!reported && buf.trim()) {
+              reported = true;
+              ids.push(buf.trim().split("\n")[0]!.trim());
+            }
+            if (code !== 0) {
+              clearTimeout(timer);
+              reject(new Error(`worker exit ${code}`));
+              return;
+            }
+            if (--left === 0) {
+              clearTimeout(timer);
+              resolve();
+            }
           });
         }
         writeFileSync(barrier, "go");
       });
+      for (const w of workers) {
+        try { w.kill("SIGKILL"); } catch { /* done */ }
+      }
       const unique = new Set(ids);
       const fileId = loadManagerInstanceIdentity(raceRoot, SPACE)?.instanceId;
       const leftovers = readdirSync(join(raceRoot, ".cotal", "auth")).filter((n) => n.endsWith(".tmp"));

--- a/packages/workspace/smoke/manager-instance-exclusive.smoke.ts
+++ b/packages/workspace/smoke/manager-instance-exclusive.smoke.ts
@@ -1,0 +1,124 @@
+/**
+ * Exclusive manager-instance identity mint (#1263).
+ *
+ * The first concurrent start on a fresh root used to observe no identity file, mint in memory,
+ * and persist with a plain write. Two processes kept different in-memory ids, took different
+ * leases, and both served. Atomic rename would still leave the loser serving under the id it
+ * minted. Exclusive create (`link` / `O_EXCL`) is the primitive: exactly one creator wins, and
+ * every other process adopts the winner or refuses with `manager-instance-identity-create-lost`.
+ *
+ * PRE-FIX CONTROL (same worker shape, load-absent-then-write): 2/40 rounds minted two in-memory
+ * identities at origin/main. This suite must stay red under that write.
+ *
+ * Run: pnpm smoke:manager-instance-exclusive
+ */
+import { Worker, isMainThread, parentPort, workerData } from "node:worker_threads";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  createManagerInstanceIdentity,
+  loadManagerInstanceIdentity,
+  saveManagerInstanceIdentity,
+} from "../src/auth-paths.js";
+
+const N = 8;
+const ROUNDS = 20;
+const SPACE = "issue-1263";
+
+function candidate(tag: string) {
+  return {
+    instanceId: `${tag}-${Math.random().toString(36).slice(2)}`,
+    serveIdentity: { id: `${tag}-id`, seed: `${tag}-seed` },
+  };
+}
+
+if (!isMainThread) {
+  const { root, barrier } = workerData as { root: string; barrier: string };
+  while (!existsSync(barrier)) {}
+  const claimed = createManagerInstanceIdentity(root, SPACE, candidate(`w${process.pid}`));
+  parentPort!.postMessage(claimed.instanceId);
+} else {
+  let pass = 0, fail = 0;
+  const check = (name: string, cond: boolean, extra?: unknown) => {
+    if (cond) { pass++; console.log(`  ✓ ${name}`); }
+    else { fail++; console.log(`  ✗ FAIL: ${name}`, extra !== undefined ? extra : ""); }
+  };
+
+  const root = mkdtempSync(join(tmpdir(), "cotal-iid-excl-"));
+  try {
+    mkdirSync(join(root, ".cotal"), { recursive: true });
+
+    const planted = candidate("planted");
+    saveManagerInstanceIdentity(root, SPACE, planted);
+    const adopted = createManagerInstanceIdentity(root, SPACE, candidate("loser"));
+    check("ACCEPT: an existing identity is adopted, the candidate is discarded",
+      adopted.instanceId === planted.instanceId && adopted.serveIdentity.id === planted.serveIdentity.id);
+
+    const refuseRoot = mkdtempSync(join(tmpdir(), "cotal-iid-refuse-"));
+    mkdirSync(join(refuseRoot, ".cotal", "auth"), { recursive: true });
+    const refusePath = join(refuseRoot, ".cotal", "auth", `manager-instance.${Buffer.from(SPACE, "utf8").toString("hex")}.json`);
+    writeFileSync(refusePath, "{not-json", { flag: "wx", mode: 0o600 });
+    let refuseMsg = "";
+    try {
+      createManagerInstanceIdentity(refuseRoot, SPACE, candidate("refuse"));
+    } catch (e) {
+      refuseMsg = (e as Error).message;
+    }
+    check("REFUSE: a present-but-malformed file is not minted over (load fails closed)",
+      /does not parse|malformed/.test(refuseMsg), refuseMsg);
+    rmSync(refuseRoot, { recursive: true, force: true });
+
+    const lostRoot = mkdtempSync(join(tmpdir(), "cotal-iid-lost-"));
+    mkdirSync(join(lostRoot, ".cotal", "auth"), { recursive: true });
+    const lostPath = join(
+      lostRoot, ".cotal", "auth",
+      `manager-instance.${Buffer.from(SPACE, "utf8").toString("hex")}.json`,
+    );
+    writeFileSync(lostPath, JSON.stringify(candidate("winner"), null, 2), { flag: "wx", mode: 0o600 });
+    const adoptedAfterExclusive = createManagerInstanceIdentity(lostRoot, SPACE, candidate("late"));
+    check("ACCEPT: exclusive-create loser adopts the winner (EEXIST then load)",
+      adoptedAfterExclusive.instanceId.startsWith("winner-"));
+    rmSync(lostRoot, { recursive: true, force: true });
+
+    let raced = 0;
+    for (let r = 0; r < ROUNDS; r++) {
+      const raceRoot = mkdtempSync(join(tmpdir(), "cotal-iid-race-"));
+      mkdirSync(join(raceRoot, ".cotal"), { recursive: true });
+      const barrier = join(raceRoot, "go");
+      const ids: string[] = [];
+      await new Promise<void>((resolve, reject) => {
+        let left = N;
+        for (let i = 0; i < N; i++) {
+          const w = new Worker(fileURLToPath(import.meta.url), { workerData: { root: raceRoot, barrier } });
+          w.on("message", (id: string) => ids.push(id));
+          w.on("error", reject);
+          w.on("exit", (code) => {
+            if (code !== 0) reject(new Error(`worker exit ${code}`));
+            if (--left === 0) resolve();
+          });
+        }
+        writeFileSync(barrier, "go");
+      });
+      const unique = new Set(ids);
+      const fileId = loadManagerInstanceIdentity(raceRoot, SPACE)?.instanceId;
+      const leftovers = readdirSync(join(raceRoot, ".cotal", "auth")).filter((n) => n.endsWith(".tmp"));
+      if (unique.size !== 1 || fileId !== [...unique][0] || leftovers.length !== 0) {
+        raced++;
+        console.log(`  ✗ FAIL: round ${r} unique=${unique.size} file=${fileId} leftovers=${leftovers.length}`);
+      }
+      rmSync(raceRoot, { recursive: true, force: true });
+    }
+    check(`N=${N} concurrent first mints over ${ROUNDS} rounds share exactly one identity`, raced === 0, { raced });
+
+    check("the planted identity file still loads after the sequential adopt",
+      loadManagerInstanceIdentity(root, SPACE)?.instanceId === planted.instanceId);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+
+  console.log(`COTAL_SMOKE_SENTINEL cells=${pass + fail} passed=${pass} failed=${fail}`);
+  console.log(`\n${fail === 0 ? "MANAGER INSTANCE EXCLUSIVE SMOKE OK" : "MANAGER INSTANCE EXCLUSIVE SMOKE FAILED"}  (${pass} passed, ${fail} failed)`);
+  process.exit(fail === 0 ? 0 : 1);
+}

--- a/packages/workspace/src/auth-paths.ts
+++ b/packages/workspace/src/auth-paths.ts
@@ -7,6 +7,7 @@ import {
   validateSpaceAuthForRead,
   writeSecretFile,
   writeSecretFileAtomic,
+  writeSecretFileCreateOnly,
   type BrokerAuth,
   type SecretStore,
   type SpaceAccountAuth,
@@ -388,6 +389,31 @@ export function saveManagerInstanceIdentity(root: string, space: string, identit
   const dir = authDir(root);
   mkSecretDir(dir); // harden the auth dir BEFORE the secret (with its seed) lands
   writeSecretFile(managerInstanceFile(root, space), JSON.stringify(identity, null, 2));
+}
+
+/**
+ * First-start identity mint: of N concurrent creators on a fresh root, exactly one creates the
+ * file and the others adopt the winner. The publication primitive is exclusive create
+ * (`writeSecretFileCreateOnly` / `link` or `O_EXCL`), not a read-then-write and not an atomic
+ * rename. A loser never keeps the identity it minted in memory: it re-reads the winner or
+ * refuses with a named error (`manager-instance-identity-create-lost`).
+ */
+export function createManagerInstanceIdentity(root: string, space: string, candidate: ManagerInstanceIdentity): ManagerInstanceIdentity {
+  const dir = authDir(root);
+  mkSecretDir(dir);
+  const path = managerInstanceFile(root, space);
+  try {
+    writeSecretFileCreateOnly(path, JSON.stringify(candidate, null, 2));
+    return candidate;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
+    const winner = loadManagerInstanceIdentity(root, space);
+    if (winner === undefined)
+      throw new Error(
+        `manager-instance-identity-create-lost: exclusive create for space "${space}" at ${path} lost and the existing file could not be adopted`,
+      );
+    return winner;
+  }
 }
 
 /** The account file's key IS {@link spaceKey} — one injective, case-safe encoder for every


### PR DESCRIPTION
## Summary
- Two concurrent first starts on one fresh workspace root could each mint a different manager instance id, take different per-instance leases, and both serve.
- Identity creation is now exclusive (`link` / `O_EXCL`): of N concurrent starts, exactly one process publishes the instance file. Losers adopt that identity before taking a lease, or refuse with a named error. Atomic rename is not the fix, because the loser of a replace would still serve under the id it minted.

Refs #1263

## Test plan
- [x] PRE-FIX CONTROL: load-absent-then-write probe minted two in-memory ids in 2/40 rounds on origin/main
- [x] `pnpm smoke:manager-instance-exclusive` 5/5
- [x] `pnpm smoke:secret-fs` including exclusive-create EEXIST
- [x] `pnpm smoke:manager-fresh-root-identity` 4/4 (sequential refuse still holds; concurrent starts mint one id; losers already-serve)
- [x] `node scripts/mutation-proof.mjs --config bin/smoke/mutations/manager-instance-exclusive.json` 3/3 KILLED
- [ ] CI at this head