### PR TITLE
test(closure-gate): assert the rc-2 and rc-3 branch bodies, not their comparisons

### DIFF
--- a/bin/smoke/mutations/publish-closure-gate.json
+++ b/bin/smoke/mutations/publish-closure-gate.json
@@ -10,7 +10,8 @@
   "proveWith": "pnpm mutation-proof --config bin/smoke/mutations/publish-closure-gate.json",
   "why": [
     "The release workflow used to check one package of twenty-two and cut a Release on that alone. A sibling that failed to publish was invisible. The closure gate now checks every package and the Release step depends on it.",
-    "A 200 without a body identifying the package at the requested version is no longer treated as presence. Each mutation below breaks one property the smoke is supposed to hold."
+    "A 200 without a body identifying the package at the requested version is no longer treated as presence. Each mutation below breaks one property the smoke is supposed to hold.",
+    "The rc-2 and rc-3 cells used to substring-match the branch comparison, which sees that the branch exists and nothing about what it does: an exit 1 added to either quiet-skip path left the suite green while every no-publish push to main would have failed (#1518). The cells now parse each branch body, and these mutations are what shows they can see into it."
   ],
   "mutations": [
     {
@@ -60,6 +61,38 @@
       "replace": "        if (body && body.version === version) continue;",
       "expectRed": "fake registry: one 200 naming a different package -> does NOT pass as published",
       "cell": "fake registry: one 200 naming a different package -> does NOT pass as published"
+    },
+    {
+      "name": "the UNSETTLED quiet skip starts failing the job",
+      "file": ".github/workflows/changesets.yml",
+      "find": "            echo \"UNSETTLED — the registry has not converged. Skipping the Release.\"\n",
+      "replace": "            echo \"UNSETTLED — the registry has not converged. Skipping the Release.\"\n            exit 1\n",
+      "expectRed": "the closure-gate step handles exit code 2 (UNSETTLED) without failing",
+      "cell": "the closure-gate step handles exit code 2 (UNSETTLED) without failing"
+    },
+    {
+      "name": "the NONE quiet skip starts failing the job",
+      "file": ".github/workflows/changesets.yml",
+      "find": "            echo \"NONE — this push published nothing. Skipping the Release.\"\n",
+      "replace": "            echo \"NONE — this push published nothing. Skipping the Release.\"\n            exit 1\n",
+      "expectRed": "the closure-gate step handles exit code 3 (NONE) without failing",
+      "cell": "the closure-gate step handles exit code 3 (NONE) without failing"
+    },
+    {
+      "name": "the PARTIAL branch stops failing the job",
+      "file": ".github/workflows/changesets.yml",
+      "find": "            echo \"PARTIAL PUBLISH — failing the job.\"\n            exit 1\n",
+      "replace": "            echo \"PARTIAL PUBLISH — failing the job.\"\n",
+      "expectRed": "the closure-gate step branches on exit code 1 (PARTIAL) to fail the job",
+      "cell": "the closure-gate step branches on exit code 1 (PARTIAL) to fail the job"
+    },
+    {
+      "name": "an unexpected exit code stops failing the job",
+      "file": ".github/workflows/changesets.yml",
+      "find": "            echo \"Unexpected exit code $rc from verify-publish-closure.mjs — failing the job.\"\n            exit 1\n",
+      "replace": "            echo \"Unexpected exit code $rc from verify-publish-closure.mjs — failing the job.\"\n",
+      "expectRed": "the closure-gate step fails the job on an unexpected exit code",
+      "cell": "the closure-gate step fails the job on an unexpected exit code"
     }
   ]
 }

--- a/bin/smoke/mutations/publish-closure-gate.json
+++ b/bin/smoke/mutations/publish-closure-gate.json
@@ -65,34 +65,52 @@
     {
       "name": "the UNSETTLED quiet skip starts failing the job",
       "file": ".github/workflows/changesets.yml",
-      "find": "            echo \"UNSETTLED — the registry has not converged. Skipping the Release.\"\n",
-      "replace": "            echo \"UNSETTLED — the registry has not converged. Skipping the Release.\"\n            exit 1\n",
+      "find": "            echo \"UNSETTLED \u2014 the registry has not converged. Skipping the Release.\"\n",
+      "replace": "            echo \"UNSETTLED \u2014 the registry has not converged. Skipping the Release.\"\n            exit 1\n",
       "expectRed": "the closure-gate step handles exit code 2 (UNSETTLED) without failing",
       "cell": "the closure-gate step handles exit code 2 (UNSETTLED) without failing"
     },
     {
       "name": "the NONE quiet skip starts failing the job",
       "file": ".github/workflows/changesets.yml",
-      "find": "            echo \"NONE — this push published nothing. Skipping the Release.\"\n",
-      "replace": "            echo \"NONE — this push published nothing. Skipping the Release.\"\n            exit 1\n",
+      "find": "            echo \"NONE \u2014 this push published nothing. Skipping the Release.\"\n",
+      "replace": "            echo \"NONE \u2014 this push published nothing. Skipping the Release.\"\n            exit 1\n",
       "expectRed": "the closure-gate step handles exit code 3 (NONE) without failing",
       "cell": "the closure-gate step handles exit code 3 (NONE) without failing"
     },
     {
       "name": "the PARTIAL branch stops failing the job",
       "file": ".github/workflows/changesets.yml",
-      "find": "            echo \"PARTIAL PUBLISH — failing the job.\"\n            exit 1\n",
-      "replace": "            echo \"PARTIAL PUBLISH — failing the job.\"\n",
+      "find": "            echo \"PARTIAL PUBLISH \u2014 failing the job.\"\n            exit 1\n",
+      "replace": "            echo \"PARTIAL PUBLISH \u2014 failing the job.\"\n",
       "expectRed": "the closure-gate step branches on exit code 1 (PARTIAL) to fail the job",
       "cell": "the closure-gate step branches on exit code 1 (PARTIAL) to fail the job"
     },
     {
       "name": "an unexpected exit code stops failing the job",
       "file": ".github/workflows/changesets.yml",
-      "find": "            echo \"Unexpected exit code $rc from verify-publish-closure.mjs — failing the job.\"\n            exit 1\n",
-      "replace": "            echo \"Unexpected exit code $rc from verify-publish-closure.mjs — failing the job.\"\n",
+      "find": "            echo \"Unexpected exit code $rc from verify-publish-closure.mjs \u2014 failing the job.\"\n            exit 1\n",
+      "replace": "            echo \"Unexpected exit code $rc from verify-publish-closure.mjs \u2014 failing the job.\"\n",
       "expectRed": "the closure-gate step fails the job on an unexpected exit code",
       "cell": "the closure-gate step fails the job on an unexpected exit code"
+    },
+    {
+      "name": "a separator-based failing exit is added to the UNSETTLED branch",
+      "file": ".github/workflows/changesets.yml",
+      "find": "            echo \"UNSETTLED \u2014 the registry has not converged. Skipping the Release.\"",
+      "replace": "            echo \"UNSETTLED \u2014 the registry has not converged. Skipping the Release.\"; exit 1",
+      "expectRed": "the closure-gate step handles exit code 2 (UNSETTLED) without failing",
+      "cell": "the closure-gate step handles exit code 2 (UNSETTLED) without failing",
+      "note": "The direction that matters for this cell: it asserts the NEGATIVE, so a matcher that cannot read the failure certifies a job-failing branch as safe and the green is indistinguishable from a correct one. The line-anchored matcher this PR replaces stayed green here."
+    },
+    {
+      "name": "the PARTIAL branch exits 0 instead of failing",
+      "file": ".github/workflows/changesets.yml",
+      "find": "            echo \"PARTIAL PUBLISH \u2014 failing the job.\"\n            exit 1",
+      "replace": "            echo \"PARTIAL PUBLISH \u2014 failing the job.\"\n            exit 0",
+      "expectRed": "the closure-gate step branches on exit code 1 (PARTIAL) to fail the job",
+      "cell": "the closure-gate step branches on exit code 1 (PARTIAL) to fail the job",
+      "note": "The accept direction, held as strict as before: a correct `exit 0` is never read as a failure, in any position. A widening that lost the non-zero lookahead would keep this cell green and would red a valid workflow elsewhere."
     }
   ]
 }

--- a/bin/smoke/mutations/publish-closure-gate.json
+++ b/bin/smoke/mutations/publish-closure-gate.json
@@ -111,6 +111,24 @@
       "expectRed": "the closure-gate step branches on exit code 1 (PARTIAL) to fail the job",
       "cell": "the closure-gate step branches on exit code 1 (PARTIAL) to fail the job",
       "note": "The accept direction, held as strict as before: a correct `exit 0` is never read as a failure, in any position. A widening that lost the non-zero lookahead would keep this cell green and would red a valid workflow elsewhere."
+    },
+    {
+      "name": "a reachable keyword-position failure is added to the UNSETTLED branch",
+      "file": ".github/workflows/changesets.yml",
+      "find": "            echo \"UNSETTLED \u2014 the registry has not converged. Skipping the Release.\"",
+      "replace": "            echo \"UNSETTLED \u2014 the registry has not converged. Skipping the Release.\"\n            if true; then exit 1; fi",
+      "expectRed": "the closure-gate step handles exit code 2 (UNSETTLED) without failing",
+      "cell": "the closure-gate step handles exit code 2 (UNSETTLED) without failing",
+      "note": "bash gives this body rc=1, so the quiet skip becomes a job failure. A matcher that treats only punctuation as a command position reads it as safe: `; exit 1` matches and `; then exit 1` does not. Five more shapes hide behind the same gap (else, while, for, until, elif)."
+    },
+    {
+      "name": "the PARTIAL branch's exit is moved inside a string",
+      "file": ".github/workflows/changesets.yml",
+      "find": "            echo \"PARTIAL PUBLISH \u2014 failing the job.\"\n            exit 1",
+      "replace": "            echo \"PARTIAL PUBLISH; exit 1\"",
+      "expectRed": "the closure-gate step branches on exit code 1 (PARTIAL) to fail the job",
+      "cell": "the closure-gate step branches on exit code 1 (PARTIAL) to fail the job",
+      "note": "bash gives this body rc=0, so a partial publish stops failing the job and a Release is cut. It is the worse direction: the vacuity guard is what licenses the two negative cells, so a guard satisfied by a body that does not fail licenses nothing."
     }
   ]
 }

--- a/bin/smoke/publish-closure-gate.smoke.ts
+++ b/bin/smoke/publish-closure-gate.smoke.ts
@@ -104,45 +104,129 @@ function rcBranchBody(run: string, code: number): string | null {
   return body.join("\n");
 }
 
-/** Where a command can begin on a line: at the start, or after a separator or an opening group.
- *  Word characters are deliberately absent, so `echo "Unexpected exit code $rc"` is prose to this
- *  matcher rather than a command. */
-const COMMAND_START = String.raw`(?:^|[;&|(){}])\s*`;
+/** Where a command can begin: the start of a line, a separator or opening group, or after a shell
+ *  keyword that introduces a command list. The keywords are the half a punctuation-only rule misses:
+ *  `; exit 1` is a command position and so is `; then exit 1`, and six reachable failure forms
+ *  (`if true; then …`, `else …`, `while/for/until … do …`) hid behind that gap. */
+const COMMAND_START = String.raw`(?:^|[;&|(){}]|\b(?:then|else|do)\b)\s*`;
 /** Where it can end and still be a command of its own: end of line, a separator, a closing group,
  *  or an inline comment. */
 const COMMAND_END = String.raw`\s*(?:$|[;&|)}#])`;
-/** An `exit` whose status is anything but the literal 0. A variable (`exit $rc`) counts: it is the
- *  natural way to forward a captured failure, and nothing static can rule out that it carries one. */
-const NONZERO_EXIT = String.raw`exit\s+(?!0${COMMAND_END})\S+`;
+/** An `exit` whose status is anything but zero. `0`, `00` and `000` are all zero to the shell; a
+ *  variable (`exit $rc`) counts as failing, since it is how a captured failure is forwarded and
+ *  nothing static can rule out that it carries one. */
+const NONZERO_EXIT = String.raw`exit\s+(?!0+${COMMAND_END})\S+`;
 const FAILING_COMMANDS = [
   NONZERO_EXIT,
-  String.raw`(?:/bin/)?false`,
+  String.raw`(?:/(?:usr/)?bin/)?false`,
   String.raw`return\s+(?!0${COMMAND_END})\d+`,
   String.raw`!\s*:`,               // negated true
   String.raw`kill\s+-\w+\s+\$\$`, // signal the shell itself
 ].join("|");
-/** `eval` is the one place a QUOTED failure command runs. Matched on the `eval` word rather than on
- *  the quote, so `echo "exit 1"` stays prose. */
-const EVAL_FAILURE = String.raw`\beval\s+["']?\s*(?:${NONZERO_EXIT}|(?:/bin/)?false)`;
-const FAILS = new RegExp(`(?:${COMMAND_START}(?:${FAILING_COMMANDS})${COMMAND_END})|(?:${EVAL_FAILURE})`, "m");
+/** `eval` is the one place a QUOTED failure command runs. Matched on the `eval` word against the
+ *  RAW body, so `echo "exit 1"` stays prose. */
+const EVAL_FAILURE = String.raw`\beval\s+["']?\s*(?:${NONZERO_EXIT}|(?:/(?:usr/)?bin/)?false)`;
+const FAILS = new RegExp(`${COMMAND_START}(?:${FAILING_COMMANDS})${COMMAND_END}`, "m");
+const EVAL_FAILS = new RegExp(EVAL_FAILURE, "m");
+
+/** A quoted span is text, not a command list: `echo "a; exit 9"` prints a string and leaves the step
+ *  green. Filled with a placeholder rather than deleted so the span still reads as ONE argument,
+ *  which is what keeps `exit "$rc"` a failing exit while hiding the separators inside `echo "…"`. */
+function withoutQuotedText(body: string): string {
+  return body.replace(/"(?:[^"\\]|\\.)*"|'[^']*'/g, (quoted) => "x".repeat(quoted.length));
+}
 
 /** Whether a branch body leaves the step with a failing status.
  *
- *  Two cells below assert the NEGATIVE of this, so under-detection is worse than a normal coverage
- *  gap: a body this cannot read is certified as safe, and that green is indistinguishable from a
- *  correct one. The line anchors this used to carry made every failure sharing its line invisible,
- *  including two forms that are house style here (`|| { echo "..."; exit 1; }` in `ci.yml`,
- *  `mutation-reproof.yml` and `installer.yml`, and `exit $rc`).
+ *  Two cells below assert the NEGATIVE of this, so under-detection is worse than an ordinary
+ *  coverage gap: a body this cannot read is certified as safe, and that green is indistinguishable
+ *  from a correct one. {@link FAILS_THE_JOB_ROWS} is the battery that grades both directions
+ *  against statuses measured from `bash -c`, rather than against reasoning about regexes.
  *
- *  The accept direction stays as strict as it was: a correct `exit 0` is never a failure, in any
- *  position, which is the property that keeps this from redding a valid workflow.
- *
- *  Not detected, and deliberately: a failure command that is present but UNREACHABLE
- *  (`if false; then exit 1; fi`). Seeing that needs a shell evaluator, which does not fit a check
- *  that also runs on the Windows shards. */
+ *  The one class it gets wrong, and the reason is structural rather than a missing pattern: it does
+ *  not evaluate conditions, so a failure command in a branch that never runs
+ *  (`if false; then exit 1; fi`) is reported as failing. Those four shapes are carried in the
+ *  battery as `"unevaluable"` and asserted to STILL disagree, so the gap cannot widen unnoticed and
+ *  closing it reds the battery instead of passing quietly. */
 function failsTheJob(body: string): boolean {
-  return FAILS.test(body);
+  return FAILS.test(withoutQuotedText(body)) || EVAL_FAILS.test(body);
 }
+
+/** Literal branch bodies, the status `bash -c` actually gave each one, and whether the matcher is
+ *  known to disagree.
+ *
+ *  Every call site of {@link failsTheJob} is workflow-derived, so nothing here tested the helper
+ *  against a body written by hand, and that is where every evasion lived. Statuses were measured,
+ *  not reasoned about: rows naming `rc` were run under `rc=2`, the way the gate's own `rc=$?` binds
+ *  it. `/bin/false` is 127 on a mac (the binary lives in `/usr/bin`) and 1 on the Linux runner;
+ *  either way it is non-zero, which is all this table claims. */
+const FAILS_THE_JOB_ROWS: ReadonlyArray<readonly [string, number] | readonly [string, number, "unevaluable"]> = [
+  ["exit 1", 1],
+  ["exit 2", 2],
+  ["exit $rc", 2],
+  ["exit \"$rc\"", 2],
+  ["exit ${rc}", 2],
+  ["exit 1 # comment", 1],
+  ["echo hi; exit 1", 1],
+  ["true && exit 1", 1],
+  ["false || exit 1", 1],
+  ["exit 1 ;", 1],
+  ["{ exit 1; }", 1],
+  ["(exit 1)", 1],
+  ["! :", 1],
+  ["eval \"exit 1\"", 1],
+  ["return 1", 1],
+  ["kill -TERM $$", 143],
+  ["/bin/false", 127],
+  ["false", 1],
+  ["case x in x) false ;; esac", 1],
+  ["case x in x) exit 1;; esac", 1],
+  ["if true; then exit 1; fi", 1],
+  ["if false; then : ; else exit 1; fi", 1],
+  ["while true; do exit 1; done", 1],
+  ["for i in 1; do exit 1; done", 1],
+  ["until false; do exit 1; done", 1],
+  ["if [ x = x ]; then exit 1; fi", 1],
+  ["if [ -n \"$rc\" ]; then exit 1; fi", 1],
+  ["if false; then exit 1; fi", 0, "unevaluable"],
+  ["echo \"a; exit 9\"", 0],
+  ["exit 00", 0],
+  ["exit 0", 0],
+  ["exit 0 # fine", 0],
+  ["echo ok; exit 0", 0],
+  ["(exit 0)", 0],
+  ["{ exit 0; }", 0],
+  ["echo \"exit 1\"", 0],
+  ["echo \"run false to fail\"", 0],
+  ["true", 0],
+  [":", 0],
+  ["echo \"PARTIAL PUBLISH - failing the job.\"", 0],
+  ["echo \"UNSETTLED - the registry has not converged. Skipping the Release.\"", 0],
+  ["until true; do exit 1; done", 0, "unevaluable"],
+  ["while false; do exit 1; done", 0, "unevaluable"],
+  ["if true; then : ; else exit 1; fi", 0, "unevaluable"],
+  ["exit 000", 0],
+  ["exit 0x0", 255],
+];
+
+
+// The battery runs FIRST: every assertion below reads `failsTheJob`, and a matcher that is wrong
+// about a hand-written body is wrong about a workflow-derived one for the same reason.
+const UNEVALUABLE = FAILS_THE_JOB_ROWS.filter((row) => row[2] === "unevaluable").map((row) => row[0]);
+const disagreements = FAILS_THE_JOB_ROWS.filter(([body, status]) => failsTheJob(body) !== (status !== 0))
+  .map(([body]) => body);
+check(
+  `failsTheJob matches the measured shell status on every evaluable body (${FAILS_THE_JOB_ROWS.length - UNEVALUABLE.length} of them)`,
+  disagreements.every((body) => UNEVALUABLE.includes(body)),
+  disagreements.filter((body) => !UNEVALUABLE.includes(body)),
+);
+// The gap is pinned, not merely documented: it may not widen, and closing it reds this cell rather
+// than passing quietly, which is the only way a reader finds out the comment above went stale.
+check(
+  "the bodies it is wrong about are exactly the branches whose condition it cannot evaluate",
+  disagreements.length === UNEVALUABLE.length && UNEVALUABLE.every((body) => disagreements.includes(body)),
+  { disagreements, UNEVALUABLE },
+);
 
 // Vacuity guard FIRST: the two "does not fail" assertions below are only worth anything if this
 // parser can see a failing exit where there is one. The branches that must fail are the proof.
@@ -342,7 +426,7 @@ const fastClock = () => { let t = 0; return { now: () => (t += 1000), sleep: asy
   );
 }
 
-const EXPECTED = 18;
+const EXPECTED = 20;
 check(`every cell ran (${EXPECTED} before sentinel)`, passed + failed === EXPECTED, passed + failed);
 console.log(`PUBLISH CLOSURE GATE SMOKE ${failed === 0 ? "OK" : "FAILED"} (${passed} passed, ${failed} failed)`);
 console.log("SUITE COMPLETE");

--- a/bin/smoke/publish-closure-gate.smoke.ts
+++ b/bin/smoke/publish-closure-gate.smoke.ts
@@ -104,9 +104,44 @@ function rcBranchBody(run: string, code: number): string | null {
   return body.join("\n");
 }
 
-/** Whether a branch body leaves the step with a failing status. */
+/** Where a command can begin on a line: at the start, or after a separator or an opening group.
+ *  Word characters are deliberately absent, so `echo "Unexpected exit code $rc"` is prose to this
+ *  matcher rather than a command. */
+const COMMAND_START = String.raw`(?:^|[;&|(){}])\s*`;
+/** Where it can end and still be a command of its own: end of line, a separator, a closing group,
+ *  or an inline comment. */
+const COMMAND_END = String.raw`\s*(?:$|[;&|)}#])`;
+/** An `exit` whose status is anything but the literal 0. A variable (`exit $rc`) counts: it is the
+ *  natural way to forward a captured failure, and nothing static can rule out that it carries one. */
+const NONZERO_EXIT = String.raw`exit\s+(?!0${COMMAND_END})\S+`;
+const FAILING_COMMANDS = [
+  NONZERO_EXIT,
+  String.raw`(?:/bin/)?false`,
+  String.raw`return\s+(?!0${COMMAND_END})\d+`,
+  String.raw`!\s*:`,               // negated true
+  String.raw`kill\s+-\w+\s+\$\$`, // signal the shell itself
+].join("|");
+/** `eval` is the one place a QUOTED failure command runs. Matched on the `eval` word rather than on
+ *  the quote, so `echo "exit 1"` stays prose. */
+const EVAL_FAILURE = String.raw`\beval\s+["']?\s*(?:${NONZERO_EXIT}|(?:/bin/)?false)`;
+const FAILS = new RegExp(`(?:${COMMAND_START}(?:${FAILING_COMMANDS})${COMMAND_END})|(?:${EVAL_FAILURE})`, "m");
+
+/** Whether a branch body leaves the step with a failing status.
+ *
+ *  Two cells below assert the NEGATIVE of this, so under-detection is worse than a normal coverage
+ *  gap: a body this cannot read is certified as safe, and that green is indistinguishable from a
+ *  correct one. The line anchors this used to carry made every failure sharing its line invisible,
+ *  including two forms that are house style here (`|| { echo "..."; exit 1; }` in `ci.yml`,
+ *  `mutation-reproof.yml` and `installer.yml`, and `exit $rc`).
+ *
+ *  The accept direction stays as strict as it was: a correct `exit 0` is never a failure, in any
+ *  position, which is the property that keeps this from redding a valid workflow.
+ *
+ *  Not detected, and deliberately: a failure command that is present but UNREACHABLE
+ *  (`if false; then exit 1; fi`). Seeing that needs a shell evaluator, which does not fit a check
+ *  that also runs on the Windows shards. */
 function failsTheJob(body: string): boolean {
-  return /^\s*exit\s+(?!0\b)\d+\s*$/m.test(body) || /^\s*(false|exit\s+1)\s*$/m.test(body);
+  return FAILS.test(body);
 }
 
 // Vacuity guard FIRST: the two "does not fail" assertions below are only worth anything if this

--- a/bin/smoke/publish-closure-gate.smoke.ts
+++ b/bin/smoke/publish-closure-gate.smoke.ts
@@ -71,21 +71,70 @@ check(
 
 // The closure-gate step must branch on all four exit codes, not treat any non-zero as failure.
 // Exit 2 (UNSETTLED) and 3 (NONE) are quiet skips, not failures. Only exit 1 (PARTIAL) fails the job.
-const gateRun = closureGateStep?.run ?? "";
+//
+// These assert on each branch's BODY, not on the presence of its comparison (#1518). A substring
+// match on `"$rc" -eq 2` sees that the branch exists and nothing about what it does, so an `exit 1`
+// added to the quiet-skip path left this suite green while every no-publish push to main would have
+// failed. That is the same weak-assertion shape as the `includes("verify-publish-closure.mjs")` hole
+// a diagnostic echo satisfied (#1502).
+const gateRun: string = closureGateStep?.run ?? "";
+
+/**
+ * The body of the gate script's `[ "$rc" -eq <code> ]` branch, or null when there is no such branch.
+ * `else` is addressed as code -1, being the unexpected-rc arm.
+ *
+ * The chain is flat shell in a YAML block scalar, so the branch ends at the next line indented the
+ * same as its own `if`/`elif`/`else` keyword and starting one of them (or `fi`). Anything indented
+ * deeper stays part of the body, so a nested block cannot hide a line from these assertions.
+ */
+function rcBranchBody(run: string, code: number): string | null {
+  const lines = run.split("\n");
+  const opener = code === -1
+    ? /^(\s*)else\s*$/
+    : new RegExp(`^(\\s*)(?:el)?if \\[ "\\$rc" -eq ${code} \\]; then\\s*$`);
+  const start = lines.findIndex((line) => opener.test(line));
+  if (start < 0) return null;
+  const indent = (opener.exec(lines[start]!) ?? [])[1] ?? "";
+  const ends = new RegExp(`^${indent}(?:elif |else\\b|fi\\b)`);
+  const body: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    if (ends.test(line)) break;
+    body.push(line);
+  }
+  return body.join("\n");
+}
+
+/** Whether a branch body leaves the step with a failing status. */
+function failsTheJob(body: string): boolean {
+  return /^\s*exit\s+(?!0\b)\d+\s*$/m.test(body) || /^\s*(false|exit\s+1)\s*$/m.test(body);
+}
+
+// Vacuity guard FIRST: the two "does not fail" assertions below are only worth anything if this
+// parser can see a failing exit where there is one. The branches that must fail are the proof.
+const partialBody = rcBranchBody(gateRun, 1);
 check(
   "the closure-gate step branches on exit code 1 (PARTIAL) to fail the job",
-  gateRun.includes('"$rc" -eq 1') && gateRun.includes('exit 1'),
-  gateRun,
+  partialBody !== null && failsTheJob(partialBody),
+  { partialBody, gateRun },
 );
+const unexpectedBody = rcBranchBody(gateRun, -1);
+check(
+  "the closure-gate step fails the job on an unexpected exit code",
+  unexpectedBody !== null && failsTheJob(unexpectedBody),
+  { unexpectedBody, gateRun },
+);
+
+const unsettledBody = rcBranchBody(gateRun, 2);
 check(
   "the closure-gate step handles exit code 2 (UNSETTLED) without failing",
-  gateRun.includes('"$rc" -eq 2'),
-  gateRun,
+  unsettledBody !== null && !failsTheJob(unsettledBody),
+  { unsettledBody, gateRun },
 );
+const noneBody = rcBranchBody(gateRun, 3);
 check(
   "the closure-gate step handles exit code 3 (NONE) without failing",
-  gateRun.includes('"$rc" -eq 3'),
-  gateRun,
+  noneBody !== null && !failsTheJob(noneBody),
+  { noneBody, gateRun },
 );
 
 // The closure-gate step must come BEFORE the release step
@@ -258,7 +307,7 @@ const fastClock = () => { let t = 0; return { now: () => (t += 1000), sleep: asy
   );
 }
 
-const EXPECTED = 17;
+const EXPECTED = 18;
 check(`every cell ran (${EXPECTED} before sentinel)`, passed + failed === EXPECTED, passed + failed);
 console.log(`PUBLISH CLOSURE GATE SMOKE ${failed === 0 ? "OK" : "FAILED"} (${passed} passed, ${failed} failed)`);
 console.log("SUITE COMPLETE");


### PR DESCRIPTION
Refs #1518.

## Reproduced first, on a clean tree

Per AGENTS.md the repro comes before the fix. On `origin/main`, injecting `exit 1` into the rc-2 branch of `.github/workflows/changesets.yml`:

```
✓ every cell ran (17 before sentinel)
PUBLISH CLOSURE GATE SMOKE OK (18 passed, 0 failed)
SUITE COMPLETE
```

Green, exactly as the issue reports, while every no-publish push to `main` would have failed the job.

## The fix

The rc-2 and rc-3 cells substring-matched the branch comparison, which sees that the branch exists and nothing about what it does. They now parse the branch **body** out of the step's run script and assert the absence of a failing exit.

`rcBranchBody(run, code)` ends a branch at the next line indented the same as its own `if`/`elif`/`else` keyword, so anything indented deeper stays part of the body and a nested block cannot hide a line from the assertion. `else` is addressed as code `-1`, being the unexpected-rc arm.

**Two cells come first as the vacuity guard**, and that ordering is the point: "this body contains no failing exit" is worth nothing unless the same parser finds a failing exit where one exists. So the PARTIAL branch and the unexpected-rc branch are asserted to fail, with the same helper, before the two quiet skips are asserted not to. That is the hole the `includes("verify-publish-closure.mjs")` cell had in #1502 — an assertion that any echo could satisfy — and it is avoidable here only by making the positive direction part of the same family.

The unexpected-rc cell is new. The `else` arm also fails the job, it is the same class of property, and nothing covered it.

## Verified

Both injections are now caught, one cell each:

```
--- exit 1 in the rc-2 branch:
  ✗ FAIL: the closure-gate step handles exit code 2 (UNSETTLED) without failing
  PUBLISH CLOSURE GATE SMOKE FAILED (18 passed, 1 failed)
--- exit 1 in the rc-3 branch:
  ✗ FAIL: the closure-gate step handles exit code 3 (NONE) without failing
  PUBLISH CLOSURE GATE SMOKE FAILED (18 passed, 1 failed)
```

Four mutation cells added to `bin/smoke/mutations/publish-closure-gate.json`, one per branch, where it had none for this branching at all: an `exit 1` inserted into either quiet skip, and a removed `exit 1` in either failing branch.

```
KILLED  the UNSETTLED quiet skip starts failing the job
  red, and named: the closure-gate step handles exit code 2 (UNSETTLED) without failing
KILLED  the NONE quiet skip starts failing the job
  red, and named: the closure-gate step handles exit code 3 (NONE) without failing
KILLED  the PARTIAL branch stops failing the job
  red, and named: the closure-gate step branches on exit code 1 (PARTIAL) to fail the job
KILLED  an unexpected exit code stops failing the job
  red, and named: the closure-gate step fails the job on an unexpected exit code

All 10 mutation(s) killed. The suite discriminates.
```

`pnpm smoke:publish-closure-gate` → 19 passed, 0 failed. The cell-count sentinel moves 17 → 18 for the one new cell. `check:docs-voice` passes; no docs page describes this, so none changed.

## Not changed

The workflow itself. It skips correctly today, which is why the issue is a coverage gap and not a bug: the committed rc-2 and rc-3 branches carry only an `echo`, and the new cells now hold them there.

AI disclosure: written by Claude (Anthropic) under my review and testing; no human reviewed it besides me.

