### PR TITLE
fail mutation reproof when selected fixtures discriminate nothing

### DIFF
--- a/.changeset/reproof-discrimination-floor.md
+++ b/.changeset/reproof-discrimination-floor.md
@@ -1,0 +1,4 @@
+---
+---
+
+A mutation reproof all-clear now requires at least one discriminated fixture among the configs it actually proved, and names those configs when it discriminated none.

--- a/bin/smoke/mutation-reproof.smoke.ts
+++ b/bin/smoke/mutation-reproof.smoke.ts
@@ -105,6 +105,16 @@ const zeroDiscUnable = (out: string): string[] => {
   return m ? m[1].split(", ") : [];
 };
 /**
+ * Parse the ORDINARY arm's trailing attribution clause. It needs its own parser: `zeroDiscUnable`
+ * requires the literal `, COULD NOT`, so asking it about an ordinary banner returns empty whether
+ * the clause is present or absent, and an assertion built on that is vacuously true. Deleting the
+ * clause from the emit left the whole suite green until this parser existed.
+ */
+const zeroDiscNotAttributable = (out: string): string[] => {
+  const m = out.match(/^MUTATION REPROOF ZERO DISCRIMINATED \(.*; not attributable to \(could not discriminate\): (.+)$/m);
+  return m ? m[1].split(", ") : [];
+};
+/**
  * Vacuous all-clear refused where NO proven fixture could have killed: pre-red, inconclusive or
  * zero-graded. Still a red, but attributed to the unit's composition rather than to a fixture that
  * was never in a position to produce a kill, and never collapsed into SURVIVED/FAILED.
@@ -1807,9 +1817,19 @@ try {
         && /MUTATION REPROOF ZERO DISCRIMINATED \(/.test(out)
         && !out.includes("ZERO DISCRIMINATED, COULD NOT")
         && zeroDiscExpected(out).includes("smoke/mutations/e.mutations.json")
-        && zeroDiscUnable(out).length === 0
         && !out.includes("MUTATION REPROOF OK"),
-      `status=${status} expected=${JSON.stringify(zeroDiscExpected(out))} unable=${JSON.stringify(zeroDiscUnable(out))}\n${out}`,
+      `status=${status} expected=${JSON.stringify(zeroDiscExpected(out))}\n${out}`,
+    );
+    // The ordinary arm also has to SAY which fixtures it is not blaming, and that clause needs a
+    // parser of its own: asking the COULD NOT parser returns empty for an ordinary banner whether
+    // the clause is there or not, so an emptiness assertion would pass with the clause deleted.
+    // Assert the positive content instead, and assert the two lists are disjoint, since a fixture
+    // cannot both have been expected to kill and have been unable to.
+    check(
+      "the ordinary arm names the fixtures it is not attributing the miss to, disjoint from the ones it expected",
+      eq(zeroDiscNotAttributable(out), ["smoke/mutations/q.mutations.json"])
+        && !zeroDiscNotAttributable(out).some((path) => zeroDiscExpected(out).includes(path)),
+      `expected=${JSON.stringify(zeroDiscExpected(out))} notAttributable=${JSON.stringify(zeroDiscNotAttributable(out))}\n${out}`,
     );
   }
   {
@@ -2312,6 +2332,25 @@ check(
 check(
   "an ordinary ZERO DISCRIMINATED banner mints no COULD NOT configs",
   zeroDiscUnable("MUTATION REPROOF ZERO DISCRIMINATED (0 of 1 proven fixture(s) discriminated; required 1 from the selected configs), expected a kill from: smoke/mutations/c.mutations.json\n").length === 0,
+);
+// The attribution clause on the ORDINARY arm, and its REFUSING twin differing only in whether the
+// clause is present. The emptiness half alone would be satisfied by a parser that never matches,
+// which is exactly how the clause went untested: the COULD NOT parser answered "absent" for every
+// ordinary banner, so an assertion that it was empty could not fail.
+check(
+  "the ordinary arm's attribution clause is parsed and stops at the clause it introduces",
+  eq(
+    zeroDiscNotAttributable("MUTATION REPROOF ZERO DISCRIMINATED (0 of 2 proven fixture(s) discriminated; required 1 from the selected configs), expected a kill from: smoke/mutations/d.mutations.json; not attributable to (could not discriminate): smoke/mutations/p.mutations.json, smoke/mutations/r.mutations.json\n"),
+    ["smoke/mutations/p.mutations.json", "smoke/mutations/r.mutations.json"],
+  ),
+);
+check(
+  "an ordinary banner carrying no attribution clause mints no not-attributable configs",
+  zeroDiscNotAttributable("MUTATION REPROOF ZERO DISCRIMINATED (0 of 1 proven fixture(s) discriminated; required 1 from the selected configs), expected a kill from: smoke/mutations/c.mutations.json\n").length === 0,
+);
+check(
+  "the COULD NOT arm's own list is not read as an ordinary attribution clause",
+  zeroDiscNotAttributable("MUTATION REPROOF ZERO DISCRIMINATED, COULD NOT (0 of 1 proven fixture(s) discriminated; required 1 from the selected configs). No proven fixture here was in a position to kill: every one was pre-red, inconclusive, or graded nothing, so this unit obtained no verdict and cannot stand as an all-clear. Not attributable to any fixture below; re-shard or repair the already-red commands: smoke/mutations/p.mutations.json\n").length === 0,
 );
 check(
   "a COULD NOT banner names the fixtures that were never in a position to kill",

--- a/bin/smoke/mutation-reproof.smoke.ts
+++ b/bin/smoke/mutation-reproof.smoke.ts
@@ -101,7 +101,7 @@ const zeroDiscExpected = (out: string): string[] => {
 };
 /** Parse configs named by the COULD NOT arm: present, but never in a position to kill. */
 const zeroDiscUnable = (out: string): string[] => {
-  const m = out.match(/^MUTATION REPROOF ZERO DISCRIMINATED — COULD NOT .*re-shard or repair the already-red commands: (.+)$/m);
+  const m = out.match(/^MUTATION REPROOF ZERO DISCRIMINATED, COULD NOT .*re-shard or repair the already-red commands: (.+)$/m);
   return m ? m[1].split(", ") : [];
 };
 /**
@@ -1651,8 +1651,8 @@ try {
   }
   // 23e. The floor's question is corpus-shaped but its scope is the unit it runs in. Under the
   //     sharded fan-out a shard can draw ONLY work that cannot discriminate, while the corpus as a
-  //     whole kills. That still reds — a unit with no verdict has not earned an all-clear, and
-  //     exempting an all-PRE-RED set is the exact vacuity #1347 is about — but it must not blame a
+  //     whole kills. That still reds, because a unit with no verdict has not earned an all-clear
+  //     and exempting an all-PRE-RED set is the exact vacuity #1347 is about, but it must not blame a
   //     fixture that was never in a position to kill. Same corpus, two shards, opposite outcomes.
   {
     const { root } = makeSingle(
@@ -1680,7 +1680,7 @@ try {
     check(
       "a shard holding only an inherited pre-red fixture reds as COULD NOT without blaming that fixture",
       preRedShard.status === 1
-        && preRedShard.out.includes("MUTATION REPROOF ZERO DISCRIMINATED — COULD NOT")
+        && preRedShard.out.includes("MUTATION REPROOF ZERO DISCRIMINATED, COULD NOT")
         && preRedShard.out.includes("re-shard or repair the already-red commands: smoke/mutations/p.mutations.json")
         && !/expected a kill from/.test(preRedShard.out),
       `status=${preRedShard.status}\n${preRedShard.out}`,
@@ -2177,7 +2177,7 @@ check(
 
 check(
   "a ZERO DISCRIMINATED banner names the configs it expected to kill",
-  eq(zeroDiscExpected("MUTATION REPROOF ZERO DISCRIMINATED (0 of 1 proven fixture(s) discriminated; required 1 from the selected configs) — expected a kill from: smoke/mutations/c.mutations.json\n"), ["smoke/mutations/c.mutations.json"]),
+  eq(zeroDiscExpected("MUTATION REPROOF ZERO DISCRIMINATED (0 of 1 proven fixture(s) discriminated; required 1 from the selected configs), expected a kill from: smoke/mutations/c.mutations.json\n"), ["smoke/mutations/c.mutations.json"]),
 );
 check(
   "a prose mention of ZERO DISCRIMINATED does not mint expected configs",
@@ -2188,7 +2188,7 @@ check(
 check(
   "the expected-kill list stops before the not-attributable tail",
   eq(
-    zeroDiscExpected("MUTATION REPROOF ZERO DISCRIMINATED (0 of 2 proven fixture(s) discriminated; required 1 from the selected configs) — expected a kill from: smoke/mutations/d.mutations.json; not attributable to (could not discriminate): smoke/mutations/p.mutations.json\n"),
+    zeroDiscExpected("MUTATION REPROOF ZERO DISCRIMINATED (0 of 2 proven fixture(s) discriminated; required 1 from the selected configs), expected a kill from: smoke/mutations/d.mutations.json; not attributable to (could not discriminate): smoke/mutations/p.mutations.json\n"),
     ["smoke/mutations/d.mutations.json"],
   ),
 );
@@ -2196,12 +2196,12 @@ check(
 // run that DID have a fixture able to kill can never be read as one that could not.
 check(
   "an ordinary ZERO DISCRIMINATED banner mints no COULD NOT configs",
-  zeroDiscUnable("MUTATION REPROOF ZERO DISCRIMINATED (0 of 1 proven fixture(s) discriminated; required 1 from the selected configs) — expected a kill from: smoke/mutations/c.mutations.json\n").length === 0,
+  zeroDiscUnable("MUTATION REPROOF ZERO DISCRIMINATED (0 of 1 proven fixture(s) discriminated; required 1 from the selected configs), expected a kill from: smoke/mutations/c.mutations.json\n").length === 0,
 );
 check(
   "a COULD NOT banner names the fixtures that were never in a position to kill",
   eq(
-    zeroDiscUnable("MUTATION REPROOF ZERO DISCRIMINATED — COULD NOT (0 of 1 proven fixture(s) discriminated; required 1 from the selected configs). No proven fixture here was in a position to kill: every one was pre-red, inconclusive, or graded nothing, so this unit obtained no verdict and cannot stand as an all-clear. Not attributable to any fixture below; re-shard or repair the already-red commands: smoke/mutations/p.mutations.json\n"),
+    zeroDiscUnable("MUTATION REPROOF ZERO DISCRIMINATED, COULD NOT (0 of 1 proven fixture(s) discriminated; required 1 from the selected configs). No proven fixture here was in a position to kill: every one was pre-red, inconclusive, or graded nothing, so this unit obtained no verdict and cannot stand as an all-clear. Not attributable to any fixture below; re-shard or repair the already-red commands: smoke/mutations/p.mutations.json\n"),
     ["smoke/mutations/p.mutations.json"],
   ),
 );

--- a/bin/smoke/mutation-reproof.smoke.ts
+++ b/bin/smoke/mutation-reproof.smoke.ts
@@ -1579,6 +1579,59 @@ try {
       `status=${status}\n${out}`,
     );
   }
+  // 23c. The floor must be satisfiable only by an OBSERVED kill, not by a bare exit 0. A fixture
+  //     whose `mutations` array is empty makes mutation-proof print "All 0 mutation(s) killed" and
+  //     exit 0, which would earn a free discrimination credit and hold the floor up for a corpus
+  //     that killed nothing. Two independent guards: the corpus refuses to admit such a fixture,
+  //     and the floor refuses to credit an exit 0 with no KILLED parsed. Each is proven separately
+  //     so neither can be shadowed by the other.
+  {
+    const { root } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "k.mjs"), "export const k = () => 1;\n");
+        writeFileSync(join(r, "suites", "k.suite.mjs"), "import { k } from '../k.mjs';\nif (k() !== 1) { console.error('✗ FAIL: k is one'); process.exit(1); }\nconsole.log('✓ k is one');\n");
+        writeFileSync(join(r, "smoke", "mutations", "k.mutations.json"), JSON.stringify({
+          suite: ["suites/k.suite.mjs"], command: "node suites/k.suite.mjs", mutations: [],
+        }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "head-note"), "head\n"),
+    );
+    const { status, out } = scanAll(root);
+    check(
+      "a fixture with an empty mutations array is refused by the corpus instead of grading nothing",
+      status === 1
+        && out.includes("mutation reproof: UNMEASURED — 1 malformed fixture(s)")
+        && out.includes("\"mutations\" array is empty")
+        && out.includes("smoke/mutations/k.mutations.json")
+        && !out.includes("MUTATION REPROOF OK"),
+      `status=${status}\n${out}`,
+    );
+  }
+  // 23d. REFUSING contrast to 23c, differing only by the array having one member: an otherwise
+  //     identical fixture with a real mutation is admitted and discriminates.
+  {
+    const { root } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "k.mjs"), "export const k = () => 1;\n");
+        writeFileSync(join(r, "suites", "k.suite.mjs"), "import { k } from '../k.mjs';\nif (k() !== 1) { console.error('✗ FAIL: k is one'); process.exit(1); }\nconsole.log('✓ k is one');\n");
+        writeFileSync(join(r, "smoke", "mutations", "k.mutations.json"), JSON.stringify({
+          suite: ["suites/k.suite.mjs"], command: "node suites/k.suite.mjs", mutations: [{
+            name: "k stops returning one", file: "k.mjs", find: "export const k = () => 1;",
+            replace: "export const k = () => 2;", expectRed: "k is one",
+          }],
+        }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "head-note"), "head\n"),
+    );
+    const { status, out } = scanAll(root);
+    check(
+      "the same fixture carrying one real mutation is admitted and discriminates",
+      status === 0
+        && /MUTATION REPROOF OK \(1 fixture\(s\) selected; 1 discriminated/.test(out)
+        && !out.includes("ZERO GRADED"),
+      `status=${status}\n${out}`,
+    );
+  }
   {
     const { root } = makeSingle(
       (r) => {

--- a/bin/smoke/mutation-reproof.smoke.ts
+++ b/bin/smoke/mutation-reproof.smoke.ts
@@ -94,6 +94,16 @@ const okCounts = (out: string): { discriminated: number; preRed: number; inconcl
   const m = out.match(/MUTATION REPROOF OK \(\d+ fixture\(s\) selected; (\d+) discriminated, (\d+) inherited pre-red, 0 attributable pre-red, 0 unmeasured pre-red, (\d+) inconclusive\)/);
   return m ? { discriminated: Number(m[1]), preRed: Number(m[2]), inconclusive: Number(m[3]) } : null;
 };
+/** Parse configs the zero-discrimination floor named as expected kills. */
+const zeroDiscExpected = (out: string): string[] => {
+  const m = out.match(/^MUTATION REPROOF ZERO DISCRIMINATED .*expected a kill from: (.+)$/m);
+  return m ? m[1].split(", ") : [];
+};
+/** Vacuous all-clear: proven configs, zero kills, named, not collapsed into SURVIVED/FAILED. */
+const floorRed = (out: string, paths: string[]): boolean =>
+  eq(zeroDiscExpected(out), paths)
+  && !out.includes("MUTATION REPROOF OK")
+  && !/^MUTATION REPROOF FAILED /m.test(out);
 
 const networkSetupEnv = (): NodeJS.ProcessEnv => {
   const env = childEnv();
@@ -1053,12 +1063,12 @@ try {
     );
     const { status, out } = scan(root, base, head);
     check(
-      "an unchanged pre-red suite selected only by a guarded-source change remains nonfatal",
-      status === 0
+      "an unchanged pre-red suite selected only by a guarded-source change remains PRE-RED and fails the zero-discrimination floor",
+      status === 1
         && eq(selectedPaths(out), ["smoke/mutations/p.mutations.json"])
         && eq(preRedPaths(out), ["smoke/mutations/p.mutations.json"])
         && attributablePreRedPaths(out).length === 0
-        && JSON.stringify(okCounts(out)) === JSON.stringify({ discriminated: 0, preRed: 1, inconclusive: 0 }),
+        && floorRed(out, ["smoke/mutations/p.mutations.json"]),
       `status=${status} selected=${JSON.stringify(selectedPaths(out))} preRed=${JSON.stringify(preRedPaths(out))} attributable=${JSON.stringify(attributablePreRedPaths(out))} counts=${JSON.stringify(okCounts(out))}\n${out}`,
     );
   }
@@ -1089,8 +1099,8 @@ try {
     );
     const { status, out } = scan(root, base, head);
     check(
-      "an untouched already-red per-mutation command stays nonfatal when only the declared GREEN suite changed",
-      status === 0
+      "an untouched already-red per-mutation command stays PRE-RED when only the declared GREEN suite changed",
+      status === 1
         && eq(preRedPaths(out), ["smoke/mutations/a.mutations.json"])
         && attributablePreRedPaths(out).length === 0
         && !out.includes("suite: suites/a.suite.mjs"),
@@ -1155,7 +1165,7 @@ try {
     const { status, out } = scan(root, base, installedHead);
     check(
       "a dist-backed inherited red command is comparable after the disposable base performs its own install and build",
-      status === 0
+      status === 1
         && eq(preRedPaths(out), ["smoke/mutations/built.mutations.json"])
         && !/ERR_MODULE_NOT_FOUND|MODULE_NOT_FOUND/.test(out),
       `status=${status} preRed=${JSON.stringify(preRedPaths(out))}\n${out}`,
@@ -1239,7 +1249,7 @@ try {
     });
     check(
       "prepared snapshots scrub head-only PATH and NODE_PATH entries while preserving pnpm and nats-server",
-      status === 0 && !out.includes("HEAD_SENTINEL_REACHED") && !out.includes("pnpm missing") && !out.includes("nats-server missing"),
+      status === 1 && !out.includes("HEAD_SENTINEL_REACHED") && !out.includes("pnpm missing") && !out.includes("nats-server missing") && eq(preRedPaths(out), ["smoke/mutations/sentinel.mutations.json"]),
       `status=${status}\n${out}`,
     );
   }
@@ -1291,7 +1301,7 @@ try {
       (r) => writeFileSync(join(r, "state.mjs"), "// select\nexport const state = 1;\n"),
     );
     const { status, out } = scan(root, base, head);
-    check("head and base run every command in the same order before comparing stateful red output", status === 0 && out.includes("base RED (exit 1) -> head RED (exit 1)") && !out.includes("B saw NO marker"), `status=${status}\n${out}`);
+    check("head and base run every command in the same order before comparing stateful red output", status === 1 && out.includes("base RED (exit 1) -> head RED (exit 1)") && !out.includes("B saw NO marker") && eq(preRedPaths(out), ["smoke/mutations/state.mutations.json"]), `status=${status}\n${out}`);
   }
 
   // 18. Failure signatures retain first-party file/function origin, ignore line/column displacement,
@@ -1323,7 +1333,7 @@ try {
   );
   {
     const { root, base, head } = stackRepo("line"); const { status, out } = scan(root, base, head);
-    check("an uncaught throw shifted only by line and column remains inherited", status === 0 && eq(preRedPaths(out), ["smoke/mutations/stack.mutations.json"]), `status=${status}\n${out}`);
+    check("an uncaught throw shifted only by line and column remains inherited", status === 1 && eq(preRedPaths(out), ["smoke/mutations/stack.mutations.json"]), `status=${status}\n${out}`);
   }
   {
     const { root, base, head } = stackRepo("file"); const { status, out } = scan(root, base, head);
@@ -1335,7 +1345,7 @@ try {
   }
   {
     const { root, base, head } = stackRepo("line", true); const { status, out } = scan(root, base, head);
-    check("a caught throw shifted only by line and column remains inherited", status === 0 && eq(preRedPaths(out), ["smoke/mutations/stack.mutations.json"]), `status=${status}\n${out}`);
+    check("a caught throw shifted only by line and column remains inherited", status === 1 && eq(preRedPaths(out), ["smoke/mutations/stack.mutations.json"]), `status=${status}\n${out}`);
   }
   {
     const { root, base, head } = stackRepo("file", true); const { status, out } = scan(root, base, head);
@@ -1351,7 +1361,7 @@ try {
   }
   {
     const { root, base, head } = stackRepo("loader"); const { status, out } = scan(root, base, head);
-    check("clone-local dependency and loader frame differences do not change a first-party failure signature", status === 0 && eq(preRedPaths(out), ["smoke/mutations/stack.mutations.json"]), `status=${status}\n${out}`);
+    check("clone-local dependency and loader frame differences do not change a first-party failure signature", status === 1 && eq(preRedPaths(out), ["smoke/mutations/stack.mutations.json"]), `status=${status}\n${out}`);
   }
   {
     const { root, base, head } = stackRepo("semantic-number"); const { status, out } = scan(root, base, head);
@@ -1415,7 +1425,7 @@ try {
     // Without a DIFFER arm, dropping the carrier makes every MATCH arm pass for the wrong reason.
     check(`a different external ${kind} file remains attributable`, fileRun.status === 1 && unmeasuredPreRedPaths(fileRun.out).length === 1, fileRun.out);
     const line = externalOriginRepo(kind, "line"); const lineRun = scan(line.root, line.base, line.head);
-    check(`an external ${kind} line shift remains inherited`, lineRun.status === 0 && eq(preRedPaths(lineRun.out), ["smoke/mutations/external.mutations.json"]), lineRun.out);
+    check(`an external ${kind} line shift remains inherited`, lineRun.status === 1 && eq(preRedPaths(lineRun.out), ["smoke/mutations/external.mutations.json"]), lineRun.out);
   }
 
   const scratchOriginRepo = (variant: "same" | "file", symlinked = false): { root: string; base: string; head: string; env?: NodeJS.ProcessEnv } => {
@@ -1448,7 +1458,7 @@ try {
   };
   for (const symlinked of [false, true]) {
     const same = scratchOriginRepo("same", symlinked); const sameRun = scan(same.root, same.base, same.head, same.env);
-    check(`${symlinked ? "raw and resolved temp spellings" : "per-run temp directories"} collapse the randomized segment`, sameRun.status === 0 && eq(preRedPaths(sameRun.out), ["smoke/mutations/scratch.mutations.json"]), sameRun.out);
+    check(`${symlinked ? "raw and resolved temp spellings" : "per-run temp directories"} collapse the randomized segment`, sameRun.status === 1 && eq(preRedPaths(sameRun.out), ["smoke/mutations/scratch.mutations.json"]), sameRun.out);
     const file = scratchOriginRepo("file", symlinked); const fileRun = scan(file.root, file.base, file.head, file.env);
     // P5b is the other sole guard, with P1a above, against erasing external origins entirely.
     check(`a different file within ${symlinked ? "a symlinked temp root" : "per-run temp directories"} remains attributable`, fileRun.status === 1 && unmeasuredPreRedPaths(fileRun.out).length === 1, fileRun.out);
@@ -1489,7 +1499,7 @@ try {
       (r) => writeFileSync(join(r, "dep.mjs"), "export const suffix = 'peer';\n"),
     );
     const { status, out } = scan(root, base, head);
-    check("dependency-origin source headers with divergent .pnpm layouts remain inherited", status === 0 && eq(preRedPaths(out), ["smoke/mutations/dep.mutations.json"]), `status=${status}\n${out}`);
+    check("dependency-origin source headers with divergent .pnpm layouts remain inherited", status === 1 && eq(preRedPaths(out), ["smoke/mutations/dep.mutations.json"]), `status=${status}\n${out}`);
   }
 
   // 22. A fixture and red command introduced only at head have no runnable base command. That is not
@@ -1537,12 +1547,36 @@ try {
     );
     const { status, out } = scanAll(root);
     check(
-      "--all keeps every pre-red nonfatal because no base transition can be measured",
-      status === 0
+      "--all keeps every pre-red as PRE-RED (not attributable) and reds the zero-discrimination floor naming the config",
+      status === 1
         && eq(preRedPaths(out), ["smoke/mutations/all.mutations.json"])
         && attributablePreRedPaths(out).length === 0
-        && unmeasuredPreRedPaths(out).length === 0,
+        && unmeasuredPreRedPaths(out).length === 0
+        && floorRed(out, ["smoke/mutations/all.mutations.json"]),
       `status=${status} preRed=${JSON.stringify(preRedPaths(out))}\n${out}`,
+    );
+  }
+  {
+    const { root } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "d.mjs"), "export function cap(input) {\n  return Math.min(input, 32);\n}\n");
+        writeFileSync(join(r, "suites", "d.suite.mjs"), "import { cap } from '../d.mjs';\nif (cap(100) !== 32) { console.error('✗ FAIL: the d cap holds'); process.exit(1); }\nconsole.log('✓ the d cap holds');\n");
+        writeFileSync(join(r, "smoke", "mutations", "d.mutations.json"), JSON.stringify({
+          suite: ["suites/d.suite.mjs"], command: "node suites/d.suite.mjs", mutations: [{
+            name: "the d cap is removed", file: "d.mjs", find: "  return Math.min(input, 32);",
+            replace: "  return input;", expectRed: "the d cap holds",
+          }],
+        }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "head-note"), "head\n"),
+    );
+    const { status, out } = scanAll(root);
+    check(
+      "a --all sweep that kills one fixture reaches OK with discriminated 1",
+      status === 0
+        && /MUTATION REPROOF OK \(1 fixture\(s\) selected; 1 discriminated/.test(out)
+        && offenderPaths(out).length === 0,
+      `status=${status}\n${out}`,
     );
   }
   {
@@ -1566,7 +1600,7 @@ try {
     else process.env.COTAL_MUTATION_REPROOF_SENTINEL = previous;
     if (previousNodeOptions === undefined) delete process.env.NODE_OPTIONS;
     else process.env.NODE_OPTIONS = previousNodeOptions;
-    check("the --all scan child strips parent COTAL_ material through the shared ambient-env chokepoint", status === 0 && !out.includes("COTAL_SCAN_PROCESS_LEAKED") && !out.includes("COTAL ambient leaked"), `status=${status}\n${out}`);
+    check("the --all scan child strips parent COTAL_ material through the shared ambient-env chokepoint", status === 1 && !out.includes("COTAL_SCAN_PROCESS_LEAKED") && !out.includes("COTAL ambient leaked") && floorRed(out, ["smoke/mutations/ambient.mutations.json"]), `status=${status}\n${out}`);
   }
   {
     const { root, base, head } = makeSingle(
@@ -1651,9 +1685,8 @@ try {
 
   // 18. INCONCLUSIVE (not a timeout — deterministic): a mutation that leaves the suite exiting 0 but
   //    never printing its named assertion. mutation-proof grades that INCONCLUSIVE, "a green status
-  //    is not a pass". The gate must report it as INCONCLUSIVE, not fail, and NOT collapse it into
-  //    SURVIVED (false blocker) or KILLED (false clearance). This is the outcome the reviewer flagged
-  //    as most likely to be lost, so it is proven with a real verdict rather than asserted.
+  //    is not a pass". The gate must still REPORT it as INCONCLUSIVE (not SURVIVED, not FAILED), and
+  //    the discrimination floor must RED the run for naming that config: zero kills is not an all-clear.
   {
     const { root, base, head } = makeSingle(
       (r) => {
@@ -1681,12 +1714,58 @@ try {
     );
     const { status, out } = scan(root, base, head);
     check(
-      "an INCONCLUSIVE proof is reported as INCONCLUSIVE, does NOT fail the gate, and is not treated as SURVIVED",
-      status === 0
+      "an INCONCLUSIVE proof is reported as INCONCLUSIVE, fails the zero-discrimination floor naming the config, and is not treated as SURVIVED",
+      status === 1
         && eq(inconclusivePaths(out), ["smoke/mutations/c.mutations.json"])
         && offenderPaths(out).length === 0
-        && JSON.stringify(okCounts(out)) === JSON.stringify({ discriminated: 0, preRed: 0, inconclusive: 1 }),
-      `status=${status} inconclusive=${JSON.stringify(inconclusivePaths(out))} offenders=${JSON.stringify(offenderPaths(out))} counts=${JSON.stringify(okCounts(out))}\n${out}`,
+        && floorRed(out, ["smoke/mutations/c.mutations.json"])
+        && !/^SURVIVED /m.test(out.replace(/\x1b\[[0-9;]*m/g, "")),
+      `status=${status} inconclusive=${JSON.stringify(inconclusivePaths(out))} offenders=${JSON.stringify(offenderPaths(out))} zero=${JSON.stringify(zeroDiscExpected(out))}\n${out}`,
+    );
+  }
+
+  // 18b. REFUSING contrast to 18: mixed KILLED+INCONCLUSIVE is not vacuous. The kill counts, so the
+  //     floor must PASS. Differing only by a sibling mutant that does print the named red.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "c.mjs"), "export const c = () => 1;\n");
+        writeFileSync(join(r, "suites", "c.suite.mjs"), [
+          "import { c } from '../c.mjs';",
+          "const v = c();",
+          "if (v === 1) console.log('✓ c is one');",
+          "else if (v === 3) { console.error('✗ FAIL: c is one'); process.exit(1); }",
+          "else console.log('c changed but the suite still exits zero');",
+          "",
+        ].join("\n"));
+        writeFileSync(join(r, "smoke", "mutations", "c.mutations.json"), JSON.stringify({
+          suite: ["suites/c.suite.mjs"],
+          command: "node suites/c.suite.mjs",
+          mutations: [{
+            name: "c returns three, so the named assertion prints and the suite exits 1",
+            file: "c.mjs",
+            find: "export const c = () => 1;",
+            replace: "export const c = () => 3;",
+            expectRed: "c is one",
+          }, {
+            name: "c returns two, so the named assertion never prints and the suite still exits 0",
+            file: "c.mjs",
+            find: "export const c = () => 1;",
+            replace: "export const c = () => 2;",
+            expectRed: "c is one",
+          }],
+        }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "c.mjs"), "export const c = () => 1; // touched so c's fixture is selected\n"),
+    );
+    const { status, out } = scan(root, base, head);
+    check(
+      "a mixed KILLED+INCONCLUSIVE fixture reaches the OK summary with a non-zero discriminated count",
+      status === 0
+        && inconclusivePaths(out).length === 0
+        && offenderPaths(out).length === 0
+        && JSON.stringify(okCounts(out)) === JSON.stringify({ discriminated: 1, preRed: 0, inconclusive: 0 }),
+      `status=${status} inconclusive=${JSON.stringify(inconclusivePaths(out))} counts=${JSON.stringify(okCounts(out))}\n${out}`,
     );
   }
 
@@ -1778,7 +1857,7 @@ try {
     const { status, out } = scan(root, base, head, { ...childEnv(), COTAL_MUTATION_REPROOF_SENTINEL: "opposite-host-value" });
     check(
       "clean snapshot commands strip injected parent COTAL_ material independently of the root proof child",
-      status === 0
+      status === 1
         && eq(preRedPaths(out), ["smoke/mutations/env-match.mutations.json"])
         && !out.includes("snapshot inherited COTAL sentinel"),
       `status=${status}\n${out}`,
@@ -1830,7 +1909,7 @@ try {
     const { status, out } = scan(root, base, head);
     check(
       "a pinned root lacking node_modules matches the prepared clean-head verdict instead of false-blocking on pnpm's environment warning",
-      status === 0
+      status === 1
         && eq(preRedPaths(out), ["smoke/mutations/stale.mutations.json"])
         && !out.includes("root execution-state contamination detected"),
       `status=${status}\n${out}`,
@@ -1907,7 +1986,7 @@ try {
     const { status, out } = scan(root, base, head);
     check(
       "clean-head command confirmation uses the snapshot cwd rather than ignored root execution state",
-      status === 0
+      status === 1
         && eq(preRedPaths(out), ["smoke/mutations/cwd-isolation.mutations.json"])
         && attributablePreRedPaths(out).length === 0
         && !out.includes("root cwd leaked into head confirmation"),
@@ -1976,6 +2055,15 @@ check(
     && spawnsWith(rootProofSpawn, "PROOF_TIMEOUT_MS")
     && spawnsWith(runCommandBody, "COMMAND_TIMEOUT_MS"),
   `runProof and the root PROOF spawn must pass timeout: PROOF_TIMEOUT_MS; runCommand keeps COMMAND_TIMEOUT_MS (runProof body ${runProofBody.length} chars, runCommand body ${runCommandBody.length} chars, root spawn ${rootProofSpawn.length} chars)`,
+);
+
+check(
+  "a ZERO DISCRIMINATED banner names the configs it expected to kill",
+  eq(zeroDiscExpected("MUTATION REPROOF ZERO DISCRIMINATED (0 of 1 proven fixture(s) discriminated; required 1 from the selected configs) — expected a kill from: smoke/mutations/c.mutations.json\n"), ["smoke/mutations/c.mutations.json"]),
+);
+check(
+  "a prose mention of ZERO DISCRIMINATED does not mint expected configs",
+  zeroDiscExpected("historically MUTATION REPROOF ZERO DISCRIMINATED expected a kill from: fake.json in yesterday's run\n").length === 0,
 );
 
 console.log(`mutation-reproof smoke: ${passed} passed, ${failed} failed`);

--- a/bin/smoke/mutation-reproof.smoke.ts
+++ b/bin/smoke/mutation-reproof.smoke.ts
@@ -96,9 +96,24 @@ const okCounts = (out: string): { discriminated: number; preRed: number; inconcl
 };
 /** Parse configs the zero-discrimination floor named as expected kills. */
 const zeroDiscExpected = (out: string): string[] => {
-  const m = out.match(/^MUTATION REPROOF ZERO DISCRIMINATED .*expected a kill from: (.+)$/m);
+  const m = out.match(/^MUTATION REPROOF ZERO DISCRIMINATED .*expected a kill from: ([^;\n]+)/m);
   return m ? m[1].split(", ") : [];
 };
+/** Parse configs named by the COULD NOT arm: present, but never in a position to kill. */
+const zeroDiscUnable = (out: string): string[] => {
+  const m = out.match(/^MUTATION REPROOF ZERO DISCRIMINATED — COULD NOT .*re-shard or repair the already-red commands: (.+)$/m);
+  return m ? m[1].split(", ") : [];
+};
+/**
+ * Vacuous all-clear refused where NO proven fixture could have killed: pre-red, inconclusive or
+ * zero-graded. Still a red, but attributed to the unit's composition rather than to a fixture that
+ * was never in a position to produce a kill, and never collapsed into SURVIVED/FAILED.
+ */
+const floorCouldNot = (out: string, paths: string[]): boolean =>
+  eq(zeroDiscUnable(out), paths)
+  && zeroDiscExpected(out).length === 0
+  && !out.includes("MUTATION REPROOF OK")
+  && !/^MUTATION REPROOF FAILED /m.test(out);
 /** Vacuous all-clear: proven configs, zero kills, named, not collapsed into SURVIVED/FAILED. */
 const floorRed = (out: string, paths: string[]): boolean =>
   eq(zeroDiscExpected(out), paths)
@@ -121,8 +136,10 @@ const scan = (root: string, base: string, head: string, env = childEnv(), shard?
   const run = spawnSync(process.execPath, args, { encoding: "utf8", env });
   return { status: run.status, out: `${run.stdout ?? ""}${run.stderr ?? ""}` };
 };
-const scanAll = (root: string): { status: number | null; out: string } => {
-  const run = spawnSync(process.execPath, [SCAN, "--root", root, "--all"], { encoding: "utf8", env: childEnv() });
+const scanAll = (root: string, shard?: string): { status: number | null; out: string } => {
+  const args = [SCAN, "--root", root, "--all"];
+  if (shard !== undefined) args.push("--shard", shard);
+  const run = spawnSync(process.execPath, args, { encoding: "utf8", env: childEnv() });
   return { status: run.status, out: `${run.stdout ?? ""}${run.stderr ?? ""}` };
 };
 
@@ -1068,7 +1085,7 @@ try {
         && eq(selectedPaths(out), ["smoke/mutations/p.mutations.json"])
         && eq(preRedPaths(out), ["smoke/mutations/p.mutations.json"])
         && attributablePreRedPaths(out).length === 0
-        && floorRed(out, ["smoke/mutations/p.mutations.json"]),
+        && floorCouldNot(out, ["smoke/mutations/p.mutations.json"]),
       `status=${status} selected=${JSON.stringify(selectedPaths(out))} preRed=${JSON.stringify(preRedPaths(out))} attributable=${JSON.stringify(attributablePreRedPaths(out))} counts=${JSON.stringify(okCounts(out))}\n${out}`,
     );
   }
@@ -1552,7 +1569,7 @@ try {
         && eq(preRedPaths(out), ["smoke/mutations/all.mutations.json"])
         && attributablePreRedPaths(out).length === 0
         && unmeasuredPreRedPaths(out).length === 0
-        && floorRed(out, ["smoke/mutations/all.mutations.json"]),
+        && floorCouldNot(out, ["smoke/mutations/all.mutations.json"]),
       `status=${status} preRed=${JSON.stringify(preRedPaths(out))}\n${out}`,
     );
   }
@@ -1632,6 +1649,54 @@ try {
       `status=${status}\n${out}`,
     );
   }
+  // 23e. The floor's question is corpus-shaped but its scope is the unit it runs in. Under the
+  //     sharded fan-out a shard can draw ONLY work that cannot discriminate, while the corpus as a
+  //     whole kills. That still reds — a unit with no verdict has not earned an all-clear, and
+  //     exempting an all-PRE-RED set is the exact vacuity #1347 is about — but it must not blame a
+  //     fixture that was never in a position to kill. Same corpus, two shards, opposite outcomes.
+  {
+    const { root } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "d.mjs"), "export function cap(input) {\n  return Math.min(input, 32);\n}\n");
+        writeFileSync(join(r, "suites", "d.suite.mjs"), "import { cap } from '../d.mjs';\nif (cap(100) !== 32) { console.error('✗ FAIL: the d cap holds'); process.exit(1); }\nconsole.log('✓ the d cap holds');\n");
+        writeFileSync(join(r, "smoke", "mutations", "d.mutations.json"), JSON.stringify({
+          suite: ["suites/d.suite.mjs"], command: "node suites/d.suite.mjs", mutations: [{
+            name: "the d cap is removed", file: "d.mjs", find: "  return Math.min(input, 32);",
+            replace: "  return input;", expectRed: "the d cap holds",
+          }],
+        }, null, 2));
+        writeFileSync(join(r, "p.mjs"), "export const p = () => 1;\n");
+        writeFileSync(join(r, "suites", "p.suite.mjs"), "console.error('✗ FAIL: pre-red before any mutation'); process.exit(1);\n");
+        writeFileSync(join(r, "smoke", "mutations", "p.mutations.json"), JSON.stringify({
+          suite: ["suites/p.suite.mjs"], command: "node suites/p.suite.mjs", mutations: [{
+            name: "p", file: "p.mjs", find: "export const p = () => 1;",
+            replace: "export const p = () => 2;", expectRed: "pre-red",
+          }],
+        }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "head-note"), "head\n"),
+    );
+    const preRedShard = scanAll(root, "0/3");
+    check(
+      "a shard holding only an inherited pre-red fixture reds as COULD NOT without blaming that fixture",
+      preRedShard.status === 1
+        && preRedShard.out.includes("MUTATION REPROOF ZERO DISCRIMINATED — COULD NOT")
+        && preRedShard.out.includes("re-shard or repair the already-red commands: smoke/mutations/p.mutations.json")
+        && !/expected a kill from/.test(preRedShard.out),
+      `status=${preRedShard.status}\n${preRedShard.out}`,
+    );
+    // REFUSING twin, same corpus and same command, differing only by which shard is asked: the
+    // shard holding the killing fixture is green, so the red above is shard composition and not a
+    // corpus-wide failure.
+    const killShard = scanAll(root, "1/3");
+    check(
+      "the sibling shard holding the killing fixture is green on the same corpus",
+      killShard.status === 0
+        && /MUTATION REPROOF OK \(1 fixture\(s\) selected; 1 discriminated/.test(killShard.out)
+        && !killShard.out.includes("ZERO DISCRIMINATED"),
+      `status=${killShard.status}\n${killShard.out}`,
+    );
+  }
   {
     const { root } = makeSingle(
       (r) => {
@@ -1653,7 +1718,7 @@ try {
     else process.env.COTAL_MUTATION_REPROOF_SENTINEL = previous;
     if (previousNodeOptions === undefined) delete process.env.NODE_OPTIONS;
     else process.env.NODE_OPTIONS = previousNodeOptions;
-    check("the --all scan child strips parent COTAL_ material through the shared ambient-env chokepoint", status === 1 && !out.includes("COTAL_SCAN_PROCESS_LEAKED") && !out.includes("COTAL ambient leaked") && floorRed(out, ["smoke/mutations/ambient.mutations.json"]), `status=${status}\n${out}`);
+    check("the --all scan child strips parent COTAL_ material through the shared ambient-env chokepoint", status === 1 && !out.includes("COTAL_SCAN_PROCESS_LEAKED") && !out.includes("COTAL ambient leaked") && floorCouldNot(out, ["smoke/mutations/ambient.mutations.json"]), `status=${status}\n${out}`);
   }
   {
     const { root, base, head } = makeSingle(
@@ -1771,7 +1836,7 @@ try {
       status === 1
         && eq(inconclusivePaths(out), ["smoke/mutations/c.mutations.json"])
         && offenderPaths(out).length === 0
-        && floorRed(out, ["smoke/mutations/c.mutations.json"])
+        && floorCouldNot(out, ["smoke/mutations/c.mutations.json"])
         && !/^SURVIVED /m.test(out.replace(/\x1b\[[0-9;]*m/g, "")),
       `status=${status} inconclusive=${JSON.stringify(inconclusivePaths(out))} offenders=${JSON.stringify(offenderPaths(out))} zero=${JSON.stringify(zeroDiscExpected(out))}\n${out}`,
     );
@@ -2117,6 +2182,28 @@ check(
 check(
   "a prose mention of ZERO DISCRIMINATED does not mint expected configs",
   zeroDiscExpected("historically MUTATION REPROOF ZERO DISCRIMINATED expected a kill from: fake.json in yesterday's run\n").length === 0,
+);
+// The expected-kill list stops at the `;` that introduces the not-attributable tail, so a mixed
+// banner never reports an unable fixture as one that should have killed.
+check(
+  "the expected-kill list stops before the not-attributable tail",
+  eq(
+    zeroDiscExpected("MUTATION REPROOF ZERO DISCRIMINATED (0 of 2 proven fixture(s) discriminated; required 1 from the selected configs) — expected a kill from: smoke/mutations/d.mutations.json; not attributable to (could not discriminate): smoke/mutations/p.mutations.json\n"),
+    ["smoke/mutations/d.mutations.json"],
+  ),
+);
+// REFUSING twin for the COULD NOT parser: the ordinary banner carries no COULD NOT marker, so a
+// run that DID have a fixture able to kill can never be read as one that could not.
+check(
+  "an ordinary ZERO DISCRIMINATED banner mints no COULD NOT configs",
+  zeroDiscUnable("MUTATION REPROOF ZERO DISCRIMINATED (0 of 1 proven fixture(s) discriminated; required 1 from the selected configs) — expected a kill from: smoke/mutations/c.mutations.json\n").length === 0,
+);
+check(
+  "a COULD NOT banner names the fixtures that were never in a position to kill",
+  eq(
+    zeroDiscUnable("MUTATION REPROOF ZERO DISCRIMINATED — COULD NOT (0 of 1 proven fixture(s) discriminated; required 1 from the selected configs). No proven fixture here was in a position to kill: every one was pre-red, inconclusive, or graded nothing, so this unit obtained no verdict and cannot stand as an all-clear. Not attributable to any fixture below; re-shard or repair the already-red commands: smoke/mutations/p.mutations.json\n"),
+    ["smoke/mutations/p.mutations.json"],
+  ),
 );
 
 console.log(`mutation-reproof smoke: ${passed} passed, ${failed} failed`);

--- a/bin/smoke/mutation-reproof.smoke.ts
+++ b/bin/smoke/mutation-reproof.smoke.ts
@@ -16,7 +16,7 @@
  *   - a guarded source RENAMED away (a dangling fixture — the fixture still points at the old path).
  */
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, realpathSync, writeFileSync, rmSync, mkdirSync, symlinkSync } from "node:fs";
+import { copyFileSync, existsSync, mkdtempSync, readdirSync, readFileSync, realpathSync, writeFileSync, rmSync, mkdirSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -369,10 +369,18 @@ try {
       if (previousNodeOptions === undefined) delete process.env.NODE_OPTIONS;
       else process.env.NODE_OPTIONS = previousNodeOptions;
     }
-    const scannerObserved = readFileSync(join(root, "scanner.env"), "utf8");
+    // The probe files exist only if the scan actually reached the scanner and the fixture child.
+    // Reading them unguarded turns "the scan selected nothing" into an uncaught ENOENT that aborts
+    // the whole suite at this line, so a later cell's failure is never reported and the run reds
+    // for a reason that names nothing. Report the absence as this cell's own failure instead.
+    const readProbe = (name: string): string => {
+      try { return readFileSync(join(root, name), "utf8"); }
+      catch { return `ABSENT: ${name} was never written, so the scan did not reach that child`; }
+    };
+    const scannerObserved = readProbe("scanner.env");
     check("scanner children do not inherit Cotal session credentials",
       scannerObserved === "CLEAN", scannerObserved);
-    const observed = readFileSync(join(root, "probe.env"), "utf8");
+    const observed = readProbe("probe.env");
     check("fixture children do not inherit Cotal session credentials",
       observed === "CLEAN" && probe.status === 0 && okCounts(probe.out)?.discriminated === 1,
       JSON.stringify({ observed, status: probe.status, counts: okCounts(probe.out) }));
@@ -1649,6 +1657,67 @@ try {
       `status=${status}\n${out}`,
     );
   }
+  // 23d-ii. The corpus guard and the kill-credit guard are independent, and until now only the
+  //     corpus guard was driven from a cell: an external probe proved the second one, so replacing
+  //     the credit test with a bare `discriminated.push(path)` left every cell green. That is this
+  //     PR's own defect one layer in, a guard whose proof lives outside the suite that claims it.
+  //     Reaching the credit needs a proof child that exits 0 having printed no KILLED verdict,
+  //     which is what `All 0 mutation(s) killed` does in the wild. The real child cannot be talked
+  //     into that from a fixture, since anything it cannot grade exits 1 as UNGRADABLE, so the
+  //     scan under test is copied beside a stub child that reproduces exactly that transcript.
+  //     The scan resolves its child next to ITSELF, and its sibling helper modules must come too:
+  //     without them it dies on ERR_MODULE_NOT_FOUND and exits 1 for a reason that has nothing to
+  //     do with the floor, which would read as a pass whether the guard was present or not.
+  {
+    const { root } = makeSingle(
+      (r) => {
+        mkdirSync(join(r, "scripts"), { recursive: true });
+        writeFileSync(join(r, "scripts", "mutation-proof.mjs"),
+          "console.log('All 0 mutation(s) killed. The suite discriminates.');\nprocess.exit(0);\n");
+        for (const entry of readdirSync(join(ROOT, "scripts"))) {
+          if (!entry.startsWith("mutation-") || !entry.endsWith(".mjs")) continue;
+          if (entry === "mutation-proof.mjs") continue;
+          copyFileSync(join(ROOT, "scripts", entry), join(r, "scripts", entry));
+        }
+        writeFileSync(join(r, "z.mjs"), "export const z = () => 1;\n");
+        writeFileSync(join(r, "suites", "z.suite.mjs"), "import { z } from '../z.mjs';\nif (z() !== 1) { console.error('x FAIL: z is one'); process.exit(1); }\nconsole.log('+ z is one');\n");
+        writeFileSync(join(r, "smoke", "mutations", "z.mutations.json"), JSON.stringify({
+          suite: ["suites/z.suite.mjs"], command: "node suites/z.suite.mjs", mutations: [{
+            name: "z stops returning one", file: "z.mjs", find: "export const z = () => 1;",
+            replace: "export const z = () => 2;", expectRed: "z is one",
+          }],
+        }, null, 2));
+      },
+      (r) => writeFileSync(join(r, "head-note"), "head\n"),
+    );
+    const localScan = join(root, "scripts", "mutation-reproof.mjs");
+    copyFileSync(SCAN, localScan);
+    const run = spawnSync(process.execPath, [localScan, "--all", "--root", root], { encoding: "utf8", env: childEnv() });
+    const out = `${run.stdout ?? ""}${run.stderr ?? ""}`;
+    check(
+      "a fixture the corpus admits whose proof exits 0 without a KILLED is named ZERO GRADED and cannot hold the floor up",
+      run.status === 1
+        && out.includes("ZERO GRADED (1 fixture(s))")
+        && out.includes("smoke/mutations/z.mutations.json")
+        && !out.includes("MUTATION REPROOF OK")
+        && !out.includes("ERR_MODULE_NOT_FOUND"),
+      `status=${run.status}\n${out}`,
+    );
+    // REFUSING twin, differing ONLY in what the stub child prints: the identical corpus, scan copy
+    // and helper set, with a transcript that carries a real KILLED line, reaches OK. So the red
+    // above is the absent kill and not the stub, the copied tree, or the module resolution.
+    writeFileSync(join(root, "scripts", "mutation-proof.mjs"),
+      "console.log('KILLED       z stops returning one');\nconsole.log('All 1 mutation(s) killed. The suite discriminates.');\nprocess.exit(0);\n");
+    const killRun = spawnSync(process.execPath, [localScan, "--all", "--root", root], { encoding: "utf8", env: childEnv() });
+    const killOut = `${killRun.stdout ?? ""}${killRun.stderr ?? ""}`;
+    check(
+      "the same run whose child prints a KILLED is credited and prints no ZERO GRADED",
+      killRun.status === 0
+        && /MUTATION REPROOF OK \(1 fixture\(s\) selected; 1 discriminated/.test(killOut)
+        && !killOut.includes("ZERO GRADED"),
+      `status=${killRun.status}\n${killOut}`,
+    );
+  }
   // 23e. The floor's question is corpus-shaped but its scope is the unit it runs in. Under the
   //     sharded fan-out a shard can draw ONLY work that cannot discriminate, while the corpus as a
   //     whole kills. That still reds, because a unit with no verdict has not earned an all-clear
@@ -1695,6 +1764,52 @@ try {
         && /MUTATION REPROOF OK \(1 fixture\(s\) selected; 1 discriminated/.test(killShard.out)
         && !killShard.out.includes("ZERO DISCRIMINATED"),
       `status=${killShard.status}\n${killShard.out}`,
+    );
+  }
+  // 23e-ii. The two arms of the floor banner were split so a shard that COULD NOT kill is not
+  //     blamed, but every end-to-end cell above reaches the COULD NOT arm: the ordinary
+  //     `expected a kill from` arm was asserted only by unit-level parser cells fed hand-written
+  //     strings. So routing EVERY floor red through COULD NOT left the suite green, and a real
+  //     unit that should have killed would have been excused as unable. Reaching the ordinary arm
+  //     needs a proven fixture that is neither pre-red, inconclusive, nor zero-graded and that
+  //     still produced no kill. An INHERITED fatal is exactly that: its survivor is nonfatal
+  //     because it predates the diff, so the run continues to the floor with a fixture that was in
+  //     a position to kill and did not, alongside a pre-red that was not.
+  {
+    const { root, base, head } = makeSingle(
+      (r) => {
+        writeFileSync(join(r, "e.mjs"), "export const e = () => 1;\n");
+        writeFileSync(join(r, "suites", "e.suite.mjs"), "import { e } from '../e.mjs';\nif (e() !== 1) { console.error('x FAIL: e is one'); process.exit(1); }\nconsole.log('+ e is one');\n");
+        writeFileSync(join(r, "smoke", "mutations", "e.mutations.json"), JSON.stringify({
+          suite: ["suites/e.suite.mjs"], command: "node suites/e.suite.mjs", mutations: [{
+            name: "equivalent survivor", file: "e.mjs", find: "export const e = () => 1;",
+            replace: "export const e = () => 1 + 0;", expectRed: "e is one",
+          }],
+        }, null, 2));
+        writeFileSync(join(r, "q.mjs"), "export const q = () => 1;\n");
+        writeFileSync(join(r, "suites", "q.suite.mjs"), "console.error('x FAIL: pre-red before any mutation'); process.exit(1);\n");
+        writeFileSync(join(r, "smoke", "mutations", "q.mutations.json"), JSON.stringify({
+          suite: ["suites/q.suite.mjs"], command: "node suites/q.suite.mjs", mutations: [{
+            name: "q", file: "q.mjs", find: "export const q = () => 1;",
+            replace: "export const q = () => 2;", expectRed: "pre-red",
+          }],
+        }, null, 2));
+      },
+      (r) => {
+        writeFileSync(join(r, "e.mjs"), "// select without moving the survivor\nexport const e = () => 1;\n");
+        writeFileSync(join(r, "q.mjs"), "// select without moving the pre-red\nexport const q = () => 1;\n");
+      },
+    );
+    const { status, out } = scan(root, base, head);
+    check(
+      "a floor red naming a fixture that could have killed uses the ordinary arm, not COULD NOT",
+      status === 1
+        && /MUTATION REPROOF ZERO DISCRIMINATED \(/.test(out)
+        && !out.includes("ZERO DISCRIMINATED, COULD NOT")
+        && zeroDiscExpected(out).includes("smoke/mutations/e.mutations.json")
+        && zeroDiscUnable(out).length === 0
+        && !out.includes("MUTATION REPROOF OK"),
+      `status=${status} expected=${JSON.stringify(zeroDiscExpected(out))} unable=${JSON.stringify(zeroDiscUnable(out))}\n${out}`,
     );
   }
   {

--- a/bin/smoke/mutation-reproof.smoke.ts
+++ b/bin/smoke/mutation-reproof.smoke.ts
@@ -124,12 +124,6 @@ const floorCouldNot = (out: string, paths: string[]): boolean =>
   && zeroDiscExpected(out).length === 0
   && !out.includes("MUTATION REPROOF OK")
   && !/^MUTATION REPROOF FAILED /m.test(out);
-/** Vacuous all-clear: proven configs, zero kills, named, not collapsed into SURVIVED/FAILED. */
-const floorRed = (out: string, paths: string[]): boolean =>
-  eq(zeroDiscExpected(out), paths)
-  && !out.includes("MUTATION REPROOF OK")
-  && !/^MUTATION REPROOF FAILED /m.test(out);
-
 const networkSetupEnv = (): NodeJS.ProcessEnv => {
   const env = childEnv();
   delete env.pnpm_config_offline;

--- a/bin/smoke/mutations/mutation-reproof.json
+++ b/bin/smoke/mutations/mutation-reproof.json
@@ -316,8 +316,8 @@
       "file": "scripts/mutation-reproof.mjs",
       "find": "    if (verdictsIn(output).includes(\"KILLED\")) discriminated.push(path);\n    else zeroGraded.push(path);",
       "replace": "    discriminated.push(path);",
-      "expectRed": "a fixture with an empty mutations array is refused by the corpus instead of grading nothing",
-      "cell": "a fixture with an empty mutations array is refused by the corpus instead of grading nothing"
+      "expectRed": "a fixture the corpus admits whose proof exits 0 without a KILLED is named ZERO GRADED and cannot hold the floor up",
+      "cell": "a fixture the corpus admits whose proof exits 0 without a KILLED is named ZERO GRADED and cannot hold the floor up"
     },
     {
       "name": "the COULD NOT split collapses so an all-pre-red shard blames the fixture it named",
@@ -332,8 +332,8 @@
       "file": "scripts/mutation-reproof.mjs",
       "find": "  if (expected.length === 0) {",
       "replace": "  if (true) {",
-      "expectRed": "a ZERO DISCRIMINATED banner names the configs it expected to kill",
-      "cell": "a ZERO DISCRIMINATED banner names the configs it expected to kill"
+      "expectRed": "a floor red naming a fixture that could have killed uses the ordinary arm, not COULD NOT",
+      "cell": "a floor red naming a fixture that could have killed uses the ordinary arm, not COULD NOT"
     },
     {
       "name": "the ordinary floor arm stops naming the fixtures it is not blaming",
@@ -341,7 +341,7 @@
       "file": "scripts/mutation-reproof.mjs",
       "find": "${unable.length ? `; not attributable to (could not discriminate): ${unable.join(\", \")}` : \"\"}",
       "replace": "",
-      "expectRed": "the ordinary arm names the fixtures it is not attributing the miss to"
+      "expectRed": "the ordinary arm names the fixtures it is not attributing the miss to, disjoint from the ones it expected"
     }
   ]
 }

--- a/bin/smoke/mutations/mutation-reproof.json
+++ b/bin/smoke/mutations/mutation-reproof.json
@@ -334,6 +334,14 @@
       "replace": "  if (true) {",
       "expectRed": "a ZERO DISCRIMINATED banner names the configs it expected to kill",
       "cell": "a ZERO DISCRIMINATED banner names the configs it expected to kill"
+    },
+    {
+      "name": "the ordinary floor arm stops naming the fixtures it is not blaming",
+      "cell": "the ordinary arm names the fixtures it is not attributing the miss to, disjoint from the ones it expected",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "${unable.length ? `; not attributable to (could not discriminate): ${unable.join(\", \")}` : \"\"}",
+      "replace": "",
+      "expectRed": "the ordinary arm names the fixtures it is not attributing the miss to"
     }
   ]
 }

--- a/bin/smoke/mutations/mutation-reproof.json
+++ b/bin/smoke/mutations/mutation-reproof.json
@@ -92,8 +92,8 @@
       "file": "scripts/mutation-reproof.mjs",
       "find": "      else if (transition.kind === \"inherited\") preRed.push(finding);",
       "replace": "      else if (transition.kind === \"inherited\") fatal.push(path);",
-      "expectRed": "an unchanged pre-red suite selected only by a guarded-source change remains nonfatal",
-      "cell": "an unchanged pre-red suite selected only by a guarded-source change remains nonfatal"
+      "expectRed": "an unchanged pre-red suite selected only by a guarded-source change remains PRE-RED and fails the zero-discrimination floor",
+      "cell": "an unchanged pre-red suite selected only by a guarded-source change remains PRE-RED and fails the zero-discrimination floor"
     },
     {
       "name": "pre-red attribution ignores the same command's base-to-head transition",
@@ -148,16 +148,16 @@
       "file": "scripts/mutation-reproof.mjs",
       "find": "  for (const line of output.replace(ANSI, \"\").split(\"\\n\")) {",
       "replace": "  for (const line of output.split(\"\\n\")) {",
-      "expectRed": "an INCONCLUSIVE proof is reported as INCONCLUSIVE, does NOT fail the gate, and is not treated as SURVIVED",
-      "cell": "an INCONCLUSIVE proof is reported as INCONCLUSIVE, does NOT fail the gate, and is not treated as SURVIVED"
+      "expectRed": "an INCONCLUSIVE proof is reported as INCONCLUSIVE, fails the zero-discrimination floor naming the config, and is not treated as SURVIVED",
+      "cell": "an INCONCLUSIVE proof is reported as INCONCLUSIVE, fails the zero-discrimination floor naming the config, and is not treated as SURVIVED"
     },
     {
       "name": "an INCONCLUSIVE run is collapsed into a fatal finding instead of its own non-fatal state",
       "file": "scripts/mutation-reproof.mjs",
       "find": "inconclusive.push(path);",
       "replace": "fatal.push(path);",
-      "expectRed": "an INCONCLUSIVE proof is reported as INCONCLUSIVE, does NOT fail the gate, and is not treated as SURVIVED",
-      "cell": "an INCONCLUSIVE proof is reported as INCONCLUSIVE, does NOT fail the gate, and is not treated as SURVIVED"
+      "expectRed": "an INCONCLUSIVE proof is reported as INCONCLUSIVE, fails the zero-discrimination floor naming the config, and is not treated as SURVIVED",
+      "cell": "an INCONCLUSIVE proof is reported as INCONCLUSIVE, fails the zero-discrimination floor naming the config, and is not treated as SURVIVED"
     },
     {
       "name": "root contamination comparison checks only exit status and ignores the exact refused failure signature",
@@ -254,6 +254,46 @@
       "replace": "    cwd, encoding: \"utf8\", maxBuffer: 64 * 1024 * 1024,\n    env,",
       "expectRed": "root and snapshot mutation-proof children share a SIGKILL budget under the 145-minute job step (a missing timeout hung shard 10/12 for 145m after WRONG-RED; 900s on the child killed mutation-reproof.json at 901s)",
       "cell": "root and snapshot mutation-proof children share a SIGKILL budget under the 145-minute job step (a missing timeout hung shard 10/12 for 145m after WRONG-RED; 900s on the child killed mutation-reproof.json at 901s)"
+    },
+    {
+      "name": "the zero-discrimination floor is skipped so a vacuous run still prints OK",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "const floor = discriminationFloor(prove.length, discriminated.length);\nif (!floor.pass) {",
+      "replace": "const floor = discriminationFloor(prove.length, discriminated.length);\nif (false && !floor.pass) {",
+      "expectRed": "an INCONCLUSIVE proof is reported as INCONCLUSIVE, fails the zero-discrimination floor naming the config, and is not treated as SURVIVED",
+      "cell": "an INCONCLUSIVE proof is reported as INCONCLUSIVE, fails the zero-discrimination floor naming the config, and is not treated as SURVIVED"
+    },
+    {
+      "name": "the discrimination floor is a corpus-size constant instead of following the selected configs",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "  if (provenCount === 0) return { pass: true, required: 0 };\n  return { pass: discriminatedCount > 0, required: 1 };",
+      "replace": "  if (provenCount === 0) return { pass: true, required: 0 };\n  return { pass: discriminatedCount >= 50, required: 50 };",
+      "expectRed": "a genuinely discriminating fixture reaches the OK summary with counts distinct from pre-red/inconclusive",
+      "cell": "a genuinely discriminating fixture reaches the OK summary with counts distinct from pre-red/inconclusive"
+    },
+    {
+      "name": "mixed KILLED+INCONCLUSIVE is bucketed as inconclusive and not counted as discriminated",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "  else if (verdicts.every((v) => v === \"INCONCLUSIVE\")) inconclusive.push(path);\n  else if (verdicts.includes(\"INCONCLUSIVE\") && verdicts.every((v) => v === \"KILLED\" || v === \"INCONCLUSIVE\")) {\n    discriminated.push(path);\n  }",
+      "replace": "  else if (verdicts.includes(\"INCONCLUSIVE\") && verdicts.every((v) => v === \"KILLED\" || v === \"INCONCLUSIVE\")) inconclusive.push(path);",
+      "expectRed": "a mixed KILLED+INCONCLUSIVE fixture reaches the OK summary with a non-zero discriminated count",
+      "cell": "a mixed KILLED+INCONCLUSIVE fixture reaches the OK summary with a non-zero discriminated count"
+    },
+    {
+      "name": "a --all pre-red corpus still prints OK despite zero kills",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "const floor = discriminationFloor(prove.length, discriminated.length);\nif (!floor.pass) {",
+      "replace": "const floor = discriminationFloor(prove.length, discriminated.length);\nif (!a.all && !floor.pass) {",
+      "expectRed": "--all keeps every pre-red as PRE-RED (not attributable) and reds the zero-discrimination floor naming the config",
+      "cell": "--all keeps every pre-red as PRE-RED (not attributable) and reds the zero-discrimination floor naming the config"
+    },
+    {
+      "name": "no applicable fixtures is collapsed into a silent non-zero instead of the distinct all-clear",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "        : \"No mutation fixtures to re-prove: no fixture config, suite, or guarded source intersects the diff.\");\n  process.exit(0);",
+      "replace": "        : \"No mutation fixtures to re-prove: no fixture config, suite, or guarded source intersects the diff.\");\n  process.exit(1);",
+      "expectRed": "the gate PASSES an unrelated change and prints the evidence of a real all-clear",
+      "cell": "the gate PASSES an unrelated change and prints the evidence of a real all-clear"
     }
   ]
 }

--- a/bin/smoke/mutations/mutation-reproof.json
+++ b/bin/smoke/mutations/mutation-reproof.json
@@ -294,6 +294,30 @@
       "replace": "        : \"No mutation fixtures to re-prove: no fixture config, suite, or guarded source intersects the diff.\");\n  process.exit(1);",
       "expectRed": "the gate PASSES an unrelated change and prints the evidence of a real all-clear",
       "cell": "the gate PASSES an unrelated change and prints the evidence of a real all-clear"
+    },
+    {
+      "name": "a zero-mutation fixture is admitted to the corpus again",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "    if (config.mutations.length === 0) {",
+      "replace": "    if (false && config.mutations.length === 0) {",
+      "expectRed": "a fixture with an empty mutations array is refused by the corpus instead of grading nothing",
+      "cell": "a fixture with an empty mutations array is refused by the corpus instead of grading nothing"
+    },
+    {
+      "name": "the corpus rejects any fixture whose mutations array is non-empty, inverting the length check",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "    if (config.mutations.length === 0) {",
+      "replace": "    if (config.mutations.length !== 0) {",
+      "expectRed": "the same fixture carrying one real mutation is admitted and discriminates",
+      "cell": "the same fixture carrying one real mutation is admitted and discriminates"
+    },
+    {
+      "name": "discrimination is credited on a bare exit 0 again, without an observed KILLED",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "    if (verdictsIn(output).includes(\"KILLED\")) discriminated.push(path);\n    else zeroGraded.push(path);",
+      "replace": "    discriminated.push(path);",
+      "expectRed": "a fixture with an empty mutations array is refused by the corpus instead of grading nothing",
+      "cell": "a fixture with an empty mutations array is refused by the corpus instead of grading nothing"
     }
   ]
 }

--- a/bin/smoke/mutations/mutation-reproof.json
+++ b/bin/smoke/mutations/mutation-reproof.json
@@ -318,6 +318,22 @@
       "replace": "    discriminated.push(path);",
       "expectRed": "a fixture with an empty mutations array is refused by the corpus instead of grading nothing",
       "cell": "a fixture with an empty mutations array is refused by the corpus instead of grading nothing"
+    },
+    {
+      "name": "the COULD NOT split collapses so an all-pre-red shard blames the fixture it named",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "  if (expected.length === 0) {",
+      "replace": "  if (false) {",
+      "expectRed": "a shard holding only an inherited pre-red fixture reds as COULD NOT without blaming that fixture",
+      "cell": "a shard holding only an inherited pre-red fixture reds as COULD NOT without blaming that fixture"
+    },
+    {
+      "name": "every floor red is reported as COULD NOT, so a shard that should have killed is excused as unable",
+      "file": "scripts/mutation-reproof.mjs",
+      "find": "  if (expected.length === 0) {",
+      "replace": "  if (true) {",
+      "expectRed": "a ZERO DISCRIMINATED banner names the configs it expected to kill",
+      "cell": "a ZERO DISCRIMINATED banner names the configs it expected to kill"
     }
   ]
 }

--- a/bin/smoke/mutations/mutation-reproof.json
+++ b/bin/smoke/mutations/mutation-reproof.json
@@ -274,7 +274,7 @@
     {
       "name": "mixed KILLED+INCONCLUSIVE is bucketed as inconclusive and not counted as discriminated",
       "file": "scripts/mutation-reproof.mjs",
-      "find": "  else if (verdicts.every((v) => v === \"INCONCLUSIVE\")) inconclusive.push(path);\n  else if (verdicts.includes(\"INCONCLUSIVE\") && verdicts.every((v) => v === \"KILLED\" || v === \"INCONCLUSIVE\")) {\n    discriminated.push(path);\n  }",
+      "find": "  else if (verdicts.length > 0 && verdicts.every((v) => v === \"INCONCLUSIVE\")) inconclusive.push(path);\n  else if (verdicts.includes(\"INCONCLUSIVE\") && verdicts.every((v) => v === \"KILLED\" || v === \"INCONCLUSIVE\")) {\n    discriminated.push(path);\n  }",
       "replace": "  else if (verdicts.includes(\"INCONCLUSIVE\") && verdicts.every((v) => v === \"KILLED\" || v === \"INCONCLUSIVE\")) inconclusive.push(path);",
       "expectRed": "a mixed KILLED+INCONCLUSIVE fixture reaches the OK summary with a non-zero discriminated count",
       "cell": "a mixed KILLED+INCONCLUSIVE fixture reaches the OK summary with a non-zero discriminated count"

--- a/scripts/mutation-reproof.mjs
+++ b/scripts/mutation-reproof.mjs
@@ -115,7 +115,7 @@ function loadCorpus(root, paths) {
       continue;
     }
     if (config.mutations.length === 0) {
-      errors.push(`${path}: "mutations" array is empty — a fixture that grades nothing cannot stand as coverage`);
+      errors.push(`${path}: "mutations" array is empty, and a fixture that grades nothing cannot stand as coverage`);
       continue;
     }
     let suites;
@@ -586,7 +586,7 @@ const attributablePreRed = []; // exit 4 + the SAME command base GREEN -> head R
 const unmeasuredPreRed = []; // exit 4 + absent/ambiguous/unrunnable base comparison — loud failure
 const inconclusive = []; // INCONCLUSIVE only — unmeasured, evidence in neither direction
 const discriminated = []; // fixtures that produced at least one KILLED (including mixed)
-const zeroGraded = []; // exit 0 with no KILLED parsed — graded nothing, never counts as discrimination
+const zeroGraded = []; // exit 0 with no KILLED parsed: graded nothing, never counts as discrimination
 for (const { path, command, mutations } of prove) {
   console.log(`\n===== ${path} =====`);
   const run = spawnSync(process.execPath, [PROOF, "--config", path], {
@@ -599,8 +599,8 @@ for (const { path, command, mutations } of prove) {
   // Exit 0 means "no mutation failed to produce a clean named red", which is NOT the same as
   // "a kill was observed": mutation-proof prints `All 0 mutation(s) killed` and exits 0 for a
   // fixture whose `mutations` array is empty. Crediting discrimination on the status alone would
-  // let a fixture that graded nothing hold the floor up for a corpus that killed nothing — the
-  // very vacuity this floor exists to refuse, one layer down. Credit the observed verdict.
+  // let a fixture that graded nothing hold the floor up for a corpus that killed nothing, which is
+  // the very vacuity this floor exists to refuse, one layer down. Credit the observed verdict.
   if (run.status === 0) {
     if (verdictsIn(output).includes("KILLED")) discriminated.push(path);
     else zeroGraded.push(path);
@@ -664,8 +664,8 @@ for (const { path, command, mutations } of prove) {
   // because another mutation in the same file was INCONCLUSIVE. INCONCLUSIVE is its own reported
   // state ONLY when every parsed verdict is INCONCLUSIVE and at least one was parsed. An empty
   // parse (`[].every` is true) is unexplained, not INCONCLUSIVE. Mixed KILLED+INCONCLUSIVE
-  // counts as discriminated: a kill was observed. Anything else — an empty parse, an exit-1
-  // with only KILLED lines, a token this gate does not know — is a finding, never a pass.
+  // counts as discriminated: a kill was observed. Anything else is a finding and never a pass,
+  // including an empty parse, an exit-1 with only KILLED lines, or a token this gate cannot name.
   if (verdicts.some((v) => FATAL_VERDICTS.has(v))) {
     if (verdicts.includes("KILLED")) discriminated.push(path);
     if (a.all) { fatal.push(path); continue; }
@@ -765,13 +765,13 @@ function discriminationFloor(provenCount, discriminatedCount) {
 // against the guard and not a pass for it, so it is named rather than folded into either: a
 // reader who sees the corpus shrink this way should see WHICH member stopped grading.
 if (zeroGraded.length) {
-  console.log(`\nZERO GRADED (${zeroGraded.length} fixture(s)) — exited 0 with no KILLED verdict parsed; graded nothing and cannot count toward the floor:\n${zeroGraded.map((path) => `  ${path}`).join("\n")}`);
+  console.log(`\nZERO GRADED (${zeroGraded.length} fixture(s)): exited 0 with no KILLED verdict parsed, so they graded nothing and cannot count toward the floor:\n${zeroGraded.map((path) => `  ${path}`).join("\n")}`);
 }
 const floor = discriminationFloor(prove.length, discriminated.length);
 if (!floor.pass) {
   // The floor's question is corpus-shaped but its scope is the unit it runs in, and under a
   // sharded fan-out that unit is one shard. A shard can therefore draw only work that CANNOT
-  // discriminate — every fixture pre-red before any mutation, or graded nothing — while the
+  // discriminate, every fixture pre-red before any mutation or graded nothing, while the
   // corpus as a whole kills. That still reds, deliberately: a unit that obtained no verdict has
   // not earned an all-clear, and exempting an all-PRE-RED set is precisely the vacuity this
   // floor exists to refuse. But the two cases need different human responses, so they are named
@@ -787,9 +787,9 @@ if (!floor.pass) {
   const expected = prove.map(({ path }) => path).filter((path) => !unableSet.has(path));
   const unable = prove.map(({ path }) => path).filter((path) => unableSet.has(path));
   if (expected.length === 0) {
-    console.error(`\nMUTATION REPROOF ZERO DISCRIMINATED — COULD NOT (0 of ${prove.length} proven fixture(s) discriminated; required ${floor.required} from the selected configs). No proven fixture here was in a position to kill: every one was pre-red, inconclusive, or graded nothing, so this unit obtained no verdict and cannot stand as an all-clear. Not attributable to any fixture below; re-shard or repair the already-red commands: ${unable.join(", ")}`);
+    console.error(`\nMUTATION REPROOF ZERO DISCRIMINATED, COULD NOT (0 of ${prove.length} proven fixture(s) discriminated; required ${floor.required} from the selected configs). No proven fixture here was in a position to kill: every one was pre-red, inconclusive, or graded nothing, so this unit obtained no verdict and cannot stand as an all-clear. Not attributable to any fixture below; re-shard or repair the already-red commands: ${unable.join(", ")}`);
   } else {
-    console.error(`\nMUTATION REPROOF ZERO DISCRIMINATED (${discriminated.length} of ${prove.length} proven fixture(s) discriminated; required ${floor.required} from the selected configs) — expected a kill from: ${expected.join(", ")}${unable.length ? `; not attributable to (could not discriminate): ${unable.join(", ")}` : ""}`);
+    console.error(`\nMUTATION REPROOF ZERO DISCRIMINATED (${discriminated.length} of ${prove.length} proven fixture(s) discriminated; required ${floor.required} from the selected configs), expected a kill from: ${expected.join(", ")}${unable.length ? `; not attributable to (could not discriminate): ${unable.join(", ")}` : ""}`);
   }
   process.exit(1);
 }

--- a/scripts/mutation-reproof.mjs
+++ b/scripts/mutation-reproof.mjs
@@ -345,8 +345,14 @@ if (prove.length === 0) {
 //                                       is no base comparison, so these remain absolute findings.
 //               INCONCLUSIVE (only)   — a timeout or a teardown hang left no evidence either way.
 //                                       Collapsing it into SURVIVED is a false blocker and into
-//                                       KILLED a false clearance, so it is its own reported state
-//                                       and does not fail the gate.
+//                                       KILLED a false clearance, so it is its own reported state.
+//                                       A run whose proven fixtures are all INCONCLUSIVE still
+//                                       fails the discrimination floor: that is vacuity, not a
+//                                       kill. A mixed KILLED+INCONCLUSIVE fixture counts as
+//                                       discriminated because a kill was observed.
+// A proven set that discriminated zero fixtures is not an all-clear. The floor is 1 when any
+// fixture was proven, and 0 when none were (the "nothing applicable" path already printed above).
+// That required count follows from the selected configs, not from a corpus-size constant.
 // The classification reads mutation-proof's own verdict lines rather than re-deriving them, so the
 // two tools cannot drift on what a verdict means. mutation-proof colours each verdict, so a line is
 // `\x1b[32mKILLED      \x1b[0m <label>`: strip ANSI before matching, or every verdict reads as
@@ -572,6 +578,7 @@ const preRed = [];      // exit 4 + base RED, or any exit 4 under --all — inhe
 const attributablePreRed = []; // exit 4 + the SAME command base GREEN -> head RED
 const unmeasuredPreRed = []; // exit 4 + absent/ambiguous/unrunnable base comparison — loud failure
 const inconclusive = []; // INCONCLUSIVE only — unmeasured, evidence in neither direction
+const discriminated = []; // fixtures that produced at least one KILLED (including mixed)
 for (const { path, command, mutations } of prove) {
   console.log(`\n===== ${path} =====`);
   const run = spawnSync(process.execPath, [PROOF, "--config", path], {
@@ -581,7 +588,7 @@ for (const { path, command, mutations } of prove) {
   const output = `${run.stdout ?? ""}${run.stderr ?? ""}`;
   process.stdout.write(run.stdout ?? "");
   process.stderr.write(run.stderr ?? "");
-  if (run.status === 0) continue; // every mutation KILLED
+  if (run.status === 0) { discriminated.push(path); continue; } // every mutation KILLED
   // Pre-red is keyed on exit 4 ALONE, the code mutation-proof sets only in its pre-mutation baseline
   // refusal and nowhere a mutation actually ran. Attribute it by the SAME command's base-to-head
   // transition, never by a declared suite path that may name a different command.
@@ -637,11 +644,13 @@ for (const { path, command, mutations } of prove) {
   }
   const verdicts = verdictsIn(output);
   // A single adverse verdict anywhere in the fixture is a finding: SURVIVED does not become benign
-  // because another mutation in the same file was INCONCLUSIVE. INCONCLUSIVE is non-fatal ONLY when
-  // no verdict is adverse and at least one is INCONCLUSIVE, i.e. the run produced no evidence against
-  // the guard. Anything else — an empty parse, an exit-1 with only KILLED lines, a token this gate
-  // does not know — is an unexplained non-zero and is treated as a finding, never as a pass.
+  // because another mutation in the same file was INCONCLUSIVE. INCONCLUSIVE is its own reported
+  // state ONLY when every verdict is INCONCLUSIVE. Mixed KILLED+INCONCLUSIVE counts as
+  // discriminated: a kill was observed. Anything else — an empty parse, an exit-1 with only
+  // KILLED lines, a token this gate does not know — is an unexplained non-zero and is treated as
+  // a finding, never as a pass.
   if (verdicts.some((v) => FATAL_VERDICTS.has(v))) {
+    if (verdicts.includes("KILLED")) discriminated.push(path);
     if (a.all) { fatal.push(path); continue; }
     ensureSnapshotPrepared(snapshots.head, "head");
     ensureSnapshotPrepared(snapshots.base, "base");
@@ -679,7 +688,10 @@ for (const { path, command, mutations } of prove) {
     else fatal.push(path);
     continue;
   }
-  else if (verdicts.includes("INCONCLUSIVE") && verdicts.every((v) => v === "KILLED" || v === "INCONCLUSIVE")) inconclusive.push(path);
+  else if (verdicts.every((v) => v === "INCONCLUSIVE")) inconclusive.push(path);
+  else if (verdicts.includes("INCONCLUSIVE") && verdicts.every((v) => v === "KILLED" || v === "INCONCLUSIVE")) {
+    discriminated.push(path);
+  }
   else fatal.push(path);
 }
 
@@ -725,6 +737,19 @@ if (fatal.length) {
 if (attributablePreRed.length || unmeasuredPreRed.length || fatal.length || unmeasuredFatal.length) {
   process.exit(1);
 }
+function discriminationFloor(provenCount, discriminatedCount) {
+  // Required kills follow the configs actually proven: none if the selector had nothing
+  // to prove, otherwise at least one. A constant such as "50" would pass today's corpus
+  // by accident and would fail a legitimate one-fixture synthetic.
+  if (provenCount === 0) return { pass: true, required: 0 };
+  return { pass: discriminatedCount > 0, required: 1 };
+}
+const floor = discriminationFloor(prove.length, discriminated.length);
+if (!floor.pass) {
+  const expected = prove.map(({ path }) => path);
+  console.error(`\nMUTATION REPROOF ZERO DISCRIMINATED (${discriminated.length} of ${prove.length} proven fixture(s) discriminated; required ${floor.required} from the selected configs) — expected a kill from: ${expected.join(", ")}`);
+  process.exit(1);
+}
 console.log(a.all
-  ? `\nMUTATION REPROOF OK (${selected.length} fixture(s) selected; ${prove.length - preRed.length - inconclusive.length} discriminated, ${preRed.length} pre-red, ${inconclusive.length} inconclusive; base not compared under --all)`
-  : `\nMUTATION REPROOF OK (${selected.length} fixture(s) selected; ${prove.length - fixtureCount(preRed) - fixtureCount(inheritedFatal) - inconclusive.length} discriminated, ${fixtureCount(preRed)} inherited pre-red, 0 attributable pre-red, 0 unmeasured pre-red, ${inconclusive.length} inconclusive)`);
+  ? `\nMUTATION REPROOF OK (${selected.length} fixture(s) selected; ${discriminated.length} discriminated, ${preRed.length} pre-red, ${inconclusive.length} inconclusive; base not compared under --all)`
+  : `\nMUTATION REPROOF OK (${selected.length} fixture(s) selected; ${discriminated.length} discriminated, ${fixtureCount(preRed)} inherited pre-red, 0 attributable pre-red, 0 unmeasured pre-red, ${inconclusive.length} inconclusive)`);

--- a/scripts/mutation-reproof.mjs
+++ b/scripts/mutation-reproof.mjs
@@ -107,8 +107,15 @@ function loadCorpus(root, paths) {
       errors.push(`${path}: ${err.message}`);
       continue;
     }
+    // Length matters, not just shape. A fixture with `"mutations": []` is well-formed JSON that
+    // grades nothing: mutation-proof reports `All 0 mutation(s) killed` and exits 0. Admitting it
+    // to the corpus lets a member that can never discriminate be counted as one that does.
     if (!Array.isArray(config.mutations)) {
       errors.push(`${path}: no top-level "mutations" array`);
+      continue;
+    }
+    if (config.mutations.length === 0) {
+      errors.push(`${path}: "mutations" array is empty — a fixture that grades nothing cannot stand as coverage`);
       continue;
     }
     let suites;
@@ -579,6 +586,7 @@ const attributablePreRed = []; // exit 4 + the SAME command base GREEN -> head R
 const unmeasuredPreRed = []; // exit 4 + absent/ambiguous/unrunnable base comparison — loud failure
 const inconclusive = []; // INCONCLUSIVE only — unmeasured, evidence in neither direction
 const discriminated = []; // fixtures that produced at least one KILLED (including mixed)
+const zeroGraded = []; // exit 0 with no KILLED parsed — graded nothing, never counts as discrimination
 for (const { path, command, mutations } of prove) {
   console.log(`\n===== ${path} =====`);
   const run = spawnSync(process.execPath, [PROOF, "--config", path], {
@@ -588,7 +596,16 @@ for (const { path, command, mutations } of prove) {
   const output = `${run.stdout ?? ""}${run.stderr ?? ""}`;
   process.stdout.write(run.stdout ?? "");
   process.stderr.write(run.stderr ?? "");
-  if (run.status === 0) { discriminated.push(path); continue; } // every mutation KILLED
+  // Exit 0 means "no mutation failed to produce a clean named red", which is NOT the same as
+  // "a kill was observed": mutation-proof prints `All 0 mutation(s) killed` and exits 0 for a
+  // fixture whose `mutations` array is empty. Crediting discrimination on the status alone would
+  // let a fixture that graded nothing hold the floor up for a corpus that killed nothing — the
+  // very vacuity this floor exists to refuse, one layer down. Credit the observed verdict.
+  if (run.status === 0) {
+    if (verdictsIn(output).includes("KILLED")) discriminated.push(path);
+    else zeroGraded.push(path);
+    continue;
+  }
   // Pre-red is keyed on exit 4 ALONE, the code mutation-proof sets only in its pre-mutation baseline
   // refusal and nowhere a mutation actually ran. Attribute it by the SAME command's base-to-head
   // transition, never by a declared suite path that may name a different command.
@@ -743,6 +760,12 @@ function discriminationFloor(provenCount, discriminatedCount) {
   // by accident and would fail a legitimate one-fixture synthetic.
   if (provenCount === 0) return { pass: true, required: 0 };
   return { pass: discriminatedCount > 0, required: 1 };
+}
+// A fixture that exited 0 without a single parsed KILLED graded nothing. It is not a finding
+// against the guard and not a pass for it, so it is named rather than folded into either: a
+// reader who sees the corpus shrink this way should see WHICH member stopped grading.
+if (zeroGraded.length) {
+  console.log(`\nZERO GRADED (${zeroGraded.length} fixture(s)) — exited 0 with no KILLED verdict parsed; graded nothing and cannot count toward the floor:\n${zeroGraded.map((path) => `  ${path}`).join("\n")}`);
 }
 const floor = discriminationFloor(prove.length, discriminated.length);
 if (!floor.pass) {

--- a/scripts/mutation-reproof.mjs
+++ b/scripts/mutation-reproof.mjs
@@ -769,8 +769,28 @@ if (zeroGraded.length) {
 }
 const floor = discriminationFloor(prove.length, discriminated.length);
 if (!floor.pass) {
-  const expected = prove.map(({ path }) => path);
-  console.error(`\nMUTATION REPROOF ZERO DISCRIMINATED (${discriminated.length} of ${prove.length} proven fixture(s) discriminated; required ${floor.required} from the selected configs) — expected a kill from: ${expected.join(", ")}`);
+  // The floor's question is corpus-shaped but its scope is the unit it runs in, and under a
+  // sharded fan-out that unit is one shard. A shard can therefore draw only work that CANNOT
+  // discriminate — every fixture pre-red before any mutation, or graded nothing — while the
+  // corpus as a whole kills. That still reds, deliberately: a unit that obtained no verdict has
+  // not earned an all-clear, and exempting an all-PRE-RED set is precisely the vacuity this
+  // floor exists to refuse. But the two cases need different human responses, so they are named
+  // differently. COULD NOT means re-shard or fix the already-red commands, and blaming a
+  // specific fixture for failing to produce a kill it was never in a position to produce is
+  // what a single banner would do.
+  const unableSet = new Set([
+    ...preRed.map(({ path }) => path),
+    ...unmeasuredPreRed.map(({ path }) => path),
+    ...inconclusive,
+    ...zeroGraded,
+  ]);
+  const expected = prove.map(({ path }) => path).filter((path) => !unableSet.has(path));
+  const unable = prove.map(({ path }) => path).filter((path) => unableSet.has(path));
+  if (expected.length === 0) {
+    console.error(`\nMUTATION REPROOF ZERO DISCRIMINATED — COULD NOT (0 of ${prove.length} proven fixture(s) discriminated; required ${floor.required} from the selected configs). No proven fixture here was in a position to kill: every one was pre-red, inconclusive, or graded nothing, so this unit obtained no verdict and cannot stand as an all-clear. Not attributable to any fixture below; re-shard or repair the already-red commands: ${unable.join(", ")}`);
+  } else {
+    console.error(`\nMUTATION REPROOF ZERO DISCRIMINATED (${discriminated.length} of ${prove.length} proven fixture(s) discriminated; required ${floor.required} from the selected configs) — expected a kill from: ${expected.join(", ")}${unable.length ? `; not attributable to (could not discriminate): ${unable.join(", ")}` : ""}`);
+  }
   process.exit(1);
 }
 console.log(a.all

--- a/scripts/mutation-reproof.mjs
+++ b/scripts/mutation-reproof.mjs
@@ -645,10 +645,10 @@ for (const { path, command, mutations } of prove) {
   const verdicts = verdictsIn(output);
   // A single adverse verdict anywhere in the fixture is a finding: SURVIVED does not become benign
   // because another mutation in the same file was INCONCLUSIVE. INCONCLUSIVE is its own reported
-  // state ONLY when every verdict is INCONCLUSIVE. Mixed KILLED+INCONCLUSIVE counts as
-  // discriminated: a kill was observed. Anything else — an empty parse, an exit-1 with only
-  // KILLED lines, a token this gate does not know — is an unexplained non-zero and is treated as
-  // a finding, never as a pass.
+  // state ONLY when every parsed verdict is INCONCLUSIVE and at least one was parsed. An empty
+  // parse (`[].every` is true) is unexplained, not INCONCLUSIVE. Mixed KILLED+INCONCLUSIVE
+  // counts as discriminated: a kill was observed. Anything else — an empty parse, an exit-1
+  // with only KILLED lines, a token this gate does not know — is a finding, never a pass.
   if (verdicts.some((v) => FATAL_VERDICTS.has(v))) {
     if (verdicts.includes("KILLED")) discriminated.push(path);
     if (a.all) { fatal.push(path); continue; }
@@ -688,7 +688,7 @@ for (const { path, command, mutations } of prove) {
     else fatal.push(path);
     continue;
   }
-  else if (verdicts.every((v) => v === "INCONCLUSIVE")) inconclusive.push(path);
+  else if (verdicts.length > 0 && verdicts.every((v) => v === "INCONCLUSIVE")) inconclusive.push(path);
   else if (verdicts.includes("INCONCLUSIVE") && verdicts.every((v) => v === "KILLED" || v === "INCONCLUSIVE")) {
     discriminated.push(path);
   }


### PR DESCRIPTION
Refs #1347

## The mechanism

A mutation reproof that selected fixtures and discriminated none still printed `MUTATION REPROOF OK`. The banner reported a discriminated count and the exit decision never read it, so the strongest signal this repo has about whether its tests can tell right from wrong was satisfiable by running nothing that discriminates.

Two shapes reached that green, both observed in production and recorded on the issue:

- **Scheduled `--all`:** an all-PRE-RED corpus. `--all` deliberately performs no base comparison, so every PRE-RED stayed nonfatal, the three fatal buckets were empty, and the sweep exited 0 having obtained no verdict at all.
- **Pull-request path:** `MUTATION REPROOF OK (1 fixture(s) selected; 0 discriminated, ... 1 inconclusive)` on run `34463111703`, shard 6/12. The single selected fixture was the PR's own, so the zero said the guard standing over that diff was never shown to discriminate. The required check was green.

This is the mutation-layer twin of a suite that asserts nothing counting as a covered pass.

## What now happens

After the pre-red and fatal exits, the reproof asserts a floor on discriminated fixtures. A run whose proven fixtures produced no kill exits 1 and names what it expected, instead of printing an all-clear.

**Discrimination is credited on an observed kill, never on an exit status.** `mutation-proof` prints `All 0 mutation(s) killed` and exits 0 for a fixture whose `mutations` array is empty, so crediting the status would let a fixture that graded nothing satisfy the floor for a sweep that killed nothing. The floor requires a parsed `KILLED`. A fixture that exits 0 with no verdict parsed is reported as `ZERO GRADED`, named, and counts toward nothing. Independently, the corpus now rejects a `"mutations": []` fixture outright: it was validated for shape but never for length, so a member that can never discriminate could sit in the corpus indefinitely.

**The floor is derived, not a tuned constant.** `discriminationFloor(provenCount, discriminatedCount)` requires 1 when the selector proved anything and 0 when it proved nothing. It never mentions a corpus size. A hardcoded threshold that today's corpus happens to clear is the same defect wearing a number: it would pass a legitimate one-fixture synthetic run and drift silently as the corpus grows. A mutation encodes that, replacing the derived floor with `>= 50` and requiring the single-fixture cell to go red.

**A unit that could not discriminate is named apart from one that should have.** The floor's question is corpus-shaped but its scope is the unit it runs in, and under the sharded fan-out that unit is one shard. A shard can draw only work that cannot discriminate, every fixture pre-red before any mutation or inconclusive or zero-graded, while the corpus as a whole kills. That still reds, because a unit that obtained no verdict has not earned an all-clear and exempting an all-PRE-RED set is exactly the vacuity this issue is about. But the remedies differ, so the banners differ:

```
MUTATION REPROOF ZERO DISCRIMINATED (... ), expected a kill from: <fixtures that could have>
MUTATION REPROOF ZERO DISCRIMINATED, COULD NOT (... ). No proven fixture here was in a
position to kill ... re-shard or repair the already-red commands: <fixtures>
```

The second does not blame a fixture for failing to produce a kill it was never in a position to produce.

**A run with genuinely nothing to prove still says so distinctly.** The "No mutation fixtures to re-prove" path prints its reason and exits 0 before the floor, and `provenCount === 0` returns `required: 0`, so an inapplicable sweep is an explicit all-clear, never a vacuous one. A mutation makes that exit non-zero and requires the unrelated-change cell to red.

Related: **an empty verdict parse is now fatal rather than INCONCLUSIVE.** `[].every(...)` is `true`, so a run that produced no parseable verdicts previously satisfied "every verdict is INCONCLUSIVE" and was filed as non-evidence. An empty parse is unexplained, which is a finding.

INCONCLUSIVE keeps its own reported state. It is not collapsed into SURVIVED (a false blocker) or KILLED (a false clearance); it stops counting as discrimination. **That policy change is visible in the test surface and is not incidental:** 13 pre-existing cells whose single fixture was inherited-PRE-RED, plus the INCONCLUSIVE-only cell, now assert a red where they asserted a green. Those cells were the gate reporting that a one-fixture unit with nothing gradable in it used to pass.

## What the full sweep discriminates today

Measured first-hand at this head: `node scripts/mutation-reproof.mjs --all --list-shards 12` selects **424 of 424 fixtures**. Classifying each selected config with the tool's own `liveShapedCommandReason`, rather than with a pattern of my own, **30 are live-shaped refusals** the tool will not execute, leaving **394 fixtures the full sweep would prove**. The floor computed from those 394 is 1. Every one of the 424 carries a non-empty `mutations` array, so the corpus-length check reds nothing today.

Those counts moved under me while this branch was open: the corpus was 419 at the first base, 422 at the second, and is 424 now, because merges elsewhere added fixtures and the selector discovers by shape over the whole tree. Any figure here is a reading at this head and not a constant.

I did **not** execute all 394 proofs, so I am not claiming how many kill today. A full sweep has never completed in CI: the issue records five consecutive scheduled runs, four cancelled and one killed at the six-hour ceiling, which is why the vacuity survived. The number this PR stands behind is the selection: 424 selected, 30 refused, 394 proven, floor 1. A reviewer measured 424/30/394 at this head while the text above still read 422/29/393, and was right: main advanced again after I wrote it. The figures are re-measured at the head this sentence ships with, and they will go stale the same way if main moves again.

## Branches and refusing cases

**11 accepting branches, 11 refusing cases**, counted per branch rather than per bug.

Classifier, after the pre-red split: exit 0 with a parsed KILLED (discriminated); exit 0 with none (zero-graded); fatal-verdict carrying a KILLED (discriminated); all-INCONCLUSIVE (inconclusive); mixed KILLED+INCONCLUSIVE (discriminated). Floor and reporting: proven-zero (pass, required 0); proven-nonzero (pass only on a kill); floor red with an able fixture present (`expected a kill from`); floor red with none (`COULD NOT`); the ordinary arm's attribution clause present when something could not discriminate; that clause absent when everything could.

Each has a refusing case differing only by context:

- an all-INCONCLUSIVE run reds the floor naming the config **vs** mixed KILLED+INCONCLUSIVE reaching OK with `discriminated 1`, differing only by a sibling mutant that prints its named red
- an empty `mutations` array is refused by the corpus **vs** the same fixture carrying one real mutation being admitted and discriminating
- an `--all` pre-red corpus reds **vs** an `--all` sweep that kills one fixture reaching `OK (1 fixture(s) selected; 1 discriminated`
- a shard holding only an inherited-PRE-RED fixture reds as `COULD NOT` **vs** its sibling shard, same corpus and same command, green because it holds the killing fixture
- a proof child that exits 0 printing no verdict is named `ZERO GRADED` and cannot hold the floor up **vs** the identical corpus, scan copy and helper set whose child prints one `KILLED` line reaching OK, differing only in that line
- a floor red where a fixture could have killed uses the ordinary arm **vs** the `COULD NOT` arm when none could, so a unit that should have killed is never excused as unable
- the ordinary arm's attribution clause is parsed and its contents asserted **vs** an ordinary banner carrying no clause minting nothing, and **vs** the `COULD NOT` arm's own list not being readable as an ordinary clause
- an unrelated change still prints the distinct "nothing applicable" all-clear at exit 0
- the banner parsers accept a real line and **refuse** a prose mention of the same words; the expected-kill list stops at the `;` introducing the not-attributable tail; an ordinary banner mints no `COULD NOT` configs

## Proof

Run in an isolated checkout at this head, on Linux:

- `pnpm smoke:mutation-reproof` → **124 passed, 0 failed**
- `pnpm typecheck` → clean across the workspace
- `pnpm check:docs-voice` → 40 pages passed
- **Pre-fix control:** the same smoke file, unchanged, against the pre-fix `scripts/mutation-reproof.mjs` restored from the merge base → **99 passed, 25 failed**, then restored and verified clean. The probes fail before the change and pass after it, so they are not describing the shape they were written against.
- **Two standalone probes**, each run against the pre-fix and post-fix script. A zero-mutation fixture that let the issue's own `--all` scenario exit 0 is now refused at the corpus boundary. A well-formed fixture whose proof grades nothing, which the corpus check admits so that only the kill-credit can refuse it, went from `OK (2 discriminated)` at exit 0 to `ZERO GRADED` plus a floor red at exit 1.
- `bin/smoke/mutations/mutation-reproof.json` carries **42 mutations**, every anchor verified to match exactly once in its own file, re-verified after the banner wording changed.
- **The full sweep was executed against this change's own guards, and it did not pass first time.** The first run over 41 mutations returned 38 KILLED, 2 SURVIVED and 1 WRONG-RED. Both survivors carried the harness's positive control, so they were real coverage gaps rather than equivalent mutants: the kill-credit guard and the ordinary floor arm were proven only by an out-of-tree probe and by parser units fed hand-written strings, so deleting either guard left every cell green. The WRONG-RED was worse in kind, because inverting the corpus-length check made an unrelated cell die on an unguarded read before the naming cell could report, so the run reddened while naming nothing.
- Review then found a fourth: the clause naming the fixtures the ordinary arm is **not** blaming had no parser of its own, and the cell that appeared to cover it asked the other arm's parser, which cannot match an ordinary banner. That assertion was not weak but unfalsifiable, and deleting the clause left the suite green. It now has its own parser, an equality-and-disjointness assertion, three refusing twins, and a registered mutation.
- Review also found that two entries named a parser-only assertion in `expectRed` while the guard they edit is proven end to end elsewhere, so each mutant proved only that something somewhere reddens. Both were retargeted, and the transcript now reads `red, and named:` against the intended assertion for each.
- **Final sweep: 42 of 42 KILLED, 0 SURVIVED, 0 WRONG-RED**, uncapped, from a clean tree, with the tree verified clean afterwards.

