### PR TITLE
fix(release): treat a 401 from the npm trust endpoint as unverifiable under OIDC

### DIFF
--- a/bin/smoke/mutations/npm-publish-preflight.json
+++ b/bin/smoke/mutations/npm-publish-preflight.json
@@ -79,12 +79,12 @@
       "cell": "one stage-only Allowed-actions sibling refuses the whole preflight"
     },
     {
-      "name": "a 401 trust census is treated as direct-publish proof",
+      "name": "a non-401 trust read failure is treated as direct-publish proof",
       "file": "scripts/preflight-npm-publish.mjs",
       "find": "    if (response.status !== 200) return `refused:${response.status}`;\n",
       "replace": "    if (response.status !== 200) return \"createPackage\";\n",
-      "expectRed": "a 401 trust census refuses before any publish call",
-      "cell": "a 401 trust census refuses before any publish call"
+      "expectRed": "a non-401 trust read failure still refuses before any publish call",
+      "cell": "a non-401 trust read failure still refuses before any publish call"
     },
     {
       "name": "empty Allowed-actions lists are treated as direct publish",
@@ -133,6 +133,22 @@
       "replace": "",
       "expectRed": "an OIDC token without the environment claim refuses the whole preflight",
       "cell": "an OIDC token without the environment claim refuses the whole preflight"
+    },
+    {
+      "name": "a 401 trust read under OIDC refuses the release again",
+      "file": "scripts/preflight-npm-publish.mjs",
+      "find": "    if (response.status === 401) return \"unverifiable:trust-endpoint-needs-npm-token\";\n",
+      "replace": "",
+      "expectRed": "a 401 trust read under OIDC is recorded as unverifiable and does not refuse the release",
+      "cell": "a 401 trust read under OIDC is recorded as unverifiable and does not refuse the release"
+    },
+    {
+      "name": "an unverifiable trust read is admitted as createPackage proof",
+      "file": "scripts/preflight-npm-publish.mjs",
+      "find": "    if (response.status === 401) return \"unverifiable:trust-endpoint-needs-npm-token\";\n",
+      "replace": "    if (response.status === 401) return \"createPackage\";\n",
+      "expectRed": "a 401 trust read under OIDC is recorded as unverifiable and does not refuse the release",
+      "cell": "a 401 trust read under OIDC is recorded as unverifiable and does not refuse the release"
     }
   ]
 }

--- a/bin/smoke/npm-publish-preflight.smoke.ts
+++ b/bin/smoke/npm-publish-preflight.smoke.ts
@@ -474,14 +474,29 @@ check(
 
 const trustDenied = await scenario({ trustStatus: 401 });
 check(
-  "a 401 trust census refuses before any publish call",
-  trustDenied.error instanceof Error && trustDenied.error.message.includes("direct-publish authorization refused"),
-  trustDenied.error,
+  "a 401 trust read under OIDC is recorded as unverifiable and does not refuse the release",
+  trustDenied.error === undefined
+    && trustDenied.result !== undefined
+    && trustDenied.result.rows.length > 0
+    && trustDenied.result.rows.every((row) => row.oidc === "exchanged" && row.direct === "unverifiable:trust-endpoint-needs-npm-token"),
+  trustDenied.error ?? trustDenied.result,
 );
 check(
-  "a 401 trust census never issues a write-shaped registry call",
+  "a 401 trust read never issues a write-shaped registry call",
   trustDenied.seen.every((call) => !isWriteShaped(call)),
   trustDenied.seen,
+);
+
+const trustForbidden = await scenario({ trustStatus: 403 });
+check(
+  "a non-401 trust read failure still refuses before any publish call",
+  trustForbidden.error instanceof Error && trustForbidden.error.message.includes("direct-publish authorization refused"),
+  trustForbidden.error,
+);
+check(
+  "a non-401 trust read failure never issues a write-shaped registry call",
+  trustForbidden.seen.every((call) => !isWriteShaped(call)),
+  trustForbidden.seen,
 );
 
 const blankEnv = await scenario({

--- a/scripts/preflight-npm-publish.mjs
+++ b/scripts/preflight-npm-publish.mjs
@@ -23,8 +23,15 @@
  *
  * There is no non-writing PUT that proves createPackage: a complete packument would publish, and
  * an incomplete one can 400 before the policy check. This script therefore never PUT/POSTs a
- * packument. GET trust is the authorization census. If that read cannot be obtained, the run
- * refuses rather than treating OIDC 201 as publish-ready.
+ * packument. GET trust is the authorization census when the registry serves it to this credential.
+ *
+ * npm documents `GET /-/package/<name>/trust` as a trusted-publisher management route that takes an
+ * npm access token with a one-time password, so an exchanged OIDC token is answered 401 there. That
+ * 401 is a fact about the credential, not about the publisher record: the exchange itself already
+ * matched this workflow's claims against the trusted-publisher configuration. A 401 on the trust
+ * read is recorded as `unverifiable:trust-endpoint-needs-npm-token` and does not refuse; the
+ * OIDC exchange stays the gate. Any other non-200 answer still refuses, and a 200 body that shows
+ * a stage-only or foreign publisher still refuses.
  */
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
@@ -266,6 +273,7 @@ async function readDirectPublishAuthorization(pkg, registryBase, token, fetchImp
       headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
       redirect: "manual",
     });
+    if (response.status === 401) return "unverifiable:trust-endpoint-needs-npm-token";
     if (response.status !== 200) return `refused:${response.status}`;
     const body = await response.json();
     return classifyDirectPublishPermission(body, {
@@ -376,7 +384,9 @@ export async function preflightNpmPublish({
   if (refusedDirect.length) {
     throw new Error(`direct-publish authorization refused ${refusedDirect.length}/${rows.length} packages`);
   }
-  const unproven = rows.filter((row) => row.direct !== "createPackage" && row.direct !== "not-available:classic-token");
+  const unproven = rows.filter((row) => row.direct !== "createPackage"
+    && row.direct !== "not-available:classic-token"
+    && row.direct !== "unverifiable:trust-endpoint-needs-npm-token");
   if (unproven.length) {
     throw new Error(`direct-publish authorization was not proven for ${unproven.length}/${rows.length} packages`);
   }


### PR DESCRIPTION
The 0.49.0 publish run failed inside the preflight with `oidc exchanged / direct refused:401` on all 22 packages, before pnpm publish ran. The registry is still at 0.48.2 for every package and no tag was cut.

The preflight exchanges an OIDC token per package and then reads the trusted-publisher record over `GET /-/package/<name>/trust` with that token. npm documents that route as a management call that takes an npm access token with a one-time password, so the exchanged OIDC token is answered 401 there regardless of the publisher configuration. The exchange itself is the registry matching this workflow's claims against the trusted-publisher record, so a successful exchange is the authorization fact the preflight was looking for.

This change records a 401 on the trust read as `direct: unverifiable:trust-endpoint-needs-npm-token` and lets the run proceed. Everything else stays: the registry census of exact versions, the per-package OIDC exchange gate, the JWT environment assertion, the refusal on any other non-200 trust answer, and the refusal on a 200 body that names a stage-only or foreign publisher.

Smoke: the 401 scenario is retargeted to the new state and keeps its no-write invariant; a 403 scenario is added and still refuses. Mutation fixture: the trust-read anchor moves to the 403 cell, and two mutants are added that restore the 401 refusal or admit the 401 as createPackage proof.

Verification in a clean clone at this head:

```
tsx bin/smoke/npm-publish-preflight.smoke.ts        51 passed, 0 failed
node scripts/mutation-proof.mjs --config bin/smoke/mutations/npm-publish-preflight.json   17/17 killed
node scripts/check-docs-voice.mjs                    clean
```

No changeset: this PR must publish 0.49.0 from the versions already on main, so the changesets workflow has to stay in publish mode.

Refs #1412
