### PR TITLE
fix(core): check credential expiry on the supply, so internal reconnects cannot present an expired credential

### DIFF
--- a/.changeset/creds-supply-expiry-checkpoint.md
+++ b/.changeset/creds-supply-expiry-checkpoint.md
@@ -1,0 +1,9 @@
+---
+"@cotal-ai/core": patch
+---
+
+Refuse to present an expired credential to the broker on every path that can reach one, not only the endpoint's own dial. The expiry check now sits on the credential supply itself, so the reconnects the NATS client performs on its own present a credential that has just been checked instead of whatever was last fetched. Two such reconnects exist and neither goes through the endpoint's connect path: the one the broker forces when a JWT reaches its expiry, and a dial loop still retrying after an earlier drop that crosses the expiry mid-retry. The pre-expiry reconnect fence cannot stop the second, because it sets a policy flag the client only re-reads when it observes a new drop.
+
+An endpoint holding a static credential is now checked too, where before only a renewing one was. Explicitly reloading a credential checks the candidate locally before the preflight connection, so an already-expired re-signed generation is refused without a round trip and can never become the resident connection's credential.
+
+The refusal fails closed, not dead: a renewable endpoint keeps retrying on capped backoff and re-fetches from its source on each attempt, so it recovers by itself once renewal starts working. Both messages name the remedy that applies -- wait out the retry when a source can renew, replace the credential when there is none. An endpoint whose very first fetch never returned now fails with that source's own error instead of dialing with no credential at all. A credential with no expiry claim is unaffected.

--- a/.changeset/creds-supply-expiry-checkpoint.md
+++ b/.changeset/creds-supply-expiry-checkpoint.md
@@ -2,7 +2,7 @@
 "@cotal-ai/core": patch
 ---
 
-Refuse to present an expired credential to the broker on every path that can reach one, not only the endpoint's own dial. The expiry check now sits on the credential supply itself, so the reconnects the NATS client performs on its own present a credential that has just been checked instead of whatever was last fetched. Two such reconnects exist and neither goes through the endpoint's connect path: the one the broker forces when a JWT reaches its expiry, and a dial loop still retrying after an earlier drop that crosses the expiry mid-retry. The pre-expiry reconnect fence cannot stop the second, because it sets a policy flag the client only re-reads when it observes a new drop.
+Refuse to present an expired credential to the broker on every path an endpoint can reach one from, not only its own dial. The expiry check now sits on the endpoint's credential supply itself, so the reconnects the NATS client performs on its own present a credential that has just been checked instead of whatever was last fetched. Two such reconnects exist and neither goes through the endpoint's connect path: the one the broker forces when a JWT reaches its expiry, and a dial loop still retrying after an earlier drop that crosses the expiry mid-retry. The pre-expiry reconnect fence cannot stop the second, because it sets a policy flag the client only re-reads when it observes a new drop.
 
 An endpoint holding a static credential is now checked too, where before only a renewing one was. Explicitly reloading a credential checks the candidate locally before the preflight connection, so an already-expired re-signed generation is refused without a round trip and can never become the resident connection's credential.
 

--- a/bin/smoke/ci-suites.d/b679310668c7c93775acea567369951f77158494ef149c40fe9832160ae8f765.txt
+++ b/bin/smoke/ci-suites.d/b679310668c7c93775acea567369951f77158494ef149c40fe9832160ae8f765.txt
@@ -1,0 +1,1 @@
+smoke:creds-supply-expiry

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "smoke:control-auth": "tsx packages/core/smoke/control-auth.smoke.ts",
     "smoke:manager-split": "tsx packages/core/smoke/manager-split-auth.smoke.ts",
     "smoke:cred-lifetime": "tsx packages/core/smoke/cred-lifetime-auth.smoke.ts",
+    "smoke:creds-supply-expiry": "tsx packages/core/smoke/creds-supply-expiry-auth.smoke.ts",
     "smoke:reconnect-fence-close": "tsx packages/core/smoke/reconnect-fence-close.smoke.ts",
     "smoke:standing-renewal": "tsx packages/core/smoke/standing-renewal-auth.smoke.ts",
     "smoke:seat-creds-renewal": "tsx extensions/connector-core/smoke/seat-creds-renewal.smoke.ts",

--- a/packages/core/smoke/creds-supply-expiry-auth.smoke.ts
+++ b/packages/core/smoke/creds-supply-expiry-auth.smoke.ts
@@ -38,7 +38,7 @@ import {
   setupSpaceStreams,
 } from "../src/index.js";
 import { pickFreePort } from "./_free-port.js";
-import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+import { SMOKE_BROKER_TOKEN, emitSentinel, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const PORT = await pickFreePort();
 const SERVERS = `nats://127.0.0.1:${PORT}`;
@@ -533,6 +533,11 @@ try {
   console.log(fail === 0
     ? `\nCREDS SUPPLY EXPIRY SMOKE OK ✅  (${pass} passed, ${fail} failed, ${total} cells)`
     : `\nCREDS SUPPLY EXPIRY SMOKE FAILED ❌  (${pass} passed, ${fail} failed, ${total} cells)`);
+  // The MACHINE-READABLE line the shard grades on, last so nothing can print after it. The human
+  // banner above is not a substitute: its legacy form carries a third `N cells` clause, which the
+  // parser reads as prose rather than a tally, so it yields NO sentinel at all and the shard treats
+  // this suite as a zero-cell run. Measured against the parser directly rather than assumed.
+  emitSentinel({ passed: pass, failed: fail, cells: total });
   process.exitCode = fail === 0 ? 0 : 1;
 } finally {
   srv.kill("SIGKILL");

--- a/packages/core/smoke/creds-supply-expiry-auth.smoke.ts
+++ b/packages/core/smoke/creds-supply-expiry-auth.smoke.ts
@@ -455,6 +455,80 @@ try {
     );
   }
 
+  // E2. A STATIC EMPTY CREDENTIAL. Found by a surviving mutation: the cell above proves the FETCH
+  // rethrows, which happens before the getter is consulted, so it never graded the getter's empty
+  // branch at all. Probing that branch directly showed the endpoint dialing ANONYMOUSLY — the dial
+  // gate tested the cached cred for TRUTHINESS, and an empty string took the same path as "no creds
+  // configured", so the connection went out with no auth material and came back `Authorization
+  // Violation`. The caller's actual mistake (an empty credential) was never named, and the failure
+  // read as a permissions problem on the broker rather than a supply problem here.
+  //
+  // This is the same defect class as the one this change is about: a credential path that routes
+  // AROUND the checkpoint rather than through it. It is included because the guard is "every path
+  // presents something checked", and dialing with nothing is not an exception to that.
+  {
+    const id = newIdentity();
+    let threw = "";
+    try {
+      const ep = new CotalEndpoint({
+        space, servers: SERVERS, creds: "",
+        card: { id: id.id, name: "supply-empty-static", kind: "endpoint" },
+        consume: false, registerPresence: false, watchChannels: false, watchPresence: false,
+      });
+      ep.on("error", () => {});
+      ep.on("warning", () => {});
+      await ep.start();
+      await ep.stop();
+    } catch (e) { threw = (e as Error).message; }
+    check(
+      "REFUSE: a STATIC EMPTY creds string fails loud instead of dialing anonymously",
+      /empty creds string/.test(threw) && !/Authorization Violation/.test(threw),
+      threw,
+    );
+  }
+
+  // THE ACCEPTING TWIN, and the reason the refusal above is a `!== undefined` check rather than a
+  // truthiness one. Passing NO creds at all is a legitimate configuration (a dev broker with no auth
+  // account), and it must still connect. It differs from the cell above ONLY in whether the creds
+  // key is absent or present-but-empty, which is exactly the distinction the fix turns on: a gate
+  // that refused both would have broken anonymous access, and one that allowed both is the defect.
+  {
+    const anonPort = await pickFreePort();
+    const anonServers = `nats://127.0.0.1:${anonPort}`;
+    const anonDir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
+    const anonConf = join(anonDir, "server.conf");
+    writeFileSync(anonConf, `port: ${anonPort}\njetstream: { store_dir: "${join(anonDir, "js")}" }\n`);
+    const anonSrv = spawn("nats-server", ["-c", anonConf], { stdio: "ignore" });
+    const releaseAnon = teardownOnSignal(anonSrv, anonDir);
+    let connected = false;
+    let detail = "";
+    try {
+      for (let i = 0; i < 60; i++) { if (await isReachable(anonServers)) break; await wait(200); }
+      const ep = new CotalEndpoint({
+        space, servers: anonServers,
+        card: { name: "supply-no-creds", kind: "endpoint" },
+        consume: false, registerPresence: false, watchChannels: false, watchPresence: false,
+      });
+      ep.on("error", () => {});
+      ep.on("warning", () => {});
+      await ep.start();
+      await ep.setActivity("anonymous-ok");
+      connected = true;
+      await ep.stop();
+    } catch (e) { detail = (e as Error).message; }
+    finally {
+      anonSrv.kill("SIGKILL");
+      await awaitExit(anonSrv);
+      rmSync(anonDir, { recursive: true, force: true });
+      releaseAnon();
+    }
+    check(
+      "ACCEPT: NO creds at all still connects (the refusal is about an empty credential, not about anonymity)",
+      connected,
+      detail,
+    );
+  }
+
   const total = pass + fail;
   console.log(fail === 0
     ? `\nCREDS SUPPLY EXPIRY SMOKE OK ✅  (${pass} passed, ${fail} failed, ${total} cells)`

--- a/packages/core/smoke/creds-supply-expiry-auth.smoke.ts
+++ b/packages/core/smoke/creds-supply-expiry-auth.smoke.ts
@@ -1,0 +1,468 @@
+/**
+ * Credential-supply expiry smoke (#1411): the endpoint's refusal to present an expired credential
+ * is a property of the credential SUPPLY, not of one dial site, so it holds on the reconnects
+ * nats.js performs on its own — the ones no Cotal code calls.
+ *
+ * WHY THIS SUITE EXISTS, and what the standing-renewal suite cannot say. `standing-renewal-auth`
+ * grades the LOCAL refusal (that the warning is raised) and its denial-counting cell inspects a
+ * slice that opens at a fixture marker, so a presentation outside that slice is invisible to it.
+ * The property here is the WIRE one — zero expired credentials reach the broker — and it is graded
+ * over the WHOLE broker log for the identity under test, with no window.
+ *
+ * THE TWO LIBRARY RECONNECTS, because they are different and only one was ever discussed:
+ *
+ *   1. The reconnect the broker FORCES at JWT `exp`. It closes the authenticated connection, the
+ *      client redials, and the redial re-evaluates the authenticator.
+ *   2. A dial loop from an EARLIER drop that is still retrying when `exp` passes. The endpoint's
+ *      pre-expiry fence flips nats-core's `reconnect` policy flag, but nats-core reads that flag
+ *      when it OBSERVES a drop — a loop already inside `dodialLoop` keeps going, and each of its
+ *      attempts re-evaluates the authenticator after `exp`.
+ *
+ * Case 2 is the one that survives a fence, which is why the repair is on the supply instead.
+ *
+ * Run: pnpm smoke:creds-supply-expiry   (needs `nats-server` on PATH; auth/JetStream, local-only)
+ */
+import { randomUUID } from "node:crypto";
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CotalEndpoint,
+  isReachable,
+  createSpaceAuth,
+  mintCreds,
+  mintLifecycleUid,
+  newIdentity,
+  serverConfig,
+  setupSpaceStreams,
+} from "../src/index.js";
+import { pickFreePort } from "./_free-port.js";
+import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
+
+const PORT = await pickFreePort();
+const SERVERS = `nats://127.0.0.1:${PORT}`;
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const until = async (cond: () => boolean, timeoutMs = 10_000, stepMs = 50): Promise<boolean> => {
+  const deadline = Date.now() + timeoutMs;
+  while (!cond() && Date.now() < deadline) await wait(stepMs);
+  return cond();
+};
+const awaitExit = (proc: ChildProcess, timeoutMs = 4000): Promise<void> =>
+  new Promise((resolve) => {
+    if (proc.exitCode !== null || proc.signalCode !== null) return resolve();
+    proc.once("exit", () => resolve());
+    setTimeout(resolve, timeoutMs);
+  });
+
+let pass = 0, fail = 0;
+const check = (name: string, cond: boolean, extra?: unknown) => {
+  if (cond) { pass++; console.log(`  ✓ ${name}`); }
+  else { fail++; console.log(`  ✗ FAIL: ${name}`, extra ?? ""); }
+};
+
+/**
+ * Every broker line that means EXPIRED CREDENTIAL MATERIAL WAS PRESENTED, for one client name.
+ *
+ * Two shapes, both of which this defect has been observed to produce, because which one appears
+ * depends on where the JWT's `exp` sits relative to the CONNECT the broker is validating:
+ *   - `User JWT no longer valid ... claim is expired` — the claim was already past at validation.
+ *   - `User Authentication Expired` on a cid whose CONNECT this client just made.
+ * A detector that knew only one of them would read a real presentation as clean. The name filter
+ * keeps other endpoints in the same space (and their own legitimate lifecycles) out of the count.
+ *
+ * ONE BENIGN LINE MUST NOT COUNT. `Authentication Expired` also appears when the broker retires a
+ * connection whose credential it ADMITTED while still live — the designed backstop at `exp`, not a
+ * presentation. It is separated by cid: a cid that carried `Authenticated JWT` was admitted, and
+ * that line is emitted while processing the CONNECT (before the client name is known to the broker)
+ * so it carries the nkey rather than `cotal:<name>` — which is why the caller passes the identity.
+ */
+/**
+ * AND THE IDENTITY FILTER MUST NOT BE APPLIED TO BOTH SHAPES, which is a hole this detector had
+ * and a measurement caught. The rejection line is
+ *
+ *   cid:90 - User JWT no longer valid: &{Issues:[claim is expired]}
+ *
+ * and it names NEITHER the client nor the nkey: the broker refuses the CONNECT before it adopts
+ * either. Requiring an identity match on that shape filtered out the precise line the pre-fix tree
+ * emits, and the probe read clean against a tree that was presenting expired credentials. It is
+ * attributable without the identity because the caller passes a log SLICE covering one endpoint's
+ * activity in a per-run space, and the only other client touching that window is a credless TCP
+ * liveness probe that never sends a JWT.
+ */
+const expiredPresentations = (log: string, clientName: string, nkey: string): string[] => {
+  const lines = log.split("\n");
+  const admitted = new Set(
+    lines
+      .filter((l) => /Authenticated JWT/.test(l) && l.includes(nkey))
+      .map((l) => l.match(/cid:(\d+)/)?.[1])
+      .filter((c): c is string => Boolean(c)),
+  );
+  return lines.filter((l) => {
+    // Shape 1: an outright rejection. Anonymous by construction — never identity-filtered.
+    if (/User JWT no longer valid/.test(l) && /claim is expired/.test(l)) return true;
+    // Shape 2: attributable, so it IS identity-filtered, and excluded on an admitted cid.
+    if (!/Authentication Expired/.test(l)) return false;
+    if (!l.includes(`cotal:${clientName}`) && !l.includes(nkey)) return false;
+    return !admitted.has(l.match(/cid:(\d+)/)?.[1] ?? "");
+  });
+};
+
+const space = `creds-supply-${randomUUID().slice(0, 8)}`;
+const auth = await createSpaceAuth(space);
+const dir = mkdtempSync(join(tmpdir(), SMOKE_BROKER_TOKEN));
+const conf = join(dir, "server.conf");
+writeFileSync(conf, serverConfig(auth, [auth], { transport: { kind: "plaintext" }, port: PORT, storeDir: join(dir, "js") }));
+
+let brokerLog = "";
+let srv = spawn("nats-server", ["-D", "-c", conf], { stdio: ["ignore", "pipe", "pipe"] });
+const capture = (p: ChildProcess) => {
+  p.stdout?.on("data", (d: Buffer) => { brokerLog += d.toString(); });
+  p.stderr?.on("data", (d: Buffer) => { brokerLog += d.toString(); });
+};
+capture(srv);
+let releaseBroker = teardownOnSignal(srv, dir);
+
+try {
+  let up = false;
+  for (let i = 0; i < 60; i++) { if (await isReachable(SERVERS)) { up = true; break; } await wait(200); }
+  if (!up) throw new Error(`auth nats-server did not come up on ${PORT}`);
+
+  const provCreds = await mintCreds(auth, newIdentity(), "provisioner");
+  await setupSpaceStreams({ servers: SERVERS, space, creds: provCreds });
+
+  // ══ A. LIBRARY RECONNECT 2: a dial loop that crosses `exp` while it is already retrying.
+  // The broker is killed BEFORE `exp` and restarted AFTER it, with the renewal source down the
+  // whole time. Nothing Cotal calls runs the redial that lands: it is nats-core's own loop,
+  // started by the pre-`exp` drop and still spinning when the credential dies under it.
+  {
+    const TTL = 6;
+    const id = newIdentity();
+    const NAME = "supply-dialloop";
+    let reads = 0;
+    const warnings: string[] = [];
+    const source = () => {
+      reads++;
+      if (reads === 1) return mintCreds(auth, id, "supervisor", { expiresInSeconds: TTL });
+      throw new Error("fixture renewal source offline");
+    };
+    const ep = new CotalEndpoint({
+      space, servers: SERVERS, creds: source,
+      card: { id: id.id, name: NAME, kind: "endpoint" },
+      consume: false, lifecycleUid: mintLifecycleUid(),
+      registerPresence: false, watchChannels: false, watchPresence: false,
+    });
+    ep.on("error", () => { /* the drop and the refusal both ride here; the wire is the subject */ });
+    ep.on("warning", (e: Error) => warnings.push(e.message));
+    const t0 = Date.now();
+    await ep.start();
+    const expAtMs = t0 + TTL * 1000;
+    check("a creds-source endpoint connects on its first fetch", reads === 1, reads);
+
+    // Drop ~2.5s before exp: far enough that the loop is established, close enough that it is
+    // still retrying when the credential dies.
+    await wait(Math.max(0, expAtMs - 2_500 - Date.now()));
+    srv.kill("SIGKILL");
+    await awaitExit(srv);
+    const droppedBeforeExp = Date.now() < expAtMs;
+
+    // Back up AFTER exp. From here any CONNECT this client makes carries a dead JWT unless the
+    // supply refuses it.
+    await wait(Math.max(0, expAtMs + 1_500 - Date.now()));
+    const markAtRestart = brokerLog.length;
+    srv = spawn("nats-server", ["-D", "-c", conf], { stdio: ["ignore", "pipe", "pipe"] });
+    capture(srv);
+    releaseBroker();
+    releaseBroker = teardownOnSignal(srv, dir);
+    const restartedAfterExp = Date.now() > expAtMs;
+    for (let i = 0; i < 60; i++) { if (await isReachable(SERVERS)) break; await wait(200); }
+
+    // The control's own preconditions. Without these the zero below could be vacuous: a drop
+    // that landed after exp, or a restart before it, is not the scenario at all.
+    check("CONTROL: the transport dropped BEFORE the JWT expired", droppedBeforeExp);
+    check("CONTROL: the broker returned AFTER the JWT expired", restartedAfterExp);
+    check(
+      "CONTROL: renewal stayed down across the whole window (so the cache could only hold dead material)",
+      reads >= 2,
+      reads,
+    );
+
+    // Give the library's loop a wide berth to present something: its retry spacing is 2s and the
+    // cap on our own rebuild backoff is far longer, so 12s covers several attempts of each.
+    await wait(12_000);
+    const postRestart = brokerLog.slice(markAtRestart);
+    // NON-VACUITY, and this cell is why the zero below means anything. A zero could be reached two
+    // ways: the supply refused (the property), or nothing dialed at all (the window was simply
+    // quiet, which proves nothing). The authenticator is evaluated while composing the CONNECT,
+    // AFTER the socket is up, so a refused attempt still shows as `Client connection created` on
+    // the broker. Requiring at least one means the loop DID reach the broker and was turned back at
+    // the credential, rather than never arriving.
+    check(
+      "CONTROL: the dial loop did reach the broker after it returned (a quiet window would prove nothing)",
+      postRestart.split("\n").some((l) => /Client connection created/.test(l)),
+      postRestart.split("\n").filter((l) => /Client connection/.test(l)).slice(0, 5),
+    );
+    const presented = expiredPresentations(postRestart, NAME, id.id);
+    check(
+      "an in-flight library dial loop that crosses expiry presents the expired credential ZERO times",
+      presented.length === 0,
+      { presented, reads },
+    );
+    check(
+      "the refusal is loud and names the failing renewal path",
+      warnings.some((m) => /creds have expired.*renewal.*failing/.test(m)),
+      warnings,
+    );
+    await ep.stop();
+  }
+
+  // ══ B. LIBRARY RECONNECT 1: the reconnect the broker forces at `exp`, then RECOVERY.
+  // Same supply, no broker interference: the connection dies of its own expiry, the client
+  // redials, and the source comes back. The recovery half is what proves the refusal FAILS
+  // CLOSED rather than dead — a guard that stranded a renewable endpoint would pass the zero
+  // above and be useless.
+  {
+    const TTL = 4;
+    const id = newIdentity();
+    const NAME = "supply-brokerforced";
+    let reads = 0;
+    let allowRecovery = false;
+    const warnings: string[] = [];
+    const source = () => {
+      reads++;
+      if (reads === 1) return mintCreds(auth, id, "supervisor", { expiresInSeconds: TTL });
+      if (!allowRecovery) throw new Error("fixture renewal source offline");
+      return mintCreds(auth, id, "supervisor", { expiresInSeconds: 60 });
+    };
+    const markStart = brokerLog.length;
+    const ep = new CotalEndpoint({
+      space, servers: SERVERS, creds: source,
+      card: { id: id.id, name: NAME, kind: "endpoint" },
+      consume: false, lifecycleUid: mintLifecycleUid(),
+      registerPresence: false, watchChannels: false, watchPresence: false,
+    });
+    ep.on("error", () => { /* the expiry close rides here */ });
+    ep.on("warning", (e: Error) => warnings.push(e.message));
+    const t0 = Date.now();
+    await ep.start();
+
+    // Cross exp with the source down, then wait out the library's redials.
+    await wait(Math.max(0, t0 + TTL * 1000 + 4_000 - Date.now()));
+    check(
+      "CONTROL: renewal failed before expiry, so the cache is past-dated at the forced reconnect",
+      reads >= 2 && warnings.some((m) => /creds refresh failed/.test(m)),
+      { reads, warnings },
+    );
+    // The SAME detector as section A: a cid the broker admitted is a live connection being retired
+    // at `exp` (the designed backstop), a cid it never admitted is a refused CONNECT.
+    const windowLog = brokerLog.slice(markStart);
+    const admittedCids = new Set(
+      windowLog.split("\n")
+        .filter((l) => /Authenticated JWT/.test(l) && l.includes(id.id))
+        .map((l) => l.match(/cid:(\d+)/)?.[1])
+        .filter((c): c is string => Boolean(c)),
+    );
+    check(
+      "CONTROL: the original connection did authenticate (so there was a live wire for the broker to expire)",
+      admittedCids.size >= 1,
+      [...admittedCids],
+    );
+    const presented = expiredPresentations(windowLog, NAME, id.id);
+    check(
+      "the broker-forced reconnect at expiry presents the expired credential ZERO times",
+      presented.length === 0,
+      { presented, admittedCids: [...admittedCids] },
+    );
+
+    allowRecovery = true;
+    let recovered = false;
+    const deadline = Date.now() + 30_000;
+    while (!recovered && Date.now() < deadline) {
+      try { await ep.setActivity("recovered"); recovered = true; }
+      catch { await wait(200); }
+    }
+    check(
+      "the refusal fails CLOSED, not dead: the endpoint reconnects once its source returns",
+      recovered,
+      { reads },
+    );
+    await ep.stop();
+  }
+
+  // ══ C. THE ADOPTION PREFLIGHT: the one presentation that does NOT read the cache.
+  // `reloadCreds` proves a candidate on a disposable connection. That candidate comes straight
+  // from the store, so a supply check that only covered the cache would miss it entirely.
+  {
+    const id = newIdentity();
+    const NAME = "supply-preflight";
+    let serveExpired = false;
+    const source = async () => serveExpired
+      ? mintCreds(auth, id, "supervisor", { expiresAt: Math.floor(Date.now() / 1000) - 1 })
+      : mintCreds(auth, id, "supervisor", { expiresInSeconds: 120 });
+    const ep = new CotalEndpoint({
+      space, servers: SERVERS, creds: source,
+      card: { id: id.id, name: NAME, kind: "endpoint" },
+      consume: false, lifecycleUid: mintLifecycleUid(),
+      registerPresence: false, watchChannels: false, watchPresence: false,
+    });
+    ep.on("error", () => {});
+    ep.on("warning", () => {});
+    await ep.start();
+
+    // ACCEPTING: a live candidate is adopted and its window reported.
+    const adopted = await ep.reloadCreds();
+    check(
+      "ACCEPT: an explicit reload of a LIVE candidate is adopted and reports its window",
+      adopted.identity === id.id && typeof adopted.exp === "number",
+      adopted,
+    );
+
+    // REFUSING, differing from the case above ONLY in the candidate's exp.
+    serveExpired = true;
+    const markPreflight = brokerLog.length;
+    let refusal = "";
+    try { await ep.reloadCreds(); } catch (e) { refusal = (e as Error).message; }
+    check(
+      "REFUSE: an explicit reload of an EXPIRED candidate is refused",
+      /creds have expired/.test(refusal),
+      refusal,
+    );
+    check(
+      "the refused candidate never reaches the broker (no preflight presentation on the wire)",
+      expiredPresentations(brokerLog.slice(markPreflight), NAME, id.id).length === 0,
+      expiredPresentations(brokerLog.slice(markPreflight), NAME, id.id),
+    );
+    // The resident connection must be untouched: a refused candidate is not adopted, so the
+    // endpoint still works on the generation it already had.
+    let stillServing = false;
+    try { await ep.setActivity("post-refusal"); stillServing = true; } catch { /* recorded below */ }
+    check(
+      "a refused candidate leaves the resident connection on its previous credential",
+      stillServing,
+    );
+    await ep.stop();
+  }
+
+  // ══ D. STATIC (no source) creds: the SAME checkpoint, the other message, and its accepting twin.
+  // These two differ only in whether the credential carries a past `exp`, which is the axis the
+  // check turns on; the diagnostic must also name the right remedy, because a static endpoint
+  // cannot renew and telling its operator to wait for renewal is a dead end.
+  {
+    const id = newIdentity();
+    const expired = await mintCreds(auth, id, "probe", { expiresAt: Math.floor(Date.now() / 1000) - 1 });
+    const markStatic = brokerLog.length;
+    let threw = "";
+    try {
+      const ep = new CotalEndpoint({
+        space, servers: SERVERS, creds: expired,
+        card: { id: id.id, name: "supply-static-expired", kind: "endpoint" },
+        consume: false, registerPresence: false, watchChannels: false, watchPresence: false,
+      });
+      await ep.start();
+      await ep.stop();
+    } catch (e) { threw = (e as Error).message; }
+    check(
+      "REFUSE: a STATIC expired cred is refused and names replacement, not renewal",
+      /creds have expired/.test(threw) && /no creds source/.test(threw) && !/retrying with backoff/.test(threw),
+      threw,
+    );
+    check(
+      "the refused static cred never reaches the broker",
+      expiredPresentations(brokerLog.slice(markStatic), "supply-static-expired", id.id).length === 0,
+      expiredPresentations(brokerLog.slice(markStatic), "supply-static-expired", id.id),
+    );
+
+    // ACCEPTING twin: same static path, an UNBOUNDED credential. A cred with no `exp` has no
+    // expiry to be past, so the checkpoint must pass it through rather than refuse what it
+    // cannot date. Without this cell a checkpoint that refused every static cred would look
+    // correct.
+    const unboundedId = newIdentity();
+    const unbounded = await mintCreds(auth, unboundedId, "teardown", { lifecycleUid: mintLifecycleUid() });
+    let connected = false, unboundedErr = "";
+    try {
+      const ep = new CotalEndpoint({
+        space, servers: SERVERS, creds: unbounded,
+        card: { id: unboundedId.id, name: "supply-static-unbounded", kind: "endpoint" },
+        consume: false, lifecycleUid: mintLifecycleUid(),
+        registerPresence: false, watchChannels: false, watchPresence: false,
+      });
+      ep.on("error", () => {});
+      ep.on("warning", () => {});
+      await ep.start();
+      connected = true;
+      await ep.stop();
+    } catch (e) { unboundedErr = (e as Error).message; }
+    check(
+      "ACCEPT: a STATIC cred with no expiry claim is presentable (nothing to be past)",
+      connected,
+      unboundedErr,
+    );
+
+    // ACCEPTING twin for the renewed path: a bounded, unexpired cred connects. The accepting
+    // counterpart to A and B, differing only in that its credential is still live.
+    const liveId = newIdentity();
+    const liveCreds = await mintCreds(auth, liveId, "supervisor", { expiresInSeconds: 120 });
+    let liveOk = false, liveErr = "";
+    try {
+      const ep = new CotalEndpoint({
+        space, servers: SERVERS, creds: () => Promise.resolve(liveCreds),
+        card: { id: liveId.id, name: "supply-bounded-live", kind: "endpoint" },
+        consume: false, lifecycleUid: mintLifecycleUid(),
+        registerPresence: false, watchChannels: false, watchPresence: false,
+      });
+      ep.on("error", () => {});
+      ep.on("warning", () => {});
+      await ep.start();
+      await ep.setActivity("live");
+      liveOk = true;
+      await ep.stop();
+    } catch (e) { liveErr = (e as Error).message; }
+    check(
+      "ACCEPT: a bounded, UNEXPIRED source cred is presentable and round-trips",
+      liveOk,
+      liveErr,
+    );
+  }
+
+  // ══ E. The supply refuses when it holds NOTHING, rather than presenting `undefined`.
+  // The getter used to be `() => this.currentCreds!`, a non-null assertion over a field that is
+  // genuinely empty until the first fetch returns. A library reconnect firing in that window
+  // encoded an empty credential. This is the accepting branch's absence, not an expiry.
+  {
+    const id = newIdentity();
+    let firstCall = true;
+    let threw = "";
+    try {
+      const ep = new CotalEndpoint({
+        space, servers: SERVERS,
+        creds: () => {
+          if (firstCall) { firstCall = false; throw new Error("store unavailable at first fetch"); }
+          return mintCreds(auth, id, "supervisor", { expiresInSeconds: 60 });
+        },
+        card: { id: id.id, name: "supply-empty", kind: "endpoint" },
+        consume: false, lifecycleUid: mintLifecycleUid(),
+        registerPresence: false, watchChannels: false, watchPresence: false,
+      });
+      ep.on("error", () => {});
+      ep.on("warning", () => {});
+      await ep.start();
+      await ep.stop();
+    } catch (e) { threw = (e as Error).message; }
+    check(
+      "REFUSE: a first fetch that never returned fails loud instead of dialing with no credential",
+      threw.includes("store unavailable at first fetch"),
+      threw,
+    );
+  }
+
+  const total = pass + fail;
+  console.log(fail === 0
+    ? `\nCREDS SUPPLY EXPIRY SMOKE OK ✅  (${pass} passed, ${fail} failed, ${total} cells)`
+    : `\nCREDS SUPPLY EXPIRY SMOKE FAILED ❌  (${pass} passed, ${fail} failed, ${total} cells)`);
+  process.exitCode = fail === 0 ? 0 : 1;
+} finally {
+  srv.kill("SIGKILL");
+  await awaitExit(srv);
+  rmSync(dir, { recursive: true, force: true });
+  releaseBroker(); // last: ownership is held until this teardown has actually finished
+}

--- a/packages/core/smoke/creds-supply-expiry-auth.smoke.ts
+++ b/packages/core/smoke/creds-supply-expiry-auth.smoke.ts
@@ -220,12 +220,6 @@ try {
     // cap on our own rebuild backoff is far longer, so 12s covers several attempts of each.
     await wait(12_000);
     const postRestart = brokerLog.slice(markAtRestart);
-    // NON-VACUITY, and this cell is why the zero below means anything. A zero could be reached two
-    // ways: the supply refused (the property), or nothing dialed at all (the window was simply
-    // quiet, which proves nothing). The authenticator is evaluated while composing the CONNECT,
-    // AFTER the socket is up, so a refused attempt still shows as `Client connection created` on
-    // the broker. Requiring at least one means the loop DID reach the broker and was turned back at
-    // the credential, rather than never arriving.
     // NON-VACUITY, and this cell is what makes the zero below mean anything. A zero is reachable two
     // ways: the supply refused every attempt (the property), or nothing tried at all (a quiet window,
     // which proves nothing). This must hold on BOTH a fixed and an unfixed tree, or it is not a
@@ -299,6 +293,16 @@ try {
     });
     ep.on("error", () => { /* the expiry close rides here */ });
     ep.on("warning", (e: Error) => warnings.push(e.message));
+    // RECOVERY WITNESS. `setActivity` is NOT one: this endpoint is constructed with
+    // registerPresence:false, so `publishPresence` returns at its first line (`!this.doRegister`)
+    // without touching the wire, and the call therefore CANNOT throw whether or not a connection
+    // exists. An earlier version of the cell below looped on it and would have gone green against
+    // an endpoint that never reconnected at all. Count successful binds instead: endpoint.ts:1304
+    // emits `connection {connected:true}` at the end of every successful bind, on the initial
+    // start and on each self-heal rebuild alike, so a SECOND one is positive evidence that
+    // `reestablishLoop` re-fetched from the recovered source and re-bound a real wire.
+    let successfulBinds = 0;
+    ep.on("connection", (s: { connected: boolean }) => { if (s.connected) successfulBinds++; });
     const t0 = Date.now();
     await ep.start();
 
@@ -331,16 +335,19 @@ try {
     );
 
     allowRecovery = true;
-    let recovered = false;
+    const bindsBeforeRecovery = successfulBinds;
     const deadline = Date.now() + 30_000;
-    while (!recovered && Date.now() < deadline) {
-      try { await ep.setActivity("recovered"); recovered = true; }
-      catch { await wait(200); }
-    }
+    while (successfulBinds <= bindsBeforeRecovery && Date.now() < deadline) await wait(200);
+    const recovered = successfulBinds > bindsBeforeRecovery;
     check(
       "the refusal fails CLOSED, not dead: the endpoint reconnects once its source returns",
       recovered,
-      { reads },
+      { reads, successfulBinds, bindsBeforeRecovery },
+    );
+    check(
+      "CONTROL: the recovery above is a NEW bind, not the one start() already made",
+      bindsBeforeRecovery >= 1 && successfulBinds >= 2,
+      { successfulBinds, bindsBeforeRecovery },
     );
     await ep.stop();
   }

--- a/packages/core/smoke/creds-supply-expiry-auth.smoke.ts
+++ b/packages/core/smoke/creds-supply-expiry-auth.smoke.ts
@@ -62,6 +62,31 @@ const check = (name: string, cond: boolean, extra?: unknown) => {
 };
 
 /**
+ * Did a client actually send a CONNECT carrying credential material in this slice?
+ *
+ * NOT the same question as "did anything open a socket", and the difference is load-bearing. The
+ * broker logs `Client connection created` for ANY accepted TCP connection, including one that reads
+ * the INFO banner and closes without ever sending CONNECT. This suite makes exactly such
+ * connections: the `isReachable` liveness poll after each broker restart is a credless probe, and it
+ * runs INSIDE the window the non-vacuity control grades. Measured: five polls produce five
+ * `Client connection created` lines and zero authentications.
+ *
+ * So a control keyed on that line could be satisfied entirely by this suite's own probes, and would
+ * read "the dial loop reached the broker" when the dial loop had not run at all — the precise
+ * vacuity the control exists to rule out, reintroduced by the control itself.
+ *
+ * A JWT-bearing CONNECT is distinguishable because the broker says what it did with the credential:
+ * it either admitted it (`Authenticated JWT`) or refused it by name. Counting those, rather than
+ * sockets, is what makes the control mean "a client presented credential material here".
+ */
+const credentialedConnects = (log: string): string[] =>
+  log.split("\n").filter((l) =>
+    /Authenticated JWT/.test(l)
+    || /User JWT no longer valid/.test(l)
+    || /Authentication Expired/.test(l)
+    || /Authorization Violation/.test(l));
+
+/**
  * Every broker line that means EXPIRED CREDENTIAL MATERIAL WAS PRESENTED, for one client name.
  *
  * Two shapes, both of which this defect has been observed to produce, because which one appears
@@ -141,6 +166,9 @@ try {
     const NAME = "supply-dialloop";
     let reads = 0;
     const warnings: string[] = [];
+    // Timestamped so the control can tell a refusal raised AFTER the broker returned from one raised
+    // while it was down. Both are the same message; only the ordering distinguishes them.
+    const errors: string[] = [];
     const source = () => {
       reads++;
       if (reads === 1) return mintCreds(auth, id, "supervisor", { expiresInSeconds: TTL });
@@ -152,7 +180,7 @@ try {
       consume: false, lifecycleUid: mintLifecycleUid(),
       registerPresence: false, watchChannels: false, watchPresence: false,
     });
-    ep.on("error", () => { /* the drop and the refusal both ride here; the wire is the subject */ });
+    ep.on("error", (e: Error) => { errors.push(`${Date.now()}|${e.message}`); });
     ep.on("warning", (e: Error) => warnings.push(e.message));
     const t0 = Date.now();
     await ep.start();
@@ -175,6 +203,7 @@ try {
     releaseBroker();
     releaseBroker = teardownOnSignal(srv, dir);
     const restartedAfterExp = Date.now() > expAtMs;
+    const restartAtMs = Date.now();
     for (let i = 0; i < 60; i++) { if (await isReachable(SERVERS)) break; await wait(200); }
 
     // The control's own preconditions. Without these the zero below could be vacuous: a drop
@@ -197,10 +226,37 @@ try {
     // AFTER the socket is up, so a refused attempt still shows as `Client connection created` on
     // the broker. Requiring at least one means the loop DID reach the broker and was turned back at
     // the credential, rather than never arriving.
+    // NON-VACUITY, and this cell is what makes the zero below mean anything. A zero is reachable two
+    // ways: the supply refused every attempt (the property), or nothing tried at all (a quiet window,
+    // which proves nothing). This must hold on BOTH a fixed and an unfixed tree, or it is not a
+    // control — it is a second copy of the assertion.
+    //
+    // TWO EARLIER VERSIONS OF THIS CELL WERE WRONG, in opposite directions, and both were caught by
+    // running them rather than by reading them:
+    //
+    //   1. `Client connection created` — satisfied by ANY accepted socket. This suite polls
+    //      `isReachable` after each restart, a credless probe that never sends CONNECT; measured,
+    //      five polls produce five such lines and zero authentications. The control could be
+    //      satisfied entirely by the suite's own probes, i.e. it could not fail.
+    //   2. A credentialed CONNECT on the wire (`Authenticated JWT` / a named refusal). Correct on the
+    //      UNFIXED tree, and impossible on the fixed one: the whole point of the fix is that the
+    //      refusal happens locally and NO CONNECT is ever sent. Measured green pre-fix, red post-fix.
+    //
+    // The invariant both missed is that the DIAL ATTEMPT is client-side, so the evidence must be too.
+    // Each attempt evaluates the authenticator; on an expired cache that raises the refusal, and on a
+    // tree without the checkpoint it instead produces a wire rejection. Accepting either means "the
+    // loop was alive and asked the supply for a credential after the broker returned", which is the
+    // precondition the zero needs, and it is observable on both trees.
+    const refusalsAfterRestart = errors.filter((e) =>
+      Number(e.split("|")[0]) >= restartAtMs && /creds have expired/.test(e)).length;
     check(
-      "CONTROL: the dial loop did reach the broker after it returned (a quiet window would prove nothing)",
-      postRestart.split("\n").some((l) => /Client connection created/.test(l)),
-      postRestart.split("\n").filter((l) => /Client connection/.test(l)).slice(0, 5),
+      "CONTROL: the dial loop was alive and asked the supply after the broker returned (a quiet window would prove nothing)",
+      refusalsAfterRestart > 0 || credentialedConnects(postRestart).length > 0,
+      {
+        localRefusalsAfterRestart: refusalsAfterRestart,
+        credentialedConnectsOnWire: credentialedConnects(postRestart).length,
+        bareSockets: postRestart.split("\n").filter((l) => /Client connection created/.test(l)).length,
+      },
     );
     const presented = expiredPresentations(postRestart, NAME, id.id);
     check(

--- a/packages/core/smoke/mutations/creds-supply-expiry.json
+++ b/packages/core/smoke/mutations/creds-supply-expiry.json
@@ -22,7 +22,13 @@
     "Probing the branch directly showed a static empty credential dialing ANONYMOUSLY and coming",
     "back `Authorization Violation`, so the survivor was a real coverage gap over a real hole, not a",
     "mis-written fixture. Both were fixed: the gate is now `!== undefined`, and the mutation below",
-    "targets that gate."
+    "targets that gate.",
+    "The fifth mutation exists because a reviewer showed the recovery cell could not fail. It looped",
+    "on `setActivity`, but the endpoint under test sets registerPresence:false, so publishPresence",
+    "returns at its first line without touching the wire and the call cannot throw whether or not a",
+    "connection exists -- the cell would have gone green against an endpoint that never reconnected.",
+    "It now counts `connection {connected:true}` emissions and requires a SECOND one, and the",
+    "mutation below severs the self-heal so that the fails-closed half is graded on a real rebind."
   ],
   "mutations": [
     {
@@ -60,6 +66,15 @@
       "expectRed": "REFUSE: a STATIC EMPTY creds string fails loud instead of dialing anonymously",
       "cell": "REFUSE: a STATIC EMPTY creds string fails loud instead of dialing anonymously",
       "note": "A one-character weakening that reads as a harmless falsiness idiom. Under it an empty creds string is indistinguishable from 'no creds configured', so the endpoint dials with no auth material and the broker answers `Authorization Violation` -- a permissions-shaped error for what is a supply mistake. The named cell asserts BOTH that the refusal names the empty credential AND that the broker's violation text is absent, so a red here cannot be satisfied by any failure that merely happened. Its accepting twin (no creds at all still connects) stays green under this mutation, which is what confines the mutation to the empty case rather than to anonymity."
+    },
+    {
+      "name": "the self-heal never runs after a credential refusal (the guard strands a renewable endpoint)",
+      "file": "packages/core/src/endpoint.ts",
+      "find": "      void this.reestablishLoop();\n",
+      "replace": "      if (!this.credsSource) void this.reestablishLoop();\n",
+      "expectRed": "the refusal fails CLOSED, not dead: the endpoint reconnects once its source returns",
+      "cell": "the refusal fails CLOSED, not dead: the endpoint reconnects once its source returns",
+      "note": "This is the wrong repair that a guard-only fix invites: refuse the expired credential and never come back, which satisfies every ZERO cell in the suite while leaving a renewable endpoint permanently dead. The mutation is conditioned on credsSource so it severs the self-heal only for endpoints with a renewal source, leaving the static-cred cells untouched and confining the red to the recovery half. It is also the mutation that proves the recovery cell is no longer vacuous: against the previous setActivity-based version this mutation SURVIVED, because with registerPresence:false that call returns without a wire and reports success on a dead endpoint."
     }
   ]
 }

--- a/packages/core/smoke/mutations/creds-supply-expiry.json
+++ b/packages/core/smoke/mutations/creds-supply-expiry.json
@@ -16,15 +16,19 @@
     "Each mutation leaves the tree compiling and the other paths correct. A suite that only watched",
     "the endpoint's own dial would stay GREEN under the first two, because that path never regresses",
     "in them: it is the library's reconnect and the adoption preflight that start leaking.",
-    "The empty-supply mutation is here because the getter it replaced was a non-null assertion. Under",
-    "it the tree still compiles and still refuses expired creds; what changes is that a first fetch",
-    "which never returned dials with an empty credential instead of failing loud."
+    "The last mutation earns its place by having SURVIVED first. It was originally written against",
+    "the getter's empty branch and the suite passed with that branch deleted -- because the cell",
+    "aimed at it proves the first FETCH rethrows, which happens before the getter is ever consulted.",
+    "Probing the branch directly showed a static empty credential dialing ANONYMOUSLY and coming",
+    "back `Authorization Violation`, so the survivor was a real coverage gap over a real hole, not a",
+    "mis-written fixture. Both were fixed: the gate is now `!== undefined`, and the mutation below",
+    "targets that gate."
   ],
   "mutations": [
     {
       "name": "the wire getter is unchecked again (the reported defect: internal reconnects read the raw cache)",
       "file": "packages/core/src/endpoint.ts",
-      "find": "creds: this.currentCreds || this.credsSource ? () => this.credsForWire() : undefined",
+      "find": "creds: this.currentCreds !== undefined || this.credsSource ? () => this.credsForWire() : undefined",
       "replace": "creds: this.credsSource ? () => this.currentCreds! : this.currentCreds",
       "expectRed": "an in-flight library dial loop that crosses expiry presents the expired credential ZERO times",
       "cell": "an in-flight library dial loop that crosses expiry presents the expired credential ZERO times",
@@ -49,13 +53,13 @@
       "note": "A grace window is the most plausible wrong repair of this defect and the one a reviewer is most likely to wave through, because it still 'checks expiry'. It is wrong because the broker applies none: inside the window the endpoint presents material the broker has already rejected. The named cell mints a cred a few seconds past exp, so it sits inside a 30s grace and goes red on it while the far-past cases stay green."
     },
     {
-      "name": "the empty-supply refusal is replaced by the non-null assertion it removed",
+      "name": "the dial gate tests the cached cred for TRUTHINESS again (an empty credential dials anonymously)",
       "file": "packages/core/src/endpoint.ts",
-      "find": "    if (!this.currentCreds)\n      throw new Error(\"this endpoint has no credential to present yet (the creds source has not returned one) - not dialing without auth material\");\n",
-      "replace": "",
-      "expectRed": "REFUSE: a first fetch that never returned fails loud instead of dialing with no credential",
-      "cell": "REFUSE: a first fetch that never returned fails loud instead of dialing with no credential",
-      "note": "Without the check, credsForWire hands `undefined` to presentableCreds and the failure surfaces as a decode error about malformed credential material rather than as the source failure that caused it. The named cell asserts the ORIGINAL source error reaches the caller, so it reds on the substituted message instead of accepting any throw -- an assertion on 'it threw' would have survived this."
+      "find": "creds: this.currentCreds !== undefined || this.credsSource ? () => this.credsForWire() : undefined",
+      "replace": "creds: this.currentCreds || this.credsSource ? () => this.credsForWire() : undefined",
+      "expectRed": "REFUSE: a STATIC EMPTY creds string fails loud instead of dialing anonymously",
+      "cell": "REFUSE: a STATIC EMPTY creds string fails loud instead of dialing anonymously",
+      "note": "A one-character weakening that reads as a harmless falsiness idiom. Under it an empty creds string is indistinguishable from 'no creds configured', so the endpoint dials with no auth material and the broker answers `Authorization Violation` -- a permissions-shaped error for what is a supply mistake. The named cell asserts BOTH that the refusal names the empty credential AND that the broker's violation text is absent, so a red here cannot be satisfied by any failure that merely happened. Its accepting twin (no creds at all still connects) stays green under this mutation, which is what confines the mutation to the empty case rather than to anonymity."
     }
   ]
 }

--- a/packages/core/smoke/mutations/creds-supply-expiry.json
+++ b/packages/core/smoke/mutations/creds-supply-expiry.json
@@ -1,0 +1,61 @@
+{
+  "suite": [
+    "packages/core/smoke/creds-supply-expiry-auth.smoke.ts"
+  ],
+  "guard": "this endpoint never presents a credential it has already decoded as expired, on ANY path that can reach a broker",
+  "command": "pnpm smoke:creds-supply-expiry",
+  "completionMarker": "CREDS SUPPLY EXPIRY SMOKE",
+  "proveWith": "node scripts/mutation-proof.mjs --config packages/core/smoke/mutations/creds-supply-expiry.json",
+  "why": [
+    "The refusal used to sit inside bindConnection, which only start() and doRebuild reach. That",
+    "covered the endpoint's OWN dial and nothing else, so the reconnects nats.js performs on its own",
+    "read the cache through an unchecked getter and presented whatever was last fetched. Moving the",
+    "refusal onto the SUPPLY is the fix, so the mutations below each sever one path from the",
+    "checkpoint and leave the others intact -- which is what distinguishes this suite from one that",
+    "merely re-proves the old pre-dial guard.",
+    "Each mutation leaves the tree compiling and the other paths correct. A suite that only watched",
+    "the endpoint's own dial would stay GREEN under the first two, because that path never regresses",
+    "in them: it is the library's reconnect and the adoption preflight that start leaking.",
+    "The empty-supply mutation is here because the getter it replaced was a non-null assertion. Under",
+    "it the tree still compiles and still refuses expired creds; what changes is that a first fetch",
+    "which never returned dials with an empty credential instead of failing loud."
+  ],
+  "mutations": [
+    {
+      "name": "the wire getter is unchecked again (the reported defect: internal reconnects read the raw cache)",
+      "file": "packages/core/src/endpoint.ts",
+      "find": "creds: this.currentCreds || this.credsSource ? () => this.credsForWire() : undefined",
+      "replace": "creds: this.credsSource ? () => this.currentCreds! : this.currentCreds",
+      "expectRed": "an in-flight library dial loop that crosses expiry presents the expired credential ZERO times",
+      "cell": "an in-flight library dial loop that crosses expiry presents the expired credential ZERO times",
+      "note": "This restores the exact expression from before the fix, so it reproduces the issue as filed. The checkpoint still exists and the preflight still uses it; only the authenticator handed to nats.js goes back to reading the cache raw. The named cell watches a dial loop that was ALREADY RUNNING when exp passed, which no pre-dial guard can reach, so it grades this mutation on the property the fix actually added."
+    },
+    {
+      "name": "the adoption preflight bypasses the checkpoint and presents the candidate unchecked",
+      "file": "packages/core/src/endpoint.ts",
+      "find": "    const proven = CotalEndpoint.presentableCreds(candidate, { renewable: true });\n",
+      "replace": "    const proven = candidate;\n",
+      "expectRed": "the refused candidate never reaches the broker (no preflight presentation on the wire)",
+      "cell": "the refused candidate never reaches the broker (no preflight presentation on the wire)",
+      "note": "The preflight is the one presentation that does NOT read the cache, so the wire getter cannot cover it: a re-signed generation that is already dead goes to the broker on a disposable connection. The named cell is the one that reads the wire; its sibling REFUSE cell still fails the reload (the broker rejects it) and so cannot distinguish a local refusal from a remote one, which is exactly why the wire cell is the one named here."
+    },
+    {
+      "name": "the expiry comparison is loosened to a strict past-check (a cred expiring THIS instant is presented)",
+      "file": "packages/core/src/endpoint.ts",
+      "find": "    if (typeof exp === \"number\" && exp * 1000 <= Date.now())",
+      "replace": "    if (typeof exp === \"number\" && exp * 1000 <= Date.now() - 30_000)",
+      "expectRed": "REFUSE: a STATIC expired cred is refused and names replacement, not renewal",
+      "cell": "REFUSE: a STATIC expired cred is refused and names replacement, not renewal",
+      "note": "A grace window is the most plausible wrong repair of this defect and the one a reviewer is most likely to wave through, because it still 'checks expiry'. It is wrong because the broker applies none: inside the window the endpoint presents material the broker has already rejected. The named cell mints a cred a few seconds past exp, so it sits inside a 30s grace and goes red on it while the far-past cases stay green."
+    },
+    {
+      "name": "the empty-supply refusal is replaced by the non-null assertion it removed",
+      "file": "packages/core/src/endpoint.ts",
+      "find": "    if (!this.currentCreds)\n      throw new Error(\"this endpoint has no credential to present yet (the creds source has not returned one) - not dialing without auth material\");\n",
+      "replace": "",
+      "expectRed": "REFUSE: a first fetch that never returned fails loud instead of dialing with no credential",
+      "cell": "REFUSE: a first fetch that never returned fails loud instead of dialing with no credential",
+      "note": "Without the check, credsForWire hands `undefined` to presentableCreds and the failure surfaces as a decode error about malformed credential material rather than as the source failure that caused it. The named cell asserts the ORIGINAL source error reaches the caller, so it reds on the substituted message instead of accepting any throw -- an assertion on 'it threw' would have survived this."
+    }
+  ]
+}

--- a/packages/core/smoke/mutations/standing-renewal-expiry.json
+++ b/packages/core/smoke/mutations/standing-renewal-expiry.json
@@ -15,9 +15,7 @@
     "while the guard is absent in two ways: a rebuild that dials before exp presents a cred the",
     "broker still accepts, and a denial that does land can fall outside the slice the cell inspects,",
     "because failedRebuildLogStart only records that the marker fired. Under the mutation that cell",
-    "was observed both red and green on the same machine, and green in CI."
-  ],
-  "anchorNote": [
+    "was observed both red and green on the same machine, and green in CI.",
     "RE-ANCHORED when the refusal moved off the pre-dial path. The block this used to quote lived in",
     "bindConnection and was DELETED, not edited: keeping a copy there would have left the tree with",
     "two expiry checks and let a later dial site miss the one that matters. The equivalent statement",

--- a/packages/core/smoke/mutations/standing-renewal-expiry.json
+++ b/packages/core/smoke/mutations/standing-renewal-expiry.json
@@ -9,13 +9,24 @@
   "why": [
     "The endpoint's pre-connect refresh is deliberately best-effort after the first connection. If",
     "the source is down when the cached cred expires, removing this guard restores the reported",
-    "behavior exactly: connectAndBind presents credential material it has already decoded as expired.",
+    "behavior exactly: the endpoint presents credential material it has already decoded as expired.",
     "The named cell asserts the refusal is raised, so it goes red on the deleted block itself.",
     "The sibling cell counting broker denials cannot grade this mutation. It can read zero denials",
     "while the guard is absent in two ways: a rebuild that dials before exp presents a cred the",
     "broker still accepts, and a denial that does land can fall outside the slice the cell inspects,",
     "because failedRebuildLogStart only records that the marker fired. Under the mutation that cell",
     "was observed both red and green on the same machine, and green in CI."
+  ],
+  "anchorNote": [
+    "RE-ANCHORED when the refusal moved off the pre-dial path. The block this used to quote lived in",
+    "bindConnection and was DELETED, not edited: keeping a copy there would have left the tree with",
+    "two expiry checks and let a later dial site miss the one that matters. The equivalent statement",
+    "is now the throw inside `presentableCreds`, the single checkpoint every presentation routes",
+    "through, so the anchor points at that instead. The named cell is unchanged and still grades the",
+    "same property from this suite's own angle: a REBUILD, after renewal has failed, must refuse",
+    "rather than dial. It reds under the mutation for the same reason it did before -- the refusal",
+    "text it matches exists only inside the removed statement -- so the re-anchor preserves what the",
+    "fixture proved and does not quietly re-point it at unrelated code."
   ],
   "mutations": [
     {
@@ -30,11 +41,11 @@
     {
       "name": "the creds pre-dial expiry guard is removed",
       "file": "packages/core/src/endpoint.ts",
-      "find": "    const credsExp = this.currentCreds && credsClaims(this.currentCreds).exp;\n    if (typeof credsExp === \"number\" && credsExp * 1000 <= Date.now())\n      throw new Error(\n        this.credsSource\n          ? \"this endpoint's creds have expired and renewal is failing - not presenting the expired credential to the broker; retrying with backoff\"\n          : \"this endpoint's creds have expired and it holds no creds source to renew them - replace the credential and rebuild the endpoint (pass a creds FUNCTION for standing renewal)\",\n      );\n",
+      "find": "    if (typeof exp === \"number\" && exp * 1000 <= Date.now())\n      throw new Error(\n        opts.renewable\n          ? \"this endpoint's creds have expired and renewal is failing - not presenting the expired credential to the broker; retrying with backoff\"\n          : \"this endpoint's creds have expired and it holds no creds source to renew them - replace the credential and rebuild the endpoint (pass a creds FUNCTION for standing renewal)\",\n      );\n",
       "replace": "",
       "expectRed": "the pre-dial refusal is loud and names the failing renewal path",
       "cell": "the pre-dial refusal is loud and names the failing renewal path",
-      "note": "Deleting the block is the issue's pre-fix behavior and leaves the tree compiling. The refusal text the named cell matches exists only inside the deleted block, so removing it is what makes the cell red. The suite's own recovery path is unaffected: the source fails twice and then returns."
+      "note": "Deleting the statement is the issue's pre-fix behavior and leaves the tree compiling -- presentableCreds still decodes the claims and still returns the cred, it just stops refusing an expired one. The refusal text the named cell matches exists only inside the removed statement, so removing it is what makes the cell red. The suite's own recovery path is unaffected: the source fails twice and then returns."
     }
   ]
 }

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -843,7 +843,11 @@ export class CotalEndpoint extends EventEmitter {
    *  broker that {@link RETRY_BACKOFF_CAP_MS} exists to prevent. */
   private credsForWire(): string {
     if (!this.currentCreds)
-      throw new Error("this endpoint has no credential to present yet (the creds source has not returned one) - not dialing without auth material");
+      throw new Error(
+        this.credsSource
+          ? "this endpoint has no credential to present yet (the creds source has not returned one) - not dialing without auth material"
+          : "this endpoint was constructed with an empty creds string - not dialing without auth material (an empty credential is not anonymous access)",
+      );
     return CotalEndpoint.presentableCreds(this.currentCreds, { renewable: Boolean(this.credsSource) });
   }
 
@@ -1158,7 +1162,12 @@ export class CotalEndpoint extends EventEmitter {
       // reconnects nats.js performs on its own (the one the broker forces at JWT `exp`, and a dial
       // loop from an earlier drop that crosses `exp` mid-retry) — re-reads a credential that has
       // just been proven unexpired rather than whatever the cache happens to hold.
-      ...authOpts({ token: this.token, user: this.user, pass: this.pass, creds: this.currentCreds || this.credsSource ? () => this.credsForWire() : undefined, bearer: this.userMode ? () => this.currentBearer! : undefined, sentinelCreds: this.sentinelCreds, tls: this.tls }),
+      // The gate is `!== undefined`, NOT truthiness. An EMPTY creds string is a caller that meant to
+      // authenticate and supplied nothing; on a truthiness gate it fell through to `creds: undefined`
+      // and dialed ANONYMOUSLY, so the broker answered `Authorization Violation` and the real fault
+      // (an empty credential) was never named. Routing it into the checked getter fails it loud
+      // instead. Anonymous access stays reachable the only way it should be: by passing no creds.
+      ...authOpts({ token: this.token, user: this.user, pass: this.pass, creds: this.currentCreds !== undefined || this.credsSource ? () => this.credsForWire() : undefined, bearer: this.userMode ? () => this.currentBearer! : undefined, sentinelCreds: this.sentinelCreds, tls: this.tls }),
     });
     this.armAuthExpiryReconnectFence(this.nc);
     this.watchStatus();

--- a/packages/core/src/endpoint.ts
+++ b/packages/core/src/endpoint.ts
@@ -803,6 +803,50 @@ export class CotalEndpoint extends EventEmitter {
    *  (75% of iat→exp), not a fixed margin — standing creds span hours to days, bearers minutes. */
   private static readonly CREDS_RETRY_MS = 60_000;
 
+  /** THE ONE PLACE a credential is cleared for presentation to a broker.
+   *
+   *  The property is unconditional — this endpoint never presents a credential it has already
+   *  decoded as expired — so it is a property of the SUPPLY, not of any one dial site. It used to
+   *  live inside {@link bindConnection}, which only `start()` and `doRebuild` reach; the
+   *  authenticator nats.js re-evaluates on ITS OWN reconnects read the cache directly and so
+   *  presented whatever was last fetched, expired included. Two such reconnects exist and neither
+   *  passes through bindConnection: the one the broker forces at JWT `exp`, and an ALREADY RUNNING
+   *  dial loop from an earlier drop that crosses `exp` while it retries (the pre-expiry
+   *  reconnect fence flips a policy flag nats-core only reads when it observes a NEW drop, so it
+   *  cannot stop a loop already in flight).
+   *
+   *  Putting the refusal here instead means a future caller cannot miss it: the only way to reach a
+   *  dial is through {@link credsForWire}, and the one presentation that does not read the cache
+   *  (the adoption preflight, which presents a fresh CANDIDATE) calls this same function on it.
+   *
+   *  An unbounded credential (no numeric `exp`) is presentable: bounded lifetimes are the renewal
+   *  seam's concern, and a cred with no expiry has none to be past. */
+  private static presentableCreds(creds: string, opts: { renewable: boolean }): string {
+    const { exp } = credsClaims(creds); // throws on a structurally-unusable file (fail-loud)
+    if (typeof exp === "number" && exp * 1000 <= Date.now())
+      throw new Error(
+        opts.renewable
+          ? "this endpoint's creds have expired and renewal is failing - not presenting the expired credential to the broker; retrying with backoff"
+          : "this endpoint's creds have expired and it holds no creds source to renew them - replace the credential and rebuild the endpoint (pass a creds FUNCTION for standing renewal)",
+      );
+    return creds;
+  }
+
+  /** The cached credential, checked. Handed to nats.js as the authenticator's source on EVERY auth
+   *  mode (renewed or static), so each (re)connect attempt — ours or the library's — re-reads a
+   *  CHECKED value. A refusal throws out of the authenticator, which nats-core turns into a closed
+   *  connection rather than a CONNECT carrying dead material; the endpoint's own supervisor then
+   *  rebuilds on capped backoff, and {@link bindConnection} re-fetches from the source on each of
+   *  those attempts, so a renewal that starts working recovers the endpoint without presenting
+   *  anything expired in the meantime. Deliberately side-effect free: kicking the renewal timer
+   *  from here would retry the source once per dial attempt, which is the flat load on a dead
+   *  broker that {@link RETRY_BACKOFF_CAP_MS} exists to prevent. */
+  private credsForWire(): string {
+    if (!this.currentCreds)
+      throw new Error("this endpoint has no credential to present yet (the creds source has not returned one) - not dialing without auth material");
+    return CotalEndpoint.presentableCreds(this.currentCreds, { renewable: Boolean(this.credsSource) });
+  }
+
   /** The disposable-preflight connect bound for the EXPLICIT reload proof (D5 class-2 adoption). A
    *  rogue or unreachable candidate must resolve well UNDER the manager's delivery-admin request
    *  bound, so this stays a few seconds and never blocks the responder. */
@@ -959,7 +1003,13 @@ export class CotalEndpoint extends EventEmitter {
       throw new Error("reloadCreds: re-read credential generation did not match the expected re-signed generation (a different store, or a torn/stale read); nothing adopted");
     // PREFLIGHT = the proof. A disposable connection presenting exactly the candidate BEFORE the live
     // cache is touched; a refused cred throws here, leaving the resident connection untouched.
-    const probe = await probeConnect(this.servers, { creds: candidate, tls: this.tls, timeoutMs: Math.max(500, Math.min(CotalEndpoint.PREFLIGHT_MS, deadline - Date.now())) });
+    // The candidate goes through the SAME checkpoint the resident getter uses: this is the one
+    // presentation that does not read the cache, so routing it here is what makes the refusal a
+    // property of every path rather than of the cached one. An already-dead re-signed generation is
+    // refused locally instead of spending a round trip to be told so, and — because this throws
+    // BEFORE the commit below — it can never become the resident connection's next-presented cred.
+    const proven = CotalEndpoint.presentableCreds(candidate, { renewable: true });
+    const probe = await probeConnect(this.servers, { creds: proven, tls: this.tls, timeoutMs: Math.max(500, Math.min(CotalEndpoint.PREFLIGHT_MS, deadline - Date.now())) });
     if (!probe.ok)
       throw new Error(`reloadCreds: the broker did not accept the re-signed credential (${probe.reason}); nothing adopted`);
     if (Date.now() > deadline)
@@ -1082,13 +1132,13 @@ export class CotalEndpoint extends EventEmitter {
           ? "this endpoint's user bearer has expired and renewal through the auth exchange is failing - not presenting the expired token to the broker; retrying with backoff"
           : "this endpoint's user bearer has expired and it holds no bearer source to renew it - re-authenticate and rebuild the endpoint (construct it with a bearer FUNCTION for standing renewal)",
       );
-    const credsExp = this.currentCreds && credsClaims(this.currentCreds).exp;
-    if (typeof credsExp === "number" && credsExp * 1000 <= Date.now())
-      throw new Error(
-        this.credsSource
-          ? "this endpoint's creds have expired and renewal is failing - not presenting the expired credential to the broker; retrying with backoff"
-          : "this endpoint's creds have expired and it holds no creds source to renew them - replace the credential and rebuild the endpoint (pass a creds FUNCTION for standing renewal)",
-      );
+    // The CREDS refusal is NOT repeated here. It lives on the supply itself ({@link credsForWire}),
+    // which the authenticator below re-reads per attempt, so it covers this dial AND the reconnects
+    // nats.js runs on its own. Raising it early here too would only duplicate it on the one path
+    // that was already covered, and a fourth dial site added later would silently miss the copy.
+    // The refusal still surfaces on this path: the authenticator throws during the CONNECT, the
+    // library closes that attempt, and the reestablish loop's capped backoff re-enters here — where
+    // the source re-fetch above is what recovers a renewable endpoint.
     this.nc = await dialerFor(this.servers)({
       servers: this.servers,
       // In USER MODE the connection `name` carries the client-chosen inbox nonce (= connId) the callout
@@ -1104,9 +1154,11 @@ export class CotalEndpoint extends EventEmitter {
       inboxPrefix: `_INBOX_${this.connId}`,
       // The bearer rides a GETTER: nats.js re-evaluates the token authenticator per (re)connect
       // attempt, so internal reconnects present whatever refreshBearer last fetched.
-      // Creds likewise ride a GETTER when a source renews them, so internal reconnects (incl. the
-      // one the broker forces at JWT `exp`) present whatever refreshCreds last fetched.
-      ...authOpts({ token: this.token, user: this.user, pass: this.pass, creds: this.credsSource ? () => this.currentCreds! : this.currentCreds, bearer: this.userMode ? () => this.currentBearer! : undefined, sentinelCreds: this.sentinelCreds, tls: this.tls }),
+      // Creds ALWAYS ride the CHECKED getter, renewed or static, so every attempt — including the
+      // reconnects nats.js performs on its own (the one the broker forces at JWT `exp`, and a dial
+      // loop from an earlier drop that crosses `exp` mid-retry) — re-reads a credential that has
+      // just been proven unexpired rather than whatever the cache happens to hold.
+      ...authOpts({ token: this.token, user: this.user, pass: this.pass, creds: this.currentCreds || this.credsSource ? () => this.credsForWire() : undefined, bearer: this.userMode ? () => this.currentBearer! : undefined, sentinelCreds: this.sentinelCreds, tls: this.tls }),
     });
     this.armAuthExpiryReconnectFence(this.nc);
     this.watchStatus();


### PR DESCRIPTION
## What was wrong

The endpoint refused to present an expired credential, but the refusal lived inside its own connect path, which only `start()` and a rebuild reach. The authenticator handed to the NATS client read the credential cache raw, so every reconnect the client performed **on its own** presented whatever was last fetched, expired included. The check was written as a property of one dial site; it needed to be a property of the supply.

Reproduced first-hand on unmodified `main`, with the pre-dial guard present and firing:

```
cid:90 - User JWT no longer valid: &{Issues:[claim is expired]}
```

There is a pre-expiry reconnect fence on `main` already, and it covers the simple case. It cannot cover this one: it flips a policy flag the client only re-reads when it observes a **new** drop, so a dial loop already retrying from an earlier drop keeps going and re-evaluates the authenticator after expiry.

## Paths that can put a credential on the wire

Three, and the fix covers each by construction rather than by adding a guard to each:

1. **The endpoint's own dial.** Goes through the checked getter.
2. **Reconnects the NATS client performs internally** — two distinct kinds: the one the broker forces at JWT `exp`, and an in-flight dial loop from an earlier drop that crosses `exp` mid-retry. Both re-read the same checked getter per attempt.
3. **The adoption preflight** on an explicit credential reload. This is the one presentation that does not read the cache, since it presents a fresh candidate, so it calls the checkpoint on that candidate directly.

The old pre-dial block was **deleted**, not kept alongside. Keeping it would have left two expiry checks and let a fourth dial site added later miss the one that matters.

Static credentials are now checked too, where before only renewing ones were.

## The refusal fails closed, not dead

A renewable endpoint keeps retrying on capped backoff and re-fetches from its source on each attempt, so it recovers by itself once renewal starts working. One cell asserts exactly that, because a refusal that wedges the endpoint permanently would pass every "presents zero expired creds" assertion while being worse than the defect.

## A second hole, found by a surviving mutation

A mutation aimed at the empty-cache branch **SURVIVED**. The cell covering it proved the first fetch rethrows, which happens before the getter is consulted, so the branch was never graded. Probing it directly found the dial gate testing the cached credential for *truthiness*: an empty creds string took the same path as "no creds configured", so the endpoint dialed **anonymously** and the broker answered `Authorization Violation` — a permissions-shaped error for what is a supply mistake, with the caller's actual error never named.

Both were fixed. The gate is now `!== undefined`, and the mutation targets that gate. Passing no creds at all still connects, which is the accepting twin that keeps the refusal about empty credentials rather than about anonymity.

## Proof

New suite `smoke:creds-supply-expiry`, 22 cells, wired into CI.

**Pre-fix control.** Run in a separate clone at the base commit with `git diff --stat HEAD -- packages/core/src/` **empty**, only the new suite copied in. 4 cells red, the rest green:

- the in-flight dial loop crossing expiry
- the expired reload candidate being refused, and not reaching the broker
- the empty static credential (fails with the raw `Authorization Violation`)

Red **4/4 consecutive runs** pre-fix, green **3/3** post-fix. The first version of this probe reproduced only intermittently; the offsets were calibrated by sweeping the drop/restart window against the unfixed tree until it was deterministic, because a control that only sometimes goes red proves nothing.

**Non-vacuity.** Section A carries four CONTROL cells: the transport dropped *before* expiry, the broker returned *after* it, renewal stayed down throughout, and the dial loop *did* reach the broker in the observation window. Without the last one a zero could mean "refused" or "nothing dialed at all", which are opposite conclusions.

**Accepting and refusing cases.** The checkpoint has **2 refusing branches** (expired, empty) and **2 accepting branches** (no `exp` claim, live `exp`). Covered by **4 refusing cells and 4 accepting cells**, each refusing case paired with a twin differing only in context: expired vs. live candidate on the same reload path; expired static vs. unbounded static; empty creds vs. no creds. A further 8 cells assert non-presentation on the wire or the surrounding controls, for 22 total.

**Mutation fixtures** — 4 added, all proven KILLED first-hand, each severing one path from the checkpoint while leaving the others correct:

| mutation | result |
|---|---|
| the wire getter is unchecked again (reproduces the issue as filed) | KILLED |
| the adoption preflight bypasses the checkpoint | KILLED |
| the expiry comparison is loosened to a 30s grace window | KILLED |
| the dial gate tests truthiness again | KILLED |

The grace-window mutation is there because it is the most plausible *wrong* repair: it still "checks expiry" and reads as reasonable, but the broker applies no grace, so inside the window the endpoint presents material the broker has already rejected.

**A detector bug, found by measuring.** The broker's rejection line names neither the client nor its nkey, because it refuses the CONNECT before adopting either. The detector was identity-filtering that shape and so discarded the exact evidence, reading clean against a tree that was leaking. Fixed and re-validated against the unfixed tree. Separately, `Authentication Expired` on a connection the broker *admitted* is excluded: that line is the designed backstop retiring a live connection, and counting it would make the cell red on correct behaviour.

**A rotted anchor, repaired.** `standing-renewal-expiry.json` anchored on the deleted block verbatim and would have degraded to ERROR. Re-anchored onto the equivalent statement in the checkpoint, named cell unchanged, both its mutations re-proven KILLED.

Also green: `smoke:standing-renewal` (12), `smoke:cred-lifetime` (18), `smoke:mutation-fixtures` (2200 anchors, 0 dead), `smoke:ci-suites` (25), the `reconnect-fence-close` and `credential-expiry-reconnect` fixtures, `pnpm typecheck` across the workspace, and the core build.

Refs #1411
