### PR TITLE
test(runtime): pin the host-starvation check count so a lost assertion cannot pass green

### DIFF
--- a/implementations/runtime/smoke/host-starvation.smoke.ts
+++ b/implementations/runtime/smoke/host-starvation.smoke.ts
@@ -492,4 +492,22 @@ const handlerWith = (lag?: LoopLagObserver, clock: () => number = () => Date.now
 // chain, so the count is part of the output and not just the exit status.
 console.log(`host-starvation.smoke: ${ok} passed, ${fail} failed`);
 done();
+
+// A reported count is a LIVENESS check; a PINNED count is a coverage check. Reporting `41 passed`
+// catches a suite that ran nothing, but it cannot catch a suite that quietly runs LESS than it
+// did: delete one executed cell and `41 passed, 0 failed` becomes `40 passed, 0 failed`, which is
+// still green and still reads like success. Measured, not assumed: removing the genuine-fault cell
+// from this file produced exactly that, a passing run one cell lighter. An assertion silently
+// stops being paid for the moment nobody counts it, which is the same way a displaced mutation
+// anchor stops grading without anything going red.
+const EXPECTED_CELLS = 41;
+const ran = ok + fail;
+if (ran !== EXPECTED_CELLS) {
+  console.error(
+    `ACCOUNTING BROKEN: ran ${ran} cells, expected ${EXPECTED_CELLS}. A cell was added or removed `
+      + `without updating EXPECTED_CELLS. If the change was intentional, update the constant in the `
+      + `same commit so the new total is reviewed rather than inherited.`,
+  );
+  process.exit(1);
+}
 process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
A smoke suite that reports how many checks it ran, but never checks that number, cannot tell you it has quietly stopped running some of them.

`host-starvation.smoke.ts` printed `41 passed, 0 failed` and exited on the failure count alone. That catches a suite which runs nothing. It does not catch the failure that actually erodes a suite over time: one that runs less than it used to.

Measured on the landed tree rather than argued. Deleting a single executed check from the file turns the banner into `40 passed, 0 failed` and the suite still exits 0. A green run, one assertion lighter, indistinguishable from success in any log or CI summary.

This pins the expected number so that loss becomes a named refusal.

Controls, each a full suite run:

    41 checks, unmodified    exit 0   accepted
    40 checks, one REMOVED   exit 1   ACCOUNTING BROKEN: ran 40 cells, expected 41
    42 checks, one ADDED     exit 1   ACCOUNTING BROKEN: ran 42 cells, expected 41
    41 restored              exit 0   accepted again

Two refusing cases, because drift runs both ways. A guard that catches only deletion silently accepts a check added without review. The accept case runs at both ends so the refusals cannot be an instrument that simply always fails.

The constant has to be updated in the same commit that changes the number of checks, so a new total is reviewed rather than inherited.

Also verified, because this edits a file that mutation fixtures grade and that is exactly where a guard gets disarmed by accident: a whole-repo scan discovering fixtures by shape rather than by directory reports 424 configs and 2281 anchors with 0 displaced by this change. Typecheck is clean.

No changeset. `implementations/runtime/package.json` declares `files: ["dist"]`, so this suite is not shipped and there is no package behaviour to version.

Scope, stated honestly: 652 smoke suites in the repository print a tally in 388 of them, and 44 pin it. This fixes one. The remaining 344 are a separate finding, not this change.

Refs #1508
