### PR TITLE
fix(core): refuse an expired rw cred on the membership feed's conn B

### DIFF
--- a/.changeset/membership-feed-rw-expiry-checkpoint.md
+++ b/.changeset/membership-feed-rw-expiry-checkpoint.md
@@ -1,0 +1,12 @@
+---
+"@cotal-ai/core": patch
+---
+
+The membership feed's conn B now refuses to present an rw credential it has already decoded as
+expired. The cached credential only ever advances through a preflight-proven adoption, so it cannot
+hold an unproven generation, but a legitimately proven one expires as the clock advances. With
+re-signing stopped, the broker closed conn B at the credential's `exp` and the client's own redial
+presented the dead credential: an auth round trip that could only be denied, reported to the host as
+the broker's "User Authentication Expired" rather than the local cause. The dial is refused before
+it leaves the process, with separate messages for a feed that can renew and one that cannot, so the
+diagnostic names the applicable remedy.

--- a/packages/core/smoke/membership-rw-renewal.smoke.ts
+++ b/packages/core/smoke/membership-rw-renewal.smoke.ts
@@ -36,6 +36,11 @@ import { SMOKE_BROKER_TOKEN, teardownOnSignal } from "@cotal-ai/smoke-kit";
 
 const enc = (s: string) => new TextEncoder().encode(s);
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const until = async (cond: () => boolean, budgetMs: number, stepMs: number): Promise<boolean> => {
+  const deadline = Date.now() + budgetMs;
+  while (Date.now() < deadline) { if (cond()) return true; await wait(stepMs); }
+  return cond();
+};
 const MANAGER_BOUND_MS = 15_000; // manager's requestDeliveryAdmin("reloadCreds") timeout
 let pass = 0, fail = 0;
 const check = (name: string, cond: boolean, extra?: unknown) => {
@@ -53,9 +58,14 @@ writeFileSync(join(dir, "server.conf"), serverConfig(auth, [auth], { transport: 
 // each call site remembering. Owning only the first child would leave the LIVE broker unowned
 // after a restart while the suite still read as migrated: ownership held on a dead pid.
 let releaseBroker = (): void => {};
+// `-D` and piped output: scenario 7 grades what conn B presents to the BROKER after its own wire
+// expires, and the auth decision is only visible in the server's debug log.
+let brokerLog = "";
 const startBroker = (): ChildProcess => {
   releaseBroker();
-  const p = spawn("nats-server", ["-c", join(dir, "server.conf")], { stdio: "ignore" });
+  const p = spawn("nats-server", ["-D", "-c", join(dir, "server.conf")], { stdio: ["ignore", "pipe", "pipe"] });
+  p.stdout?.on("data", (d: Buffer) => { brokerLog += d.toString(); });
+  p.stderr?.on("data", (d: Buffer) => { brokerLog += d.toString(); });
   releaseBroker = teardownOnSignal(p, dir);
   return p;
 };
@@ -269,6 +279,48 @@ try {
   const h2after = await provesLive(feed5, boundedInit, h2hb);
   check("post-validation-failure the cache is UNCHANGED — bounded cred still presented after reconnect (H2)", h2after > h2hb, { h2after, h2hb });
   await feed5.stop();
+  feed = undefined;
+
+  // ---- Scenario 7: an expired rw cred is never presented, even by the client's own redial ----
+  // "Proven when adopted" and "unexpired now" are different properties. `currentRwCreds` only advances
+  // through a preflight-proven adoption, so it cannot hold an UNPROVEN generation - but the clock alone
+  // expires a proven one. With renewal failing (manager down, store unreachable), the broker closes conn B
+  // at `exp` and the client redials; before the checkpoint that redial presented the dead credential, which
+  // cost an auth round trip and reported the broker's words rather than the local, actionable cause.
+  const expiringId = newIdentity();
+  let expiringReads = 0;
+  const expiringLog: string[] = [];
+  const expiringFeed = await startMembershipFeed({
+    servers: SERVERS, space, accountId, observerCreds, intervalMs: 60_000,
+    log: (m) => { expiringLog.push(m); },
+    rwCreds: async () => {
+      expiringReads++;
+      if (expiringReads === 1) return mintCreds(auth, expiringId, "membership-rw", { expiresInSeconds: 3 });
+      throw new Error("fixture renewal source offline"); // renewal keeps failing, as in the report
+    },
+  });
+  feed = expiringFeed;
+  const expiryWindowStart = brokerLog.length; // grade only what this scenario's wire does
+  // Past `exp`, plus the broker's expiry-close and the client's redial attempt.
+  await until(() => /rw creds have expired/.test(expiringLog.join("\n")), 12_000, 100);
+  // Every broker-side connection that carried this feed's nkey into an expiry decision. The original wire
+  // is one; a redial that presented the dead cred would be a second cid on the same nkey.
+  const expiredCids = new Set(
+    brokerLog.slice(expiryWindowStart).split("\n")
+      .filter((l) => l.includes(`nkey:${expiringId.id}`) && /Authentication Expired/.test(l))
+      .map((l) => /cid:(\d+)/.exec(l)?.[1] ?? "?"),
+  );
+  check(
+    "the refusal is loud and names the failing renewal path",
+    expiringLog.some((m) => /rw creds have expired.*renewal is failing/.test(m)),
+    expiringLog,
+  );
+  check(
+    "conn B's own wire expires ONCE and no redial presents the dead cred to the broker",
+    expiredCids.size === 1,
+    { cids: [...expiredCids], reads: expiringReads },
+  );
+  await expiringFeed.stop();
   feed = undefined;
 
   console.log(`\n${fail ? "✗" : "✓"} MEMBERSHIP-RW RENEWAL ${pass}/${pass + fail}`);

--- a/packages/core/smoke/mutations/membership-rw-expiry.json
+++ b/packages/core/smoke/mutations/membership-rw-expiry.json
@@ -1,0 +1,29 @@
+{
+  "suite": [
+    "packages/core/smoke/membership-rw-renewal.smoke.ts"
+  ],
+  "guard": "the membership feed's conn B never presents its cached rw credential after that credential has expired",
+  "command": "pnpm smoke:membership-rw-renewal",
+  "completionMarker": "MEMBERSHIP-RW RENEWAL",
+  "proveWith": "node scripts/mutation-proof.mjs --config packages/core/smoke/mutations/membership-rw-expiry.json",
+  "why": [
+    "The cache only advances through a preflight-proven adoption, so it can never hold an UNPROVEN",
+    "generation. It can hold a proven one the clock has since expired. Disarming the guard restores the",
+    "reported behavior: the client's own redial presents credential material already decoded as dead.",
+    "The named cell counts the broker-side connections that carried this feed's nkey into an expiry",
+    "decision, so it grades what reached the BROKER rather than what the feed logged.",
+    "The sibling cell asserting the refusal text cannot grade this alone: it reads the feed's log, which",
+    "a future change could emit without the dial ever being refused."
+  ],
+  "mutations": [
+    {
+      "name": "the rw expiry checkpoint never fires",
+      "file": "packages/core/src/membership-feed.ts",
+      "find": "    if (typeof exp !== \"number\" || exp * 1000 > Date.now()) return;",
+      "replace": "    if (typeof exp !== \"number\" || exp * 1000 > 0) return;",
+      "expectRed": "conn B's own wire expires ONCE and no redial presents the dead cred to the broker",
+      "cell": "conn B's own wire expires ONCE and no redial presents the dead cred to the broker",
+      "note": "A real cred's exp is always > 0, so the guard returns before it can refuse: the issue's pre-fix behavior with the tree still compiling and the helper still referenced. Under the mutation the cell reports two distinct cids on the feed's nkey (the original wire plus the redial); with the guard armed it reports one."
+    }
+  ]
+}

--- a/packages/core/src/membership-feed.ts
+++ b/packages/core/src/membership-feed.ts
@@ -162,12 +162,27 @@ export async function startMembershipFeed(opts: MembershipFeedOpts): Promise<Mem
   // incidental reconnect (broker expiry-close, a network blip) can never present an unproven or
   // broker-refused generation and strand conn B — closing the membership half of the D5 blocker.
   let currentRwCreds = initialRw;
+  // Proven when adopted is not unexpired now. The cache only ever advances through a preflight-proven
+  // adoption, so it cannot hold an UNPROVEN generation, but the clock alone expires a legitimately
+  // proven one. If re-signing has stopped (the manager is down, the store unreachable) and conn B drops
+  // after `exp`, the client's own redial presents the expired credential to the broker: a denial that
+  // still costs the auth round trip, and one that reports the broker's words instead of the local cause.
+  // Refuse here instead, the same pre-dial checkpoint the endpoint raises before its own dial.
+  const refuseExpiredRwCreds = (): void => {
+    const exp = credsClaims(currentRwCreds).exp;
+    if (typeof exp !== "number" || exp * 1000 > Date.now()) return;
+    const why = rwIsSource
+      ? "the membership feed's rw creds have expired and renewal is failing - not presenting the expired credential to the broker; retrying with backoff"
+      : "the membership feed's rw creds have expired and the feed holds no rw creds source to renew them - replace the credential and restart the feed (pass an rw creds FUNCTION for standing renewal)";
+    log(why);
+    throw new Error(why);
+  };
   const connB = await connect({
     servers: opts.servers,
     // Synchronous per (re)connect attempt: presents the last BROKER-PROVEN cred, never a fresh
     // un-preflighted source read. The 75% timer / explicit reload advance `currentRwCreds` only AFTER a
     // disposable preflight proves the broker accepts the candidate.
-    authenticator: (nonce?: string) => credsAuthenticator(enc(currentRwCreds))(nonce),
+    authenticator: (nonce?: string) => { refuseExpiredRwCreds(); return credsAuthenticator(enc(currentRwCreds))(nonce); },
     name: "cotal-membership-rw",
     // The rw cred's sub.allow is `_INBOX_<id>.>`, so the connection's inbox prefix MUST match it — else
     // every KV reply / ordered-consumer delivery (kv.get/keys/watch) lands on a subject it can't subscribe.


### PR DESCRIPTION
Fixes #1522.

## Reproduced first

A feed whose rw source returns a 3s credential once and then fails, on a real broker with `-D`:

```
D> cid:93 - "cotal-membership-rw" - ... - User Authentication Expired
D> cid:93 - "cotal-membership-rw" - ... - Client connection closed: Authentication Expired
D> cid:98 - "cotal-membership-rw" - ... - Client connection closed: Authentication Expired
feed log: conn B (data) closed: User Authentication Expired
```

`cid:98` is the point. The broker closes the original wire at `exp`, the client redials, and that redial carries the dead credential back to the broker, which takes it through the auth path before rejecting it. Two connections on the feed's nkey; one of them could only ever be denied.

The report is right about why the surrounding comments do not cover it: `currentRwCreds` only advances through a preflight-proven adoption, so it cannot hold an *unproven* generation. Proven when adopted and unexpired now are different properties, and nothing re-checked the second.

One correction to the report, since it matters for how bad this is: the redial does not loop forever. `maxReconnectAttempts: -1` keeps the socket loop alive, but nats.js aborts on the auth error, so conn B closes after the one extra presentation. The cost is that round trip plus a diagnostic that names the broker instead of the local, actionable cause.

## The change

The shape the issue asks for, and the one the endpoint already raises before its own dial:

```ts
const refuseExpiredRwCreds = (): void => {
  const exp = credsClaims(currentRwCreds).exp;
  if (typeof exp !== "number" || exp * 1000 > Date.now()) return;
  const why = rwIsSource
    ? "the membership feed's rw creds have expired and renewal is failing - not presenting the expired credential to the broker; retrying with backoff"
    : "the membership feed's rw creds have expired and the feed holds no rw creds source to renew them - replace the credential and restart the feed (pass an rw creds FUNCTION for standing renewal)";
  log(why);
  throw new Error(why);
};
```

called from the authenticator. Two messages, so the diagnostic names the remedy that applies. The same run after the change:

```
D> cid:93 - "cotal-membership-rw" - ... - User Authentication Expired
D> cid:93 - "cotal-membership-rw" - ... - Client connection closed: Authentication Expired
feed log: the membership feed's rw creds have expired and renewal is failing -
          not presenting the expired credential to the broker; retrying with backoff
feed log: conn B (data) closed: <the same sentence>
```

One connection, and the close reason a host reads is now the local cause. The refusal is logged once here rather than per attempt, because the client stops after the auth error; nothing paces it beyond that.

## Proof

Scenario 7 in `membership-rw-renewal.smoke.ts`, on the live broker the rest of that matrix already uses. It grades what reached the **broker**, not what the feed logged: it counts the distinct connections that carried this feed's nkey into an expiry decision.

- `the refusal is loud and names the failing renewal path`
- `conn B's own wire expires ONCE and no redial presents the dead cred to the broker`

Pre-fix control, with the checkpoint removed from the authenticator:

```
✗ FAIL: the refusal is loud and names the failing renewal path
✗ FAIL: conn B's own wire expires ONCE and no redial presents the dead cred   { cids: [ '143', '148' ], reads: 2 }
✗ MEMBERSHIP-RW RENEWAL 28/30
```

With it: `✓ MEMBERSHIP-RW RENEWAL 30/30`.

Mutation fixture `packages/core/smoke/mutations/membership-rw-expiry.json` disarms the guard by a condition that can never fire (`exp * 1000 > 0`), which leaves the tree compiling and the helper referenced:

```
KILLED  the rw expiry checkpoint never fires
  red, and named: conn B's own wire expires ONCE and no redial presents the dead cred to the broker
  28 marks (baseline 31)
```

The suite's broker now starts with `-D` and piped output, since the auth decision is only visible in the server log.

## Notes

- Scope held to conn B, as the issue frames it. Nothing in the endpoint or the delivery daemon is touched.
- No `docs/` page changes: the protocol contract is unchanged (past the renewal horizon the feed still stops), and what moved is the sentence a host reads in its own log.
- Unrelated, found while running the suite: `implementations/auth/smoke/backup-continuity.smoke.ts:381` calls `rmSync(linkedRowSpace)` on a path the assertion two lines above requires to be a directory, so it throws `ERR_FS_EISDIR` on a clean tree here. Left alone; happy to file it separately.