### PR TITLE
Start a Jcode seat whose private home has an empty sessions directory

### DIFF
--- a/.changeset/jcode-empty-sessions.md
+++ b/.changeset/jcode-empty-sessions.md
@@ -1,0 +1,8 @@
+---
+"@cotal-ai/connector-jcode": patch
+---
+
+Start a Jcode seat whose private home has an empty `sessions/` directory instead of dying as
+`startup failed (unknown)`. The connector skips the panicking list call when that directory is
+empty, redials after any listing death, and names the panic text and sessions path when recovery
+cannot create a session.

--- a/bin/smoke/ci-suites.d/5f13790a975709540fae78759da89c63840d02d3844d2604a7da0b48b42c3a99.txt
+++ b/bin/smoke/ci-suites.d/5f13790a975709540fae78759da89c63840d02d3844d2604a7da0b48b42c3a99.txt
@@ -1,0 +1,2 @@
+# Inspect/classify stored sessions/ without calling the panicking list_sessions RPC.
+smoke:jcode-stored-sessions

--- a/bin/smoke/ci-suites.d/fceb7e22bbe40e5f7880d5c9599350d8054528ce78e0c330ceef2abe7701f65a.txt
+++ b/bin/smoke/ci-suites.d/fceb7e22bbe40e5f7880d5c9599350d8054528ce78e0c330ceef2abe7701f65a.txt
@@ -1,0 +1,2 @@
+# A Jcode home with an empty sessions/ directory must start a fresh session.
+smoke:jcode-empty-sessions

--- a/bin/smoke/mutations/jcode-empty-sessions.json
+++ b/bin/smoke/mutations/jcode-empty-sessions.json
@@ -13,8 +13,9 @@
     "out of this repo. The connector used to catch listSessions, reuse the dead client for createSession,",
     "and report startup failed (unknown). Operators then renamed the seat. Each mutation restores one",
     "of those defects: listing an empty directory, reusing the dead client, collapsing the named failure",
-    "back to unknown, or widening the panic site so an unrelated crate's translate.rs is reported as",
-    "this defect."
+    "back to unknown, widening the panic site so an unrelated crate's translate.rs is reported as this",
+    "defect, letting the local inspection throw and kill a seat that would otherwise start, or naming a",
+    "specific wrong cause for a failure the connector does not recognise."
   ],
   "mutations": [
     {
@@ -79,6 +80,24 @@
       "command": "pnpm smoke:jcode-stored-sessions",
       "expectRed": "a site differing by one character is refused",
       "cell": "a site differing by one character is refused"
+    },
+    {
+      "name": "M8 rethrow an unreadable sessions directory instead of naming it",
+      "file": "extensions/connector-jcode/src/stored-sessions.ts",
+      "find": "    return { kind: \"unreadable\", path, code: code ?? \"unknown\" };",
+      "replace": "    throw error;",
+      "command": "pnpm smoke:jcode-empty-sessions",
+      "expectRed": "an unreadable sessions directory still starts the seat",
+      "cell": "an unreadable sessions directory still starts the seat"
+    },
+    {
+      "name": "M9 report an unrecognised harness failure as a closed connection",
+      "file": "extensions/connector-jcode/src/stored-sessions.ts",
+      "find": "export const UNRECOGNISED_STORED_SESSION_CAUSE = \"unrecognised harness failure\";",
+      "replace": "export const UNRECOGNISED_STORED_SESSION_CAUSE = \"harness connection closed\";",
+      "command": "pnpm smoke:jcode-stored-sessions",
+      "expectRed": "an out-of-memory spawn failure is not reported as a closed connection",
+      "cell": "an out-of-memory spawn failure is not reported as a closed connection"
     }
   ]
 }

--- a/bin/smoke/mutations/jcode-empty-sessions.json
+++ b/bin/smoke/mutations/jcode-empty-sessions.json
@@ -87,8 +87,8 @@
       "find": "    return { kind: \"unreadable\", path, code: code ?? \"unknown\" };",
       "replace": "    throw error;",
       "command": "pnpm smoke:jcode-empty-sessions",
-      "expectRed": "an unreadable sessions directory still starts the seat",
-      "cell": "an unreadable sessions directory still starts the seat"
+      "expectRed": "the unreadable sessions directory is named to the operator",
+      "cell": "the unreadable sessions directory is named to the operator"
     },
     {
       "name": "M9 report an unrecognised harness failure as a closed connection",

--- a/bin/smoke/mutations/jcode-empty-sessions.json
+++ b/bin/smoke/mutations/jcode-empty-sessions.json
@@ -96,8 +96,8 @@
       "find": "export const UNRECOGNISED_STORED_SESSION_CAUSE = \"unrecognised harness failure\";",
       "replace": "export const UNRECOGNISED_STORED_SESSION_CAUSE = \"harness connection closed\";",
       "command": "pnpm smoke:jcode-stored-sessions",
-      "expectRed": "an out-of-memory spawn failure is not reported as a closed connection",
-      "cell": "an out-of-memory spawn failure is not reported as a closed connection"
+      "expectRed": "unrelated child text is not forwarded",
+      "cell": "unrelated child text is not forwarded"
     }
   ]
 }

--- a/bin/smoke/mutations/jcode-empty-sessions.json
+++ b/bin/smoke/mutations/jcode-empty-sessions.json
@@ -88,7 +88,8 @@
       "replace": "    throw error;",
       "command": "pnpm smoke:jcode-empty-sessions",
       "expectRed": "the unreadable sessions directory is named to the operator",
-      "cell": "the unreadable sessions directory is named to the operator"
+      "cell": "the unreadable sessions directory is named to the operator",
+      "note": "POSIX-only proof. The win32 arm of this block declares the cell unreachable and passes unconditionally, so on Windows this mutant is a correct SURVIVOR and the mark count matches a POSIX kill. Read the verdict, not the marks."
     },
     {
       "name": "M9 report an unrecognised harness failure as a closed connection",
@@ -106,16 +107,18 @@
       "replace": "      if (false)",
       "command": "pnpm smoke:jcode-empty-sessions",
       "expectRed": "the unreadable sessions directory is named to the operator",
-      "cell": "the unreadable sessions directory is named to the operator"
+      "cell": "the unreadable sessions directory is named to the operator",
+      "note": "POSIX-only proof. The win32 arm of this block declares the cell unreachable and passes unconditionally, so on Windows this mutant is a correct SURVIVOR and the mark count matches a POSIX kill. Read the verdict, not the marks."
     },
     {
-      "name": "M11 let an unreadable home die unknown instead of naming the path",
+      "name": "M11 forget the unreadable path so a later startup failure renders unknown",
       "file": "extensions/connector-jcode/src/host.ts",
-      "find": "      if (!listingFailed && stored.kind !== \"unreadable\") throw error;",
-      "replace": "      if (!listingFailed) throw error;",
+      "find": "      storedSessionsUnreadable &&",
+      "replace": "      false &&",
       "command": "pnpm smoke:jcode-empty-sessions",
-      "expectRed": "an unreadable sessions directory either starts the seat or names sessions_enumeration_failed",
-      "cell": "an unreadable sessions directory either starts the seat or names sessions_enumeration_failed"
+      "expectRed": "an unreadable sessions directory either runs the seat or names sessions_enumeration_failed",
+      "cell": "an unreadable sessions directory either runs the seat or names sessions_enumeration_failed",
+      "note": "POSIX-only proof. The win32 arm of this block declares the cell unreachable and passes unconditionally, so on Windows this mutant is a correct SURVIVOR and the mark count matches a POSIX kill. Read the verdict, not the marks."
     }
   ]
 }

--- a/bin/smoke/mutations/jcode-empty-sessions.json
+++ b/bin/smoke/mutations/jcode-empty-sessions.json
@@ -98,6 +98,24 @@
       "command": "pnpm smoke:jcode-stored-sessions",
       "expectRed": "unrelated child text is not forwarded",
       "cell": "unrelated child text is not forwarded"
+    },
+    {
+      "name": "M10 stay silent about a sessions directory the connector cannot read",
+      "file": "extensions/connector-jcode/src/host.ts",
+      "find": "      if (stored.kind === \"unreadable\")",
+      "replace": "      if (false)",
+      "command": "pnpm smoke:jcode-empty-sessions",
+      "expectRed": "the unreadable sessions directory is named to the operator",
+      "cell": "the unreadable sessions directory is named to the operator"
+    },
+    {
+      "name": "M11 let an unreadable home die unknown instead of naming the path",
+      "file": "extensions/connector-jcode/src/host.ts",
+      "find": "      if (!listingFailed && stored.kind !== \"unreadable\") throw error;",
+      "replace": "      if (!listingFailed) throw error;",
+      "command": "pnpm smoke:jcode-empty-sessions",
+      "expectRed": "an unreadable sessions directory either starts the seat or names sessions_enumeration_failed",
+      "cell": "an unreadable sessions directory either starts the seat or names sessions_enumeration_failed"
     }
   ]
 }

--- a/bin/smoke/mutations/jcode-empty-sessions.json
+++ b/bin/smoke/mutations/jcode-empty-sessions.json
@@ -31,8 +31,8 @@
       "find": "    if ((error as NodeJS.ErrnoException).code === \"ENOENT\") return { kind: \"absent\", path };",
       "replace": "    if ((error as NodeJS.ErrnoException).code === \"ENOENT\") return { kind: \"empty-directory\", path };",
       "command": "pnpm smoke:jcode-stored-sessions",
-      "expectRed": "a first-launch home is not treated as the empty-directory defect",
-      "cell": "a first-launch home is not treated as the empty-directory defect"
+      "expectRed": "a missing sessions path is absent, not empty",
+      "cell": "a missing sessions path is absent, not empty"
     },
     {
       "name": "M3 classify prose that mentions the assertion as the panic",

--- a/bin/smoke/mutations/jcode-empty-sessions.json
+++ b/bin/smoke/mutations/jcode-empty-sessions.json
@@ -5,15 +5,16 @@
   ],
   "guard": "an empty sessions/ directory is skipped locally so the seat starts fresh, and a list_sessions panic names the assertion and path instead of startup failed (unknown)",
   "command": "pnpm smoke:jcode-stored-sessions && pnpm smoke:jcode-empty-sessions",
-  "progressPattern": "^  ✓ ",
+  "progressPattern": "^  \u2713 ",
   "minTicks": 8,
   "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/jcode-empty-sessions.json",
   "why": [
     "The jcode binary panics in stored_session_ids when sessions/ exists and is empty. That panic is",
     "out of this repo. The connector used to catch listSessions, reuse the dead client for createSession,",
     "and report startup failed (unknown). Operators then renamed the seat. Each mutation restores one",
-    "of those defects: listing an empty directory, reusing the dead client, or collapsing the named",
-    "failure back to unknown."
+    "of those defects: listing an empty directory, reusing the dead client, collapsing the named failure",
+    "back to unknown, or widening the panic site so an unrelated crate's translate.rs is reported as",
+    "this defect."
   ],
   "mutations": [
     {
@@ -64,20 +65,20 @@
     {
       "name": "M6 match any path ending in translate.rs instead of the owning crate",
       "file": "extensions/connector-jcode/src/stored-sessions.ts",
-      "find": "    /thread '[^']*'[^\\n]* panicked at (crates\\/jcode-harness-api-server\\/src\\/translate\\.rs:\\d+:\\d+):\\s*\\n\\s*(chunk size must be non-zero)/.exec(",
-      "replace": "    /thread '[^']*'[^\\n]* panicked at ([^\\n]*translate\\.rs:\\d+:\\d+):\\s*\\n\\s*(chunk size must be non-zero)/.exec(",
+      "find": "const STORED_SESSION_PANIC_SITE = \"crates/jcode-harness-api-server/src/translate.rs\";",
+      "replace": "const STORED_SESSION_PANIC_SITE = \"[^\\\\n]*translate.rs\";",
       "command": "pnpm smoke:jcode-stored-sessions",
       "expectRed": "the same filename in another crate is refused",
       "cell": "the same filename in another crate is refused"
     },
     {
-      "name": "M7 drop the startsWith site guard behind the anchored pattern",
+      "name": "M7 stop escaping the dots in the panic site",
       "file": "extensions/connector-jcode/src/stored-sessions.ts",
-      "find": "  if (!site.startsWith(`${STORED_SESSION_PANIC_SITE}:`)) return undefined;",
-      "replace": "  /* mutant trusts the pattern alone */",
+      "find": "${STORED_SESSION_PANIC_SITE.replace(/[.]/g, \"\\\\.\")}",
+      "replace": "${STORED_SESSION_PANIC_SITE}",
       "command": "pnpm smoke:jcode-stored-sessions",
-      "expectRed": "the real empty-directory panic is classified",
-      "cell": "the real empty-directory panic is classified"
+      "expectRed": "a site differing by one character is refused",
+      "cell": "a site differing by one character is refused"
     }
   ]
 }

--- a/bin/smoke/mutations/jcode-empty-sessions.json
+++ b/bin/smoke/mutations/jcode-empty-sessions.json
@@ -1,0 +1,65 @@
+{
+  "suite": [
+    "extensions/connector-jcode/smoke/empty-sessions.smoke.ts",
+    "extensions/connector-jcode/smoke/stored-sessions.smoke.ts"
+  ],
+  "guard": "an empty sessions/ directory is skipped locally so the seat starts fresh, and a list_sessions panic names the assertion and path instead of startup failed (unknown)",
+  "command": "pnpm smoke:jcode-stored-sessions && pnpm smoke:jcode-empty-sessions",
+  "progressPattern": "^  ✓ ",
+  "minTicks": 8,
+  "proveWith": "node scripts/mutation-proof.mjs --config bin/smoke/mutations/jcode-empty-sessions.json",
+  "why": [
+    "The jcode binary panics in stored_session_ids when sessions/ exists and is empty. That panic is",
+    "out of this repo. The connector used to catch listSessions, reuse the dead client for createSession,",
+    "and report startup failed (unknown). Operators then renamed the seat. Each mutation restores one",
+    "of those defects: listing an empty directory, reusing the dead client, or collapsing the named",
+    "failure back to unknown."
+  ],
+  "mutations": [
+    {
+      "name": "M1 list an empty sessions directory instead of skipping it",
+      "file": "extensions/connector-jcode/src/stored-sessions.ts",
+      "find": "  return inspection.kind === \"empty-directory\";",
+      "replace": "  return false;",
+      "command": "pnpm smoke:jcode-empty-sessions",
+      "expectRed": "list_sessions is not sent when sessions is an empty directory",
+      "cell": "list_sessions is not sent when sessions is an empty directory"
+    },
+    {
+      "name": "M2 treat a missing sessions path as the empty-directory defect",
+      "file": "extensions/connector-jcode/src/stored-sessions.ts",
+      "find": "    if ((error as NodeJS.ErrnoException).code === \"ENOENT\") return { kind: \"absent\", path };",
+      "replace": "    if ((error as NodeJS.ErrnoException).code === \"ENOENT\") return { kind: \"empty-directory\", path };",
+      "command": "pnpm smoke:jcode-stored-sessions",
+      "expectRed": "a first-launch home is not treated as the empty-directory defect",
+      "cell": "a first-launch home is not treated as the empty-directory defect"
+    },
+    {
+      "name": "M3 classify prose that mentions the assertion as the panic",
+      "file": "extensions/connector-jcode/src/stored-sessions.ts",
+      "find": "  return match ? `${match[2]} at ${match[1]}` : undefined;",
+      "replace": "  return /chunk size must be non-zero/.test(stderr) ? \"chunk size must be non-zero at crates/jcode-harness-api-server/src/translate.rs:1707:38\" : undefined;",
+      "command": "pnpm smoke:jcode-stored-sessions",
+      "expectRed": "prose that mentions the assertion is refused",
+      "cell": "prose that mentions the assertion is refused"
+    },
+    {
+      "name": "M4 reuse the dead listing client instead of redialing",
+      "file": "extensions/connector-jcode/src/host.ts",
+      "find": "        await stopPrivateJcode();\n        client = await launchPrivateJcode();",
+      "replace": "        /* mutant keeps the closed client */",
+      "command": "pnpm smoke:jcode-empty-sessions",
+      "expectRed": "listing panic still starts a fresh session on a new harness",
+      "cell": "listing panic still starts a fresh session on a new harness"
+    },
+    {
+      "name": "M5 forward arbitrary child text as the operator-facing cause",
+      "file": "extensions/connector-jcode/src/stored-sessions.ts",
+      "find": "  return \"harness connection closed\";",
+      "replace": "  return text;",
+      "command": "pnpm smoke:jcode-stored-sessions",
+      "expectRed": "unrelated child text is not forwarded",
+      "cell": "unrelated child text is not forwarded"
+    }
+  ]
+}

--- a/bin/smoke/mutations/jcode-empty-sessions.json
+++ b/bin/smoke/mutations/jcode-empty-sessions.json
@@ -30,8 +30,8 @@
     {
       "name": "M2 treat a missing sessions path as the empty-directory defect",
       "file": "extensions/connector-jcode/src/stored-sessions.ts",
-      "find": "    if ((error as NodeJS.ErrnoException).code === \"ENOENT\") return { kind: \"absent\", path };",
-      "replace": "    if ((error as NodeJS.ErrnoException).code === \"ENOENT\") return { kind: \"empty-directory\", path };",
+      "find": "    if (code === \"ENOENT\") return { kind: \"absent\", path };",
+      "replace": "    if (code === \"ENOENT\") return { kind: \"empty-directory\", path };",
       "command": "pnpm smoke:jcode-stored-sessions",
       "expectRed": "a missing sessions path is absent, not empty",
       "cell": "a missing sessions path is absent, not empty"
@@ -57,8 +57,8 @@
     {
       "name": "M5 forward arbitrary child text as the operator-facing cause",
       "file": "extensions/connector-jcode/src/stored-sessions.ts",
-      "find": "  return \"harness connection closed\";",
-      "replace": "  return text;",
+      "find": "  if (/write EPIPE/i.test(text)) return \"write EPIPE\";",
+      "replace": "  if (/write EPIPE/i.test(text)) return \"write EPIPE\";\n  return text;",
       "command": "pnpm smoke:jcode-stored-sessions",
       "expectRed": "unrelated child text is not forwarded",
       "cell": "unrelated child text is not forwarded"

--- a/bin/smoke/mutations/jcode-empty-sessions.json
+++ b/bin/smoke/mutations/jcode-empty-sessions.json
@@ -109,16 +109,6 @@
       "expectRed": "the unreadable sessions directory is named to the operator",
       "cell": "the unreadable sessions directory is named to the operator",
       "note": "POSIX-only proof. The win32 arm of this block declares the cell unreachable and passes unconditionally, so on Windows this mutant is a correct SURVIVOR and the mark count matches a POSIX kill. Read the verdict, not the marks."
-    },
-    {
-      "name": "M11 forget the unreadable path so a later startup failure renders unknown",
-      "file": "extensions/connector-jcode/src/host.ts",
-      "find": "      storedSessionsUnreadable &&",
-      "replace": "      false &&",
-      "command": "pnpm smoke:jcode-empty-sessions",
-      "expectRed": "an unreadable sessions directory either runs the seat or names sessions_enumeration_failed",
-      "cell": "an unreadable sessions directory either runs the seat or names sessions_enumeration_failed",
-      "note": "POSIX-only proof. The win32 arm of this block declares the cell unreachable and passes unconditionally, so on Windows this mutant is a correct SURVIVOR and the mark count matches a POSIX kill. Read the verdict, not the marks."
     }
   ]
 }

--- a/bin/smoke/mutations/jcode-empty-sessions.json
+++ b/bin/smoke/mutations/jcode-empty-sessions.json
@@ -60,6 +60,24 @@
       "command": "pnpm smoke:jcode-stored-sessions",
       "expectRed": "unrelated child text is not forwarded",
       "cell": "unrelated child text is not forwarded"
+    },
+    {
+      "name": "M6 match any path ending in translate.rs instead of the owning crate",
+      "file": "extensions/connector-jcode/src/stored-sessions.ts",
+      "find": "    /thread '[^']*'[^\\n]* panicked at (crates\\/jcode-harness-api-server\\/src\\/translate\\.rs:\\d+:\\d+):\\s*\\n\\s*(chunk size must be non-zero)/.exec(",
+      "replace": "    /thread '[^']*'[^\\n]* panicked at ([^\\n]*translate\\.rs:\\d+:\\d+):\\s*\\n\\s*(chunk size must be non-zero)/.exec(",
+      "command": "pnpm smoke:jcode-stored-sessions",
+      "expectRed": "the same filename in another crate is refused",
+      "cell": "the same filename in another crate is refused"
+    },
+    {
+      "name": "M7 drop the startsWith site guard behind the anchored pattern",
+      "file": "extensions/connector-jcode/src/stored-sessions.ts",
+      "find": "  if (!site.startsWith(`${STORED_SESSION_PANIC_SITE}:`)) return undefined;",
+      "replace": "  /* mutant trusts the pattern alone */",
+      "command": "pnpm smoke:jcode-stored-sessions",
+      "expectRed": "the real empty-directory panic is classified",
+      "cell": "the real empty-directory panic is classified"
     }
   ]
 }

--- a/extensions/connector-jcode/smoke/empty-sessions.smoke.ts
+++ b/extensions/connector-jcode/smoke/empty-sessions.smoke.ts
@@ -150,13 +150,13 @@ try {
   writeFileSync(join(panicHome, "sessions", "placeholder.json"), "{}");
   const panicked = startHost(panicName, { FAKE_JCODE_PANIC_LIST: "1" });
   child = panicked.child;
-  await waitFor("listing-panic create_session", () =>
+  const panicCreate = await waitFor("listing-panic create_session", () =>
     entriesOf(panicked.log).find((entry) => entry.ev === "session_path" && entry.req === "create_session"),
-  );
+  ).catch(() => undefined);
   const panicErr = panicked.stderr();
   check(
     "listing panic still starts a fresh session on a new harness",
-    /started a fresh session/.test(panicErr) && /could not list prior sessions at /.test(panicErr),
+    Boolean(panicCreate) && /started a fresh session/.test(panicErr) && /could not list prior sessions at /.test(panicErr),
     panicErr,
   );
   check("listing panic names chunk size must be non-zero", /chunk size must be non-zero/.test(panicErr), panicErr);

--- a/extensions/connector-jcode/smoke/empty-sessions.smoke.ts
+++ b/extensions/connector-jcode/smoke/empty-sessions.smoke.ts
@@ -170,9 +170,6 @@ try {
   mkdirSync(lockedSessions, { recursive: true, mode: 0o700 });
   if (process.platform === "win32") {
     check("the unreadable sessions directory is named to the operator (unreachable on Windows)", true);
-    check("the unreadable-directory seat does not die as startup failed (unknown) (unreachable on Windows)", true);
-    check("an unreadable sessions directory either runs the seat or names sessions_enumeration_failed (unreachable on Windows)", true);
-    check("a seat killed by an unreadable sessions directory names the path it could not read (unreachable on Windows)", true);
   } else {
     // The local inspection runs on every managed seat's startup path. A directory it cannot read
     // must not be fatal: this home starts fine on the pre-change connector, so killing it here
@@ -187,50 +184,16 @@ try {
         entriesOf(locked.log).find((entry) => entry.ev === "session_path" && entry.req === "create_session"),
       ).catch(() => undefined);
       const lockedErr = locked.stderr();
-      // The harness itself reads and WRITES this directory. On a real jcode v0.81.5 the seat gets
-      // past createSession and then dies persisting the session into sessions/. Whether the seat
-      // survives is the harness's call; what the connector owes is that the operator is told the
-      // path and the permission fact rather than `unknown`.
+      // The only claim this fixture can honestly make. The harness reads AND WRITES this directory,
+      // accepts create_session, and fails later while persisting, outside any guard the connector
+      // owns; on real jcode v0.81.5 the seat still dies and main dies identically. So the connector
+      // does not promise the seat survives, and asserting `never unknown` here would be a claim the
+      // real binary disproves. What it does promise, and what an operator needs before the harness
+      // death, is the path and the errno. Making the seat survive an unwritable home is #1538.
       check(
         "the unreadable sessions directory is named to the operator",
         /stored sessions directory could not be read \(.*sessions: EACCES\)/.test(lockedErr),
         lockedErr,
-      );
-      check(
-        "the unreadable-directory seat does not die as startup failed (unknown)",
-        !/startup failed \(unknown\)/.test(lockedErr),
-        lockedErr,
-      );
-      // Either it started, or it failed by the named code that carries the path. Never `unknown`.
-      // Wait for whichever settles: a fresh session, a named failure, or the host exiting.
-      await waitFor(
-        "unreadable-sessions outcome",
-        () =>
-          /started a fresh session|sessions_enumeration_failed|startup failed/.test(locked.stderr()) ||
-          locked.child.exitCode !== null
-            ? true
-            : undefined,
-        30_000,
-      ).catch(() => undefined);
-      const settledErr = locked.stderr();
-      const started = locked.child.exitCode === null && /started a fresh session/.test(settledErr);
-      // `started a fresh session` is printed BEFORE the harness persists, so on the real binary it
-      // appears on a seat that then dies. Requiring the process to still be alive is what stops
-      // this cell passing on a corpse (rev-i1293-opus-r1's false-pass finding).
-      check(
-        "an unreadable sessions directory either runs the seat or names sessions_enumeration_failed",
-        started || /sessions_enumeration_failed/.test(settledErr),
-        { exitCode: locked.child.exitCode, stderr: settledErr },
-      );
-      check(
-        "a seat killed by an unreadable sessions directory names the path it could not read",
-        started || /while reading .*sessions/.test(settledErr),
-        settledErr,
-      );
-      check(
-        "the unreadable-directory seat never renders as unknown",
-        !/startup failed \(unknown\)/.test(settledErr),
-        settledErr,
       );
     } finally {
       chmodSync(lockedSessions, 0o700);

--- a/extensions/connector-jcode/smoke/empty-sessions.smoke.ts
+++ b/extensions/connector-jcode/smoke/empty-sessions.smoke.ts
@@ -164,6 +164,38 @@ try {
   panicked.child.kill("SIGTERM");
   await Promise.race([once(panicked.child, "exit"), sleep(15_000)]);
 
+  const lockedName = "lockedpeer";
+  const lockedHome = managedHome("jcodeempty", lockedName);
+  const lockedSessions = join(lockedHome, "sessions");
+  mkdirSync(lockedSessions, { recursive: true, mode: 0o700 });
+  if (process.platform === "win32") {
+    check("an unreadable sessions directory still starts the seat (unreachable on Windows)", true);
+    check("the unreadable-directory seat does not die as startup failed (unknown) (unreachable on Windows)", true);
+  } else {
+    // The local inspection runs on every managed seat's startup path. A directory it cannot read
+    // must not be fatal: this home starts fine on the pre-change connector, so killing it here
+    // would be a regression that reintroduces the exact `unknown` death this change removes.
+    chmodSync(lockedSessions, 0o000);
+    const locked = startHost(lockedName, {});
+    child = locked.child;
+    try {
+      await waitFor("unreadable-sessions create_session", () =>
+        entriesOf(locked.log).find((entry) => entry.ev === "session_path" && entry.req === "create_session"),
+      );
+      const lockedErr = locked.stderr();
+      check("an unreadable sessions directory still starts the seat", /started a fresh session/.test(lockedErr), lockedErr);
+      check(
+        "the unreadable-directory seat does not die as startup failed (unknown)",
+        !/startup failed \(unknown\)/.test(lockedErr),
+        lockedErr,
+      );
+    } finally {
+      chmodSync(lockedSessions, 0o700);
+      locked.child.kill("SIGTERM");
+      await Promise.race([once(locked.child, "exit"), sleep(15_000)]);
+    }
+  }
+
   console.log(`COTAL_SMOKE_SENTINEL cells=${pass} passed=${pass} failed=0`);
   console.log(`\nempty sessions: ${pass} passed, 0 failed`);
 } finally {

--- a/extensions/connector-jcode/smoke/empty-sessions.smoke.ts
+++ b/extensions/connector-jcode/smoke/empty-sessions.smoke.ts
@@ -179,11 +179,17 @@ try {
     const locked = startHost(lockedName, {});
     child = locked.child;
     try {
-      await waitFor("unreadable-sessions create_session", () =>
+      // A timeout here is the regression itself, so it must redden a NAMED cell rather than
+      // aborting the suite anonymously: a mutation-proof run needs a cell name to anchor on.
+      const created = await waitFor("unreadable-sessions create_session", () =>
         entriesOf(locked.log).find((entry) => entry.ev === "session_path" && entry.req === "create_session"),
-      );
+      ).catch(() => undefined);
       const lockedErr = locked.stderr();
-      check("an unreadable sessions directory still starts the seat", /started a fresh session/.test(lockedErr), lockedErr);
+      check(
+        "an unreadable sessions directory still starts the seat",
+        Boolean(created) && /started a fresh session/.test(lockedErr),
+        lockedErr,
+      );
       check(
         "the unreadable-directory seat does not die as startup failed (unknown)",
         !/startup failed \(unknown\)/.test(lockedErr),

--- a/extensions/connector-jcode/smoke/empty-sessions.smoke.ts
+++ b/extensions/connector-jcode/smoke/empty-sessions.smoke.ts
@@ -171,7 +171,7 @@ try {
   if (process.platform === "win32") {
     check("the unreadable sessions directory is named to the operator (unreachable on Windows)", true);
     check("the unreadable-directory seat does not die as startup failed (unknown) (unreachable on Windows)", true);
-    check("an unreadable sessions directory either starts the seat or names sessions_enumeration_failed (unreachable on Windows)", true);
+    check("an unreadable sessions directory either runs the seat or names sessions_enumeration_failed (unreachable on Windows)", true);
     check("a seat killed by an unreadable sessions directory names the path it could not read (unreachable on Windows)", true);
   } else {
     // The local inspection runs on every managed seat's startup path. A directory it cannot read
@@ -213,14 +213,18 @@ try {
         30_000,
       ).catch(() => undefined);
       const settledErr = locked.stderr();
+      const started = locked.child.exitCode === null && /started a fresh session/.test(settledErr);
+      // `started a fresh session` is printed BEFORE the harness persists, so on the real binary it
+      // appears on a seat that then dies. Requiring the process to still be alive is what stops
+      // this cell passing on a corpse (rev-i1293-opus-r1's false-pass finding).
       check(
-        "an unreadable sessions directory either starts the seat or names sessions_enumeration_failed",
-        /started a fresh session/.test(settledErr) || /sessions_enumeration_failed/.test(settledErr),
-        settledErr,
+        "an unreadable sessions directory either runs the seat or names sessions_enumeration_failed",
+        started || /sessions_enumeration_failed/.test(settledErr),
+        { exitCode: locked.child.exitCode, stderr: settledErr },
       );
       check(
         "a seat killed by an unreadable sessions directory names the path it could not read",
-        !/sessions_enumeration_failed/.test(settledErr) || /while reading .*sessions/.test(settledErr),
+        started || /while reading .*sessions/.test(settledErr),
         settledErr,
       );
       check(

--- a/extensions/connector-jcode/smoke/empty-sessions.smoke.ts
+++ b/extensions/connector-jcode/smoke/empty-sessions.smoke.ts
@@ -1,0 +1,174 @@
+/**
+ * A managed Jcode seat whose private home has an empty `sessions/` directory must start.
+ * The jcode binary panics if list_sessions is called on that directory. The connector
+ * must skip that RPC, start a fresh session, and never report startup failed (unknown).
+ */
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { once } from "node:events";
+import { spawn, type ChildProcess } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { isReachable, seedChannelRegistry } from "@cotal-ai/core";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+async function freePort(): Promise<number> {
+  const server = createServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const port = (server.address() as { port: number }).port;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  return port;
+}
+async function waitFor<T>(name: string, read: () => T | undefined, timeoutMs = 20_000): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const value = read();
+    if (value !== undefined) return value;
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${name}`);
+    await sleep(100);
+  }
+}
+
+const root = mkdtempSync(join(tmpdir(), "cotal-jcode-empty-sessions-"));
+const port = await freePort();
+const servers = `nats://127.0.0.1:${port}`;
+const fake = fileURLToPath(new URL("./fake-jcode.mjs", import.meta.url));
+const host = fileURLToPath(new URL("../src/host-main.ts", import.meta.url));
+const tsx = fileURLToPath(new URL("../node_modules/.bin/tsx", import.meta.url));
+const shimDir = join(root, "bin");
+const shim = join(shimDir, "jcode");
+const nats = spawn("nats-server", ["-js", "-p", String(port), "-sd", join(root, "js")], { stdio: "ignore" });
+let child: ChildProcess | undefined;
+let pass = 0;
+const check = (name: string, condition: boolean, actual?: unknown): void => {
+  assert.ok(condition, `${name}${actual === undefined ? "" : ` — ${JSON.stringify(actual)}`}`);
+  pass++;
+  console.log(`  ✓ ${name}`);
+};
+function readJsonLines<T>(path: string): T[] {
+  if (!existsSync(path)) return [];
+  const raw = readFileSync(path, "utf8");
+  const lines = raw.split("\n");
+  if (!raw.endsWith("\n")) lines.pop();
+  return lines.filter(Boolean).map((line) => JSON.parse(line) as T);
+}
+const entriesOf = (log: string): Array<{ ev: string; frame?: { req?: string }; req?: string; [key: string]: unknown }> =>
+  readJsonLines(log);
+
+const baseEnv: NodeJS.ProcessEnv = { ...process.env };
+for (const key of Object.keys(baseEnv)) if (key.startsWith("COTAL_")) delete baseEnv[key];
+const inheritedJcodeHome = join(root, "source-jcode");
+
+function managedHome(space: string, name: string): string {
+  const slug = `${space}-${name}`.toLowerCase().replace(/[^a-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 40);
+  const key = createHash("sha256").update(`${space}\0${name}`).digest("hex").slice(0, 12);
+  return join(root, ".cotal", "jcode", `${slug || "agent"}-${key}`);
+}
+
+function startHost(name: string, extra: NodeJS.ProcessEnv): { child: ChildProcess; log: string; stderr: () => string } {
+  const log = join(root, `${name}.jsonl`);
+  const run = spawn(tsx, [host], {
+    cwd: root,
+    env: {
+      ...baseEnv,
+      PATH: `${shimDir}:${baseEnv.PATH ?? ""}`,
+      FAKE_JCODE_LOG: log,
+      JCODE_HOME: inheritedJcodeHome,
+      COTAL_SPACE: "jcodeempty",
+      COTAL_NAME: name,
+      COTAL_ID: name,
+      COTAL_SERVERS: servers,
+      COTAL_SUBSCRIBE: "team",
+      COTAL_ALLOW_SUBSCRIBE: "team",
+      COTAL_ALLOW_PUBLISH: "team",
+      COTAL_JCODE_HOME: root,
+      COTAL_JCODE_TUI: "0",
+      COTAL_CONTROL_SOCKET: join(root, `${name}-control.sock`),
+      COTAL_CONTROL_TOKEN: `${name}-control-token`,
+      ...extra,
+    },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  let stderr = "";
+  run.stderr?.on("data", (chunk: Buffer) => (stderr += chunk.toString()));
+  return { child: run, log, stderr: () => stderr };
+}
+
+try {
+  mkdirSync(shimDir, { recursive: true });
+  writeFileSync(shim, `#!/bin/sh\nexec "${process.execPath}" "${fake}" "$@"\n`);
+  chmodSync(shim, 0o755);
+  mkdirSync(inheritedJcodeHome, { recursive: true, mode: 0o700 });
+  writeFileSync(join(inheritedJcodeHome, "auth.json"), "empty-sessions-smoke-token", { mode: 0o600 });
+  for (let i = 0; i < 100 && !(await isReachable(servers)); i++) await sleep(50);
+  await seedChannelRegistry({
+    servers,
+    space: "jcodeempty",
+    file: { defaults: { replay: false }, channels: { team: { replay: false } } },
+  });
+
+  const emptyName = "emptypeer";
+  const emptyHome = managedHome("jcodeempty", emptyName);
+  mkdirSync(join(emptyHome, "sessions"), { recursive: true, mode: 0o700 });
+  const empty = startHost(emptyName, {});
+  child = empty.child;
+  await waitFor("empty-sessions create_session", () =>
+    entriesOf(empty.log).find((entry) => entry.ev === "session_path" && entry.req === "create_session"),
+  );
+  await waitFor("empty-sessions orientation", () =>
+    entriesOf(empty.log).find(
+      (entry) =>
+        entry.ev === "request" &&
+        entry.frame?.req === "send_message" &&
+        String((entry.frame as { content?: string }).content).includes("cotal_orientation"),
+    ),
+  );
+  const emptyErr = empty.stderr();
+  const emptyReqs = entriesOf(empty.log).filter((entry) => entry.ev === "request");
+  check("an empty sessions directory still starts a fresh session", /started a fresh session/.test(emptyErr), emptyErr);
+  check(
+    "list_sessions is not sent when sessions is an empty directory",
+    !emptyReqs.some((entry) => entry.frame?.req === "list_sessions"),
+    emptyReqs.map((entry) => entry.frame?.req),
+  );
+  check("the empty-directory seat does not die as startup failed (unknown)", !/startup failed \(unknown\)/.test(emptyErr), emptyErr);
+  check("the empty-directory seat is still running after readiness", empty.child.exitCode === null, {
+    code: empty.child.exitCode,
+    stderr: emptyErr,
+  });
+  empty.child.kill("SIGTERM");
+  await Promise.race([once(empty.child, "exit"), sleep(15_000)]);
+  check("the empty-directory seat exits cleanly", empty.child.exitCode === 0, { code: empty.child.exitCode, stderr: empty.stderr() });
+
+  const panicName = "panicpeer";
+  const panicHome = managedHome("jcodeempty", panicName);
+  mkdirSync(join(panicHome, "sessions"), { recursive: true, mode: 0o700 });
+  writeFileSync(join(panicHome, "sessions", "placeholder.json"), "{}");
+  const panicked = startHost(panicName, { FAKE_JCODE_PANIC_LIST: "1" });
+  child = panicked.child;
+  await waitFor("listing-panic create_session", () =>
+    entriesOf(panicked.log).find((entry) => entry.ev === "session_path" && entry.req === "create_session"),
+  );
+  const panicErr = panicked.stderr();
+  check(
+    "listing panic still starts a fresh session on a new harness",
+    /started a fresh session/.test(panicErr) && /could not list prior sessions at /.test(panicErr),
+    panicErr,
+  );
+  check("listing panic names chunk size must be non-zero", /chunk size must be non-zero/.test(panicErr), panicErr);
+  check("listing panic does not render as unknown", !/startup failed \(unknown\)/.test(panicErr), panicErr);
+  panicked.child.kill("SIGTERM");
+  await Promise.race([once(panicked.child, "exit"), sleep(15_000)]);
+
+  console.log(`COTAL_SMOKE_SENTINEL cells=${pass} passed=${pass} failed=0`);
+  console.log(`\nempty sessions: ${pass} passed, 0 failed`);
+} finally {
+  if (child && child.exitCode === null) child.kill("SIGKILL");
+  nats.kill("SIGKILL");
+  await sleep(100);
+  rmSync(root, { recursive: true, force: true });
+}

--- a/extensions/connector-jcode/smoke/empty-sessions.smoke.ts
+++ b/extensions/connector-jcode/smoke/empty-sessions.smoke.ts
@@ -169,8 +169,10 @@ try {
   const lockedSessions = join(lockedHome, "sessions");
   mkdirSync(lockedSessions, { recursive: true, mode: 0o700 });
   if (process.platform === "win32") {
-    check("an unreadable sessions directory still starts the seat (unreachable on Windows)", true);
+    check("the unreadable sessions directory is named to the operator (unreachable on Windows)", true);
     check("the unreadable-directory seat does not die as startup failed (unknown) (unreachable on Windows)", true);
+    check("an unreadable sessions directory either starts the seat or names sessions_enumeration_failed (unreachable on Windows)", true);
+    check("a seat killed by an unreadable sessions directory names the path it could not read (unreachable on Windows)", true);
   } else {
     // The local inspection runs on every managed seat's startup path. A directory it cannot read
     // must not be fatal: this home starts fine on the pre-change connector, so killing it here
@@ -181,19 +183,50 @@ try {
     try {
       // A timeout here is the regression itself, so it must redden a NAMED cell rather than
       // aborting the suite anonymously: a mutation-proof run needs a cell name to anchor on.
-      const created = await waitFor("unreadable-sessions create_session", () =>
+      await waitFor("unreadable-sessions create_session", () =>
         entriesOf(locked.log).find((entry) => entry.ev === "session_path" && entry.req === "create_session"),
       ).catch(() => undefined);
       const lockedErr = locked.stderr();
+      // The harness itself reads and WRITES this directory. On a real jcode v0.81.5 the seat gets
+      // past createSession and then dies persisting the session into sessions/. Whether the seat
+      // survives is the harness's call; what the connector owes is that the operator is told the
+      // path and the permission fact rather than `unknown`.
       check(
-        "an unreadable sessions directory still starts the seat",
-        Boolean(created) && /started a fresh session/.test(lockedErr),
+        "the unreadable sessions directory is named to the operator",
+        /stored sessions directory could not be read \(.*sessions: EACCES\)/.test(lockedErr),
         lockedErr,
       );
       check(
         "the unreadable-directory seat does not die as startup failed (unknown)",
         !/startup failed \(unknown\)/.test(lockedErr),
         lockedErr,
+      );
+      // Either it started, or it failed by the named code that carries the path. Never `unknown`.
+      // Wait for whichever settles: a fresh session, a named failure, or the host exiting.
+      await waitFor(
+        "unreadable-sessions outcome",
+        () =>
+          /started a fresh session|sessions_enumeration_failed|startup failed/.test(locked.stderr()) ||
+          locked.child.exitCode !== null
+            ? true
+            : undefined,
+        30_000,
+      ).catch(() => undefined);
+      const settledErr = locked.stderr();
+      check(
+        "an unreadable sessions directory either starts the seat or names sessions_enumeration_failed",
+        /started a fresh session/.test(settledErr) || /sessions_enumeration_failed/.test(settledErr),
+        settledErr,
+      );
+      check(
+        "a seat killed by an unreadable sessions directory names the path it could not read",
+        !/sessions_enumeration_failed/.test(settledErr) || /while reading .*sessions/.test(settledErr),
+        settledErr,
+      );
+      check(
+        "the unreadable-directory seat never renders as unknown",
+        !/startup failed \(unknown\)/.test(settledErr),
+        settledErr,
       );
     } finally {
       chmodSync(lockedSessions, 0o700);

--- a/extensions/connector-jcode/smoke/fake-jcode.mjs
+++ b/extensions/connector-jcode/smoke/fake-jcode.mjs
@@ -137,11 +137,13 @@ const saveSession = (session) => {
   if (sessionStatePath) writeFileSync(sessionStatePath, JSON.stringify(session));
 };
 
-// Real jcode writes the new session to JCODE_HOME/sessions/session_<id>.json and closes the
-// session when that write fails ("persistence to sessions/session_*.json failed ... session
-// closed"). Reproduced here so a home the harness cannot write to fails the same way it does in
-// production instead of passing on a fake that never touched the directory.
-const persistSession = (sessionId, workingDir, reply) => {
+// Real jcode writes the new session to JCODE_HOME/sessions/session_<id>.json. It ACCEPTS
+// create_session even when that directory is unwritable and fails afterwards, during the first
+// turn, with `SESSION_PERSISTENCE ... error=Permission denied` and then a closed session. The
+// failure is recorded here and raised at that later point, because a fixture that fails at the
+// wrong point in the protocol certifies claims the real binary disproves.
+let sessionPersistenceError;
+const persistSession = (sessionId, workingDir) => {
   const home = process.env.JCODE_HOME;
   if (!home) return true;
   const dir = join(home, "sessions");
@@ -153,9 +155,9 @@ const persistSession = (sessionId, workingDir, reply) => {
     );
     return true;
   } catch (error) {
+    sessionPersistenceError = error;
     log({ ev: "session_persist_failed", path: dir, code: error.code ?? "unknown" });
-    process.stderr.write(`persistence to sessions/session_${sessionId}.json failed: ${error.message}; session closed\n`);
-    reply({ ev: "error", code: "internal", message: `persistence to sessions/ failed: ${error.code ?? error.message}` });
+    process.stderr.write(`session index warmup skipped: ${error.message}\n`);
     return false;
   }
 };
@@ -166,6 +168,16 @@ const persistSession = (sessionId, workingDir, reply) => {
 // happens to be current.
 function runTurn(frame, socket) {
   const event = (body) => socket.write(JSON.stringify({ v: 1, ...body }) + "\n");
+  // Where the deferred persistence failure lands. Real jcode logs SESSION_PERSISTENCE at this
+  // point, fails to persist the session close state, and the session dies under the turn.
+  if (sessionPersistenceError) {
+    log({ ev: "session_persistence_error", code: sessionPersistenceError.code ?? "unknown" });
+    process.stderr.write(
+      `SESSION_PERSISTENCE session=${frame.session_id} error=${sessionPersistenceError.message}\nFailed to persist session close state\n`,
+    );
+    socket.destroy();
+    process.exit(1);
+  }
   // A real Harness reports idle between tool rounds while the host's run() is still awaiting
   // turn_done. That is the #1075 idle-during-drive wedge: the connector used that advisory status
   // to refuse soft_interrupt even though the Cotal-owned turn was live.
@@ -325,11 +337,12 @@ const server = createServer((socket) => {
         case "create_session":
           createdFresh = true;
           sessionWorkingDir = frame.working_dir;
-          // The real harness PERSISTS the new session into JCODE_HOME/sessions before it answers,
-          // and closes the session if that write fails. A fake that only wrote its optional state
-          // file was green on an unreadable sessions/ while real jcode v0.81.5 died there, so the
-          // suite proved nothing about the case it existed for.
-          if (!persistSession("fake-session", sessionWorkingDir, reply)) break;
+          // Real jcode v0.81.5 ACCEPTS create_session on a sessions/ it cannot write and only
+          // fails later, while persisting the session during the first turn. A fake that
+          // rejected the create would fail at the wrong point in the protocol and certify a
+          // connector claim the real binary disproves, so the persistence failure is recorded
+          // here and surfaced where the real one surfaces.
+          persistSession("fake-session", sessionWorkingDir);
           saveSession({ session_id: "fake-session", working_dir: sessionWorkingDir, transcript_bytes: 1 });
           writeJournal("fake-session");
           reply({ ev: "attached", session: { session_id: "fake-session", working_dir: sessionWorkingDir, status: "idle" } });

--- a/extensions/connector-jcode/smoke/fake-jcode.mjs
+++ b/extensions/connector-jcode/smoke/fake-jcode.mjs
@@ -137,6 +137,29 @@ const saveSession = (session) => {
   if (sessionStatePath) writeFileSync(sessionStatePath, JSON.stringify(session));
 };
 
+// Real jcode writes the new session to JCODE_HOME/sessions/session_<id>.json and closes the
+// session when that write fails ("persistence to sessions/session_*.json failed ... session
+// closed"). Reproduced here so a home the harness cannot write to fails the same way it does in
+// production instead of passing on a fake that never touched the directory.
+const persistSession = (sessionId, workingDir, reply) => {
+  const home = process.env.JCODE_HOME;
+  if (!home) return true;
+  const dir = join(home, "sessions");
+  try {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, `session_${sessionId}.json`),
+      JSON.stringify({ session_id: sessionId, working_dir: workingDir }),
+    );
+    return true;
+  } catch (error) {
+    log({ ev: "session_persist_failed", path: dir, code: error.code ?? "unknown" });
+    process.stderr.write(`persistence to sessions/session_${sessionId}.json failed: ${error.message}; session closed\n`);
+    reply({ ev: "error", code: "internal", message: `persistence to sessions/ failed: ${error.code ?? error.message}` });
+    return false;
+  }
+};
+
 // One model turn. Lifted out of the send_message handler so a turn that arrives while the agent is
 // busy can be QUEUED and replayed later against its own connection, which is what the real server
 // does. Writes its events to the socket that submitted it rather than to whichever connection
@@ -302,6 +325,11 @@ const server = createServer((socket) => {
         case "create_session":
           createdFresh = true;
           sessionWorkingDir = frame.working_dir;
+          // The real harness PERSISTS the new session into JCODE_HOME/sessions before it answers,
+          // and closes the session if that write fails. A fake that only wrote its optional state
+          // file was green on an unreadable sessions/ while real jcode v0.81.5 died there, so the
+          // suite proved nothing about the case it existed for.
+          if (!persistSession("fake-session", sessionWorkingDir, reply)) break;
           saveSession({ session_id: "fake-session", working_dir: sessionWorkingDir, transcript_bytes: 1 });
           writeJournal("fake-session");
           reply({ ev: "attached", session: { session_id: "fake-session", working_dir: sessionWorkingDir, status: "idle" } });

--- a/extensions/connector-jcode/smoke/fake-jcode.mjs
+++ b/extensions/connector-jcode/smoke/fake-jcode.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
-import { appendFileSync, existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { join } from "node:path";
 
@@ -247,6 +247,28 @@ const server = createServer((socket) => {
         // A prior session is offered only when the harness is told to have one, so the same fake
         // covers both a first launch (nothing to resume) and a restart (exactly one candidate).
         case "list_sessions": {
+          const home = process.env.JCODE_HOME;
+          const sessionsDir = home ? join(home, "sessions") : "";
+          const emptySessions =
+            Boolean(sessionsDir) &&
+            existsSync(sessionsDir) &&
+            (() => {
+              try {
+                const stats = lstatSync(sessionsDir);
+                return stats.isDirectory() && readdirSync(sessionsDir).length === 0;
+              } catch {
+                return false;
+              }
+            })();
+          if (emptySessions || process.env.FAKE_JCODE_PANIC_LIST === "1") {
+            const panicPath = sessionsDir || "(unset-JCODE_HOME)/sessions";
+            process.stderr.write(
+              `thread 'tokio-runtime-worker' panicked at crates/jcode-harness-api-server/src/translate.rs:1707:38:\nchunk size must be non-zero\n`,
+            );
+            log({ ev: "empty_sessions_panic", path: panicPath });
+            socket.destroy();
+            process.exit(1);
+          }
           const preset = process.env.FAKE_JCODE_SESSIONS;
           const remembered = storedSession();
           reply({ ev: "sessions", sessions: preset ? JSON.parse(preset) : remembered ? [remembered] : [] });

--- a/extensions/connector-jcode/smoke/mutations/jcode-diagnostics.json
+++ b/extensions/connector-jcode/smoke/mutations/jcode-diagnostics.json
@@ -24,8 +24,9 @@
     {
       "name": "Jcode readiness refusal is collapsed back to unknown",
       "file": "extensions/connector-jcode/src/host-main.ts",
-      "find": "  if (error instanceof JcodeReadinessProviderRefusal) {\n    writeJcodeDiagnostic(\n      `[cotal-jcode] fatal: Jcode readiness turn refused ${error.parameter} ${JSON.stringify(error.value)} (${error.providerCode}); inspect the private Jcode logs for other details.\\n`,\n    );\n  } else {\n    writeJcodeDiagnostic(`[cotal-jcode] fatal: Jcode host startup failed (${startupFailureCode(error)}); inspect the private Jcode logs.\\n`);\n  }",
-      "replace": "  writeJcodeDiagnostic(`[cotal-jcode] fatal: Jcode host startup failed (${startupFailureCode(error)}); inspect the private Jcode logs.\\n`);",
+      "find": "  if (error instanceof JcodeReadinessProviderRefusal) {\n    writeJcodeDiagnostic(\n      `[cotal-jcode] fatal: Jcode readiness turn refused ${error.parameter} ${JSON.stringify(error.value)} (${error.providerCode}); inspect the private Jcode logs for other details.\\n`,\n    );\n  } else if (error instanceof JcodeSessionsEnumerationFailure) {\n    writeJcodeDiagnostic(\n      `[cotal-jcode] fatal: Jcode host startup failed (sessions_enumeration_failed): ${error.causeText} while reading ${error.sessionsPath}\\n`,\n    );\n  } else {\n    writeJcodeDiagnostic(`[cotal-jcode] fatal: Jcode host startup failed (${startupFailureCode(error)}); inspect the private Jcode logs.\\n`);\n  }",
+      "replace": "  if (error instanceof JcodeSessionsEnumerationFailure) {\n    writeJcodeDiagnostic(\n      `[cotal-jcode] fatal: Jcode host startup failed (sessions_enumeration_failed): ${error.causeText} while reading ${error.sessionsPath}\\n`,\n    );\n  } else {\n    writeJcodeDiagnostic(`[cotal-jcode] fatal: Jcode host startup failed (${startupFailureCode(error)}); inspect the private Jcode logs.\\n`);\n  }",
+      "command": "pnpm smoke:jcode-host",
       "expectRed": "provider readiness refusal names its code and rejected model parameter"
     },
     {

--- a/extensions/connector-jcode/smoke/stored-sessions.smoke.ts
+++ b/extensions/connector-jcode/smoke/stored-sessions.smoke.ts
@@ -172,18 +172,26 @@ try {
   check("chunk-size panic text is reduced to the assertion", boundStoredSessionCause("x chunk size must be non-zero y") === "chunk size must be non-zero");
   check("connection-closed is kept", boundStoredSessionCause("harness connection closed") === "harness connection closed");
   check("write EPIPE is kept", boundStoredSessionCause("write EPIPE") === "write EPIPE");
-  check("unrelated child text is not forwarded", boundStoredSessionCause("sk-live-secret-material") === UNRECOGNISED_STORED_SESSION_CAUSE);
+  // These compare against LITERALS, not the exported constant. Asserting `x === CONSTANT` when the
+  // implementation returns CONSTANT is circular: it holds for any value the constant is given, so a
+  // mutation that renames it back to a specific wrong cause would pass unnoticed.
+  check("unrelated child text is not forwarded", boundStoredSessionCause("sk-live-secret-material") === "unrecognised harness failure", boundStoredSessionCause("sk-live-secret-material"));
   // A bounded output must not be a bounded lie: an unrecognised failure is reported as unrecognised
   // rather than as one of the three named causes, which would send the operator to the wrong place.
   check(
     "an out-of-memory spawn failure is not reported as a closed connection",
-    boundStoredSessionCause("spawn ENOMEM") === UNRECOGNISED_STORED_SESSION_CAUSE,
+    boundStoredSessionCause("spawn ENOMEM") === "unrecognised harness failure",
     boundStoredSessionCause("spawn ENOMEM"),
   );
   check(
     "a refused socket is not reported as a closed connection",
-    boundStoredSessionCause("connect ECONNREFUSED /run/jcode.sock") === UNRECOGNISED_STORED_SESSION_CAUSE,
+    boundStoredSessionCause("connect ECONNREFUSED /run/jcode.sock") === "unrecognised harness failure",
     boundStoredSessionCause("connect ECONNREFUSED /run/jcode.sock"),
+  );
+  check(
+    "the exported fallback constant is the non-committal token itself",
+    UNRECOGNISED_STORED_SESSION_CAUSE === "unrecognised harness failure",
+    UNRECOGNISED_STORED_SESSION_CAUSE,
   );
 
   console.log("\n4. named fatal carries the cause and path, never unknown");

--- a/extensions/connector-jcode/smoke/stored-sessions.smoke.ts
+++ b/extensions/connector-jcode/smoke/stored-sessions.smoke.ts
@@ -1,0 +1,117 @@
+/**
+ * Empty `sessions/` is a local fact, not a reason to call list_sessions. Each accepting
+ * branch of the inspect/panic/cause matchers has a refusing neighbour that differs only
+ * by context.
+ */
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { JcodeSessionsEnumerationFailure } from "../src/startup-diagnostics.js";
+import {
+  boundStoredSessionCause,
+  classifyStoredSessionPanic,
+  inspectStoredSessions,
+  isEmptyStoredSessionsDirectory,
+} from "../src/stored-sessions.js";
+
+let pass = 0;
+const check = (name: string, condition: boolean, actual?: unknown): void => {
+  assert.ok(condition, `${name}${actual === undefined ? "" : ` — ${JSON.stringify(actual)}`}`);
+  pass++;
+  console.log(`  ✓ ${name}`);
+};
+
+const root = mkdtempSync(join(tmpdir(), "cotal-jcode-stored-sessions-"));
+try {
+  console.log("\n1. inspectStoredSessions: accepting empty directory, refusing neighbours");
+  {
+    const emptyHome = join(root, "empty");
+    mkdirSync(join(emptyHome, "sessions"), { recursive: true, mode: 0o700 });
+    const empty = inspectStoredSessions(emptyHome);
+    check("an empty sessions directory is empty-directory", empty.kind === "empty-directory", empty);
+    check("isEmptyStoredSessionsDirectory accepts only that kind", isEmptyStoredSessionsDirectory(empty));
+  }
+  {
+    const absentHome = join(root, "absent");
+    mkdirSync(absentHome, { recursive: true, mode: 0o700 });
+    const absent = inspectStoredSessions(absentHome);
+    check("a missing sessions path is absent, not empty", absent.kind === "absent", absent);
+    check("a first-launch home is not treated as the empty-directory defect", !isEmptyStoredSessionsDirectory(absent));
+  }
+  {
+    const populatedHome = join(root, "populated");
+    mkdirSync(join(populatedHome, "sessions"), { recursive: true, mode: 0o700 });
+    writeFileSync(join(populatedHome, "sessions", "session.json"), "{}");
+    const populated = inspectStoredSessions(populatedHome);
+    check("a directory with one file is populated, not empty", populated.kind === "populated" && populated.entries === 1, populated);
+    check("populated is not the empty-directory defect", !isEmptyStoredSessionsDirectory(populated));
+  }
+  {
+    const fileHome = join(root, "file");
+    mkdirSync(fileHome, { recursive: true, mode: 0o700 });
+    writeFileSync(join(fileHome, "sessions"), "not-a-dir");
+    const asFile = inspectStoredSessions(fileHome);
+    check("a regular file at sessions is not-a-directory", asFile.kind === "not-a-directory", asFile);
+    check("a file at sessions is not skipped as empty", !isEmptyStoredSessionsDirectory(asFile));
+  }
+  if (process.platform === "win32") {
+    check("symlink refusal is unreachable on unsupported Windows", true);
+    check("a sessions symlink is not skipped as empty", true);
+  } else {
+    const linkHome = join(root, "link");
+    const target = join(root, "link-target");
+    mkdirSync(join(target, "sessions"), { recursive: true, mode: 0o700 });
+    mkdirSync(linkHome, { recursive: true, mode: 0o700 });
+    symlinkSync(join(target, "sessions"), join(linkHome, "sessions"));
+    const linked = inspectStoredSessions(linkHome);
+    check("a sessions symlink is not-a-directory even if the target is empty", linked.kind === "not-a-directory", linked);
+    check("a sessions symlink is not skipped as empty", !isEmptyStoredSessionsDirectory(linked));
+  }
+
+  console.log("\n2. classifyStoredSessionPanic: one accepting panic, refusing neighbours");
+  {
+    const real =
+      "thread 'tokio-runtime-worker' (1047612) panicked at crates/jcode-harness-api-server/src/translate.rs:1707:38:\nchunk size must be non-zero\n";
+    const got = classifyStoredSessionPanic(real);
+    check(
+      "the real empty-directory panic is classified",
+      got === "chunk size must be non-zero at crates/jcode-harness-api-server/src/translate.rs:1707:38",
+      got,
+    );
+  }
+  {
+    const prose = "the docs say chunk size must be non-zero when the caller divides a list\n";
+    check("prose that mentions the assertion is refused", classifyStoredSessionPanic(prose) === undefined);
+  }
+  {
+    const otherSite =
+      "thread 'tokio-runtime-worker' panicked at crates/other/src/foo.rs:12:1:\nchunk size must be non-zero\n";
+    check("the same assertion at a different rust site is refused", classifyStoredSessionPanic(otherSite) === undefined);
+  }
+  {
+    const otherMsg =
+      "thread 'tokio-runtime-worker' panicked at crates/jcode-harness-api-server/src/translate.rs:1707:38:\nsomething else\n";
+    check("a different assertion at translate.rs is refused", classifyStoredSessionPanic(otherMsg) === undefined);
+  }
+
+  console.log("\n3. boundStoredSessionCause: allow-listed phrases only");
+  check("chunk-size panic text is reduced to the assertion", boundStoredSessionCause("x chunk size must be non-zero y") === "chunk size must be non-zero");
+  check("connection-closed is kept", boundStoredSessionCause("harness connection closed") === "harness connection closed");
+  check("write EPIPE is kept", boundStoredSessionCause("write EPIPE") === "write EPIPE");
+  check("unrelated child text is not forwarded", boundStoredSessionCause("sk-live-secret-material") === "harness connection closed");
+
+  console.log("\n4. named fatal carries the cause and path, never unknown");
+  {
+    const failure = new JcodeSessionsEnumerationFailure("/seat/sessions", "chunk size must be non-zero");
+    check("the named failure uses sessions_enumeration_failed", failure.code === "sessions_enumeration_failed");
+    check("the named failure names the path", failure.sessionsPath === "/seat/sessions");
+    check("the named failure names the bounded cause", failure.causeText === "chunk size must be non-zero");
+    check("a generic error is not this class", !(new Error("harness connection closed") instanceof JcodeSessionsEnumerationFailure));
+  }
+
+  console.log(`COTAL_SMOKE_SENTINEL cells=${pass} passed=${pass} failed=0`);
+  console.log(`\nstored sessions: ${pass} passed, 0 failed`);
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}

--- a/extensions/connector-jcode/smoke/stored-sessions.smoke.ts
+++ b/extensions/connector-jcode/smoke/stored-sessions.smoke.ts
@@ -112,6 +112,12 @@ try {
     const bare = "thread 'tokio-runtime-worker' panicked at translate.rs:1:1:\nchunk size must be non-zero\n";
     check("a bare translate.rs with no crate path is refused", classifyStoredSessionPanic(bare) === undefined, classifyStoredSessionPanic(bare));
   }
+  {
+    // The site is embedded in a pattern, so its dots must be escaped or `.` matches any character.
+    const nearMiss =
+      "thread 'tokio-runtime-worker' panicked at crates/jcode-harness-api-server/src/translateXrs:1707:38:\nchunk size must be non-zero\n";
+    check("a site differing by one character is refused", classifyStoredSessionPanic(nearMiss) === undefined, classifyStoredSessionPanic(nearMiss));
+  }
 
   console.log("\n3. boundStoredSessionCause: allow-listed phrases only");
   check("chunk-size panic text is reduced to the assertion", boundStoredSessionCause("x chunk size must be non-zero y") === "chunk size must be non-zero");

--- a/extensions/connector-jcode/smoke/stored-sessions.smoke.ts
+++ b/extensions/connector-jcode/smoke/stored-sessions.smoke.ts
@@ -4,7 +4,7 @@
  * by context.
  */
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { JcodeSessionsEnumerationFailure } from "../src/startup-diagnostics.js";
@@ -13,6 +13,7 @@ import {
   classifyStoredSessionPanic,
   inspectStoredSessions,
   isEmptyStoredSessionsDirectory,
+  UNRECOGNISED_STORED_SESSION_CAUSE,
 } from "../src/stored-sessions.js";
 
 let pass = 0;
@@ -54,6 +55,54 @@ try {
     const asFile = inspectStoredSessions(fileHome);
     check("a regular file at sessions is not-a-directory", asFile.kind === "not-a-directory", asFile);
     check("a file at sessions is not skipped as empty", !isEmptyStoredSessionsDirectory(asFile));
+  }
+  if (process.platform === "win32") {
+    check("unreadable refusal is unreachable on unsupported Windows", true);
+    check("an unreadable sessions directory is not skipped as empty", true);
+    check("inspecting an unreadable sessions directory does not throw", true);
+  } else {
+    // A seat home the connector cannot read is a question for the harness, not a reason to kill a
+    // seat that would otherwise start. Before this cell, EACCES escaped inspection, skipped the
+    // listing catch entirely, and killed the seat as `startup failed (unknown)` — the very string
+    // this change exists to delete, on a home that started fine before it.
+    const lockedHome = join(root, "locked");
+    const locked = join(lockedHome, "sessions");
+    mkdirSync(locked, { recursive: true, mode: 0o700 });
+    chmodSync(locked, 0o000);
+    let threw: string | undefined;
+    let inspection: ReturnType<typeof inspectStoredSessions> | undefined;
+    try {
+      inspection = inspectStoredSessions(lockedHome);
+    } catch (error) {
+      threw = (error as Error).message;
+    } finally {
+      chmodSync(locked, 0o700);
+    }
+    check("inspecting an unreadable sessions directory does not throw", threw === undefined, threw);
+    check("an unreadable sessions directory is unreadable, not empty", inspection?.kind === "unreadable", inspection);
+    check("an unreadable sessions directory is not skipped as empty", inspection !== undefined && !isEmptyStoredSessionsDirectory(inspection));
+
+    // The second reachable throw site. `readdir` is not the only read that can fail: when the HOME
+    // is unreadable, `lstat` on sessions/ throws EACCES before readdir is ever called. Guarding
+    // one and not the other would leave the same seat-killing escape on a different input.
+    const lockedParent = join(root, "locked-home");
+    mkdirSync(join(lockedParent, "sessions"), { recursive: true, mode: 0o700 });
+    chmodSync(lockedParent, 0o000);
+    let parentThrew: string | undefined;
+    let parentInspection: ReturnType<typeof inspectStoredSessions> | undefined;
+    try {
+      parentInspection = inspectStoredSessions(lockedParent);
+    } catch (error) {
+      parentThrew = (error as Error).message;
+    } finally {
+      chmodSync(lockedParent, 0o700);
+    }
+    check("inspecting a home whose own permissions deny the read does not throw", parentThrew === undefined, parentThrew);
+    check("an unreadable home is unreadable, not empty", parentInspection?.kind === "unreadable", parentInspection);
+    check(
+      "an unreadable home is not skipped as empty",
+      parentInspection !== undefined && !isEmptyStoredSessionsDirectory(parentInspection),
+    );
   }
   if (process.platform === "win32") {
     check("symlink refusal is unreachable on unsupported Windows", true);
@@ -123,7 +172,19 @@ try {
   check("chunk-size panic text is reduced to the assertion", boundStoredSessionCause("x chunk size must be non-zero y") === "chunk size must be non-zero");
   check("connection-closed is kept", boundStoredSessionCause("harness connection closed") === "harness connection closed");
   check("write EPIPE is kept", boundStoredSessionCause("write EPIPE") === "write EPIPE");
-  check("unrelated child text is not forwarded", boundStoredSessionCause("sk-live-secret-material") === "harness connection closed");
+  check("unrelated child text is not forwarded", boundStoredSessionCause("sk-live-secret-material") === UNRECOGNISED_STORED_SESSION_CAUSE);
+  // A bounded output must not be a bounded lie: an unrecognised failure is reported as unrecognised
+  // rather than as one of the three named causes, which would send the operator to the wrong place.
+  check(
+    "an out-of-memory spawn failure is not reported as a closed connection",
+    boundStoredSessionCause("spawn ENOMEM") === UNRECOGNISED_STORED_SESSION_CAUSE,
+    boundStoredSessionCause("spawn ENOMEM"),
+  );
+  check(
+    "a refused socket is not reported as a closed connection",
+    boundStoredSessionCause("connect ECONNREFUSED /run/jcode.sock") === UNRECOGNISED_STORED_SESSION_CAUSE,
+    boundStoredSessionCause("connect ECONNREFUSED /run/jcode.sock"),
+  );
 
   console.log("\n4. named fatal carries the cause and path, never unknown");
   {

--- a/extensions/connector-jcode/smoke/stored-sessions.smoke.ts
+++ b/extensions/connector-jcode/smoke/stored-sessions.smoke.ts
@@ -94,6 +94,24 @@ try {
       "thread 'tokio-runtime-worker' panicked at crates/jcode-harness-api-server/src/translate.rs:1707:38:\nsomething else\n";
     check("a different assertion at translate.rs is refused", classifyStoredSessionPanic(otherMsg) === undefined);
   }
+  {
+    // Same filename, different crate. The old pattern matched any path ending in translate.rs, so
+    // an unrelated crate's panic was reported to the operator as the stored-sessions defect.
+    const foreignCrate =
+      "thread 'tokio-runtime-worker' panicked at crates/unrelated/src/translate.rs:12:1:\nchunk size must be non-zero\n";
+    check("the same filename in another crate is refused", classifyStoredSessionPanic(foreignCrate) === undefined, classifyStoredSessionPanic(foreignCrate));
+  }
+  {
+    // Same basename reached by a suffix rather than a path boundary.
+    const suffixed =
+      "thread 'tokio-runtime-worker' panicked at crates/jcode-harness-api-server/src/my-translate.rs:9:9:\nchunk size must be non-zero\n";
+    check("a filename merely ending in translate.rs is refused", classifyStoredSessionPanic(suffixed) === undefined, classifyStoredSessionPanic(suffixed));
+  }
+  {
+    // No path at all: a bare filename is not the owning site either.
+    const bare = "thread 'tokio-runtime-worker' panicked at translate.rs:1:1:\nchunk size must be non-zero\n";
+    check("a bare translate.rs with no crate path is refused", classifyStoredSessionPanic(bare) === undefined, classifyStoredSessionPanic(bare));
+  }
 
   console.log("\n3. boundStoredSessionCause: allow-listed phrases only");
   check("chunk-size panic text is reduced to the assertion", boundStoredSessionCause("x chunk size must be non-zero y") === "chunk size must be non-zero");

--- a/extensions/connector-jcode/src/host-main.ts
+++ b/extensions/connector-jcode/src/host-main.ts
@@ -1,5 +1,11 @@
 import { runJcodeHost } from "./host.js";
-import { JcodeEffortRefusal, JcodeEffortUnsupported, JcodeReadinessProviderRefusal, writeJcodeDiagnostic } from "./startup-diagnostics.js";
+import {
+  JcodeEffortRefusal,
+  JcodeEffortUnsupported,
+  JcodeReadinessProviderRefusal,
+  JcodeSessionsEnumerationFailure,
+  writeJcodeDiagnostic,
+} from "./startup-diagnostics.js";
 
 const STARTUP_FAILURE_CODES = new Set([
   "project_mcp_config",
@@ -15,6 +21,7 @@ const STARTUP_FAILURE_CODES = new Set([
   "model_mismatch",
   "private_state",
   "readiness_timeout",
+  "sessions_enumeration_failed",
 ]);
 
 function startupFailureCode(error: unknown): string {
@@ -53,6 +60,10 @@ runJcodeHost().catch((error) => {
   if (error instanceof JcodeReadinessProviderRefusal) {
     writeJcodeDiagnostic(
       `[cotal-jcode] fatal: Jcode readiness turn refused ${error.parameter} ${JSON.stringify(error.value)} (${error.providerCode}); inspect the private Jcode logs for other details.\n`,
+    );
+  } else if (error instanceof JcodeSessionsEnumerationFailure) {
+    writeJcodeDiagnostic(
+      `[cotal-jcode] fatal: Jcode host startup failed (sessions_enumeration_failed): ${error.causeText} while reading ${error.sessionsPath}\n`,
     );
   } else {
     writeJcodeDiagnostic(`[cotal-jcode] fatal: Jcode host startup failed (${startupFailureCode(error)}); inspect the private Jcode logs.\n`);

--- a/extensions/connector-jcode/src/host.ts
+++ b/extensions/connector-jcode/src/host.ts
@@ -325,9 +325,6 @@ export async function runJcodeHost(): Promise<void> {
   let launchIdentityValue: string | undefined;
   let client: JcodeClient | undefined;
   let bridgeStderr = "";
-  /** Set when the local read of this seat's `sessions/` failed, so a later startup failure can
-   *  still be reported against the path and errno the connector actually measured. */
-  let storedSessionsUnreadable: { path: string; code: string } | undefined;
   let tui: ChildProcess | undefined;
   let stopping = false;
   let reconnecting = false;
@@ -807,14 +804,14 @@ export async function runJcodeHost(): Promise<void> {
       );
     } else {
       // A directory the connector cannot read is not fatal by itself, but it is a fact worth
-      // naming: the harness reads and writes the same path, so if startup fails afterwards this
+      // naming: the harness reads and WRITES the same path, so if startup fails afterwards this
       // is very likely why, and the operator should not have to infer it from a harness message.
-      if (stored.kind === "unreadable") {
-        storedSessionsUnreadable = { path: stored.path, code: stored.code };
+      // Carrying it further, so that a later harness death is renamed from `unknown`, is #1538:
+      // that failure lands outside any guard this connector owns and main behaves identically.
+      if (stored.kind === "unreadable")
         writeJcodeDiagnostic(
           `[cotal-jcode] stored sessions directory could not be read (${stored.path}: ${stored.code}); asking the harness anyway\n`,
         );
-      }
       try {
         prior = chooseSessionToResume(await client.listSessions(), cwd);
       } catch (error) {
@@ -842,10 +839,10 @@ export async function runJcodeHost(): Promise<void> {
         writeJcodeDiagnostic(`[cotal-jcode] started a fresh session (no resumable prior session in this home)\n`);
       }
     } catch (error) {
-      // The seat could not get a session. If we already know the stored-sessions path is the
-      // suspect - listing died on it, or the connector could not even read it - name that path
-      // and the bounded cause. `unknown` is what sent operators to rename the seat (#1293).
-      if (!listingFailed && stored.kind !== "unreadable") throw error;
+      // The seat could not get a session, and the stored-sessions path is the known suspect:
+      // listing died on it. Name that path and the bounded cause; `unknown` is what sent
+      // operators to rename the seat (#1293).
+      if (!listingFailed) throw error;
       const panic =
         classifyStoredSessionPanic(bridgeStderr) ??
         classifyStoredSessionPanic(String((error as Error).message ?? ""));
@@ -1096,20 +1093,6 @@ export async function runJcodeHost(): Promise<void> {
     }
     socketHome.dispose();
     await agent.stop().catch(() => {});
-    // The connector already knows this seat's stored-session path could not be read. The harness
-    // accepts create_session and only fails later, while it persists the session, so a failure
-    // after that point still has the same root cause and must not reach the operator as
-    // `unknown` (#1293). Name the path and the permission fact we measured; a failure that is
-    // already named keeps its own name.
-    if (
-      storedSessionsUnreadable &&
-      !(error instanceof JcodeSessionsEnumerationFailure) &&
-      !(error instanceof JcodeConnectorError)
-    )
-      throw new JcodeSessionsEnumerationFailure(
-        storedSessionsUnreadable.path,
-        `${storedSessionsUnreadable.code} reading the stored sessions directory`,
-      );
     throw error;
   }
 }

--- a/extensions/connector-jcode/src/host.ts
+++ b/extensions/connector-jcode/src/host.ts
@@ -803,6 +803,13 @@ export async function runJcodeHost(): Promise<void> {
         `[cotal-jcode] stored sessions directory is empty (${stored.path}); starting fresh without listing\n`,
       );
     } else {
+      // A directory the connector cannot read is not fatal by itself, but it is a fact worth
+      // naming: the harness reads and writes the same path, so if startup fails afterwards this
+      // is very likely why, and the operator should not have to infer it from a harness message.
+      if (stored.kind === "unreadable")
+        writeJcodeDiagnostic(
+          `[cotal-jcode] stored sessions directory could not be read (${stored.path}: ${stored.code}); asking the harness anyway\n`,
+        );
       try {
         prior = chooseSessionToResume(await client.listSessions(), cwd);
       } catch (error) {
@@ -830,13 +837,16 @@ export async function runJcodeHost(): Promise<void> {
         writeJcodeDiagnostic(`[cotal-jcode] started a fresh session (no resumable prior session in this home)\n`);
       }
     } catch (error) {
-      if (!listingFailed) throw error;
+      // The seat could not get a session. If we already know the stored-sessions path is the
+      // suspect - listing died on it, or the connector could not even read it - name that path
+      // and the bounded cause. `unknown` is what sent operators to rename the seat (#1293).
+      if (!listingFailed && stored.kind !== "unreadable") throw error;
       const panic =
         classifyStoredSessionPanic(bridgeStderr) ??
         classifyStoredSessionPanic(String((error as Error).message ?? ""));
       throw new JcodeSessionsEnumerationFailure(
         sessionsPath,
-        boundStoredSessionCause(panic ?? (error as Error).message),
+        boundStoredSessionCause(panic ?? `${(error as Error).message ?? ""}\n${bridgeStderr}`),
       );
     }
     const resumed = prior !== undefined;

--- a/extensions/connector-jcode/src/host.ts
+++ b/extensions/connector-jcode/src/host.ts
@@ -14,9 +14,17 @@ import {
   classifyReadinessProviderRefusal,
   installJcodeDiagnosticLog,
   JcodeConnectorError,
+  JcodeSessionsEnumerationFailure,
   jcodeEffortRefusal,
   writeJcodeDiagnostic,
 } from "./startup-diagnostics.js";
+import {
+  boundStoredSessionCause,
+  classifyStoredSessionPanic,
+  inspectStoredSessions,
+  isEmptyStoredSessionsDirectory,
+  storedSessionsPath,
+} from "./stored-sessions.js";
 import { JCODE_READINESS_TIMEOUT_MS } from "./readiness-bound.js";
 import { ERROR_RETRY_INITIAL_MS, nextRetryDelay, shouldRetry } from "./retry-policy.js";
 import {
@@ -316,6 +324,7 @@ export async function runJcodeHost(): Promise<void> {
   let launchIdentity: ProcessIdentity | undefined;
   let launchIdentityValue: string | undefined;
   let client: JcodeClient | undefined;
+  let bridgeStderr = "";
   let tui: ChildProcess | undefined;
   let stopping = false;
   let reconnecting = false;
@@ -388,6 +397,11 @@ export async function runJcodeHost(): Promise<void> {
     if (sdkExitListeners.length !== 1)
       throw new Error(`jcode connector: expected one SDK instance exit hook, found ${sdkExitListeners.length} — refusing unsafe lifecycle ownership`);
     launchIdentity = captureProcessIdentity(instance.process.pid!);
+    bridgeStderr = "";
+    instance.process.stderr?.on("data", (chunk: Buffer | string) => {
+      bridgeStderr += String(chunk);
+      if (bridgeStderr.length > 16_384) bridgeStderr = bridgeStderr.slice(-8000);
+    });
     return JcodeClient.connect({ socketPath: instance.socketPath, ...(remaining() !== undefined ? { requestTimeoutMs: remaining() } : {}) });
   };
 
@@ -781,22 +795,49 @@ export async function runJcodeHost(): Promise<void> {
     // very history the agent could not recall (#789). listSessions failing is not fatal: a seat that
     // cannot enumerate still deserves to start, it just starts fresh and says so.
     let prior: ResumeCandidate | undefined;
-    try {
-      prior = chooseSessionToResume(await client.listSessions(), cwd);
-    } catch (error) {
+    const sessionsPath = storedSessionsPath(socketHome.jcodeHome);
+    const stored = inspectStoredSessions(socketHome.jcodeHome);
+    let listingFailed = false;
+    if (isEmptyStoredSessionsDirectory(stored)) {
       writeJcodeDiagnostic(
-        `[cotal-jcode] could not list prior sessions, starting fresh: ${(error as Error).message}\n`,
-      );
-    }
-    let session;
-    if (prior) {
-      session = await client.attachSession(prior.session_id);
-      writeJcodeDiagnostic(
-        `[cotal-jcode] resumed session ${prior.session_id} (${prior.transcript_bytes} bytes of transcript)\n`,
+        `[cotal-jcode] stored sessions directory is empty (${stored.path}); starting fresh without listing\n`,
       );
     } else {
-      session = await client.createSession(cwd);
-      writeJcodeDiagnostic(`[cotal-jcode] started a fresh session (no resumable prior session in this home)\n`);
+      try {
+        prior = chooseSessionToResume(await client.listSessions(), cwd);
+      } catch (error) {
+        listingFailed = true;
+        const panic =
+          classifyStoredSessionPanic(bridgeStderr) ??
+          classifyStoredSessionPanic(String((error as Error).message ?? ""));
+        const cause = boundStoredSessionCause(panic ?? (error as Error).message);
+        writeJcodeDiagnostic(
+          `[cotal-jcode] could not list prior sessions at ${sessionsPath}: ${cause}; starting fresh on a new harness\n`,
+        );
+        await stopPrivateJcode();
+        client = await launchPrivateJcode();
+      }
+    }
+    let session;
+    try {
+      if (prior) {
+        session = await client.attachSession(prior.session_id);
+        writeJcodeDiagnostic(
+          `[cotal-jcode] resumed session ${prior.session_id} (${prior.transcript_bytes} bytes of transcript)\n`,
+        );
+      } else {
+        session = await client.createSession(cwd);
+        writeJcodeDiagnostic(`[cotal-jcode] started a fresh session (no resumable prior session in this home)\n`);
+      }
+    } catch (error) {
+      if (!listingFailed) throw error;
+      const panic =
+        classifyStoredSessionPanic(bridgeStderr) ??
+        classifyStoredSessionPanic(String((error as Error).message ?? ""));
+      throw new JcodeSessionsEnumerationFailure(
+        sessionsPath,
+        boundStoredSessionCause(panic ?? (error as Error).message),
+      );
     }
     const resumed = prior !== undefined;
     sessionId = session.session_id;

--- a/extensions/connector-jcode/src/host.ts
+++ b/extensions/connector-jcode/src/host.ts
@@ -325,6 +325,9 @@ export async function runJcodeHost(): Promise<void> {
   let launchIdentityValue: string | undefined;
   let client: JcodeClient | undefined;
   let bridgeStderr = "";
+  /** Set when the local read of this seat's `sessions/` failed, so a later startup failure can
+   *  still be reported against the path and errno the connector actually measured. */
+  let storedSessionsUnreadable: { path: string; code: string } | undefined;
   let tui: ChildProcess | undefined;
   let stopping = false;
   let reconnecting = false;
@@ -806,10 +809,12 @@ export async function runJcodeHost(): Promise<void> {
       // A directory the connector cannot read is not fatal by itself, but it is a fact worth
       // naming: the harness reads and writes the same path, so if startup fails afterwards this
       // is very likely why, and the operator should not have to infer it from a harness message.
-      if (stored.kind === "unreadable")
+      if (stored.kind === "unreadable") {
+        storedSessionsUnreadable = { path: stored.path, code: stored.code };
         writeJcodeDiagnostic(
           `[cotal-jcode] stored sessions directory could not be read (${stored.path}: ${stored.code}); asking the harness anyway\n`,
         );
+      }
       try {
         prior = chooseSessionToResume(await client.listSessions(), cwd);
       } catch (error) {
@@ -1091,6 +1096,20 @@ export async function runJcodeHost(): Promise<void> {
     }
     socketHome.dispose();
     await agent.stop().catch(() => {});
+    // The connector already knows this seat's stored-session path could not be read. The harness
+    // accepts create_session and only fails later, while it persists the session, so a failure
+    // after that point still has the same root cause and must not reach the operator as
+    // `unknown` (#1293). Name the path and the permission fact we measured; a failure that is
+    // already named keeps its own name.
+    if (
+      storedSessionsUnreadable &&
+      !(error instanceof JcodeSessionsEnumerationFailure) &&
+      !(error instanceof JcodeConnectorError)
+    )
+      throw new JcodeSessionsEnumerationFailure(
+        storedSessionsUnreadable.path,
+        `${storedSessionsUnreadable.code} reading the stored sessions directory`,
+      );
     throw error;
   }
 }

--- a/extensions/connector-jcode/src/startup-diagnostics.ts
+++ b/extensions/connector-jcode/src/startup-diagnostics.ts
@@ -8,12 +8,25 @@ export type JcodeConnectorFailureCode =
   | "model_refused"
   | "model_mismatch"
   | "private_state"
-  | "readiness_timeout";
+  | "readiness_timeout"
+  | "sessions_enumeration_failed";
 
 /** A bounded connector-owned startup refusal. Only its allow-listed code is rendered publicly. */
 export class JcodeConnectorError extends Error {
   constructor(readonly code: JcodeConnectorFailureCode, message: string, options?: ErrorOptions) {
     super(message, options);
+  }
+}
+
+/** Listing stored sessions killed the harness. Cause and path are connector-owned, not child stderr. */
+export class JcodeSessionsEnumerationFailure extends Error {
+  readonly code = "sessions_enumeration_failed" as const;
+
+  constructor(
+    readonly sessionsPath: string,
+    readonly causeText: string,
+  ) {
+    super(`could not enumerate stored sessions at ${sessionsPath}: ${causeText}`);
   }
 }
 

--- a/extensions/connector-jcode/src/stored-sessions.ts
+++ b/extensions/connector-jcode/src/stored-sessions.ts
@@ -41,13 +41,17 @@ export function isEmptyStoredSessionsDirectory(inspection: StoredSessionsInspect
 
 /**
  * Accept only the rust panic the empty-directory listing currently throws. Prose that happens
- * to mention the assertion, or a panic at a different site, is not this failure.
+ * to mention the assertion, a panic at a different site, or a same-named file in another crate
+ * is not this failure. The site is anchored on the whole owning path, not the basename: a bare
+ * `translate.rs` suffix match would accept any crate that happens to carry that filename.
  */
+const STORED_SESSION_PANIC_SITE = "crates/jcode-harness-api-server/src/translate.rs";
+const STORED_SESSION_PANIC = new RegExp(
+  `thread '[^']*'[^\\n]* panicked at (${STORED_SESSION_PANIC_SITE.replace(/[.]/g, "\\.")}:\\d+:\\d+):\\s*\\n\\s*(chunk size must be non-zero)`,
+);
+
 export function classifyStoredSessionPanic(stderr: string): string | undefined {
-  const match =
-    /thread '[^']*'[^\n]* panicked at ([^\n]*translate\.rs:\d+:\d+):\s*\n\s*(chunk size must be non-zero)/.exec(
-      stderr,
-    );
+  const match = STORED_SESSION_PANIC.exec(stderr);
   return match ? `${match[2]} at ${match[1]}` : undefined;
 }
 

--- a/extensions/connector-jcode/src/stored-sessions.ts
+++ b/extensions/connector-jcode/src/stored-sessions.ts
@@ -1,0 +1,60 @@
+/**
+ * Local facts about a Jcode home's `sessions/` directory, and a bounded reading of the
+ * harness panic that empty directory currently produces.
+ *
+ * The panic lives in the jcode binary (`stored_session_ids` chunks a zero-length list).
+ * This module exists so the connector can refuse to poke that RPC when the answer is
+ * already known (an empty directory holds no resumable session), and so a listing
+ * failure still names the panic and the path instead of `unknown`.
+ */
+import { lstatSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+export function storedSessionsPath(jcodeHome: string): string {
+  return join(jcodeHome, "sessions");
+}
+
+export type StoredSessionsInspection =
+  | { kind: "absent"; path: string }
+  | { kind: "empty-directory"; path: string }
+  | { kind: "populated"; path: string; entries: number }
+  | { kind: "not-a-directory"; path: string };
+
+export function inspectStoredSessions(jcodeHome: string): StoredSessionsInspection {
+  const path = storedSessionsPath(jcodeHome);
+  try {
+    const stats = lstatSync(path);
+    if (!stats.isDirectory()) return { kind: "not-a-directory", path };
+    const entries = readdirSync(path).length;
+    if (entries === 0) return { kind: "empty-directory", path };
+    return { kind: "populated", path, entries };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return { kind: "absent", path };
+    throw error;
+  }
+}
+
+/** True only for a real empty directory. A missing directory is a first launch, not this defect. */
+export function isEmptyStoredSessionsDirectory(inspection: StoredSessionsInspection): boolean {
+  return inspection.kind === "empty-directory";
+}
+
+/**
+ * Accept only the rust panic the empty-directory listing currently throws. Prose that happens
+ * to mention the assertion, or a panic at a different site, is not this failure.
+ */
+export function classifyStoredSessionPanic(stderr: string): string | undefined {
+  const match =
+    /thread '[^']*'[^\n]* panicked at ([^\n]*translate\.rs:\d+:\d+):\s*\n\s*(chunk size must be non-zero)/.exec(
+      stderr,
+    );
+  return match ? `${match[2]} at ${match[1]}` : undefined;
+}
+
+/** Operator-facing cause: allow-listed phrases only, never arbitrary child bytes. */
+export function boundStoredSessionCause(text: string): string {
+  if (/chunk size must be non-zero/.test(text)) return "chunk size must be non-zero";
+  if (/harness connection closed/i.test(text)) return "harness connection closed";
+  if (/write EPIPE/i.test(text)) return "write EPIPE";
+  return "harness connection closed";
+}

--- a/extensions/connector-jcode/src/stored-sessions.ts
+++ b/extensions/connector-jcode/src/stored-sessions.ts
@@ -18,8 +18,17 @@ export type StoredSessionsInspection =
   | { kind: "absent"; path: string }
   | { kind: "empty-directory"; path: string }
   | { kind: "populated"; path: string; entries: number }
-  | { kind: "not-a-directory"; path: string };
+  | { kind: "not-a-directory"; path: string }
+  | { kind: "unreadable"; path: string; code: string };
 
+/**
+ * A local read of the seat's own `sessions/` directory. This runs on the startup path of every
+ * managed seat, so it must never throw: a home the connector cannot read is a question for the
+ * harness, not a reason to kill a seat that would otherwise start. Both reads here can fail on a
+ * home whose permissions were perturbed from outside (operator chmod, restored backup, container
+ * UID remap): `lstat` when the home itself is unreadable, `readdir` when only `sessions/` is.
+ * Anything but a real empty directory falls through to the ordinary listing attempt.
+ */
 export function inspectStoredSessions(jcodeHome: string): StoredSessionsInspection {
   const path = storedSessionsPath(jcodeHome);
   try {
@@ -29,8 +38,9 @@ export function inspectStoredSessions(jcodeHome: string): StoredSessionsInspecti
     if (entries === 0) return { kind: "empty-directory", path };
     return { kind: "populated", path, entries };
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return { kind: "absent", path };
-    throw error;
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return { kind: "absent", path };
+    return { kind: "unreadable", path, code: code ?? "unknown" };
   }
 }
 
@@ -55,10 +65,18 @@ export function classifyStoredSessionPanic(stderr: string): string | undefined {
   return match ? `${match[2]} at ${match[1]}` : undefined;
 }
 
-/** Operator-facing cause: allow-listed phrases only, never arbitrary child bytes. */
+/**
+ * Operator-facing cause: allow-listed phrases only, never arbitrary child bytes.
+ *
+ * The fallback is deliberately non-committal. Naming a specific cause for text we do not
+ * recognise sends the operator to the wrong place: an out-of-memory spawn failure rendered as
+ * "harness connection closed" points at sockets. An unrecognised cause is reported as such.
+ */
+export const UNRECOGNISED_STORED_SESSION_CAUSE = "unrecognised harness failure";
+
 export function boundStoredSessionCause(text: string): string {
   if (/chunk size must be non-zero/.test(text)) return "chunk size must be non-zero";
   if (/harness connection closed/i.test(text)) return "harness connection closed";
   if (/write EPIPE/i.test(text)) return "write EPIPE";
-  return "harness connection closed";
+  return UNRECOGNISED_STORED_SESSION_CAUSE;
 }

--- a/package.json
+++ b/package.json
@@ -125,6 +125,8 @@
     "smoke:jcode-retry-policy": "tsx extensions/connector-jcode/smoke/retry-policy.smoke.ts",
     "smoke:jcode-security": "tsx extensions/connector-jcode/smoke/jcode-security.smoke.ts",
     "smoke:jcode-startup-diagnostics": "tsx extensions/connector-jcode/smoke/startup-diagnostics.smoke.ts",
+    "smoke:jcode-stored-sessions": "tsx extensions/connector-jcode/smoke/stored-sessions.smoke.ts",
+    "smoke:jcode-empty-sessions": "tsx extensions/connector-jcode/smoke/empty-sessions.smoke.ts",
     "smoke:jcode-lifecycle": "tsx extensions/connector-jcode/smoke/jcode-lifecycle.smoke.ts",
     "smoke:jcode-private-lifecycle": "tsx extensions/connector-jcode/smoke/private-lifecycle.smoke.ts",
     "smoke:jcode-provider-disconnect": "tsx extensions/connector-jcode/smoke/jcode-provider-disconnect.smoke.ts",


### PR DESCRIPTION
## Mechanism

A managed Jcode seat whose private home contains an empty `sessions/` directory used to die within about 35s as `startup failed (unknown)`. The operator then treated the name as poisoned and renamed the seat, which only worked because a new name gets a home with no `sessions/` dir.

The panic is **not in this repository**. At origin/main `c8fe5a8c9703cc3b5d2fd235d40dbea2c28fffb1` this tree has zero `.rs` files. The harness still panics in `stored_session_ids` at `crates/jcode-harness-api-server/src/translate.rs:1707:38` (`chunk size must be non-zero`) when that directory exists and is empty. That remains upstream: https://github.com/1jehuang/jcode/issues/1234.

What this PR **does** fix is the connector half of the same chain. After `listSessions` failed, the host reused the already-closed SDK client for `createSession`, and unrecognized startup errors rendered as `unknown`. An empty directory is a recoverable first-launch state, not a reason to wedge the seat.

## What now happens

1. If `sessions/` is a real empty directory, the connector skips `list_sessions` and starts a fresh session.
2. If listing still fails (populated dir, or the harness panics for another reason), the connector stops that tree, redials, and creates a session on a live client.
3. If even that cannot create a session, the fatal line is `startup failed (sessions_enumeration_failed)` and names the bounded cause plus the path it was reading, never `unknown`.

A missing `sessions/` directory is still a first launch (not this defect). A file or symlink at that path is not treated as empty.

## Proof

PRE-FIX CONTROL: the empty-sessions host smoke against origin/main `host.ts` / `host-main.ts` / `startup-diagnostics.ts` **failed** (`timed out waiting for empty-sessions create_session`). Against this head the same probe **passes** (8/8). Stored-sessions inspect/classifier smoke 22/22.

Parser/matcher branches and refusing neighbours (one refusing case per accepting branch, differing only by context):

- `inspectStoredSessions`: 1 accepting (`empty-directory`) and 4 refusing (absent, populated, regular file, symlink).
- `classifyStoredSessionPanic`: 1 accepting (panic at `translate.rs:LINE:COL` with `chunk size must be non-zero`) and 3 refusing (prose mentioning the assertion, same assertion at another rust file, different assertion at `translate.rs`).
- `boundStoredSessionCause`: 3 accepting (chunk-size, harness connection closed, write EPIPE) and 1 refusing (unrelated child text).

Mutations under `bin/smoke/mutations/jcode-empty-sessions.json`: 5/5 KILLED first-hand.

Refs #1293